### PR TITLE
[Service Bus] Session peek and state operations shouldnt require a session receiver

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -140,6 +140,59 @@ export class QueueClient extends Client {
     });
   }
 
+  /**
+   * Sets the state of the MessageSession.
+   * @param state The state that needs to be set.
+   */
+  async setSessionState(sessionId: string, state: any): Promise<void> {
+    return this._context.managementClient!.setSessionState(sessionId, state);
+  }
+
+  /**
+   * Gets the state of the MessageSession.
+   * @returns Promise<any> The state of that session
+   */
+  async getSessionState(sessionId: string): Promise<any> {
+    return this._context.managementClient!.getSessionState(sessionId);
+  }
+
+  /**
+   * Fetches the next batch of active messages (including deferred but not deadlettered messages) in
+   * the current session. The first call to `peek()` fetches the first active message. Each
+   * subsequent call fetches the subsequent message.
+   *
+   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
+   *
+   * @param messageCount The number of messages to retrieve. Default value `1`.
+   * @returns Promise<ReceivedMessageInfo[]>
+   */
+  async peekSession(sessionId: string, messageCount?: number): Promise<ReceivedMessageInfo[]> {
+    return this._context.managementClient!.peekMessagesBySession(sessionId, messageCount);
+  }
+
+  /**
+   * Peeks the desired number of active messages (including deferred but not deadlettered messages)
+   * from the specified sequence number in the current session.
+   *
+   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
+   *
+   * @param fromSequenceNumber The sequence number from where to read the message.
+   * @param [messageCount] The number of messages to retrieve. Default value `1`.
+   * @returns Promise<ReceivedSBMessage[]>
+   */
+  async peekSessionBySequenceNumber(
+    sessionId: string,
+    fromSequenceNumber: Long,
+    messageCount?: number
+  ): Promise<ReceivedMessageInfo[]> {
+    return this._context.managementClient!.peekBySequenceNumber(fromSequenceNumber, {
+      sessionId: sessionId,
+      messageCount: messageCount
+    });
+  }
+
   // /**
   //  * Lists the ids of the sessions on the ServiceBus Queue.
   //  * @param maxNumberOfSessions Maximum number of sessions.

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -141,24 +141,6 @@ export class QueueClient extends Client {
   }
 
   /**
-   * Sets the state of the MessageSession.
-   * @param sessionId  Id of the session for which the state needs to be set.
-   * @param state The state that needs to be set.
-   */
-  async setSessionState(sessionId: string, state: any): Promise<void> {
-    return this._context.managementClient!.setSessionState(sessionId, state);
-  }
-
-  /**
-   * Gets the state of the MessageSession.
-   * @param sessionId  Id of the session for which the state needs to be retrieved.
-   * @returns Promise<any> The state of that session
-   */
-  async getSessionState(sessionId: string): Promise<any> {
-    return this._context.managementClient!.getSessionState(sessionId);
-  }
-
-  /**
    * Fetches the next batch of active messages (including deferred but not deadlettered messages) in
    * the current session. The first call to `peek()` fetches the first active message. Each
    * subsequent call fetches the subsequent message.

--- a/packages/@azure/servicebus/data-plane/lib/queueClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/queueClient.ts
@@ -142,6 +142,7 @@ export class QueueClient extends Client {
 
   /**
    * Sets the state of the MessageSession.
+   * @param sessionId  Id of the session for which the state needs to be set.
    * @param state The state that needs to be set.
    */
   async setSessionState(sessionId: string, state: any): Promise<void> {
@@ -150,6 +151,7 @@ export class QueueClient extends Client {
 
   /**
    * Gets the state of the MessageSession.
+   * @param sessionId  Id of the session for which the state needs to be retrieved.
    * @returns Promise<any> The state of that session
    */
   async getSessionState(sessionId: string): Promise<any> {
@@ -164,6 +166,7 @@ export class QueueClient extends Client {
    * Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
+   * @param sessionId  Id of the session for which the messages are to be peeked.
    * @param messageCount The number of messages to retrieve. Default value `1`.
    * @returns Promise<ReceivedMessageInfo[]>
    */
@@ -178,6 +181,7 @@ export class QueueClient extends Client {
    * Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
+   * @param sessionId  Id of the session for which the messages are to be peeked.
    * @param fromSequenceNumber The sequence number from where to read the message.
    * @param [messageCount] The number of messages to retrieve. Default value `1`.
    * @returns Promise<ReceivedSBMessage[]>

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -6,7 +6,7 @@ import { StreamingReceiver, MessageHandlerOptions } from "./core/streamingReceiv
 import { BatchingReceiver } from "./core/batchingReceiver";
 import { ReceiveOptions, OnError, OnMessage, ReceiverType } from "./core/messageReceiver";
 import { ClientEntityContext } from "./clientEntityContext";
-import { ServiceBusMessage, ReceiveMode, ReceivedMessageInfo } from "./serviceBusMessage";
+import { ServiceBusMessage, ReceiveMode } from "./serviceBusMessage";
 import { MessageSession, SessionMessageHandlerOptions } from "./session/messageSession";
 import { throwErrorIfConnectionClosed } from "./util/utils";
 

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -309,42 +309,6 @@ export class SessionReceiver {
   }
 
   /**
-   * Fetches the next batch of active messages (including deferred but not deadlettered messages) in
-   * the current session. The first call to `peek()` fetches the first active message. Each
-   * subsequent call fetches the subsequent message.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
-   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
-   *
-   * @param messageCount The number of messages to retrieve. Default value `1`.
-   * @returns Promise<ReceivedMessageInfo[]>
-   */
-  async peek(messageCount?: number): Promise<ReceivedMessageInfo[]> {
-    return this._context.managementClient!.peekMessagesBySession(this.sessionId!, messageCount);
-  }
-
-  /**
-   * Peeks the desired number of active messages (including deferred but not deadlettered messages)
-   * from the specified sequence number in the current session.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
-   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
-   *
-   * @param fromSequenceNumber The sequence number from where to read the message.
-   * @param [messageCount] The number of messages to retrieve. Default value `1`.
-   * @returns Promise<ReceivedSBMessage[]>
-   */
-  async peekBySequenceNumber(
-    fromSequenceNumber: Long,
-    messageCount?: number
-  ): Promise<ReceivedMessageInfo[]> {
-    return this._context.managementClient!.peekBySequenceNumber(fromSequenceNumber, {
-      sessionId: this.sessionId!,
-      messageCount: messageCount
-    });
-  }
-
-  /**
    * Receives a deferred message identified by the given `sequenceNumber`.
    * @param sequenceNumber The sequence number of the message that will be received.
    * @returns Promise<ServiceBusMessage | undefined>

--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -6,7 +6,7 @@ import { StreamingReceiver, MessageHandlerOptions } from "./core/streamingReceiv
 import { BatchingReceiver } from "./core/batchingReceiver";
 import { ReceiveOptions, OnError, OnMessage, ReceiverType } from "./core/messageReceiver";
 import { ClientEntityContext } from "./clientEntityContext";
-import { ServiceBusMessage, ReceiveMode, ReceivedMessageInfo } from "./serviceBusMessage";
+import { ServiceBusMessage, ReceiveMode } from "./serviceBusMessage";
 import { MessageSession, SessionMessageHandlerOptions } from "./session/messageSession";
 import { throwErrorIfConnectionClosed } from "./util/utils";
 
@@ -290,58 +290,6 @@ export class SessionReceiver {
       this.sessionId!
     );
     return this._messageSession.sessionLockedUntilUtc;
-  }
-
-  /**
-   * Sets the state of the MessageSession.
-   * @param state The state that needs to be set.
-   */
-  async setState(state: any): Promise<void> {
-    return this._context.managementClient!.setSessionState(this.sessionId!, state);
-  }
-
-  /**
-   * Gets the state of the MessageSession.
-   * @returns Promise<any> The state of that session
-   */
-  async getState(): Promise<any> {
-    return this._context.managementClient!.getSessionState(this.sessionId!);
-  }
-
-  /**
-   * Fetches the next batch of active messages (including deferred but not deadlettered messages) in
-   * the current session. The first call to `peek()` fetches the first active message. Each
-   * subsequent call fetches the subsequent message.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
-   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
-   *
-   * @param messageCount The number of messages to retrieve. Default value `1`.
-   * @returns Promise<ReceivedMessageInfo[]>
-   */
-  async peek(messageCount?: number): Promise<ReceivedMessageInfo[]> {
-    return this._context.managementClient!.peekMessagesBySession(this.sessionId!, messageCount);
-  }
-
-  /**
-   * Peeks the desired number of active messages (including deferred but not deadlettered messages)
-   * from the specified sequence number in the current session.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
-   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
-   *
-   * @param fromSequenceNumber The sequence number from where to read the message.
-   * @param [messageCount] The number of messages to retrieve. Default value `1`.
-   * @returns Promise<ReceivedSBMessage[]>
-   */
-  async peekBySequenceNumber(
-    fromSequenceNumber: Long,
-    messageCount?: number
-  ): Promise<ReceivedMessageInfo[]> {
-    return this._context.managementClient!.peekBySequenceNumber(fromSequenceNumber, {
-      sessionId: this.sessionId!,
-      messageCount: messageCount
-    });
   }
 
   /**

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -142,24 +142,6 @@ export class SubscriptionClient extends Client {
   }
 
   /**
-   * Sets the state of the MessageSession.
-   * @param sessionId  Id of the session for which the state needs to be set.
-   * @param state The state that needs to be set.
-   */
-  async setSessionState(sessionId: string, state: any): Promise<void> {
-    return this._context.managementClient!.setSessionState(sessionId, state);
-  }
-
-  /**
-   * Gets the state of the MessageSession.
-   * @param sessionId  Id of the session for which the state needs to be retrieved.
-   * @returns Promise<any> The state of that session
-   */
-  async getSessionState(sessionId: string): Promise<any> {
-    return this._context.managementClient!.getSessionState(sessionId);
-  }
-
-  /**
    * Fetches the next batch of active messages (including deferred but not deadlettered messages) in
    * the current session. The first call to `peek()` fetches the first active message. Each
    * subsequent call fetches the subsequent message.

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -143,6 +143,7 @@ export class SubscriptionClient extends Client {
 
   /**
    * Sets the state of the MessageSession.
+   * @param sessionId  Id of the session for which the state needs to be set.
    * @param state The state that needs to be set.
    */
   async setSessionState(sessionId: string, state: any): Promise<void> {
@@ -151,6 +152,7 @@ export class SubscriptionClient extends Client {
 
   /**
    * Gets the state of the MessageSession.
+   * @param sessionId  Id of the session for which the state needs to be retrieved.
    * @returns Promise<any> The state of that session
    */
   async getSessionState(sessionId: string): Promise<any> {
@@ -165,6 +167,7 @@ export class SubscriptionClient extends Client {
    * Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
+   * @param sessionId  Id of the session for which the messages are to be peeked.
    * @param messageCount The number of messages to retrieve. Default value `1`.
    * @returns Promise<ReceivedMessageInfo[]>
    */
@@ -179,6 +182,7 @@ export class SubscriptionClient extends Client {
    * Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
+   * @param sessionId  Id of the session for which the messages are to be peeked.
    * @param fromSequenceNumber The sequence number from where to read the message.
    * @param [messageCount] The number of messages to retrieve. Default value `1`.
    * @returns Promise<ReceivedSBMessage[]>

--- a/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/subscriptionClient.ts
@@ -141,6 +141,59 @@ export class SubscriptionClient extends Client {
     });
   }
 
+  /**
+   * Sets the state of the MessageSession.
+   * @param state The state that needs to be set.
+   */
+  async setSessionState(sessionId: string, state: any): Promise<void> {
+    return this._context.managementClient!.setSessionState(sessionId, state);
+  }
+
+  /**
+   * Gets the state of the MessageSession.
+   * @returns Promise<any> The state of that session
+   */
+  async getSessionState(sessionId: string): Promise<any> {
+    return this._context.managementClient!.getSessionState(sessionId);
+  }
+
+  /**
+   * Fetches the next batch of active messages (including deferred but not deadlettered messages) in
+   * the current session. The first call to `peek()` fetches the first active message. Each
+   * subsequent call fetches the subsequent message.
+   *
+   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
+   *
+   * @param messageCount The number of messages to retrieve. Default value `1`.
+   * @returns Promise<ReceivedMessageInfo[]>
+   */
+  async peekSession(sessionId: string, messageCount?: number): Promise<ReceivedMessageInfo[]> {
+    return this._context.managementClient!.peekMessagesBySession(sessionId, messageCount);
+  }
+
+  /**
+   * Peeks the desired number of active messages (including deferred but not deadlettered messages)
+   * from the specified sequence number in the current session.
+   *
+   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
+   *
+   * @param fromSequenceNumber The sequence number from where to read the message.
+   * @param [messageCount] The number of messages to retrieve. Default value `1`.
+   * @returns Promise<ReceivedSBMessage[]>
+   */
+  async peekSessionBySequenceNumber(
+    sessionId: string,
+    fromSequenceNumber: Long,
+    messageCount?: number
+  ): Promise<ReceivedMessageInfo[]> {
+    return this._context.managementClient!.peekBySequenceNumber(fromSequenceNumber, {
+      sessionId: sessionId,
+      messageCount: messageCount
+    });
+  }
+
   //#region topic-filters
 
   /**

--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -612,9 +612,10 @@ describe("Errors after namespace.close()", function(): void {
    */
   async function testSessionReceiver(): Promise<void> {
     await testReceiver(true);
+    const sessionReceiver = receiver as SessionReceiver;
 
     let errorPeek = false;
-    await receiverClient.peekSession((receiver as SessionReceiver).sessionId).catch((err) => {
+    await receiverClient.peekSession(sessionReceiver.sessionId).catch((err) => {
       errorPeek = err && err.message === expectedErrorMsg;
     });
     should.equal(
@@ -636,18 +637,16 @@ describe("Errors after namespace.close()", function(): void {
     );
 
     let errorGetState = false;
-    await receiverClient.getSessionState((receiver as SessionReceiver).sessionId).catch((err) => {
+    await sessionReceiver.getState().catch((err) => {
       errorGetState = err && err.message === expectedErrorMsg;
     });
-    should.equal(errorGetState, true, "InvalidOperationError not thrown for getSessionState()");
+    should.equal(errorGetState, true, "InvalidOperationError not thrown for getState()");
 
     let errorSetState = false;
-    await receiverClient
-      .setSessionState((receiver as SessionReceiver).sessionId, "state!!")
-      .catch((err) => {
-        errorSetState = err && err.message === expectedErrorMsg;
-      });
-    should.equal(errorSetState, true, "InvalidOperationError not thrown for setSessionState()");
+    await sessionReceiver.setState("state!!").catch((err) => {
+      errorSetState = err && err.message === expectedErrorMsg;
+    });
+    should.equal(errorSetState, true, "InvalidOperationError not thrown for setState()");
   }
 
   /**

--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -612,39 +612,42 @@ describe("Errors after namespace.close()", function(): void {
    */
   async function testSessionReceiver(): Promise<void> {
     await testReceiver(true);
-    const sessionReceiver = receiver as SessionReceiver;
 
     let errorPeek = false;
-    await sessionReceiver.peek().catch((err) => {
+    await receiverClient.peekSession((receiver as SessionReceiver).sessionId).catch((err) => {
       errorPeek = err && err.message === expectedErrorMsg;
     });
     should.equal(
       errorPeek,
       true,
-      "InvalidOperationError not thrown for peek() from sessionReceiver"
+      "InvalidOperationError not thrown for peekSession() from sessionReceiver"
     );
 
     let errorPeekBySequence = false;
-    await sessionReceiver.peekBySequenceNumber(long.ZERO).catch((err) => {
-      errorPeekBySequence = err && err.message === expectedErrorMsg;
-    });
+    await receiverClient
+      .peekSessionBySequenceNumber((receiver as SessionReceiver).sessionId, long.ZERO)
+      .catch((err) => {
+        errorPeekBySequence = err && err.message === expectedErrorMsg;
+      });
     should.equal(
       errorPeekBySequence,
       true,
-      "InvalidOperationError not thrown for peekBySequenceNumber() from sessionReceiver"
+      "InvalidOperationError not thrown for peekSessionBySequenceNumber() from sessionReceiver"
     );
 
     let errorGetState = false;
-    await sessionReceiver.getState().catch((err) => {
+    await receiverClient.getSessionState((receiver as SessionReceiver).sessionId).catch((err) => {
       errorGetState = err && err.message === expectedErrorMsg;
     });
-    should.equal(errorGetState, true, "InvalidOperationError not thrown for getState()");
+    should.equal(errorGetState, true, "InvalidOperationError not thrown for getSessionState()");
 
     let errorSetState = false;
-    await sessionReceiver.setState("state!!").catch((err) => {
-      errorSetState = err && err.message === expectedErrorMsg;
-    });
-    should.equal(errorSetState, true, "InvalidOperationError not thrown for setState()");
+    await receiverClient
+      .setSessionState((receiver as SessionReceiver).sessionId, "state!!")
+      .catch((err) => {
+        errorSetState = err && err.message === expectedErrorMsg;
+      });
+    should.equal(errorSetState, true, "InvalidOperationError not thrown for setSessionState()");
   }
 
   /**

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -348,10 +348,10 @@ describe("Session State", function(): void {
     should.equal(msgs[0].messageId, testMessage.messageId, "MessageId is different than expected");
     should.equal(msgs[0].sessionId, testMessage.sessionId, "SessionId is different than expected");
 
-    let testState = await receiverClient.getSessionState(receiver.sessionId);
+    let testState = await receiver.getState();
     should.equal(!!testState, false, "SessionState is different than expected");
-    await receiverClient.setSessionState(receiver.sessionId, "new_state");
-    testState = await receiverClient.getSessionState(receiver.sessionId);
+    await receiver.setState("new_state");
+    testState = await receiver.getState();
     should.equal(testState, "new_state", "SessionState is different than expected");
 
     await receiver.close();
@@ -364,10 +364,10 @@ describe("Session State", function(): void {
     should.equal(msgs[0].messageId, testMessage.messageId, "MessageId is different than expected");
     should.equal(msgs[0].sessionId, testMessage.sessionId, "SessionId is different than expected");
 
-    testState = await receiverClient.getSessionState(receiver.sessionId);
+    testState = await receiver.getState();
     should.equal(testState, "new_state", "SessionState is different than expected");
 
-    await receiverClient.setSessionState(receiver.sessionId, ""); // clearing the session-state
+    await receiver.setState(""); // clearing the session-state
     await msgs[0].complete();
     await testPeekMsgsLength(receiverClient, 0);
   }

--- a/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/sessionsTests.spec.ts
@@ -348,10 +348,10 @@ describe("Session State", function(): void {
     should.equal(msgs[0].messageId, testMessage.messageId, "MessageId is different than expected");
     should.equal(msgs[0].sessionId, testMessage.sessionId, "SessionId is different than expected");
 
-    let testState = await receiver.getState();
+    let testState = await receiverClient.getSessionState(receiver.sessionId);
     should.equal(!!testState, false, "SessionState is different than expected");
-    await receiver.setState("new_state");
-    testState = await receiver.getState();
+    await receiverClient.setSessionState(receiver.sessionId, "new_state");
+    testState = await receiverClient.getSessionState(receiver.sessionId);
     should.equal(testState, "new_state", "SessionState is different than expected");
 
     await receiver.close();
@@ -364,10 +364,10 @@ describe("Session State", function(): void {
     should.equal(msgs[0].messageId, testMessage.messageId, "MessageId is different than expected");
     should.equal(msgs[0].sessionId, testMessage.sessionId, "SessionId is different than expected");
 
-    testState = await receiver.getState();
+    testState = await receiverClient.getSessionState(receiver.sessionId);
     should.equal(testState, "new_state", "SessionState is different than expected");
 
-    await receiver.setState(""); // clearing the session-state
+    await receiverClient.setSessionState(receiver.sessionId, ""); // clearing the session-state
     await msgs[0].complete();
     await testPeekMsgsLength(receiverClient, 0);
   }


### PR DESCRIPTION
**Issue** - #1330 

**Description**
- Move the features into the queueClient/subscriptionClient with the following renames
`peek` -> `peekSession`
`peekBySequenceNumber` -> `peekSessionBySequenceNumber`
`getState` -> `getSessionState`
`setState` -> `setSessionState`

- `sessionId` is made a mandatory attribute
- Updated the corresponding tests