### PR TITLE
Ensure promise does not resolve until write stream is closed

### DIFF
--- a/packages/@azure/storage/blob/tests/utils/index.ts
+++ b/packages/@azure/storage/blob/tests/utils/index.ts
@@ -119,11 +119,13 @@ export async function readStreamToLocalFile(
   return new Promise<void>((resolve, reject) => {
     const ws = fs.createWriteStream(file);
 
+    // Set STREAM_DEBUG env var to log stream events while running tests
     if (process.env.STREAM_DEBUG) {
       rs.on("close", () => console.log("rs.close"));
       rs.on("data", () => console.log("rs.data"));
       rs.on("end", () => console.log("rs.end"));
       rs.on("error", () => console.log("rs.error"));
+
       ws.on("close", () => console.log("ws.close"));
       ws.on("drain", () => console.log("ws.drain"));
       ws.on("error", () => console.log("ws.error"));

--- a/packages/@azure/storage/blob/tests/utils/index.ts
+++ b/packages/@azure/storage/blob/tests/utils/index.ts
@@ -116,8 +116,10 @@ export async function readStreamToLocalFile(
   return new Promise<void>((resolve, reject) => {
     const ws = fs.createWriteStream(file);
     rs.pipe(ws);
-    rs.on("error", reject);
-    ws.on("error", reject);
-    ws.on("finish", resolve);
+
+    let error : Error;
+    rs.on("error", (err: Error) => { if (error === null) error = err; ws.end(); });
+    ws.on("error", (err: Error) => { if (error === null) error = err; });
+    ws.on("close", () => { if (error) reject(error); else resolve(); });
   });
 }

--- a/packages/@azure/storage/blob/tests/utils/index.ts
+++ b/packages/@azure/storage/blob/tests/utils/index.ts
@@ -118,20 +118,32 @@ export async function readStreamToLocalFile(
 ) {
   return new Promise<void>((resolve, reject) => {
     const ws = fs.createWriteStream(file);
-    rs.pipe(ws);
+
+    // Debug
+    rs.on("close", () => console.log("rs.close"));
+    rs.on("data", () => console.log("rs.data"));
+    rs.on("end", () => console.log("rs.end"));
+    rs.on("error", () => console.log("rs.error"));
+    ws.on("close", () => console.log("ws.close"));
+    ws.on("drain", () => console.log("ws.drain"));
+    ws.on("error", () => console.log("ws.error"));
+    ws.on("finish", () => console.log("ws.finish"));
+    ws.on("pipe", () => console.log("ws.pipe"));
+    ws.on("unpipe", () => console.log("ws.unpipe"));
 
     let error : Error;
 
     rs.on("error", (err: Error) => {
       // First error wins
-      if (error === null) {
+      if (!error) {
         error = err;
       }
+      rs.emit("end");
     });
 
     ws.on("error", (err: Error) => {
       // First error wins
-      if (error === null) {
+      if (!error) {
         error = err;
       }
     });
@@ -143,5 +155,7 @@ export async function readStreamToLocalFile(
         resolve();
       }
     });
+
+    rs.pipe(ws);
   });
 }

--- a/packages/@azure/storage/blob/tests/utils/index.ts
+++ b/packages/@azure/storage/blob/tests/utils/index.ts
@@ -139,6 +139,9 @@ export async function readStreamToLocalFile(
       if (!error) {
         error = err;
       }
+
+      // When rs.error is raised, rs.end will never be raised automatically, so it must be raised manually
+      // to ensure ws.close is eventually raised.
       rs.emit("end");
     });
 

--- a/packages/@azure/storage/blob/tests/utils/index.ts
+++ b/packages/@azure/storage/blob/tests/utils/index.ts
@@ -119,17 +119,18 @@ export async function readStreamToLocalFile(
   return new Promise<void>((resolve, reject) => {
     const ws = fs.createWriteStream(file);
 
-    // Debug
-    rs.on("close", () => console.log("rs.close"));
-    rs.on("data", () => console.log("rs.data"));
-    rs.on("end", () => console.log("rs.end"));
-    rs.on("error", () => console.log("rs.error"));
-    ws.on("close", () => console.log("ws.close"));
-    ws.on("drain", () => console.log("ws.drain"));
-    ws.on("error", () => console.log("ws.error"));
-    ws.on("finish", () => console.log("ws.finish"));
-    ws.on("pipe", () => console.log("ws.pipe"));
-    ws.on("unpipe", () => console.log("ws.unpipe"));
+    if (process.env.STREAM_DEBUG) {
+      rs.on("close", () => console.log("rs.close"));
+      rs.on("data", () => console.log("rs.data"));
+      rs.on("end", () => console.log("rs.end"));
+      rs.on("error", () => console.log("rs.error"));
+      ws.on("close", () => console.log("ws.close"));
+      ws.on("drain", () => console.log("ws.drain"));
+      ws.on("error", () => console.log("ws.error"));
+      ws.on("finish", () => console.log("ws.finish"));
+      ws.on("pipe", () => console.log("ws.pipe"));
+      ws.on("unpipe", () => console.log("ws.unpipe"));  
+    }
 
     let error : Error;
 

--- a/packages/@azure/storage/file/tests/utils/index.ts
+++ b/packages/@azure/storage/file/tests/utils/index.ts
@@ -119,17 +119,18 @@ export async function readStreamToLocalFile(
   return new Promise<void>((resolve, reject) => {
     const ws = fs.createWriteStream(file);
 
-    // Debug
-    rs.on("close", () => console.log("rs.close"));
-    rs.on("data", () => console.log("rs.data"));
-    rs.on("end", () => console.log("rs.end"));
-    rs.on("error", () => console.log("rs.error"));
-    ws.on("close", () => console.log("ws.close"));
-    ws.on("drain", () => console.log("ws.drain"));
-    ws.on("error", () => console.log("ws.error"));
-    ws.on("finish", () => console.log("ws.finish"));
-    ws.on("pipe", () => console.log("ws.pipe"));
-    ws.on("unpipe", () => console.log("ws.unpipe"));
+    if (process.env.STREAM_DEBUG) {
+      rs.on("close", () => console.log("rs.close"));
+      rs.on("data", () => console.log("rs.data"));
+      rs.on("end", () => console.log("rs.end"));
+      rs.on("error", () => console.log("rs.error"));
+      ws.on("close", () => console.log("ws.close"));
+      ws.on("drain", () => console.log("ws.drain"));
+      ws.on("error", () => console.log("ws.error"));
+      ws.on("finish", () => console.log("ws.finish"));
+      ws.on("pipe", () => console.log("ws.pipe"));
+      ws.on("unpipe", () => console.log("ws.unpipe"));
+    }
 
     let error : Error;
 

--- a/packages/@azure/storage/file/tests/utils/index.ts
+++ b/packages/@azure/storage/file/tests/utils/index.ts
@@ -119,11 +119,13 @@ export async function readStreamToLocalFile(
   return new Promise<void>((resolve, reject) => {
     const ws = fs.createWriteStream(file);
 
+    // Set STREAM_DEBUG env var to log stream events while running tests
     if (process.env.STREAM_DEBUG) {
       rs.on("close", () => console.log("rs.close"));
       rs.on("data", () => console.log("rs.data"));
       rs.on("end", () => console.log("rs.end"));
       rs.on("error", () => console.log("rs.error"));
+
       ws.on("close", () => console.log("ws.close"));
       ws.on("drain", () => console.log("ws.drain"));
       ws.on("error", () => console.log("ws.error"));

--- a/packages/@azure/storage/file/tests/utils/index.ts
+++ b/packages/@azure/storage/file/tests/utils/index.ts
@@ -118,20 +118,32 @@ export async function readStreamToLocalFile(
 ) {
   return new Promise<void>((resolve, reject) => {
     const ws = fs.createWriteStream(file);
-    rs.pipe(ws);
+
+    // Debug
+    rs.on("close", () => console.log("rs.close"));
+    rs.on("data", () => console.log("rs.data"));
+    rs.on("end", () => console.log("rs.end"));
+    rs.on("error", () => console.log("rs.error"));
+    ws.on("close", () => console.log("ws.close"));
+    ws.on("drain", () => console.log("ws.drain"));
+    ws.on("error", () => console.log("ws.error"));
+    ws.on("finish", () => console.log("ws.finish"));
+    ws.on("pipe", () => console.log("ws.pipe"));
+    ws.on("unpipe", () => console.log("ws.unpipe"));
 
     let error : Error;
 
     rs.on("error", (err: Error) => {
       // First error wins
-      if (error === null) {
+      if (!error) {
         error = err;
       }
+      rs.emit("end");
     });
 
     ws.on("error", (err: Error) => {
       // First error wins
-      if (error === null) {
+      if (!error) {
         error = err;
       }
     });
@@ -143,5 +155,7 @@ export async function readStreamToLocalFile(
         resolve();
       }
     });
+
+    rs.pipe(ws);
   });
 }

--- a/packages/@azure/storage/file/tests/utils/index.ts
+++ b/packages/@azure/storage/file/tests/utils/index.ts
@@ -139,6 +139,9 @@ export async function readStreamToLocalFile(
       if (!error) {
         error = err;
       }
+
+      // When rs.error is raised, rs.end will never be raised automatically, so it must be raised manually
+      // to ensure ws.close is eventually raised.
       rs.emit("end");
     });
 


### PR DESCRIPTION
I have decided to simplify this PR, and just fix the race condition without trying to rewrite and add unit tests for `readStreamToLocalFile()`.  It was becoming too much work for a test-only fix.

## Validation Builds
* Blob: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=12542
* File: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=12538

# Old

## Remaining Work
* [ ] Create more generic function `readStreamToWriteStream(rs: ReadableStream, ws: WritableStream)`, and have `readStreamToWriteStream(rs: ReadableStream, file: string)` call it.
* [ ] Add unit tests for `readStreamToWriteStream(rs: ReadableStream, ws: WritableStream)`, verifying proper events are triggered on both read and write streams
* [ ] Share `readStreamToLocalFile()` code across both `blob` and `files` tests

## Open Questions
* [ ] Is calling `ws.end()` from `rs.error` correct?  It seems to cause `ws.error` with `attempted write after end`.  I do think `ws.end()` needs to be called, but maybe it should be called from a different event, or put on the event loop rather than called synchronously.
* [ ] Does `ws.error` need to call `ws.end()`?  Does this depend on whether `autoClose` was `true` or `false`?  If we wrote a more generic `readStreamToWriteStream(rs: ReadableStream, ws: WritableStream)` API, where the function doesn't know about `autoClose`, how would it need to work?

CC: @tg-msft 