### PR TITLE
update broken link in readme for event-processor-host

### DIFF
--- a/sdk/eventhub/event-processor-host/README.md
+++ b/sdk/eventhub/event-processor-host/README.md
@@ -7,10 +7,10 @@ all the partitions. It will checkpoint metadata about the received messages at r
 Azure Storage Blob. This makes it easy to continue receiving messages from where you left at a later time.
 
 #### Conceptual Overview
-![overview](https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/packages/%40azure/eventhubs/processor/eph.png)
+![overview](https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/sdk/eventhub/event-processor-host/eph.png)
 
 - More information about Azure Event Processor Host can be found over [here](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-event-processor-host).
-- General overview of how the Event Processor Host SDK works internally can be found over [here](https://github.com/Azure/azure-sdk-for-js/blob/master/packages/%40azure/eventhubs/processor/overview.md).
+- General overview of how the Event Processor Host SDK works internally can be found over [here](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-processor-host/overview.md).
 
 ## Pre-requisite ##
 - **Node.js version: 6.x or higher.** 


### PR DESCRIPTION
Update to broken links in readme for event-processor-host (sdk/eventhub/event-processor-host)

@jeremymeng 