### PR TITLE
Adding Impression Pixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,6 @@ get your code included into the project.
 1. Commit your changes (`git commit -am 'Add some feature'`)
 2. Push to the branch (`git push origin my-new-feature`)
 3. Create new Pull Request
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2FREADME.png)

--- a/packages/@azure/applicationinsights-query/README.md
+++ b/packages/@azure/applicationinsights-query/README.md
@@ -110,3 +110,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fapplicationinsights-query%2FREADME.png)

--- a/packages/@azure/arm-advisor/README.md
+++ b/packages/@azure/arm-advisor/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-advisor%2FREADME.png)

--- a/packages/@azure/arm-analysisservices/README.md
+++ b/packages/@azure/arm-analysisservices/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-analysisservices%2FREADME.png)

--- a/packages/@azure/arm-apimanagement/README.md
+++ b/packages/@azure/arm-apimanagement/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-apimanagement%2FREADME.png)

--- a/packages/@azure/arm-appinsights/README.md
+++ b/packages/@azure/arm-appinsights/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-appinsights%2FREADME.png)

--- a/packages/@azure/arm-appservice/README.md
+++ b/packages/@azure/arm-appservice/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-appservice%2FREADME.png)

--- a/packages/@azure/arm-authorization/README.md
+++ b/packages/@azure/arm-authorization/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-authorization%2FREADME.png)

--- a/packages/@azure/arm-automation/README.md
+++ b/packages/@azure/arm-automation/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-automation%2FREADME.png)

--- a/packages/@azure/arm-azurestack/README.md
+++ b/packages/@azure/arm-azurestack/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-azurestack%2FREADME.png)

--- a/packages/@azure/arm-batch/README.md
+++ b/packages/@azure/arm-batch/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-batch%2FREADME.png)

--- a/packages/@azure/arm-batchai/README.md
+++ b/packages/@azure/arm-batchai/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-batchai%2FREADME.png)

--- a/packages/@azure/arm-billing/README.md
+++ b/packages/@azure/arm-billing/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-billing%2FREADME.png)

--- a/packages/@azure/arm-cdn/README.md
+++ b/packages/@azure/arm-cdn/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-cdn%2FREADME.png)

--- a/packages/@azure/arm-cognitiveservices/README.md
+++ b/packages/@azure/arm-cognitiveservices/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-cognitiveservices%2FREADME.png)

--- a/packages/@azure/arm-commerce/README.md
+++ b/packages/@azure/arm-commerce/README.md
@@ -104,3 +104,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-commerce%2FREADME.png)

--- a/packages/@azure/arm-commitmentplans/README.md
+++ b/packages/@azure/arm-commitmentplans/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-commitmentplans%2FREADME.png)

--- a/packages/@azure/arm-compute/README.md
+++ b/packages/@azure/arm-compute/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-compute%2FREADME.png)

--- a/packages/@azure/arm-consumption/README.md
+++ b/packages/@azure/arm-consumption/README.md
@@ -104,3 +104,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-consumption%2FREADME.png)

--- a/packages/@azure/arm-containerinstance/README.md
+++ b/packages/@azure/arm-containerinstance/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-containerinstance%2FREADME.png)

--- a/packages/@azure/arm-containerregistry/README.md
+++ b/packages/@azure/arm-containerregistry/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-containerregistry%2FREADME.png)

--- a/packages/@azure/arm-containerservice/README.md
+++ b/packages/@azure/arm-containerservice/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-containerservice%2FREADME.png)

--- a/packages/@azure/arm-cosmosdb/README.md
+++ b/packages/@azure/arm-cosmosdb/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-cosmosdb%2FREADME.png)

--- a/packages/@azure/arm-customerinsights/README.md
+++ b/packages/@azure/arm-customerinsights/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-customerinsights%2FREADME.png)

--- a/packages/@azure/arm-databox/README.md
+++ b/packages/@azure/arm-databox/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-databox%2FREADME.png)

--- a/packages/@azure/arm-databricks/README.md
+++ b/packages/@azure/arm-databricks/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-databricks%2FREADME.png)

--- a/packages/@azure/arm-datacatalog/README.md
+++ b/packages/@azure/arm-datacatalog/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-datacatalog%2FREADME.png)

--- a/packages/@azure/arm-datafactory/README.md
+++ b/packages/@azure/arm-datafactory/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-datafactory%2FREADME.png)

--- a/packages/@azure/arm-deploymentmanager/README.md
+++ b/packages/@azure/arm-deploymentmanager/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-deploymentmanager%2FREADME.png)

--- a/packages/@azure/arm-deviceprovisioningservices/README.md
+++ b/packages/@azure/arm-deviceprovisioningservices/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-deviceprovisioningservices%2FREADME.png)

--- a/packages/@azure/arm-devspaces/README.md
+++ b/packages/@azure/arm-devspaces/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-devspaces%2FREADME.png)

--- a/packages/@azure/arm-devtestlabs/README.md
+++ b/packages/@azure/arm-devtestlabs/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-devtestlabs%2FREADME.png)

--- a/packages/@azure/arm-dns/README.md
+++ b/packages/@azure/arm-dns/README.md
@@ -102,3 +102,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-dns%2FREADME.png)

--- a/packages/@azure/arm-domainservices/README.md
+++ b/packages/@azure/arm-domainservices/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-domainservices%2FREADME.png)

--- a/packages/@azure/arm-edgegateway/README.md
+++ b/packages/@azure/arm-edgegateway/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-edgegateway%2FREADME.png)

--- a/packages/@azure/arm-eventgrid/README.md
+++ b/packages/@azure/arm-eventgrid/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-eventgrid%2FREADME.png)

--- a/packages/@azure/arm-eventhub/README.md
+++ b/packages/@azure/arm-eventhub/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-eventhub%2FREADME.png)

--- a/packages/@azure/arm-features/README.md
+++ b/packages/@azure/arm-features/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-features%2FREADME.png)

--- a/packages/@azure/arm-frontdoor/README.md
+++ b/packages/@azure/arm-frontdoor/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-frontdoor%2FREADME.png)

--- a/packages/@azure/arm-hanaonazure/README.md
+++ b/packages/@azure/arm-hanaonazure/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-hanaonazure%2FREADME.png)

--- a/packages/@azure/arm-hdinsight/README.md
+++ b/packages/@azure/arm-hdinsight/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-hdinsight%2FREADME.png)

--- a/packages/@azure/arm-iotcentral/README.md
+++ b/packages/@azure/arm-iotcentral/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-iotcentral%2FREADME.png)

--- a/packages/@azure/arm-iothub/README.md
+++ b/packages/@azure/arm-iothub/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-iothub%2FREADME.png)

--- a/packages/@azure/arm-iotspaces/README.md
+++ b/packages/@azure/arm-iotspaces/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-iotspaces%2FREADME.png)

--- a/packages/@azure/arm-kusto/README.md
+++ b/packages/@azure/arm-kusto/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-kusto%2FREADME.png)

--- a/packages/@azure/arm-labservices/README.md
+++ b/packages/@azure/arm-labservices/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-labservices%2FREADME.png)

--- a/packages/@azure/arm-links/README.md
+++ b/packages/@azure/arm-links/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-links%2FREADME.png)

--- a/packages/@azure/arm-locks/README.md
+++ b/packages/@azure/arm-locks/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-locks%2FREADME.png)

--- a/packages/@azure/arm-logic/README.md
+++ b/packages/@azure/arm-logic/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-logic%2FREADME.png)

--- a/packages/@azure/arm-machinelearningcompute/README.md
+++ b/packages/@azure/arm-machinelearningcompute/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-machinelearningcompute%2FREADME.png)

--- a/packages/@azure/arm-machinelearningexperimentation/README.md
+++ b/packages/@azure/arm-machinelearningexperimentation/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-machinelearningexperimentation%2FREADME.png)

--- a/packages/@azure/arm-machinelearningservices/README.md
+++ b/packages/@azure/arm-machinelearningservices/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-machinelearningservices%2FREADME.png)

--- a/packages/@azure/arm-managedapplications/README.md
+++ b/packages/@azure/arm-managedapplications/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-managedapplications%2FREADME.png)

--- a/packages/@azure/arm-managementgroups/README.md
+++ b/packages/@azure/arm-managementgroups/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-managementgroups%2FREADME.png)

--- a/packages/@azure/arm-managementpartner/README.md
+++ b/packages/@azure/arm-managementpartner/README.md
@@ -96,3 +96,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-managementpartner%2FREADME.png)

--- a/packages/@azure/arm-maps/README.md
+++ b/packages/@azure/arm-maps/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-maps%2FREADME.png)

--- a/packages/@azure/arm-mariadb/README.md
+++ b/packages/@azure/arm-mariadb/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-mariadb%2FREADME.png)

--- a/packages/@azure/arm-marketplaceordering/README.md
+++ b/packages/@azure/arm-marketplaceordering/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-marketplaceordering%2FREADME.png)

--- a/packages/@azure/arm-mediaservices/README.md
+++ b/packages/@azure/arm-mediaservices/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-mediaservices%2FREADME.png)

--- a/packages/@azure/arm-migrate/README.md
+++ b/packages/@azure/arm-migrate/README.md
@@ -96,3 +96,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-migrate%2FREADME.png)

--- a/packages/@azure/arm-mixedreality/README.md
+++ b/packages/@azure/arm-mixedreality/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-mixedreality%2FREADME.png)

--- a/packages/@azure/arm-monitor/README.md
+++ b/packages/@azure/arm-monitor/README.md
@@ -96,3 +96,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-monitor%2FREADME.png)

--- a/packages/@azure/arm-msi/README.md
+++ b/packages/@azure/arm-msi/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-msi%2FREADME.png)

--- a/packages/@azure/arm-mysql/README.md
+++ b/packages/@azure/arm-mysql/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-mysql%2FREADME.png)

--- a/packages/@azure/arm-netapp/README.md
+++ b/packages/@azure/arm-netapp/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-netapp%2FREADME.png)

--- a/packages/@azure/arm-network/README.md
+++ b/packages/@azure/arm-network/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-network%2FREADME.png)

--- a/packages/@azure/arm-notificationhubs/README.md
+++ b/packages/@azure/arm-notificationhubs/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-notificationhubs%2FREADME.png)

--- a/packages/@azure/arm-operationalinsights/README.md
+++ b/packages/@azure/arm-operationalinsights/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-operationalinsights%2FREADME.png)

--- a/packages/@azure/arm-operations/README.md
+++ b/packages/@azure/arm-operations/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-operations%2FREADME.png)

--- a/packages/@azure/arm-policy/README.md
+++ b/packages/@azure/arm-policy/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-policy%2FREADME.png)

--- a/packages/@azure/arm-policyinsights/README.md
+++ b/packages/@azure/arm-policyinsights/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-policyinsights%2FREADME.png)

--- a/packages/@azure/arm-postgresql/README.md
+++ b/packages/@azure/arm-postgresql/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-postgresql%2FREADME.png)

--- a/packages/@azure/arm-powerbidedicated/README.md
+++ b/packages/@azure/arm-powerbidedicated/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-powerbidedicated%2FREADME.png)

--- a/packages/@azure/arm-powerbiembedded/README.md
+++ b/packages/@azure/arm-powerbiembedded/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-powerbiembedded%2FREADME.png)

--- a/packages/@azure/arm-privatedns/README.md
+++ b/packages/@azure/arm-privatedns/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-privatedns%2FREADME.png)

--- a/packages/@azure/arm-recoveryservices-siterecovery/README.md
+++ b/packages/@azure/arm-recoveryservices-siterecovery/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-recoveryservices-siterecovery%2FREADME.png)

--- a/packages/@azure/arm-recoveryservices/README.md
+++ b/packages/@azure/arm-recoveryservices/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-recoveryservices%2FREADME.png)

--- a/packages/@azure/arm-recoveryservicesbackup/README.md
+++ b/packages/@azure/arm-recoveryservicesbackup/README.md
@@ -102,3 +102,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-recoveryservicesbackup%2FREADME.png)

--- a/packages/@azure/arm-rediscache/README.md
+++ b/packages/@azure/arm-rediscache/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-rediscache%2FREADME.png)

--- a/packages/@azure/arm-relay/README.md
+++ b/packages/@azure/arm-relay/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-relay%2FREADME.png)

--- a/packages/@azure/arm-reservations/README.md
+++ b/packages/@azure/arm-reservations/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-reservations%2FREADME.png)

--- a/packages/@azure/arm-resourcehealth/README.md
+++ b/packages/@azure/arm-resourcehealth/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-resourcehealth%2FREADME.png)

--- a/packages/@azure/arm-resources/README.md
+++ b/packages/@azure/arm-resources/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-resources%2FREADME.png)

--- a/packages/@azure/arm-search/README.md
+++ b/packages/@azure/arm-search/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-search%2FREADME.png)

--- a/packages/@azure/arm-security/README.md
+++ b/packages/@azure/arm-security/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-security%2FREADME.png)

--- a/packages/@azure/arm-servicebus/README.md
+++ b/packages/@azure/arm-servicebus/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-servicebus%2FREADME.png)

--- a/packages/@azure/arm-servicefabricmesh/README.md
+++ b/packages/@azure/arm-servicefabricmesh/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-servicefabricmesh%2FREADME.png)

--- a/packages/@azure/arm-servicemap/README.md
+++ b/packages/@azure/arm-servicemap/README.md
@@ -108,3 +108,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-servicemap%2FREADME.png)

--- a/packages/@azure/arm-signalr/README.md
+++ b/packages/@azure/arm-signalr/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-signalr%2FREADME.png)

--- a/packages/@azure/arm-sql/README.md
+++ b/packages/@azure/arm-sql/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-sql%2FREADME.png)

--- a/packages/@azure/arm-sqlvirtualmachine/README.md
+++ b/packages/@azure/arm-sqlvirtualmachine/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-sqlvirtualmachine%2FREADME.png)

--- a/packages/@azure/arm-storage/README.md
+++ b/packages/@azure/arm-storage/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-storage%2FREADME.png)

--- a/packages/@azure/arm-storageimportexport/README.md
+++ b/packages/@azure/arm-storageimportexport/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-storageimportexport%2FREADME.png)

--- a/packages/@azure/arm-storagesync/README.md
+++ b/packages/@azure/arm-storagesync/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-storagesync%2FREADME.png)

--- a/packages/@azure/arm-storsimple1200series/README.md
+++ b/packages/@azure/arm-storsimple1200series/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-storsimple1200series%2FREADME.png)

--- a/packages/@azure/arm-storsimple8000series/README.md
+++ b/packages/@azure/arm-storsimple8000series/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-storsimple8000series%2FREADME.png)

--- a/packages/@azure/arm-streamanalytics/README.md
+++ b/packages/@azure/arm-streamanalytics/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-streamanalytics%2FREADME.png)

--- a/packages/@azure/arm-subscriptions/README.md
+++ b/packages/@azure/arm-subscriptions/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-subscriptions%2FREADME.png)

--- a/packages/@azure/arm-timeseriesinsights/README.md
+++ b/packages/@azure/arm-timeseriesinsights/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-timeseriesinsights%2FREADME.png)

--- a/packages/@azure/arm-trafficmanager/README.md
+++ b/packages/@azure/arm-trafficmanager/README.md
@@ -102,3 +102,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-trafficmanager%2FREADME.png)

--- a/packages/@azure/arm-visualstudio/README.md
+++ b/packages/@azure/arm-visualstudio/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-visualstudio%2FREADME.png)

--- a/packages/@azure/arm-webservices/README.md
+++ b/packages/@azure/arm-webservices/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-webservices%2FREADME.png)

--- a/packages/@azure/arm-workspaces/README.md
+++ b/packages/@azure/arm-workspaces/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Farm-workspaces%2FREADME.png)

--- a/packages/@azure/batch/README.md
+++ b/packages/@azure/batch/README.md
@@ -104,3 +104,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fbatch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-autosuggest/README.md
+++ b/packages/@azure/cognitiveservices-autosuggest/README.md
@@ -116,3 +116,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-autosuggest%2FREADME.png)

--- a/packages/@azure/cognitiveservices-computervision/README.md
+++ b/packages/@azure/cognitiveservices-computervision/README.md
@@ -92,3 +92,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-computervision%2FREADME.png)

--- a/packages/@azure/cognitiveservices-contentmoderator/README.md
+++ b/packages/@azure/cognitiveservices-contentmoderator/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-contentmoderator%2FREADME.png)

--- a/packages/@azure/cognitiveservices-customimagesearch/README.md
+++ b/packages/@azure/cognitiveservices-customimagesearch/README.md
@@ -150,3 +150,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-customimagesearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-customsearch/README.md
+++ b/packages/@azure/cognitiveservices-customsearch/README.md
@@ -122,3 +122,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-customsearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-customvision-prediction/README.md
+++ b/packages/@azure/cognitiveservices-customvision-prediction/README.md
@@ -104,3 +104,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-customvision-prediction%2FREADME.png)

--- a/packages/@azure/cognitiveservices-customvision-training/README.md
+++ b/packages/@azure/cognitiveservices-customvision-training/README.md
@@ -92,3 +92,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-customvision-training%2FREADME.png)

--- a/packages/@azure/cognitiveservices-entitysearch/README.md
+++ b/packages/@azure/cognitiveservices-entitysearch/README.md
@@ -118,3 +118,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-entitysearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-face/README.md
+++ b/packages/@azure/cognitiveservices-face/README.md
@@ -98,3 +98,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-face%2FREADME.png)

--- a/packages/@azure/cognitiveservices-imagesearch/README.md
+++ b/packages/@azure/cognitiveservices-imagesearch/README.md
@@ -148,3 +148,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-imagesearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-localsearch/README.md
+++ b/packages/@azure/cognitiveservices-localsearch/README.md
@@ -126,3 +126,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-localsearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-luis-authoring/README.md
+++ b/packages/@azure/cognitiveservices-luis-authoring/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-luis-authoring%2FREADME.png)

--- a/packages/@azure/cognitiveservices-luis-runtime/README.md
+++ b/packages/@azure/cognitiveservices-luis-runtime/README.md
@@ -108,3 +108,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-luis-runtime%2FREADME.png)

--- a/packages/@azure/cognitiveservices-newssearch/README.md
+++ b/packages/@azure/cognitiveservices-newssearch/README.md
@@ -126,3 +126,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-newssearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-qnamaker/README.md
+++ b/packages/@azure/cognitiveservices-qnamaker/README.md
@@ -92,3 +92,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-qnamaker%2FREADME.png)

--- a/packages/@azure/cognitiveservices-spellcheck/README.md
+++ b/packages/@azure/cognitiveservices-spellcheck/README.md
@@ -130,3 +130,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-spellcheck%2FREADME.png)

--- a/packages/@azure/cognitiveservices-textanalytics/README.md
+++ b/packages/@azure/cognitiveservices-textanalytics/README.md
@@ -106,3 +106,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-textanalytics%2FREADME.png)

--- a/packages/@azure/cognitiveservices-videosearch/README.md
+++ b/packages/@azure/cognitiveservices-videosearch/README.md
@@ -130,3 +130,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-videosearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-visualsearch/README.md
+++ b/packages/@azure/cognitiveservices-visualsearch/README.md
@@ -114,3 +114,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-visualsearch%2FREADME.png)

--- a/packages/@azure/cognitiveservices-websearch/README.md
+++ b/packages/@azure/cognitiveservices-websearch/README.md
@@ -130,3 +130,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fcognitiveservices-websearch%2FREADME.png)

--- a/packages/@azure/eventgrid/README.md
+++ b/packages/@azure/eventgrid/README.md
@@ -114,3 +114,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Feventgrid%2FREADME.png)

--- a/packages/@azure/eventhubs/README.md
+++ b/packages/@azure/eventhubs/README.md
@@ -3,3 +3,6 @@
 We have two client libraries for Azure Event Hubs
 - `@azure/event-hubs` - The Event Hubs client for sending and receiving messages. You can find more info over [here](./client).
 - `@azure/event-processor-host` - The Event Processor Host for efficient receiving of messages. You can find more info over [here](./processor).
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Feventhubs%2FREADME.png)

--- a/packages/@azure/eventhubs/client/README.md
+++ b/packages/@azure/eventhubs/client/README.md
@@ -254,3 +254,6 @@ main().catch((err) => {
 
 ## AMQP Dependencies ##
 It depends on [rhea](https://github.com/amqp/rhea) library for managing connections, sending and receiving events over the [AMQP](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-complete-v1.0-os.pdf) protocol.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Feventhubs%2Fclient%2FREADME.png)

--- a/packages/@azure/eventhubs/client/examples/README.md
+++ b/packages/@azure/eventhubs/client/examples/README.md
@@ -45,3 +45,6 @@ ts-node <sample>.ts
 ```bash
 "program": "${workspaceFolder}/client/examples/<sample>.ts"
 ```
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Feventhubs%2Fclient%2Fexamples%2FREADME.png)

--- a/packages/@azure/eventhubs/processor/README.md
+++ b/packages/@azure/eventhubs/processor/README.md
@@ -293,3 +293,6 @@ main().catch((err) => {
 
 ## AMQP Dependencies ##
 It depends on [rhea](https://github.com/amqp/rhea) library for managing connections, sending and receiving events over the [AMQP](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-complete-v1.0-os.pdf) protocol.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Feventhubs%2Fprocessor%2FREADME.png)

--- a/packages/@azure/eventhubs/processor/examples/README.md
+++ b/packages/@azure/eventhubs/processor/examples/README.md
@@ -46,3 +46,6 @@ ts-node <sample>.ts
 ```bash
 "program": "${workspaceFolder}/processor/examples/<sample>.ts"
 ```
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Feventhubs%2Fprocessor%2Fexamples%2FREADME.png)

--- a/packages/@azure/eventhubs/testhub/README.md
+++ b/packages/@azure/eventhubs/testhub/README.md
@@ -109,3 +109,6 @@ Options:
 
 #### Debug
 - If you would like to see more in-depth information about what is happening, `export DEBUG=azure*` or `export DEBUG=azure*,rhea*`.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Feventhubs%2Ftesthub%2FREADME.png)

--- a/packages/@azure/graph/README.md
+++ b/packages/@azure/graph/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fgraph%2FREADME.png)

--- a/packages/@azure/keyvault/README.md
+++ b/packages/@azure/keyvault/README.md
@@ -100,3 +100,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fkeyvault%2FREADME.png)

--- a/packages/@azure/loganalytics/README.md
+++ b/packages/@azure/loganalytics/README.md
@@ -104,3 +104,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Floganalytics%2FREADME.png)

--- a/packages/@azure/servicebus/data-plane/README.md
+++ b/packages/@azure/servicebus/data-plane/README.md
@@ -57,3 +57,6 @@ export DEBUG=azure:service-bus:error,azure-amqp-common:error,rhea-promise:error,
       node your-test-script.js &> out.log
     ```
 
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fservicebus%2Fdata-plane%2FREADME.png)

--- a/packages/@azure/servicebus/data-plane/examples/README.md
+++ b/packages/@azure/servicebus/data-plane/examples/README.md
@@ -40,3 +40,6 @@ Copy the sample to your samples folder and use `ts-node` to run it.
 ```bash
 ts-node sample.ts
 ```
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fservicebus%2Fdata-plane%2Fexamples%2FREADME.png)

--- a/packages/@azure/servicebus/data-plane/test/README.md
+++ b/packages/@azure/servicebus/data-plane/test/README.md
@@ -111,3 +111,6 @@ Then run `npm run unit` from your terminal.
 - Start Debugging
 
 
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fservicebus%2Fdata-plane%2Ftest%2FREADME.png)

--- a/packages/@azure/servicefabric/README.md
+++ b/packages/@azure/servicefabric/README.md
@@ -94,3 +94,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fservicefabric%2FREADME.png)

--- a/packages/@azure/storage-datalake/README.md
+++ b/packages/@azure/storage-datalake/README.md
@@ -106,3 +106,6 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Fstorage-datalake%2FREADME.png)

--- a/packages/@azure/template/README.md
+++ b/packages/@azure/template/README.md
@@ -26,3 +26,6 @@ The overall build pipeline looks like the following:
 3. Rollup builds `./dist-esm` to an optimized browser bundle under `./browser/index.js`.
 
 Tests follow a similar pipeline, however output folders have the `test-` prefix.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fpackages%2F%40azure%2Ftemplate%2FREADME.png)


### PR DESCRIPTION
Peter and co want to be able to see distribution of viewership in the context of all this Track 2 work we're doing.

Adding an impression pixel is the only way currently that github can't curtail.

@Azure/azure-sdk-eng