### PR TITLE
[Service Bus] send, renewLock API changes for Preview 2

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -87,7 +87,7 @@ function to send messages.
 ```javascript
 const queueClient = serviceBusClient.createQueueClient("my-queue");
 const sender = queueClient.createSender();
-await sender.sendMessage({
+await sender.send({
   body: "my-message-body"
 });
 ```
@@ -151,7 +151,7 @@ message, set the `sessionId` property in the message body to ensure your message
 ```javascript
 const queueClient = serviceBusClient.createQueueClient("my-session-queue");
 const sender = queueClient.createSender();
-await sender.sendMessage({
+await sender.send({
   body: "my-message-body",
   sessionId: "my-session"
 });

--- a/sdk/servicebus/service-bus/changelog.md
+++ b/sdk/servicebus/service-bus/changelog.md
@@ -22,6 +22,8 @@ longer supported. Use `createReceiver` instead and pass the `sessionOptions` par
 `sessionId` and the duration until which you want to lock the session.
 * `receive` and `receiveBatch` functions on the reciever are renamed to `registerMessageHandler` and
 `receiveMessages`
+* `renewLock` on the receiver is renamed to `renewMessageLock`. In case of receiver from sessions,
+this is renamed to `renewSessionLock`.
 * A third way of receiving messages is introduced on the receiver via `getMessageIterator` function
 which returns an async iterator over messages.
 

--- a/sdk/servicebus/service-bus/changelog.md
+++ b/sdk/servicebus/service-bus/changelog.md
@@ -20,7 +20,6 @@ meant to do.
 * The function to get a receiver for a session enabled Queue/Subsciption, `getSessionReceiver` is no
 longer supported. Use `createReceiver` instead and pass the `sessionOptions` parameter to provide
 `sessionId` and the duration until which you want to lock the session.
-* `send` and `sendBatch` functions on the sender are renamed to `sendMessage` and `sendMessages`
 * `receive` and `receiveBatch` functions on the reciever are renamed to `registerMessageHandler` and
 `receiveMessages`
 * A third way of receiving messages is introduced on the receiver via `getMessageIterator` function

--- a/sdk/servicebus/service-bus/changelog.md
+++ b/sdk/servicebus/service-bus/changelog.md
@@ -1,4 +1,4 @@
-# 2019-04-05 1.0.0-preview.2
+# 2019-04-08 1.0.0-preview.2
 
 ### Breaking Changes
 

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -47,15 +47,15 @@ export class Sender {
    * @param message - Message to send.
    * @returns Promise<void>
    */
-  async sendMessage(message: SendableMessageInfo): Promise<void> {
+  async send(message: SendableMessageInfo): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     const sender = MessageSender.create(this._context);
     return sender.send(message);
   }
 
   /**
-   * Sends the given messages in a batch i.e. in a single AMQP message after creating an AMQP Sender
-   * link if it doesnt already exists.
+   * Sends the given messages in a single batch i.e. in a single AMQP message after creating an AMQP
+   * Sender link if it doesnt already exists.
    *
    * To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
    * and/or `partitionKey` properties respectively on the messages. When doing so, all
@@ -65,7 +65,7 @@ export class Sender {
    * @param messages - An array of SendableMessageInfo objects to be sent in a Batch message.
    * @return Promise<void>
    */
-  async sendMessages(messages: SendableMessageInfo[]): Promise<void> {
+  async sendBatch(messages: SendableMessageInfo[]): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     const sender = MessageSender.create(this._context);
     return sender.sendBatch(messages);

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -104,13 +104,13 @@ async function beforeEachTest(
 async function afterEachTest(): Promise<void> {
   await ns.close();
 }
-describe("Batch Receiver - Settle message", function (): void {
+describe("Batch Receiver - Settle message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function sendReceiveMsg(testMessages: SendableMessageInfo): Promise<ServiceBusMessage> {
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
     const msgs = await receiver.receiveMessages(1);
 
     should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
@@ -131,27 +131,27 @@ describe("Batch Receiver - Settle message", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: complete() removes message", async function (): Promise<void> {
+  it("Partitioned Queue: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testComplete();
   });
 
-  it("Partitioned Subscription: complete() removes message", async function (): Promise<void> {
+  it("Partitioned Subscription: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testComplete();
   });
 
-  it("Unpartitioned Queue: complete() removes message", async function (): Promise<void> {
+  it("Unpartitioned Queue: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testComplete();
   });
 
-  it("Unpartitioned Subscription: complete() removes message", async function (): Promise<void> {
+  it("Unpartitioned Subscription: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testComplete();
   });
 
-  it("Partitioned Queue with Sessions: complete() removes message", async function (): Promise<
+  it("Partitioned Queue with Sessions: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -162,7 +162,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testComplete(true);
   });
 
-  it("Partitioned Subscription with Sessions: complete() removes message", async function (): Promise<
+  it("Partitioned Subscription with Sessions: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -173,7 +173,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testComplete(true);
   });
 
-  it("Unpartitioned Queue with Sessions: complete() removes message", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -184,7 +184,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testComplete(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: complete() removes message", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -217,35 +217,35 @@ describe("Batch Receiver - Settle message", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Partitioned Queue: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testAbandon();
   });
 
-  it("Partitioned Subscription: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Partitioned Subscription: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testAbandon();
   });
 
-  it("Unpartitioned Queue: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Unpartitioned Queue: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testAbandon();
   });
 
-  it("Unpartitioned Subscription: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Unpartitioned Subscription: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testAbandon();
   });
 
-  it("Partitioned Queue with Sessions: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Partitioned Queue with Sessions: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -256,7 +256,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testAbandon(true);
   });
 
-  it("Partitioned Subscription with Sessions: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Partitioned Subscription with Sessions: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -267,7 +267,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testAbandon(true);
   });
 
-  it("Unpartitioned Queue with Sessions: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -278,7 +278,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testAbandon(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: abandon() retains message with incremented deliveryCount", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: abandon() retains message with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -291,7 +291,7 @@ describe("Batch Receiver - Settle message", function (): void {
 
   async function testAbandonMsgsTillMaxDeliveryCount(useSessions?: boolean): Promise<void> {
     const testMessages = useSessions ? TestMessage.getSessionSample() : TestMessage.getSample();
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
     let abandonMsgCount = 0;
 
     while (abandonMsgCount < maxDeliveryCount) {
@@ -340,56 +340,56 @@ describe("Batch Receiver - Settle message", function (): void {
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Partitioned Queue: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testAbandonMsgsTillMaxDeliveryCount();
   });
 
-  it("Partitioned Subscription: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Partitioned Subscription: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testAbandonMsgsTillMaxDeliveryCount();
   });
 
-  it("Unpartitioned Queue: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Unpartitioned Queue: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testAbandonMsgsTillMaxDeliveryCount();
   });
 
-  it("Unpartitioned Subscription: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Unpartitioned Subscription: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testAbandonMsgsTillMaxDeliveryCount();
   });
 
-  it("Partitioned Queue with Sessions: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Partitioned Queue with Sessions: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testAbandonMsgsTillMaxDeliveryCount(true);
   });
 
-  it("Partitioned Subscription with Sessions: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Partitioned Subscription with Sessions: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testAbandonMsgsTillMaxDeliveryCount(true);
   });
 
-  it("Unpartitioned Queue with Sessions: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testAbandonMsgsTillMaxDeliveryCount(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: Multiple abandons until maxDeliveryCount.", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: Multiple abandons until maxDeliveryCount.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -423,19 +423,19 @@ describe("Batch Receiver - Settle message", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: defer() moves message to deferred queue", async function (): Promise<void> {
+  it("Partitioned Queue: defer() moves message to deferred queue", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDefer();
   });
 
-  it("Partitioned Subscription: defer() moves message to deferred queue", async function (): Promise<
+  it("Partitioned Subscription: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDefer();
   });
 
-  it("Partitioned Queue with Sessions: defer() moves message to deferred queue", async function (): Promise<
+  it("Partitioned Queue with Sessions: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -446,7 +446,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testDefer(true);
   });
 
-  it("Partitioned Subscription with Sessions: defer() moves message to deferred queue", async function (): Promise<
+  it("Partitioned Subscription with Sessions: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -457,21 +457,21 @@ describe("Batch Receiver - Settle message", function (): void {
     await testDefer(true);
   });
 
-  it("Unpartitioned Queue: defer() moves message to deferred queue", async function (): Promise<
+  it("Unpartitioned Queue: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDefer();
   });
 
-  it("Unpartitioned Subscription: defer() moves message to deferred queue", async function (): Promise<
+  it("Unpartitioned Subscription: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testDefer();
   });
 
-  it("Unpartitioned Queue with Sessions: defer() moves message to deferred queue", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -482,7 +482,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testDefer(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: defer() moves message to deferred queue", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -525,35 +525,35 @@ describe("Batch Receiver - Settle message", function (): void {
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Partitioned Queue: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDeadletter();
   });
 
-  it("Partitioned Subscription: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Partitioned Subscription: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDeadletter();
   });
 
-  it("Unpartitioned Queue: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Unpartitioned Queue: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDeadletter();
   });
 
-  it("Unpartitioned Subscription: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Unpartitioned Subscription: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testDeadletter();
   });
 
-  it("Partitioned Queue with Sessions: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Partitioned Queue with Sessions: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -564,7 +564,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testDeadletter(true);
   });
 
-  it("Partitioned Subscription with Sessions: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Partitioned Subscription with Sessions: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -575,7 +575,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testDeadletter(true);
   });
 
-  it("Unpartitioned Queue with Sessions: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -586,7 +586,7 @@ describe("Batch Receiver - Settle message", function (): void {
     await testDeadletter(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -598,7 +598,7 @@ describe("Batch Receiver - Settle message", function (): void {
   });
 });
 
-describe("Batch Receiver - Settle deadlettered message", function (): void {
+describe("Batch Receiver - Settle deadlettered message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -606,7 +606,7 @@ describe("Batch Receiver - Settle deadlettered message", function (): void {
   let deadletterReceiver: Receiver;
 
   async function deadLetterMessage(testMessage: SendableMessageInfo): Promise<ServiceBusMessage> {
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
     const receivedMsgs = await receiver.receiveMessages(1);
 
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
@@ -682,28 +682,28 @@ describe("Batch Receiver - Settle deadlettered message", function (): void {
     await completeDeadLetteredMessage(testMessage, deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: Throws error when dead lettering a dead lettered message", async function (): Promise<
+  it("Partitioned Queue: Throws error when dead lettering a dead lettered message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDeadletter(TestMessage.getSample());
   });
 
-  it("Partitioned Subscription: Throws error when dead lettering a dead lettered message", async function (): Promise<
+  it("Partitioned Subscription: Throws error when dead lettering a dead lettered message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDeadletter(TestMessage.getSample());
   });
 
-  it("Unpartitioned Queue: Throws error when dead lettering a dead lettered message", async function (): Promise<
+  it("Unpartitioned Queue: Throws error when dead lettering a dead lettered message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDeadletter(TestMessage.getSample());
   });
 
-  it("Unpartitioned Subscription: Throws error when dead lettering a dead lettered message", async function (): Promise<
+  it("Unpartitioned Subscription: Throws error when dead lettering a dead lettered message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -718,28 +718,28 @@ describe("Batch Receiver - Settle deadlettered message", function (): void {
     await completeDeadLetteredMessage(testMessage, deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: Abandon a message received from dead letter queue", async function (): Promise<
+  it("Partitioned Queue: Abandon a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testAbandon(TestMessage.getSample());
   });
 
-  it("Partitioned Subscription: Abandon a message received from dead letter queue", async function (): Promise<
+  it("Partitioned Subscription: Abandon a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testAbandon(TestMessage.getSample());
   });
 
-  it("Unpartitioned Queue: Abandon a message received from dead letter queue", async function (): Promise<
+  it("Unpartitioned Queue: Abandon a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testAbandon(TestMessage.getSample());
   });
 
-  it("Unpartitioned Subscription: Abandon a message received from dead letter queue", async function (): Promise<
+  it("Unpartitioned Subscription: Abandon a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -774,28 +774,28 @@ describe("Batch Receiver - Settle deadlettered message", function (): void {
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: Defer a message received from dead letter queue", async function (): Promise<
+  it("Partitioned Queue: Defer a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDefer(TestMessage.getSample());
   });
 
-  it("Partitioned Subscription: Defer a message received from dead letter queue", async function (): Promise<
+  it("Partitioned Subscription: Defer a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDefer(TestMessage.getSample());
   });
 
-  it("Unpartitioned Queue: Defer a message received from dead letter queue", async function (): Promise<
+  it("Unpartitioned Queue: Defer a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDefer(TestMessage.getSample());
   });
 
-  it("Unpartitioned Subscription: Defer a message received from dead letter queue", async function (): Promise<
+  it("Unpartitioned Subscription: Defer a message received from dead letter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -803,7 +803,7 @@ describe("Batch Receiver - Settle deadlettered message", function (): void {
   });
 });
 
-describe("Batch Receiver - Multiple Receiver Operations", function (): void {
+describe("Batch Receiver - Multiple Receiver Operations", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -814,16 +814,24 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await delay(5000);
 
     let errorMessage;
-    let expectedErrorMessage = `The receiver for "${receiverClient.entityPath}" is already receiving messages.`;
+    let expectedErrorMessage = `The receiver for "${
+      receiverClient.entityPath
+    }" is already receiving messages.`;
     if (useSessions) {
-      expectedErrorMessage = `The receiver for session "${TestMessage.sessionId}" in "${receiverClient.entityPath}" is already receiving messages.`;
+      expectedErrorMessage = `The receiver for session "${TestMessage.sessionId}" in "${
+        receiverClient.entityPath
+      }" is already receiving messages.`;
     }
     try {
       await receiver.receiveMessages(1);
     } catch (err) {
       errorMessage = err && err.message;
     }
-    should.equal(errorMessage, expectedErrorMessage, "Unexpected error message for receiveMessages");
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for receiveMessages"
+    );
 
     let unexpectedError;
     try {
@@ -838,42 +846,49 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     } catch (err) {
       errorMessage = err && err.message;
     }
-    should.equal(errorMessage, expectedErrorMessage, "Unexpected error message for registerMessageHandler");
-    should.equal(unexpectedError, undefined, "Unexpected error found in errorHandler for registerMessageHandler");
-
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for registerMessageHandler"
+    );
+    should.equal(
+      unexpectedError,
+      undefined,
+      "Unexpected error found in errorHandler for registerMessageHandler"
+    );
 
     await firstBatchPromise;
   }
 
-  it("Partitioned Queue: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Partitioned Queue: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testParallelReceiveCalls();
   });
 
-  it("Partitioned Subscription: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Partitioned Subscription: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testParallelReceiveCalls();
   });
 
-  it("Unpartitioned Queue: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Unpartitioned Queue: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testParallelReceiveCalls();
   });
 
-  it("Unpartitioned Subscription: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Unpartitioned Subscription: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testParallelReceiveCalls();
   });
 
-  it("Partitioned Queue with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Partitioned Queue with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -884,7 +899,7 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await testParallelReceiveCalls(true);
   });
 
-  it("Partitioned Subscription with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Partitioned Subscription with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -895,7 +910,7 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await testParallelReceiveCalls(true);
   });
 
-  it("Unpartitioned Queue with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -906,7 +921,7 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await testParallelReceiveCalls(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: Throws error when ReceiveBatch is called while the previous call is not done", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -946,7 +961,7 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
   // See https://github.com/Azure/azure-service-bus-node/issues/31
   async function testSequentialReceiveBatchCalls(useSessions?: boolean): Promise<void> {
     const testMessages = useSessions ? messageWithSessions : messages;
-    await sender.sendMessages(testMessages);
+    await sender.sendBatch(testMessages);
     const msgs1 = await receiver.receiveMessages(1);
     const msgs2 = await receiver.receiveMessages(1);
 
@@ -973,35 +988,35 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await msgs2[0].complete();
   }
 
-  it("Partitioned Queue: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Partitioned Queue: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testSequentialReceiveBatchCalls();
   });
 
-  it("Partitioned Subscription: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Partitioned Subscription: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testSequentialReceiveBatchCalls();
   });
 
-  it("Unpartitioned Queue: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Unpartitioned Queue: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testSequentialReceiveBatchCalls();
   });
 
-  it("Unpartitioned Subscription: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Unpartitioned Subscription: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testSequentialReceiveBatchCalls();
   });
 
-  it("Partitioned Queue with Sessions: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Partitioned Queue with Sessions: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1012,7 +1027,7 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await testSequentialReceiveBatchCalls(true);
   });
 
-  it("Partitioned Subscription with Sessions: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Partitioned Subscription with Sessions: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1023,7 +1038,7 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await testSequentialReceiveBatchCalls(true);
   });
 
-  it("Unpartitioned Queue with Sessions: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1034,7 +1049,7 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
     await testSequentialReceiveBatchCalls(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: Multiple sequential receiveMessages calls", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: Multiple sequential receiveMessages calls", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1046,14 +1061,14 @@ describe("Batch Receiver - Multiple Receiver Operations", function (): void {
   });
 });
 
-describe("Batch Receiver - Others", function (): void {
+describe("Batch Receiver - Others", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testNoSettlement(useSessions?: boolean): Promise<void> {
     const testMessages = useSessions ? TestMessage.getSessionSample() : TestMessage.getSample();
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
 
     let receivedMsgs = await receiver.receiveMessages(1);
 
@@ -1080,28 +1095,28 @@ describe("Batch Receiver - Others", function (): void {
     await receivedMsgs[0].complete();
   }
 
-  it("Partitioned Queue: No settlement of the message is retained with incremented deliveryCount", async function (): Promise<
+  it("Partitioned Queue: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testNoSettlement();
   });
 
-  it("Partitioned Subscription: No settlement of the message is retained with incremented deliveryCount", async function (): Promise<
+  it("Partitioned Subscription: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testNoSettlement();
   });
 
-  it("Unpartitioned Queue: No settlement of the message is retained with incremented deliveryCount", async function (): Promise<
+  it("Unpartitioned Queue: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testNoSettlement();
   });
 
-  it("Unpartitioned Subscription: No settlement of the message is retained with incremented deliveryCount", async function (): Promise<
+  it("Unpartitioned Subscription: No settlement of the message is retained with incremented deliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -1110,7 +1125,7 @@ describe("Batch Receiver - Others", function (): void {
 
   async function testAskForMore(useSessions?: boolean): Promise<void> {
     const testMessages = useSessions ? TestMessage.getSessionSample() : TestMessage.getSample();
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
     const receivedMsgs = await receiver.receiveMessages(2);
 
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
@@ -1126,7 +1141,7 @@ describe("Batch Receiver - Others", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: Receive n messages but queue only has m messages, where m < n", async function (): Promise<
+  it("Partitioned Queue: Receive n messages but queue only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
@@ -1134,7 +1149,7 @@ describe("Batch Receiver - Others", function (): void {
     await testAskForMore();
   });
 
-  it("Partitioned Subscription: Receive n messages but subscription only has m messages, where m < n", async function (): Promise<
+  it("Partitioned Subscription: Receive n messages but subscription only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
@@ -1142,7 +1157,7 @@ describe("Batch Receiver - Others", function (): void {
     await testAskForMore();
   });
 
-  it("Unpartitioned Queue: Receive n messages but queue only has m messages, where m < n", async function (): Promise<
+  it("Unpartitioned Queue: Receive n messages but queue only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
@@ -1150,7 +1165,7 @@ describe("Batch Receiver - Others", function (): void {
     await testAskForMore();
   });
 
-  it("Unpartitioned Subscription: Receive n messages but subscription only has m messages, where m < n", async function (): Promise<
+  it("Unpartitioned Subscription: Receive n messages but subscription only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -1158,7 +1173,7 @@ describe("Batch Receiver - Others", function (): void {
     await testAskForMore();
   });
 
-  it("Partitioned Queue with Sessions: Receive n messages but queue only has m messages, where m < n", async function (): Promise<
+  it("Partitioned Queue with Sessions: Receive n messages but queue only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1169,7 +1184,7 @@ describe("Batch Receiver - Others", function (): void {
     await testAskForMore(true);
   });
 
-  it("Partitioned Subscription with Sessions: Receive n messages but subscription only has m messages, where m < n", async function (): Promise<
+  it("Partitioned Subscription with Sessions: Receive n messages but subscription only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1180,7 +1195,7 @@ describe("Batch Receiver - Others", function (): void {
     await testAskForMore(true);
   });
 
-  it("Unpartitioned Queue with Sessions: Receive n messages but queue only has m messages, where m < n", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: Receive n messages but queue only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1191,7 +1206,7 @@ describe("Batch Receiver - Others", function (): void {
     await testAskForMore(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: Receive n messages but subscription only has m messages, where m < n", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: Receive n messages but subscription only has m messages, where m < n", async function(): Promise<
     void
   > {
     await beforeEachTest(

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -102,7 +102,7 @@ async function afterEachTest(): Promise<void> {
 }
 
 async function deferMessage(testMessages: SendableMessageInfo): Promise<ServiceBusMessage> {
-  await sender.sendMessage(testMessages);
+  await sender.send(testMessages);
   const receivedMsgs = await receiver.receiveMessages(1);
 
   should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
@@ -165,7 +165,7 @@ async function completeDeferredMessage(
   await testPeekMsgsLength(receiverClient, 0);
 }
 
-describe("Abandon/Defer/Deadletter deferred message", function (): void {
+describe("Abandon/Defer/Deadletter deferred message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -181,21 +181,21 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await completeDeferredMessage(sequenceNumber, 2, testMessages);
   }
 
-  it("Partitioned Queue: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Queue: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testAbandon();
   });
 
-  it("Partitioned Subscription: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Subscription: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testAbandon();
   });
 
-  it("Partitioned Queue with Sessions: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Queue with Sessions: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -206,7 +206,7 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testAbandon(true);
   });
 
-  it("Partitioned Subscription with Sessions: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Subscription with Sessions: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -217,21 +217,21 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testAbandon(true);
   });
 
-  it("Unpartitioned Queue: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Queue: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testAbandon();
   });
 
-  it("Unpartitioned Subscription: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Subscription: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testAbandon();
   });
 
-  it("Unpartitioned Queue with Sessions:: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Queue with Sessions:: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -242,7 +242,7 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testAbandon(true);
   });
 
-  it("Unpartitioned Subscription with Sessions:: Abandoning a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions:: Abandoning a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -264,21 +264,21 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await completeDeferredMessage(sequenceNumber, 2, testMessages);
   }
 
-  it("Partitioned Queue: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Queue: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDefer();
   });
 
-  it("Partitioned Subscription: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Subscription: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDefer();
   });
 
-  it("Partitioned Queue with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Queue with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -289,7 +289,7 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testDefer(true);
   });
 
-  it("Partitioned Subscription with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Partitioned Subscription with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -300,21 +300,21 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testDefer(true);
   });
 
-  it("Unpartitioned Queue: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Queue: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDefer();
   });
 
-  it("Unpartitioned Subscription: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Subscription: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testDefer();
   });
 
-  it("Unpartitioned Queue with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -325,7 +325,7 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testDefer(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: Deferring a deferred message puts it back to the deferred queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -365,21 +365,21 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Partitioned Queue: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDeadletter();
   });
 
-  it("Partitioned Subscription: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Partitioned Subscription: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDeadletter();
   });
 
-  it("Partitioned Queue with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Partitioned Queue with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -390,7 +390,7 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testDeadletter(true);
   });
 
-  it("Partitioned Subscription with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Partitioned Subscription with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -401,21 +401,21 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testDeadletter(true);
   });
 
-  it("Unpartitioned Queue: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Unpartitioned Queue: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDeadletter();
   });
 
-  it("Unpartitioned Subscription: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Unpartitioned Subscription: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testDeadletter();
   });
 
-  it("Unpartitioned Queue with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Unpartitioned Queue with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -426,7 +426,7 @@ describe("Abandon/Defer/Deadletter deferred message", function (): void {
     await testDeadletter(true);
   });
 
-  it("Unpartitioned Subscription with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function (): Promise<
+  it("Unpartitioned Subscription with Sessions: Deadlettering a deferred message moves it to dead letter queue.", async function(): Promise<
     void
   > {
     await beforeEachTest(

--- a/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
@@ -100,7 +100,7 @@ describe("Batch Receiver in ReceiveAndDelete mode", function(): void {
   });
 
   async function sendReceiveMsg(testMessages: SendableMessageInfo): Promise<void> {
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
     const msgs = await receiver.receiveMessages(1);
 
     should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
@@ -201,7 +201,7 @@ describe("Streaming Receiver in ReceiveAndDelete mode", function(): void {
     testMessages: SendableMessageInfo,
     autoCompleteFlag: boolean
   ): Promise<void> {
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
     const receivedMsgs: ServiceBusMessage[] = [];
 
     receiver.registerMessageHandler(
@@ -394,7 +394,7 @@ describe("Unsupported features in ReceiveAndDelete mode", function(): void {
     await afterEachTest();
   });
   async function sendReceiveMsg(testMessages: SendableMessageInfo): Promise<ServiceBusMessage> {
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
     const msgs = await receiver.receiveMessages(1);
 
     should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
@@ -687,7 +687,7 @@ describe("Unsupported features in ReceiveAndDelete mode", function(): void {
   async function testRenewLock(): Promise<void> {
     const msg = await sendReceiveMsg(TestMessage.getSample());
 
-    await receiver.renewLock(msg).catch((err) => testError(err));
+    await (<Receiver>receiver).renewMessageLock(msg).catch((err) => testError(err));
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
   }

--- a/sdk/servicebus/service-bus/test/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLock.spec.ts
@@ -49,7 +49,7 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("Unpartitioned Queue - Lock Renewal", function (): void {
+describe("Unpartitioned Queue - Lock Renewal", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
   });
@@ -58,25 +58,25 @@ describe("Unpartitioned Queue - Lock Renewal", function (): void {
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -86,7 +86,7 @@ describe("Unpartitioned Queue - Lock Renewal", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -96,7 +96,7 @@ describe("Unpartitioned Queue - Lock Renewal", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -106,7 +106,7 @@ describe("Unpartitioned Queue - Lock Renewal", function (): void {
     });
   }).timeout(90000);
 
-  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function (): Promise<
+  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -117,7 +117,7 @@ describe("Unpartitioned Queue - Lock Renewal", function (): void {
   });
 });
 
-describe("Partitioned Queue - Lock Renewal", function (): void {
+describe("Partitioned Queue - Lock Renewal", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
   });
@@ -126,25 +126,25 @@ describe("Partitioned Queue - Lock Renewal", function (): void {
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -155,7 +155,7 @@ describe("Partitioned Queue - Lock Renewal", function (): void {
     // Complete fails as expected
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -165,7 +165,7 @@ describe("Partitioned Queue - Lock Renewal", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -175,7 +175,7 @@ describe("Partitioned Queue - Lock Renewal", function (): void {
     });
   }).timeout(90000);
 
-  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function (): Promise<
+  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -186,7 +186,7 @@ describe("Partitioned Queue - Lock Renewal", function (): void {
   });
 });
 
-describe("Unpartitioned Subscription - Lock Renewal", function (): void {
+describe("Unpartitioned Subscription - Lock Renewal", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
   });
@@ -195,25 +195,25 @@ describe("Unpartitioned Subscription - Lock Renewal", function (): void {
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -224,7 +224,7 @@ describe("Unpartitioned Subscription - Lock Renewal", function (): void {
     // Complete fails as expected
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -234,7 +234,7 @@ describe("Unpartitioned Subscription - Lock Renewal", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -244,7 +244,7 @@ describe("Unpartitioned Subscription - Lock Renewal", function (): void {
     });
   }).timeout(90000);
 
-  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function (): Promise<
+  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -255,7 +255,7 @@ describe("Unpartitioned Subscription - Lock Renewal", function (): void {
   });
 });
 
-describe("Partitioned Subscription - Lock Renewal", function (): void {
+describe("Partitioned Subscription - Lock Renewal", function(): void {
   beforeEach(async () => {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
   });
@@ -264,25 +264,25 @@ describe("Partitioned Subscription - Lock Renewal", function (): void {
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -293,7 +293,7 @@ describe("Partitioned Subscription - Lock Renewal", function (): void {
     // Complete fails as expected
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -303,7 +303,7 @@ describe("Partitioned Subscription - Lock Renewal", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -313,7 +313,7 @@ describe("Partitioned Subscription - Lock Renewal", function (): void {
     });
   }).timeout(90000);
 
-  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function (): Promise<
+  it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -340,7 +340,7 @@ async function testBatchReceiverManualLockRenewalHappyCase(
   receiverClient: QueueClient | SubscriptionClient
 ): Promise<void> {
   const testMessage = TestMessage.getSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
 
   const receiver = receiverClient.createReceiver(ReceiveMode.peekLock);
   const msgs = await receiver.receiveMessages(1);
@@ -365,7 +365,7 @@ async function testBatchReceiverManualLockRenewalHappyCase(
 
   await delay(5000);
   if (msgs[0].lockToken) {
-    await receiver.renewLock(msgs[0].lockToken);
+    await receiver.renewMessageLock(msgs[0].lockToken);
   }
 
   // Compute expected lock expiry time after renewing lock after 5 seconds
@@ -389,7 +389,7 @@ async function testBatchReceiverManualLockRenewalErrorOnLockExpiry(
   receiverClient: QueueClient | SubscriptionClient
 ): Promise<void> {
   const testMessage = TestMessage.getSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
 
   const receiver = receiverClient.createReceiver(ReceiveMode.peekLock);
   const msgs = await receiver.receiveMessages(1);
@@ -424,7 +424,7 @@ async function testStreamingReceiverManualLockRenewalHappyCase(
 ): Promise<void> {
   let numOfMessagesReceived = 0;
   const testMessage = TestMessage.getSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
   const receiver = receiverClient.createReceiver(ReceiveMode.peekLock);
 
   const onMessage: OnMessage = async (brokeredMessage: ServiceBusMessage) => {
@@ -456,7 +456,7 @@ async function testStreamingReceiverManualLockRenewalHappyCase(
       );
 
       await delay(5000);
-      await receiver.renewLock(brokeredMessage);
+      await receiver.renewMessageLock(brokeredMessage);
 
       // Compute expected lock expiry time after renewing lock after 5 seconds
       expectedLockExpiryTimeUtc.setSeconds(expectedLockExpiryTimeUtc.getSeconds() + 5);
@@ -499,7 +499,7 @@ async function testAutoLockRenewalConfigBehavior(
 ): Promise<void> {
   let numOfMessagesReceived = 0;
   const testMessage = TestMessage.getSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
   const receiver = receiverClient.createReceiver(ReceiveMode.peekLock);
 
   const onMessage: OnMessage = async (brokeredMessage: ServiceBusMessage) => {

--- a/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
@@ -49,7 +49,7 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("Unpartitioned Queue - Lock Renewal for Sessions", function (): void {
+describe("Unpartitioned Queue - Lock Renewal for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
@@ -61,25 +61,25 @@ describe("Unpartitioned Queue - Lock Renewal for Sessions", function (): void {
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -89,7 +89,7 @@ describe("Unpartitioned Queue - Lock Renewal for Sessions", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -99,7 +99,7 @@ describe("Unpartitioned Queue - Lock Renewal for Sessions", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -109,7 +109,7 @@ describe("Unpartitioned Queue - Lock Renewal for Sessions", function (): void {
     });
   }).timeout(95000);
 
-  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function (): Promise<
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -120,7 +120,7 @@ describe("Unpartitioned Queue - Lock Renewal for Sessions", function (): void {
   });
 });
 
-describe("Partitioned Queue - Lock Renewal for Sessions", function (): void {
+describe("Partitioned Queue - Lock Renewal for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
@@ -132,25 +132,25 @@ describe("Partitioned Queue - Lock Renewal for Sessions", function (): void {
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -160,7 +160,7 @@ describe("Partitioned Queue - Lock Renewal for Sessions", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -170,7 +170,7 @@ describe("Partitioned Queue - Lock Renewal for Sessions", function (): void {
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -180,7 +180,7 @@ describe("Partitioned Queue - Lock Renewal for Sessions", function (): void {
     });
   }).timeout(95000);
 
-  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function (): Promise<
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -191,7 +191,7 @@ describe("Partitioned Queue - Lock Renewal for Sessions", function (): void {
   });
 });
 
-describe("Unpartitioned Subscription - Lock Renewal for Sessions", function (): void {
+describe("Unpartitioned Subscription - Lock Renewal for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.UnpartitionedTopicWithSessions,
@@ -203,25 +203,25 @@ describe("Unpartitioned Subscription - Lock Renewal for Sessions", function (): 
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -231,7 +231,7 @@ describe("Unpartitioned Subscription - Lock Renewal for Sessions", function (): 
     });
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -241,7 +241,7 @@ describe("Unpartitioned Subscription - Lock Renewal for Sessions", function (): 
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -251,7 +251,7 @@ describe("Unpartitioned Subscription - Lock Renewal for Sessions", function (): 
     });
   }).timeout(95000);
 
-  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function (): Promise<
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -262,7 +262,7 @@ describe("Unpartitioned Subscription - Lock Renewal for Sessions", function (): 
   });
 });
 
-describe("Partitioned Subscription - Lock Renewal for Sessions", function (): void {
+describe("Partitioned Subscription - Lock Renewal for Sessions", function(): void {
   beforeEach(async () => {
     await beforeEachTest(
       ClientType.PartitionedTopicWithSessions,
@@ -274,25 +274,25 @@ describe("Partitioned Subscription - Lock Renewal for Sessions", function (): vo
     await afterEachTest();
   });
 
-  it("Batch Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Batch Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Batch Receiver: complete() after lock expiry with throws error", async function (): Promise<
+  it("Batch Receiver: complete() after lock expiry with throws error", async function(): Promise<
     void
   > {
     await testBatchReceiverManualLockRenewalErrorOnLockExpiry(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: renewLock() resets lock duration each time.", async function (): Promise<
+  it("Streaming Receiver: renewLock() resets lock duration each time.", async function(): Promise<
     void
   > {
     await testStreamingReceiverManualLockRenewalHappyCase(senderClient, receiverClient);
   });
 
-  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function (): Promise<
+  it("Streaming Receiver: complete() after lock expiry with auto-renewal disabled throws error", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -302,7 +302,7 @@ describe("Partitioned Subscription - Lock Renewal for Sessions", function (): vo
     });
   });
 
-  it("Streaming Receiver: lock will not expire until configured time", async function (): Promise<
+  it("Streaming Receiver: lock will not expire until configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -312,7 +312,7 @@ describe("Partitioned Subscription - Lock Renewal for Sessions", function (): vo
     });
   });
 
-  it("Streaming Receiver: lock expires sometime after configured time", async function (): Promise<
+  it("Streaming Receiver: lock expires sometime after configured time", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -322,7 +322,7 @@ describe("Partitioned Subscription - Lock Renewal for Sessions", function (): vo
     });
   }).timeout(95000);
 
-  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function (): Promise<
+  it("Receive a msg using Streaming Receiver, lock renewal does not take place when config value is less than lock duration", async function(): Promise<
     void
   > {
     await testAutoLockRenewalConfigBehavior(senderClient, receiverClient, {
@@ -349,7 +349,7 @@ async function testBatchReceiverManualLockRenewalHappyCase(
   receiverClient: QueueClient | SubscriptionClient
 ): Promise<void> {
   const testMessage = TestMessage.getSessionSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
 
   const sessionClient = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: TestMessage.sessionId,
@@ -376,7 +376,7 @@ async function testBatchReceiverManualLockRenewalHappyCase(
   );
 
   await delay(5000);
-  await sessionClient.renewLock();
+  await sessionClient.renewSessionLock();
 
   // Compute expected lock expiry time after renewing lock after 5 seconds
   expectedLockExpiryTimeUtc.setSeconds(expectedLockExpiryTimeUtc.getSeconds() + 5);
@@ -399,7 +399,7 @@ async function testBatchReceiverManualLockRenewalErrorOnLockExpiry(
   receiverClient: QueueClient | SubscriptionClient
 ): Promise<void> {
   const testMessage = TestMessage.getSessionSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
 
   let sessionClient = receiverClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: TestMessage.sessionId,
@@ -440,7 +440,7 @@ async function testStreamingReceiverManualLockRenewalHappyCase(
 ): Promise<void> {
   let numOfMessagesReceived = 0;
   const testMessage = TestMessage.getSessionSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
   const sessionClient = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: TestMessage.sessionId,
     maxSessionAutoRenewLockDurationInSeconds: 0
@@ -475,7 +475,7 @@ async function testStreamingReceiverManualLockRenewalHappyCase(
       );
 
       await delay(5000);
-      await sessionClient.renewLock();
+      await sessionClient.renewSessionLock();
 
       // Compute expected lock expiry time after renewing lock after 5 seconds
       expectedLockExpiryTimeUtc.setSeconds(expectedLockExpiryTimeUtc.getSeconds() + 5);
@@ -517,7 +517,7 @@ async function testAutoLockRenewalConfigBehavior(
 ): Promise<void> {
   let numOfMessagesReceived = 0;
   const testMessage = TestMessage.getSessionSample();
-  await senderClient.createSender().sendMessage(testMessage);
+  await senderClient.createSender().send(testMessage);
 
   const sessionClient = receiverClient.createReceiver(ReceiveMode.peekLock, {
     sessionId: TestMessage.sessionId,

--- a/sdk/servicebus/service-bus/test/sendSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendSchedule.spec.ts
@@ -84,7 +84,7 @@ describe("Simple Send", function(): void {
 
   async function testSimpleSend(useSessions?: boolean): Promise<void> {
     const testMessages = useSessions ? TestMessage.getSessionSample() : TestMessage.getSample();
-    await senderClient.createSender().sendMessage(testMessages);
+    await senderClient.createSender().send(testMessages);
     const msgs = await receiver.receiveMessages(1);
 
     should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
@@ -554,7 +554,7 @@ describe("Message validations", function(): void {
     let actualErrorMsg = "";
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     const sender = senderClient.createSender();
-    await sender.sendMessage(msg).catch((err) => {
+    await sender.send(msg).catch((err) => {
       actualErrorMsg = err.message;
     });
     should.equal(actualErrorMsg, expectedErrorMsg, "Error not thrown as expected");

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -134,7 +134,7 @@ describe("Errors with non existing Namespace", function(): void {
     const client = namespace.createQueueClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch(testError);
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
@@ -146,7 +146,7 @@ describe("Errors with non existing Namespace", function(): void {
     const client = namespace.createTopicClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch(testError);
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
@@ -158,7 +158,7 @@ describe("Errors with non existing Namespace", function(): void {
     const client = namespace.createQueueClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch(testError);
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
   });
@@ -169,7 +169,7 @@ describe("Errors with non existing Namespace", function(): void {
     const client = namespace.createTopicClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch(testError);
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
@@ -243,7 +243,7 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
     const client = namespace.createQueueClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch((err) => testError(err, "some-name"));
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
@@ -253,7 +253,7 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
     const client = namespace.createTopicClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch((err) => testError(err, "some-name"));
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
@@ -265,7 +265,7 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
     const client = namespace.createQueueClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch((err) => testError(err, "some-name"));
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
@@ -277,7 +277,7 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
     const client = namespace.createTopicClient("some-name");
     await client
       .createSender()
-      .sendMessage({ body: "hello" })
+      .send({ body: "hello" })
       .catch((err) => testError(err, "some-name"));
 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
@@ -363,7 +363,7 @@ describe("Test createFromAadTokenCredentials", function(): void {
 
     const sender = clients.senderClient.createSender();
     const receiver = await clients.receiverClient.createReceiver(ReceiveMode.peekLock);
-    await sender.sendMessage(testMessages);
+    await sender.send(testMessages);
     const msgs = await receiver.receiveMessages(1);
 
     should.equal(Array.isArray(msgs), true, "`ReceivedMessages` is not an array");
@@ -468,7 +468,7 @@ describe("Errors after close()", function(): void {
 
     // Normal send/receive
     const testMessage = useSessions ? TestMessage.getSessionSample() : TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
     const receivedMsgs = await receiver.receiveMessages(1, 3);
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages received");
     await receivedMsgs[0].complete();
@@ -501,13 +501,13 @@ describe("Errors after close()", function(): void {
   async function testSender(expectedErrorMsg: string): Promise<void> {
     const testMessage = TestMessage.getSample();
     let errorSend: string = "";
-    await sender.sendMessage(testMessage).catch((err) => {
+    await sender.send(testMessage).catch((err) => {
       errorSend = err.message;
     });
     should.equal(errorSend, expectedErrorMsg, "Expected error not thrown for send()");
 
     let errorSendBatch: string = "";
-    await sender.sendMessages([testMessage]).catch((err) => {
+    await sender.sendBatch([testMessage]).catch((err) => {
       errorSendBatch = err.message;
     });
     should.equal(errorSendBatch, expectedErrorMsg, "Expected error not thrown for sendBatch()");
@@ -612,11 +612,13 @@ describe("Errors after close()", function(): void {
       "Expected error not thrown for receiveDeferredMessages()"
     );
 
-    let errorRenewLock: string = "";
-    await receiver.renewLock("randomLockToken").catch((err) => {
-      errorRenewLock = err.message;
-    });
-    should.equal(errorRenewLock, expectedErrorMsg, "Expected error not thrown for renewLock()");
+    if (!useSessions) {
+      let errorRenewLock: string = "";
+      await (<Receiver>receiver).renewMessageLock("randomLockToken").catch((err) => {
+        errorRenewLock = err.message;
+      });
+      should.equal(errorRenewLock, expectedErrorMsg, "Expected error not thrown for renewLock()");
+    }
   }
 
   /**

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -82,14 +82,14 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("SessionReceiver with invalid sessionId", function (): void {
+describe("SessionReceiver with invalid sessionId", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function test_batching(): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await senderClient.createSender().sendMessage(testMessage);
+    await senderClient.createSender().send(testMessage);
 
     let receiver = receiverClient.createReceiver(ReceiveMode.peekLock, {
       sessionId: "non" + TestMessage.sessionId
@@ -108,7 +108,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Partitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -118,7 +118,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await test_batching();
   });
 
-  it("Partitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Partitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -128,7 +128,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await test_batching();
   });
 
-  it("Unpartitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Unpartitioned Queue - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -138,7 +138,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await test_batching();
   });
 
-  it("Unpartitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Unpartitioned Subscription - Batch Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -150,7 +150,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
 
   async function test_streaming(): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await senderClient.createSender().sendMessage(testMessage);
+    await senderClient.createSender().send(testMessage);
 
     let receiver = receiverClient.createReceiver(ReceiveMode.peekLock, {
       sessionId: "non" + TestMessage.sessionId
@@ -185,7 +185,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Partitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -195,7 +195,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await test_streaming();
   });
 
-  it("Partitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Partitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -205,7 +205,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await test_streaming();
   });
 
-  it("Unpartitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Unpartitioned Queue - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -215,7 +215,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
     await test_streaming();
   });
 
-  it("Unpartitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function (): Promise<
+  it("Unpartitioned Subscription - Streaming Receiver: no messages received for invalid sessionId", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -226,7 +226,7 @@ describe("SessionReceiver with invalid sessionId", function (): void {
   });
 });
 
-describe("SessionReceiver with no sessionId", function (): void {
+describe("SessionReceiver with no sessionId", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -246,8 +246,8 @@ describe("SessionReceiver with no sessionId", function (): void {
 
   async function testComplete_batching(): Promise<void> {
     const sender = senderClient.createSender();
-    await sender.sendMessage(testMessagesWithDifferentSessionIds[0]);
-    await sender.sendMessage(testMessagesWithDifferentSessionIds[1]);
+    await sender.send(testMessagesWithDifferentSessionIds[0]);
+    await sender.send(testMessagesWithDifferentSessionIds[1]);
 
     let receiver = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
       sessionId: undefined
@@ -290,7 +290,7 @@ describe("SessionReceiver with no sessionId", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: complete() removes message from random session", async function (): Promise<
+  it("Partitioned Queue: complete() removes message from random session", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -301,7 +301,7 @@ describe("SessionReceiver with no sessionId", function (): void {
     await testComplete_batching();
   });
 
-  it("Partitioned Subscription: complete() removes message from random session", async function (): Promise<
+  it("Partitioned Subscription: complete() removes message from random session", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -312,7 +312,7 @@ describe("SessionReceiver with no sessionId", function (): void {
     await testComplete_batching();
   });
 
-  it("Unpartitioned Queue: complete() removes message from random session", async function (): Promise<
+  it("Unpartitioned Queue: complete() removes message from random session", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -323,7 +323,7 @@ describe("SessionReceiver with no sessionId", function (): void {
     await testComplete_batching();
   });
 
-  it("Unpartitioned Subscription: complete() removes message from random session", async function (): Promise<
+  it("Unpartitioned Subscription: complete() removes message from random session", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -335,7 +335,7 @@ describe("SessionReceiver with no sessionId", function (): void {
   });
 });
 
-describe("Session State", function (): void {
+describe("Session State", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -343,7 +343,7 @@ describe("Session State", function (): void {
   async function testGetSetState(): Promise<void> {
     const sender = senderClient.createSender();
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     let receiver = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
       sessionId: undefined
@@ -380,7 +380,7 @@ describe("Session State", function (): void {
     await msgs[0].complete();
     await testPeekMsgsLength(receiverClient, 0);
   }
-  it("Partitioned Queue - Testing getState and setState", async function (): Promise<void> {
+  it("Partitioned Queue - Testing getState and setState", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
@@ -388,7 +388,7 @@ describe("Session State", function (): void {
     await purge(receiverClient, testSessionId2);
     await testGetSetState();
   });
-  it("Partitioned Subscription - Testing getState and setState", async function (): Promise<void> {
+  it("Partitioned Subscription - Testing getState and setState", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedTopicWithSessions,
       ClientType.PartitionedSubscriptionWithSessions
@@ -396,7 +396,7 @@ describe("Session State", function (): void {
     await purge(receiverClient, testSessionId2);
     await testGetSetState();
   });
-  it("Unpartitioned Queue - Testing getState and setState", async function (): Promise<void> {
+  it("Unpartitioned Queue - Testing getState and setState", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
@@ -404,7 +404,7 @@ describe("Session State", function (): void {
     await purge(receiverClient, testSessionId2);
     await testGetSetState();
   });
-  it("Unpartitioned Subscription - Testing getState and setState", async function (): Promise<void> {
+  it("Unpartitioned Subscription - Testing getState and setState", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedTopicWithSessions,
       ClientType.UnpartitionedSubscriptionWithSessions
@@ -414,7 +414,7 @@ describe("Session State", function (): void {
   });
 });
 
-describe("Peek session", function (): void {
+describe("Peek session", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -422,7 +422,7 @@ describe("Peek session", function (): void {
   async function peekSession(useSessionId: boolean): Promise<void> {
     const sender = senderClient.createSender();
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receiver = <SessionReceiver>receiverClient.createReceiver(ReceiveMode.peekLock, {
       sessionId: useSessionId ? testMessage.sessionId : undefined
@@ -433,8 +433,16 @@ describe("Peek session", function (): void {
     const peekedMsgs = await receiver.peek(1);
     should.equal(peekedMsgs.length, 1, "Unexpected number of messages");
     should.equal(peekedMsgs[0].body, testMessage.body, "MessageBody is different than expected");
-    should.equal(peekedMsgs[0].messageId, testMessage.messageId, "MessageId is different than expected");
-    should.equal(peekedMsgs[0].sessionId, testMessage.sessionId, "SessionId is different than expected");
+    should.equal(
+      peekedMsgs[0].messageId,
+      testMessage.messageId,
+      "MessageId is different than expected"
+    );
+    should.equal(
+      peekedMsgs[0].sessionId,
+      testMessage.sessionId,
+      "SessionId is different than expected"
+    );
 
     const msgs = await receiver.receiveMessages(1);
     should.equal(msgs.length, 1, "Unexpected number of messages");
@@ -445,28 +453,28 @@ describe("Peek session", function (): void {
     await msgs[0].complete();
   }
 
-  it("Partitioned Queue - Peek Session with sessionId", async function (): Promise<void> {
+  it("Partitioned Queue - Peek Session with sessionId", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
     );
     await peekSession(true);
   });
-  it("Partitioned Subscription - Peek Session with sessionId", async function (): Promise<void> {
+  it("Partitioned Subscription - Peek Session with sessionId", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedTopicWithSessions,
       ClientType.PartitionedSubscriptionWithSessions
     );
     await peekSession(true);
   });
-  it("Unpartitioned Queue - Peek Session with sessionId", async function (): Promise<void> {
+  it("Unpartitioned Queue - Peek Session with sessionId", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
     );
     await peekSession(true);
   });
-  it("Unpartitioned Subscription - Peek Session with sessionId", async function (): Promise<void> {
+  it("Unpartitioned Subscription - Peek Session with sessionId", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedTopicWithSessions,
       ClientType.UnpartitionedSubscriptionWithSessions
@@ -474,28 +482,30 @@ describe("Peek session", function (): void {
     await peekSession(true);
   });
 
-  it("Partitioned Queue - Peek Session without sessionId", async function (): Promise<void> {
+  it("Partitioned Queue - Peek Session without sessionId", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
     );
     await peekSession(false);
   });
-  it("Partitioned Subscription - Peek Session without sessionId", async function (): Promise<void> {
+  it("Partitioned Subscription - Peek Session without sessionId", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedTopicWithSessions,
       ClientType.PartitionedSubscriptionWithSessions
     );
     await peekSession(false);
   });
-  it("Unpartitioned Queue - Peek Session without sessionId", async function (): Promise<void> {
+  it("Unpartitioned Queue - Peek Session without sessionId", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
     );
     await peekSession(false);
   });
-  it("Unpartitioned Subscription - Peek Session without sessionId", async function (): Promise<void> {
+  it("Unpartitioned Subscription - Peek Session without sessionId", async function(): Promise<
+    void
+  > {
     await beforeEachTest(
       ClientType.UnpartitionedTopicWithSessions,
       ClientType.UnpartitionedSubscriptionWithSessions

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -111,14 +111,14 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("Streaming - Misc Tests", function (): void {
+describe("Streaming - Misc Tests", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testAutoComplete(): Promise<void> {
     const testMessage = TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     receiver.registerMessageHandler((msg: ServiceBusMessage) => {
@@ -147,22 +147,22 @@ describe("Streaming - Misc Tests", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: AutoComplete removes the message", async function (): Promise<void> {
+  it("Partitioned Queue: AutoComplete removes the message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testAutoComplete();
   });
 
-  it("Partitioned Subscription: AutoComplete removes the message", async function (): Promise<void> {
+  it("Partitioned Subscription: AutoComplete removes the message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testAutoComplete();
   });
 
-  it("UnPartitioned Queue: AutoComplete removes the message", async function (): Promise<void> {
+  it("UnPartitioned Queue: AutoComplete removes the message", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testAutoComplete();
   });
 
-  it("UnPartitioned Subscription: AutoComplete removes the message", async function (): Promise<
+  it("UnPartitioned Subscription: AutoComplete removes the message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -171,7 +171,7 @@ describe("Streaming - Misc Tests", function (): void {
 
   async function testManualComplete(): Promise<void> {
     const testMessage = TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     receiver.registerMessageHandler(
@@ -198,28 +198,28 @@ describe("Streaming - Misc Tests", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: Disabled autoComplete, no manual complete retains the message", async function (): Promise<
+  it("Partitioned Queue: Disabled autoComplete, no manual complete retains the message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testManualComplete();
   });
 
-  it("Partitioned Subscription: Disabled autoComplete, no manual complete retains the message", async function (): Promise<
+  it("Partitioned Subscription: Disabled autoComplete, no manual complete retains the message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testManualComplete();
   });
 
-  it("UnPartitioned Queue: Disabled autoComplete, no manual complete retains the message", async function (): Promise<
+  it("UnPartitioned Queue: Disabled autoComplete, no manual complete retains the message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testManualComplete();
   });
 
-  it("UnPartitioned Subscription: Disabled autoComplete, no manual complete retains the message", async function (): Promise<
+  it("UnPartitioned Subscription: Disabled autoComplete, no manual complete retains the message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -227,14 +227,14 @@ describe("Streaming - Misc Tests", function (): void {
   });
 });
 
-describe("Streaming - Complete message", function (): void {
+describe("Streaming - Complete message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testComplete(autoComplete: boolean): Promise<void> {
     const testMessage = TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     receiver.registerMessageHandler(
@@ -256,48 +256,48 @@ describe("Streaming - Complete message", function (): void {
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
     await testPeekMsgsLength(receiverClient, 0);
   }
-  it("Partitioned Queue: complete() removes message", async function (): Promise<void> {
+  it("Partitioned Queue: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testComplete(false);
   });
 
-  it("Partitioned Subscription: complete() removes message", async function (): Promise<void> {
+  it("Partitioned Subscription: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testComplete(false);
   });
 
-  it("UnPartitioned Queue: complete() removes message", async function (): Promise<void> {
+  it("UnPartitioned Queue: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testComplete(false);
   });
 
-  it("UnPartitioned Subscription: complete() removes message", async function (): Promise<void> {
+  it("UnPartitioned Subscription: complete() removes message", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testComplete(false);
   });
 
-  it("Partitioned Queue with autoComplete: complete() removes message", async function (): Promise<
+  it("Partitioned Queue with autoComplete: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testComplete(true);
   });
 
-  it("Partitioned Subscription with autoComplete: complete() removes message", async function (): Promise<
+  it("Partitioned Subscription with autoComplete: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testComplete(true);
   });
 
-  it("UnPartitioned Queue with autoComplete: complete() removes message", async function (): Promise<
+  it("UnPartitioned Queue with autoComplete: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testComplete(true);
   });
 
-  it("UnPartitioned Subscription with autoComplete: complete() removes message", async function (): Promise<
+  it("UnPartitioned Subscription with autoComplete: complete() removes message", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -305,14 +305,14 @@ describe("Streaming - Complete message", function (): void {
   });
 });
 
-describe("Streaming - Abandon message", function (): void {
+describe("Streaming - Abandon message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testMultipleAbandons(): Promise<void> {
     const testMessage = TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     let checkDeliveryCount = 0;
 
@@ -359,28 +359,28 @@ describe("Streaming - Abandon message", function (): void {
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: Multiple abandons until maxDeliveryCount", async function (): Promise<
+  it("Partitioned Queue: Multiple abandons until maxDeliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testMultipleAbandons();
   });
 
-  it("Partitioned Subscription: Multiple abandons until maxDeliveryCount", async function (): Promise<
+  it("Partitioned Subscription: Multiple abandons until maxDeliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testMultipleAbandons();
   });
 
-  it("Unpartitioned Queue: Multiple abandons until maxDeliveryCount", async function (): Promise<
+  it("Unpartitioned Queue: Multiple abandons until maxDeliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testMultipleAbandons();
   });
 
-  it("Unpartitioned Subscription: Multiple abandons until maxDeliveryCount", async function (): Promise<
+  it("Unpartitioned Subscription: Multiple abandons until maxDeliveryCount", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -388,14 +388,14 @@ describe("Streaming - Abandon message", function (): void {
   });
 });
 
-describe("Streaming - Defer message", function (): void {
+describe("Streaming - Defer message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testDefer(autoComplete: boolean): Promise<void> {
     const testMessage = TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
     let sequenceNum: any = 0;
     receiver.registerMessageHandler(
       (msg: ServiceBusMessage) => {
@@ -435,54 +435,54 @@ describe("Streaming - Defer message", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: defer() moves message to deferred queue", async function (): Promise<void> {
+  it("Partitioned Queue: defer() moves message to deferred queue", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDefer(false);
   });
 
-  it("Partitioned Subscription: defer() moves message to deferred queue", async function (): Promise<
+  it("Partitioned Subscription: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDefer(false);
   });
 
-  it("UnPartitioned Queue: defer() moves message to deferred queue", async function (): Promise<
+  it("UnPartitioned Queue: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDefer(false);
   });
 
-  it("UnPartitioned Subscription: defer() moves message to deferred queue", async function (): Promise<
+  it("UnPartitioned Subscription: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testDefer(false);
   });
 
-  it("Partitioned Queue with autoComplete: defer() moves message to deferred queue", async function (): Promise<
+  it("Partitioned Queue with autoComplete: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDefer(true);
   });
 
-  it("Partitioned Subscription with autoComplete: defer() moves message to deferred queue", async function (): Promise<
+  it("Partitioned Subscription with autoComplete: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDefer(true);
   });
 
-  it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue", async function (): Promise<
+  it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDefer(true);
   });
 
-  it("UnPartitioned Subscription with autoComplete: defer() moves message to deferred queue", async function (): Promise<
+  it("UnPartitioned Subscription with autoComplete: defer() moves message to deferred queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -490,14 +490,14 @@ describe("Streaming - Defer message", function (): void {
   });
 });
 
-describe("Streaming - Deadletter message", function (): void {
+describe("Streaming - Deadletter message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testDeadletter(autoComplete: boolean): Promise<void> {
     const testMessage = TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     receiver.registerMessageHandler(
@@ -533,56 +533,56 @@ describe("Streaming - Deadletter message", function (): void {
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Partitioned Queue: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDeadletter(false);
   });
 
-  it("Partitioned Subscription: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Partitioned Subscription: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDeadletter(false);
   });
 
-  it("UnPartitioned Queue: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("UnPartitioned Queue: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDeadletter(false);
   });
 
-  it("UnPartitioned Subscription: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("UnPartitioned Subscription: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testDeadletter(false);
   });
 
-  it("Partitioned Queue with autoComplete: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("Partitioned Queue with autoComplete: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testDeadletter(true);
   });
 
-  it("Partitioned Subscription with autoComplete: deadLetter() moves message to deadletter", async function (): Promise<
+  it("Partitioned Subscription with autoComplete: deadLetter() moves message to deadletter", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testDeadletter(true);
   });
 
-  it("UnPartitioned Queue with autoComplete: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("UnPartitioned Queue with autoComplete: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testDeadletter(true);
   });
 
-  it("UnPartitioned Subscription with autoComplete: deadLetter() moves message to deadletter queue", async function (): Promise<
+  it("UnPartitioned Subscription with autoComplete: deadLetter() moves message to deadletter queue", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -590,29 +590,32 @@ describe("Streaming - Deadletter message", function (): void {
   });
 });
 
-describe("Streaming - Multiple Receiver Operations", function (): void {
+describe("Streaming - Multiple Receiver Operations", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testMultipleReceiveCalls(): Promise<void> {
     let errorMessage;
-    const expectedErrorMessage = `The receiver for "${receiverClient.entityPath}" is already receiving messages.`;
+    const expectedErrorMessage = `The receiver for "${
+      receiverClient.entityPath
+    }" is already receiving messages.`;
     receiver.registerMessageHandler((msg: ServiceBusMessage) => {
       return msg.complete();
     }, unExpectedErrorHandler);
     await delay(5000);
     try {
-      receiver.registerMessageHandler(
-        (msg: ServiceBusMessage) => {
-          return Promise.resolve();
-        },
-        unExpectedErrorHandler
-      );
+      receiver.registerMessageHandler((msg: ServiceBusMessage) => {
+        return Promise.resolve();
+      }, unExpectedErrorHandler);
     } catch (err) {
       errorMessage = err && err.message;
     }
-    should.equal(errorMessage, expectedErrorMessage, "Unexpected error message for registerMessageHandler");
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for registerMessageHandler"
+    );
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 
     errorMessage = "";
@@ -621,31 +624,35 @@ describe("Streaming - Multiple Receiver Operations", function (): void {
     } catch (err) {
       errorMessage = err && err.message;
     }
-    should.equal(errorMessage, expectedErrorMessage, "Unexpected error message for receiveMessages");
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for receiveMessages"
+    );
   }
 
-  it("Partitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped", async function (): Promise<
+  it("Partitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testMultipleReceiveCalls();
   });
 
-  it("Partitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped", async function (): Promise<
+  it("Partitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testMultipleReceiveCalls();
   });
 
-  it("UnPartitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped", async function (): Promise<
+  it("UnPartitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testMultipleReceiveCalls();
   });
 
-  it("UnPartitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped", async function (): Promise<
+  it("UnPartitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -669,7 +676,7 @@ describe("Streaming - Settle an already Settled message throws error", () => {
 
   async function testSettlement(operation: DispositionType): Promise<void> {
     const testMessage = TestMessage.getSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
     const receivedMsgs: ServiceBusMessage[] = [];
     receiver.registerMessageHandler((msg: ServiceBusMessage) => {
       receivedMsgs.push(msg);
@@ -712,94 +719,94 @@ describe("Streaming - Settle an already Settled message throws error", () => {
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
   }
 
-  it("Partitioned Queue: complete() throws error", async function (): Promise<void> {
+  it("Partitioned Queue: complete() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testSettlement(DispositionType.complete);
   });
 
-  it("Partitioned Subscription: complete() throws error", async function (): Promise<void> {
+  it("Partitioned Subscription: complete() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testSettlement(DispositionType.complete);
   });
 
-  it("UnPartitioned Queue: complete() throws error", async function (): Promise<void> {
+  it("UnPartitioned Queue: complete() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testSettlement(DispositionType.complete);
   });
 
-  it("UnPartitioned Subscription: complete() throws error", async function (): Promise<void> {
+  it("UnPartitioned Subscription: complete() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testSettlement(DispositionType.complete);
   });
 
-  it("Partitioned Queue: abandon() throws error", async function (): Promise<void> {
+  it("Partitioned Queue: abandon() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testSettlement(DispositionType.abandon);
   });
 
-  it("Partitioned Subscription: abandon() throws error", async function (): Promise<void> {
+  it("Partitioned Subscription: abandon() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testSettlement(DispositionType.abandon);
   });
 
-  it("UnPartitioned Queue: abandon() throws error", async function (): Promise<void> {
+  it("UnPartitioned Queue: abandon() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testSettlement(DispositionType.abandon);
   });
 
-  it("UnPartitioned Subscription: abandon() throws error", async function (): Promise<void> {
+  it("UnPartitioned Subscription: abandon() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testSettlement(DispositionType.abandon);
   });
 
-  it("Partitioned Queue: defer() throws error", async function (): Promise<void> {
+  it("Partitioned Queue: defer() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testSettlement(DispositionType.defer);
   });
 
-  it("Partitioned Subscription: defer() throws error", async function (): Promise<void> {
+  it("Partitioned Subscription: defer() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testSettlement(DispositionType.defer);
   });
 
-  it("UnPartitioned Queue: defer() throws error", async function (): Promise<void> {
+  it("UnPartitioned Queue: defer() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testSettlement(DispositionType.defer);
   });
 
-  it("UnPartitioned Subscription: defer() throws error", async function (): Promise<void> {
+  it("UnPartitioned Subscription: defer() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testSettlement(DispositionType.defer);
   });
 
-  it("Partitioned Queue: deadLetter() throws error", async function (): Promise<void> {
+  it("Partitioned Queue: deadLetter() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testSettlement(DispositionType.deadletter);
   });
 
-  it("Partitioned Subscription: deadLetter() throws error", async function (): Promise<void> {
+  it("Partitioned Subscription: deadLetter() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testSettlement(DispositionType.deadletter);
   });
 
-  it("UnPartitioned Queue: deadLetter() throws error", async function (): Promise<void> {
+  it("UnPartitioned Queue: deadLetter() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testSettlement(DispositionType.deadletter);
   });
 
-  it("UnPartitioned Subscription: deadLetter() throws error", async function (): Promise<void> {
+  it("UnPartitioned Subscription: deadLetter() throws error", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testSettlement(DispositionType.deadletter);
   });
 });
 
-describe("Streaming - User Error", function (): void {
+describe("Streaming - User Error", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testUserError(): Promise<void> {
-    await sender.sendMessage(TestMessage.getSample());
+    await sender.send(TestMessage.getSample());
     const errorMessage = "Will we see this error message?";
 
     const receivedMsgs: ServiceBusMessage[] = [];
@@ -823,28 +830,28 @@ describe("Streaming - User Error", function (): void {
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
   }
 
-  it("Partitioned Queue: onError handler is called for user error", async function (): Promise<
+  it("Partitioned Queue: onError handler is called for user error", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testUserError();
   });
 
-  it("Partitioned Subscription: onError handler is called for user error", async function (): Promise<
+  it("Partitioned Subscription: onError handler is called for user error", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testUserError();
   });
 
-  it("UnPartitioned Queue: onError handler is called for user error", async function (): Promise<
+  it("UnPartitioned Queue: onError handler is called for user error", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testUserError();
   });
 
-  it("UnPartitioned Subscription: onError handler is called for user error", async function (): Promise<
+  it("UnPartitioned Subscription: onError handler is called for user error", async function(): Promise<
     void
   > {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
@@ -852,14 +859,14 @@ describe("Streaming - User Error", function (): void {
   });
 });
 
-describe("Streaming - maxConcurrentCalls", function (): void {
+describe("Streaming - maxConcurrentCalls", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testConcurrency(maxConcurrentCalls?: number): Promise<void> {
     const testMessages = [TestMessage.getSample(), TestMessage.getSample()];
-    await sender.sendMessages(testMessages);
+    await sender.sendBatch(testMessages);
 
     const settledMsgs: ServiceBusMessage[] = [];
     const receivedMsgs: ServiceBusMessage[] = [];
@@ -897,62 +904,62 @@ describe("Streaming - maxConcurrentCalls", function (): void {
     should.equal(settledMsgs.length, 2, `Expected 2, received ${settledMsgs.length} messages.`);
   }
 
-  it("Partitioned Queue: no maxConcurrentCalls passed", async function (): Promise<void> {
+  it("Partitioned Queue: no maxConcurrentCalls passed", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testConcurrency();
   });
 
-  it("Partitioned Queue: pass 1 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Partitioned Queue: pass 1 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testConcurrency(1);
   });
 
-  it("Partitioned Queue: pass 2 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Partitioned Queue: pass 2 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedQueue, ClientType.PartitionedQueue);
     await testConcurrency(2);
   });
 
-  it("Unpartitioned Queue: no maxConcurrentCalls passed", async function (): Promise<void> {
+  it("Unpartitioned Queue: no maxConcurrentCalls passed", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testConcurrency();
   });
 
-  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testConcurrency(1);
   });
 
-  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedQueue, ClientType.UnpartitionedQueue);
     await testConcurrency(2);
   });
 
-  it("Partitioned Subscription: no maxConcurrentCalls passed", async function (): Promise<void> {
+  it("Partitioned Subscription: no maxConcurrentCalls passed", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testConcurrency();
   });
 
-  it("Partitioned Queue: pass 1 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Partitioned Queue: pass 1 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testConcurrency(1);
   });
 
-  it("Partitioned Queue: pass 2 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Partitioned Queue: pass 2 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.PartitionedTopic, ClientType.PartitionedSubscription);
     await testConcurrency(2);
   });
 
-  it("Unpartitioned Subscription: no maxConcurrentCalls passed", async function (): Promise<void> {
+  it("Unpartitioned Subscription: no maxConcurrentCalls passed", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testConcurrency();
   });
 
-  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testConcurrency(1);
   });
 
-  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls", async function (): Promise<void> {
+  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls", async function(): Promise<void> {
     await beforeEachTest(ClientType.UnpartitionedTopic, ClientType.UnpartitionedSubscription);
     await testConcurrency(2);
   });

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -107,14 +107,14 @@ async function afterEachTest(): Promise<void> {
   await ns.close();
 }
 
-describe("Sessions Streaming - Misc Tests", function (): void {
+describe("Sessions Streaming - Misc Tests", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testAutoComplete(): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     sessionReceiver.registerMessageHandler((msg: ServiceBusMessage) => {
@@ -139,7 +139,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: AutoComplete removes the message(with sessions)", async function (): Promise<
+  it("Partitioned Queue: AutoComplete removes the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -149,7 +149,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testAutoComplete();
   });
 
-  it("Partitioned Subscription: AutoComplete removes the message(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: AutoComplete removes the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -159,7 +159,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testAutoComplete();
   });
 
-  it("UnPartitioned Queue: AutoComplete removes the message(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: AutoComplete removes the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -169,7 +169,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testAutoComplete();
   });
 
-  it("UnPartitioned Subscription: AutoComplete removes the message(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: AutoComplete removes the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -181,7 +181,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
 
   async function testManualComplete(): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     sessionReceiver.registerMessageHandler(
@@ -207,7 +207,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testPeekMsgsLength(receiverClient, 0);
   }
 
-  it("Partitioned Queue: Disabled autoComplete, no manual complete retains the message(with sessions)", async function (): Promise<
+  it("Partitioned Queue: Disabled autoComplete, no manual complete retains the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -217,7 +217,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testManualComplete();
   });
 
-  it("Partitioned Subscription: Disabled autoComplete, no manual complete retains the message(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: Disabled autoComplete, no manual complete retains the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -227,7 +227,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testManualComplete();
   });
 
-  it("UnPartitioned Queue: Disabled autoComplete, no manual complete retains the message(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: Disabled autoComplete, no manual complete retains the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -237,7 +237,7 @@ describe("Sessions Streaming - Misc Tests", function (): void {
     await testManualComplete();
   });
 
-  it("UnPartitioned Subscription: Disabled autoComplete, no manual complete retains the message(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: Disabled autoComplete, no manual complete retains the message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -248,14 +248,14 @@ describe("Sessions Streaming - Misc Tests", function (): void {
   });
 });
 
-describe("Sessions Streaming - Complete message", function (): void {
+describe("Sessions Streaming - Complete message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testComplete(autoComplete: boolean): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     sessionReceiver.registerMessageHandler(
@@ -278,7 +278,7 @@ describe("Sessions Streaming - Complete message", function (): void {
 
     await testPeekMsgsLength(receiverClient, 0);
   }
-  it("Partitioned Queue: complete() removes message(with sessions)", async function (): Promise<
+  it("Partitioned Queue: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -288,7 +288,7 @@ describe("Sessions Streaming - Complete message", function (): void {
     await testComplete(false);
   });
 
-  it("Partitioned Subscription: complete() removes message(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -298,7 +298,7 @@ describe("Sessions Streaming - Complete message", function (): void {
     await testComplete(false);
   });
 
-  it("UnPartitioned Queue: complete() removes message(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -308,7 +308,7 @@ describe("Sessions Streaming - Complete message", function (): void {
     await testComplete(false);
   });
 
-  it("UnPartitioned Subscription: complete() removes message(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -318,7 +318,7 @@ describe("Sessions Streaming - Complete message", function (): void {
     await testComplete(false);
   });
 
-  it("Partitioned Queue with autoComplete: complete() removes message(with sessions)", async function (): Promise<
+  it("Partitioned Queue with autoComplete: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -328,7 +328,7 @@ describe("Sessions Streaming - Complete message", function (): void {
     await testComplete(true);
   });
 
-  it("Partitioned Subscription with autoComplete: complete() removes message(with sessions)", async function (): Promise<
+  it("Partitioned Subscription with autoComplete: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -338,7 +338,7 @@ describe("Sessions Streaming - Complete message", function (): void {
     await testComplete(true);
   });
 
-  it("UnPartitioned Queue with autoComplete: complete() removes message(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue with autoComplete: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -348,7 +348,7 @@ describe("Sessions Streaming - Complete message", function (): void {
     await testComplete(true);
   });
 
-  it("UnPartitioned Subscription with autoComplete: complete() removes message(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription with autoComplete: complete() removes message(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -359,14 +359,14 @@ describe("Sessions Streaming - Complete message", function (): void {
   });
 });
 
-describe("Sessions Streaming - Abandon message", function (): void {
+describe("Sessions Streaming - Abandon message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testAbandon(autoComplete: boolean): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
     let abandonFlag = 0;
     sessionReceiver.registerMessageHandler(
       (msg: ServiceBusMessage) => {
@@ -404,7 +404,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await receivedMsgs[0].complete();
     await testPeekMsgsLength(receiverClient, 0);
   }
-  it("Partitioned Queue: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("Partitioned Queue: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -414,7 +414,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await testAbandon(false);
   });
 
-  it("Partitioned Subscription: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -424,7 +424,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await testAbandon(false);
   });
 
-  it("UnPartitioned Queue: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -434,7 +434,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await testAbandon(false);
   });
 
-  it("UnPartitioned Subscription: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -444,7 +444,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await testAbandon(false);
   });
 
-  it("Partitioned Queue with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("Partitioned Queue with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -454,7 +454,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await testAbandon(true);
   });
 
-  it("Partitioned Subscription with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("Partitioned Subscription with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -464,7 +464,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await testAbandon(true);
   });
 
-  it("UnPartitioned Queue with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -474,7 +474,7 @@ describe("Sessions Streaming - Abandon message", function (): void {
     await testAbandon(true);
   });
 
-  it("UnPartitioned Subscription with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription with autoComplete: abandon() retains message with incremented deliveryCount(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -485,14 +485,14 @@ describe("Sessions Streaming - Abandon message", function (): void {
   });
 });
 
-describe("Sessions Streaming - Defer message", function (): void {
+describe("Sessions Streaming - Defer message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testDefer(autoComplete: boolean): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     let sequenceNum: any = 0;
     sessionReceiver.registerMessageHandler(
@@ -530,7 +530,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await deferredMsg.complete();
     await testPeekMsgsLength(receiverClient, 0);
   }
-  it("Partitioned Queue: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("Partitioned Queue: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -540,7 +540,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await testDefer(false);
   });
 
-  it("Partitioned Subscription: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -550,7 +550,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await testDefer(false);
   });
 
-  it("UnPartitioned Queue: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -560,7 +560,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await testDefer(false);
   });
 
-  it("UnPartitioned Subscription: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -570,7 +570,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await testDefer(false);
   });
 
-  it("Partitioned Queue with autoComplete: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("Partitioned Queue with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -580,7 +580,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await testDefer(true);
   });
 
-  it("Partitioned Subscription with autoComplete: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("Partitioned Subscription with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -590,7 +590,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await testDefer(true);
   });
 
-  it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -600,7 +600,7 @@ describe("Sessions Streaming - Defer message", function (): void {
     await testDefer(true);
   });
 
-  it("UnPartitioned Subscription with autoComplete: defer() moves message to deferred queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription with autoComplete: defer() moves message to deferred queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -611,14 +611,14 @@ describe("Sessions Streaming - Defer message", function (): void {
   });
 });
 
-describe("Sessions Streaming - Deadletter message", function (): void {
+describe("Sessions Streaming - Deadletter message", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testDeadletter(autoComplete: boolean): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     let msgCount = 0;
     sessionReceiver.registerMessageHandler(
@@ -652,7 +652,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testPeekMsgsLength(deadLetterClient, 0);
   }
 
-  it("Partitioned Queue: deadLetter() moves message to deadletter queue(with sessions)", async function (): Promise<
+  it("Partitioned Queue: deadLetter() moves message to deadletter queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -662,7 +662,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testDeadletter(false);
   });
 
-  it("Partitioned Subscription: deadLetter() moves message to deadletter queue(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: deadLetter() moves message to deadletter queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -672,7 +672,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testDeadletter(false);
   });
 
-  it("UnPartitioned Queue: deadLetter() moves message to deadletter queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: deadLetter() moves message to deadletter queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -682,7 +682,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testDeadletter(false);
   });
 
-  it("UnPartitioned Subscription: deadLetter() moves message to deadletter queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: deadLetter() moves message to deadletter queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -692,7 +692,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testDeadletter(false);
   });
 
-  it("Partitioned Queue with autoComplete: deadLetter() moves message to deadletter queue(with sessions)", async function (): Promise<
+  it("Partitioned Queue with autoComplete: deadLetter() moves message to deadletter queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -702,7 +702,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testDeadletter(true);
   });
 
-  it("Partitioned Subscription with autoComplete: deadLetter() moves message to deadletter(with sessions)", async function (): Promise<
+  it("Partitioned Subscription with autoComplete: deadLetter() moves message to deadletter(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -712,7 +712,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testDeadletter(true);
   });
 
-  it("UnPartitioned Queue with autoComplete: deadLetter() moves message to deadletter queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue with autoComplete: deadLetter() moves message to deadletter queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -722,7 +722,7 @@ describe("Sessions Streaming - Deadletter message", function (): void {
     await testDeadletter(true);
   });
 
-  it("UnPartitioned Subscription with autoComplete: deadLetter() moves message to deadletter queue(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription with autoComplete: deadLetter() moves message to deadletter queue(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -733,29 +733,32 @@ describe("Sessions Streaming - Deadletter message", function (): void {
   });
 });
 
-describe("Sessions Streaming - Multiple Receive Operations", function (): void {
+describe("Sessions Streaming - Multiple Receive Operations", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testMultipleReceiveCalls(): Promise<void> {
     let errorMessage;
-    const expectedErrorMessage = `The receiver for session "${TestMessage.sessionId}" in "${receiverClient.entityPath}" is already receiving messages.`;
+    const expectedErrorMessage = `The receiver for session "${TestMessage.sessionId}" in "${
+      receiverClient.entityPath
+    }" is already receiving messages.`;
     sessionReceiver.registerMessageHandler((msg: ServiceBusMessage) => {
       return msg.complete();
     }, unExpectedErrorHandler);
     await delay(5000);
     try {
-      sessionReceiver.registerMessageHandler(
-        (msg: ServiceBusMessage) => {
-          return Promise.resolve();
-        },
-        unExpectedErrorHandler
-      );
+      sessionReceiver.registerMessageHandler((msg: ServiceBusMessage) => {
+        return Promise.resolve();
+      }, unExpectedErrorHandler);
     } catch (err) {
       errorMessage = err && err.message;
     }
-    should.equal(errorMessage, expectedErrorMessage, "Unexpected error message for registerMessageHandler");
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for registerMessageHandler"
+    );
     should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
 
     errorMessage = "";
@@ -764,10 +767,14 @@ describe("Sessions Streaming - Multiple Receive Operations", function (): void {
     } catch (err) {
       errorMessage = err && err.message;
     }
-    should.equal(errorMessage, expectedErrorMessage, "Unexpected error message for receiveMessages");
+    should.equal(
+      errorMessage,
+      expectedErrorMessage,
+      "Unexpected error message for receiveMessages"
+    );
   }
 
-  it("Partitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function (): Promise<
+  it("Partitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -777,7 +784,7 @@ describe("Sessions Streaming - Multiple Receive Operations", function (): void {
     await testMultipleReceiveCalls();
   });
 
-  it("Partitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -787,7 +794,7 @@ describe("Sessions Streaming - Multiple Receive Operations", function (): void {
     await testMultipleReceiveCalls();
   });
 
-  it("UnPartitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -797,7 +804,7 @@ describe("Sessions Streaming - Multiple Receive Operations", function (): void {
     await testMultipleReceiveCalls();
   });
 
-  it("UnPartitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: Second receive operation should fail if the first streaming receiver is not stopped(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -824,7 +831,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
 
   async function testSettlement(operation: DispositionType): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
 
     const receivedMsgs: ServiceBusMessage[] = [];
     sessionReceiver.registerMessageHandler((msg: ServiceBusMessage) => {
@@ -867,7 +874,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
   }
 
-  it("Partitioned Queue: complete() throws error(with sessions)", async function (): Promise<void> {
+  it("Partitioned Queue: complete() throws error(with sessions)", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
@@ -875,7 +882,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.complete);
   });
 
-  it("Partitioned Subscription: complete() throws error(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: complete() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -885,7 +892,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.complete);
   });
 
-  it("UnPartitioned Queue: complete() throws error(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: complete() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -895,7 +902,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.complete);
   });
 
-  it("UnPartitioned Subscription: complete() throws error(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: complete() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -905,7 +912,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.complete);
   });
 
-  it("Partitioned Queue: abandon() throws error(with sessions)", async function (): Promise<void> {
+  it("Partitioned Queue: abandon() throws error(with sessions)", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
@@ -913,7 +920,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.abandon);
   });
 
-  it("Partitioned Subscription: abandon() throws error(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: abandon() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -923,7 +930,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.abandon);
   });
 
-  it("UnPartitioned Queue: abandon() throws error(with sessions)", async function (): Promise<void> {
+  it("UnPartitioned Queue: abandon() throws error(with sessions)", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
@@ -931,7 +938,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.abandon);
   });
 
-  it("UnPartitioned Subscription: abandon() throws error(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: abandon() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -941,7 +948,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.abandon);
   });
 
-  it("Partitioned Queue: defer() throws error(with sessions)", async function (): Promise<void> {
+  it("Partitioned Queue: defer() throws error(with sessions)", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.PartitionedQueueWithSessions,
       ClientType.PartitionedQueueWithSessions
@@ -949,7 +956,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.defer);
   });
 
-  it("Partitioned Subscription: defer() throws error(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: defer() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -959,7 +966,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.defer);
   });
 
-  it("UnPartitioned Queue: defer() throws error(with sessions)", async function (): Promise<void> {
+  it("UnPartitioned Queue: defer() throws error(with sessions)", async function(): Promise<void> {
     await beforeEachTest(
       ClientType.UnpartitionedQueueWithSessions,
       ClientType.UnpartitionedQueueWithSessions
@@ -967,7 +974,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.defer);
   });
 
-  it("UnPartitioned Subscription: defer() throws error(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: defer() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -977,7 +984,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.defer);
   });
 
-  it("Partitioned Queue: deadLetter() throws error(with sessions)", async function (): Promise<
+  it("Partitioned Queue: deadLetter() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -987,7 +994,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.deadletter);
   });
 
-  it("Partitioned Subscription: deadLetter() throws error(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: deadLetter() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -997,7 +1004,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.deadletter);
   });
 
-  it("UnPartitioned Queue: deadLetter() throws error(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: deadLetter() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1007,7 +1014,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
     await testSettlement(DispositionType.deadletter);
   });
 
-  it("UnPartitioned Subscription: deadLetter() throws error(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: deadLetter() throws error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1018,14 +1025,14 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
   });
 });
 
-describe("Sessions Streaming - User Error", function (): void {
+describe("Sessions Streaming - User Error", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
 
   async function testUserError(): Promise<void> {
     const testMessage = TestMessage.getSessionSample();
-    await sender.sendMessage(testMessage);
+    await sender.send(testMessage);
     const errorMessage = "Will we see this error message?";
 
     const receivedMsgs: ServiceBusMessage[] = [];
@@ -1049,7 +1056,7 @@ describe("Sessions Streaming - User Error", function (): void {
     should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
   }
 
-  it("Partitioned Queue: onError handler is called for user error(with sessions)", async function (): Promise<
+  it("Partitioned Queue: onError handler is called for user error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1059,7 +1066,7 @@ describe("Sessions Streaming - User Error", function (): void {
     await testUserError();
   });
 
-  it("Partitioned Subscription: onError handler is called for user error(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: onError handler is called for user error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1069,7 +1076,7 @@ describe("Sessions Streaming - User Error", function (): void {
     await testUserError();
   });
 
-  it("UnPartitioned Queue: onError handler is called for user error(with sessions)", async function (): Promise<
+  it("UnPartitioned Queue: onError handler is called for user error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1079,7 +1086,7 @@ describe("Sessions Streaming - User Error", function (): void {
     await testUserError();
   });
 
-  it("UnPartitioned Subscription: onError handler is called for user error(with sessions)", async function (): Promise<
+  it("UnPartitioned Subscription: onError handler is called for user error(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1090,7 +1097,7 @@ describe("Sessions Streaming - User Error", function (): void {
   });
 });
 
-describe("Sessions Streaming - maxConcurrentCalls", function (): void {
+describe("Sessions Streaming - maxConcurrentCalls", function(): void {
   afterEach(async () => {
     await afterEachTest();
   });
@@ -1106,7 +1113,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     }
 
     const testMessages = [TestMessage.getSessionSample(), TestMessage.getSessionSample()];
-    await sender.sendMessages(testMessages);
+    await sender.sendBatch(testMessages);
 
     const settledMsgs: ServiceBusMessage[] = [];
     const receivedMsgs: ServiceBusMessage[] = [];
@@ -1144,7 +1151,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     should.equal(settledMsgs.length, 2, `Expected 2, received ${settledMsgs.length} messages.`);
   }
 
-  it("Partitioned Queue: no maxConcurrentCalls passed(with sessions)", async function (): Promise<
+  it("Partitioned Queue: no maxConcurrentCalls passed(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1154,7 +1161,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Partitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Partitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1164,7 +1171,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Partitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Partitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1174,7 +1181,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Unpartitioned Queue: no maxConcurrentCalls passed(with sessions)", async function (): Promise<
+  it("Unpartitioned Queue: no maxConcurrentCalls passed(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1184,7 +1191,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1194,7 +1201,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1204,7 +1211,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Partitioned Subscription: no maxConcurrentCalls passed(with sessions)", async function (): Promise<
+  it("Partitioned Subscription: no maxConcurrentCalls passed(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1214,7 +1221,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Partitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Partitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1224,7 +1231,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency(1);
   });
 
-  it("Partitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Partitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1234,7 +1241,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency(2);
   });
 
-  it("Unpartitioned Subscription: no maxConcurrentCalls passed(with sessions)", async function (): Promise<
+  it("Unpartitioned Subscription: no maxConcurrentCalls passed(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1244,7 +1251,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency();
   });
 
-  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Unpartitioned Queue: pass 1 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(
@@ -1254,7 +1261,7 @@ describe("Sessions Streaming - maxConcurrentCalls", function (): void {
     await testConcurrency(1);
   });
 
-  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function (): Promise<
+  it("Unpartitioned Queue: pass 2 for maxConcurrentCalls(with sessions)", async function(): Promise<
     void
   > {
     await beforeEachTest(

--- a/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsMultipleQueues.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsMultipleQueues.ts
@@ -71,7 +71,7 @@ async function sendReceiveMessagesPerClient(sender: Sender, receiver: Receiver):
       label: `${msgId}`
     };
     msgId++;
-    await sender.sendMessage(message);
+    await sender.send(message);
     const messagesReceived = await receiver.receiveMessages(1);
     await messagesReceived[0].complete();
   }

--- a/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsSingleQueue.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsSingleQueue.ts
@@ -73,7 +73,7 @@ async function sendReceiveMessagesPerClient(sender: Sender, receiver: Receiver):
       label: `${msgId}`
     };
     msgId++;
-    await sender.sendMessage(message);
+    await sender.send(message);
     const messagesReceived = await receiver.receiveMessages(1);
     await messagesReceived[0].complete();
   }

--- a/sdk/servicebus/service-bus/test/stress/stress_messageRandomDisposition.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_messageRandomDisposition.ts
@@ -60,7 +60,7 @@ async function sendMessages(): Promise<void> {
       };
       messagesToProcess.add(msgId);
       msgId++;
-      await sender.sendMessage(message);
+      await sender.send(message);
       await delay(2000); // Throttling send to not increase queue size
     }
   } finally {

--- a/sdk/servicebus/service-bus/test/stress/stress_messageRandomDispositionOnSession.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_messageRandomDispositionOnSession.ts
@@ -62,7 +62,7 @@ async function sendMessages(): Promise<void> {
       };
       messagesToProcess.add(msgId);
       msgId++;
-      await sender.sendMessage(message);
+      await sender.send(message);
       await delay(2000); // Throttling send to not increase queue size
     }
   } finally {

--- a/sdk/servicebus/service-bus/test/stress/stress_singleClient.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_singleClient.ts
@@ -48,7 +48,7 @@ async function sendReceiveMessages(): Promise<void> {
         label: `${msgId}`
       };
       msgId++;
-      await sender.sendMessage(message);
+      await sender.send(message);
       await sender.close();
 
       const receiver = client.createReceiver(ReceiveMode.peekLock);

--- a/sdk/servicebus/service-bus/test/stress/stress_singleMessageComplete.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_singleMessageComplete.ts
@@ -53,7 +53,7 @@ async function sendMessages(): Promise<void> {
       };
       messageMap.add(msgId);
       msgId++;
-      await sender.sendMessage(message);
+      await sender.send(message);
       await delay(2000); // Throttling send to not increase queue size
     }
   } finally {

--- a/sdk/servicebus/service-bus/test/topicFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/topicFilters.spec.ts
@@ -709,7 +709,7 @@ describe("Multiple subscriptions on single topic - Receive messages", function()
         label: `${index + 1}`,
         partitionKey: "dummy" // Ensures all messages go to same parition to make peek work reliably
       };
-      await sender.sendMessage(message);
+      await sender.send(message);
     }
 
     const receivedMsgs: ServiceBusMessage[] = [];

--- a/sdk/servicebus/service-bus/test/topicFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/topicFilters.spec.ts
@@ -112,7 +112,7 @@ async function sendOrders(): Promise<void> {
       },
       partitionKey: "dummy" // Ensures all messages go to same parition to make peek work reliably
     };
-    await sender.sendMessage(message);
+    await sender.send(message);
   }
 }
 


### PR DESCRIPTION
This PR has the below name changes in preparation for Preview 2

**RenewLock**
To avoid confusion on which lock is actually getting renewed, below are the name changes on the receivers
- `renewLock` -> `renewMessageLock` on normal receiver
- `renewLock` -> `renewSessionLock` on session receiver

**Send**
In https://github.com/Azure/azure-sdk-for-js/issues/1729#issuecomment-479697253, we decided to change `send` to `sendMessage` and `sendBatch` to `sendMessages` to be in sync with the new name `receiveMessages` for receiving messages.

The problem with this is that this gives the idea that the difference between `sendMessage` and `sendMessages` is just that the latter deals with multiple messages just like `receiveDeferredMessage` vs `receiveDeferredMessages`, `scheduleMessage` vs `scheduleMessages` and `cancelScheduleMessage` vs `cancelScheduleMessages`.

But the difference is much more than that. `sendBatch` sends the multiple messages in a single AMQP message. The user has the below to think about now
- the size of the entire batch
- all messages should have the same sessionId
- all messages should have the same partitionKey

Therefore, `sendMessages` is much more than just `sendMessage` for multiple messages. And so, I suggest going back to `send` and `sendBatch` for Preview 2. If we have smarter ideas, then we can use that for GA

