### PR TITLE
[Service Bus] Throw error when sender/receivers are used after closing namespace

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/client.ts
+++ b/packages/@azure/servicebus/data-plane/lib/client.ts
@@ -5,6 +5,7 @@ import * as log from "./log";
 import { ConnectionContext } from "./connectionContext";
 import { ClientEntityContext } from "./clientEntityContext";
 import { AmqpError, generate_uuid } from "rhea-promise";
+import { throwErrorIfConnectionClosed } from "./util/utils";
 
 /**
  * Describes the base class for a client.
@@ -36,6 +37,7 @@ export abstract class Client {
    * Default value: SasTokenProvider.
    */
   constructor(name: string, context: ConnectionContext) {
+    throwErrorIfConnectionClosed(context);
     this.name = name;
     this.id = `${name}/${generate_uuid()}`;
     this._context = ClientEntityContext.create(name, context);

--- a/packages/@azure/servicebus/data-plane/lib/connectionContext.ts
+++ b/packages/@azure/servicebus/data-plane/lib/connectionContext.ts
@@ -27,11 +27,6 @@ export interface ConnectionContext extends ConnectionContextBase {
    * given amqp connection.
    */
   clients: Dictionary<Client>;
-
-  /**
-   * @property {boolean} wasConnectionEverOpened Indicates whether the connection was ever opened.
-   */
-  wasConnectionEverOpened: boolean;
 }
 
 export namespace ConnectionContext {
@@ -63,7 +58,6 @@ export namespace ConnectionContext {
     // Define listeners to be added to the connection object for
     // "connection_open" and "connection_error" events.
     const onConnectionOpen: OnAmqpEvent = (context: EventContext) => {
-      connectionContext.wasConnectionEverOpened = true;
       connectionContext.wasConnectionCloseCalled = false;
       log.connectionCtxt(
         "[%s] setting 'wasConnectionCloseCalled' property of connection context to %s.",

--- a/packages/@azure/servicebus/data-plane/lib/connectionContext.ts
+++ b/packages/@azure/servicebus/data-plane/lib/connectionContext.ts
@@ -27,6 +27,11 @@ export interface ConnectionContext extends ConnectionContextBase {
    * given amqp connection.
    */
   clients: Dictionary<Client>;
+
+  /**
+   * @property {boolean} wasConnectionOpened Indicates whether the connection was ever opened.
+   */
+  wasConnectionEverOpened: boolean;
 }
 
 export namespace ConnectionContext {
@@ -58,6 +63,7 @@ export namespace ConnectionContext {
     // Define listeners to be added to the connection object for
     // "connection_open" and "connection_error" events.
     const onConnectionOpen: OnAmqpEvent = (context: EventContext) => {
+      connectionContext.wasConnectionEverOpened = true;
       connectionContext.wasConnectionCloseCalled = false;
       log.connectionCtxt(
         "[%s] setting 'wasConnectionCloseCalled' property of connection context to %s.",

--- a/packages/@azure/servicebus/data-plane/lib/connectionContext.ts
+++ b/packages/@azure/servicebus/data-plane/lib/connectionContext.ts
@@ -29,7 +29,7 @@ export interface ConnectionContext extends ConnectionContextBase {
   clients: Dictionary<Client>;
 
   /**
-   * @property {boolean} wasConnectionOpened Indicates whether the connection was ever opened.
+   * @property {boolean} wasConnectionEverOpened Indicates whether the connection was ever opened.
    */
   wasConnectionEverOpened: boolean;
 }

--- a/packages/@azure/servicebus/data-plane/lib/core/batchingReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/batchingReceiver.ts
@@ -13,6 +13,7 @@ import {
   OnAmqpEventAsPromise
 } from "./messageReceiver";
 import { ClientEntityContext } from "../clientEntityContext";
+import { throwErrorIfConnectionClosed } from "../util/utils";
 
 /**
  * Describes the batching receiver where the user can receive a specified number of messages for
@@ -47,6 +48,7 @@ export class BatchingReceiver extends MessageReceiver {
    * @returns {Promise<ServiceBusMessage[]>} A promise that resolves with an array of Message objects.
    */
   receive(maxMessageCount: number, idleTimeoutInSeconds?: number): Promise<ServiceBusMessage[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!maxMessageCount || (maxMessageCount && typeof maxMessageCount !== "number")) {
       throw new Error(
         "'maxMessageCount' is a required parameter of type number with a value " + "greater than 0."
@@ -397,6 +399,7 @@ export class BatchingReceiver extends MessageReceiver {
    * @param {ReceiveOptions} [options]     Receive options.
    */
   static create(context: ClientEntityContext, options?: ReceiveOptions): BatchingReceiver {
+    throwErrorIfConnectionClosed(context.namespace);
     const bReceiver = new BatchingReceiver(context, options);
     context.batchingReceiver = bReceiver;
     return bReceiver;

--- a/packages/@azure/servicebus/data-plane/lib/core/managementClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/managementClient.ts
@@ -33,7 +33,7 @@ import {
 import { LinkEntity } from "./linkEntity";
 import * as log from "../log";
 import { ReceiveMode } from "../serviceBusMessage";
-import { reorderLockTokens, toBuffer } from "../util/utils";
+import { reorderLockTokens, toBuffer, throwErrorIfConnectionClosed } from "../util/utils";
 import { Typed } from "rhea/typings/types";
 import { max32BitNumber } from "../util/constants";
 
@@ -263,6 +263,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<ReceivedSBMessage[]>
    */
   async peek(messageCount?: number): Promise<ReceivedMessageInfo[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     return this.peekBySequenceNumber(this._lastPeekedSequenceNumber.add(1), {
       messageCount: messageCount
     });
@@ -285,6 +286,7 @@ export class ManagementClient extends LinkEntity {
     sessionId: string,
     messageCount?: number
   ): Promise<ReceivedMessageInfo[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (sessionId == undefined) {
       throw new Error("'sessionId' is a required parameter and must be of type 'string'.");
     }
@@ -304,6 +306,7 @@ export class ManagementClient extends LinkEntity {
     fromSequenceNumber: Long,
     options?: PeekOptions
   ): Promise<ReceivedMessageInfo[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!options) options = {};
     if (fromSequenceNumber == undefined || !Long.isLong(fromSequenceNumber)) {
       throw new Error(
@@ -394,6 +397,7 @@ export class ManagementClient extends LinkEntity {
     lockTokenOrMessage: string | ServiceBusMessage,
     options?: SendRequestOptions
   ): Promise<Date> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!lockTokenOrMessage) {
       throw new Error("'lockTokenOrMessage' is a required parameter.");
     }
@@ -457,6 +461,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<number> The sequence numbers of messages that were scheduled.
    */
   async scheduleMessages(messages: ScheduleMessage[]): Promise<Long[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!Array.isArray(messages)) {
       throw new Error("'messages' is a required parameter of type 'Array'.");
     }
@@ -560,6 +565,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<void>
    */
   async cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!Array.isArray(sequenceNumbers)) {
       throw new Error("'sequenceNumbers' is a required parameter of type 'Array'.");
     }
@@ -637,6 +643,7 @@ export class ManagementClient extends LinkEntity {
     receiveMode: ReceiveMode,
     sessionId?: string
   ): Promise<ServiceBusMessage | undefined> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!Long.isLong(sequenceNumber)) {
       throw new Error(
         "'sequenceNumber' is a required parameter and must be an instance of 'Long'."
@@ -664,6 +671,7 @@ export class ManagementClient extends LinkEntity {
     receiveMode: ReceiveMode,
     sessionId?: string
   ): Promise<ServiceBusMessage[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!Array.isArray(sequenceNumbers)) {
       throw new Error("'sequenceNumbers' is a required parameter and must be of type 'Array'.");
     }
@@ -775,6 +783,7 @@ export class ManagementClient extends LinkEntity {
     dispositionStatus: DispositionStatus,
     options?: DispositionStatusOptions
   ): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!Array.isArray(lockTokens)) {
       throw new Error("'lockTokens' is a required parameter and must be of type 'Array'.");
     }
@@ -842,6 +851,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<Date> New lock token expiry date and time in UTC format.
    */
   async renewSessionLock(sessionId: string, options?: SendRequestOptions): Promise<Date> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (typeof sessionId !== "string") {
       throw new Error("'sessionId' is a required parameter and must be of type 'string'.");
     }
@@ -898,6 +908,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<void>
    */
   async setSessionState(sessionId: string, state: any): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (typeof sessionId !== "string") {
       throw new Error("'sessionId' is a required parameter and must be of type 'string'.");
     }
@@ -943,6 +954,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<any> The state of that session
    */
   async getSessionState(sessionId: string): Promise<any> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (typeof sessionId !== "string") {
       throw new Error("'sessionId' is a required parameter and must be of type 'string'.");
     }
@@ -991,6 +1003,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<string[]> A list of session ids.
    */
   async listMessageSessions(skip: number, top: number, lastUpdatedTime?: Date): Promise<string[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     const defaultLastUpdatedTimeForListingSessions: number = 259200000; // 3 * 24 * 3600 * 1000
     if (typeof skip !== "number") {
       throw new Error("'skip' is a required parameter and must be of type 'number'.");
@@ -1047,6 +1060,7 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<RuleDescription[]> A list of rules.
    */
   async getRules(): Promise<RuleDescription[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     try {
       const request: AmqpMessage = {
         body: {
@@ -1170,6 +1184,7 @@ export class ManagementClient extends LinkEntity {
    * @param ruleName
    */
   async removeRule(ruleName: string): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!ruleName || typeof ruleName !== "string") {
       throw new Error("Cannot remove rule. Rule name is missing or is not a string.");
     }
@@ -1220,6 +1235,7 @@ export class ManagementClient extends LinkEntity {
     filter: boolean | string | CorrelationFilter,
     sqlRuleActionExpression?: string
   ): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!ruleName || typeof ruleName !== "string") {
       throw new Error("Cannot add rule. Rule name is missing or is not a string.");
     }
@@ -1318,6 +1334,7 @@ export class ManagementClient extends LinkEntity {
    * @ignore
    */
   private async _init(): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     try {
       if (!this._isMgmtRequestResponseLinkOpen()) {
         await this._negotiateClaim();

--- a/packages/@azure/servicebus/data-plane/lib/core/messageSender.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/messageSender.ts
@@ -28,7 +28,7 @@ import {
 import { SendableMessageInfo } from "../serviceBusMessage";
 import { ClientEntityContext } from "../clientEntityContext";
 import { LinkEntity } from "./linkEntity";
-import { getUniqueName } from "../util/utils";
+import { getUniqueName, throwErrorIfConnectionClosed } from "../util/utils";
 
 /**
  * @ignore
@@ -338,6 +338,7 @@ export class MessageSender extends LinkEntity {
    * @returns {Promise<void>}
    */
   async send(data: SendableMessageInfo): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     try {
       if (!data || (data && typeof data !== "object")) {
         throw new Error("data is required and it must be of type object.");
@@ -371,6 +372,7 @@ export class MessageSender extends LinkEntity {
    * @return {Promise<void>}
    */
   async sendBatch(datas: SendableMessageInfo[]): Promise<void> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     try {
       if (!datas || (datas && !Array.isArray(datas))) {
         throw new Error("data is required and it must be an Array.");
@@ -688,6 +690,7 @@ export class MessageSender extends LinkEntity {
    * @returns {Promise<MessageSender>}
    */
   static create(context: ClientEntityContext): MessageSender {
+    throwErrorIfConnectionClosed(context.namespace);
     if (!context.sender) {
       context.sender = new MessageSender(context);
     }

--- a/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/streamingReceiver.ts
@@ -12,6 +12,7 @@ import {
 import { ClientEntityContext } from "../clientEntityContext";
 
 import * as log from "../log";
+import { throwErrorIfConnectionClosed } from "../util/utils";
 
 /**
  * Describes the options to control receiving of messages in streaming mode.
@@ -85,6 +86,7 @@ export class StreamingReceiver extends MessageReceiver {
    * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
    */
   receive(onMessage: OnMessage, onError: OnError): void {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!onMessage || typeof onMessage !== "function") {
       throw new Error("'onMessage' is a required parameter and must be of type 'function'.");
     }
@@ -114,6 +116,7 @@ export class StreamingReceiver extends MessageReceiver {
    * @return {StreamingReceiver} An instance of StreamingReceiver.
    */
   static create(context: ClientEntityContext, options?: ReceiveOptions): StreamingReceiver {
+    throwErrorIfConnectionClosed(context.namespace);
     if (!options) options = {};
     if (options.autoComplete == undefined) options.autoComplete = true;
     const sReceiver = new StreamingReceiver(context, options);

--- a/packages/@azure/servicebus/data-plane/lib/namespace.ts
+++ b/packages/@azure/servicebus/data-plane/lib/namespace.ts
@@ -131,7 +131,8 @@ export class Namespace {
   }
 
   /**
-   * Closes the namespace, the AMQP connection and all the entities on this conenction.
+   * Closes the AMQP connection created by this namespace along with AMQP links for sender/receivers
+   * created by the queue/topic/subscription clients created in this namespace.
    * @returns {Promise<any>}
    */
   async close(): Promise<any> {

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -9,6 +9,7 @@ import { Client } from "./client";
 import { MessageSession, SessionReceiverOptions } from "./session/messageSession";
 import { Sender } from "./sender";
 import { Receiver, MessageReceiverOptions, SessionReceiver } from "./receiver";
+import { throwErrorIfConnectionClosed } from "./util/utils";
 
 /**
  * Describes the client that will maintain an AMQP connection to a ServiceBus Queue.
@@ -84,6 +85,7 @@ export class QueueClient extends Client {
    * and cancelling such scheduled messages.
    */
   getSender(): Sender {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!this._currentSender) {
       this._currentSender = new Sender(this._context);
     }
@@ -96,6 +98,7 @@ export class QueueClient extends Client {
    * @param options Options for creating the receiver.
    */
   getReceiver(options?: MessageReceiverOptions): Receiver {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!this._currentReceiver) {
       this._currentReceiver = new Receiver(this._context, options);
     }
@@ -165,6 +168,7 @@ export class QueueClient extends Client {
    * @returns SessionReceiver An instance of a SessionReceiver to receive messages from the session.
    */
   async getSessionReceiver(options?: SessionReceiverOptions): Promise<SessionReceiver> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!options) options = {};
     if (options.sessionId) {
       if (

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -34,7 +34,7 @@ export class QueueClient extends Client {
   }
 
   /**
-   * Closes the AMQP connection to the ServiceBus Queue for this client.
+   * Closes all the AMQP links for sender/receivers created by this client.
    *
    * @returns {Promise<void>}
    */

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -8,6 +8,7 @@ import { ReceiveOptions, OnError, OnMessage, ReceiverType } from "./core/message
 import { ClientEntityContext } from "./clientEntityContext";
 import { ServiceBusMessage, ReceiveMode, ReceivedMessageInfo } from "./serviceBusMessage";
 import { MessageSession, SessionMessageHandlerOptions } from "./session/messageSession";
+import { throwErrorIfConnectionClosed } from "./util/utils";
 
 /**
  * Describes the options for creating a Receiver.
@@ -33,6 +34,7 @@ export class Receiver {
   private _receiveMode: ReceiveMode;
 
   constructor(context: ClientEntityContext, options?: MessageReceiverOptions) {
+    throwErrorIfConnectionClosed(context.namespace);
     this._context = context;
     if (!options) {
       options = {};
@@ -272,6 +274,7 @@ export class SessionReceiver {
   }
 
   constructor(context: ClientEntityContext, messageSession: MessageSession) {
+    throwErrorIfConnectionClosed(context.namespace);
     this._context = context;
     this._receiveMode = messageSession.receiveMode;
     this._sessionId = messageSession.sessionId;

--- a/packages/@azure/servicebus/data-plane/lib/sender.ts
+++ b/packages/@azure/servicebus/data-plane/lib/sender.ts
@@ -7,6 +7,7 @@ import { MessageSender } from "./core/messageSender";
 import { SendableMessageInfo } from "./serviceBusMessage";
 import { ScheduleMessage } from "./core/managementClient";
 import { ClientEntityContext } from "./clientEntityContext";
+import { throwErrorIfConnectionClosed } from "./util/utils";
 
 /**
  * An abstraction over the underlying sender link.
@@ -21,6 +22,7 @@ export class Sender {
   private _context: ClientEntityContext;
 
   constructor(context: ClientEntityContext) {
+    throwErrorIfConnectionClosed(context.namespace);
     this._context = context;
   }
   /**

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -26,7 +26,11 @@ import {
 } from "../core/messageReceiver";
 import { LinkEntity } from "../core/linkEntity";
 import { ClientEntityContext } from "../clientEntityContext";
-import { convertTicksToDate, calculateRenewAfterDuration } from "../util/utils";
+import {
+  convertTicksToDate,
+  calculateRenewAfterDuration,
+  throwErrorIfConnectionClosed
+} from "../util/utils";
 import { ServiceBusMessage, DispositionType, ReceiveMode } from "../serviceBusMessage";
 import { messageDispositionTimeout } from "../util/constants";
 
@@ -516,6 +520,7 @@ export class MessageSession extends LinkEntity {
    * @returns void
    */
   receive(onMessage: OnMessage, onError: OnError, options?: SessionMessageHandlerOptions): void {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (this._isReceivingMessages) {
       throw new Error(
         `MessageSession '${this.name}' with sessionId '${this.sessionId}' is ` +
@@ -681,6 +686,7 @@ export class MessageSession extends LinkEntity {
     maxMessageCount: number,
     idleTimeoutInSeconds?: number
   ): Promise<ServiceBusMessage[]> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (this._isReceivingMessages) {
       throw new Error(
         `MessageSession '${this.name}' with sessionId '${this.sessionId}' is ` +
@@ -1176,6 +1182,7 @@ export class MessageSession extends LinkEntity {
     context: ClientEntityContext,
     options?: MessageSessionOptions
   ): Promise<MessageSession> {
+    throwErrorIfConnectionClosed(context.namespace);
     const messageSession = new MessageSession(context, options);
     await messageSession._init();
     return messageSession;

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -8,6 +8,7 @@ import { ReceivedMessageInfo } from "./serviceBusMessage";
 import { Client } from "./client";
 import { CorrelationFilter, RuleDescription } from "./core/managementClient";
 import { MessageSession, SessionReceiverOptions } from "./session/messageSession";
+import { throwErrorIfConnectionClosed } from "./util/utils";
 
 /**
  * Describes the client that will maintain an AMQP connection to a ServiceBus Subscription.
@@ -98,6 +99,7 @@ export class SubscriptionClient extends Client {
    * @param options Options for creating the receiver.
    */
   getReceiver(options?: MessageReceiverOptions): Receiver {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!this._currentReceiver) {
       this._currentReceiver = new Receiver(this._context, options);
     }
@@ -207,6 +209,7 @@ export class SubscriptionClient extends Client {
    * @returns SessionReceiver An instance of a SessionReceiver to receive messages from the session.
    */
   async getSessionReceiver(options?: SessionReceiverOptions): Promise<SessionReceiver> {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!options) options = {};
     if (options.sessionId) {
       if (

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -53,7 +53,7 @@ export class SubscriptionClient extends Client {
   }
 
   /**
-   * Closes the AMQP connection to the ServiceBus Subscription for this client.
+   * Closes the AMQP link for the receivers created by this client.
    *
    * @returns {Promise<void>}
    */

--- a/packages/@azure/servicebus/data-plane/lib/topicClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/topicClient.ts
@@ -28,7 +28,7 @@ export class TopicClient extends Client {
   }
 
   /**
-   * Closes the AMQP connection to the ServiceBus Topic for this client.
+   * Closes the AMQP link for the sender created by this client.
    *
    * @returns {Promise<void>}
    */

--- a/packages/@azure/servicebus/data-plane/lib/topicClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/topicClient.ts
@@ -5,6 +5,7 @@ import * as log from "./log";
 import { ConnectionContext } from "./connectionContext";
 import { Client } from "./client";
 import { Sender } from "./sender";
+import { throwErrorIfConnectionClosed } from "./util/utils";
 
 /**
  * Describes the client that will maintain an AMQP connection to a ServiceBus Topic.
@@ -56,6 +57,7 @@ export class TopicClient extends Client {
    * property will go to the dead letter queue of such subscriptions.
    */
   getSender(): Sender {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (!this._currentSender) {
       this._currentSender = new Sender(this._context);
     }

--- a/packages/@azure/servicebus/data-plane/lib/util/utils.ts
+++ b/packages/@azure/servicebus/data-plane/lib/util/utils.ts
@@ -181,7 +181,7 @@ export function toBuffer(input: any): Buffer {
  * @param context The ConnectionContext associated with the current AMQP connection.
  */
 export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
-  if (context && context.wasConnectionEverOpened && !context.connection.isOpen()) {
+  if (context && context.wasConnectionCloseCalled) {
     const err = new Error("The underlying AMQP connection is closed.");
     err.name = "InvalidOperationError";
     throw err;

--- a/packages/@azure/servicebus/data-plane/lib/util/utils.ts
+++ b/packages/@azure/servicebus/data-plane/lib/util/utils.ts
@@ -182,8 +182,6 @@ export function toBuffer(input: any): Buffer {
  */
 export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
   if (context && context.wasConnectionCloseCalled) {
-    const err = new Error("The underlying AMQP connection is closed.");
-    err.name = "InvalidOperationError";
-    throw err;
+    throw new Error("The underlying AMQP connection is closed.");
   }
 }

--- a/packages/@azure/servicebus/data-plane/lib/util/utils.ts
+++ b/packages/@azure/servicebus/data-plane/lib/util/utils.ts
@@ -5,6 +5,7 @@ import Long from "long";
 import * as log from "../log";
 import { generate_uuid, string_to_uuid } from "rhea-promise";
 import { isBuffer } from "util";
+import { ConnectionContext } from "../connectionContext";
 
 /**
  * A constant that indicates whether the environment is node.js or browser based.
@@ -173,4 +174,16 @@ export function toBuffer(input: any): Buffer {
   }
   log.utils("[utils.toBuffer] The converted buffer is: %O.", result);
   return result;
+}
+
+/**
+ * Throws InvalidOperationError if the current AMQP connection is closed.
+ * @param context The ConnectionContext associated with the current AMQP connection.
+ */
+export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
+  if (context && context.wasConnectionEverOpened && !context.connection.isOpen()) {
+    const err = new Error("The underlying AMQP connection is closed.");
+    err.name = "InvalidOperationError";
+    throw err;
+  }
 }

--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -357,9 +357,6 @@ describe("Errors after namespace.close()", function(): void {
     receiverType: ClientType,
     useSessions?: boolean
   ): Promise<void> {
-    // The tests in this file expect the env variables to contain the connection string and
-    // the names of empty queue/topic/subscription that are to be tested
-
     if (!process.env.SERVICEBUS_CONNECTION_STRING) {
       throw new Error(
         "Define SERVICEBUS_CONNECTION_STRING in your environment before running integration tests."

--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -342,7 +342,7 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
   });
 });
 
-describe("Errors after namespace.close()", function(): void {
+describe.only("Errors after namespace.close()", function(): void {
   const expectedErrorName = "InvalidOperationError";
   const expectedErrorMsg = "The underlying AMQP connection is closed.";
 
@@ -643,6 +643,56 @@ describe("Errors after namespace.close()", function(): void {
     await beforeEachTest(
       ClientType.PartitionedTopicWithSessions,
       ClientType.PartitionedSubscriptionWithSessions,
+      true
+    );
+
+    await testSender();
+
+    await testReceiver();
+
+    await testSessionReceiver();
+  });
+
+  it("Unpartitioned Queue: errors after namespace.close()", async function(): Promise<void> {
+    await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
+
+    await testSender();
+
+    await testReceiver();
+  });
+
+  it("Unpartitioned Queue with sessions: errors after namespace.close()", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions,
+      true
+    );
+
+    await testSender();
+
+    await testSessionReceiver();
+  });
+
+  it("Unpartitioned Topic/Subscription: errors after namespace.close()", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
+
+    await testSender();
+
+    await testReceiver();
+
+    await testRules();
+  });
+
+  it("Unpartitioned Topic/Subscription with sessions: errors after namespace.close()", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions,
       true
     );
 

--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -342,7 +342,7 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
   });
 });
 
-describe.only("Errors after namespace.close()", function(): void {
+describe("Errors after namespace.close()", function(): void {
   const expectedErrorName = "InvalidOperationError";
   const expectedErrorMsg = "The underlying AMQP connection is closed.";
 
@@ -701,5 +701,52 @@ describe.only("Errors after namespace.close()", function(): void {
     await testReceiver();
 
     await testSessionReceiver();
+  });
+
+  it("Create Queue/Topic/Subscription clients throws error after namespace.close()", async function(): Promise<
+    void
+  > {
+    // beforeEachTest() can be run for any entity type, we need it only to ensure that the
+    // connection is indeed opened
+    await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
+
+    let errorCreateQueueClient = false;
+    try {
+      namespace.createQueueClient("random-name");
+    } catch (err) {
+      errorCreateQueueClient =
+        err && err.name === expectedErrorName && err.message === expectedErrorMsg;
+    }
+    should.equal(
+      errorCreateQueueClient,
+      true,
+      "InvalidOperationError not thrown for createQueueClient()"
+    );
+
+    let errorCreateTopicClient = false;
+    try {
+      namespace.createTopicClient("random-name");
+    } catch (err) {
+      errorCreateTopicClient =
+        err && err.name === expectedErrorName && err.message === expectedErrorMsg;
+    }
+    should.equal(
+      errorCreateTopicClient,
+      true,
+      "InvalidOperationError not thrown for createTopicClient()"
+    );
+
+    let errorCreateSubscriptionClient = false;
+    try {
+      namespace.createSubscriptionClient("random-name", "random-name");
+    } catch (err) {
+      errorCreateSubscriptionClient =
+        err && err.name === expectedErrorName && err.message === expectedErrorMsg;
+    }
+    should.equal(
+      errorCreateSubscriptionClient,
+      true,
+      "InvalidOperationError not thrown for createubscriptionClient()"
+    );
   });
 });


### PR DESCRIPTION
When `namespace.close()` is called, the underlying AMQP connection is closed.
After this point, any send or receive operation results in a `OperationTimeoutError` after 60 seconds. Any creation of queue/topic/subscription client succeeds, but which is pointless as when used for send/receive, they will give `OperationTimeoutError` as well.

This PR 
- pre-empts such attempts and gives the user a more meaningful error.
- updates comments on the `close()` method to clarify exactly what is getting closed

The error being thrown has the name `InvalidOperationError` which is what the .Net SDK is using for  errors thrown directly by the .SDK when pre-empting wrongful attempts by the user.

We will use https://github.com/Azure/azure-sdk-for-js/issues/1145 to cover the discussion around standard error names