### PR TITLE
[Service Bus] Add typedefs for throwIfReceiverOrConnectionClosed

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/receiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/receiver.ts
@@ -254,7 +254,7 @@ export class Receiver {
     }
   }
 
-  private throwIfReceiverOrConnectionClosed() {
+  private throwIfReceiverOrConnectionClosed(): void {
     throwErrorIfConnectionClosed(this._context.namespace);
     if (this.isClosed) {
       throw new Error("The receiver has been closed and can no longer be used.");
@@ -494,7 +494,7 @@ export class SessionReceiver {
     return this._messageSession.isOpen();
   }
 
-  private throwIfReceiverOrConnectionClosed() {
+  private throwIfReceiverOrConnectionClosed(): void {
     throwErrorIfConnectionClosed(this._context.namespace);
     if (this.isClosed) {
       throw new Error("The receiver has been closed and can no longer be used.");


### PR DESCRIPTION
Fixes the build error that occurred due to the absence of the return type on `throwIfReceiverOrConnectionClosed` function