### PR TITLE
Service bus completes the message even when the session lock expires

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -84,7 +84,7 @@ describe("Standard", function(): void {
         await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
       });
 
-      it.only("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
+      it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
         void
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -84,15 +84,14 @@ describe("Standard", function(): void {
         await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
       });
 
-      it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
+      it.only("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
         void
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
-        // Complete fails as expected
+        // Service bus completes the message even when the session lock expires.
       });
 
       it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
@@ -100,8 +99,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          willCompleteFail: false
+          delayBeforeAttemptingToCompleteMessageInSeconds: 35
         });
       });
 
@@ -110,8 +108,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 55
         });
       }).timeout(80000);
 
@@ -120,8 +117,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
       });
     });
@@ -164,8 +160,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
         // Complete fails as expected
       });
@@ -175,8 +170,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          willCompleteFail: false
+          delayBeforeAttemptingToCompleteMessageInSeconds: 35
         });
       });
 
@@ -185,8 +179,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 55
         });
       }).timeout(80000);
 
@@ -195,8 +188,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
       });
     });
@@ -245,8 +237,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
         // Complete fails as expected
       });
@@ -256,8 +247,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          willCompleteFail: false
+          delayBeforeAttemptingToCompleteMessageInSeconds: 35
         });
       });
 
@@ -266,8 +256,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 55
         });
       }).timeout(80000);
 
@@ -276,8 +265,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
       });
     });
@@ -325,8 +313,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
         // Complete fails as expected
       });
@@ -336,8 +323,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          willCompleteFail: false
+          delayBeforeAttemptingToCompleteMessageInSeconds: 35
         });
       });
 
@@ -346,8 +332,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 55
         });
       }).timeout(80000);
 
@@ -356,8 +341,7 @@ describe("Standard", function(): void {
       > {
         await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
           maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          willCompleteFail: true
+          delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
       });
     });
@@ -565,7 +549,6 @@ async function testStreamingReceiverManualLockRenewalHappyCase(
 interface AutoLockRenewalTestOptions {
   maxSessionAutoRenewLockDurationInSeconds: number | undefined;
   delayBeforeAttemptingToCompleteMessageInSeconds: number;
-  willCompleteFail: boolean;
 }
 
 async function testAutoLockRenewalConfigBehavior(
@@ -577,7 +560,7 @@ async function testAutoLockRenewalConfigBehavior(
 
   await senderClient.getSender().send(testMessage);
 
-  let sessionClient = await receiverClient.getSessionReceiver({
+  const sessionClient = await receiverClient.getSessionReceiver({
     sessionId: testSessionId,
     maxSessionAutoRenewLockDurationInSeconds: options.maxSessionAutoRenewLockDurationInSeconds
   });
@@ -590,20 +573,14 @@ async function testAutoLockRenewalConfigBehavior(
         should.equal(brokeredMessage.messageId, testMessage.messageId);
 
         // Sleeping...
-        await delay(
-          options.delayBeforeAttemptingToCompleteMessageInSeconds * 1000 +
-            lockDurationInMilliseconds +
-            1000
-        );
+        await delay(options.delayBeforeAttemptingToCompleteMessageInSeconds * 1000);
 
         let errorWasThrown: boolean = false;
         await brokeredMessage.complete().catch((err) => {
-          should.equal(err.name, "Error");
-          should.equal(!(err.message.search("Cannot find the receiver with name") + 1), false);
-          errorWasThrown = true;
+          errorWasThrown = true; // Service bus completes the message even when the session lock expires.
         });
 
-        should.equal(errorWasThrown, options.willCompleteFail, "Error Thrown flag value mismatch");
+        should.equal(errorWasThrown, false, "Error Thrown flag value mismatch");
       }
     },
     onError,
@@ -611,7 +588,7 @@ async function testAutoLockRenewalConfigBehavior(
       autoComplete: false
     }
   );
-  await delay(options.delayBeforeAttemptingToCompleteMessageInSeconds * 1000 + 10000);
+  await delay(options.delayBeforeAttemptingToCompleteMessageInSeconds * 1000 + 4000);
   await sessionClient.close();
 
   if (uncaughtErrorFromHandlers) {
@@ -619,13 +596,6 @@ async function testAutoLockRenewalConfigBehavior(
   }
 
   should.equal(numOfMessagesReceived, 1, "Mismatch in number of messages received");
-
-  if (options.willCompleteFail) {
-    // Clean up any left over messages
-    sessionClient = await receiverClient.getSessionReceiver({ sessionId: testSessionId });
-    const unprocessedMsgs = await sessionClient.receiveBatch(1);
-    await unprocessedMsgs[0].complete();
-  }
 }
 
 // Helper functions

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -20,31 +20,6 @@ import {
 import { delay } from "rhea-promise";
 import { testSessionId1, purge } from "./testUtils";
 
-// describe("Premium", function(): void {
-//   const PREMIUM_SERVICEBUS_CONNECTION_STRING = check(
-//     process.env.PREMIUM_SERVICEBUS_CONNECTION_STRING,
-//     "PREMIUM_SERVICEBUS_CONNECTION_STRING"
-//   );
-//   const namespace = Namespace.createFromConnectionString(PREMIUM_SERVICEBUS_CONNECTION_STRING);
-
-//   const PREMIUM_QUEUE = check(process.env.PREMIUM_QUEUE, "PREMIUM_QUEUE");
-//   describe("Unpartitioned Queues", function(): void {
-//     const senderClient = namespace.createQueueClient(PREMIUM_QUEUE);
-//     const sessionClient = senderClient;
-
-//     // Copy paste tests applicable for Unpartitioned Queues in Premium pricing here from the Standard section
-//   });
-
-//   const PREMIUM_TOPIC = check(process.env.PREMIUM_TOPIC, "PREMIUM_TOPIC");
-//   const PREMIUM_SUBSCRIPTION = check(process.env.PREMIUM_SUBSCRIPTION, "PREMIUM_SUBSCRIPTION");
-//   describe("Unpartitioned Topic/Subscription", function(): void {
-//     const senderClient = namespace.createTopicClient(PREMIUM_TOPIC);
-//     const sessionClient = namespace.createSubscriptionClient(PREMIUM_TOPIC, PREMIUM_SUBSCRIPTION);
-
-//     // Copy paste tests applicable for Unpartitioned Topic/Subscription Premium pricing here from the Standard section
-//   });
-// });
-
 describe("Standard", function(): void {
   const SERVICEBUS_CONNECTION_STRING = check(
     process.env.SERVICEBUS_CONNECTION_STRING,
@@ -93,33 +68,6 @@ describe("Standard", function(): void {
         });
         // Service bus completes the message even when the session lock expires.
       });
-
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55
-        });
-      }).timeout(80000);
-
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31
-        });
-      });
     });
   });
 
@@ -162,34 +110,7 @@ describe("Standard", function(): void {
           maxSessionAutoRenewLockDurationInSeconds: 0,
           delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
-        // Complete fails as expected
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55
-        });
-      }).timeout(80000);
-
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31
-        });
+        // Service bus completes the message even when the session lock expires.
       });
     });
   });
@@ -239,34 +160,7 @@ describe("Standard", function(): void {
           maxSessionAutoRenewLockDurationInSeconds: 0,
           delayBeforeAttemptingToCompleteMessageInSeconds: 31
         });
-        // Complete fails as expected
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55
-        });
-      }).timeout(80000);
-
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31
-        });
+        // Service bus completes the message even when the session lock expires.
       });
     });
   });
@@ -347,30 +241,6 @@ describe("Standard", function(): void {
     });
   });
 });
-
-// describe("Basic", function(): void {
-//   const BASIC_SERVICEBUS_CONNECTION_STRING = check(
-//     process.env.BASIC_SERVICEBUS_CONNECTION_STRING,
-//     "BASIC_SERVICEBUS_CONNECTION_STRING"
-//   );
-//   const namespace = Namespace.createFromConnectionString(BASIC_SERVICEBUS_CONNECTION_STRING);
-
-//   const BASIC_QUEUE = check(process.env.BASIC_QUEUE, "BASIC_QUEUE");
-//   describe("Unpartitioned Queues", function(): void {
-//     const senderClient = namespace.createQueueClient(BASIC_QUEUE);
-//     const sessionClient = senderClient;
-
-//     // Copy paste tests applicable for Unpartitioned Queues in Basic pricing here from the Standard section
-//   });
-
-//   const BASIC_QUEUE_PARTITION = check(process.env.BASIC_QUEUE_PARTITION, "BASIC_QUEUE_PARTITION");
-//   describe("Partitioned Queues", function(): void {
-//     const senderClient = namespace.createQueueClient(BASIC_QUEUE_PARTITION);
-//     const sessionClient = senderClient;
-
-//     // Copy paste tests applicable for Partitioned Queues in Premium pricing here from the Standard section
-//   });
-// });
 
 const lockDurationInMilliseconds = 30000;
 // const maxSessionAutoRenewLockDurationInSeconds = 300;


### PR DESCRIPTION
**Current observation:**
If we provide enough time inside delay here https://github.com/Azure/azure-sdk-for-js/blob/master/packages/%40azure/servicebus/data-plane/test/renewLockSessions.spec.ts#L614.
It should give an error but Instead of giving an error it is completing the message and removing it from the queue.