### PR TITLE
Don't need to reorder lockToken when receive deferred messages

### DIFF
--- a/packages/@azure/servicebus/data-plane/lib/core/batchingReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/batchingReceiver.ts
@@ -173,7 +173,8 @@ export class BatchingReceiver extends MessageReceiver {
           const data: ServiceBusMessage = new ServiceBusMessage(
             this._context,
             context.message!,
-            context.delivery!
+            context.delivery!,
+            true
           );
           if (brokeredMessages.length < maxMessageCount) {
             brokeredMessages.push(data);

--- a/packages/@azure/servicebus/data-plane/lib/core/managementClient.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/managementClient.ts
@@ -376,7 +376,7 @@ export class ManagementClient extends LinkEntity {
       const error = translate(err);
       log.error(
         "An error occurred while sending the request to peek messages to " +
-        "$management endpoint: %O",
+          "$management endpoint: %O",
         error
       );
       // statusCode == 404 then do not throw
@@ -491,7 +491,7 @@ export class ManagementClient extends LinkEntity {
       if (enqueueTimeInMs < now) {
         throw new Error(
           `Cannot schedule messages in the past. Given scheduledEnqueueTimeUtc` +
-          `(${enqueueTimeInMs}) < current time (${now}).`
+            `(${enqueueTimeInMs}) < current time (${now}).`
         );
       }
       item.message.scheduledEnqueueTimeUtc = item.scheduledEnqueueTimeUtc;
@@ -562,7 +562,7 @@ export class ManagementClient extends LinkEntity {
       const error = translate(err);
       log.error(
         "An error occurred while sending the request to schedule messages to " +
-        "$management endpoint: %O",
+          "$management endpoint: %O",
         error
       );
       throw error;
@@ -592,7 +592,7 @@ export class ManagementClient extends LinkEntity {
         const error = translate(err);
         log.error(
           "An error occurred while encoding the item at position %d in the " +
-          "sequenceNumbers array: %O",
+            "sequenceNumbers array: %O",
           i,
           error
         );
@@ -632,7 +632,7 @@ export class ManagementClient extends LinkEntity {
       const error = translate(err);
       log.error(
         "An error occurred while sending the request to cancel the scheduled message to " +
-        "$management endpoint: %O",
+          "$management endpoint: %O",
         error
       );
       throw error;
@@ -708,7 +708,7 @@ export class ManagementClient extends LinkEntity {
         const error = translate(err);
         log.error(
           "An error occurred while encoding the item at position %d in the " +
-          "sequenceNumbers array: %O",
+            "sequenceNumbers array: %O",
           i,
           error
         );
@@ -759,7 +759,8 @@ export class ManagementClient extends LinkEntity {
         const message = new ServiceBusMessage(
           this._context,
           decodedMessage as any,
-          { tag: msg["lock-token"] } as any
+          { tag: msg["lock-token"] } as any,
+          false
         );
         this._context.requestResponseLockedMessages.set(
           message.lockToken!,
@@ -772,7 +773,7 @@ export class ManagementClient extends LinkEntity {
       const error = translate(err);
       log.error(
         "An error occurred while sending the request to receive deferred messages to " +
-        "$management endpoint: %O",
+          "$management endpoint: %O",
         error
       );
       throw error;
@@ -847,7 +848,7 @@ export class ManagementClient extends LinkEntity {
       const error = translate(err);
       log.error(
         "An error occurred while sending the request to update disposition status to " +
-        "$management endpoint: %O",
+          "$management endpoint: %O",
         error
       );
       throw error;
@@ -1354,7 +1355,7 @@ export class ManagementClient extends LinkEntity {
             const ehError = translate(context.session!.error!);
             log.error(
               "[%s] An error occurred on the session for request/response links for " +
-              "$management: %O",
+                "$management: %O",
               id,
               ehError
             );
@@ -1363,7 +1364,7 @@ export class ManagementClient extends LinkEntity {
         const sropt: SenderOptions = { target: { address: this.address } };
         log.mgmt(
           "[%s] Creating sender/receiver links on a session for $management endpoint with " +
-          "srOpts: %o, receiverOpts: %O.",
+            "srOpts: %o, receiverOpts: %O.",
           this._context.namespace.connectionId,
           sropt,
           rxopt

--- a/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
+++ b/packages/@azure/servicebus/data-plane/lib/core/messageReceiver.ts
@@ -340,7 +340,8 @@ export class MessageReceiver extends LinkEntity {
       const bMessage: ServiceBusMessage = new ServiceBusMessage(
         this._context,
         context.message!,
-        context.delivery!
+        context.delivery!,
+        true
       );
       if (this.autoRenewLock) {
         // - We need to renew locks before they expire by looking at bMessage.lockedUntilUtc.

--- a/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
+++ b/packages/@azure/servicebus/data-plane/lib/session/messageSession.ts
@@ -615,7 +615,8 @@ export class MessageSession extends LinkEntity {
         const bMessage: ServiceBusMessage = new ServiceBusMessage(
           this._context,
           context.message!,
-          context.delivery!
+          context.delivery!,
+          true
         );
         try {
           await this._onMessage(bMessage);
@@ -884,7 +885,8 @@ export class MessageSession extends LinkEntity {
           const data: ServiceBusMessage = new ServiceBusMessage(
             this._context,
             context.message!,
-            context.delivery!
+            context.delivery!,
+            true
           );
           if (brokeredMessages.length < maxMessageCount) {
             brokeredMessages.push(data);


### PR DESCRIPTION
**Reference** https://github.com/Azure/azure-sdk-for-js/pull/1671

Service Bus uses .net's guid->byte[] encoder to encode locktoken in a normal message, and for deferred message service bus uses amqp's UUID encoder.

When Service Bus encodes the lock token as amqp uuid in deferred messages, we get everything in the right order.When Service Bus uses the .Net encoding Guid.ToByteArray() to encode locktoken in a normal message, it ends up messing up the order.

This PR adds a condition if we receive deferred message then reorder the lockToken otherwise don't.