### PR TITLE
[Service Bus] Update env vars for ServiceBus live tests

### DIFF
--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -34,7 +34,7 @@ jobs:
       - task: Npm@1
         inputs:
           command: 'custom'
-          customCommand: 'run live-test-client -- -- -- --reporter mocha-junit-reporter'
+          customCommand: 'run live-test-client -- -- -- --reporter mocha-junit-reporter -f "Batch Receiver - Settle message Partitioned Queue: complete() removes message"'
         displayName: 'npm run live-test-client'
         env:
           AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
           AAD_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-          AAD_SERVICEBUS_SECRET: $(aad-azure-sdk-test-client-id)
+          AAD_SERVICEBUS_SECRET: $(aad-azure-sdk-test-client-secret)
           AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
           CLEAN_NAMESPACE: 'true'
           RESOURCE_GROUP: $(service-bus-test-resource-group)

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -37,7 +37,13 @@ jobs:
           customCommand: 'run live-test-client -- -- -- --reporter mocha-junit-reporter'
         displayName: 'npm run live-test-client'
         env:
-          SERVICEBUS_CONNECTION_STRING: $(js-service-bus-test-connection-string)
+          AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+          AAD_TENANT_ID: $(aad-azure-sdk-test-client-id)
+          AAD_SERVICEBUS_SECRET: $(aad-azure-sdk-test-client-id)
+          AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
+          CLEAN_NAMESPACE: 'true'
+          RESOURCE_GROUP: $(service-bus-test-resource-group)
+          SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
 
       - task: PublishTestResults@2
         inputs:

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -38,7 +38,7 @@ jobs:
         displayName: 'npm run live-test-client'
         env:
           AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-          AAD_TENANT_ID: $(aad-azure-sdk-test-client-id)
+          AAD_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
           AAD_SERVICEBUS_SECRET: $(aad-azure-sdk-test-client-id)
           AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
           CLEAN_NAMESPACE: 'true'

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -34,7 +34,7 @@ jobs:
       - task: Npm@1
         inputs:
           command: 'custom'
-          customCommand: 'run live-test-client -- -- -- --reporter mocha-junit-reporter -f "Batch Receiver - Settle message Partitioned Queue: complete() removes message"'
+          customCommand: 'run live-test-client -- -- -- --reporter mocha-junit-reporter'
         displayName: 'npm run live-test-client'
         env:
           AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
@@ -126,7 +126,7 @@ describe("Batch Receiver - Settle message", function(): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: complete() removes message", async function(): Promise<void> {
+  it.only("Partitioned Queue: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testComplete();
   });

--- a/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/batchReceiver.spec.ts
@@ -126,7 +126,7 @@ describe("Batch Receiver - Settle message", function(): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it.only("Partitioned Queue: complete() removes message", async function(): Promise<void> {
+  it("Partitioned Queue: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testComplete();
   });


### PR DESCRIPTION
- Allows resources to be created and deleted directly by the tests
- Fixes #1196 

Build running single test to verify env vars: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5508