### PR TITLE
[Service Bus] RenewLock - create namespace inside before each

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
@@ -48,7 +48,7 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("Unpartitioned Queue - Lock Renewal Tests - Peeklock Mode", function(): void {
+describe("Unpartitioned Queue - Lock Renewal Tests", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
   });
@@ -117,7 +117,7 @@ describe("Unpartitioned Queue - Lock Renewal Tests - Peeklock Mode", function():
   });
 });
 
-describe("Partitioned Queue - Lock Renewal Tests - Peeklock Mode", function(): void {
+describe("Partitioned Queue - Lock Renewal Tests", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
   });
@@ -186,7 +186,7 @@ describe("Partitioned Queue - Lock Renewal Tests - Peeklock Mode", function(): v
   });
 });
 
-describe("Unpartitioned Topic/Subscription - Lock Renewal Tests - Peeklock Mode", function(): void {
+describe("Unpartitioned Subscription - Lock Renewal Tests", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
   });
@@ -255,7 +255,7 @@ describe("Unpartitioned Topic/Subscription - Lock Renewal Tests - Peeklock Mode"
   });
 });
 
-describe("Partitioned Topic/Subscription - Lock Renewal Tests - Peeklock Mode", function(): void {
+describe("Partitioned Subscription - Lock Renewal Tests", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
   });

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -53,296 +53,286 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("Standard", function(): void {
-  describe("Unpartitioned Queue", function(): void {
-    describe("Tests - Lock Renewal for Sessions - Peeklock Mode", function(): void {
-      beforeEach(async () => {
-        await beforeEachTest(
-          ClientType.UnpartitionedQueueWithSessions,
-          ClientType.UnpartitionedQueueWithSessions
-        );
-      });
+describe("Unpartitioned Queue - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+  beforeEach(async () => {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions
+    );
+  });
 
-      afterEach(async () => {
-        await afterEachTest();
-      });
+  afterEach(async () => {
+    await afterEachTest();
+  });
 
-      it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
+  it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
 
-      it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
-      });
+  it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
+  });
 
-      it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
-        void
-      > {
-        await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
+  it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
+    void
+  > {
+    await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
 
-      it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          expectSessionLockLostErrorToBeThrown: false
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 80,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      }).timeout(95000);
-
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
+  it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 0,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
     });
   });
 
-  describe("Partitioned Queue", function(): void {
-    describe("Tests - Lock Renewal for Sessions - Peeklock Mode", function(): void {
-      beforeEach(async () => {
-        await beforeEachTest(
-          ClientType.PartitionedQueueWithSessions,
-          ClientType.PartitionedQueueWithSessions
-        );
-      });
-
-      afterEach(async () => {
-        await afterEachTest();
-      });
-
-      it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
-
-      it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
-      });
-
-      it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
-        void
-      > {
-        await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
-
-      it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          expectSessionLockLostErrorToBeThrown: false
-        });
-      });
-
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 80,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      }).timeout(95000);
-
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
+  it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 38,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 35,
+      expectSessionLockLostErrorToBeThrown: false
     });
   });
 
-  describe("Unpartitioned Topic/Subscription", function(): void {
-    describe("Tests - Lock Renewal for Sessions - Peeklock Mode", function(): void {
-      beforeEach(async () => {
-        await beforeEachTest(
-          ClientType.UnpartitionedTopicWithSessions,
-          ClientType.UnpartitionedSubscriptionWithSessions
-        );
-      });
+  it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 35,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 80,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  }).timeout(95000);
 
-      afterEach(async () => {
-        await afterEachTest();
-      });
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 15,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  });
+});
 
-      it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
+describe("Partitioned Queue - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+  beforeEach(async () => {
+    await beforeEachTest(
+      ClientType.PartitionedQueueWithSessions,
+      ClientType.PartitionedQueueWithSessions
+    );
+  });
 
-      it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
-      });
+  afterEach(async () => {
+    await afterEachTest();
+  });
 
-      it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
-        void
-      > {
-        await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
+  it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
 
-      it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
+  it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
+  });
 
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          expectSessionLockLostErrorToBeThrown: false
-        });
-      });
+  it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
+    void
+  > {
+    await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
 
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 80,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      }).timeout(95000);
-
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
+  it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 0,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
     });
   });
 
-  describe("Partitioned Topic/Subscription", function(): void {
-    describe("Tests - Lock Renewal for Sessions - Peeklock Mode", function(): void {
-      beforeEach(async () => {
-        await beforeEachTest(
-          ClientType.PartitionedTopicWithSessions,
-          ClientType.PartitionedSubscriptionWithSessions
-        );
-      });
+  it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 38,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 35,
+      expectSessionLockLostErrorToBeThrown: false
+    });
+  });
 
-      afterEach(async () => {
-        await afterEachTest();
-      });
+  it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 35,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 80,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  }).timeout(95000);
 
-      it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 15,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  });
+});
 
-      it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
-        void
-      > {
-        await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
-      });
+describe("Unpartitioned Topic/Subscription - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+  beforeEach(async () => {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions
+    );
+  });
 
-      it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
-        void
-      > {
-        await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
-      });
+  afterEach(async () => {
+    await afterEachTest();
+  });
 
-      it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 0,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
+  it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
 
-      it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 38,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 35,
-          expectSessionLockLostErrorToBeThrown: false
-        });
-      });
+  it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
+  });
 
-      it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 35,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 80,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      }).timeout(95000);
+  it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
+    void
+  > {
+    await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
 
-      it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
-        void
-      > {
-        await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
-          maxSessionAutoRenewLockDurationInSeconds: 15,
-          delayBeforeAttemptingToCompleteMessageInSeconds: 31,
-          expectSessionLockLostErrorToBeThrown: true
-        });
-      });
+  it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 0,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  });
+
+  it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 38,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 35,
+      expectSessionLockLostErrorToBeThrown: false
+    });
+  });
+
+  it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 35,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 80,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  }).timeout(95000);
+
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 15,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  });
+});
+
+describe("Partitioned Topic/Subscription - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+  beforeEach(async () => {
+    await beforeEachTest(
+      ClientType.PartitionedTopicWithSessions,
+      ClientType.PartitionedSubscriptionWithSessions
+    );
+  });
+
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  it(`renewLock() with Batch Receiver resets lock duration each time.`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
+
+  it(`Receive a msg using Batch Receiver, wait until its lock expires, completing it now results in error`, async function(): Promise<
+    void
+  > {
+    await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
+  });
+
+  it("Receives a message using Streaming Receiver renewLock() resets lock duration each time.", async function(): Promise<
+    void
+  > {
+    await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
+  });
+
+  it("Receive a msg using Streaming Receiver, lock expires after 30 sec when auto renewal is disabled", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 0,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  });
+
+  it("Receive a msg using Streaming Receiver, lock will not expire until configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 38,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 35,
+      expectSessionLockLostErrorToBeThrown: false
+    });
+  });
+
+  it("Receive a msg using Streaming Receiver, lock will expire sometime after the configured time", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 35,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 80,
+      expectSessionLockLostErrorToBeThrown: true
+    });
+  }).timeout(95000);
+
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
+    void
+  > {
+    await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
+      maxSessionAutoRenewLockDurationInSeconds: 15,
+      delayBeforeAttemptingToCompleteMessageInSeconds: 31,
+      expectSessionLockLostErrorToBeThrown: true
     });
   });
 });

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -53,7 +53,7 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("Unpartitioned Queue - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+describe("Unpartitioned Queue - Lock Renewal Tests for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
@@ -124,7 +124,7 @@ describe("Unpartitioned Queue - Lock Renewal Tests for Sessions - Peeklock Mode"
   });
 });
 
-describe("Partitioned Queue - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+describe("Partitioned Queue - Lock Renewal Tests for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
@@ -195,7 +195,7 @@ describe("Partitioned Queue - Lock Renewal Tests for Sessions - Peeklock Mode", 
   });
 });
 
-describe("Unpartitioned Topic/Subscription - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+describe("Unpartitioned Subscription - Lock Renewal Tests for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.UnpartitionedTopicWithSessions,
@@ -266,7 +266,7 @@ describe("Unpartitioned Topic/Subscription - Lock Renewal Tests for Sessions - P
   });
 });
 
-describe("Partitioned Topic/Subscription - Lock Renewal Tests for Sessions - Peeklock Mode", function(): void {
+describe("Partitioned Subscription - Lock Renewal Tests for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.PartitionedTopicWithSessions,


### PR DESCRIPTION
**Files changed**
`renewLockSessions.spec.ts` and `renewLock.spec.ts`

**Description**
Created namespace inside `beforeEachTest` for the tests corresponding to Lock renewal.
Verified that all the tests passed after this.


