### PR TITLE
[Service Bus] Fix various built-in lib and library type dependencies

### DIFF
--- a/packages/@azure/servicebus/data-plane/README.md
+++ b/packages/@azure/servicebus/data-plane/README.md
@@ -1,48 +1,65 @@
-@azure/service-bus
-================
+# @azure/service-bus
 
 This library provides a convenient way to interact with [Azure Service Bus](https://azure.microsoft.com/en-us/services/service-bus/).
 
-## Status ##
+## Status
 
 This library is currently in preview and may change prior to release.
 
-## Pre-requisite ##
-- **Node.js version: 6.x or higher.** 
+## Pre-requisite
 
-## Installation ##
+- **Node.js version: 6.x or higher.**
+
+## Installation
+
 ```bash
 npm install @azure/service-bus
 ```
 
-## Examples 
+TypeScript users need to install Node types:
 
-Please take a look at the [examples](https://github.com/Azure/azure-sdk-for-js/tree/master/packages/%40azure/servicebus/data-plane/examples) 
-directory for detailed examples on how to use this library to send and receive messages to/from 
+```bash
+npm install @types/node
+```
+
+And also enable `compilerOptions.esModuleInterop` in tsconfig.json.
+
+## Examples
+
+Please take a look at the [examples](https://github.com/Azure/azure-sdk-for-js/tree/master/packages/%40azure/servicebus/data-plane/examples)
+directory for detailed examples on how to use this library to send and receive messages to/from
 [Service Bus Queues, Topics and Subscriptions](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview).
 
-## Debug logs ##
+## Debug logs
 
 You can set the following environment variable to get the debug logs when using this library.
 
 - Getting debug logs from the Service Bus SDK
+
 ```bash
 export DEBUG=azure*
 ```
+
 - Getting debug logs from the Service Bus SDK and the protocol level library.
+
 ```bash
 export DEBUG=azure*,rhea*
 ```
+
 - If you are **not interested in viewing the message transformation** (which consumes lot of console/disk space) then you can set the `DEBUG` environment variable as follows:
+
 ```bash
 export DEBUG=azure*,rhea*,-rhea:raw,-rhea:message,-azure:amqp-common:datatransformer
 ```
+
 - If you are interested only in **errors**, then you can set the `DEBUG` environment variable as follows:
+
 ```bash
 export DEBUG=azure:service-bus:error,azure-amqp-common:error,rhea-promise:error,rhea:events,rhea:frames,rhea:io,rhea:flow
 ```
 
 #### Logging to a file
+
 - Set the `DEBUG` environment variable as shown above and then run your test script as follows:
   - Logging statements from you test script go to `out.log` and logging statement from the sdk go to `debug.log`.
     ```bash
@@ -56,4 +73,3 @@ export DEBUG=azure:service-bus:error,azure-amqp-common:error,rhea-promise:error,
     ```bash
       node your-test-script.js &> out.log
     ```
-

--- a/packages/@azure/servicebus/data-plane/README.md
+++ b/packages/@azure/servicebus/data-plane/README.md
@@ -16,13 +16,15 @@ This library is currently in preview and may change prior to release.
 npm install @azure/service-bus
 ```
 
-TypeScript users need to install Node types:
+### TypeScript
+
+TypeScript users need to have Node type definitions installed:
 
 ```bash
 npm install @types/node
 ```
 
-And also enable `compilerOptions.esModuleInterop` in tsconfig.json.
+You also need to enable `compilerOptions.allowSyntheticDefaultImports` in your tsconfig.json. Note that if you have enabled `compilerOptions.esModuleInterop`, `allowSyntheticDefaultImports` is enabled by default.
 
 ## Examples
 

--- a/packages/@azure/servicebus/data-plane/README.md
+++ b/packages/@azure/servicebus/data-plane/README.md
@@ -24,7 +24,7 @@ TypeScript users need to have Node type definitions installed:
 npm install @types/node
 ```
 
-You also need to enable `compilerOptions.allowSyntheticDefaultImports` in your tsconfig.json. Note that if you have enabled `compilerOptions.esModuleInterop`, `allowSyntheticDefaultImports` is enabled by default.
+You also need to enable `compilerOptions.allowSyntheticDefaultImports` in your tsconfig.json. Note that if you have enabled `compilerOptions.esModuleInterop`, `allowSyntheticDefaultImports` is enabled by default. See [TypeScript's compiler options handbook](https://www.typescriptlang.org/docs/handbook/compiler-options.html) for more information.
 
 ## Examples
 

--- a/packages/@azure/servicebus/data-plane/lib/index.ts
+++ b/packages/@azure/servicebus/data-plane/lib/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+/// <reference lib="es2015" />
+
 export { Namespace, NamespaceOptions, NamespaceOptionsBase } from "./namespace";
 export {
   TokenInfo,

--- a/packages/@azure/servicebus/data-plane/lib/util/utils.ts
+++ b/packages/@azure/servicebus/data-plane/lib/util/utils.ts
@@ -7,6 +7,13 @@ import { generate_uuid, string_to_uuid } from "rhea-promise";
 import { isBuffer } from "util";
 import { ConnectionContext } from "../connectionContext";
 
+// This is the only dependency we have on DOM types, so rather than require
+// the DOM lib we can just shim this in.
+interface Navigator {
+  hardwareConcurrency: number;
+}
+declare var navigator: Navigator;
+
 /**
  * A constant that indicates whether the environment is node.js or browser based.
  */

--- a/packages/@azure/servicebus/data-plane/package-lock.json
+++ b/packages/@azure/servicebus/data-plane/package-lock.json
@@ -364,8 +364,7 @@
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==",
-      "dev": true
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/mocha": {
       "version": "5.2.5",
@@ -374,9 +373,10 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
-      "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA=="
+      "version": "11.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
+      "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q==",
+      "dev": true
     },
     "@types/tunnel": {
       "version": "0.0.0",
@@ -407,6 +407,13 @@
         "uuid": "^3.1.0",
         "xmldom": ">= 0.1.x",
         "xpath.js": "~1.1.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.40",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.40.tgz",
+          "integrity": "sha512-RRSjdwz63kS4u7edIwJUn8NqKLLQ6LyqF/X4+4jp38MBT3Vwetewi2N4dgJEshLbDwNgOJXNYoOwzVZUSSLhkQ=="
+        }
       }
     },
     "ajv": {

--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -28,7 +28,9 @@
     "long": "^4.0.0",
     "ms-rest-azure": "^2.5.9",
     "rhea-promise": "^0.1.13",
-    "tslib": "^1.9.3"
+    "tslib": "^1.9.3",
+    "@types/node": "^8.0.37",
+    "@types/long": "^4.0.0"
   },
   "devDependencies": {
     "@azure/arm-servicebus": "^0.1.0",
@@ -39,9 +41,7 @@
     "@types/chai-as-promised": "^7.1.0",
     "@types/debug": "^0.0.31",
     "@types/dotenv": "^4.0.3",
-    "@types/long": "^4.0.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^8.0.37",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^5.2.0",

--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -23,14 +23,13 @@
   },
   "dependencies": {
     "@azure/amqp-common": "^1.0.0-preview.1",
+    "@types/long": "^4.0.0",
     "debug": "^3.1.0",
     "is-buffer": "^2.0.3",
     "long": "^4.0.0",
     "ms-rest-azure": "^2.5.9",
     "rhea-promise": "^0.1.13",
-    "tslib": "^1.9.3",
-    "@types/node": "^8.0.37",
-    "@types/long": "^4.0.0"
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@azure/arm-servicebus": "^0.1.0",
@@ -42,6 +41,7 @@
     "@types/debug": "^0.0.31",
     "@types/dotenv": "^4.0.3",
     "@types/mocha": "^5.2.5",
+    "@types/node": "^11.9.5",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^5.2.0",

--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -41,7 +41,7 @@
     "@types/debug": "^0.0.31",
     "@types/dotenv": "^4.0.3",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^11.9.5",
+    "@types/node": "^8.0.37",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^5.2.0",

--- a/packages/@azure/servicebus/data-plane/tsconfig.json
+++ b/packages/@azure/servicebus/data-plane/tsconfig.json
@@ -3,24 +3,22 @@
     /* Basic Options */
     "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "es6" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-
+    "lib": [] /* lib dependencies are triple-slash directives in lib/index.ts */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     "sourceMap": true /* Generates corresponding '.map' file. */,
-    
-    "outDir": "./dist-esm" /* Redirect output structure to the directory. */,
-    "declarationDir": "./typings", /* Output directory for generated declaration files.*/
- 
-    "stripInternal": true, /* Do not emit declarations for code with @internal annotation*/
 
+    "outDir": "./dist-esm" /* Redirect output structure to the directory. */,
+    "stripInternal": true /* Do not emit declarations for code with @internal annotation*/,
+    "declarationDir": "./typings" /* Output directory for generated declaration files.*/,
     "importHelpers": true /* Import emit helpers from 'tslib'. */,
-    
+
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
-    "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
 
     /* Additional Checks */
-    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
 
     /* Module Resolution Options */
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
@@ -31,17 +29,10 @@
     "forceConsistentCasingInFileNames": true,
 
     /* Other options */
-    "newLine": "LF", /*	Use the specified end of line sequence to be used when emitting files: "crlf" (windows) or "lf" (unix).”*/
-    "allowJs": false, /* Don't allow JavaScript files to be compiled.*/
+    "newLine": "LF" /*	Use the specified end of line sequence to be used when emitting files: "crlf" (windows) or "lf" (unix).”*/,
+    "allowJs": false /* Don't allow JavaScript files to be compiled.*/
   },
   "compileOnSave": true,
-  "exclude": [
-    "node_modules",
-    "typings/**",
-    "./examples/**/*.ts"
-  ],
-  "include": [
-    "./lib/**/*.ts",
-    "./test/**/*.ts",
-  ]
+  "exclude": ["node_modules", "typings/**", "./examples/**/*.ts"],
+  "include": ["./lib/**/*.ts", "./test/**/*.ts"]
 }


### PR DESCRIPTION
Fixes #1332 and addresses related problems by:
* Adding @types/long as a normal dependency. These types are part of our public surface area and are needed to compile programs depending on our library.
* Removing the dependency on the DOM lib by shimming our only dependency (on navigator).
* Moving the dependency on es2015 lib into a triple-slash reference directive. This is the recommended approach by the TypeScript team. It has the effect of implicitly enabling the es2015 lib setting for our users which is good to be aware of (not sure if it needs to be documented).
* Documenting the remaining TypeScript configuration requirements in readme: installing @types/node and setting esModuleInterop to `true`.

Regarding @types/node, adding it as a dep is convenient as users don't need to configure anything and it "just works". However, having multiple versions of @types/node in a compilation (e.g. due to various transitive dependencies) can cause subtle and frustrating issues. Also, users like to set the @types/node version based on the version of the Node runtime they target.

A peerDependency makes some sense and is something we can investigate going forward. In the meantime, this PR documents the requirement for node types in the readme.