### PR TITLE
[Service Bus] Wait for session expiry to check for incremented deliveryCount

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
@@ -1073,50 +1073,6 @@ describe("Batch Receiver - Others", function(): void {
     await testNoSettlement();
   });
 
-  // it("Partitioned Queue with Sessions: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(
-  //     ClientType.PartitionedQueueWithSessions,
-  //     ClientType.PartitionedQueueWithSessions,
-  //     true
-  //   );
-  //   await testNoSettlement(true);
-  // });
-
-  // it("Partitioned Subscription with Sessions: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(
-  //     ClientType.PartitionedTopicWithSessions,
-  //     ClientType.PartitionedSubscriptionWithSessions,
-  //     true
-  //   );
-  //   await testNoSettlement(true);
-  // });
-
-  // it("Unpartitioned Queue with Sessions: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(
-  //     ClientType.UnpartitionedQueueWithSessions,
-  //     ClientType.UnpartitionedQueueWithSessions,
-  //     true
-  //   );
-  //   await testNoSettlement(true);
-  // });
-
-  // it("Unpartitioned Subscription with Sessions: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
-  //   void
-  // > {
-  //   await beforeEachTest(
-  //     ClientType.UnpartitionedTopicWithSessions,
-  //     ClientType.UnpartitionedSubscriptionWithSessions,
-  //     true
-  //   );
-  //   await testNoSettlement(true);
-  // });
-
   async function testAskForMore(useSessions?: boolean): Promise<void> {
     const testMessages = useSessions ? TestMessage.getSessionSample() : TestMessage.getSample();
     await sender.send(testMessages);

--- a/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLockSessions.spec.ts
@@ -423,6 +423,7 @@ async function testBatchReceiverManualLockRenewalErrorOnLockExpiry(
   // Subsequent receivers for the same session should work as expected.
   sessionClient = await receiverClient.getSessionReceiver();
   const unprocessedMsgs = await sessionClient.receiveBatch(1);
+  should.equal(unprocessedMsgs[0].deliveryCount, 1, "Unexpected deliveryCount");
   await unprocessedMsgs[0].complete();
 }
 


### PR DESCRIPTION
We now know from the service team that the expectation that the second delivery of a message (after not being settled the first time) will have its deliveryCount incremented in session enabled queues/subscriptions is only true if the session lock expired the first time.

Therefore, moved the test for incremented deliveryCount to `renewLockSessions.spec.ts` file as we already wait for session lock expiry there