### PR TITLE
[Service Bus] Purge queue/subscription before each test

### DIFF
--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -76,7 +76,7 @@
     "build-test": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js",
     "build-samples": "cd examples && tsc -p .",
     "test": "npm run build",
-    "unit": "npm run build-test && mocha -t 50000 test-dist/index.js",
+    "unit": "npm run build-test && mocha -t 65000 test-dist/index.js",
     "prepack": "npm i && npm run build"
   }
 }

--- a/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
@@ -24,7 +24,8 @@ import {
   testSessionId,
   getSenderClient,
   getReceiverClient,
-  ClientType
+  ClientType,
+  purge
 } from "./testUtils";
 import { Receiver } from "../lib/receiver";
 import { Sender } from "../lib/sender";
@@ -87,18 +88,26 @@ async function beforeEachTest(
     );
   }
 
+  await purge(receiverClient, useSessions);
+  await purge(deadLetterClient, useSessions);
+  const peekedMsgs = await receiverClient.peek();
+  const receiverEntityType = receiverClient instanceof QueueClient ? "queue" : "topic";
+  if (peekedMsgs.length) {
+    chai.assert.fail(`Please use an empty ${receiverEntityType} for integration testing`);
+  }
+  const peekedDeadMsgs = await deadLetterClient.peek();
+  if (peekedDeadMsgs.length) {
+    chai.assert.fail(
+      `Please use an empty dead letter ${receiverEntityType} for integration testing`
+    );
+  }
+
   sender = senderClient.getSender();
   receiver = useSessions
     ? await receiverClient.getSessionReceiver({
         sessionId: testSessionId
       })
     : receiverClient.getReceiver();
-
-  const peekedMsgs = await receiverClient.peek();
-  const receiverEntityType = receiverClient instanceof QueueClient ? "queue" : "topic";
-  if (peekedMsgs.length) {
-    throw new Error(`Please use an empty ${receiverEntityType} for integration testing`);
-  }
 }
 
 async function afterEachTest(): Promise<void> {

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -22,7 +22,8 @@ import {
   getSenderClient,
   getReceiverClient,
   ClientType,
-  testSessionId
+  testSessionId,
+  purge
 } from "./testUtils";
 
 async function testPeekMsgsLength(
@@ -64,6 +65,13 @@ async function beforeEachTest(senderType: ClientType, sessionType: ClientType): 
 
   senderClient = getSenderClient(ns, senderType);
   receiverClient = getReceiverClient(ns, sessionType);
+
+  await purge(receiverClient, true);
+  const peekedMsgs = await receiverClient.peek();
+  const receiverEntityType = receiverClient instanceof QueueClient ? "queue" : "topic";
+  if (peekedMsgs.length) {
+    chai.assert.fail(`Please use an empty ${receiverEntityType} for integration testing`);
+  }
 }
 
 async function afterEachTest(): Promise<void> {

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -24,7 +24,8 @@ import {
   testSessionId,
   getSenderClient,
   getReceiverClient,
-  ClientType
+  ClientType,
+  purge
 } from "./testUtils";
 import { Sender } from "../lib/sender";
 
@@ -88,14 +89,18 @@ async function beforeEachTest(senderType: ClientType, receiverType: ClientType):
       receiverClient.subscriptionName
     );
   }
-  sessionReceiver = await receiverClient.getSessionReceiver({
-    sessionId: testSessionId
-  });
+
+  await purge(receiverClient, true);
   const peekedMsgs = await receiverClient.peek();
   const receiverEntityType = receiverClient instanceof QueueClient ? "queue" : "topic";
   if (peekedMsgs.length) {
-    throw new Error(`Please use an empty ${receiverEntityType} for integration testing`);
+    chai.assert.fail(`Please use an empty ${receiverEntityType} for integration testing`);
   }
+
+  sessionReceiver = await receiverClient.getSessionReceiver({
+    sessionId: testSessionId
+  });
+
   errorWasThrown = false;
   unexpectedError = undefined;
 }

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -206,6 +206,6 @@ export async function purge(
     : recieverClient.getReceiver();
 
   receiver.receive(() => Promise.resolve(), (err) => console.log(`Error when purging: ${err}`));
-  await delay(3000);
+  await delay(5000);
   await receiver.close();
 }

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -7,7 +7,8 @@ import {
   QueueClient,
   TopicClient,
   Namespace,
-  SubscriptionClient
+  SubscriptionClient,
+  delay
 } from "../lib";
 
 export const testSimpleMessages: SendableMessageInfo[] = [
@@ -189,4 +190,22 @@ export function getReceiverClient(
   }
 
   throw new Error("Cannot create receiver client for give client type");
+}
+
+export async function purge(
+  recieverClient: QueueClient | SubscriptionClient,
+  useSessions?: boolean
+): Promise<void> {
+  const peekedMsgs = await recieverClient.peek();
+  if (!peekedMsgs.length) {
+    return;
+  }
+
+  const receiver = useSessions
+    ? await recieverClient.getSessionReceiver()
+    : recieverClient.getReceiver();
+
+  receiver.receive(() => Promise.resolve(), (err) => console.log(`Error when purging: ${err}`));
+  await delay(3000);
+  await receiver.close();
 }

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -17,7 +17,7 @@ import {
   delay,
   CorrelationFilter
 } from "../lib";
-import { getSenderClient, getReceiverClient, ClientType } from "./testUtils";
+import { getSenderClient, getReceiverClient, ClientType, purge } from "./testUtils";
 
 // We need to remove rules before adding one because otherwise the existing default rule will let in all messages.
 async function removeAllRules(client: SubscriptionClient): Promise<void> {
@@ -66,14 +66,16 @@ async function beforeEachTest(): Promise<void> {
     ClientType.TopicFilterTestDefaultSubscription
   ) as SubscriptionClient;
 
+  await purge(defaultSubscriptionClient);
+  await purge(subscriptionClient);
   const peekedDefaultSubscriptionMsg = await defaultSubscriptionClient.peek();
   if (peekedDefaultSubscriptionMsg.length) {
-    throw new Error("Please use an empty Default Subscription for integration testing");
+    chai.assert.fail("Please use an empty Default Subscription for integration testing");
   }
 
   const peekedSubscriptionMsg = await subscriptionClient.peek();
   if (peekedSubscriptionMsg.length) {
-    throw new Error("Please use an empty Subscription for integration testing");
+    chai.assert.fail("Please use an empty Subscription for integration testing");
   }
   await removeAllRules(subscriptionClient);
 }
@@ -170,7 +172,7 @@ async function addRules(
   }
 }
 
-describe.skip("Topic Filters -  Add Rule - Positive Test Cases", function(): void {
+describe("Topic Filters -  Add Rule - Positive Test Cases", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -208,7 +210,7 @@ describe.skip("Topic Filters -  Add Rule - Positive Test Cases", function(): voi
     await subscriptionClient.addRule(
       "Priority_1",
       "(priority = 1 OR priority = 3) AND (sys.label LIKE '%String1')",
-      "SET sys.body = 'MessageX'"
+      "SET sys.label = 'MessageX'"
     );
     const rules = await subscriptionClient.getRules();
     should.equal(rules.length, 1);
@@ -226,7 +228,7 @@ describe.skip("Topic Filters -  Add Rule - Positive Test Cases", function(): voi
   });
 });
 
-describe.skip("Topic Filters -  Add Rule - Negative Test Cases", function(): void {
+describe("Topic Filters -  Add Rule - Negative Test Cases", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -287,7 +289,7 @@ describe.skip("Topic Filters -  Add Rule - Negative Test Cases", function(): voi
   });
 });
 
-describe.skip("Topic Filters -  Remove Rule", function(): void {
+describe("Topic Filters -  Remove Rule", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -324,7 +326,7 @@ describe.skip("Topic Filters -  Remove Rule", function(): void {
   });
 });
 
-describe.skip("Topic Filters: Get Rules", function(): void {
+describe("Topic Filters: Get Rules", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -370,7 +372,7 @@ describe.skip("Topic Filters: Get Rules", function(): void {
     await subscriptionClient.addRule(
       "Priority_1",
       "(priority = 1 OR priority = 3) AND (sys.label LIKE '%String1')",
-      "SET sys.body = 'MessageX'"
+      "SET sys.label = 'MessageX'"
     );
     const rules = await subscriptionClient.getRules();
     should.equal(rules[0].name, "Priority_1");
@@ -383,23 +385,23 @@ describe.skip("Topic Filters: Get Rules", function(): void {
     });
     const rules = await subscriptionClient.getRules();
     should.equal(rules[0].name, "Correlationfilter");
-    const matchexpr = {
+    const expectedFilter = {
       correlationId: "high",
-      messageId: undefined,
-      to: undefined,
-      replyTo: undefined,
       label: "red",
-      sessionId: undefined,
-      replyToSessionId: undefined,
-      contentType: undefined,
       userProperties: []
     };
     should.equal(rules.length, 1);
-    should.equal(JSON.stringify(rules[0].filter), JSON.stringify(matchexpr));
+    rules.forEach((rule) => {
+      should.equal((<CorrelationFilter>rule.filter).correlationId, expectedFilter.correlationId);
+      should.equal((<CorrelationFilter>rule.filter).label, expectedFilter.label);
+      const userProperties = (<CorrelationFilter>rule.filter).userProperties;
+      should.equal(Array.isArray(userProperties), true);
+      should.equal(userProperties.length, 0);
+    });
   });
 });
 
-describe.skip("Send/Receive messages using default filter of subscription", function(): void {
+describe("Send/Receive messages using default filter of subscription", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -419,7 +421,7 @@ describe.skip("Send/Receive messages using default filter of subscription", func
   });
 });
 
-describe.skip("Send/Receive messages using boolean filters of subscription", function(): void {
+describe("Send/Receive messages using boolean filters of subscription", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -468,7 +470,7 @@ describe.skip("Send/Receive messages using boolean filters of subscription", fun
   });
 });
 
-describe.skip("Send/Receive messages using sql filters of subscription", function(): void {
+describe("Send/Receive messages using sql filters of subscription", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });
@@ -570,7 +572,7 @@ describe.skip("Send/Receive messages using sql filters of subscription", functio
   });*/
 });
 
-describe.skip("Send/Receive messages using correlation filters of subscription", function(): void {
+describe("Send/Receive messages using correlation filters of subscription", function(): void {
   beforeEach(async () => {
     await beforeEachTest();
   });


### PR DESCRIPTION
To avoid one test failure in affecting the other tests, this PR empties out the queue/subscription before each test is run.

The margin of time check in the renew lock tests is increased as well