### PR TITLE
[Service Bus] Throw error when sender/receivers are used after they are closed or after clients are closed

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/client.ts
+++ b/packages/@azure/servicebus/data-plane/lib/client.ts
@@ -23,7 +23,7 @@ export abstract class Client {
    */
   id: string;
   /**
-   * @property {boolean} _isClosed Denotes whether the close() function has been called.
+   * @property {boolean} _isClosed Denotes if close() was called on this client.
    */
   protected _isClosed: boolean = false;
   /**

--- a/packages/@azure/servicebus/data-plane/lib/client.ts
+++ b/packages/@azure/servicebus/data-plane/lib/client.ts
@@ -23,6 +23,10 @@ export abstract class Client {
    */
   id: string;
   /**
+   * @property {boolean} _isClosed Denotes whether the close() function has been called.
+   */
+  protected _isClosed: boolean = false;
+  /**
    * @property {ClientEntityContext} _context Describes the amqp connection context for the QueueClient.
    */
   protected _context: ClientEntityContext;

--- a/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
+++ b/packages/@azure/servicebus/data-plane/lib/clientEntityContext.ts
@@ -217,7 +217,7 @@ export namespace ClientEntityContext {
       }
       let isManagementClientInUse = false;
       for (const id of Object.keys(context.clients)) {
-        if (context.clients[id].name === name) {
+        if (context.clients[id].name === entityContext.entityPath) {
           isManagementClientInUse = true;
           break;
         }

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -33,6 +33,10 @@ export class Receiver {
   private _context: ClientEntityContext;
   private _receiveMode: ReceiveMode;
   private _isClosed: boolean = false;
+
+  /**
+   * Denotes if close() was called on this receiver.
+   */
   public get isClosed(): boolean {
     return this._isClosed;
   }
@@ -277,6 +281,13 @@ export class SessionReceiver {
   private _messageSession: MessageSession;
 
   /**
+   * Denotes if close() was called on this receiver.
+   */
+  public get isClosed(): boolean {
+    return !this._context.messageSessions[this.sessionId];
+  }
+
+  /**
    * @property {string} [sessionId] The sessionId for the message session.
    */
   public get sessionId(): string {
@@ -486,7 +497,7 @@ export class SessionReceiver {
 
   private throwIfReceiverOrConnectionClosed() {
     throwErrorIfConnectionClosed(this._context.namespace);
-    if (!this._context.messageSessions[this.sessionId]) {
+    if (this.isClosed) {
       throw new Error("The receiver has been closed and can no longer be used.");
     }
   }

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -32,6 +32,10 @@ export class Receiver {
    */
   private _context: ClientEntityContext;
   private _receiveMode: ReceiveMode;
+  private _isClosed: boolean = false;
+  public get isClosed(): boolean {
+    return this._isClosed;
+  }
 
   constructor(context: ClientEntityContext, options?: MessageReceiverOptions) {
     throwErrorIfConnectionClosed(context.namespace);
@@ -58,6 +62,7 @@ export class Receiver {
    * @returns void
    */
   receive(onMessage: OnMessage, onError: OnError, options?: MessageHandlerOptions): void {
+    throwIfReceiverClosed(this);
     this.validateNewReceiveCall(ReceiverType.streaming);
 
     if (!options) options = {};
@@ -87,6 +92,7 @@ export class Receiver {
     maxMessageCount: number,
     idleTimeoutInSeconds?: number
   ): Promise<ServiceBusMessage[]> {
+    throwIfReceiverClosed(this);
     this.validateNewReceiveCall(ReceiverType.batching);
 
     if (!this._context.batchingReceiver || !this._context.batchingReceiver.isOpen()) {
@@ -127,6 +133,7 @@ export class Receiver {
    * @returns Promise<Date> - New lock token expiry date and time in UTC format.
    */
   async renewLock(lockTokenOrMessage: string | ServiceBusMessage): Promise<Date> {
+    throwIfReceiverClosed(this);
     if (this._receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
@@ -142,6 +149,7 @@ export class Receiver {
    * - Throws an error if the message has not been deferred.
    */
   async receiveDeferredMessage(sequenceNumber: Long): Promise<ServiceBusMessage | undefined> {
+    throwIfReceiverClosed(this);
     if (this._receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
@@ -160,6 +168,7 @@ export class Receiver {
    * - Throws an error if the messages have not been deferred.
    */
   async receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ServiceBusMessage[]> {
+    throwIfReceiverClosed(this);
     if (this._receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
@@ -190,6 +199,7 @@ export class Receiver {
         // Make sure that we clear the map of deferred messages
         this._context.requestResponseLockedMessages.clear();
       }
+      this._isClosed = true;
     } catch (err) {
       const msg =
         `An error occurred while closing the receiver for` +
@@ -258,6 +268,10 @@ export class SessionReceiver {
   private _receiveMode: ReceiveMode;
   private _sessionId: string | undefined;
   private _messageSession: MessageSession;
+  private _isClosed: boolean = false;
+  public get isClosed(): boolean {
+    return this._isClosed;
+  }
 
   /**
    * @property {string} [sessionId] The sessionId for the message session.
@@ -286,6 +300,7 @@ export class SessionReceiver {
    * @returns Promise<Date> New lock token expiry date and time in UTC format.
    */
   async renewLock(): Promise<Date> {
+    throwIfReceiverClosed(this);
     this._messageSession.sessionLockedUntilUtc = await this._context.managementClient!.renewSessionLock(
       this.sessionId!
     );
@@ -297,6 +312,7 @@ export class SessionReceiver {
    * @param state The state that needs to be set.
    */
   async setState(state: any): Promise<void> {
+    throwIfReceiverClosed(this);
     return this._context.managementClient!.setSessionState(this.sessionId!, state);
   }
 
@@ -305,6 +321,7 @@ export class SessionReceiver {
    * @returns Promise<any> The state of that session
    */
   async getState(): Promise<any> {
+    throwIfReceiverClosed(this);
     return this._context.managementClient!.getSessionState(this.sessionId!);
   }
 
@@ -320,6 +337,7 @@ export class SessionReceiver {
    * @returns Promise<ReceivedMessageInfo[]>
    */
   async peek(messageCount?: number): Promise<ReceivedMessageInfo[]> {
+    throwIfReceiverClosed(this);
     return this._context.managementClient!.peekMessagesBySession(this.sessionId!, messageCount);
   }
 
@@ -338,6 +356,7 @@ export class SessionReceiver {
     fromSequenceNumber: Long,
     messageCount?: number
   ): Promise<ReceivedMessageInfo[]> {
+    throwIfReceiverClosed(this);
     return this._context.managementClient!.peekBySequenceNumber(fromSequenceNumber, {
       sessionId: this.sessionId!,
       messageCount: messageCount
@@ -353,6 +372,7 @@ export class SessionReceiver {
    * - Throws an error if the message has not been deferred.
    */
   async receiveDeferredMessage(sequenceNumber: Long): Promise<ServiceBusMessage | undefined> {
+    throwIfReceiverClosed(this);
     if (this._receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
@@ -372,6 +392,7 @@ export class SessionReceiver {
    * - Throws an error if the messages have not been deferred.
    */
   async receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ServiceBusMessage[]> {
+    throwIfReceiverClosed(this);
     if (this._receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
@@ -397,6 +418,7 @@ export class SessionReceiver {
     maxMessageCount: number,
     maxWaitTimeInSeconds?: number
   ): Promise<ServiceBusMessage[]> {
+    throwIfReceiverClosed(this);
     try {
       return await this._messageSession.receiveBatch(maxMessageCount, maxWaitTimeInSeconds);
     } catch (err) {
@@ -428,6 +450,7 @@ export class SessionReceiver {
    * @returns void
    */
   receive(onMessage: OnMessage, onError: OnError, options?: SessionMessageHandlerOptions): void {
+    throwIfReceiverClosed(this);
     return this._messageSession.receive(onMessage, onError, options);
   }
 
@@ -438,7 +461,8 @@ export class SessionReceiver {
    */
   async close(): Promise<void> {
     try {
-      return await this._messageSession.close();
+      await this._messageSession.close();
+      this._isClosed = true;
     } catch (err) {
       log.error(
         "[%s] An error occurred while closing the message session with id '%s': %O.",
@@ -456,5 +480,11 @@ export class SessionReceiver {
    */
   isOpen(): boolean {
     return this._messageSession.isOpen();
+  }
+}
+
+function throwIfReceiverClosed(receiver: Receiver | SessionReceiver) {
+  if (receiver.isClosed) {
+    throw new Error("The receiver has been closed and can no longer be used.");
   }
 }

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -275,10 +275,6 @@ export class SessionReceiver {
   private _receiveMode: ReceiveMode;
   private _sessionId: string | undefined;
   private _messageSession: MessageSession;
-  private _isClosed: boolean = false;
-  public get isClosed(): boolean {
-    return this._isClosed;
-  }
 
   /**
    * @property {string} [sessionId] The sessionId for the message session.
@@ -469,7 +465,6 @@ export class SessionReceiver {
   async close(): Promise<void> {
     try {
       await this._messageSession.close();
-      this._isClosed = true;
     } catch (err) {
       log.error(
         "[%s] An error occurred while closing the message session with id '%s': %O.",
@@ -491,7 +486,7 @@ export class SessionReceiver {
 
   private throwIfReceiverOrConnectionClosed() {
     throwErrorIfConnectionClosed(this._context.namespace);
-    if (this.isClosed) {
+    if (!this._context.messageSessions[this.sessionId]) {
       throw new Error("The receiver has been closed and can no longer be used.");
     }
   }

--- a/packages/@azure/servicebus/data-plane/lib/sender.ts
+++ b/packages/@azure/servicebus/data-plane/lib/sender.ts
@@ -23,7 +23,7 @@ export class Sender {
   private _isClosed: boolean = false;
 
   /**
-   * Denotes if the sender was explicitly closed.
+   * Denotes if close() was called on this sender.
    */
   public get isClosed(): boolean {
     return this._isClosed;

--- a/packages/@azure/servicebus/data-plane/lib/sender.ts
+++ b/packages/@azure/servicebus/data-plane/lib/sender.ts
@@ -20,6 +20,14 @@ export class Sender {
    * @property {ClientEntityContext} _context Describes the amqp connection context for the Client.
    */
   private _context: ClientEntityContext;
+  private _isClosed: boolean = false;
+
+  /**
+   * Denotes if the sender was explicitly closed.
+   */
+  public get isClosed(): boolean {
+    return this._isClosed;
+  }
 
   constructor(context: ClientEntityContext) {
     throwErrorIfConnectionClosed(context.namespace);
@@ -35,6 +43,7 @@ export class Sender {
    * @returns Promise<void>
    */
   async send(message: SendableMessageInfo): Promise<void> {
+    this.throwIfSenderClosed();
     const sender = MessageSender.create(this._context);
     return sender.send(message);
   }
@@ -52,6 +61,7 @@ export class Sender {
    * @return Promise<void>
    */
   async sendBatch(messages: SendableMessageInfo[]): Promise<void> {
+    this.throwIfSenderClosed();
     const sender = MessageSender.create(this._context);
     return sender.sendBatch(messages);
   }
@@ -70,6 +80,7 @@ export class Sender {
     scheduledEnqueueTimeUtc: Date,
     message: SendableMessageInfo
   ): Promise<Long> {
+    this.throwIfSenderClosed();
     const scheduleMessages: ScheduleMessage[] = [
       { message: message, scheduledEnqueueTimeUtc: scheduledEnqueueTimeUtc }
     ];
@@ -91,6 +102,7 @@ export class Sender {
     scheduledEnqueueTimeUtc: Date,
     messages: SendableMessageInfo[]
   ): Promise<Long[]> {
+    this.throwIfSenderClosed();
     const scheduleMessages: ScheduleMessage[] = messages.map((message) => {
       return {
         message,
@@ -106,6 +118,7 @@ export class Sender {
    * @returns Promise<void>
    */
   async cancelScheduledMessage(sequenceNumber: Long): Promise<void> {
+    this.throwIfSenderClosed();
     return this._context.managementClient!.cancelScheduledMessages([sequenceNumber]);
   }
 
@@ -115,6 +128,7 @@ export class Sender {
    * @returns Promise<void>
    */
   async cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void> {
+    this.throwIfSenderClosed();
     return this._context.managementClient!.cancelScheduledMessages(sequenceNumbers);
   }
 
@@ -132,12 +146,19 @@ export class Sender {
       ) {
         await this._context.sender.close();
       }
+      this._isClosed = true;
     } catch (err) {
       const msg =
         `An error occurred while closing the sender for` +
         `"${this._context.entityPath}": ${JSON.stringify(err)} `;
       log.error(msg);
       throw new Error(msg);
+    }
+  }
+
+  private throwIfSenderClosed(): void {
+    if (this._isClosed) {
+      throw new Error("The sender has been closed and can no longer be used.");
     }
   }
 }

--- a/packages/@azure/servicebus/data-plane/lib/sender.ts
+++ b/packages/@azure/servicebus/data-plane/lib/sender.ts
@@ -43,7 +43,7 @@ export class Sender {
    * @returns Promise<void>
    */
   async send(message: SendableMessageInfo): Promise<void> {
-    this.throwIfSenderClosed();
+    this.throwIfSenderOrConnectionClosed();
     const sender = MessageSender.create(this._context);
     return sender.send(message);
   }
@@ -61,7 +61,7 @@ export class Sender {
    * @return Promise<void>
    */
   async sendBatch(messages: SendableMessageInfo[]): Promise<void> {
-    this.throwIfSenderClosed();
+    this.throwIfSenderOrConnectionClosed();
     const sender = MessageSender.create(this._context);
     return sender.sendBatch(messages);
   }
@@ -80,7 +80,7 @@ export class Sender {
     scheduledEnqueueTimeUtc: Date,
     message: SendableMessageInfo
   ): Promise<Long> {
-    this.throwIfSenderClosed();
+    this.throwIfSenderOrConnectionClosed();
     const scheduleMessages: ScheduleMessage[] = [
       { message: message, scheduledEnqueueTimeUtc: scheduledEnqueueTimeUtc }
     ];
@@ -102,7 +102,7 @@ export class Sender {
     scheduledEnqueueTimeUtc: Date,
     messages: SendableMessageInfo[]
   ): Promise<Long[]> {
-    this.throwIfSenderClosed();
+    this.throwIfSenderOrConnectionClosed();
     const scheduleMessages: ScheduleMessage[] = messages.map((message) => {
       return {
         message,
@@ -118,7 +118,7 @@ export class Sender {
    * @returns Promise<void>
    */
   async cancelScheduledMessage(sequenceNumber: Long): Promise<void> {
-    this.throwIfSenderClosed();
+    this.throwIfSenderOrConnectionClosed();
     return this._context.managementClient!.cancelScheduledMessages([sequenceNumber]);
   }
 
@@ -128,7 +128,7 @@ export class Sender {
    * @returns Promise<void>
    */
   async cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void> {
-    this.throwIfSenderClosed();
+    this.throwIfSenderOrConnectionClosed();
     return this._context.managementClient!.cancelScheduledMessages(sequenceNumbers);
   }
 
@@ -156,7 +156,8 @@ export class Sender {
     }
   }
 
-  private throwIfSenderClosed(): void {
+  private throwIfSenderOrConnectionClosed(): void {
+    throwErrorIfConnectionClosed(this._context.namespace);
     if (this._isClosed) {
       throw new Error("The sender has been closed and can no longer be used.");
     }

--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -417,9 +417,7 @@ describe("Test createFromAadTokenCredentials", function(): void {
   });
 });
 
-describe("Errors after namespace.close()", function(): void {
-  const expectedErrorMsg = "The underlying AMQP connection is closed.";
-
+describe("Errors after close()", function(): void {
   let namespace: Namespace;
   let senderClient: QueueClient | TopicClient;
   let receiverClient: QueueClient | SubscriptionClient;
@@ -429,6 +427,7 @@ describe("Errors after namespace.close()", function(): void {
   async function beforeEachTest(
     senderType: ClientType,
     receiverType: ClientType,
+    entityToClose: string,
     useSessions?: boolean
   ): Promise<void> {
     if (!process.env.SERVICEBUS_CONNECTION_STRING) {
@@ -464,137 +463,156 @@ describe("Errors after namespace.close()", function(): void {
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages received");
     await receivedMsgs[0].complete();
 
-    // Close namespace, so that we can then test the InvalidOperationError error.
-    await namespace.close();
+    // close(), so that we can then test the resulting error.
+    switch (entityToClose) {
+      case "namespace":
+        await namespace.close();
+        break;
+      case "senderClient":
+        await senderClient.close();
+        break;
+      case "receiverClient":
+        await receiverClient.close();
+        break;
+      case "sender":
+        await sender.close();
+        break;
+      case "receiver":
+        await receiver.close();
+        break;
+      default:
+        break;
+    }
   }
 
   /**
-   * Tests that each feature of the sender client throws expected error
+   * Tests that each feature of the sender throws expected error
    */
-  async function testSender(): Promise<void> {
+  async function testSender(expectedErrorMsg: string): Promise<void> {
     const testMessage = TestMessage.getSample();
-    let errorSend = false;
+    let errorSend: string = "";
     await sender.send(testMessage).catch((err) => {
-      errorSend = err && err.message === expectedErrorMsg;
+      errorSend = err.message;
     });
-    should.equal(errorSend, true, "InvalidOperationError not thrown for send()");
+    should.equal(errorSend, expectedErrorMsg, "Expected error not thrown for send()");
 
-    let errorSendBatch = false;
+    let errorSendBatch: string = "";
     await sender.sendBatch([testMessage]).catch((err) => {
-      errorSendBatch = err && err.message === expectedErrorMsg;
+      errorSendBatch = err.message;
     });
-    should.equal(errorSendBatch, true, "InvalidOperationError not thrown for sendBatch()");
+    should.equal(errorSendBatch, expectedErrorMsg, "Expected error not thrown for sendBatch()");
 
-    let errorScheduleMsg = false;
+    let errorScheduleMsg: string = "";
     await sender.scheduleMessage(new Date(Date.now() + 30000), testMessage).catch((err) => {
-      errorScheduleMsg = err && err.message === expectedErrorMsg;
+      errorScheduleMsg = err.message;
     });
-    should.equal(errorScheduleMsg, true, "InvalidOperationError not thrown for scheduleMessage()");
+    should.equal(
+      errorScheduleMsg,
+      expectedErrorMsg,
+      "Expected error not thrown for scheduleMessage()"
+    );
 
-    let errorScheduleMsgs = false;
+    let errorScheduleMsgs: string = "";
     await sender.scheduleMessages(new Date(Date.now() + 30000), [testMessage]).catch((err) => {
-      errorScheduleMsgs = err && err.message === expectedErrorMsg;
+      errorScheduleMsgs = err.message;
     });
     should.equal(
       errorScheduleMsgs,
-      true,
-      "InvalidOperationError not thrown for scheduleMessages()"
+      expectedErrorMsg,
+      "Expected error not thrown for scheduleMessages()"
     );
 
-    let errorCancelMsg = false;
+    let errorCancelMsg: string = "";
     await sender.cancelScheduledMessage(long.ZERO).catch((err) => {
-      errorCancelMsg = err && err.message === expectedErrorMsg;
+      errorCancelMsg = err.message;
     });
     should.equal(
       errorCancelMsg,
-      true,
-      "InvalidOperationError not thrown for cancelScheduledMessage()"
+      expectedErrorMsg,
+      "Expected error not thrown for cancelScheduledMessage()"
     );
 
-    let errorCancelMsgs = false;
+    let errorCancelMsgs: string = "";
     await sender.cancelScheduledMessages([long.ZERO]).catch((err) => {
-      errorCancelMsgs = err && err.message === expectedErrorMsg;
+      errorCancelMsgs = err.message;
     });
     should.equal(
       errorCancelMsgs,
-      true,
-      "InvalidOperationError not thrown for cancelScheduledMessages()"
+      expectedErrorMsg,
+      "Expected error not thrown for cancelScheduledMessages()"
     );
-
-    let errorNewSender = false;
-    try {
-      senderClient.getSender();
-    } catch (err) {
-      errorNewSender = err && err.message === expectedErrorMsg;
-    }
-    should.equal(errorNewSender, true, "InvalidOperationError not thrown for getSender()");
   }
 
   /**
-   * Tests that each feature of the receiver client throws expected error
+   * Tests that each feature of the senderClient throws expected error
    */
-  async function testReceiver(useSessions?: boolean): Promise<void> {
-    let errorPeek = false;
-    await receiverClient.peek().catch((err) => {
-      errorPeek = err && err.message === expectedErrorMsg;
-    });
-    should.equal(
-      errorPeek,
-      true,
-      "InvalidOperationError not thrown for peek() from receiverClient"
-    );
+  async function testSenderClient(expectedErrorMsg: string): Promise<void> {
+    let errorNewSender: string = "";
+    try {
+      senderClient.getSender();
+    } catch (err) {
+      errorNewSender = err.message;
+    }
+    should.equal(errorNewSender, expectedErrorMsg, "Expected error not thrown for getSender()");
+  }
 
-    let errorPeekBySequence = false;
-    await receiverClient.peekBySequenceNumber(long.ZERO).catch((err) => {
-      errorPeekBySequence = err && err.message === expectedErrorMsg;
-    });
-    should.equal(
-      errorPeekBySequence,
-      true,
-      "InvalidOperationError not thrown for peekBySequenceNumber() from receiverClient"
-    );
-
-    let errorReceiveBatch = false;
+  /**
+   * Tests that each feature of the receiver throws expected error
+   */
+  async function testReceiver(expectedErrorMsg: string, useSessions?: boolean): Promise<void> {
+    let errorReceiveBatch: string = "";
     await receiver.receiveBatch(1, 1).catch((err) => {
-      errorReceiveBatch = err && err.message === expectedErrorMsg;
+      errorReceiveBatch = err.message;
     });
-    should.equal(errorReceiveBatch, true, "InvalidOperationError not thrown for receiveBatch()");
+    should.equal(
+      errorReceiveBatch,
+      expectedErrorMsg,
+      "Expected error not thrown for receiveBatch()"
+    );
 
-    let errorReceiveStream = false;
+    let errorReceiveStream: string = "";
     try {
       receiver.receive(() => Promise.resolve(), (e) => console.log(e));
     } catch (err) {
-      errorReceiveStream = err && err.message === expectedErrorMsg;
+      errorReceiveStream = err.message;
     }
-    should.equal(errorReceiveStream, true, "InvalidOperationError not thrown for receive()");
+    should.equal(errorReceiveStream, expectedErrorMsg, "Expected error not thrown for receive()");
 
-    let errorDeferredMsg = false;
+    let errorDeferredMsg: string = "";
     await receiver.receiveDeferredMessage(long.ZERO).catch((err) => {
-      errorDeferredMsg = err && err.message === expectedErrorMsg;
+      errorDeferredMsg = err.message;
     });
     should.equal(
       errorDeferredMsg,
-      true,
-      "InvalidOperationError not thrown for receiveDeferredMessage()"
+      expectedErrorMsg,
+      "Expected error not thrown for receiveDeferredMessage()"
     );
 
-    let errorDeferredMsgs = false;
+    let errorDeferredMsgs: string = "";
     await receiver.receiveDeferredMessage(long.ZERO).catch((err) => {
-      errorDeferredMsgs = err && err.message === expectedErrorMsg;
+      errorDeferredMsgs = err.message;
     });
     should.equal(
       errorDeferredMsgs,
-      true,
-      "InvalidOperationError not thrown for receiveDeferredMessages()"
+      expectedErrorMsg,
+      "Expected error not thrown for receiveDeferredMessages()"
     );
 
-    let errorRenewLock = false;
+    let errorRenewLock: string = "";
     await receiver.renewLock("randomLockToken").catch((err) => {
-      errorRenewLock = err && err.message === expectedErrorMsg;
+      errorRenewLock = err.message;
     });
-    should.equal(errorRenewLock, true, "InvalidOperationError not thrown for renewLock()");
+    should.equal(errorRenewLock, expectedErrorMsg, "Expected error not thrown for renewLock()");
+  }
 
-    let errorNewReceiver = false;
+  /**
+   * Tests that each feature of the receiverClient throws expected error
+   */
+  async function testReceiverClient(
+    expectedErrorMsg: string,
+    useSessions?: boolean
+  ): Promise<void> {
+    let errorNewReceiver: string = "";
     try {
       useSessions
         ? await receiverClient.getSessionReceiver({
@@ -602,217 +620,684 @@ describe("Errors after namespace.close()", function(): void {
           })
         : receiverClient.getReceiver();
     } catch (err) {
-      errorNewReceiver = err && err.message === expectedErrorMsg;
+      errorNewReceiver = err.message;
     }
-    should.equal(errorNewReceiver, true, "InvalidOperationError not thrown for getReceiver()");
+    should.equal(errorNewReceiver, expectedErrorMsg, "Expected error not thrown for getReceiver()");
+
+    let errorPeek: string = "";
+    await receiverClient.peek().catch((err) => {
+      errorPeek = err.message;
+    });
+    should.equal(
+      errorPeek,
+      expectedErrorMsg,
+      "Expected error not thrown for peek() from receiverClient"
+    );
+
+    let errorPeekBySequence: string = "";
+    await receiverClient.peekBySequenceNumber(long.ZERO).catch((err) => {
+      errorPeekBySequence = err.message;
+    });
+    should.equal(
+      errorPeekBySequence,
+      expectedErrorMsg,
+      "Expected error not thrown for peekBySequenceNumber() from receiverClient"
+    );
   }
 
   /**
    * Tests that each feature of the receiver client with sessions throws expected error
    */
-  async function testSessionReceiver(): Promise<void> {
-    await testReceiver(true);
+  async function testSessionReceiver(expectedErrorMsg: string): Promise<void> {
+    await testReceiver(expectedErrorMsg, true);
     const sessionReceiver = receiver as SessionReceiver;
 
-    let errorPeek = false;
+    let errorPeek: string = "";
     await sessionReceiver.peek().catch((err) => {
-      errorPeek = err && err.message === expectedErrorMsg;
+      errorPeek = err.message;
     });
     should.equal(
       errorPeek,
-      true,
-      "InvalidOperationError not thrown for peek() from sessionReceiver"
+      expectedErrorMsg,
+      "Expected error not thrown for peek() from sessionReceiver"
     );
 
-    let errorPeekBySequence = false;
+    let errorPeekBySequence: string = "";
     await sessionReceiver.peekBySequenceNumber(long.ZERO).catch((err) => {
-      errorPeekBySequence = err && err.message === expectedErrorMsg;
+      errorPeekBySequence = err.message;
     });
     should.equal(
       errorPeekBySequence,
-      true,
-      "InvalidOperationError not thrown for peekBySequenceNumber() from sessionReceiver"
+      expectedErrorMsg,
+      "Expected error not thrown for peekBySequenceNumber() from sessionReceiver"
     );
 
-    let errorGetState = false;
+    let errorGetState: string = "";
     await sessionReceiver.getState().catch((err) => {
-      errorGetState = err && err.message === expectedErrorMsg;
+      errorGetState = err.message;
     });
-    should.equal(errorGetState, true, "InvalidOperationError not thrown for getState()");
+    should.equal(errorGetState, expectedErrorMsg, "Expected error not thrown for getState()");
 
-    let errorSetState = false;
+    let errorSetState: string = "";
     await sessionReceiver.setState("state!!").catch((err) => {
-      errorSetState = err && err.message === expectedErrorMsg;
+      errorSetState = err.message;
     });
-    should.equal(errorSetState, true, "InvalidOperationError not thrown for setState()");
+    should.equal(errorSetState, expectedErrorMsg, "Expected error not thrown for setState()");
   }
 
   /**
    * Tests that each feature of the topic filters throws expected error
    */
-  async function testRules(): Promise<void> {
+  async function testRules(expectedErrorMsg: string): Promise<void> {
     const subscriptionClient = receiverClient as SubscriptionClient;
 
-    let errorAddRule = false;
+    let errorAddRule: string = "";
     await subscriptionClient.addRule("myRule", true).catch((err) => {
-      errorAddRule = err && err.message === expectedErrorMsg;
+      errorAddRule = err.message;
     });
-    should.equal(errorAddRule, true, "InvalidOperationError not thrown for addRule()");
+    should.equal(errorAddRule, expectedErrorMsg, "Expected error not thrown for addRule()");
 
-    let errorRemoveRule = false;
+    let errorRemoveRule: string = "";
     await subscriptionClient.removeRule("myRule").catch((err) => {
-      errorRemoveRule = err && err.message === expectedErrorMsg;
+      errorRemoveRule = err.message;
     });
-    should.equal(errorRemoveRule, true, "InvalidOperationError not thrown for removeRule()");
+    should.equal(errorRemoveRule, expectedErrorMsg, "Expected error not thrown for removeRule()");
 
-    let errorGetRules = false;
+    let errorGetRules: string = "";
     await subscriptionClient.getRules().catch((err) => {
-      errorGetRules = err && err.message === expectedErrorMsg;
+      errorGetRules = err.message;
     });
-    should.equal(errorGetRules, true, "InvalidOperationError not thrown for getRule()");
+    should.equal(errorGetRules, expectedErrorMsg, "Expected error not thrown for getRule()");
   }
 
-  it("Partitioned Queue: errors after namespace.close()", async function(): Promise<void> {
-    await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
+  describe("Errors after close() on namespace", function(): void {
+    const entityToClose = "namespace";
+    const expectedErrorMsg = "The underlying AMQP connection is closed.";
 
-    await testSender();
+    it("Partitioned Queue: errors after close() on namespace", async function(): Promise<void> {
+      await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue, entityToClose);
 
-    await testReceiver();
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg);
+    });
+
+    it("Partitioned Queue with sessions: errors after close() on namespace", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedQueueWithSessions,
+        ClientType.PartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testSessionReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg, true);
+    });
+
+    it("Partitioned Topic/Subscription: errors after close() on namespace", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopic,
+        ClientType.PartitionedSubscription,
+        entityToClose
+      );
+
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg);
+      await testRules(expectedErrorMsg);
+    });
+
+    it("Partitioned Topic/Subscription with sessions: errors after close() on namespace", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopicWithSessions,
+        ClientType.PartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testSessionReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg, true);
+      await testRules(expectedErrorMsg);
+    });
+
+    it("Unpartitioned Queue: errors after close() on namespace", async function(): Promise<void> {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueue,
+        ClientType.UnpartitionedQueue,
+        entityToClose
+      );
+
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg);
+    });
+
+    it("Unpartitioned Queue with sessions: errors after close() on namespace", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueueWithSessions,
+        ClientType.UnpartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testSessionReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg, true);
+    });
+
+    it("Unpartitioned Topic/Subscription: errors after close() on namespace", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopic,
+        ClientType.UnpartitionedSubscription,
+        entityToClose
+      );
+
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg);
+      await testRules(expectedErrorMsg);
+    });
+
+    it("Unpartitioned Topic/Subscription with sessions: errors after close() on namespace", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopicWithSessions,
+        ClientType.UnpartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedErrorMsg);
+      await testSenderClient(expectedErrorMsg);
+      await testSessionReceiver(expectedErrorMsg);
+      await testReceiverClient(expectedErrorMsg, true);
+      await testRules(expectedErrorMsg);
+    });
+
+    it("Create Queue/Topic/Subscription clients throws error after namespace.close()", async function(): Promise<
+      void
+    > {
+      // beforeEachTest() can be run for any entity type, we need it only to ensure that the
+      // connection is indeed opened
+      await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue, entityToClose);
+
+      let errorCreateQueueClient: string = "";
+      try {
+        namespace.createQueueClient("random-name");
+      } catch (err) {
+        errorCreateQueueClient = err.message;
+      }
+      should.equal(
+        errorCreateQueueClient,
+        expectedErrorMsg,
+        "Expected error not thrown for createQueueClient()"
+      );
+
+      let errorCreateTopicClient: string = "";
+      try {
+        namespace.createTopicClient("random-name");
+      } catch (err) {
+        errorCreateTopicClient = err.message;
+      }
+      should.equal(
+        errorCreateTopicClient,
+        expectedErrorMsg,
+        "Expected error not thrown for createTopicClient()"
+      );
+
+      let errorCreateSubscriptionClient: string = "";
+      try {
+        namespace.createSubscriptionClient("random-name", "random-name");
+      } catch (err) {
+        errorCreateSubscriptionClient = err.message;
+      }
+      should.equal(
+        errorCreateSubscriptionClient,
+        expectedErrorMsg,
+        "Expected error not thrown for createubscriptionClient()"
+      );
+    });
   });
 
-  it("Partitioned Queue with sessions: errors after namespace.close()", async function(): Promise<
-    void
-  > {
-    await beforeEachTest(
-      ClientType.PartitionedQueueWithSessions,
-      ClientType.PartitionedQueueWithSessions,
-      true
-    );
+  describe("Errors after close() on senderClient", function(): void {
+    const entityToClose = "senderClient";
+    const expectedSenderErrorMsg = "The sender has been closed and can no longer be used.";
+    const expectedQueueClientErrorMsg =
+      "The queueClient has been closed and can no longer be used.";
+    const expectedTopicClientErrorMsg =
+      "The topicClient has been closed and can no longer be used.";
 
-    await testSender();
+    it("Partitioned Queue: errors after close() on senderClient", async function(): Promise<void> {
+      await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue, entityToClose);
 
-    await testSessionReceiver();
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedQueueClientErrorMsg);
+    });
+
+    it("Partitioned Queue with sessions: errors after close() on senderClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedQueueWithSessions,
+        ClientType.PartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedQueueClientErrorMsg);
+    });
+
+    it("Partitioned Topic/Subscription: errors after close() on senderClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopic,
+        ClientType.PartitionedSubscription,
+        entityToClose
+      );
+
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedTopicClientErrorMsg);
+    });
+
+    it("Partitioned Topic/Subscription with sessions: errors after close() on senderClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopicWithSessions,
+        ClientType.PartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedTopicClientErrorMsg);
+    });
+
+    it("Unpartitioned Queue: errors after close() on senderClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueue,
+        ClientType.UnpartitionedQueue,
+        entityToClose
+      );
+
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedQueueClientErrorMsg);
+    });
+
+    it("Unpartitioned Queue with sessions: errors after close() on senderClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueueWithSessions,
+        ClientType.UnpartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedQueueClientErrorMsg);
+    });
+
+    it("Unpartitioned Topic/Subscription: errors after close() on senderClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopic,
+        ClientType.UnpartitionedSubscription,
+        entityToClose
+      );
+
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedTopicClientErrorMsg);
+    });
+
+    it("Unpartitioned Topic/Subscription with sessions: errors after close() on senderClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopicWithSessions,
+        ClientType.UnpartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+      await testSenderClient(expectedTopicClientErrorMsg);
+    });
   });
 
-  it("Partitioned Topic/Subscription: errors after namespace.close()", async function(): Promise<
-    void
-  > {
-    await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
+  describe("Errors after close() on receiverClient", function(): void {
+    const entityToClose = "receiverClient";
+    const expectedReceiverErrorMsg = "The receiver has been closed and can no longer be used.";
+    const expectedQueueClientErrorMsg =
+      "The queueClient has been closed and can no longer be used.";
+    const expectedSubscriptionClientErrorMsg =
+      "The subscriptionClient has been closed and can no longer be used.";
 
-    await testSender();
+    it("Partitioned Queue: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue, entityToClose);
 
-    await testReceiver();
+      await testReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedQueueClientErrorMsg);
+    });
 
-    await testRules();
+    it("Partitioned Queue with sessions: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedQueueWithSessions,
+        ClientType.PartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      //    await testSessionReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedQueueClientErrorMsg, true);
+    });
+
+    it("Partitioned Topic/Subscription: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopic,
+        ClientType.PartitionedSubscription,
+        entityToClose
+      );
+
+      await testReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedSubscriptionClientErrorMsg);
+      await testRules(expectedSubscriptionClientErrorMsg);
+    });
+
+    it.only("Partitioned Topic/Subscription with sessions: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopicWithSessions,
+        ClientType.PartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      //    await testSessionReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedSubscriptionClientErrorMsg, true);
+      await testRules(expectedSubscriptionClientErrorMsg);
+    });
+
+    it("Unpartitioned Queue: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueue,
+        ClientType.UnpartitionedQueue,
+        entityToClose
+      );
+
+      await testReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedQueueClientErrorMsg);
+    });
+
+    it("Unpartitioned Queue with sessions: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueueWithSessions,
+        ClientType.UnpartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      //    await testSessionReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedQueueClientErrorMsg, true);
+    });
+
+    it("Unpartitioned Topic/Subscription: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopic,
+        ClientType.UnpartitionedSubscription,
+        entityToClose
+      );
+
+      await testReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedSubscriptionClientErrorMsg);
+      await testRules(expectedSubscriptionClientErrorMsg);
+    });
+
+    it("Unpartitioned Topic/Subscription with sessions: errors after close() on receiverClient", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopicWithSessions,
+        ClientType.UnpartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      //     await testSessionReceiver(expectedReceiverErrorMsg);
+      await testReceiverClient(expectedSubscriptionClientErrorMsg, true);
+      await testRules(expectedSubscriptionClientErrorMsg);
+    });
   });
 
-  it("Partitioned Topic/Subscription with sessions: errors after namespace.close()", async function(): Promise<
-    void
-  > {
-    await beforeEachTest(
-      ClientType.PartitionedTopicWithSessions,
-      ClientType.PartitionedSubscriptionWithSessions,
-      true
-    );
+  describe("Errors after close() on sender", function(): void {
+    const entityToClose = "sender";
+    const expectedSenderErrorMsg = "The sender has been closed and can no longer be used.";
 
-    await testSender();
+    it("Partitioned Queue: errors after close() on sender", async function(): Promise<void> {
+      await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue, entityToClose);
 
-    await testReceiver();
+      await testSender(expectedSenderErrorMsg);
+    });
 
-    await testSessionReceiver();
+    it("Partitioned Queue with sessions: errors after close() on sender", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedQueueWithSessions,
+        ClientType.PartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+    });
+
+    it("Partitioned Topic/Subscription: errors after close() on sender", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopic,
+        ClientType.PartitionedSubscription,
+        entityToClose
+      );
+
+      await testSender(expectedSenderErrorMsg);
+    });
+
+    it("Partitioned Topic/Subscription with sessions: errors after close() on sender", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopicWithSessions,
+        ClientType.PartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+    });
+
+    it("Unpartitioned Queue: errors after close() on sender", async function(): Promise<void> {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueue,
+        ClientType.UnpartitionedQueue,
+        entityToClose
+      );
+
+      await testSender(expectedSenderErrorMsg);
+    });
+
+    it("Unpartitioned Queue with sessions: errors after close() on sender", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueueWithSessions,
+        ClientType.UnpartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+    });
+
+    it("Unpartitioned Topic/Subscription: errors after close() on sender", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopic,
+        ClientType.UnpartitionedSubscription,
+        entityToClose
+      );
+
+      await testSender(expectedSenderErrorMsg);
+    });
+
+    it("Unpartitioned Topic/Subscription with sessions: errors after close() on sender", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopicWithSessions,
+        ClientType.UnpartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
+
+      await testSender(expectedSenderErrorMsg);
+    });
   });
 
-  it("Unpartitioned Queue: errors after namespace.close()", async function(): Promise<void> {
-    await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
+  describe("Errors after close() on receiver", function(): void {
+    const entityToClose = "receiver";
+    const expectedReceiverErrorMsg = "The receiver has been closed and can no longer be used.";
 
-    await testSender();
+    it("Partitioned Queue: errors after close() on receiver", async function(): Promise<void> {
+      await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue, entityToClose);
 
-    await testReceiver();
-  });
+      await testReceiver(expectedReceiverErrorMsg);
+    });
 
-  it("Unpartitioned Queue with sessions: errors after namespace.close()", async function(): Promise<
-    void
-  > {
-    await beforeEachTest(
-      ClientType.UnpartitionedQueueWithSessions,
-      ClientType.UnpartitionedQueueWithSessions,
-      true
-    );
+    it("Partitioned Queue with sessions: errors after close() on receiver", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedQueueWithSessions,
+        ClientType.PartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
 
-    await testSender();
+      await testSessionReceiver(expectedReceiverErrorMsg);
+    });
 
-    await testSessionReceiver();
-  });
+    it("Partitioned Topic/Subscription: errors after close() on receiver", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopic,
+        ClientType.PartitionedSubscription,
+        entityToClose
+      );
 
-  it("Unpartitioned Topic/Subscription: errors after namespace.close()", async function(): Promise<
-    void
-  > {
-    await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
+      await testReceiver(expectedReceiverErrorMsg);
+    });
 
-    await testSender();
+    it("Partitioned Topic/Subscription with sessions: errors after close() on receiver", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.PartitionedTopicWithSessions,
+        ClientType.PartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
 
-    await testReceiver();
+      await testSessionReceiver(expectedReceiverErrorMsg);
+    });
 
-    await testRules();
-  });
+    it("Unpartitioned Queue: errors after close() on receiver", async function(): Promise<void> {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueue,
+        ClientType.UnpartitionedQueue,
+        entityToClose
+      );
 
-  it("Unpartitioned Topic/Subscription with sessions: errors after namespace.close()", async function(): Promise<
-    void
-  > {
-    await beforeEachTest(
-      ClientType.UnpartitionedTopicWithSessions,
-      ClientType.UnpartitionedSubscriptionWithSessions,
-      true
-    );
+      await testReceiver(expectedReceiverErrorMsg);
+    });
 
-    await testSender();
+    it("Unpartitioned Queue with sessions: errors after close() on receiver", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedQueueWithSessions,
+        ClientType.UnpartitionedQueueWithSessions,
+        entityToClose,
+        true
+      );
 
-    await testReceiver();
+      await testSessionReceiver(expectedReceiverErrorMsg);
+    });
 
-    await testSessionReceiver();
-  });
+    it("Unpartitioned Topic/Subscription: errors after close() on receiver", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopic,
+        ClientType.UnpartitionedSubscription,
+        entityToClose
+      );
 
-  it("Create Queue/Topic/Subscription clients throws error after namespace.close()", async function(): Promise<
-    void
-  > {
-    // beforeEachTest() can be run for any entity type, we need it only to ensure that the
-    // connection is indeed opened
-    await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
+      await testReceiver(expectedReceiverErrorMsg);
+    });
 
-    let errorCreateQueueClient = false;
-    try {
-      namespace.createQueueClient("random-name");
-    } catch (err) {
-      errorCreateQueueClient = err && err.message === expectedErrorMsg;
-    }
-    should.equal(
-      errorCreateQueueClient,
-      true,
-      "InvalidOperationError not thrown for createQueueClient()"
-    );
+    it("Unpartitioned Topic/Subscription with sessions: errors after close() on receiver", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(
+        ClientType.UnpartitionedTopicWithSessions,
+        ClientType.UnpartitionedSubscriptionWithSessions,
+        entityToClose,
+        true
+      );
 
-    let errorCreateTopicClient = false;
-    try {
-      namespace.createTopicClient("random-name");
-    } catch (err) {
-      errorCreateTopicClient = err && err.message === expectedErrorMsg;
-    }
-    should.equal(
-      errorCreateTopicClient,
-      true,
-      "InvalidOperationError not thrown for createTopicClient()"
-    );
-
-    let errorCreateSubscriptionClient = false;
-    try {
-      namespace.createSubscriptionClient("random-name", "random-name");
-    } catch (err) {
-      errorCreateSubscriptionClient = err && err.message === expectedErrorMsg;
-    }
-    should.equal(
-      errorCreateSubscriptionClient,
-      true,
-      "InvalidOperationError not thrown for createubscriptionClient()"
-    );
+      await testSessionReceiver(expectedReceiverErrorMsg);
+    });
   });
 });

--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -1017,7 +1017,7 @@ describe("Errors after close()", function(): void {
         true
       );
 
-      //    await testSessionReceiver(expectedReceiverErrorMsg);
+      await testSessionReceiver(expectedReceiverErrorMsg);
       await testReceiverClient(expectedQueueClientErrorMsg, true);
     });
 
@@ -1035,7 +1035,7 @@ describe("Errors after close()", function(): void {
       await testRules(expectedSubscriptionClientErrorMsg);
     });
 
-    it.only("Partitioned Topic/Subscription with sessions: errors after close() on receiverClient", async function(): Promise<
+    it("Partitioned Topic/Subscription with sessions: errors after close() on receiverClient", async function(): Promise<
       void
     > {
       await beforeEachTest(
@@ -1045,7 +1045,7 @@ describe("Errors after close()", function(): void {
         true
       );
 
-      //    await testSessionReceiver(expectedReceiverErrorMsg);
+      await testSessionReceiver(expectedReceiverErrorMsg);
       await testReceiverClient(expectedSubscriptionClientErrorMsg, true);
       await testRules(expectedSubscriptionClientErrorMsg);
     });
@@ -1073,7 +1073,7 @@ describe("Errors after close()", function(): void {
         true
       );
 
-      //    await testSessionReceiver(expectedReceiverErrorMsg);
+      await testSessionReceiver(expectedReceiverErrorMsg);
       await testReceiverClient(expectedQueueClientErrorMsg, true);
     });
 
@@ -1101,7 +1101,7 @@ describe("Errors after close()", function(): void {
         true
       );
 
-      //     await testSessionReceiver(expectedReceiverErrorMsg);
+      await testSessionReceiver(expectedReceiverErrorMsg);
       await testReceiverClient(expectedSubscriptionClientErrorMsg, true);
       await testRules(expectedSubscriptionClientErrorMsg);
     });


### PR DESCRIPTION
When `close()` is called on queueClient/topicClient/subscriptionClient, 

- they can still be used to send/receive messages. The `close()` only ensures current sender/receiver links are closed. This can be counter-intuitive to the user
- references to them and the corresponding $managementClient connection (which is shared across clients to the same queue/topic/subscription) are held in the namespace's context. Which means that as long the `namespace` is in scope, unused clients will not be garbage collected


When close() is called on a sender/receiver that the user gets from calling `getSender()` or `getReceiver()`, 
- they can still be used to send/receive messages. The `close()` only ensures current sender/receiver links are closed. This can be counter-intuitive to the user


This PR attempts to fix the above scenarios by throwing appropriate errors when sender/receivers are used after they are closed or after clients are closed