### PR TITLE
SessionLockLostError error handling on streaming receiver with sessions enabled

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -587,6 +587,10 @@ export class MessageSession extends LinkEntity {
                 translatedError
               );
               this._notifyError(translatedError);
+            } finally {
+              if (this._receiver) {
+                this._receiver!.addCredit(1);
+              }
             }
           }
           return;
@@ -624,7 +628,6 @@ export class MessageSession extends LinkEntity {
       // setting the "message" event listener.
       this._receiver.on(ReceiverEvents.message, onSessionMessage);
       // adding credit
-      this._receiver!.setCreditWindow(this.maxConcurrentCallsPerSession);
       this._receiver!.addCredit(this.maxConcurrentCallsPerSession);
     } else {
       this._isReceivingMessages = false;

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -454,7 +454,7 @@ async function testAutoLockRenewalConfigBehavior(
       autoComplete: false
     }
   );
-  await delay(options.delayBeforeAttemptingToCompleteMessageInSeconds * 1000 + 10000);
+  await delay(options.delayBeforeAttemptingToCompleteMessageInSeconds * 1000 + 4000);
   await sessionClient.close();
 
   if (uncaughtErrorFromHandlers) {


### PR DESCRIPTION
This PR has changes to surface SessionLockLostError on using streaming receiver with sessions enabled.
Updated the tests as well. 

Theory behind this PR:
* About why addCredit() needs to be invoked in the finally, it looks like the underlying flow()/addCredit() call eventually executes this code https://github.com/amqp/rhea/blob/3ef54378e67bd63be6f057d9b74132ae18d0abac/lib/connection.js#L661 which is blocking until the link has been settled (which occurs when the delay within OnMessage ends) and hence the error event when emitted by service bus does not get received by the link.
  Invoking addCredit before executing onMessage handler does not surface the error event, while invoking after it does surface the error. So it seems like the polling phase of eventloop is likely obstructed by the spin wait - this seems like an unreliable yet consistent issue and may be a bug to be fixed in rhea.
  Since nothing stops message from getting completed other than receiver being closed, the message gets completed as receiver's still open.

Testing done: All tests pass in renewLockSessions.spec.ts 

Refer to https://github.com/Azure/azure-sdk-for-js/issues/1051#issuecomment-460853986, https://github.com/Azure/azure-sdk-for-js/issues/1051#issuecomment-461264529 and https://github.com/Azure/azure-sdk-for-js/issues/1051#issuecomment-461287666 for more context. 