### PR TITLE
Move mocha reporter into pipeline

### DIFF
--- a/.azure-pipelines/client.test.yml
+++ b/.azure-pipelines/client.test.yml
@@ -45,7 +45,7 @@ jobs:
       - task: Npm@1
         inputs:
           command: 'custom'
-          customCommand: 'run test-client'
+          customCommand: 'run test-client -- -- -- --reporter mocha-junit-reporter'
         displayName: 'npm run test-client'
 
       - task: PublishTestResults@2

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "pack-client-keyvault": "cd packages/@azure/keyvault && npm pack",
     "pack-client-template": "cd packages/@azure/template && npm pack",
     "pack-client": "npm-run-all -p -l pack-client-*",
-    "test-client-template": "cd packages/@azure/template && npm run test -- --reporter mocha-junit-reporter",
-    "test-client": "npm-run-all -p -l test-client-*",
+    "test-client-template": "cd packages/@azure/template && npm run test",
+    "test-client": "npm-run-all -p -l \"test-client-* -- {@}\"",
     "audit-client-keyvault": "cd packages/@azure/keyvault && npm i --package-lock-only && npm audit",
     "audit-client-template": "cd packages/@azure/template && npm i --package-lock-only && npm audit",
     "audit-client": "npm-run-all -p -l audit-client-*"


### PR DESCRIPTION
- By default, "npm run test-client" should use the default reporter.
- Default reporter is better for inner-loop development.
- Pipeline can override reporter during CI

CC: @Azure/azure-sdk-eng 