### PR TITLE
[Service Bus] Increase delay when using streaming receiver

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -188,7 +188,7 @@ describe("Errors when send/receive to/from non existing Namespace", function(): 
 
     client.getReceiver().receive(onMessage, testError);
 
-    await delay(1000);
+    await delay(3000);
     await client.close();
     should.equal(errorWasThrown, true);
   });
@@ -298,7 +298,7 @@ describe("Errors when send/receive to/from non existing Queue/Topic/Subscription
     };
     client.getReceiver().receive(onMessage, (err) => testError(err, "some-name"));
 
-    await delay(1000);
+    await delay(3000);
     await client.close();
     should.equal(errorWasThrown, true);
   });
@@ -316,7 +316,7 @@ describe("Errors when send/receive to/from non existing Queue/Topic/Subscription
         testError(err, "some-topic-name/Subscriptions/some-subscription-name")
       );
 
-    await delay(1000);
+    await delay(3000);
     await client.close();
     should.equal(errorWasThrown, true);
   });


### PR DESCRIPTION

Issue:
https://github.com/Azure/azure-sdk-for-js/issues/1048#issuecomment-460868831
 Increase delay when using streaming receiver to avoid failure.


[ Fixing the failed test ] 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4006&view=ms.vss-test-web.build-test-results-tab