### PR TITLE
[Service Bus] Avoid creating multiple receivers

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -15,6 +15,7 @@ import { Receiver, MessageReceiverOptions, SessionReceiver } from "./receiver";
  * @class QueueClient
  */
 export class QueueClient extends Client {
+  private _currentReceiver: Receiver | undefined;
   /**
    * Constructor for QueueClient.
    * This is not meant for the user to call directly.
@@ -90,13 +91,13 @@ export class QueueClient extends Client {
   /**
    * Gets the Receiver to be used for receiving messages in batches or by registering handlers.
    *
-   * The Receiver uses an underlying AMQP receiver link. If no such link is active, then a new one
-   * is created by establishing an AMQP session and an AMQP receiver link on the session.
-   *
    * @param options Options for creating the receiver.
    */
   getReceiver(options?: MessageReceiverOptions): Receiver {
-    return new Receiver(this._context, options);
+    if (!this._currentReceiver) {
+      this._currentReceiver = new Receiver(this._context, options);
+    }
+    return this._currentReceiver;
   }
 
   /**
@@ -156,9 +157,6 @@ export class QueueClient extends Client {
    * session enabled Queue. When no sessionId is given, a random session among the available
    * sessions is used.
    *
-   * The Receiver uses an underlying AMQP receiver link. If no such link is active, then a new one
-   * is created by establishing an AMQP session and an AMQP receiver link on the session.
-   *
    * @param options Options to provide sessionId and ReceiveMode for receiving messages from the
    * session enabled Servicebus Queue.
    *
@@ -166,6 +164,17 @@ export class QueueClient extends Client {
    */
   async getSessionReceiver(options?: SessionReceiverOptions): Promise<SessionReceiver> {
     if (!options) options = {};
+    if (
+      options.sessionId &&
+      this._context.messageSessions[options.sessionId] &&
+      this._context.messageSessions[options.sessionId].isOpen()
+    ) {
+      throw new Error(
+        `Close the current session receiver for sessionId ${
+          options.sessionId
+        } before using "getSessionReceiver" to create a new one for the same sessionId`
+      );
+    }
     this._context.isSessionEnabled = true;
     const messageSession = await MessageSession.create(this._context, options);
     return new SessionReceiver(this._context, messageSession);

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -16,6 +16,8 @@ import { Receiver, MessageReceiverOptions, SessionReceiver } from "./receiver";
  */
 export class QueueClient extends Client {
   private _currentReceiver: Receiver | undefined;
+  private _currentSender: Sender | undefined;
+
   /**
    * Constructor for QueueClient.
    * This is not meant for the user to call directly.
@@ -80,12 +82,12 @@ export class QueueClient extends Client {
   /**
    * Gets the Sender to be used for sending messages, scheduling messages to be sent at a later time
    * and cancelling such scheduled messages.
-   *
-   * The Sender uses an underlying AMQP sender link. If no such link is active, then a new one is
-   * created by establishing an AMQP session and an AMQP sender link on the session.
    */
   getSender(): Sender {
-    return new Sender(this._context);
+    if (!this._currentSender) {
+      this._currentSender = new Sender(this._context);
+    }
+    return this._currentSender;
   }
 
   /**

--- a/packages/@azure/servicebus/data-plane/lib/topicClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/topicClient.ts
@@ -11,6 +11,8 @@ import { Sender } from "./sender";
  * @class TopicClient
  */
 export class TopicClient extends Client {
+  private _currentSender: Sender | undefined;
+
   /**
    * Constructor for TopicClient.
    * This is not meant for the user to call directly.
@@ -50,11 +52,11 @@ export class TopicClient extends Client {
   /**
    * Gets the Sender to be used for sending messages, scheduling messages to be sent at a later time
    * and cancelling such scheduled messages.
-   *
-   * The Sender uses an underlying AMQP sender link. If no such link is active, then a new one is
-   * created by establishing an AMQP session and an AMQP sender link on the session.
    */
   getSender(): Sender {
-    return new Sender(this._context);
+    if (!this._currentSender) {
+      this._currentSender = new Sender(this._context);
+    }
+    return this._currentSender;
   }
 }

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -404,7 +404,7 @@ describe("SessionTests - getState and setState in Session enabled Queues/Subscri
   });
 });
 
-describe.only("SessionTests - Second Session Receiver for same session id", function(): void {
+describe("SessionTests - Second Session Receiver for same session id", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -414,7 +414,7 @@ describe.only("SessionTests - Second Session Receiver for same session id", func
     await sender.send(testMessagesWithSessions[0]);
 
     const firstReceiver = await receiverClient.getSessionReceiver();
-    should.equal(firstReceiver.sessionId, testMessagesWithSessions[0]);
+    should.equal(firstReceiver.sessionId, testMessagesWithSessions[0].sessionId);
 
     let errorWasThrown = false;
     try {

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -403,3 +403,77 @@ describe("SessionTests - getState and setState in Session enabled Queues/Subscri
     await testGetSetState();
   });
 });
+
+describe.only("SessionTests - Second Session Receiver for same session id", function(): void {
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  async function testSecondSessionReceiverForSameSession(): Promise<void> {
+    const sender = senderClient.getSender();
+    await sender.send(testMessagesWithSessions[0]);
+
+    const firstReceiver = await receiverClient.getSessionReceiver();
+    should.equal(firstReceiver.sessionId, testMessagesWithSessions[0]);
+
+    let errorWasThrown = false;
+    try {
+      const secondReceiver = await receiverClient.getSessionReceiver({
+        sessionId: testMessagesWithSessions[0].sessionId
+      });
+      if (secondReceiver) {
+        chai.assert.fail("Second receiver for same session id should not have been created");
+      }
+    } catch (error) {
+      errorWasThrown =
+        error &&
+        error.message ===
+          `Close the current session receiver for sessionId ${
+            testMessagesWithSessions[0].sessionId
+          } before using "getSessionReceiver" to create a new one for the same sessionId`;
+    }
+
+    should.equal(errorWasThrown, true);
+  }
+
+  it("Partitioned Queue - Second Session Receiver for same session id throws error", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.PartitionedQueueWithSessions,
+      ClientType.PartitionedQueueWithSessions
+    );
+
+    await testSecondSessionReceiverForSameSession();
+  });
+  it("Partitioned Subscription - Second Session Receiver for same session id throws error", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.PartitionedTopicWithSessions,
+      ClientType.PartitionedSubscriptionWithSessions
+    );
+
+    await testSecondSessionReceiverForSameSession();
+  });
+  it("Unpartitioned Queue - Second Session Receiver for same session id throws error", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions
+    );
+
+    await testSecondSessionReceiverForSameSession();
+  });
+  it("Unpartitioned Subscription - Second Session Receiver for same session id throws error", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions
+    );
+
+    await testSecondSessionReceiverForSameSession();
+  });
+});


### PR DESCRIPTION
As part of the redesign in #1002, we introduced an abstraction layer for Sender and Receiver in the Queue/Topic/Subscription clients. These senders and receivers are to be used by the user after calling `getSender` & `getReceiver` on the client.

Under the hood, `getSender` & `getReceiver` create new instances of Sender and Receiver each time they are called, which is unnecessary.

Once a sender/receiver link is created, they were designed to be re-used. Previously, I relied on the doc comments on the `getSender` & `getReceiver` to communicate this fact. But the changes in this PR avoids the user knowing about any of the inner workings

This PR includes:
- Updates to `getSender` and `getReceiver` to create 1 Sender and Receiver per client and re-use them in subsequent calls
- Updates to `getSessionReceiver` to throw an error when user calls it for a session id for which a receiver already exists

