### PR TITLE
Comment listMessageSessions which doesnt work as expected

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -127,22 +127,22 @@ export class QueueClient extends Client {
     });
   }
 
-  /**
-   * Lists the ids of the sessions on the ServiceBus Queue.
-   * @param maxNumberOfSessions Maximum number of sessions.
-   * @param lastUpdateTime Filter to include only sessions updated after a given time. Default
-   * value is 3 days before the current time.
-   */
-  async listMessageSessions(
-    maxNumberOfSessions: number,
-    lastUpdatedTime?: Date
-  ): Promise<string[]> {
-    return this._context.managementClient!.listMessageSessions(
-      0,
-      maxNumberOfSessions,
-      lastUpdatedTime
-    );
-  }
+  // /**
+  //  * Lists the ids of the sessions on the ServiceBus Queue.
+  //  * @param maxNumberOfSessions Maximum number of sessions.
+  //  * @param lastUpdateTime Filter to include only sessions updated after a given time. Default
+  //  * value is 3 days before the current time.
+  //  */
+  // async listMessageSessions(
+  //   maxNumberOfSessions: number,
+  //   lastUpdatedTime?: Date
+  // ): Promise<string[]> {
+  //   return this._context.managementClient!.listMessageSessions(
+  //     0,
+  //     maxNumberOfSessions,
+  //     lastUpdatedTime
+  //   );
+  // }
 
   /**
    * Creates a sessionReceiver with given sessionId from the ServiceBus Queue.

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -173,22 +173,22 @@ export class SubscriptionClient extends Client {
 
   //#region sessions
 
-  /**
-   * Lists the ids of the sessions on the ServiceBus Subscription.
-   * @param maxNumberOfSessions Maximum number of sessions.
-   * @param lastUpdateTime Filter to include only sessions updated after a given time. Default
-   * value is 3 days before the current time.
-   */
-  async listMessageSessions(
-    maxNumberOfSessions: number,
-    lastUpdatedTime?: Date
-  ): Promise<string[]> {
-    return this._context.managementClient!.listMessageSessions(
-      0,
-      maxNumberOfSessions,
-      lastUpdatedTime
-    );
-  }
+  // /**
+  //  * Lists the ids of the sessions on the ServiceBus Subscription.
+  //  * @param maxNumberOfSessions Maximum number of sessions.
+  //  * @param lastUpdateTime Filter to include only sessions updated after a given time. Default
+  //  * value is 3 days before the current time.
+  //  */
+  // async listMessageSessions(
+  //   maxNumberOfSessions: number,
+  //   lastUpdatedTime?: Date
+  // ): Promise<string[]> {
+  //   return this._context.managementClient!.listMessageSessions(
+  //     0,
+  //     maxNumberOfSessions,
+  //     lastUpdatedTime
+  //   );
+  // }
 
   /**
    * Creates a session client with given sessionId in the ServiceBus Subscription.


### PR DESCRIPTION
`listMessageSessions` is giving us an empty array regardless of the session enabled queue/subscription having messages. #1059 is tracking this bug.

Commenting this function in the code as we cannot ship a feature that does not work :)