### PR TITLE
Write live test results in realtime

### DIFF
--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -31,6 +31,8 @@ jobs:
           customCommand: 'run install-client'
         displayName: 'npm run install-client'
 
+      # Task "Npm@1" currently buffers output (https://github.com/Microsoft/azure-pipelines-tasks/issues/8171)
+      # Use "script" as a workaround since it does not buffer
       - script: npm run live-test-client -- -- -- --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-
         displayName: 'npm run live-test-client'
         env:

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -31,8 +31,8 @@ jobs:
           customCommand: 'run install-client'
         displayName: 'npm run install-client'
 
-      # Task "Npm@1" currently buffers output (https://github.com/Microsoft/azure-pipelines-tasks/issues/8171)
-      # Use "script" as a workaround since it does not buffer
+      # To get realtime logging of test progress in Azure Pipelines, we need to use "script" instead of "Npm@1",
+      # since "Npm@1" currently buffers output (https://github.com/Microsoft/azure-pipelines-tasks/issues/8171).
       - script: npm run live-test-client -- -- -- --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-
         displayName: 'npm run live-test-client'
         env:

--- a/.azure-pipelines/client.test.live.yml
+++ b/.azure-pipelines/client.test.live.yml
@@ -31,10 +31,7 @@ jobs:
           customCommand: 'run install-client'
         displayName: 'npm run install-client'
 
-      - task: Npm@1
-        inputs:
-          command: 'custom'
-          customCommand: 'run live-test-client -- -- -- --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-'
+      - script: npm run live-test-client -- -- -- --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-
         displayName: 'npm run live-test-client'
         env:
           AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)


### PR DESCRIPTION
- Task "Npm@1" currently buffers output
  - https://github.com/Microsoft/azure-pipelines-tasks/issues/8171
- Use "script" as a workaround since it does not buffer
- Fixes #1325

Verification build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5640