### PR TITLE
[Service Bus] Fix test failure due to receivers not being  reusable anymore

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/renewLock.spec.ts
@@ -542,7 +542,8 @@ async function testAutoLockRenewalConfigBehavior(
 
   if (options.willCompleteFail) {
     // Clean up any left over messages
-    const unprocessedMsgs = await receiver.receiveBatch(1);
+    const newReceiver = receiverClient.getReceiver();
+    const unprocessedMsgs = await newReceiver.receiveBatch(1);
     await unprocessedMsgs[0].complete();
   }
 }


### PR DESCRIPTION
With #1334 we no longer allow using receivers once they are closed.
This PR is to update our tests that were doing just that