### PR TITLE
Fix gulpfile build errors

### DIFF
--- a/.scripts/gulp.ts
+++ b/.scripts/gulp.ts
@@ -31,7 +31,7 @@ function containsPackageName(packageNames: string[], packageName: string): boole
     return result;
 }
 
-export async function generateSdk(azureRestAPISpecsRoot: string, azureSDKForJSRepoRoot: string, packageName: string, use?: boolean, useDebugger?: boolean) {
+export async function generateSdk(azureRestAPISpecsRoot: string, azureSDKForJSRepoRoot: string, packageName: string, use?: string, useDebugger?: boolean) {
     const typeScriptReadmeFilePaths: string[] = findReadmeTypeScriptMdFilePaths(azureRestAPISpecsRoot);
 
     for (let i = 0; i < typeScriptReadmeFilePaths.length; ++i) {

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -422,9 +422,12 @@ gulp.task("regenerate", async () => {
     }
 
     const branchName = argv.branch || pullRequestData.branchName;
-    const packageName = argv.package || pullRequestData.packageName;
-
     if (!branchName) {
+      throw new Error("Unable to find the name of the branch. Please specify the --branch parameter");
+    }
+
+    const packageName: string | undefined = argv.package || pullRequestData.packageName;
+    if (!packageName) {
       throw new Error("Unable to find the name of the package. Please specify the --package parameter");
     }
 


### PR DESCRIPTION
Fix the build errors that @mikeharder pointed out.
I still got issues if a gulpfile.js exists, so make sure that you don't have a lingering gulpfile.js or any .js files in the .scripts folder.