### PR TITLE
[Service Bus] Allow running individual tests without setting up AAD creds

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -349,7 +349,6 @@ describe("Test createFromAadTokenCredentials", function(): void {
   const serviceBusEndpoint = (process.env.SERVICEBUS_CONNECTION_STRING.match(
     "Endpoint=sb://((.*).servicebus.windows.net)"
   ) || "")[1];
-  const env = getEnvVars();
 
   async function testCreateFromAadTokenCredentials(host: string, tokenCreds: any): Promise<void> {
     const testMessages = TestMessage.getSample();
@@ -372,6 +371,7 @@ describe("Test createFromAadTokenCredentials", function(): void {
   }
 
   it("throws error for an invalid host", async function(): Promise<void> {
+    const env = getEnvVars();
     tokenCreds = await loginWithServicePrincipalSecret(
       env.clientId,
       env.clientSecret,
@@ -404,6 +404,7 @@ describe("Test createFromAadTokenCredentials", function(): void {
   });
 
   it("sends a message to the ServiceBus entity", async function(): Promise<void> {
+    const env = getEnvVars();
     tokenCreds = await loginWithServicePrincipalSecret(
       env.clientId,
       env.clientSecret,


### PR DESCRIPTION
Currently, we are not able to run individual tests due to the newly added test `createFromAadTokenCredentials`

This PR updates the test such that other tests can be run with the `.only` tag