### PR TITLE
Handling error for receiveBatch() method.

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -736,13 +736,17 @@ export class SessionReceiver extends LinkEntity {
           firstMessageWaitTimer = undefined;
         }
         resetTimerOnNewMessageReceived();
-        const data: ServiceBusMessage = new ServiceBusMessage(
-          this._context,
-          context.message!,
-          context.delivery!
-        );
-        if (brokeredMessages.length < maxMessageCount) {
-          brokeredMessages.push(data);
+        try {
+          const data: ServiceBusMessage = new ServiceBusMessage(
+            this._context,
+            context.message!,
+            context.delivery!
+          );
+          if (brokeredMessages.length < maxMessageCount) {
+            brokeredMessages.push(data);
+          }
+        } catch (err) {
+          reject(`Error while converting AmqpMessage to ReceivedSBMessage: ${err}`);
         }
         if (brokeredMessages.length === maxMessageCount) {
           finalAction();


### PR DESCRIPTION
**Solution** : Added try catch block inside async onReceiveMessage function while converting AmqpMessage to ReceivedSBMessage and rejected the error inside the catch block. This way users will be able to see the actual error.