### PR TITLE
[AutoPR network/resource-manager] updated the destination address description to also include service tags

### DIFF
--- a/packages/@azure/arm-network/lib/models/index.ts
+++ b/packages/@azure/arm-network/lib/models/index.ts
@@ -3380,7 +3380,7 @@ export interface AzureFirewallNatRule {
   sourceAddresses?: string[];
   /**
    * @member {string[]} [destinationAddresses] List of destination IP addresses
-   * for this rule.
+   * for this rule. Supports IP ranges, prefixes, and service tags.
    */
   destinationAddresses?: string[];
   /**


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5112