### PR TITLE
[Event Hubs] Increase the receiver tests' receiving timeout

### DIFF
--- a/packages/@azure/eventhubs/client/lib/batchingReceiver.ts
+++ b/packages/@azure/eventhubs/client/lib/batchingReceiver.ts
@@ -83,8 +83,8 @@ export class BatchingReceiver extends EventHubReceiver {
       // Action to be performed after the max wait time is over.
       actionAfterWaitTimeout = () => {
         timeOver = true;
-        log.batching("[%s] Batching Receiver '%s'  max wait time in seconds %d over.",
-          this._context.connectionId, this.name, maxWaitTimeInSeconds);
+        log.batching("[%s] Batching Receiver '%s', %d messages received when max wait time in seconds %d is over.",
+          this._context.connectionId, this.name, eventDatas.length, maxWaitTimeInSeconds);
         return finalAction(timeOver);
       };
 
@@ -96,6 +96,8 @@ export class BatchingReceiver extends EventHubReceiver {
           eventDatas.push(data);
         }
         if (eventDatas.length === maxMessageCount) {
+          log.batching("[%s] Batching Receiver '%s', %d messages received within %d seconds.",
+            this._context.connectionId, this.name, eventDatas.length, maxWaitTimeInSeconds);
           finalAction(timeOver, data);
         }
       };

--- a/packages/@azure/eventhubs/client/tests/misc.spec.ts
+++ b/packages/@azure/eventhubs/client/tests/misc.spec.ts
@@ -41,11 +41,11 @@ describe("Misc tests", function (): void {
     debug(`Partition ${partitionId} has last message with offset ${offset}.`);
     debug("Sending one message with %d bytes.", bodysize);
     breceiver = BatchingReceiver.create((client as any)._context, partitionId, { eventPosition: EventPosition.fromOffset(offset) });
-    let data = await breceiver.receive(5, 5);
-    data.length.should.equal(0);
+    let data = await breceiver.receive(5, 10);
+    data.length.should.equal(0, "Unexpected to receive message before client sends it");
     await client.send(obj, partitionId);
     debug("Successfully sent the large message.");
-    data = await breceiver.receive(5, 10);
+    data = await breceiver.receive(5, 30);
     debug("Closing the receiver..");
     await breceiver.close();
     debug("received message: ", data.length);
@@ -76,7 +76,7 @@ describe("Misc tests", function (): void {
     breceiver = BatchingReceiver.create((client as any)._context, partitionId, { eventPosition: EventPosition.fromOffset(offset) });
     await client.send(obj, partitionId);
     debug("Successfully sent the large message.");
-    const data = await breceiver.receive(5, 10);
+    const data = await breceiver.receive(5, 30);
     await breceiver.close();
     debug("received message: ", data);
     should.exist(data);
@@ -105,7 +105,7 @@ describe("Misc tests", function (): void {
     breceiver = BatchingReceiver.create((client as any)._context, partitionId, { eventPosition: EventPosition.fromOffset(offset) });
     await client.send(obj, partitionId);
     debug("Successfully sent the large message.");
-    const data = await breceiver.receive(5, 5);
+    const data = await breceiver.receive(5, 30);
     await breceiver.close();
     debug("received message: ", data);
     should.exist(data);
@@ -125,7 +125,7 @@ describe("Misc tests", function (): void {
     breceiver = BatchingReceiver.create((client as any)._context, partitionId, { eventPosition: EventPosition.fromOffset(offset) });
     await client.send(obj, partitionId);
     debug("Successfully sent the large message.");
-    const data = await breceiver.receive(5, 5);
+    const data = await breceiver.receive(5, 30);
     await breceiver.close();
     debug("received message: ", data);
     should.exist(data);
@@ -142,7 +142,7 @@ describe("Misc tests", function (): void {
       debug(`Partition ${partitionId} has last message with offset ${offset}.`);
       breceiver = BatchingReceiver.create((client as any)._context, partitionId, { eventPosition: EventPosition.fromOffset(offset) });
       let data = await breceiver.receive(5, 10);
-      data.length.should.equal(0);
+      data.length.should.equal(0, "Unexpected to receive message before client sends it");
       const messageCount = 5;
       const d: EventData[] = [];
       for (let i = 0; i < messageCount; i++) {
@@ -153,7 +153,7 @@ describe("Misc tests", function (): void {
 
       await client.sendBatch(d, partitionId);
       debug("Successfully sent 5 messages batched together.");
-      data = await breceiver.receive(5, 15);
+      data = await breceiver.receive(5, 30);
       await breceiver.close();
       debug("received message: ", data);
       should.exist(data);
@@ -173,8 +173,8 @@ describe("Misc tests", function (): void {
       const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
       debug(`Partition ${partitionId} has last message with offset ${offset}.`);
       breceiver = BatchingReceiver.create((client as any)._context, partitionId, { eventPosition: EventPosition.fromOffset(offset) });
-      let data = await breceiver.receive(5, 5);
-      data.length.should.equal(0);
+      let data = await breceiver.receive(5, 10);
+      data.length.should.equal(0, "Unexpected to receive message before client sends it");
       const messageCount = 5;
       const d: EventData[] = [];
       for (let i = 0; i < messageCount; i++) {
@@ -202,7 +202,7 @@ describe("Misc tests", function (): void {
 
       await client.sendBatch(d, partitionId);
       debug("Successfully sent 5 messages batched together.");
-      data = await breceiver.receive(5, 10);
+      data = await breceiver.receive(5, 30);
       await breceiver.close();
       debug("received message: ", data);
       should.exist(data);


### PR DESCRIPTION
With 5 seconds wait, the tests are failing randomly when running on
two different machines. After increasing the receiving timeout the
tests passed in multiple local runs and manual CI builds.

  - Wait for 10s when not expecting any messages.
  - Wait for 20s for a single message.
  - Wait for 30s for two or more messages, or large messages.

While at it, 
 - Log number of messages received at the end.
 - Rename datas => data.