### PR TITLE
[Service Bus] Implement support for async generators

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -62,12 +62,12 @@ export class Receiver {
     onError?: OnError,
     options?: MessageHandlerOptions
   ): AsyncIterableIterator<ServiceBusMessage> | void {
-    let onMessage: OnMessage | null;
+    let onMessage: OnMessage | undefined;
 
     if (!onMessageOrOptions) {
       // called without any parameters
       options = {};
-      onMessage = null;
+      onMessage = undefined;
     } else if (typeof onMessageOrOptions === "function") {
       // called with a callback for OnMessage
       options = options || {};
@@ -75,14 +75,14 @@ export class Receiver {
     } else {
       // called with just options
       options = onMessageOrOptions;
-      onMessage = null;
+      onMessage = undefined;
     }
 
     this.validateNewReceiveCall(ReceiverType.streaming);
     const receiver = this;
 
     if (!onMessage || !onError) {
-      return (async function*() {
+      return (async function*(): AsyncIterableIterator<ServiceBusMessage> {
         while (true) {
           const [message] = await receiver.receiveBatch(1);
           yield message;

--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -85,6 +85,7 @@
     "unit": "npm run build-test && mocha -t 65000 test-dist/index.js",
     "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 65000 test-dist/index.js",
     "prepack": "npm i && npm run build",
-    "extract-api": "tsc -p . && api-extractor run --local"
+    "extract-api": "tsc -p . && api-extractor run --local",
+    "test-tsnode": "cross-env TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" mocha -t 65000 -r ts-node/register ./test/**/*.ts"
   }
 }

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -222,11 +222,8 @@ describe("Streaming - Async Iterator", function(): void {
 
   it("Partitioned Queue: receive returns an async iterator", async () => {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
-
-    sender.sendBatch([TestMessage.getSample(), TestMessage.getSample(), TestMessage.getSample()]);
-
+    await sender.sendBatch([TestMessage.getSample(), TestMessage.getSample(), TestMessage.getSample()]);
     const messages = [];
-
     for await (const message of receiver.receive()) {
       messages.push(message);
       if (messages.length === 3) {

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -215,6 +215,45 @@ describe("Streaming - Misc Tests", function(): void {
   });
 });
 
+describe("Streaming - Async Iterator", function(): void {
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  it.only("Partitioned Queue: receive returns an async iterator", async () => {
+    await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
+
+    sender.sendBatch([TestMessage.getSample(), TestMessage.getSample(), TestMessage.getSample()]);
+
+    const messages = [];
+
+    for await (const message of receiver.receive()) {
+      messages.push(message);
+      if (messages.length === 3) {
+        break;
+      }
+    }
+
+    should.equal(messages.length, 3, "receive 3 messages");
+  });
+
+  it.only("Partitioned Queue: receive with options returns an async iterator", async () => {
+    await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
+
+    sender.sendBatch([TestMessage.getSample(), TestMessage.getSample(), TestMessage.getSample()]);
+
+    const messages = [];
+    for await (const message of receiver.receive()) {
+      messages.push(message);
+      if (messages.length === 3) {
+        break;
+      }
+    }
+
+    should.equal(messages.length, 3, "receive 3 messages");
+  });
+});
+
 describe("Streaming - Complete message", function(): void {
   afterEach(async () => {
     await afterEachTest();
@@ -244,6 +283,7 @@ describe("Streaming - Complete message", function(): void {
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
     await testPeekMsgsLength(receiverClient, 0);
   }
+
   it("Partitioned Queue: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testComplete(false);

--- a/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/streamingReceiver.spec.ts
@@ -220,29 +220,13 @@ describe("Streaming - Async Iterator", function(): void {
     await afterEachTest();
   });
 
-  it.only("Partitioned Queue: receive returns an async iterator", async () => {
+  it("Partitioned Queue: receive returns an async iterator", async () => {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
 
     sender.sendBatch([TestMessage.getSample(), TestMessage.getSample(), TestMessage.getSample()]);
 
     const messages = [];
 
-    for await (const message of receiver.receive()) {
-      messages.push(message);
-      if (messages.length === 3) {
-        break;
-      }
-    }
-
-    should.equal(messages.length, 3, "receive 3 messages");
-  });
-
-  it.only("Partitioned Queue: receive with options returns an async iterator", async () => {
-    await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
-
-    sender.sendBatch([TestMessage.getSample(), TestMessage.getSample(), TestMessage.getSample()]);
-
-    const messages = [];
     for await (const message of receiver.receive()) {
       messages.push(message);
       if (messages.length === 3) {

--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -109,7 +109,7 @@ async function sendOrders(): Promise<void> {
         quantity: element.Quantity,
         priority: `${element.Priority}`
       },
-      partitionKey: "dummy" //Ensures all messages go to same parition to make peek work reliably
+      partitionKey: "dummy" // Ensures all messages go to same parition to make peek work reliably
     };
     await sender.send(message);
   }

--- a/packages/@azure/servicebus/data-plane/tsconfig.json
+++ b/packages/@azure/servicebus/data-plane/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "es6" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-
+    "lib": ["dom", "es2015", "esnext.asynciterable"],
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     "sourceMap": true /* Generates corresponding '.map' file. */,


### PR DESCRIPTION
This PR implements support for subscribing to a QTS (gonna make this a thing). I would like to see this land for track 2. It lets me write code like this:
```
    for await (const message of receiver.receive()) {
      messages.push(message);
    }
```

I added a simple test, but probably more coverage is required. A few tasks left here:

* [ ] Async generator error handling (what happens when errors are thrown during iteration)
* [ ] Async generator with options (e.g. autocomplete)
* [ ] Add sample.
* [ ] How to run tests that will only run in Node v10+?