### PR TITLE
[Service Bus] Close namespace after tests to fix hanging tests

### DIFF
--- a/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
+++ b/packages/@azure/servicebus/data-plane/test/namespace.spec.ts
@@ -425,6 +425,10 @@ describe("Errors after close()", function(): void {
   let sender: Sender;
   let receiver: Receiver | SessionReceiver;
 
+  afterEach(() => {
+    return namespace.close();
+  });
+
   async function beforeEachTest(
     senderType: ClientType,
     receiverType: ClientType,


### PR DESCRIPTION
The tests for the close() feature dont have a `afterEach` to close the namespace causing the tests to not exit. This PR fixes this problems