### PR TITLE
CI update

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,9 @@
 pool:
   vmImage: 'Ubuntu 16.04'
 
+trigger:
+- master
+
 steps:
 - task: NodeTool@0
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,13 +13,20 @@ steps:
   displayName: 'Install Node.js'
 
 - script: cd .. && git clone https://github.com/Azure/azure-rest-api-specs
-  displayName: git clone https://github.com/Azure/azure-rest-api-specs
-- script: npm install
-  displayName: npm install
-- script: npm run build
-  displayName: npm run build
+  displayName: cd.. && git clone https://github.com/Azure/azure-rest-api-specs
+
+- task: Npm@1
+  displayName: 'npm install'
+  inputs:
+    verbose: false
+
+- task: Npm@1
+  displayName: 'npm run build'
+  inputs:
+    command: custom
+    verbose: false
+    customCommand: run build
 
 - task: PublishBuildArtifacts@1
   inputs:
-    pathtoPublish: $(Build.SourcesDirectory)/pack
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    pathtoPublish: $(Build.SourcesDirectory)/drop

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -110,9 +110,9 @@ const createPackages = (type: CreatePackageType = "pack") => {
   let publishedPackages = 0;
   let publishedPackagesSkipped = 0;
 
-  const packPath = path.join(azureSDKForJSRepoRoot, "pack");
-  if (!fs.existsSync(packPath)) {
-    fs.mkdirSync(packPath);
+  const dropPath = path.join(azureSDKForJSRepoRoot, "drop");
+  if (!fs.existsSync(dropPath)) {
+    fs.mkdirSync(dropPath);
   }
   for (const typeScriptReadmeFilePath of typeScriptReadmeFilePaths) {
     _logger.logTrace(`INFO: Processing ${typeScriptReadmeFilePath}`);
@@ -171,7 +171,7 @@ const createPackages = (type: CreatePackageType = "pack") => {
                     execSync(`npm ${type}`, { cwd: packageFolderPath });
                     const packFileName = `${packageName.replace("/", "-").replace("@", "")}-${localPackageVersion}.tgz`
                     const packFilePath = path.join(packageFolderPath, packFileName);
-                    fs.renameSync(packFilePath, path.join(packPath, packFileName));
+                    fs.renameSync(packFilePath, path.join(dropPath, packFileName));
                     console.log(`Filename: ${packFileName}`);
                     publishedPackages++;
                   }


### PR DESCRIPTION
- rename `pack` folder to `drop` to be consistent.
- better output (using NPM task instead of script)
- trigger CI only on `master` branch.