### PR TITLE
[Service Bus] Fix flaky peek session tests

### DIFF
--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -82,7 +82,7 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("SessionReceiver with invalid sessionId", function(): void {
+describe("SessionReceiver with invalid sessionId", function (): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -108,7 +108,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Partitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -118,7 +118,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await test_batching();
   });
 
-  it("Partitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Partitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -128,7 +128,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await test_batching();
   });
 
-  it("Unpartitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Unpartitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -138,7 +138,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await test_batching();
   });
 
-  it("Unpartitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Unpartitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -185,7 +185,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Partitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -195,7 +195,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await test_streaming();
   });
 
-  it("Partitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Partitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -205,7 +205,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await test_streaming();
   });
 
-  it("Unpartitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Unpartitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -215,7 +215,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
     await test_streaming();
   });
 
-  it("Unpartitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
+  it("Unpartitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -226,7 +226,7 @@ describe("SessionReceiver with invalid sessionId", function(): void {
   });
 });
 
-describe("SessionReceiver with no sessionId", function(): void {
+describe("SessionReceiver with no sessionId", function (): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -253,20 +253,15 @@ describe("SessionReceiver with no sessionId", function(): void {
       sessionId: undefined
     });
     let msgs = await receiver.receiveMessages(2);
-    let peekInSessionResults = await receiver.peek(1);
 
     should.equal(msgs.length, 1, "Unexpected number of messages received");
-    should.equal(peekInSessionResults.length, 1, "Unexpected number of messages peeked");
 
     should.equal(
       testMessagesWithDifferentSessionIds.some(
         (x) =>
           msgs[0].body === x.body &&
           msgs[0].messageId === x.messageId &&
-          msgs[0].sessionId === x.sessionId &&
-          peekInSessionResults[0].body === x.body &&
-          peekInSessionResults[0].messageId === x.messageId &&
-          peekInSessionResults[0].sessionId === x.sessionId
+          msgs[0].sessionId === x.sessionId
       ),
       true,
       "Received Message doesnt match any of the test messages"
@@ -278,20 +273,15 @@ describe("SessionReceiver with no sessionId", function(): void {
       receiverClient.createReceiver(ReceiveMode.peekLock, { sessionId: undefined })
     );
     msgs = await receiver.receiveMessages(2);
-    peekInSessionResults = await receiver.peek(1);
 
     should.equal(msgs.length, 1, "Unexpected number of messages received");
-    should.equal(peekInSessionResults.length, 1, "Unexpected number of messages peeked");
 
     should.equal(
       testMessagesWithDifferentSessionIds.some(
         (x) =>
           msgs[0].body === x.body &&
           msgs[0].messageId === x.messageId &&
-          msgs[0].sessionId === x.sessionId &&
-          peekInSessionResults[0].body === x.body &&
-          peekInSessionResults[0].messageId === x.messageId &&
-          peekInSessionResults[0].sessionId === x.sessionId
+          msgs[0].sessionId === x.sessionId
       ),
       true,
       "Received Message doesnt match any of the test messages"
@@ -300,7 +290,7 @@ describe("SessionReceiver with no sessionId", function(): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: complete() removes message from random session", async function(): Promise<
+  it("Partitioned Queue: complete() removes message from random session", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -311,7 +301,7 @@ describe("SessionReceiver with no sessionId", function(): void {
     await testComplete_batching();
   });
 
-  it("Partitioned Subscription: complete() removes message from random session", async function(): Promise<
+  it("Partitioned Subscription: complete() removes message from random session", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -322,7 +312,7 @@ describe("SessionReceiver with no sessionId", function(): void {
     await testComplete_batching();
   });
 
-  it("Unpartitioned Queue: complete() removes message from random session", async function(): Promise<
+  it("Unpartitioned Queue: complete() removes message from random session", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -333,7 +323,7 @@ describe("SessionReceiver with no sessionId", function(): void {
     await testComplete_batching();
   });
 
-  it("Unpartitioned Subscription: complete() removes message from random session", async function(): Promise<
+  it("Unpartitioned Subscription: complete() removes message from random session", async function (): Promise<
     void
   > {
     await beforeEachTest(
@@ -345,7 +335,7 @@ describe("SessionReceiver with no sessionId", function(): void {
   });
 });
 
-describe("Session State", function(): void {
+describe("Session State", function (): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -390,7 +380,7 @@ describe("Session State", function(): void {
     await msgs[0].complete();
     await testPeekMsgsLength(receiverClient, 0);
   }
-  it("Partitioned Queue - Testing getState and setState", async function(): Promise<void> {
+  it("Partitioned Queue - Testing getState and setState", async function (): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
@@ -398,7 +388,7 @@ describe("Session State", function(): void {
     await purge(receiverClient, testSessionId2);
     await testGetSetState();
   });
-  it("Partitioned Subscription - Testing getState and setState", async function(): Promise<void> {
+  it("Partitioned Subscription - Testing getState and setState", async function (): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedTopicWithSessions,
       ClientType.PartitionedSubscriptionWithSessions
@@ -406,7 +396,7 @@ describe("Session State", function(): void {
     await purge(receiverClient, testSessionId2);
     await testGetSetState();
   });
-  it("Unpartitioned Queue - Testing getState and setState", async function(): Promise<void> {
+  it("Unpartitioned Queue - Testing getState and setState", async function (): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
@@ -414,12 +404,109 @@ describe("Session State", function(): void {
     await purge(receiverClient, testSessionId2);
     await testGetSetState();
   });
-  it("Unpartitioned Subscription - Testing getState and setState", async function(): Promise<void> {
+  it("Unpartitioned Subscription - Testing getState and setState", async function (): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedTopicWithSessions,
       ClientType.UnpartitionedSubscriptionWithSessions
     );
     await purge(receiverClient, testSessionId2);
     await testGetSetState();
+  });
+});
+
+describe.only("Peek session", function (): void {
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  async function peekSession(useSessionId: boolean): Promise<void> {
+    const sender = senderClient.createSender();
+    const testMessage = TestMessage.getSessionSample();
+    await sender.sendMessage(testMessage);
+
+    let receiver = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
+      sessionId: useSessionId ? testMessage.sessionId : undefined
+    });
+
+    // At this point AMQP reciever link has not been established.
+    const peekedMsgs = await receiver.peek(1);
+    should.equal(peekedMsgs.length, 1, "Unexpected number of messages");
+    should.equal(peekedMsgs[0].body, testMessage.body, "MessageBody is different than expected");
+    should.equal(peekedMsgs[0].messageId, testMessage.messageId, "MessageId is different than expected");
+    should.equal(peekedMsgs[0].sessionId, testMessage.sessionId, "SessionId is different than expected");
+
+    const msgs = await receiver.receiveMessages(1);
+    should.equal(msgs.length, 1, "Unexpected number of messages");
+    should.equal(msgs[0].body, testMessage.body, "MessageBody is different than expected");
+    should.equal(msgs[0].messageId, testMessage.messageId, "MessageId is different than expected");
+    should.equal(msgs[0].sessionId, testMessage.sessionId, "SessionId is different than expected");
+
+    await msgs[0].complete();
+  }
+
+  it("Partitioned Queue - Peek Session with sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.PartitionedQueueWithSessions,
+      ClientType.PartitionedQueueWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(true);
+  });
+  it("Partitioned Subscription - Peek Session with sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.PartitionedTopicWithSessions,
+      ClientType.PartitionedSubscriptionWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(true);
+  });
+  it("Unpartitioned Queue - Peek Session with sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(true);
+  });
+  it("Unpartitioned Subscription - Peek Session with sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(true);
+  });
+
+  it("Partitioned Queue - Peek Session without sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.PartitionedQueueWithSessions,
+      ClientType.PartitionedQueueWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(false);
+  });
+  it("Partitioned Subscription - Peek Session without sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.PartitionedTopicWithSessions,
+      ClientType.PartitionedSubscriptionWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(false);
+  });
+  it("Unpartitioned Queue - Peek Session without sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.UnpartitionedQueueWithSessions,
+      ClientType.UnpartitionedQueueWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(false);
+  });
+  it("Unpartitioned Subscription - Peek Session without sessionId", async function (): Promise<void> {
+    await beforeEachTest(
+      ClientType.UnpartitionedTopicWithSessions,
+      ClientType.UnpartitionedSubscriptionWithSessions
+    );
+    await purge(receiverClient, testSessionId2);
+    await peekSession(false);
   });
 });

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -424,11 +424,12 @@ describe("Peek session", function (): void {
     const testMessage = TestMessage.getSessionSample();
     await sender.sendMessage(testMessage);
 
-    let receiver = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
+    const receiver = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
       sessionId: useSessionId ? testMessage.sessionId : undefined
     });
 
     // At this point AMQP reciever link has not been established.
+    // peek() will not establish the link if sessionId was provided
     const peekedMsgs = await receiver.peek(1);
     should.equal(peekedMsgs.length, 1, "Unexpected number of messages");
     should.equal(peekedMsgs[0].body, testMessage.body, "MessageBody is different than expected");

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -414,7 +414,7 @@ describe("Session State", function (): void {
   });
 });
 
-describe.only("Peek session", function (): void {
+describe("Peek session", function (): void {
   afterEach(async () => {
     await afterEachTest();
   });

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -450,7 +450,6 @@ describe("Peek session", function (): void {
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(true);
   });
   it("Partitioned Subscription - Peek Session with sessionId", async function (): Promise<void> {
@@ -458,7 +457,6 @@ describe("Peek session", function (): void {
       ClientType.PartitionedTopicWithSessions,
       ClientType.PartitionedSubscriptionWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(true);
   });
   it("Unpartitioned Queue - Peek Session with sessionId", async function (): Promise<void> {
@@ -466,7 +464,6 @@ describe("Peek session", function (): void {
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(true);
   });
   it("Unpartitioned Subscription - Peek Session with sessionId", async function (): Promise<void> {
@@ -474,7 +471,6 @@ describe("Peek session", function (): void {
       ClientType.UnpartitionedTopicWithSessions,
       ClientType.UnpartitionedSubscriptionWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(true);
   });
 
@@ -483,7 +479,6 @@ describe("Peek session", function (): void {
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(false);
   });
   it("Partitioned Subscription - Peek Session without sessionId", async function (): Promise<void> {
@@ -491,7 +486,6 @@ describe("Peek session", function (): void {
       ClientType.PartitionedTopicWithSessions,
       ClientType.PartitionedSubscriptionWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(false);
   });
   it("Unpartitioned Queue - Peek Session without sessionId", async function (): Promise<void> {
@@ -499,7 +493,6 @@ describe("Peek session", function (): void {
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(false);
   });
   it("Unpartitioned Subscription - Peek Session without sessionId", async function (): Promise<void> {
@@ -507,7 +500,6 @@ describe("Peek session", function (): void {
       ClientType.UnpartitionedTopicWithSessions,
       ClientType.UnpartitionedSubscriptionWithSessions
     );
-    await purge(receiverClient, testSessionId2);
     await peekSession(false);
   });
 });


### PR DESCRIPTION
The peek tests added for peeking in a session earlier today seem to be flaky.
This PR moves the peek related tests into their separate tests