### PR TITLE
[Service Bus] SessionId to have value only after AMQP link setup

### DIFF
--- a/sdk/servicebus/service-bus/src/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receiver.ts
@@ -304,6 +304,7 @@ export class SessionReceiver {
   private _messageSession: MessageSession | undefined;
   private _sessionOptions: SessionReceiverOptions;
   private _isClosed: boolean = false;
+  private _sessionId: string | undefined;
 
   /**
    * @property {boolean} [isClosed] Denotes if close() was called on this receiver.
@@ -321,7 +322,7 @@ export class SessionReceiver {
    * @readonly
    */
   public get sessionId(): string | undefined {
-    return this._messageSession && this._messageSession.sessionId;
+    return this._sessionId;
   }
 
   /**
@@ -658,6 +659,7 @@ export class SessionReceiver {
       log.error(`[${this._context.namespace.connectionId}] %O`, error);
       throw error;
     }
+    this._sessionId = this._messageSession.sessionId;
     delete this._context.expiredMessageSessions[this._messageSession.sessionId];
   }
 

--- a/sdk/servicebus/service-bus/src/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receiver.ts
@@ -317,16 +317,16 @@ export class SessionReceiver {
 
   /**
    * @property {string} [sessionId] The sessionId for the message session.
+   * Will return undefined until a AMQP receiver link has been successfully set up for the session.
    * @readonly
    */
   public get sessionId(): string | undefined {
-    return (
-      (this._messageSession && this._messageSession.sessionId) || this._sessionOptions.sessionId
-    );
+    return this._messageSession && this._messageSession.sessionId;
   }
 
   /**
    * @property {Date} [sessionLockedUntilUtc] The time in UTC until which the session is locked.
+   * Will return undefined until a AMQP receiver link has been successfully set up for the session.
    * @readonly
    */
   public get sessionLockedUntilUtc(): Date | undefined {

--- a/sdk/servicebus/service-bus/src/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receiver.ts
@@ -420,10 +420,7 @@ export class SessionReceiver {
    */
   async peek(maxMessageCount?: number): Promise<ReceivedMessageInfo[]> {
     this._throwIfReceiverOrConnectionClosed();
-    // Peek doesnt need an AMQP receiver link unless no sessionId was given
-    if (!this.sessionId) {
-      await this._createMessageSessionIfDoesntExist();
-    }
+    await this._createMessageSessionIfDoesntExist();
     return this._context.managementClient!.peekMessagesBySession(this.sessionId!, maxMessageCount);
   }
 
@@ -443,10 +440,7 @@ export class SessionReceiver {
     maxMessageCount?: number
   ): Promise<ReceivedMessageInfo[]> {
     this._throwIfReceiverOrConnectionClosed();
-    // Peek doesnt need an AMQP receiver link unless no sessionId was given
-    if (!this.sessionId) {
-      await this._createMessageSessionIfDoesntExist();
-    }
+    await this._createMessageSessionIfDoesntExist();
     return this._context.managementClient!.peekBySequenceNumber(fromSequenceNumber, {
       sessionId: this.sessionId!,
       messageCount: maxMessageCount
@@ -466,10 +460,7 @@ export class SessionReceiver {
     if (this._receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
-    // receiveDeferredMessage doesnt need an AMQP receiver link unless no sessionId was given
-    if (!this.sessionId) {
-      await this._createMessageSessionIfDoesntExist();
-    }
+    await this._createMessageSessionIfDoesntExist();
     return this._context.managementClient!.receiveDeferredMessage(
       sequenceNumber,
       this._receiveMode,
@@ -490,10 +481,7 @@ export class SessionReceiver {
     if (this._receiveMode !== ReceiveMode.peekLock) {
       throw new Error("The operation is only supported in 'PeekLock' receive mode.");
     }
-    // receiveDeferredMessage doesnt need an AMQP receiver link unless no sessionId was given
-    if (!this.sessionId) {
-      await this._createMessageSessionIfDoesntExist();
-    }
+    await this._createMessageSessionIfDoesntExist();
     return this._context.managementClient!.receiveDeferredMessages(
       sequenceNumbers,
       this._receiveMode,


### PR DESCRIPTION
All tests related to SessionReceivers are currently failing with the below

`Error: The receiver for session "my-session" in "..." has been closed and can no longer be used. Please create a new receiver using the "createReceiver" function.`

This is due to a change to the `sessionId` getter in the `SessionReceiver` that was made as part of https://github.com/Azure/azure-sdk-for-js/pull/2207. The `isClosed` property always returns `true` now.

Changes in this PR
- The `sessionId` is set only after successfully setting up an AMQP receiver link for the session i.e. after creating the `_messageSession` object
- The prior optimizations of creating `_messageSession` for peek and receiveDeferredMessages operations only if `sessionId` was not present is removed. This is because this was a moot point. We could have replaced the `if (!this.sessionId)` check with `if (!this.sessionOptions.sessionId)` to have the right optimization, but foregoing that for now in favor of simplicity