### PR TITLE
[Service Bus] Work around build timeout

### DIFF
--- a/packages/@azure/servicebus/data-plane/package.json
+++ b/packages/@azure/servicebus/data-plane/package.json
@@ -83,8 +83,8 @@
     "build-test": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js",
     "build-samples": "cd examples && tsc -p .",
     "test": "npm run build",
-    "unit": "npm run build-test && mocha -t 120000 test-dist/index.js",
-    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 120000 test-dist/index.js",
+    "unit": "npm run build-test && mocha -t 120000 test-dist/index.js --exit",
+    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 120000 test-dist/index.js --exit",
     "prepack": "npm i && npm run build",
     "extract-api": "tsc -p . && api-extractor run --local"
   }


### PR DESCRIPTION
Since v4.0.0 Mocha no longer forces its own process to exit after
tests completed. So if there are active resources (e.g., timers) it
will wait until all of them are released.

Some of our tests don't clean up correctly when failing which leads to
build timeout. This change works around it by asking Mocha to exit
when tests finish.

A separate issue is logged to investigate the issue of active
resources held by failing tests.