### PR TITLE
Add create_sdk_pull_requests property to swagger_to_sdk_config.json

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -8,7 +8,8 @@
       "use": "@microsoft.azure/autorest.typescript@2.1.1"
     },
     "advanced_options": {
-      "clone_dir": "./azure-sdk-for-js"
+      "clone_dir": "./azure-sdk-for-js",
+      "create_sdk_pull_requests": true
     },
     "version": "0.2.0"
   }


### PR DESCRIPTION
This property will be used by the new SDK Automation service to enable or disable auto-pull requests. I'm setting it to true for my tests, but I'm still using a fake GitHub implementation.