### PR TITLE
[Service Bus] Enable receiveDeferredMsgs on unpartitioned entities

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/core/managementClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/managementClient.ts
@@ -704,7 +704,7 @@ export class ManagementClient extends LinkEntity {
         undefined
       );
       const receiverSettleMode: number = receiveMode === ReceiveMode.receiveAndDelete ? 0 : 1;
-      messageBody[Constants.receiverSettleMode] = types.wrap_ubyte(receiverSettleMode);
+      messageBody[Constants.receiverSettleMode] = types.wrap_uint(receiverSettleMode);
       if (sessionId != undefined) {
         messageBody[Constants.sessionIdMapKey] = sessionId;
       }

--- a/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
@@ -361,41 +361,41 @@ describe("Complete/Abandon/Defer/Deadletter normal message", function(): void {
     await testDefer(true);
   });
 
-  // it("Unpartitioned Queues: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  // await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
-  //   await testDefer();
-  // });
+  it("Unpartitioned Queues: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
+    await testDefer();
+  });
 
-  // it("Unpartitioned Topics and Subscription: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  // await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
-  //   await testDefer();
-  // });
+  it("Unpartitioned Topics and Subscription: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
+    await testDefer();
+  });
 
-  // it("Unpartitioned Queues with Sessions: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  // await beforeEachTest(
-  //   ClientType.UnpartitionedQueueWithSessions,
-  //   ClientType.UnpartitionedQueueWithSessions,
-  //   true
-  // );
-  //   await testDefer(true);
-  // });
+  it("Unpartitioned Queues with Sessions: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions,
+      true
+    );
+    await testDefer(true);
+  });
 
-  // it("Unpartitioned Topics and Subscription with Sessions: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  // await beforeEachTest(
-  //   ClientType.UnpartitionedTopicWithSessions,
-  //   ClientType.UnpartitionedSubscriptionWithSessions,
-  //   true
-  // );
-  //   await testDefer(true);
-  // });
+  it("Unpartitioned Topics and Subscription with Sessions: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions,
+      true
+    );
+    await testDefer(true);
+  });
 
   async function testDeadletter(useSessions?: boolean): Promise<void> {
     const testMessages = useSessions ? testMessagesWithSessions : testSimpleMessages;
@@ -639,19 +639,19 @@ describe("Abandon/Defer/Deadletter deadlettered message", function(): void {
     await testDefer();
   });
 
-  // it("Unpartitioned Queues: Defer a message received from dead letter queue", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
-  //   await testDefer();
-  // });
+  it("Unpartitioned Queues: Defer a message received from dead letter queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
+    await testDefer();
+  });
 
-  // it("Unpartitioned Topics and Subscription: Defer a message received from dead letter queue", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
-  //   await testDefer();
-  // });
+  it("Unpartitioned Topics and Subscription: Defer a message received from dead letter queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
+    await testDefer();
+  });
 });
 
 describe("Multiple ReceiveBatch calls", function(): void {

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -441,19 +441,19 @@ describe("Defer message", function(): void {
     await testDefer(false);
   });
 
-  // it("UnPartitioned Queue: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
-  //   await testDefer(false);
-  // });
+  it("UnPartitioned Queue: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
+    await testDefer(false);
+  });
 
-  // it("UnPartitioned Topics and Subscription: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
-  //   await testDefer(false);
-  // });
+  it("UnPartitioned Topics and Subscription: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
+    await testDefer(false);
+  });
 
   it("Partitioned Queues with autoComplete: defer() moves message to deferred queue", async function(): Promise<
     void
@@ -469,19 +469,19 @@ describe("Defer message", function(): void {
     await testDefer(true);
   });
 
-  // it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
-  //   await testDefer(true);
-  // });
+  it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
+    await testDefer(true);
+  });
 
-  // it("UnPartitioned Topics and Subscription with autoComplete: defer() moves message to deferred queue", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
-  //   await testDefer(true);
-  // });
+  it("UnPartitioned Topics and Subscription with autoComplete: defer() moves message to deferred queue", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
+    await testDefer(true);
+  });
 });
 
 describe("Deadletter message", function(): void {

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -542,25 +542,25 @@ describe("Defer message(with sessions)", function(): void {
     await testDefer(false);
   });
 
-  // it("UnPartitioned Queue: defer() moves message to deferred queue(with sessions)", async function(): Promise<
-  //   void
-  // > {
-  //  await beforeEachTest(
-  //    ClientType.UnpartitionedQueueWithSessions,
-  //    ClientType.UnpartitionedQueueWithSessions
-  //  );
-  //  await testDefer(false);
-  // });
+  it("UnPartitioned Queue: defer() moves message to deferred queue(with sessions)", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions
+    );
+    await testDefer(false);
+  });
 
-  // it("UnPartitioned Topics and Subscription: defer() moves message to deferred queue(with sessions)", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(
-  //    ClientType.UnpartitionedTopicWithSessions,
-  //    ClientType.UnpartitionedSubscriptionWithSessions
-  //  );
-  //  await testDefer(false);
-  // });
+  it("UnPartitioned Topics and Subscription: defer() moves message to deferred queue(with sessions)", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions
+    );
+    await testDefer(false);
+  });
 
   it("Partitioned Queues with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
@@ -582,26 +582,25 @@ describe("Defer message(with sessions)", function(): void {
     await testDefer(true);
   });
 
-  // it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(
-  //    ClientType.UnpartitionedQueueWithSessions,
-  //    ClientType.UnpartitionedQueueWithSessions
-  //  );
-  //  await testDefer(  true);
-  // });
+  it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions
+    );
+    await testDefer(true);
+  });
 
-  // it("UnPartitioned Topics and Subscription with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
-  //   void
-  // > {
-  //
-  //  await beforeEachTest(
-  //    ClientType.UnpartitionedTopicWithSessions,
-  //    ClientType.UnpartitionedSubscriptionWithSessions
-  //  );
-  //  await testDefer(  true);
-  // });
+  it("UnPartitioned Topics and Subscription with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions
+    );
+    await testDefer(true);
+  });
 });
 
 describe("Deadletter message(with sessions)", function(): void {


### PR DESCRIPTION
This PR wraps the receiver mode being sent in the request to receiveDeferredMessages as unit which fixes https://github.com/Azure/azure-service-bus-node/issues/146

I have also taken this opportunity to refactor the tests in deferredMessage.spec.ts to match with the new model in batchingReceiver.spec.ts