### PR TITLE
[Service Bus] Fix test fails, remove redundant tests

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -446,4 +446,12 @@ export class SessionReceiver {
       throw err;
     }
   }
+
+  /**
+   * Determines whether the underlying AMQP receiver link is open.
+   * When this is true, a new Session Receiver with the same session id cannot be created successfully.
+   */
+  isOpen(): boolean {
+    return this._messageSession.isOpen();
+  }
 }

--- a/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
@@ -402,7 +402,7 @@ let testMessage: any;
 async function beforeEachTest(receiverClient: QueueClient | SubscriptionClient): Promise<void> {
   testMessage = {
     body: `hello-world-1 : ${Math.random()}`,
-    messageId: Math.random()
+    messageId: `test message ${Math.random()}`
   };
   await purge(receiverClient);
   const peekedMsgs = await receiverClient.peek();

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -210,33 +210,6 @@ describe("Standard", function(): void {
         });
         // Complete fails as expected
       });
-
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 55
-        });
-      }).timeout(80000);
-
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31
-        });
-      });
     });
   });
 });

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -334,7 +334,7 @@ describe("SessionTests - getState and setState in Session enabled Queues/Subscri
     );
 
     let testState = await receiver.getState();
-    should.equal(testState, "");
+    should.equal(!!testState, false);
     await receiver.setState("new_state");
     testState = await receiver.getState();
     should.equal(testState, "new_state");

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -374,7 +374,7 @@ describe("Streaming Receiver - Complete message(with sessions)", function(): voi
   });
 });
 
-describe.only("Streaming Receiver - Abandon message(with sessions)", function(): void {
+describe("Streaming Receiver - Abandon message(with sessions)", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -387,6 +387,7 @@ describe.only("Streaming Receiver - Abandon message(with sessions)", function():
           if (sessionReceiver.isOpen()) {
             return sessionReceiver.close();
           }
+          return Promise.resolve();
         });
       },
       unExpectedErrorHandler,

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -374,7 +374,7 @@ describe("Streaming Receiver - Complete message(with sessions)", function(): voi
   });
 });
 
-describe("Streaming Receiver - Abandon message(with sessions)", function(): void {
+describe.only("Streaming Receiver - Abandon message(with sessions)", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -384,13 +384,19 @@ describe("Streaming Receiver - Abandon message(with sessions)", function(): void
     await sessionReceiver.receive(
       (msg: ServiceBusMessage) => {
         return msg.abandon().then(() => {
-          return sessionReceiver.close();
+          if (sessionReceiver.isOpen()) {
+            return sessionReceiver.close();
+          }
         });
       },
       unExpectedErrorHandler,
       { autoComplete }
     );
     await delay(4000);
+
+    if (sessionReceiver.isOpen()) {
+      await sessionReceiver.close();
+    }
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
     sessionReceiver = await receiverClient.getSessionReceiver({

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -126,6 +126,9 @@ async function sendOrders(): Promise<void> {
 async function receiveOrders(client: SubscriptionClient): Promise<ServiceBusMessage[]> {
   const receiver = client.getReceiver();
   const msgs = await receiver.receiveBatch(data.length);
+  for (let index = 0; index < msgs.length; index++) {
+    await msgs[index].complete();
+  }
   await receiver.close();
   return msgs;
 }


### PR DESCRIPTION
This PR fixes few of the test failures

- renewLock.spec.ts
   - As part of #1092, we removed the export of the `generateUuid` from the library. In our test cases, `generateUuid` was replaced with `Math.random()`. This exposed a bug where message ids with numbers were losing their precision. This bug is being tracked in #1098.
- renewLockSessions.spec.ts
     - Removal of redundant tests cases in one of the sections in `renewLockSessions.spec.ts` which we missed to do as part of #1070
- sessionsTests.spec.ts
     - The initial state of a session will be null not empty string which is what the test was checking.
- streamingReceiverSessions.spec.ts
     - We expect the onMessage handler to close the session receiver. This does not always happen in time, before creating a new session receiver for the same session id, resulting in a SessionLockLost error
- topicFilters.spec.ts
     - The tests do not complete the messages before peeking and expecting the subscription to be empty