### PR TITLE
Change file path for "main" inside node_modules/@azure/event-hubs

### DIFF
--- a/packages/@azure/eventhubs/client/examples/getHubRuntimeInfo.ts
+++ b/packages/@azure/eventhubs/client/examples/getHubRuntimeInfo.ts
@@ -9,7 +9,6 @@ const connectionString = "EVENTHUB_CONNECTION_STRING";
 const entityPath = "EVENTHUB_NAME";
 const str = process.env[connectionString] || "";
 const path = process.env[entityPath] || "";
-console.log(path);
 
 async function main(): Promise<void> {
   const client = EventHubClient.createFromConnectionString(str, path);

--- a/packages/@azure/eventhubs/client/package.json
+++ b/packages/@azure/eventhubs/client/package.json
@@ -15,7 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/azure/azure-sdk-for-js/issues"
 	},
-	"main": "./dist/lib/index.js",
+	"main": "./dist/index.js",
 	"module": "dist-esm/lib/index.js",
 	"types": "./typings/lib/index.d.ts",
 	"browser": {


### PR DESCRIPTION
File path for `main`  inside `node_modules/@azure/event-hubs`  was pointing to the incorrect directory in the `package.json` file.

This PR adds the correct path for "main".