### PR TITLE
Restrict what goes into the published packages by whitelisting required files in package.json

### DIFF
--- a/sdk/eventhub/event-hubs/.npmignore
+++ b/sdk/eventhub/event-hubs/.npmignore
@@ -35,7 +35,6 @@ sample.env
 # misc #
 contribute.md
 .idea/
-changelog.md
 samples/
 typings/samples/
 dist/samples/

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -69,13 +69,10 @@
     "typescript": "^3.2.1"
   },
   "files": [
-    "LICENSE",
-    "changelog.md",
-    "README.md",
     "dist/",
     "dist-esm/src/",
     "src/",
-    "typings/"
+    "typings/src"
   ],
   "scripts": {
     "tslint": "tslint -p . -c tslint.json",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -62,14 +62,10 @@
     "typescript": "^3.2.1"
   },
   "files": [
-    "LICENSE",
-    "changelog.md",
-    "overview.md",
-    "README.md",
     "dist/",
     "dist-esm/src/",
     "src/",
-    "typings/"
+    "typings/src"
   ],
   "scripts": {
     "tslint": "tslint -p . -c tslint.json",

--- a/sdk/keyvault/keyvault/package.json
+++ b/sdk/keyvault/keyvault/package.json
@@ -34,15 +34,9 @@
     "url": "https://github.com/azure/azure-sdk-for-js/issues"
   },
   "files": [
-    "dist/**/*.js",
-    "dist/**/*.js.map",
-    "dist/**/*.d.ts",
-    "dist/**/*.d.ts.map",
-    "esm/**/*.js",
-    "esm/**/*.js.map",
-    "esm/**/*.d.ts",
-    "esm/**/*.d.ts.map",
-    "src/**/*.ts"
+    "dist/",
+    "esm/",
+    "src/"
   ],
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify",

--- a/sdk/keyvault/keyvault/package.json
+++ b/sdk/keyvault/keyvault/package.json
@@ -42,9 +42,7 @@
     "esm/**/*.js.map",
     "esm/**/*.d.ts",
     "esm/**/*.d.ts.map",
-    "src/**/*.ts",
-    "rollup.config.js",
-    "tsconfig.json"
+    "src/**/*.ts"
   ],
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -64,13 +64,10 @@
     "typescript": "^3.2.1"
   },
   "files": [
-    "LICENSE",
-    "changelog.md",
-    "Readme.md",
     "dist/",
     "dist-esm/src/",
     "src/",
-    "typings/"
+    "typings/src"
   ],
   "scripts": {
     "tslint": "tslint -p . -c tslint.json",

--- a/sdk/storage/storage-blob/.npmignore
+++ b/sdk/storage/storage-blob/.npmignore
@@ -2,11 +2,6 @@
 browser/azure-storage.blob.js
 browser/azure-storage.blob.js.map
 
-# dist-esm #
-!dist-esm/src/**/*.js
-dist-esm/tests
-dist-esm/samples
-
 # dist-test #
 dist-test/
 
@@ -19,11 +14,6 @@ samples/
 # Swagger #
 swagger/
 
-# typings #
-!typings/src/**/*.d.ts
-typings/tests
-typings/samples
-
 # git #
 .git*
 
@@ -33,20 +23,13 @@ tests/
 # Others #
 .vscode/
 .idea/
-.travis.yml
 .gitignore
 gulpfile.js
 .git
 .DS_Store
-tsconfig.json
-tslint.json
 *.zip
-package-lock.json
-karma.conf.js
 temp
 gulpfile.js
-rollup.config.js
-rollup.test.config.js
 *.html
 coverage/
 .nyc_output/

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -63,6 +63,13 @@
     "ts-node": "^7.0.1",
     "typescript": "^3.2.2"
   },
+  "files": [
+    "browser/",
+    "dist/",
+    "dist-esm/src/",
+    "src/",
+    "typings/src"
+  ],
   "scripts": {
     "unit-node": "npm run build && npm run test:node",
     "unit-browser": "npm run build && npm run test:browser",

--- a/sdk/storage/storage-datalake/package.json
+++ b/sdk/storage/storage-datalake/package.json
@@ -42,10 +42,8 @@
     "esm/**/*.js.map",
     "esm/**/*.d.ts",
     "esm/**/*.d.ts.map",
-    "src/**/*.ts",
-    "rollup.config.js",
-    "tsconfig.json"
-  ],
+    "src/**/*.ts"
+  ], 
   "scripts": {
     "build": "tsc && rollup -c rollup.config.js && npm run minify",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/storage-datalake.js.map'\" -o ./dist/storage-datalake.min.js ./dist/storage-datalake.js",

--- a/sdk/storage/storage-file/.npmignore
+++ b/sdk/storage/storage-file/.npmignore
@@ -2,33 +2,17 @@
 browser/azure-storage.file.js
 browser/azure-storage.file.js.map
 
-# dist-esm #
-!dist-esm/src/**/*.js
-dist-esm/test
-dist-esm/samples
-
 # dist-test #
 dist-test/
 
 # Node #
 node_modules/
 
-# Samples #
-samples/
-
 # Swagger #
 swagger/
 
-# typings #
-!typings/src/**/*.d.ts
-typings/test
-typings/samples
-
 # git #
 .git*
-
-# Test #
-tests/
 
 # Others #
 .vscode/
@@ -38,15 +22,8 @@ tests/
 gulpfile.js
 .git
 .DS_Store
-tsconfig.json
-tslint.json
 *.zip
-package-lock.json
-karma.conf.js
 temp
-gulpfile.js
-rollup.config.js
-rollup.test.config.js
 *.html
 coverage/
 .nyc_output/

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -62,6 +62,12 @@
     "ts-node": "^7.0.1",
     "typescript": "^3.2.2"
   },
+  "files": [
+    "dist/",
+    "dist-esm/src/",
+    "src/",
+    "typings/src"
+  ],
   "scripts": {
     "unit-node": "npm run build && npm run test:node",
     "unit-browser": "npm run build && npm run test:browser",

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -63,6 +63,7 @@
     "typescript": "^3.2.2"
   },
   "files": [
+    "browser/",
     "dist/",
     "dist-esm/src/",
     "src/",

--- a/sdk/storage/storage-queue/.npmignore
+++ b/sdk/storage/storage-queue/.npmignore
@@ -2,11 +2,6 @@
 browser/azure-storage.queue.js
 browser/azure-storage.queue.js.map
 
-# dist-esm #
-!dist-esm/src/**/*.js
-dist-esm/tests
-dist-esm/samples
-
 # dist-test #
 dist-test/
 
@@ -14,39 +9,27 @@ dist-test/
 node_modules/
 
 # Samples #
-samples/
 
 # Swagger #
 swagger/
 
 # typings #
-!typings/src/**/*.d.ts
-typings/tests
-typings/samples
 
 # git #
 .git*
 
 # Test #
-tests/
 
 # Others #
 .vscode/
 .idea/
-.travis.yml
 .gitignore
 gulpfile.js
 .git
 .DS_Store
-tsconfig.json
-tslint.json
 *.zip
-package-lock.json
-karma.conf.js
 temp
 gulpfile.js
-rollup.config.js
-rollup.test.config.js
 *.html
 coverage/
 .nyc_output/

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -61,6 +61,13 @@
         "ts-node": "^7.0.1",
         "typescript": "^3.2.2"
     },
+    "files": [
+        "browser/",
+        "dist/",
+        "dist-esm/src/",
+        "src/",
+        "typings/src"
+      ],
     "scripts": {
         "unit-node": "npm run build && npm run test:node",
         "unit-browser": "npm run build && npm run test:browser",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -24,6 +24,12 @@
     "eslint-fix": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c .eslintrc.json --fix --fix-type [problem,suggestion]",
     "lint-and-test": "npm run eslint && npm run test"
   },
+  "files": [  
+    "dist/",
+    "dist-esm/src/",
+    "src/",
+    "typings/src"
+  ],
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",


### PR DESCRIPTION
This PR involves modifying the package.json for each of the following services to restrict what files are part of the published packages by whitelisting them in files array in package.json, instead of blacklisting the files not required in .npmignore. 
- keyvault
- storage-file
- storage-queue
- storage-blob
- storage-datalake
- template
- event-hubs
- event-processor-host
- service-bus

This is done as part of the guidelines:
- https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-files-required
- https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-no-npmignore

@Azure/azure-sdk-eng @bterlson @ramya-rao-a @schaabs @HarshaNalluru 