### PR TITLE
[Do not merge] Enable 'maxConcurrentMessages' feature

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/core/batchingReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/batchingReceiver.ts
@@ -364,7 +364,7 @@ export class BatchingReceiver extends MessageReceiver {
         // while creating the receiver link for batching receiver the max concurrent calls
         // i.e. the credit_window on the link is set to zero. After the link is created
         // successfully, we add credit which is the maxMessageCount specified by the user.
-        this.maxConcurrentCalls = 0;
+        this.maxConcurrentMessages = 0;
         const rcvrOptions = this._createReceiverOptions(false, {
           onMessage: onReceiveMessage,
           onError: onReceiveError,

--- a/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
@@ -251,6 +251,10 @@ export class MessageReceiver extends LinkEntity {
     };
     // If explicitly set to false then autoComplete is false else true (default).
     this.autoComplete = options.autoComplete === false ? options.autoComplete : true;
+    this.maxConcurrentCalls =
+      typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0
+        ? options.maxConcurrentCalls
+        : 1;
     this.maxAutoRenewDurationInSeconds =
       options.maxMessageAutoRenewLockDurationInSeconds != undefined
         ? options.maxMessageAutoRenewLockDurationInSeconds

--- a/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
@@ -80,14 +80,6 @@ export interface ReceiveOptions extends MessageHandlerOptions {
    * Default: ReceiveMode.peekLock
    */
   receiveMode?: ReceiveMode;
-  /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
-   * fetched over the network concurrently while in peek lock mode.
-   * This setting can be customized to take a higher number if the Service Bus client is
-   * running on a multi-core platform.
-   * - **Default**: `1`
-   */
-  maxConcurrentCalls?: number;
 }
 
 /**
@@ -253,8 +245,6 @@ export class MessageReceiver extends LinkEntity {
     if (!options) options = {};
     this.receiverType = receiverType;
     this.receiveMode = options.receiveMode || ReceiveMode.peekLock;
-    this.maxConcurrentCalls =
-      options.maxConcurrentCalls != undefined ? options.maxConcurrentCalls : 1;
     this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
     this.resetTimerOnNewMessageReceived = () => {
       /** */

--- a/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
@@ -112,12 +112,14 @@ export class MessageReceiver extends LinkEntity {
    */
   receiverType: ReceiverType;
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that should be
-   * processed concurrently while in peek lock mode. Once this limit has been reached, more
-   * messages will not be received until messages currently being processed have been settled.
-   * Default: 1
+   * @property {number} [maxConcurrentMessages] The maximum number of messages that can be
+   * fetched over the network at a time when .
+   * For more information, refer to the underlying messaging library - https://github.com/amqp/rhea.
+   * - **Default**: `1000`
+   * - **Minimum**: `1`
+   * - **Maximum**: `2048`
    */
-  maxConcurrentCalls?: number;
+  maxConcurrentMessages?: number;
   /**
    * @property {number} [receiveMode] The mode in which messages should be received.
    * Default: ReceiveMode.peekLock
@@ -251,9 +253,9 @@ export class MessageReceiver extends LinkEntity {
     };
     // If explicitly set to false then autoComplete is false else true (default).
     this.autoComplete = options.autoComplete === false ? options.autoComplete : true;
-    this.maxConcurrentCalls =
-      typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0
-        ? options.maxConcurrentCalls
+    this.maxConcurrentMessages =
+      typeof options.maxConcurrentMessages === "number" && options.maxConcurrentMessages > 0
+        ? options.maxConcurrentMessages
         : 1;
     this.maxAutoRenewDurationInSeconds =
       options.maxMessageAutoRenewLockDurationInSeconds != undefined
@@ -989,7 +991,7 @@ export class MessageReceiver extends LinkEntity {
       source: {
         address: this.address
       },
-      credit_window: this.maxConcurrentCalls,
+      credit_window: this.maxConcurrentMessages,
       ...options
     };
     return rcvrOptions;

--- a/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
@@ -81,10 +81,11 @@ export interface ReceiveOptions extends MessageHandlerOptions {
    */
   receiveMode?: ReceiveMode;
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that should be
-   * processed concurrently while in peek lock mode. Once this limit has been reached, more
-   * messages will not be received until messages currently being processed have been settled.
-   * - **Default**: `1` (message at a time).
+   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
+   * fetched over the network concurrently while in peek lock mode.
+   * This setting can be customized to take a higher number if the Service Bus client is
+   * running on a multi-core platform.
+   * - **Default**: `1`
    */
   maxConcurrentCalls?: number;
 }

--- a/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
@@ -43,6 +43,14 @@ export interface MessageHandlerOptions {
    * If this option is not provided, then receiver link will stay open until manually closed.
    */
   newMessageWaitTimeoutInSeconds?: number;
+  /**
+   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
+   * fetched over the network concurrently.
+   * This setting can be customized to take a higher number if the Service Bus client is
+   * running on a multi-core platform.
+   * - **Default**: `1`
+   */
+  maxConcurrentCalls?: number;
 }
 
 /**

--- a/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
@@ -45,7 +45,7 @@ export interface MessageHandlerOptions {
   newMessageWaitTimeoutInSeconds?: number;
   /**
    * @property {number} [maxConcurrentMessages] The maximum number of messages that can be
-   * fetched over the network at a time when .
+   * fetched over the network at a time.
    * For more information, refer to the underlying messaging library - https://github.com/amqp/rhea.
    * - **Default**: `1000`
    * - **Minimum**: `1`

--- a/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
@@ -44,13 +44,14 @@ export interface MessageHandlerOptions {
    */
   newMessageWaitTimeoutInSeconds?: number;
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
-   * fetched over the network concurrently.
-   * This setting can be customized to take a higher number if the Service Bus client is
-   * running on a multi-core platform.
-   * - **Default**: `1`
+   * @property {number} [maxConcurrentMessages] The maximum number of messages that can be
+   * fetched over the network at a time when .
+   * For more information, refer to the underlying messaging library - https://github.com/amqp/rhea.
+   * - **Default**: `1000`
+   * - **Minimum**: `1`
+   * - **Maximum**: `2048`
    */
-  maxConcurrentCalls?: number;
+  maxConcurrentMessages?: number;
 }
 
 /**

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -58,12 +58,9 @@ export class Receiver {
   receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): void {
     this.validateNewReceiveCall(ReceiverType.streaming);
     if (!options) options = {};
-    const _maxConcurrentCalls =
-      typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0
-        ? options.maxConcurrentCalls
-        : 1;
+
     const rcvOptions: ReceiveOptions = {
-      maxConcurrentCalls: _maxConcurrentCalls,
+      maxConcurrentCalls: options.maxConcurrentCalls,
       receiveMode: this._receiveMode,
       autoComplete: options.autoComplete,
       maxMessageAutoRenewLockDurationInSeconds: options.maxMessageAutoRenewLockDurationInSeconds

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -60,7 +60,7 @@ export class Receiver {
     if (!options) options = {};
 
     const rcvOptions: ReceiveOptions = {
-      maxConcurrentCalls: options.maxConcurrentCalls,
+      maxConcurrentMessages: options.maxConcurrentMessages,
       receiveMode: this._receiveMode,
       autoComplete: options.autoComplete,
       maxMessageAutoRenewLockDurationInSeconds: options.maxMessageAutoRenewLockDurationInSeconds
@@ -89,7 +89,7 @@ export class Receiver {
 
     if (!this._context.batchingReceiver || !this._context.batchingReceiver.isOpen()) {
       const options: ReceiveOptions = {
-        maxConcurrentCalls: 0,
+        maxConcurrentMessages: 0,
         receiveMode: this._receiveMode,
         newMessageWaitTimeoutInSeconds: 1
       };

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -58,9 +58,14 @@ export class Receiver {
   receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): void {
     this.validateNewReceiveCall(ReceiverType.streaming);
 
+    const _maxConcurrentCalls =
+      (options != undefined && options.maxConcurrentCalls != undefined
+        && typeof options.maxConcurrentCalls == "number" 
+        && options.maxConcurrentCalls > 0) ? options.maxConcurrentCalls : 1;
+        
     if (!options) options = {};
     const rcvOptions: ReceiveOptions = {
-      maxConcurrentCalls: 1,
+      maxConcurrentCalls: _maxConcurrentCalls,
       receiveMode: this._receiveMode,
       autoComplete: options.autoComplete,
       maxMessageAutoRenewLockDurationInSeconds: options.maxMessageAutoRenewLockDurationInSeconds

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -57,13 +57,11 @@ export class Receiver {
    */
   receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): void {
     this.validateNewReceiveCall(ReceiverType.streaming);
-
-    const _maxConcurrentCalls =
-      (options != undefined && options.maxConcurrentCalls != undefined
-        && typeof options.maxConcurrentCalls == "number" 
-        && options.maxConcurrentCalls > 0) ? options.maxConcurrentCalls : 1;
-        
     if (!options) options = {};
+    const _maxConcurrentCalls =
+      typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0
+        ? options.maxConcurrentCalls
+        : 1;
     const rcvOptions: ReceiveOptions = {
       maxConcurrentCalls: _maxConcurrentCalls,
       receiveMode: this._receiveMode,

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -88,7 +88,7 @@ export interface SessionMessageHandlerOptions {
   newMessageWaitTimeoutInSeconds?: number;
   /**
    * @property {number} [maxConcurrentMessages] The maximum number of messages that can be
-   * fetched over the network at a time when .
+   * fetched over the network at a time.
    * For more information, refer to the underlying messaging library - https://github.com/amqp/rhea.
    * - **Default**: `1000`
    * - **Minimum**: `1`
@@ -136,7 +136,7 @@ export class MessageSession extends LinkEntity {
   maxConcurrentSessions?: number;
   /**
    * @property {number} [maxConcurrentMessages] The maximum number of messages that can be
-   * fetched over the network at a time when .
+   * fetched over the network at a time.
    * For more information, refer to the underlying messaging library - https://github.com/amqp/rhea.
    * - **Default**: `1000`
    * - **Minimum**: `1`
@@ -534,10 +534,17 @@ export class MessageSession extends LinkEntity {
     }
     if (!options) options = {};
     this._isReceivingMessages = true;
-    this.maxConcurrentMessages =
-      typeof options.maxConcurrentMessages === "number" && options.maxConcurrentMessages > 0
-        ? options.maxConcurrentMessages
-        : 1;
+    if (typeof options.maxConcurrentMessages === "number") {
+      if (options.maxConcurrentMessages <= 0 || options.maxConcurrentMessages > 2048) {
+        throw new Error(
+          "Invalid argument error: 'maxConcurrentMessages' value must be between 1 and 2048"
+        );
+      } else {
+        this.maxConcurrentMessages = options.maxConcurrentMessages;
+      }
+    } else {
+      this.maxConcurrentMessages = 1000;
+    }
     this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
 
     // If explicitly set to false then autoComplete is false else true (default).

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -87,13 +87,14 @@ export interface SessionMessageHandlerOptions {
    */
   newMessageWaitTimeoutInSeconds?: number;
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
-   * fetched over the network concurrently.
-   * This setting can be customized to take a higher number if the Service Bus client is
-   * running on a multi-core platform.
-   * - **Default**: `1`
+   * @property {number} [maxConcurrentMessages] The maximum number of messages that can be
+   * fetched over the network at a time when .
+   * For more information, refer to the underlying messaging library - https://github.com/amqp/rhea.
+   * - **Default**: `1000`
+   * - **Minimum**: `1`
+   * - **Maximum**: `2048`
    */
-  maxConcurrentCalls?: number;
+  maxConcurrentMessages?: number;
 }
 /**
  * Describes the options for creating a Session Manager.
@@ -134,13 +135,14 @@ export class MessageSession extends LinkEntity {
    */
   maxConcurrentSessions?: number;
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
-   * fetched over the network concurrently.
-   * This setting can be customized to take a higher number if the Service Bus client is
-   * running on a multi-core platform.
-   * - **Default**: `1`
+   * @property {number} [maxConcurrentMessages] The maximum number of messages that can be
+   * fetched over the network at a time when .
+   * For more information, refer to the underlying messaging library - https://github.com/amqp/rhea.
+   * - **Default**: `1000`
+   * - **Minimum**: `1`
+   * - **Maximum**: `2048`
    */
-  maxConcurrentCalls?: number;
+  maxConcurrentMessages?: number;
   /**
    * @property {number} [receiveMode] The mode in which messages should be received.
    * Default: ReceiveMode.peekLock
@@ -532,9 +534,9 @@ export class MessageSession extends LinkEntity {
     }
     if (!options) options = {};
     this._isReceivingMessages = true;
-    this.maxConcurrentCalls =
-      typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0
-        ? options.maxConcurrentCalls
+    this.maxConcurrentMessages =
+      typeof options.maxConcurrentMessages === "number" && options.maxConcurrentMessages > 0
+        ? options.maxConcurrentMessages
         : 1;
     this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
 
@@ -654,7 +656,7 @@ export class MessageSession extends LinkEntity {
       // setting the "message" event listener.
       this._receiver.on(ReceiverEvents.message, onSessionMessage);
       // adding credit
-      this._receiver!.addCredit(this.maxConcurrentCalls);
+      this._receiver!.addCredit(this.maxConcurrentMessages);
     } else {
       this._isReceivingMessages = false;
       const msg =

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -86,6 +86,14 @@ export interface SessionMessageHandlerOptions {
    * If this option is not provided, then receiver link will stay open until manually closed.
    */
   newMessageWaitTimeoutInSeconds?: number;
+  /**
+   * @property {number} [maxConcurrentCallsPerSession] The maximum number of messages that can be
+   * fetched over the network concurrently for a session while in peek lock mode.
+   * This setting can be customized to take a higher number if the Service Bus client is
+   * running on a multi-core platform.
+   * - **Default**: `1`
+   */
+  maxConcurrentCallsPerSession?: number;
 }
 /**
  * Describes the options for creating a Session Manager.
@@ -126,10 +134,11 @@ export class MessageSession extends LinkEntity {
    */
   maxConcurrentSessions?: number;
   /**
-   * @property {number} [maxConcurrentCallsPerSession] The maximum number of messages that should be
-   * processed concurrently in a session while in peek lock mode. Once this limit has been reached,
-   * more messages will not be received until messages currently being processed have been settled.
-   * - **Default**: `1` (message in a session at a time).
+   * @property {number} [maxConcurrentCallsPerSession] The maximum number of messages that can be
+   * fetched over the network concurrently for a session while in peek lock mode.
+   * This setting can be customized to take a higher number if the Service Bus client is
+   * running on a multi-core platform.
+   * - **Default**: `1`
    */
   maxConcurrentCallsPerSession?: number;
   /**
@@ -523,7 +532,7 @@ export class MessageSession extends LinkEntity {
     }
     if (!options) options = {};
     this._isReceivingMessages = true;
-    this.maxConcurrentCallsPerSession = 1;
+    this.maxConcurrentCallsPerSession = options.maxConcurrentCallsPerSession != undefined ? options.maxConcurrentCallsPerSession : 1;
     this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
 
     // If explicitly set to false then autoComplete is false else true (default).

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -87,13 +87,13 @@ export interface SessionMessageHandlerOptions {
    */
   newMessageWaitTimeoutInSeconds?: number;
   /**
-   * @property {number} [maxConcurrentCallsPerSession] The maximum number of messages that can be
-   * fetched over the network concurrently for a session.
+   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
+   * fetched over the network concurrently.
    * This setting can be customized to take a higher number if the Service Bus client is
    * running on a multi-core platform.
    * - **Default**: `1`
    */
-  maxConcurrentCallsPerSession?: number;
+  maxConcurrentCalls?: number;
 }
 /**
  * Describes the options for creating a Session Manager.
@@ -134,13 +134,13 @@ export class MessageSession extends LinkEntity {
    */
   maxConcurrentSessions?: number;
   /**
-   * @property {number} [maxConcurrentCallsPerSession] The maximum number of messages that can be
-   * fetched over the network concurrently for a session.
+   * @property {number} [maxConcurrentCalls] The maximum number of messages that can be
+   * fetched over the network concurrently.
    * This setting can be customized to take a higher number if the Service Bus client is
    * running on a multi-core platform.
    * - **Default**: `1`
    */
-  maxConcurrentCallsPerSession?: number;
+  maxConcurrentCalls?: number;
   /**
    * @property {number} [receiveMode] The mode in which messages should be received.
    * Default: ReceiveMode.peekLock
@@ -532,10 +532,10 @@ export class MessageSession extends LinkEntity {
     }
     if (!options) options = {};
     this._isReceivingMessages = true;
-    this.maxConcurrentCallsPerSession = 
-      (options.maxConcurrentCallsPerSession != undefined 
-        && typeof options.maxConcurrentCallsPerSession == "number"
-        && options.maxConcurrentCallsPerSession > 0) ? options.maxConcurrentCallsPerSession : 1;
+    this.maxConcurrentCalls =
+      typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0
+        ? options.maxConcurrentCalls
+        : 1;
     this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
 
     // If explicitly set to false then autoComplete is false else true (default).
@@ -654,7 +654,7 @@ export class MessageSession extends LinkEntity {
       // setting the "message" event listener.
       this._receiver.on(ReceiverEvents.message, onSessionMessage);
       // adding credit
-      this._receiver!.addCredit(this.maxConcurrentCallsPerSession);
+      this._receiver!.addCredit(this.maxConcurrentCalls);
     } else {
       this._isReceivingMessages = false;
       const msg =

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -88,7 +88,7 @@ export interface SessionMessageHandlerOptions {
   newMessageWaitTimeoutInSeconds?: number;
   /**
    * @property {number} [maxConcurrentCallsPerSession] The maximum number of messages that can be
-   * fetched over the network concurrently for a session while in peek lock mode.
+   * fetched over the network concurrently for a session.
    * This setting can be customized to take a higher number if the Service Bus client is
    * running on a multi-core platform.
    * - **Default**: `1`
@@ -135,7 +135,7 @@ export class MessageSession extends LinkEntity {
   maxConcurrentSessions?: number;
   /**
    * @property {number} [maxConcurrentCallsPerSession] The maximum number of messages that can be
-   * fetched over the network concurrently for a session while in peek lock mode.
+   * fetched over the network concurrently for a session.
    * This setting can be customized to take a higher number if the Service Bus client is
    * running on a multi-core platform.
    * - **Default**: `1`
@@ -532,7 +532,10 @@ export class MessageSession extends LinkEntity {
     }
     if (!options) options = {};
     this._isReceivingMessages = true;
-    this.maxConcurrentCallsPerSession = options.maxConcurrentCallsPerSession != undefined ? options.maxConcurrentCallsPerSession : 1;
+    this.maxConcurrentCallsPerSession = 
+      (options.maxConcurrentCallsPerSession != undefined 
+        && typeof options.maxConcurrentCallsPerSession == "number"
+        && options.maxConcurrentCallsPerSession > 0) ? options.maxConcurrentCallsPerSession : 1;
     this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
 
     // If explicitly set to false then autoComplete is false else true (default).


### PR DESCRIPTION
Based on recent findings, we see that 'credit_window' is related to concurrently transferring messages over rhea link, and can make a difference at controlling/optimizing rate of flow of messages at link/network level and not at the higher interactions with service bus level.
Testing the rhea events ordering and specific maxConcurrency behavior would be deep and internal to the SDK.
 
Testing the correctness may be taken up as part of https://github.com/Azure/azure-sdk-for-js/issues/1193 or https://github.com/Azure/azure-service-bus-node/issues/49

Current changes
- addresses doc and interface updates to expose the option to be customizable by user.

Pending investigation:
- difference in credit_window / circular buffer size use in 'incoming and outgoing windows'
- clarity on role of OS thread concurrency in messages fetches (is it a push / pull way of transfer, how many messages per thread on average etc)
- other aspects to consider/address - message/session locks, effect on implementation of 'receive and delete' mode, etc.
 