### PR TITLE
[Service Bus] Update readme for tests to include details on expected entities and names

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/README.md
+++ b/packages/@azure/servicebus/data-plane/test/README.md
@@ -1,23 +1,37 @@
 ## Pre-requisites
 
-- Run `npm i` to install all the dependencies of this project. This is a one time task
-- Have a file by the name `.env` in the root folder of this project.
-- This file should contain the below environment variables pointing to the various Service Bus resources
-    - SERVICEBUS_CONNECTION_STRING
-    - QUEUE_NAME (without sessions enabled)
-    - TOPIC_NAME
-    - SUBSCRIPTION_NAME
+- Run `npm i` to install all the dependencies of this project. This is a one time task.
+- The tests expect a series of queues, topics and subscriptions to exist in a single Service Bus instance.
+  The connection string for the service bus should be in the environment variable `SERVICEBUS_CONNECTION_STRING`.
+
+  Note that the tests will empty the messages in these entities to get a clean start before running each test.
+
+  We suggest to name your entities as defined below. If you have these entities with different names, ensure
+  that you have the corresponding environment variables populated with your entity names.
+
+ 
+  
+  Entitiy Name  | Entity Description | Environment Variable if not using default names
+  ------------- | ------------------|----------
+  partitioned-queue | Queue with partitions enabled and sessions disabled | QUEUE_NAME
+  unpartitioned-queue | Queue with partitions and sessions, both disabled | QUEUE_NAME_NO_PARTITION
+  partitioned-queue-sessions | Queue with partitions and sessions, both enabled | QUEUE_NAME_SESSION
+  unpartitioned-queue-sessions | Queue with partitions disabled and sessions enabled | QUEUE_NAME_NO_PARTITION_SESSION
+  partitioned-topic | Topic with partitions enabled, meant for testing subscriptions with sessions disabled | TOPIC_NAME
+  unpartitioned-topic | Topic with partitions disabled, meant for testing subscriptions with sessions disabled | TOPIC_NAME_NO_PARTITION
+  partitioned-topic-sessions | Topic with partitions enabled, meant for testing subscriptions with sessions enabled | TOPIC_NAME_SESSION
+  unpartitioned-topic-sessions | Topic with partitions disabled, meant for testing subscriptions with sessions enabled | TOPIC_NAME_NO_PARTITION_SESSION
+  partitioned-topic-subscription | Subscription with sessions disabled in the Topic, `partitioned-topic` | SUBSCRIPTION_NAME
+  unpartitioned-topic-subscription | Subscription with sessions disabled in the Topic, `unpartitioned-topic` | SUBSCRIPTION_NAME_NO_PARTITION
+  partitioned-topic-sessions-subscription | Subscription with sessions enabled in the Topic, `partitioned-topic-sessions` | SUBSCRIPTION_NAME_SESSION
+  unpartitioned-topic-sessions-subscription | Subscription with sessions enabled in the Topic, `unpartitioned-topic-sessions` | SUBSCRIPTION_NAME_NO_PARTITION_SESSION
+  topic-filter | Topic for testing topic filters | TOPIC_FILTER
+  topic-filter-subscription | Subscription in the Topic `topic-filter` | TOPIC_FILTER_SUBSCRIPTION
+  topic-filter-default-subscription | Subscription in the Topic `topic-filter` | TOPIC_FILTER_DEFAULT_SUBSCRIPTION
 
 ## Run all tests
 
 Run `npm run unit` from your terminal to run all the tests under the `./test` folder
-
-## Run all tests from a single file
-
-Update the npm script for `unit` in the package.json file to replace the glob pattern that matches
-all test files under the `test` folder with the relative path to the file you want to target.
-
-Then run `npm run unit` from your terminal.
 
 ## Run all tests in a single test suite
 


### PR DESCRIPTION
Update readme for tests to include details on expected entities and names

These will show up as a table

<img width="1539" alt="screen shot 2019-01-29 at 12 27 31 pm" src="https://user-images.githubusercontent.com/16890566/51938157-45e7f300-23c1-11e9-867f-0308ed4b26b7.png">
