### PR TITLE
[AutoPR storage/resource-manager] Remove GZRS and RAGZRS sku from SRP 2018-11-01 because feature slipped.

### DIFF
--- a/packages/@azure/arm-storage/lib/models/index.ts
+++ b/packages/@azure/arm-storage/lib/models/index.ts
@@ -229,8 +229,8 @@ export interface Sku {
    * @member {SkuName} name Gets or sets the SKU name. Required for account
    * creation; optional for update. Note that in older versions, SKU name was
    * called accountType. Possible values include: 'Standard_LRS',
-   * 'Standard_GRS', 'Standard_GZRS', 'Standard_RAGRS', 'Standard_RAGZRS',
-   * 'Standard_ZRS', 'Premium_LRS', 'Premium_ZRS'
+   * 'Standard_GRS', 'Standard_RAGRS', 'Standard_ZRS', 'Premium_LRS',
+   * 'Premium_ZRS'
    */
   name: SkuName;
   /**
@@ -2206,12 +2206,12 @@ export type ReasonCode = 'QuotaId' | 'NotAvailableForSubscription';
 
 /**
  * Defines values for SkuName.
- * Possible values include: 'Standard_LRS', 'Standard_GRS', 'Standard_GZRS', 'Standard_RAGRS',
- * 'Standard_RAGZRS', 'Standard_ZRS', 'Premium_LRS', 'Premium_ZRS'
+ * Possible values include: 'Standard_LRS', 'Standard_GRS', 'Standard_RAGRS', 'Standard_ZRS',
+ * 'Premium_LRS', 'Premium_ZRS'
  * @readonly
  * @enum {string}
  */
-export type SkuName = 'Standard_LRS' | 'Standard_GRS' | 'Standard_GZRS' | 'Standard_RAGRS' | 'Standard_RAGZRS' | 'Standard_ZRS' | 'Premium_LRS' | 'Premium_ZRS';
+export type SkuName = 'Standard_LRS' | 'Standard_GRS' | 'Standard_RAGRS' | 'Standard_ZRS' | 'Premium_LRS' | 'Premium_ZRS';
 
 /**
  * Defines values for SkuTier.

--- a/packages/@azure/arm-storage/lib/models/mappers.ts
+++ b/packages/@azure/arm-storage/lib/models/mappers.ts
@@ -297,9 +297,7 @@ export const Sku: msRest.CompositeMapper = {
           allowedValues: [
             "Standard_LRS",
             "Standard_GRS",
-            "Standard_GZRS",
             "Standard_RAGRS",
-            "Standard_RAGZRS",
             "Standard_ZRS",
             "Premium_LRS",
             "Premium_ZRS"


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5377