### PR TITLE
update template package.json to whitelist files

### DIFF
--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -24,6 +24,12 @@
     "eslint-fix": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c .eslintrc.json --fix --fix-type [problem,suggestion]",
     "lint-and-test": "npm run eslint && npm run test"
   },
+  "files": [  
+    "dist/",
+    "dist-esm/src/",
+    "src/",
+    "typings/src"
+  ],
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [
     "azure",


### PR DESCRIPTION
This PR involves modifying the package.json for each of the following services to restrict what files are part of the published packages by whitelisting them in files array in package.json, instead of blacklisting the files not required in .npmignore.
- template

This PR changes what contents will be part of the package
This is done as part of the guidelines:
https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-files-required
https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-no-npmignore
@Azure/azure-sdk-eng @bterlson 