### PR TITLE
[Service Bus] Update Delays in Streaming Receiver

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/README.md
+++ b/packages/@azure/servicebus/data-plane/test/README.md
@@ -25,9 +25,35 @@
   unpartitioned-topic-subscription | Subscription with sessions disabled in the Topic, `unpartitioned-topic` | SUBSCRIPTION_NAME_NO_PARTITION
   partitioned-topic-sessions-subscription | Subscription with sessions enabled in the Topic, `partitioned-topic-sessions` | SUBSCRIPTION_NAME_SESSION
   unpartitioned-topic-sessions-subscription | Subscription with sessions enabled in the Topic, `unpartitioned-topic-sessions` | SUBSCRIPTION_NAME_NO_PARTITION_SESSION
-  topic-filter | Topic for testing topic filters | TOPIC_FILTER
-  topic-filter-subscription | Subscription in the Topic `topic-filter` | TOPIC_FILTER_SUBSCRIPTION
-  topic-filter-default-subscription | Subscription in the Topic `topic-filter` | TOPIC_FILTER_DEFAULT_SUBSCRIPTION
+  topic-filter | Topic for testing topic filters | TOPIC_FILTER_NAME
+  topic-filter-subscription | Subscription in the Topic `topic-filter` | TOPIC_FILTER_SUBSCRIPTION_NAME
+  topic-filter-default-subscription | Subscription in the Topic `topic-filter` | TOPIC_FILTER_DEFAULT_SUBSCRIPTION_NAME
+
+
+    The environment variables can be set by adding a file by the name `.env` in the root folder of this project.
+    Following is a sample .env file template that can be re-used for your environment:
+    ```
+    SERVICEBUS_CONNECTION_STRING=
+    
+    QUEUE_NAME=partitioned-queue
+    QUEUE_NAME_NO_PARTITION=unpartitioned-queue
+    QUEUE_NAME_SESSION=partitioned-queue-sessions
+    QUEUE_NAME_NO_PARTITION_SESSION=unpartitioned-queue-sessions
+    
+    TOPIC_NAME=partitioned-topic
+    TOPIC_NAME_NO_PARTITION=unpartitioned-topic
+    TOPIC_NAME_SESSION=partitioned-topic-sessions
+    TOPIC_NAME_NO_PARTITION_SESSION=unpartitioned-topic-sessions
+    SUBSCRIPTION_NAME=partitioned-topic-subscription
+    SUBSCRIPTION_NAME_NO_PARTITION=unpartitioned-topic-subscription
+    SUBSCRIPTION_NAME_SESSION=partitioned-topic-sessions-subscription
+    SUBSCRIPTION_NAME_NO_PARTITION_SESSION=unpartitioned-topic-sessions-subscription
+    
+    TOPIC_FILTER_NAME=topic-filter
+    TOPIC_FILTER_SUBSCRIPTION_NAME=topic-filter-subscription
+    TOPIC_FILTER_DEFAULT_SUBSCRIPTION_NAME=topic-filter-default-subscription
+
+    ```
 
 ## Run all tests
 

--- a/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
@@ -220,7 +220,7 @@ describe("Streaming Receiver from Queue/Subscription", function(): void {
     );
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(receivedMsgs[0].body, testMessages.body);
     should.equal(receivedMsgs[0].messageId, testMessages.messageId);

--- a/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
@@ -26,7 +26,7 @@ import {
   getSenderReceiverClients,
   ClientType,
   purge,
-  delayStreaming
+  checkWithTimeout
 } from "./testUtils";
 
 import { Receiver, SessionReceiver } from "../lib/receiver";
@@ -219,7 +219,7 @@ describe("Streaming Receiver from Queue/Subscription", function(): void {
       { autoComplete: autoCompleteFlag }
     );
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");

--- a/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
@@ -13,7 +13,6 @@ import {
   TopicClient,
   SubscriptionClient,
   ServiceBusMessage,
-  delay,
   SendableMessageInfo,
   ReceiveMode
 } from "../lib";

--- a/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
@@ -26,7 +26,7 @@ import {
   getSenderReceiverClients,
   ClientType,
   purge,
-  DelayStreaming
+  delayStreaming
 } from "./testUtils";
 
 import { Receiver, SessionReceiver } from "../lib/receiver";
@@ -219,7 +219,7 @@ describe("Streaming Receiver from Queue/Subscription", function(): void {
       { autoComplete: autoCompleteFlag }
     );
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");

--- a/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/receiveAndDeleteMode.spec.ts
@@ -26,7 +26,8 @@ import {
   testSessionId1,
   getSenderReceiverClients,
   ClientType,
-  purge
+  purge,
+  DelayStreaming
 } from "./testUtils";
 
 import { Receiver, SessionReceiver } from "../lib/receiver";
@@ -219,11 +220,9 @@ describe("Streaming Receiver from Queue/Subscription", function(): void {
       { autoComplete: autoCompleteFlag }
     );
 
-    await delay(2000);
+    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    should.equal(msgsCheck, true, "Did not receive messages in time");
 
-    should.equal(receivedMsgs.length, 1);
-    should.equal(receivedMsgs[0].body, testMessages.body);
-    should.equal(receivedMsgs[0].messageId, testMessages.messageId);
     should.equal(receivedMsgs[0].body, testMessages.body);
     should.equal(receivedMsgs[0].messageId, testMessages.messageId);
 

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -22,7 +22,8 @@ import {
   getSenderReceiverClients,
   ClientType,
   testSessionId1,
-  purge
+  purge,
+  DelayStreaming
 } from "./testUtils";
 
 async function testPeekMsgsLength(
@@ -182,8 +183,9 @@ describe("SessionTests - Accept a session by passing non-existing sessionId rece
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    await delay(2000);
-    should.equal(receivedMsgs.length, 1);
+    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    should.equal(msgsCheck, true, "Did not receive messages in time");
+
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 
     await testPeekMsgsLength(receiverClient, 0);

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -23,7 +23,7 @@ import {
   ClientType,
   testSessionId1,
   purge,
-  delayStreaming
+  checkWithTimeout
 } from "./testUtils";
 
 async function testPeekMsgsLength(
@@ -199,7 +199,7 @@ describe("SessionTests - Accept a session by passing non-existing sessionId rece
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
 

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -184,7 +184,7 @@ describe("SessionTests - Accept a session by passing non-existing sessionId rece
     }, unExpectedErrorHandler);
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -23,7 +23,7 @@ import {
   ClientType,
   testSessionId1,
   purge,
-  DelayStreaming
+  delayStreaming
 } from "./testUtils";
 
 async function testPeekMsgsLength(
@@ -199,7 +199,7 @@ describe("SessionTests - Accept a session by passing non-existing sessionId rece
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
 

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -186,6 +186,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
 
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     await testPeekMsgsLength(receiverClient, 1);
+    should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
 
     await receivedMsgs[0].complete();
     await receiver.close();
@@ -251,7 +252,7 @@ describe("Streaming Receiver - Complete message", function(): void {
 
     await receiver.close();
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
-
+    should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
     await testPeekMsgsLength(receiverClient, 0);
   }
   it("Partitioned Queue: complete() removes message", async function(): Promise<void> {
@@ -510,6 +511,7 @@ describe("Streaming Receiver - Deadletter message", function(): void {
 
     await receiver.close();
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
+    should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
 
     await testPeekMsgsLength(receiverClient, 0);
 

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -50,7 +50,9 @@ function unExpectedErrorHandler(err: Error): void {
   }
 }
 
+// Maximum wait duration for the Streaming Receiver to receive the messages = `10000 ms`(10 seconds)
 const maxDelayForStreamingReceiver = 10000;
+// Keep checking whether the boolCheck is true after every `1000 ms`(1 second)
 const delayBetweenRetriesForStreamingReceiver = 1000;
 
 async function DelayStreaming(

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -127,7 +127,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
 
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     await receiver.close();
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -175,7 +175,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
 
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     await testPeekMsgsLength(receiverClient, 1);
 
     await receivedMsgs[0].complete();
@@ -234,7 +234,7 @@ describe("Streaming Receiver - Complete message", function(): void {
     );
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await receiver.close();
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -473,7 +473,7 @@ describe("Streaming Receiver - Deadletter message", function(): void {
     );
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await receiver.close();
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -622,7 +622,7 @@ describe("Streaming Receiver - Settle an already Settled message throws error", 
     }, unExpectedErrorHandler);
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -118,7 +118,7 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe.only("Streaming Receiver - Misc Tests", function(): void {
+describe("Streaming Receiver - Misc Tests", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -231,7 +231,7 @@ describe.only("Streaming Receiver - Misc Tests", function(): void {
   });
 });
 
-describe.only("Streaming Receiver - Complete message", function(): void {
+describe("Streaming Receiver - Complete message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -313,7 +313,7 @@ describe.only("Streaming Receiver - Complete message", function(): void {
   });
 });
 
-describe.only("Streaming Receiver - Abandon message", function(): void {
+describe("Streaming Receiver - Abandon message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -382,7 +382,7 @@ describe.only("Streaming Receiver - Abandon message", function(): void {
   });
 });
 
-describe.only("Streaming Receiver - Defer message", function(): void {
+describe("Streaming Receiver - Defer message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -472,7 +472,7 @@ describe.only("Streaming Receiver - Defer message", function(): void {
   });
 });
 
-describe.only("Streaming Receiver - Deadletter message", function(): void {
+describe("Streaming Receiver - Deadletter message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -561,7 +561,7 @@ describe.only("Streaming Receiver - Deadletter message", function(): void {
   });
 });
 
-describe.only("Streaming Receiver - Multiple Streaming Receivers", function(): void {
+describe("Streaming Receiver - Multiple Streaming Receivers", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -618,7 +618,7 @@ describe.only("Streaming Receiver - Multiple Streaming Receivers", function(): v
   });
 });
 
-describe.only("Streaming Receiver - Settle an already Settled message throws error", () => {
+describe("Streaming Receiver - Settle an already Settled message throws error", () => {
   afterEach(async () => {
     await afterEachTest();
   });

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -23,7 +23,7 @@ import {
   getSenderReceiverClients,
   ClientType,
   purge,
-  delayStreaming
+  checkWithTimeout
 } from "./testUtils";
 import { Receiver } from "../lib/receiver";
 import { Sender } from "../lib/sender";
@@ -129,7 +129,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
 
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     await receiver.close();
@@ -182,7 +182,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
       { autoComplete: false }
     );
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
 
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     await testPeekMsgsLength(receiverClient, 1);
@@ -246,7 +246,7 @@ describe("Streaming Receiver - Complete message", function(): void {
       { autoComplete }
     );
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await receiver.close();
@@ -327,7 +327,7 @@ describe("Streaming Receiver - Abandon message", function(): void {
       { autoComplete: false }
     );
 
-    const deliveryCountFlag = await delayStreaming(() => checkDeliveryCount === maxDeliveryCount);
+    const deliveryCountFlag = await checkWithTimeout(() => checkDeliveryCount === maxDeliveryCount);
     should.equal(deliveryCountFlag, true, "DeliveryCount is different than expected");
 
     await receiver.close();
@@ -400,7 +400,7 @@ describe("Streaming Receiver - Defer message", function(): void {
       { autoComplete }
     );
 
-    const sequenceNumCheck = await delayStreaming(() => sequenceNum !== 0);
+    const sequenceNumCheck = await checkWithTimeout(() => sequenceNum !== 0);
     should.equal(
       sequenceNumCheck,
       true,
@@ -505,7 +505,7 @@ describe("Streaming Receiver - Deadletter message", function(): void {
       { autoComplete }
     );
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await receiver.close();
@@ -666,7 +666,7 @@ describe("Streaming Receiver - Settle an already Settled message throws error", 
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -18,7 +18,13 @@ import {
 
 import { DispositionType } from "../lib/serviceBusMessage";
 
-import { testSimpleMessages, getSenderReceiverClients, ClientType, purge } from "./testUtils";
+import {
+  testSimpleMessages,
+  getSenderReceiverClients,
+  ClientType,
+  purge,
+  DelayStreaming
+} from "./testUtils";
 import { Receiver } from "../lib/receiver";
 import { Sender } from "../lib/sender";
 
@@ -48,24 +54,6 @@ function unExpectedErrorHandler(err: Error): void {
   if (err) {
     unexpectedError = err;
   }
-}
-
-// Maximum wait duration for the Streaming Receiver to receive the messages = `10000 ms`(10 seconds)(= maxWaitTime)
-// Keep checking whether the predicate is true after every `1000 ms`(1 second) (= delayBetweenRetries)
-async function DelayStreaming(
-  predicate: () => boolean,
-  delayBetweenRetries: number = 1000,
-  maxWaitTime: number = 10000
-): Promise<boolean> {
-  const maxTime = Date.now() + maxWaitTime;
-  while (Date.now() < maxTime) {
-    if (predicate()) {
-      console.log("hello");
-      return true;
-    }
-    await delay(delayBetweenRetries);
-  }
-  return false;
 }
 
 async function beforeEachTest(senderType: ClientType, receiverType: ClientType): Promise<void> {
@@ -617,7 +605,7 @@ describe("Streaming Receiver - Multiple Streaming Receivers", function(): void {
   });
 });
 
-describe("Streaming Receiver - Settle an already Settled message throws error", () => {
+describe.only("Streaming Receiver - Settle an already Settled message throws error", () => {
   afterEach(async () => {
     await afterEachTest();
   });

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -358,7 +358,7 @@ describe("Streaming Receiver - Abandon message", function(): void {
   });
 });
 
-describe.only("Streaming Receiver - Defer message", function(): void {
+describe("Streaming Receiver - Defer message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -486,7 +486,6 @@ describe("Streaming Receiver - Deadletter message", function(): void {
     should.equal(deadLetterMsgs[0].messageId, testSimpleMessages.messageId);
 
     await deadLetterMsgs[0].complete();
-
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
@@ -604,7 +603,7 @@ describe("Streaming Receiver - Multiple Streaming Receivers", function(): void {
   });
 });
 
-describe.only("Streaming Receiver - Settle an already Settled message throws error", () => {
+describe("Streaming Receiver - Settle an already Settled message throws error", () => {
   afterEach(async () => {
     await afterEachTest();
   });

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -358,7 +358,7 @@ describe("Streaming Receiver - Abandon message", function(): void {
   });
 });
 
-describe("Streaming Receiver - Defer message", function(): void {
+describe.only("Streaming Receiver - Defer message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -396,7 +396,6 @@ describe("Streaming Receiver - Defer message", function(): void {
     should.equal(deferredMsgs[0].deliveryCount, 1);
 
     await deferredMsgs[0].complete();
-    await delay(10000);
     await testPeekMsgsLength(receiverClient, 0);
   }
 

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -23,7 +23,7 @@ import {
   getSenderReceiverClients,
   ClientType,
   purge,
-  DelayStreaming
+  delayStreaming
 } from "./testUtils";
 import { Receiver } from "../lib/receiver";
 import { Sender } from "../lib/sender";
@@ -129,7 +129,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
 
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     await receiver.close();
@@ -182,7 +182,7 @@ describe("Streaming Receiver - Misc Tests", function(): void {
       { autoComplete: false }
     );
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
 
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     await testPeekMsgsLength(receiverClient, 1);
@@ -246,7 +246,7 @@ describe("Streaming Receiver - Complete message", function(): void {
       { autoComplete }
     );
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await receiver.close();
@@ -327,7 +327,7 @@ describe("Streaming Receiver - Abandon message", function(): void {
       { autoComplete: false }
     );
 
-    const deliveryCountFlag = await DelayStreaming(() => checkDeliveryCount === maxDeliveryCount);
+    const deliveryCountFlag = await delayStreaming(() => checkDeliveryCount === maxDeliveryCount);
     should.equal(deliveryCountFlag, true, "DeliveryCount is different than expected");
 
     await receiver.close();
@@ -400,7 +400,7 @@ describe("Streaming Receiver - Defer message", function(): void {
       { autoComplete }
     );
 
-    const sequenceNumCheck = await DelayStreaming(() => sequenceNum !== 0);
+    const sequenceNumCheck = await delayStreaming(() => sequenceNum !== 0);
     should.equal(
       sequenceNumCheck,
       true,
@@ -505,7 +505,7 @@ describe("Streaming Receiver - Deadletter message", function(): void {
       { autoComplete }
     );
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await receiver.close();
@@ -666,7 +666,7 @@ describe("Streaming Receiver - Settle an already Settled message throws error", 
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -351,10 +351,11 @@ describe("Streaming Receiver - Abandon message(with sessions)", function(): void
 
   async function testAbandon(autoComplete: boolean): Promise<void> {
     await sender.send(testMessagesWithSessions);
-
+    let abandonFlag = 0;
     await sessionReceiver.receive(
       (msg: ServiceBusMessage) => {
         return msg.abandon().then(() => {
+          abandonFlag = 1;
           if (sessionReceiver.isOpen()) {
             return sessionReceiver.close();
           }
@@ -364,7 +365,9 @@ describe("Streaming Receiver - Abandon message(with sessions)", function(): void
       unExpectedErrorHandler,
       { autoComplete }
     );
-    await delay(4000);
+
+    const msgAbandonCheck = await DelayStreaming(() => abandonFlag === 1);
+    should.equal(msgAbandonCheck, true, "Abandoning the message results in a failure");
 
     if (sessionReceiver.isOpen()) {
       await sessionReceiver.close();

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -123,7 +123,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
     }, unExpectedErrorHandler);
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
     should.equal(receivedMsgs.length, 1);
@@ -186,7 +186,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
     );
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await testPeekMsgsLength(receiverClient, 1);
 
@@ -257,7 +257,7 @@ describe("Streaming Receiver - Complete message(with sessions)", function(): voi
     );
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 
@@ -604,7 +604,7 @@ describe("Streaming Receiver - Deadletter message(with sessions)", function(): v
     );
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
     await testPeekMsgsLength(receiverClient, 0);
@@ -786,7 +786,7 @@ describe("Streaming Receiver - Settle an already Settled message throws error(wi
     }, unExpectedErrorHandler);
 
     const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
-    should.equal(msgsCheck, true, "Did not receive messages in time");
+    should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 
     should.equal(receivedMsgs[0].body, testMessagesWithSessions.body);

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -24,7 +24,7 @@ import {
   getSenderReceiverClients,
   ClientType,
   purge,
-  DelayStreaming
+  delayStreaming
 } from "./testUtils";
 import { Sender } from "../lib/sender";
 import { SessionReceiver } from "../lib/receiver";
@@ -130,7 +130,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -201,7 +201,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
       { autoComplete: false }
     );
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await testPeekMsgsLength(receiverClient, 1);
@@ -280,7 +280,7 @@ describe("Streaming Receiver - Complete message(with sessions)", function(): voi
       { autoComplete }
     );
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -390,7 +390,7 @@ describe("Streaming Receiver - Abandon message(with sessions)", function(): void
       { autoComplete }
     );
 
-    const msgAbandonCheck = await DelayStreaming(() => abandonFlag === 1);
+    const msgAbandonCheck = await delayStreaming(() => abandonFlag === 1);
     should.equal(msgAbandonCheck, true, "Abandoning the message results in a failure");
 
     if (sessionReceiver.isOpen()) {
@@ -511,7 +511,7 @@ describe("Streaming Receiver - Defer message(with sessions)", function(): void {
       { autoComplete }
     );
 
-    const sequenceNumCheck = await DelayStreaming(() => sequenceNum !== 0);
+    const sequenceNumCheck = await delayStreaming(() => sequenceNum !== 0);
     should.equal(
       sequenceNumCheck,
       true,
@@ -639,7 +639,7 @@ describe("Streaming Receiver - Deadletter message(with sessions)", function(): v
       { autoComplete }
     );
 
-    const msgsCheck = await DelayStreaming(() => msgCount === 1);
+    const msgsCheck = await delayStreaming(() => msgCount === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -833,7 +833,7 @@ describe("Streaming Receiver - Settle an already Settled message throws error(wi
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -209,6 +209,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
     await receivedMsgs[0].complete();
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
+    should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
   }
 
   it("Disabled autoComplete, no manual complete retains the message in Partitioned Queue(with sessions)", async function(): Promise<
@@ -284,6 +285,7 @@ describe("Streaming Receiver - Complete message(with sessions)", function(): voi
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
+    should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
 
     await testPeekMsgsLength(receiverClient, 0);
   }
@@ -643,6 +645,7 @@ describe("Streaming Receiver - Deadletter message(with sessions)", function(): v
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
+    should.equal(msgCount, 1, "Unexpected number of messages");
     await testPeekMsgsLength(receiverClient, 0);
 
     const deadLetterMsgs = await deadLetterClient.getReceiver().receiveBatch(1);

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -24,7 +24,7 @@ import {
   getSenderReceiverClients,
   ClientType,
   purge,
-  delayStreaming
+  checkWithTimeout
 } from "./testUtils";
 import { Sender } from "../lib/sender";
 import { SessionReceiver } from "../lib/receiver";
@@ -130,7 +130,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -201,7 +201,7 @@ describe("Streaming Receiver - Misc Tests(with sessions)", function(): void {
       { autoComplete: false }
     );
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     await testPeekMsgsLength(receiverClient, 1);
@@ -280,7 +280,7 @@ describe("Streaming Receiver - Complete message(with sessions)", function(): voi
       { autoComplete }
     );
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -390,7 +390,7 @@ describe("Streaming Receiver - Abandon message(with sessions)", function(): void
       { autoComplete }
     );
 
-    const msgAbandonCheck = await delayStreaming(() => abandonFlag === 1);
+    const msgAbandonCheck = await checkWithTimeout(() => abandonFlag === 1);
     should.equal(msgAbandonCheck, true, "Abandoning the message results in a failure");
 
     if (sessionReceiver.isOpen()) {
@@ -511,7 +511,7 @@ describe("Streaming Receiver - Defer message(with sessions)", function(): void {
       { autoComplete }
     );
 
-    const sequenceNumCheck = await delayStreaming(() => sequenceNum !== 0);
+    const sequenceNumCheck = await checkWithTimeout(() => sequenceNum !== 0);
     should.equal(
       sequenceNumCheck,
       true,
@@ -639,7 +639,7 @@ describe("Streaming Receiver - Deadletter message(with sessions)", function(): v
       { autoComplete }
     );
 
-    const msgsCheck = await delayStreaming(() => msgCount === 1);
+    const msgsCheck = await checkWithTimeout(() => msgCount === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
@@ -833,7 +833,7 @@ describe("Streaming Receiver - Settle an already Settled message throws error(wi
       return Promise.resolve();
     }, unExpectedErrorHandler);
 
-    const msgsCheck = await delayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiverSessions.spec.ts
@@ -629,17 +629,17 @@ describe("Streaming Receiver - Deadletter message(with sessions)", function(): v
   async function testDeadletter(autoComplete: boolean): Promise<void> {
     await sender.send(testMessagesWithSessions);
 
-    const receivedMsgs: ServiceBusMessage[] = [];
+    let msgCount = 0;
     await sessionReceiver.receive(
       (msg: ServiceBusMessage) => {
-        receivedMsgs.push(msg);
+        msgCount++;
         return msg.deadLetter();
       },
       unExpectedErrorHandler,
       { autoComplete }
     );
 
-    const msgsCheck = await DelayStreaming(() => receivedMsgs.length === 1);
+    const msgsCheck = await DelayStreaming(() => msgCount === 1);
     should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -6,7 +6,8 @@ import {
   QueueClient,
   TopicClient,
   Namespace,
-  SubscriptionClient
+  SubscriptionClient,
+  delay
 } from "../lib";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { ServiceBusManagementClient } from "@azure/arm-servicebus";
@@ -382,4 +383,19 @@ export async function purge(
       await receiver.close();
     }
   }
+}
+
+// Maximum wait duration for the Streaming Receiver to receive the messages = `10000 ms`(10 seconds)(= maxWaitTime)
+// Keep checking whether the predicate is true after every `1000 ms`(1 second) (= delayBetweenRetries)
+export async function DelayStreaming(
+  predicate: () => boolean,
+  delayBetweenRetries: number = 1000,
+  maxWaitTime: number = 10000
+): Promise<boolean> {
+  const maxTime = Date.now() + maxWaitTime;
+  while (Date.now() < maxTime) {
+    if (predicate()) return true;
+    await delay(delayBetweenRetries);
+  }
+  return false;
 }

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -389,13 +389,13 @@ export async function purge(
 // Keep checking whether the predicate is true after every `1000 ms`(1 second) (= delayBetweenRetries)
 export async function delayStreaming(
   predicate: () => boolean,
-  delayBetweenRetries: number = 1000,
-  maxWaitTime: number = 10000
+  delayBetweenRetriesInMilliseconds: number = 1000,
+  maxWaitTimeInMilliseconds: number = 10000
 ): Promise<boolean> {
-  const maxTime = Date.now() + maxWaitTime;
+  const maxTime = Date.now() + maxWaitTimeInMilliseconds;
   while (Date.now() < maxTime) {
     if (predicate()) return true;
-    await delay(delayBetweenRetries);
+    await delay(delayBetweenRetriesInMilliseconds);
   }
   return false;
 }

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -387,7 +387,7 @@ export async function purge(
 
 // Maximum wait duration for the Streaming Receiver to receive the messages = `10000 ms`(10 seconds)(= maxWaitTime)
 // Keep checking whether the predicate is true after every `1000 ms`(1 second) (= delayBetweenRetries)
-export async function DelayStreaming(
+export async function delayStreaming(
   predicate: () => boolean,
   delayBetweenRetries: number = 1000,
   maxWaitTime: number = 10000

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -385,8 +385,10 @@ export async function purge(
   }
 }
 
-// Maximum wait duration for the Streaming Receiver to receive the messages = `10000 ms`(10 seconds)(= maxWaitTime)
-// Keep checking whether the predicate is true after every `1000 ms`(1 second) (= delayBetweenRetries)
+/**
+ * Maximum wait duration for the expected event to happen = `10000 ms`(default value is 10 seconds)(= maxWaitTimeInMilliseconds)
+ * Keep checking whether the predicate is true after every `1000 ms`(default value is 1 second) (= delayBetweenRetriesInMilliseconds)
+ */
 export async function delayStreaming(
   predicate: () => boolean,
   delayBetweenRetriesInMilliseconds: number = 1000,

--- a/packages/@azure/servicebus/data-plane/test/testUtils.ts
+++ b/packages/@azure/servicebus/data-plane/test/testUtils.ts
@@ -389,7 +389,7 @@ export async function purge(
  * Maximum wait duration for the expected event to happen = `10000 ms`(default value is 10 seconds)(= maxWaitTimeInMilliseconds)
  * Keep checking whether the predicate is true after every `1000 ms`(default value is 1 second) (= delayBetweenRetriesInMilliseconds)
  */
-export async function delayStreaming(
+export async function checkWithTimeout(
   predicate: () => boolean,
   delayBetweenRetriesInMilliseconds: number = 1000,
   maxWaitTimeInMilliseconds: number = 10000

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -15,7 +15,7 @@ import {
   SendableMessageInfo,
   CorrelationFilter
 } from "../lib";
-import { getSenderReceiverClients, ClientType, purge, DelayStreaming } from "./testUtils";
+import { getSenderReceiverClients, ClientType, purge, delayStreaming } from "./testUtils";
 
 // We need to remove rules before adding one because otherwise the existing default rule will let in all messages.
 async function removeAllRules(client: SubscriptionClient): Promise<void> {
@@ -133,7 +133,7 @@ async function receiveOrders(
     }
   );
 
-  const msgsCheck = await DelayStreaming(() => receivedMsgs.length === expectedMessageCount);
+  const msgsCheck = await delayStreaming(() => receivedMsgs.length === expectedMessageCount);
   should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
   await receiver.close();

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -142,6 +142,7 @@ async function receiveOrders(
     undefined,
     errorFromErrorHandler && errorFromErrorHandler.message
   );
+  should.equal(receivedMsgs.length, expectedMessageCount, "Unexpected number of messages");
 
   return receivedMsgs;
 }

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -16,7 +16,7 @@ import {
   CorrelationFilter,
   delay
 } from "../lib";
-import { getSenderReceiverClients, ClientType, purge } from "./testUtils";
+import { getSenderReceiverClients, ClientType, purge, DelayStreaming } from "./testUtils";
 
 // We need to remove rules before adding one because otherwise the existing default rule will let in all messages.
 async function removeAllRules(client: SubscriptionClient): Promise<void> {
@@ -133,9 +133,8 @@ async function receiveOrders(
     }
   );
 
-  for (let i = 0; i < 10 && receivedMsgs.length < expectedMessageCount; i++) {
-    await delay(1000);
-  }
+  const msgsCheck = await DelayStreaming(() => receivedMsgs.length === expectedMessageCount);
+  should.equal(msgsCheck, true, "Did not receive messages in time");
 
   await receiver.close();
   should.equal(

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -15,7 +15,7 @@ import {
   SendableMessageInfo,
   CorrelationFilter
 } from "../lib";
-import { getSenderReceiverClients, ClientType, purge, delayStreaming } from "./testUtils";
+import { getSenderReceiverClients, ClientType, purge, checkWithTimeout } from "./testUtils";
 
 // We need to remove rules before adding one because otherwise the existing default rule will let in all messages.
 async function removeAllRules(client: SubscriptionClient): Promise<void> {
@@ -133,7 +133,7 @@ async function receiveOrders(
     }
   );
 
-  const msgsCheck = await delayStreaming(() => receivedMsgs.length === expectedMessageCount);
+  const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === expectedMessageCount);
   should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
   await receiver.close();

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -135,7 +135,7 @@ async function receiveOrders(
   );
 
   const msgsCheck = await DelayStreaming(() => receivedMsgs.length === expectedMessageCount);
-  should.equal(msgsCheck, true, "Did not receive messages in time");
+  should.equal(msgsCheck, true, "Could not receive the messages in expected time.");
 
   await receiver.close();
   should.equal(

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -13,8 +13,7 @@ import {
   ServiceBusMessage,
   TopicClient,
   SendableMessageInfo,
-  CorrelationFilter,
-  delay
+  CorrelationFilter
 } from "../lib";
 import { getSenderReceiverClients, ClientType, purge, DelayStreaming } from "./testUtils";
 


### PR DESCRIPTION
**Issue**
https://github.com/Azure/azure-sdk-for-js/issues/1147

**Description**
- Can reuse the DelayStreaming function in all the streaming receiver tests
- Fixed number of iterations is being changed to `maxDelay`  
- `delayBetweenRetries, maxDelay` are constants and will remain same for all the tests (easier to update them if needed)
- This new function can be used anywhere (not just for streaming receiver)

All the tests in Streaming Receiver passed after the changes(local).
Thanks to @mikeharder - https://github.com/Azure/azure-sdk-for-js/issues/1147#issuecomment-461630928 .