### PR TITLE
Remove unnecessary type casting when using @azure/ms-rest-nodeauth library 

### DIFF
--- a/packages/@azure/eventhubs/client/examples/sendReceiveWithInteractiveAuth.ts
+++ b/packages/@azure/eventhubs/client/examples/sendReceiveWithInteractiveAuth.ts
@@ -7,7 +7,7 @@ import {
   aadEventHubsAudience,
   EventPosition
 } from "../lib";
-import {interactiveLogin} from "@azure/ms-rest-nodeauth";
+import { interactiveLogin } from "@azure/ms-rest-nodeauth";
 import * as dotenv from "dotenv";
 dotenv.config();
 
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
   // For now the interactive user needs to explicitly be assigned
   // the role of a constributor/owner even if the user is a subscription owner.
   // azure role assignment create -o contributor --scope /subscriptions/<subscriptionId>/resourceGroups/<rgName>/providers/Microsoft.EventHub/namespaces/<ehNamespaceName> --signInName <user@example.com>
-  const credentials = <any> (await interactiveLogin({tokenAudience: aadEventHubsAudience}));
+  const credentials = await interactiveLogin({tokenAudience: aadEventHubsAudience});
   const client = EventHubClient.createFromAadTokenCredentials(address, path, credentials);
   const partitionIds = await client.getPartitionIds();
   await client.send({ body: "Hello awesome world!!" }, partitionIds[0]);

--- a/packages/@azure/eventhubs/client/examples/sendReceiveWithSPAuth.ts
+++ b/packages/@azure/eventhubs/client/examples/sendReceiveWithSPAuth.ts
@@ -7,13 +7,17 @@ import { loginWithServicePrincipalSecret } from "@azure/ms-rest-nodeauth";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-const address = "shivangieventhubs.servicebus.windows.net";
-const path = "myeventhub";
+const endpoint = "ENDPOINT";
+const entityPath = "EVENTHUB_NAME";
+const address = process.env[endpoint] || "";
+const path = process.env[entityPath] || "";
 
-
-const clientId = "2ac7a52a-c1bf-449b-b3e6-5d4254df8997";
-const secret = "}TO*h(nwmB)Y5U3cF4M}|Cc#/+6?8L9w_YRbz8mAh.";
-const domain = "72f988bf-86f1-41af-91ab-2d7cd011db47";
+const cid = "CLIENT_ID";
+const sec = "APPLICATION_SECRET";
+const doma = "DOMAIN";
+const clientId = process.env[cid] || "";
+const secret = process.env[sec] || "";
+const domain = process.env[doma] || "";
 async function main(): Promise<void> {
   const credentials = await loginWithServicePrincipalSecret(clientId, secret, domain, { tokenAudience: aadEventHubsAudience });
   const client = EventHubClient.createFromAadTokenCredentials(address, path, credentials);

--- a/packages/@azure/eventhubs/client/examples/sendReceiveWithSPAuth.ts
+++ b/packages/@azure/eventhubs/client/examples/sendReceiveWithSPAuth.ts
@@ -3,23 +3,19 @@
 // Licensed under the MIT License.
 
 import { EventHubClient, EventData, aadEventHubsAudience, EventPosition } from "../lib";
-import {loginWithServicePrincipalSecret} from "@azure/ms-rest-nodeauth";
+import { loginWithServicePrincipalSecret } from "@azure/ms-rest-nodeauth";
 import * as dotenv from "dotenv";
 dotenv.config();
 
-const endpoint = "ENDPOINT";
-const entityPath = "EVENTHUB_NAME";
-const address = process.env[endpoint] || "";
-const path = process.env[entityPath] || "";
+const address = "shivangieventhubs.servicebus.windows.net";
+const path = "myeventhub";
 
-const cid = "CLIENT_ID";
-const sec = "APPLICATION_SECRET";
-const doma = "DOMAIN";
-const clientId = process.env[cid] || "";
-const secret = process.env[sec] || "";
-const domain = process.env[doma] || "";
+
+const clientId = "2ac7a52a-c1bf-449b-b3e6-5d4254df8997";
+const secret = "}TO*h(nwmB)Y5U3cF4M}|Cc#/+6?8L9w_YRbz8mAh.";
+const domain = "72f988bf-86f1-41af-91ab-2d7cd011db47";
 async function main(): Promise<void> {
-  const credentials = <any> (await loginWithServicePrincipalSecret(clientId, secret, domain, { tokenAudience: aadEventHubsAudience }));
+  const credentials = await loginWithServicePrincipalSecret(clientId, secret, domain, { tokenAudience: aadEventHubsAudience });
   const client = EventHubClient.createFromAadTokenCredentials(address, path, credentials);
   const partitionIds = await client.getPartitionIds();
   await client.send({ body: "Hello awesome world!!" }, partitionIds[0]);


### PR DESCRIPTION
This PR removes unnecessary type casting when using @azure/ms-rest-nodeauth library for authentication.