### PR TITLE
[Service Bus] Error message when messageId is number with decimal points

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
+++ b/packages/@azure/servicebus/data-plane/lib/serviceBusMessage.ts
@@ -131,10 +131,9 @@ export interface SendableMessageInfo {
   body: any;
   /**
    * @property {string | number | Buffer} [messageId] The message identifier is an
-   * application-defined value that uniquely identifies the message and its payload. The identifier
-   * is a free-form string and can reflect a GUID or an identifier derived from the application
-   * context. If enabled, the {@link https://docs.microsoft.com/azure/service-bus-messaging/duplicate-detection duplicate detection}
-   * identifies and removes second and further submissions of messages with the same MessageId.
+   * application-defined value that uniquely identifies the message and its payload.
+   *
+   * Note: Numbers that are not whole integers are not allowed.
    */
   messageId?: string | number | Buffer;
   /**
@@ -309,6 +308,14 @@ export module SendableMessageInfo {
       !Buffer.isBuffer(msg.messageId)
     ) {
       throw new Error("'messageId' must be of type 'string' | 'number' | Buffer.");
+    }
+
+    if (
+      msg.messageId &&
+      typeof msg.messageId === "number" &&
+      Math.floor(msg.messageId) !== msg.messageId
+    ) {
+      throw new Error("'messageId must be a whole integer. Decimal points are not allowed.");
     }
 
     if (

--- a/packages/@azure/servicebus/data-plane/test/sendSchedule.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sendSchedule.spec.ts
@@ -540,3 +540,46 @@ describe("Cancel multiple Scheduled messages", function(): void {
     await testCancelScheduleMessages(true);
   });
 });
+
+describe("Message validations", function(): void {
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  it("MessageId validations", async function(): Promise<void> {
+    await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
+    const sender = senderClient.getSender();
+    let errorMessageIdDecimal = false;
+    await sender.send({ body: "", messageId: 1.5 }).catch((err) => {
+      errorMessageIdDecimal =
+        err &&
+        err.message === "'messageId must be a whole integer. Decimal points are not allowed.";
+    });
+
+    should.equal(
+      errorMessageIdDecimal,
+      true,
+      "Error not thrown when messageId is not a whole number"
+    );
+
+    let errorMessageIdLongString = false;
+    await sender
+      .send({
+        body: "",
+        messageId:
+          "A very very very very very very very very very very very very very very very very very very very very very very very very very long string."
+      })
+      .catch((err) => {
+        errorMessageIdLongString =
+          err &&
+          err.message ===
+            "Length of 'messageId' of type 'string' cannot be greater than 128 characters.";
+      });
+
+    should.equal(
+      errorMessageIdLongString,
+      true,
+      "Error not thrown when messageId is not a whole number"
+    );
+  });
+});


### PR DESCRIPTION
As seen in #1098, messageIds that are numbers with decimal points lose the decimal parts as AMQP doesnt support non integer numbers in message id.

This PR adds a error message if user ever uses such numbers.

Also added are tests to cover this error and 2 others.

Logged #1300 to extend the above tests to cover other validations on the message