### PR TITLE
[AutoPR logic/resource-manager] Microsoft.Logic - Don't make ResourceReference id readonly

### DIFF
--- a/packages/@azure/arm-logic/lib/models/index.ts
+++ b/packages/@azure/arm-logic/lib/models/index.ts
@@ -75,10 +75,8 @@ export interface SubResource extends BaseResource {
 export interface ResourceReference {
   /**
    * @member {string} [id] The resource id.
-   * **NOTE: This property will not be serialized. It can only be populated by
-   * the server.**
    */
-  readonly id?: string;
+  id?: string;
   /**
    * @member {string} [name] Gets the resource name.
    * **NOTE: This property will not be serialized. It can only be populated by

--- a/packages/@azure/arm-logic/lib/models/mappers.ts
+++ b/packages/@azure/arm-logic/lib/models/mappers.ts
@@ -86,7 +86,6 @@ export const ResourceReference: msRest.CompositeMapper = {
     className: "ResourceReference",
     modelProperties: {
       id: {
-        readOnly: true,
         serializedName: "id",
         type: {
           name: "String"


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/4491