### PR TITLE
[AutoPR cognitiveservices/data-plane/VisualSearch] enable swagger-to-sdk in visual search for Go SDK

### DIFF
--- a/packages/@azure/cognitiveservices-visualsearch/lib/operations/images.ts
+++ b/packages/@azure/cognitiveservices-visualsearch/lib/operations/images.ts
@@ -45,7 +45,7 @@ export class Images {
    * @param callback The callback
    */
   visualSearch(options: Models.ImagesVisualSearchOptionalParams, callback: msRest.ServiceCallback<Models.ImageKnowledge>): void;
-  visualSearch(options?: Models.ImagesVisualSearchOptionalParams | msRest.ServiceCallback<Models.ImageKnowledge>, callback?: msRest.ServiceCallback<Models.ImageKnowledge>): Promise<Models.ImagesVisualSearchResponse> {
+  visualSearch(options?: Models.ImagesVisualSearchOptionalParams, callback?: msRest.ServiceCallback<Models.ImageKnowledge>): Promise<Models.ImagesVisualSearchResponse> {
     return this.client.sendOperationRequest(
       {
         options

--- a/packages/@azure/cognitiveservices-visualsearch/lib/visualSearchAPIClientContext.ts
+++ b/packages/@azure/cognitiveservices-visualsearch/lib/visualSearchAPIClientContext.ts
@@ -30,10 +30,6 @@ export class VisualSearchAPIClientContext extends msRest.ServiceClient {
     if (!options) {
       options = {};
     }
-    if(!options.userAgent) {
-      const defaultUserAgent = msRest.getDefaultUserAgentValue();
-      options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
-    }
 
     super(credentials, options);
 
@@ -41,5 +37,6 @@ export class VisualSearchAPIClientContext extends msRest.ServiceClient {
     this.requestContentType = "multipart/form-data";
     this.credentials = credentials;
 
+    this.addUserAgentInfo(`${packageName}/${packageVersion}`);
   }
 }

--- a/packages/@azure/cognitiveservices-visualsearch/package.json
+++ b/packages/@azure/cognitiveservices-visualsearch/package.json
@@ -4,7 +4,7 @@
   "description": "VisualSearchAPIClient Library with typescript type definitions for node.js and browser.",
   "version": "1.0.0",
   "dependencies": {
-    "ms-rest-js": "^1.0.460",
+    "ms-rest-js": "^1.0.455",
     "tslib": "^1.9.3"
   },
   "keywords": [


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4398