### PR TITLE
[Service Bus] Ensure to wait until msg is settled in streaming receiver tests

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/topicFilters.spec.ts
@@ -124,8 +124,9 @@ async function receiveOrders(
   const receiver = client.getReceiver();
   receiver.receive(
     (msg: ServiceBusMessage) => {
-      receivedMsgs.push(msg);
-      return Promise.resolve();
+      return msg.complete().then(() => {
+        receivedMsgs.push(msg);
+      });
     },
     (err: Error) => {
       if (err) {


### PR DESCRIPTION
This PR updates tests that use the streaming receiver as per #1307