### PR TITLE
[AutoPR network/resource-manager] Port AppGw changes from 2018-11-01 into 2018-12-01

### DIFF
--- a/packages/@azure/arm-network/lib/models/index.ts
+++ b/packages/@azure/arm-network/lib/models/index.ts
@@ -2648,6 +2648,11 @@ export interface ApplicationGatewayAutoscaleConfiguration {
    * instances
    */
   minCapacity: number;
+  /**
+   * @member {number} [maxCapacity] Upper bound on number of Application
+   * Gateway capacity
+   */
+  maxCapacity?: number;
 }
 
 /**

--- a/packages/@azure/arm-network/lib/models/mappers.ts
+++ b/packages/@azure/arm-network/lib/models/mappers.ts
@@ -3498,6 +3498,15 @@ export const ApplicationGatewayAutoscaleConfiguration: msRest.CompositeMapper = 
         type: {
           name: "Number"
         }
+      },
+      maxCapacity: {
+        serializedName: "maxCapacity",
+        constraints: {
+          InclusiveMinimum: 2
+        },
+        type: {
+          name: "Number"
+        }
       }
     }
   }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5044