### PR TITLE
[Service Bus] Avoid unnecessary peek checks

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -119,7 +119,6 @@ describe("Streaming Receiver - Misc Tests", function(): void {
 
   async function testAutoComplete(): Promise<void> {
     await sender.sendBatch(testSimpleMessages);
-    await testPeekMsgsLength(receiverClient, testSimpleMessages.length);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     receiver.receive((msg: ServiceBusMessage) => {
@@ -142,7 +141,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
     await receiver.close();
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
-
+    should.equal(receivedMsgs.length, 2);
     await testPeekMsgsLength(receiverClient, 0);
   }
 
@@ -515,7 +514,7 @@ describe("Streaming Receiver - Deadletter message", function(): void {
 
   async function testDeadletter(autoComplete: boolean): Promise<void> {
     await sender.sendBatch(testSimpleMessages);
-    await testPeekMsgsLength(receiverClient, 2);
+
     receiver.receive(
       (msg: ServiceBusMessage) => {
         return msg.deadLetter();

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -117,7 +117,6 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
 
   async function testAutoComplete(): Promise<void> {
     await sender.sendBatch(testMessagesWithSessions);
-    await testPeekMsgsLength(receiverClient, testMessagesWithSessions.length);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     sessionReceiver.receive((msg: ServiceBusMessage) => {
@@ -137,7 +136,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
       }
     }
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
-
+    should.equal(receivedMsgs.length, testMessagesWithSessions.length);
     await testPeekMsgsLength(receiverClient, 0);
   }
 

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -627,7 +627,7 @@ describe("Streaming Receiver - Deadletter message(with sessions)", function(): v
 
   async function testDeadletter(autoComplete: boolean): Promise<void> {
     await sender.sendBatch(testMessagesWithSessions);
-    await testPeekMsgsLength(receiverClient, 2);
+
     await sessionReceiver.receive(
       (msg: ServiceBusMessage) => {
         return msg.deadLetter();


### PR DESCRIPTION
A lot of test failures are around the peek test right after sending messages. See https://github.com/Azure/azure-sdk-for-js/issues/1048.

This PR skips that check as we have follow up checks in the same test, that will test the length of messages received