### PR TITLE
Increase ServiceBus test timeout

### DIFF
--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -83,8 +83,8 @@
     "build-test": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js",
     "build-samples": "cd examples && tsc -p .",
     "test": "npm run build",
-    "unit": "npm run build-test && mocha -t 65000 test-dist/index.js",
-    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 65000 test-dist/index.js",
+    "unit": "npm run build-test && mocha -t 120000 test-dist/index.js",
+    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 120000 test-dist/index.js",
     "prepack": "npm i && npm run build",
     "extract-api": "tsc -p . && api-extractor run --local"
   }


### PR DESCRIPTION
- The expected runtime for some tests is as high as 60s
- A timeout of 65s may not leave enough buffer for unexpected delays
- A good default timeout is to double the expected runtime