### PR TITLE
Updates to SessionLockLost error handling for batching receiver

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
+++ b/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
@@ -57,8 +57,7 @@ export interface ClientEntityContextBase {
    */
   messageSessions: Dictionary<MessageSession>;
   /**
-   * @property {Dictionary<MessageSession>} messageSessions A dictionary of the MessageSession
-   * objects associated with this client.
+   * @property {Dictionary<MessageSession>} expiredMessageSessions A dictionary that stores expired message sessions IDs.
    */
   expiredMessageSessions: Dictionary<Boolean>;
   /**
@@ -127,8 +126,7 @@ export namespace ClientEntityContext {
     );
 
     (entityContext as ClientEntityContext).getReceiver = (name: string, sessionId?: string) => {
-      if (sessionId != undefined && entityContext.expiredMessageSessions[sessionId] === true) {
-        // TODO: Use an error constructor utility which could also serve as interface documentation for all types of errors thrown
+      if (sessionId && entityContext.expiredMessageSessions[sessionId]) {
         const error = new Error();
         error.name = "SessionLockLostError";
         error.message = `Session Lock is lost for: ${sessionId}. Open a new Session using getSessionReceiver()`;

--- a/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
+++ b/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
@@ -81,7 +81,7 @@ export interface ClientEntityContextBase {
  */
 export interface ClientEntityContext extends ClientEntityContextBase {
   detached(error?: AmqpError | Error): Promise<void>;
-  getReceiver(name: string, sessionId?: string): MessageReceiver | MessageSession | undefined;
+  getReceiver(name: string, sessionId?: string): MessageReceiver | MessageSession;
 }
 
 /**

--- a/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
+++ b/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
@@ -127,9 +127,10 @@ export namespace ClientEntityContext {
 
     (entityContext as ClientEntityContext).getReceiver = (name: string, sessionId?: string) => {
       if (sessionId && entityContext.expiredMessageSessions[sessionId]) {
-        const error = new Error();
+        const error = new Error(
+          `Session Lock is lost for: ${sessionId}. Open a new Session using getSessionReceiver()`
+        );
         error.name = "SessionLockLostError";
-        error.message = `Session Lock is lost for: ${sessionId}. Open a new Session using getSessionReceiver()`;
         throw error;
       }
 
@@ -144,6 +145,8 @@ export namespace ClientEntityContext {
         receiver = entityContext.streamingReceiver;
       } else if (entityContext.batchingReceiver && entityContext.batchingReceiver.name === name) {
         receiver = entityContext.batchingReceiver;
+      } else {
+        throw new Error(`Cannot find the receiver with name '${name}'.`);
       }
       return receiver;
     };

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -177,6 +177,7 @@ export class QueueClient extends Client {
         } before using "getSessionReceiver" to create a new one for the same sessionId`
       );
     }
+    this._context.expiredMessageSessions = {};
     this._context.isSessionEnabled = true;
     const messageSession = await MessageSession.create(this._context, options);
     return new SessionReceiver(this._context, messageSession);

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -166,18 +166,19 @@ export class QueueClient extends Client {
    */
   async getSessionReceiver(options?: SessionReceiverOptions): Promise<SessionReceiver> {
     if (!options) options = {};
-    if (
-      options.sessionId &&
-      this._context.messageSessions[options.sessionId] &&
-      this._context.messageSessions[options.sessionId].isOpen()
-    ) {
-      throw new Error(
-        `Close the current session receiver for sessionId ${
-          options.sessionId
-        } before using "getSessionReceiver" to create a new one for the same sessionId`
-      );
+    if (options.sessionId) {
+      if (
+        this._context.messageSessions[options.sessionId] &&
+        this._context.messageSessions[options.sessionId].isOpen()
+      ) {
+        throw new Error(
+          `Close the current session receiver for sessionId ${
+            options.sessionId
+          } before using "getSessionReceiver" to create a new one for the same sessionId`
+        );
+      }
+      delete this._context.expiredMessageSessions[options.sessionId];
     }
-    this._context.expiredMessageSessions = {};
     this._context.isSessionEnabled = true;
     const messageSession = await MessageSession.create(this._context, options);
     return new SessionReceiver(this._context, messageSession);

--- a/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
+++ b/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
@@ -886,15 +886,14 @@ export class ServiceBusMessage implements ReceivedMessage {
       return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
-    if (receiver) {
-      if (receiver.receiveMode !== ReceiveMode.peekLock) {
-        throw new Error("The operation is only supported in 'PeekLock' receive mode.");
-      }
-      if (this.delivery.remote_settled) {
-        throw new Error("This message has been already settled.");
-      }
-      return receiver.settleMessage(this, DispositionType.complete);
+
+    if (receiver.receiveMode !== ReceiveMode.peekLock) {
+      throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
+    if (this.delivery.remote_settled) {
+      throw new Error("This message has been already settled.");
+    }
+    return receiver.settleMessage(this, DispositionType.complete);
   }
   /**
    * Abandons a message using it's lock token. This will make the message available again in
@@ -922,17 +921,16 @@ export class ServiceBusMessage implements ReceivedMessage {
       return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
-    if (receiver) {
-      if (receiver.receiveMode !== ReceiveMode.peekLock) {
-        throw new Error("The operation is only supported in 'PeekLock' receive mode.");
-      }
-      if (this.delivery.remote_settled) {
-        throw new Error("This message has been already settled.");
-      }
-      return receiver.settleMessage(this, DispositionType.abandon, {
-        propertiesToModify: propertiesToModify
-      });
+
+    if (receiver.receiveMode !== ReceiveMode.peekLock) {
+      throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
+    if (this.delivery.remote_settled) {
+      throw new Error("This message has been already settled.");
+    }
+    return receiver.settleMessage(this, DispositionType.abandon, {
+      propertiesToModify: propertiesToModify
+    });
   }
 
   /**
@@ -962,17 +960,16 @@ export class ServiceBusMessage implements ReceivedMessage {
       return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
-    if (receiver) {
-      if (receiver.receiveMode !== ReceiveMode.peekLock) {
-        throw new Error("The operation is only supported in 'PeekLock' receive mode.");
-      }
-      if (this.delivery.remote_settled) {
-        throw new Error("This message has been already settled.");
-      }
-      return receiver.settleMessage(this, DispositionType.defer, {
-        propertiesToModify: propertiesToModify
-      });
+
+    if (receiver.receiveMode !== ReceiveMode.peekLock) {
+      throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
+    if (this.delivery.remote_settled) {
+      throw new Error("This message has been already settled.");
+    }
+    return receiver.settleMessage(this, DispositionType.defer, {
+      propertiesToModify: propertiesToModify
+    });
   }
 
   /**
@@ -1012,17 +1009,16 @@ export class ServiceBusMessage implements ReceivedMessage {
       return;
     }
     const receiver = this._context.getReceiver(this.delivery.link.name, this.sessionId);
-    if (receiver) {
-      if (receiver.receiveMode !== ReceiveMode.peekLock) {
-        throw new Error("The operation is only supported in 'PeekLock' receive mode.");
-      }
-      if (this.delivery.remote_settled) {
-        throw new Error("This message has been already settled.");
-      }
-      return receiver.settleMessage(this, DispositionType.deadletter, {
-        error: error
-      });
+
+    if (receiver.receiveMode !== ReceiveMode.peekLock) {
+      throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
+    if (this.delivery.remote_settled) {
+      throw new Error("This message has been already settled.");
+    }
+    return receiver.settleMessage(this, DispositionType.deadletter, {
+      error: error
+    });
   }
 
   /**

--- a/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
+++ b/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
@@ -894,8 +894,6 @@ export class ServiceBusMessage implements ReceivedMessage {
         throw new Error("This message has been already settled.");
       }
       return receiver.settleMessage(this, DispositionType.complete);
-    } else {
-      throw new Error(`Cannot find the receiver with name '${this.delivery.link.name}'.`);
     }
   }
   /**
@@ -934,8 +932,6 @@ export class ServiceBusMessage implements ReceivedMessage {
       return receiver.settleMessage(this, DispositionType.abandon, {
         propertiesToModify: propertiesToModify
       });
-    } else {
-      throw new Error(`Cannot find the receiver with name '${this.delivery.link.name}'.`);
     }
   }
 
@@ -976,8 +972,6 @@ export class ServiceBusMessage implements ReceivedMessage {
       return receiver.settleMessage(this, DispositionType.defer, {
         propertiesToModify: propertiesToModify
       });
-    } else {
-      throw new Error(`Cannot find the receiver with name '${this.delivery.link.name}'.`);
     }
   }
 
@@ -1028,8 +1022,6 @@ export class ServiceBusMessage implements ReceivedMessage {
       return receiver.settleMessage(this, DispositionType.deadletter, {
         error: error
       });
-    } else {
-      throw new Error(`Cannot find the receiver with name '${this.delivery.link.name}'.`);
     }
   }
 

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -341,8 +341,12 @@ export class MessageSession extends LinkEntity {
       const connectionId = this._context.namespace.connectionId;
       const receiverError = context.receiver && context.receiver.error;
       const receiver = this._receiver || context.receiver!;
+      let clearExpiredSessionFlag = true;
       if (receiverError) {
         const sbError = translate(receiverError);
+        if (sbError.name === "SessionLockLostError") {
+          clearExpiredSessionFlag = false;
+        }
         log.error(
           "[%s] 'receiver_close' event occurred for receiver '%s' for sessionId '%s'. " +
             "The associated error is: %O",
@@ -381,6 +385,10 @@ export class MessageSession extends LinkEntity {
           this.name,
           this.sessionId
         );
+      }
+
+      if (this.sessionId && clearExpiredSessionFlag) {
+        delete this._context.expiredMessageSessions[this.sessionId];
       }
     };
 

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -594,7 +594,9 @@ export class MessageSession extends LinkEntity {
           }
           return;
         } finally {
-          this._receiver!.addCredit(1);
+          if (this._receiver) {
+            this._receiver!.addCredit(1);
+          }
         }
 
         // If we've made it this far, then user's message handler completed fine. Let us try

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -926,7 +926,6 @@ export class MessageSession extends LinkEntity {
   private _deleteFromCache(): void {
     this._receiver = undefined;
     delete this._context.messageSessions[this.sessionId!];
-    delete this._context.expiredMessageSessions[this.sessionId!];
     log.error(
       "[%s] Deleted the receiver '%s' with sessionId '%s' from the client cache.",
       this._context.namespace.connectionId,

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -624,7 +624,7 @@ export class MessageSession extends LinkEntity {
       // setting the "message" event listener.
       this._receiver.on(ReceiverEvents.message, onSessionMessage);
       // adding credit
-      this._receiver!.setCreditWindow(this.maxConcurrentCallsPerSession);
+      // this._receiver!.setCreditWindow(this.maxConcurrentCallsPerSession);
       this._receiver!.addCredit(this.maxConcurrentCallsPerSession);
     } else {
       this._isReceivingMessages = false;

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -593,10 +593,6 @@ export class MessageSession extends LinkEntity {
             }
           }
           return;
-        } finally {
-          if (this._receiver) {
-            this._receiver!.addCredit(1);
-          }
         }
 
         // If we've made it this far, then user's message handler completed fine. Let us try
@@ -631,6 +627,7 @@ export class MessageSession extends LinkEntity {
       // setting the "message" event listener.
       this._receiver.on(ReceiverEvents.message, onSessionMessage);
       // adding credit
+      this._receiver!.setCreditWindow(this.maxConcurrentCallsPerSession);
       this._receiver!.addCredit(this.maxConcurrentCallsPerSession);
     } else {
       this._isReceivingMessages = false;

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -552,6 +552,7 @@ export class MessageSession extends LinkEntity {
     if (this._receiver && this._receiver.isOpen()) {
       const onSessionMessage = async (context: EventContext) => {
         resetTimerOnNewMessageReceived();
+        this._receiver!.addCredit(1);
         const bMessage: ServiceBusMessage = new ServiceBusMessage(
           this._context,
           context.message!,
@@ -624,7 +625,6 @@ export class MessageSession extends LinkEntity {
       // setting the "message" event listener.
       this._receiver.on(ReceiverEvents.message, onSessionMessage);
       // adding credit
-      // this._receiver!.setCreditWindow(this.maxConcurrentCallsPerSession);
       this._receiver!.addCredit(this.maxConcurrentCallsPerSession);
     } else {
       this._isReceivingMessages = false;

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -595,7 +595,7 @@ export class MessageSession extends LinkEntity {
           return;
         } finally {
           if (this._receiver) {
-            this._receiver!.addCredit(this.maxConcurrentCallsPerSession!);
+            this._receiver!.addCredit(1);
           }
         }
 

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -595,7 +595,7 @@ export class MessageSession extends LinkEntity {
           return;
         } finally {
           if (this._receiver) {
-            this._receiver!.addCredit(1);
+            this._receiver!.addCredit(this.maxConcurrentCallsPerSession!);
           }
         }
 

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -208,18 +208,19 @@ export class SubscriptionClient extends Client {
    */
   async getSessionReceiver(options?: SessionReceiverOptions): Promise<SessionReceiver> {
     if (!options) options = {};
-    if (
-      options.sessionId &&
-      this._context.messageSessions[options.sessionId] &&
-      this._context.messageSessions[options.sessionId].isOpen()
-    ) {
-      throw new Error(
-        `Close the current session receiver for sessionId ${
-          options.sessionId
-        } before using "getSessionReceiver" to create a new one for the same sessionId`
-      );
+    if (options.sessionId) {
+      if (
+        this._context.messageSessions[options.sessionId] &&
+        this._context.messageSessions[options.sessionId].isOpen()
+      ) {
+        throw new Error(
+          `Close the current session receiver for sessionId ${
+            options.sessionId
+          } before using "getSessionReceiver" to create a new one for the same sessionId`
+        );
+      }
+      delete this._context.expiredMessageSessions[options.sessionId];
     }
-    this._context.expiredMessageSessions = {};
     this._context.isSessionEnabled = true;
     const messageSession = await MessageSession.create(this._context, options);
     return new SessionReceiver(this._context, messageSession);

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -219,6 +219,7 @@ export class SubscriptionClient extends Client {
         } before using "getSessionReceiver" to create a new one for the same sessionId`
       );
     }
+    this._context.expiredMessageSessions = {};
     this._context.isSessionEnabled = true;
     const messageSession = await MessageSession.create(this._context, options);
     return new SessionReceiver(this._context, messageSession);

--- a/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
@@ -54,18 +54,25 @@ describe("Standard", function(): void {
   );
   const namespace = Namespace.createFromConnectionString(SERVICEBUS_CONNECTION_STRING);
 
+  after(async () => {
+    await namespace.close();
+  });
+
   const STANDARD_QUEUE = process.env.QUEUE_NAME_NO_PARTITION || "unpartitioned-queue";
   describe("Unpartitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE);
+        receiverClient = senderClient;
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -131,16 +138,20 @@ describe("Standard", function(): void {
 
   const STANDARD_QUEUE_PARTITION = process.env.QUEUE_NAME || "partitioned-queue";
   describe("Partitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION);
+        receiverClient = senderClient;
+
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -208,19 +219,19 @@ describe("Standard", function(): void {
   const STANDARD_SUBSCRIPTION =
     process.env.SUBSCRIPTION_NAME_NO_PARTITION || "unpartitioned-topic-subscription";
   describe("Unpartitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC,
-      STANDARD_SUBSCRIPTION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC);
+        receiverClient = namespace.createSubscriptionClient(STANDARD_TOPIC, STANDARD_SUBSCRIPTION);
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -288,19 +299,22 @@ describe("Standard", function(): void {
   const STANDARD_SUBSCRIPTION_PARTITION =
     process.env.SUBSCRIPTION_NAME || "partitioned-topic-subscription";
   describe("Partitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC_PARTITION,
-      STANDARD_SUBSCRIPTION_PARTITION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal - Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION);
+        receiverClient = namespace.createSubscriptionClient(
+          STANDARD_TOPIC_PARTITION,
+          STANDARD_SUBSCRIPTION_PARTITION
+        );
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -26,18 +26,26 @@ describe("Standard", function(): void {
   );
   const namespace = Namespace.createFromConnectionString(SERVICEBUS_CONNECTION_STRING);
 
+  after(async () => {
+    await namespace.close();
+  });
+
   const STANDARD_QUEUE_SESSION =
     process.env.QUEUE_NAME_NO_PARTITION_SESSION || "unpartitioned-queue-sessions";
   describe("Unpartitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE_SESSION);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
+
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE_SESSION);
+        receiverClient = senderClient;
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -73,16 +81,19 @@ describe("Standard", function(): void {
   const STANDARD_QUEUE_PARTITION_SESSION =
     process.env.QUEUE_NAME_SESSION || "partitioned-queue-sessions";
   describe("Partitioned Queue", function(): void {
-    const senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION_SESSION);
-    const receiverClient = senderClient;
+    let senderClient: QueueClient;
+    let receiverClient: QueueClient;
 
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createQueueClient(STANDARD_QUEUE_PARTITION_SESSION);
+        receiverClient = senderClient;
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -121,19 +132,22 @@ describe("Standard", function(): void {
     process.env.SUBSCRIPTION_NAME_NO_PARTITION_SESSION ||
     "unpartitioned-topic-sessions-subscription";
   describe("Unpartitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC_SESSION);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC_SESSION,
-      STANDARD_SUBSCRIPTION_SESSION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC_SESSION);
+        receiverClient = namespace.createSubscriptionClient(
+          STANDARD_TOPIC_SESSION,
+          STANDARD_SUBSCRIPTION_SESSION
+        );
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
@@ -171,19 +185,22 @@ describe("Standard", function(): void {
   const STANDARD_SUBSCRIPTION_PARTITION_SESSION =
     process.env.SUBSCRIPTION_NAME_SESSION || "partitioned-topic-sessions-subscription";
   describe("Partitioned Topic/Subscription", function(): void {
-    const senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION_SESSION);
-    const receiverClient = namespace.createSubscriptionClient(
-      STANDARD_TOPIC_PARTITION_SESSION,
-      STANDARD_SUBSCRIPTION_PARTITION_SESSION
-    );
+    let senderClient: TopicClient;
+    let receiverClient: SubscriptionClient;
 
     describe("Tests - Lock Renewal for Sessions- Peeklock Mode", function(): void {
       beforeEach(async () => {
+        senderClient = namespace.createTopicClient(STANDARD_TOPIC_PARTITION_SESSION);
+        receiverClient = namespace.createSubscriptionClient(
+          STANDARD_TOPIC_PARTITION_SESSION,
+          STANDARD_SUBSCRIPTION_PARTITION_SESSION
+        );
         await beforeEachTest(receiverClient);
       });
 
       afterEach(async () => {
-        await namespace.close();
+        await senderClient.close();
+        await receiverClient.close();
       });
 
       it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -441,14 +441,10 @@ async function testAutoLockRenewalConfigBehavior(
           errorWasThrown = true;
         });
 
-        should.equal(errorWasThrown, true, "Error Thrown flag value mismatch");
+        should.equal(errorWasThrown, false, "Error Thrown flag value mismatch");
       }
     },
-    (err: MessagingError | Error) => {
-      if (err.name !== "SessionLockLostError") {
-        onError(err);
-      }
-    },
+    onError,
     {
       autoComplete: false
     }

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -54,7 +54,7 @@ describe("Standard", function(): void {
         await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
       });
 
-      it.only(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
+      it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
         void
       > {
         await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -438,7 +438,7 @@ async function testAutoLockRenewalConfigBehavior(
 
         let errorWasThrown: boolean = false;
         await brokeredMessage.complete().catch(() => {
-          errorWasThrown = true;
+          errorWasThrown = true; // Service bus completes the message even when the session lock expires.
         });
 
         should.equal(errorWasThrown, false, "Error Thrown flag value mismatch");


### PR DESCRIPTION
Testing done: All tests pass

This PR contains changes related to batching receiver. 

Changes and research related to streaming receiver are being tracked in #1152 

Refer to https://github.com/Azure/azure-sdk-for-js/issues/1051#issuecomment-460853986, https://github.com/Azure/azure-sdk-for-js/issues/1051#issuecomment-461264529 and https://github.com/Azure/azure-sdk-for-js/issues/1051#issuecomment-461287666 for more context. 

