### PR TITLE
[Event Hubs] Close client in finally block

### DIFF
--- a/packages/@azure/eventhubs/processor/lib/hostContext.ts
+++ b/packages/@azure/eventhubs/processor/lib/hostContext.ts
@@ -243,8 +243,7 @@ export namespace HostContext {
     ctxt.getHubRuntimeInformation = async () => {
       const client = ctxt.getEventHubClient();
       try {
-        const result = await client.getHubRuntimeInformation();
-        return result;
+        return await client.getHubRuntimeInformation();
       } finally {
         client.close().catch(/* do nothing */);
       }
@@ -252,8 +251,7 @@ export namespace HostContext {
     ctxt.getPartitionInformation = async (id: string | number) => {
       const client = ctxt.getEventHubClient();
       try {
-        const result = await client.getPartitionInformation(id);
-        return result;
+        return await client.getPartitionInformation(id);
       } finally {
         client.close().catch(/* do nothing */);
       }

--- a/packages/@azure/eventhubs/processor/lib/hostContext.ts
+++ b/packages/@azure/eventhubs/processor/lib/hostContext.ts
@@ -242,21 +242,30 @@ export namespace HostContext {
     };
     ctxt.getHubRuntimeInformation = async () => {
       const client = ctxt.getEventHubClient();
-      const result = await client.getHubRuntimeInformation();
-      client.close().catch(/* do nothing */);
-      return result;
+      try {
+        const result = await client.getHubRuntimeInformation();
+        return result;
+      } finally {
+        client.close().catch(/* do nothing */);
+      }
     };
     ctxt.getPartitionInformation = async (id: string | number) => {
       const client = ctxt.getEventHubClient();
-      const result = await client.getPartitionInformation(id);
-      client.close().catch(/* do nothing */);
-      return result;
+      try {
+        const result = await client.getPartitionInformation(id);
+        return result;
+      } finally {
+        client.close().catch(/* do nothing */);
+      }
     };
     ctxt.getPartitionIds = async () => {
       if (!ctxt.partitionIds.length) {
         const client = ctxt.getEventHubClient();
-        ctxt.partitionIds = await client.getPartitionIds();
-        client.close().catch(/* do nothing */);
+        try {
+          ctxt.partitionIds = await client.getPartitionIds();
+        } finally {
+          client.close().catch(/* do nothing */);
+        }
       }
       return ctxt.partitionIds;
     };

--- a/packages/@azure/eventhubs/processor/package.json
+++ b/packages/@azure/eventhubs/processor/package.json
@@ -75,8 +75,8 @@
     "build-test": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js",
     "build-samples": "cd examples && tsc -p .",
     "test": "npm run build",
-    "unit": "npm run build-test && mocha -t 120000 test-dist/index.js --exit",
-    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 120000 test-dist/index.js --exit",
+    "unit": "npm run build-test && mocha -t 120000 test-dist/index.js",
+    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 120000 test-dist/index.js",
     "prepack": "npm i && npm run build",
     "extract-api": "tsc -p . && api-extractor run --local"
   },

--- a/packages/@azure/eventhubs/processor/tests/eph.spec.ts
+++ b/packages/@azure/eventhubs/processor/tests/eph.spec.ts
@@ -477,6 +477,8 @@ describe("EPH", function (): void {
           await host.getPartitionInformation("");
         } catch (err) {
           err.message.should.match(/.*The specified partition is invalid for an EventHub partition sender or receiver.*/ig);
+        } finally {
+          await host.stop();
         }
       };
       test().then(() => { done(); }).catch((err) => { done(err); });
@@ -498,6 +500,8 @@ describe("EPH", function (): void {
           await host.getPartitionInformation(-1);
         } catch (err) {
           err.message.should.match(/.*The specified partition is invalid for an EventHub partition sender or receiver.*/ig);
+        } finally {
+          await host.stop();
         }
       };
       test().then(() => { done(); }).catch((err) => { done(err); });


### PR DESCRIPTION
We have negative tests that still hold onto resources after test
complete which causes Mocha to hang. This exposes an issue that
`HostContext` doesn't close client after an error is thrown.

This change ensures that in the error cases client is closed properly.
Mocha will also exit at the end so we can remove the hacky `--exit`
workaround that forces Mocha to exit after tests complete.