### PR TITLE
Option to bail on test-runs after any single one fails.

### DIFF
--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -76,7 +76,7 @@
     "build-test": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js",
     "build-samples": "cd examples && tsc -p .",
     "test": "npm run build",
-    "unit": "npm run build-test && mocha -t 65000 test-dist/index.js",
+    "unit": "npm run build-test && mocha -bt 65000 test-dist/index.js",
     "prepack": "npm i && npm run build"
   }
 }


### PR DESCRIPTION
Mocha has a -b / --bail option to stop executing remaining tests after any one fails.
For a CI/CD setup as well as local debugging, it seems to make sense to have this option enabled by default.
Thoughts?