### PR TITLE
[Service Bus] Fix regex to match multi line imports

### DIFF
--- a/sdk/servicebus/service-bus/test/samples.spec.ts
+++ b/sdk/servicebus/service-bus/test/samples.spec.ts
@@ -4,8 +4,8 @@ import path from "path";
 
 // Since `npm run build-samples` now update the typescript samples to make them debuggable,
 // we now have the below tests to ensure such updates dont get checked in.
-describe("Ensure typescript samples use published package", function(): void {
-  const regex = new RegExp('import (.*) from "@azure/service-bus"');
+describe.only("Ensure typescript samples use published package", function(): void {
+  const regex = new RegExp('from "@azure/service-bus"');
 
   function testSamples(folder: string): void {
     const files = fs.readdirSync(folder);

--- a/sdk/servicebus/service-bus/test/samples.spec.ts
+++ b/sdk/servicebus/service-bus/test/samples.spec.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // Since `npm run build-samples` now update the typescript samples to make them debuggable,
 // we now have the below tests to ensure such updates dont get checked in.
-describe.only("Ensure typescript samples use published package", function(): void {
+describe("Ensure typescript samples use published package", function(): void {
   const regex = new RegExp('from "@azure/service-bus"');
 
   function testSamples(folder: string): void {


### PR DESCRIPTION
Fixes failure of the test that ensures that the samples use published package.
The previous regex would fail at multi line imports