### PR TITLE
[Service Bus] Recreate clients before each renew lock related tests

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
@@ -56,11 +56,13 @@ describe("Standard", function(): void {
 
   const STANDARD_QUEUE = process.env.QUEUE_NAME_NO_PARTITION || "unpartitioned-queue";
   describe("Unpartitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE);
+        receiverClient = senderClient;
         await beforeEachTest(receiverClient);
       });
 
@@ -131,11 +133,14 @@ describe("Standard", function(): void {
 
   const STANDARD_QUEUE_PARTITION = process.env.QUEUE_NAME || "partitioned-queue";
   describe("Partitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION);
+        receiverClient = senderClient;
+
         await beforeEachTest(receiverClient);
       });
 
@@ -208,14 +213,13 @@ describe("Standard", function(): void {
   const STANDARD_SUBSCRIPTION =
     process.env.SUBSCRIPTION_NAME_NO_PARTITION || "unpartitioned-topic-subscription";
   describe("Unpartitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC,
-      STANDARD_SUBSCRIPTION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC);
+        receiverClient = namespace.createSubscriptionClient(STANDARD_TOPIC, STANDARD_SUBSCRIPTION);
         await beforeEachTest(receiverClient);
       });
 
@@ -288,14 +292,16 @@ describe("Standard", function(): void {
   const STANDARD_SUBSCRIPTION_PARTITION =
     process.env.SUBSCRIPTION_NAME || "partitioned-topic-subscription";
   describe("Partitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC_PARTITION,
-      STANDARD_SUBSCRIPTION_PARTITION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION);
+        receiverClient = namespace.createSubscriptionClient(
+          STANDARD_TOPIC_PARTITION,
+          STANDARD_SUBSCRIPTION_PARTITION
+        );
         await beforeEachTest(receiverClient);
       });
 

--- a/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
@@ -54,6 +54,10 @@ describe("Standard", function(): void {
   );
   const namespace = Namespace.createFromConnectionString(SERVICEBUS_CONNECTION_STRING);
 
+  after(async () => {
+    await namespace.close();
+  });
+
   const STANDARD_QUEUE = process.env.QUEUE_NAME_NO_PARTITION || "unpartitioned-queue";
   describe("Unpartitioned Queue", function(): void {
     let senderClient: QueueClient;
@@ -67,7 +71,8 @@ describe("Standard", function(): void {
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -145,7 +150,8 @@ describe("Standard", function(): void {
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -224,7 +230,8 @@ describe("Standard", function(): void {
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -306,7 +313,8 @@ describe("Standard", function(): void {
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -29,10 +29,13 @@ describe("Standard", function(): void {
   const STANDARD_QUEUE_SESSION =
     process.env.QUEUE_NAME_NO_PARTITION_SESSION || "unpartitioned-queue-sessions";
   describe("Unpartitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE_SESSION);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
+
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE_SESSION);
+        receiverClient = senderClient;
         await beforeEachTest(receiverClient);
       });
 
@@ -73,11 +76,13 @@ describe("Standard", function(): void {
   const STANDARD_QUEUE_PARTITION_SESSION =
     process.env.QUEUE_NAME_SESSION || "partitioned-queue-sessions";
   describe("Partitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION_SESSION);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
 
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION_SESSION);
+        receiverClient = senderClient;
         await beforeEachTest(receiverClient);
       });
 
@@ -121,14 +126,16 @@ describe("Standard", function(): void {
     process.env.SUBSCRIPTION_NAME_NO_PARTITION_SESSION ||
     "unpartitioned-topic-sessions-subscription";
   describe("Unpartitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC_SESSION);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC_SESSION,
-      STANDARD_SUBSCRIPTION_SESSION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC_SESSION);
+        receiverClient = namespace.createSubscriptionClient(
+          STANDARD_TOPIC_SESSION,
+          STANDARD_SUBSCRIPTION_SESSION
+        );
         await beforeEachTest(receiverClient);
       });
 
@@ -171,14 +178,16 @@ describe("Standard", function(): void {
   const STANDARD_SUBSCRIPTION_PARTITION_SESSION =
     process.env.SUBSCRIPTION_NAME_SESSION || "partitioned-topic-sessions-subscription";
   describe("Partitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION_SESSION);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC_PARTITION_SESSION,
-      STANDARD_SUBSCRIPTION_PARTITION_SESSION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION_SESSION);
+        receiverClient = namespace.createSubscriptionClient(
+          STANDARD_TOPIC_PARTITION_SESSION,
+          STANDARD_SUBSCRIPTION_PARTITION_SESSION
+        );
         await beforeEachTest(receiverClient);
       });
 

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -39,8 +39,13 @@ describe("Standard", function(): void {
         await beforeEachTest(receiverClient);
       });
 
-      afterEach(async () => {
+      after(async () => {
         await namespace.close();
+      });
+
+      afterEach(async () => {
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -86,8 +91,13 @@ describe("Standard", function(): void {
         await beforeEachTest(receiverClient);
       });
 
-      afterEach(async () => {
+      after(async () => {
         await namespace.close();
+      });
+
+      afterEach(async () => {
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -139,8 +149,13 @@ describe("Standard", function(): void {
         await beforeEachTest(receiverClient);
       });
 
-      afterEach(async () => {
+      after(async () => {
         await namespace.close();
+      });
+
+      afterEach(async () => {
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -191,8 +206,13 @@ describe("Standard", function(): void {
         await beforeEachTest(receiverClient);
       });
 
-      afterEach(async () => {
+      after(async () => {
         await namespace.close();
+      });
+
+      afterEach(async () => {
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -26,6 +26,10 @@ describe("Standard", function(): void {
   );
   const namespace = Namespace.createFromConnectionString(SERVICEBUS_CONNECTION_STRING);
 
+  after(async () => {
+    await namespace.close();
+  });
+
   const STANDARD_QUEUE_SESSION =
     process.env.QUEUE_NAME_NO_PARTITION_SESSION || "unpartitioned-queue-sessions";
   describe("Unpartitioned Queue", function(): void {
@@ -37,10 +41,6 @@ describe("Standard", function(): void {
         senderClient = namespace.createQueueClient(STANDARD_QUEUE_SESSION);
         receiverClient = senderClient;
         await beforeEachTest(receiverClient);
-      });
-
-      after(async () => {
-        await namespace.close();
       });
 
       afterEach(async () => {
@@ -89,10 +89,6 @@ describe("Standard", function(): void {
         senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION_SESSION);
         receiverClient = senderClient;
         await beforeEachTest(receiverClient);
-      });
-
-      after(async () => {
-        await namespace.close();
       });
 
       afterEach(async () => {
@@ -149,10 +145,6 @@ describe("Standard", function(): void {
         await beforeEachTest(receiverClient);
       });
 
-      after(async () => {
-        await namespace.close();
-      });
-
       afterEach(async () => {
         await senderClient.close();
         await receiverClient.close();
@@ -204,10 +196,6 @@ describe("Standard", function(): void {
           STANDARD_SUBSCRIPTION_PARTITION_SESSION
         );
         await beforeEachTest(receiverClient);
-      });
-
-      after(async () => {
-        await namespace.close();
       });
 
       afterEach(async () => {


### PR DESCRIPTION
We are consistently seeing the OperationTimeoutError in the tests for renewLocks.
For example:

```

  1) Standard
       Partitioned Queue
         Tests - Lock Renewal - Peeklock Mode
           "before each" hook for "renewLock() with Batch Receiver resets lock duration each time.":
     OperationTimeoutError: Unable to create the amqp session due to operation timeout.
      at Timeout.actionAfterTimeout (node_modules\rhea-promise\dist\lib\connection.js:277:31)

  2) Standard
       Partitioned Topic/Subscription
         Tests - Lock Renewal - Peeklock Mode
           "before each" hook for "renewLock() with Batch Receiver resets lock duration each time.":
     OperationTimeoutError: Unable to create the amqp sender 3d5fe6cc-18d7-d940-88f0-8284840a2e85 due to operation timeout.
      at Timeout.actionAfterTimeout (node_modules\rhea-promise\dist\lib\session.js:290:31)

  3) Standard
       Unpartitioned Queue
         Tests - Lock Renewal - Peeklock Mode
           "before each" hook for "Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled":
     OperationTimeoutError: Unable to create the amqp sender 09a36e4a-4d4e-2f49-ae8c-2ddaf1e80f30 due to operation timeout.
      at Timeout.actionAfterTimeout (node_modules\rhea-promise\dist\lib\session.js:290:31)

  4) Standard
       Unpartitioned Topic/Subscription
         Tests - Lock Renewal - Peeklock Mode
           "before each" hook for "Receives a message using Streaming Receiver renewLock() resets lock duration each time.":
     OperationTimeoutError: Unable to create the amqp session due to operation timeout.
      at Timeout.actionAfterTimeout (node_modules\rhea-promise\dist\lib\connection.js:277:31)
```

My theory is that this is due to the fact that the sender/receiver clients dont get re-created between each tests where as the namespace gets closed between each test which means that the underlying connection will be closed. 