### PR TITLE
[Service Bus] Added a comment - `getSender` in the topic client #1118

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/topicClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/topicClient.ts
@@ -52,7 +52,8 @@ export class TopicClient extends Client {
   /**
    * Gets the Sender to be used for sending messages, scheduling messages to be sent at a later time
    * and cancelling such scheduled messages.
-   * Sending a message without `sessionId` goes to the `deadletter` in case of session-enabled Subscriptions of the Topic.
+   * If the Topic has session enabled Subscriptions, then messages sent without the `sessionId`
+   * property will go to the dead letter queue of such subscriptions.
    */
   getSender(): Sender {
     if (!this._currentSender) {

--- a/packages/@azure/servicebus/data-plane/lib/topicClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/topicClient.ts
@@ -52,6 +52,7 @@ export class TopicClient extends Client {
   /**
    * Gets the Sender to be used for sending messages, scheduling messages to be sent at a later time
    * and cancelling such scheduled messages.
+   * Sending a message without `sessionId` goes to the `deadletter` in case of session-enabled Subscriptions of the Topic.
    */
   getSender(): Sender {
     if (!this._currentSender) {


### PR DESCRIPTION
**Issue** 
#1118 

**Comment**
Sending a message without `sessionId` goes to the `deadletter` in case of session-enabled Subscriptions of the Topic.