### PR TITLE
[Service Bus] Update failing tests due to change in #2285

### DIFF
--- a/sdk/servicebus/service-bus/test/sendSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendSchedule.spec.ts
@@ -592,7 +592,7 @@ describe("Message validations", function(): void {
   }
 
   it("Error thrown when the 'msg' is undefined", async function(): Promise<void> {
-    await validationTest(undefined!, "data is required and it must be of type object.");
+    await validationTest(undefined!, "'msg' cannot be null or undefined.");
   });
 
   it("Error thrown when the 'contentType' is not of type 'string'", async function(): Promise<

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -354,27 +354,6 @@ describe("Test createFromAadTokenCredentials", function(): void {
     should.equal(msgs.length, 1, "Unexpected number of messages");
   }
 
-  it("throws error for an invalid host", async function(): Promise<void> {
-    const env = getEnvVars();
-    tokenCreds = await loginWithServicePrincipalSecret(
-      env.clientId,
-      env.clientSecret,
-      env.tenantId,
-      {
-        tokenAudience: aadServiceBusAudience
-      }
-    );
-    await testCreateFromAadTokenCredentials("", tokenCreds).catch((err) => {
-      errorWasThrown = true;
-      should.equal(
-        err.message,
-        "'host' is a required parameter and must be of type: 'string'.",
-        "ErrorMessage is different than expected"
-      );
-    });
-    should.equal(errorWasThrown, true, "Error thrown flag must be true");
-  });
-
   it("throws error for invalid tokenCredentials", async function(): Promise<void> {
     await testCreateFromAadTokenCredentials(serviceBusEndpoint, "").catch((err) => {
       errorWasThrown = true;


### PR DESCRIPTION
Changes done as part of #2285 made 1 test obsolete and the other use a different error message
This PR updates the 2 tests.

- sending empty message gets error from `SendableMessageInfo.validate()` instead of `send()`. So the message is different
- test for empty host being invalid is removed, as this doesnt stop us from making the connection request.