### PR TITLE
Documentation updates to fix api extractor bugs and to add more clarity

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
@@ -92,12 +92,22 @@ export interface ReceiveOptions extends MessageHandlerOptions {
 /**
  * Describes the message handler signature.
  */
-export type OnMessage = (message: ServiceBusMessage) => Promise<void>;
+export interface OnMessage {
+  /**
+   * Handler for processing each incoming message.
+   */
+  (message: ServiceBusMessage): Promise<void>;
+}
 
 /**
  * Describes the error handler signature.
  */
-export type OnError = (error: MessagingError | Error) => void;
+export interface OnError {
+  /**
+   * Handler for any error that occurs while receiving or processing messages.
+   */
+  (error: MessagingError | Error): void;
+}
 
 /**
  * Describes the MessageReceiver that will receive messages from ServiceBus.

--- a/packages/@azure/servicebus/data-plane/lib/index.ts
+++ b/packages/@azure/servicebus/data-plane/lib/index.ts
@@ -1,16 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export { Namespace, NamespaceOptions } from "./namespace";
+export { Namespace, NamespaceOptions, NamespaceOptionsBase } from "./namespace";
 export {
-  ConnectionConfig,
   TokenInfo,
   TokenType,
   TokenProvider,
   DataTransformer,
-  DefaultDataTransformer,
   delay,
-  Timeout,
   MessagingError
 } from "@azure/amqp-common";
 
@@ -23,7 +20,7 @@ export { Receiver, MessageReceiverOptions, SessionReceiver } from "./receiver";
 
 export { MessageHandlerOptions } from "./core/streamingReceiver";
 export { OnError, OnMessage } from "./core/messageReceiver";
-export { SessionReceiverOptions } from "./session/messageSession";
+export { SessionReceiverOptions, SessionMessageHandlerOptions } from "./session/messageSession";
 
 export { SQLExpression, CorrelationFilter, RuleDescription } from "./core/managementClient";
 
@@ -34,4 +31,4 @@ export {
   DeadLetterOptions,
   ReceiveMode
 } from "./serviceBusMessage";
-export { AmqpError, Delivery, Dictionary, generate_uuid as generateUuid } from "rhea-promise";
+export { AmqpError, Delivery, Dictionary } from "rhea-promise";

--- a/packages/@azure/servicebus/data-plane/lib/namespace.ts
+++ b/packages/@azure/servicebus/data-plane/lib/namespace.ts
@@ -68,7 +68,7 @@ export class Namespace {
    * @param {TokenProvider} [tokenProvider] - The token provider that provides the token for
    * authentication. Default value: `SasTokenProvider`.
    */
-  constructor(config: ConnectionConfig, options?: NamespaceOptions) {
+  private constructor(config: ConnectionConfig, options?: NamespaceOptions) {
     if (!options) options = {};
     this.name = config.endpoint;
     this._context = ConnectionContext.create(config, options);
@@ -244,10 +244,19 @@ export class Namespace {
     return Namespace.createFromTokenProvider(host, tokenProvider, options);
   }
 
+  /**
+   * Returns the corresponding dead letter queue name for the given queue name.
+   * @param queueName
+   */
   static getDeadLetterQueuePathForQueue(queueName: string): string {
     return `${queueName}/$DeadLetterQueue`;
   }
 
+  /**
+   * Returns the corresponding dead letter subscription name for the given topic and subscription names.
+   * @param topicName
+   * @param subscriptionName
+   */
   static getDeadLetterSubcriptionPathForSubcription(
     topicName: string,
     subscriptionName: string

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -10,13 +10,18 @@ import { MessageSession, SessionReceiverOptions } from "./session/messageSession
 import { Sender } from "./sender";
 import { Receiver, MessageReceiverOptions, SessionReceiver } from "./receiver";
 
+/**
+ * Describes the client that will maintain an AMQP connection to a ServiceBus Queue.
+ * @class QueueClient
+ */
 export class QueueClient extends Client {
   /**
-   * Instantiates a client that will maintain an AMQP connection to a ServiceBus Queue.
+   * Constructor for QueueClient.
    * This is not meant for the user to call directly.
    * The user should use the `createQueueClient` on the Namespace instead.
    *
    * @constructor
+   * @internal
    * @param name The Queue name.
    * @param context The connection context to create the QueueClient.
    */

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -77,19 +77,21 @@ export class QueueClient extends Client {
   }
 
   /**
-   * Creates a Sender by establishing an AMQP session and an AMQP sender link on the session.
-   * This Sender can be used to send messages, schedule messages to be sent at a later time
-   * and cancel such scheduled messages.
+   * Gets the Sender to be used for sending messages, scheduling messages to be sent at a later time
+   * and cancelling such scheduled messages.
+   *
+   * The Sender uses an underlying AMQP sender link. If no such link is active, then a new one is
+   * created by establishing an AMQP session and an AMQP sender link on the session.
    */
   getSender(): Sender {
     return new Sender(this._context);
   }
 
   /**
-   * Creates a Receiver by establishing an AMQP session and an AMQP receiver link on the session.
-   * This Receiver can be used to receive messages in batches or by registering handlers.
+   * Gets the Receiver to be used for receiving messages in batches or by registering handlers.
    *
-   * You can have multiple receivers for the same Queue.
+   * The Receiver uses an underlying AMQP receiver link. If no such link is active, then a new one
+   * is created by establishing an AMQP session and an AMQP receiver link on the session.
    *
    * @param options Options for creating the receiver.
    */
@@ -150,11 +152,12 @@ export class QueueClient extends Client {
   // }
 
   /**
-   * Creates a SessionReceiver with given sessionId from the ServiceBus Queue.
-   * When no sessionId is given, a random session among the available sessions is used.
-   * This Receiver can be used to receive messages in batches or by registering handlers.
+   * Gets the SessionReceiver for receiving messages in batches or by registering handlers from a
+   * session enabled Queue. When no sessionId is given, a random session among the available
+   * sessions is used.
    *
-   * Note that you cannot have more than 1 session receiver for the same session.
+   * The Receiver uses an underlying AMQP receiver link. If no such link is active, then a new one
+   * is created by establishing an AMQP session and an AMQP receiver link on the session.
    *
    * @param options Options to provide sessionId and ReceiveMode for receiving messages from the
    * session enabled Servicebus Queue.

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -23,6 +23,7 @@ export interface MessageReceiverOptions {
 /**
  * An abstraction over the underlying receiver link.
  * The Receiver class can be used to receive messages in a batch or by registering handlers.
+ * @class Receiver
  */
 export class Receiver {
   /**
@@ -244,6 +245,7 @@ export class Receiver {
 /**
  * An abstraction over the underlying session-receiver.
  * The SessionReceiver class can be used to receive messages in a batch or by registering handlers.
+ * @class SessionReceiver
  */
 export class SessionReceiver {
   /**
@@ -255,10 +257,16 @@ export class SessionReceiver {
   private _sessionId: string | undefined;
   private _messageSession: MessageSession;
 
+  /**
+   * @property {string} [sessionId] The sessionId for the message session.
+   */
   public get sessionId(): string {
     return this._sessionId || "";
   }
 
+  /**
+   * @property {Date} [sessionLockedUntilUtc] The time in UTC until which the session is locked.
+   */
   public get sessionLockedUntilUtc(): Date | undefined {
     return this._messageSession.sessionLockedUntilUtc;
   }

--- a/packages/@azure/servicebus/data-plane/lib/sender.ts
+++ b/packages/@azure/servicebus/data-plane/lib/sender.ts
@@ -8,6 +8,12 @@ import { SendableMessageInfo } from "./serviceBusMessage";
 import { ScheduleMessage } from "./core/managementClient";
 import { ClientEntityContext } from "./clientEntityContext";
 
+/**
+ * An abstraction over the underlying sender link.
+ * This Sender can be used to send messages, schedule messages to be sent at a later time
+ * and cancel such scheduled messages.
+ * @class Sender
+ */
 export class Sender {
   /**
    * @property {ClientEntityContext} _context Describes the amqp connection context for the Client.

--- a/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
+++ b/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
@@ -231,6 +231,9 @@ export interface SendableMessageInfo {
   userProperties?: Dictionary<any>;
 }
 
+/**
+ * Describes the message to be sent to ServiceBus.
+ */
 export module SendableMessageInfo {
   export function validate(msg: SendableMessageInfo): void {
     if (!msg) {

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -91,10 +91,10 @@ export class SubscriptionClient extends Client {
   }
 
   /**
-   * Creates a Receiver by establishing an AMQP session and an AMQP receiver link on the session.
-   * This Receiver can be used to receive messages in batches or by registering handlers.
+   * Gets the Receiver to be used for receiving messages in batches or by registering handlers.
    *
-   * You can have multiple receivers for the same Subscription.
+   * The Receiver uses an underlying AMQP receiver link. If no such link is active, then a new one
+   * is created by establishing an AMQP session and an AMQP receiver link on the session.
    *
    * @param options Options for creating the receiver.
    */
@@ -195,11 +195,12 @@ export class SubscriptionClient extends Client {
   // }
 
   /**
-   * Creates a SessionReceiver with given sessionId in the ServiceBus Subscription.
-   * When no sessionId is given, a random session among the available sessions is used.
-   * This Receiver can be used to receive messages in batches or by registering handlers.
+   * Gets the SessionReceiver for receiving messages in batches or by registering handlers from a
+   * session enabled Subscription. When no sessionId is given, a random session among the available
+   * sessions is used.
    *
-   * Note that you cannot have more than 1 session receiver for the same session.
+   * The Receiver uses an underlying AMQP receiver link. If no such link is active, then a new one
+   * is created by establishing an AMQP session and an AMQP receiver link on the session.
    *
    * @param options Options to provide sessionId and ReceiveMode for receiving messages from the
    * session enabled Servicebus Subscription.

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -9,6 +9,10 @@ import { Client } from "./client";
 import { CorrelationFilter, RuleDescription } from "./core/managementClient";
 import { MessageSession, SessionReceiverOptions } from "./session/messageSession";
 
+/**
+ * Describes the client that will maintain an AMQP connection to a ServiceBus Subscription.
+ * @class SubscriptionClient
+ */
 export class SubscriptionClient extends Client {
   /**
    * @property {string} topicPath The topic path.
@@ -29,7 +33,7 @@ export class SubscriptionClient extends Client {
   readonly defaultRuleName: string = "$Default";
 
   /**
-   * Instantiates a client that will maintain an AMQP connection to a Service Bus Subscription.
+   * Constructor for SubscriptionClient.
    * This is not meant for the user to call directly.
    * The user should use the `createSubscriptionClient` on the Namespace instead.
    *

--- a/packages/@azure/servicebus/data-plane/lib/topicClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/topicClient.ts
@@ -48,9 +48,11 @@ export class TopicClient extends Client {
   }
 
   /**
-   * Creates a Sender by establishing an AMQP session and an AMQP sender link on the session.
-   * This Sender can be used to send messages, schedule messages to be sent at a later time
-   * and cancel such scheduled messages.
+   * Gets the Sender to be used for sending messages, scheduling messages to be sent at a later time
+   * and cancelling such scheduled messages.
+   *
+   * The Sender uses an underlying AMQP sender link. If no such link is active, then a new one is
+   * created by establishing an AMQP session and an AMQP sender link on the session.
    */
   getSender(): Sender {
     return new Sender(this._context);

--- a/packages/@azure/servicebus/data-plane/lib/topicClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/topicClient.ts
@@ -6,9 +6,13 @@ import { ConnectionContext } from "./connectionContext";
 import { Client } from "./client";
 import { Sender } from "./sender";
 
+/**
+ * Describes the client that will maintain an AMQP connection to a ServiceBus Topic.
+ * @class TopicClient
+ */
 export class TopicClient extends Client {
   /**
-   * Instantiates a client that will maintain an AMQP connection to a ServiceBus Topic.
+   * Constructor for TopicClient.
    * This is not meant for the user to call directly.
    * The user should use the `createTopicClient` on the Namespace instead.
    *

--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -80,6 +80,6 @@
     "test": "npm run build",
     "unit": "npm run build-test && mocha -t 65000 test-dist/index.js",
     "prepack": "npm i && npm run build",
-    "extract-api": "api-extractor run --local"
+    "extract-api": "tsc -p . && api-extractor run --local"
   }
 }

--- a/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
@@ -10,7 +10,6 @@ chai.use(chaiAsPromised);
 import {
   Namespace,
   QueueClient,
-  generateUuid,
   TopicClient,
   SubscriptionClient,
   OnMessage,
@@ -402,8 +401,8 @@ let testMessage: any;
 
 async function beforeEachTest(receiverClient: QueueClient | SubscriptionClient): Promise<void> {
   testMessage = {
-    body: `hello-world-1 : ${generateUuid()}`,
-    messageId: generateUuid()
+    body: `hello-world-1 : ${Math.random()}`,
+    messageId: Math.random()
   };
   await purge(receiverClient);
   const peekedMsgs = await receiverClient.peek();

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -10,7 +10,6 @@ chai.use(chaiAsPromised);
 import {
   Namespace,
   QueueClient,
-  generateUuid,
   TopicClient,
   SubscriptionClient,
   ServiceBusMessage,
@@ -254,7 +253,7 @@ let testMessage: any;
 async function beforeEachTest(receiverClient: QueueClient | SubscriptionClient): Promise<void> {
   testMessage = {
     body: "hello1",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     sessionId: testSessionId1
   };
   await purge(receiverClient, testSessionId1);

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -3,7 +3,6 @@
 
 import {
   SendableMessageInfo,
-  generateUuid,
   QueueClient,
   TopicClient,
   Namespace,
@@ -13,23 +12,23 @@ import {
 export const testSimpleMessages: SendableMessageInfo[] = [
   {
     body: "hello1",
-    messageId: `test message ${generateUuid()}`
+    messageId: `test message ${Math.random()}`
   },
   {
     body: "hello2",
-    messageId: `test message ${generateUuid()}`
+    messageId: `test message ${Math.random()}`
   }
 ];
 
 export const testMessagesToSamePartitions: SendableMessageInfo[] = [
   {
     body: "hello1",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     partitionKey: "dummy"
   },
   {
     body: "hello2",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     partitionKey: "dummy"
   }
 ];
@@ -39,37 +38,37 @@ export const testSessionId2 = "my-session2";
 export const testMessagesWithSessions: SendableMessageInfo[] = [
   {
     body: "hello1",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     sessionId: testSessionId1
   },
   {
     body: "hello2",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     sessionId: testSessionId1
   }
 ];
 export const testMessagesWithDifferentSessionIds: SendableMessageInfo[] = [
   {
     body: "hello1",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     sessionId: testSessionId1
   },
   {
     body: "hello2",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     sessionId: testSessionId2
   }
 ];
 export const testMessagesToSamePartitionsWithSessions: SendableMessageInfo[] = [
   {
     body: "hello1",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     partitionKey: "dummy",
     sessionId: testSessionId1
   },
   {
     body: "hello2",
-    messageId: `test message ${generateUuid()}`,
+    messageId: `test message ${Math.random()}`,
     partitionKey: "dummy",
     sessionId: testSessionId1
   }

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -11,7 +11,6 @@ import {
   Namespace,
   SubscriptionClient,
   ServiceBusMessage,
-  generateUuid,
   TopicClient,
   SendableMessageInfo,
   CorrelationFilter
@@ -111,7 +110,7 @@ async function sendOrders(): Promise<void> {
     const element = data[index];
     const message: SendableMessageInfo = {
       body: "",
-      messageId: generateUuid(),
+      messageId: Math.random(),
       correlationId: `${element.Priority}`,
       label: `${element.Color}`,
       userProperties: {


### PR DESCRIPTION
Running the api extractor exposed some bugs which we need to fix before Preview 1.

This PR fixes such bugs and updates the comments for `getSender`, `getReceiver` and `getSessionReceiver` to provide clarity