### PR TITLE
whitelist files in package.json for eventhub and processor-host

### DIFF
--- a/sdk/eventhub/event-hubs/.npmignore
+++ b/sdk/eventhub/event-hubs/.npmignore
@@ -35,7 +35,6 @@ sample.env
 # misc #
 contribute.md
 .idea/
-changelog.md
 samples/
 typings/samples/
 dist/samples/

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -69,13 +69,10 @@
     "typescript": "^3.2.1"
   },
   "files": [
-    "LICENSE",
-    "changelog.md",
-    "README.md",
     "dist/",
     "dist-esm/src/",
     "src/",
-    "typings/"
+    "typings/src"
   ],
   "scripts": {
     "tslint": "tslint -p . -c tslint.json",

--- a/sdk/eventhub/event-processor-host/.npmignore
+++ b/sdk/eventhub/event-processor-host/.npmignore
@@ -35,8 +35,6 @@ sample.env
 # misc #
 contribute.md
 .idea/
-changelog.md
-samples/
 typings/samples/
 dist/samples/
 docs/

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -62,14 +62,11 @@
     "typescript": "^3.2.1"
   },
   "files": [
-    "LICENSE",
-    "changelog.md",
     "overview.md",
-    "README.md",
     "dist/",
     "dist-esm/src/",
     "src/",
-    "typings/"
+    "typings/src"
   ],
   "scripts": {
     "tslint": "tslint -p . -c tslint.json",


### PR DESCRIPTION
This PR involves modifying the package.json for each of the following services to restrict what files are part of the published packages by whitelisting them in files array in package.json, instead of blacklisting the files not required in .npmignore. 
- event-hubs
- event-processor-host
Note: The default files (like license, readme, changelog) get included in the package without needing to specify them in `files`. Referencing : https://docs.npmjs.com/files/package.json#files
This PR changes what contents will be part of the package
This is done as part of the guidelines:
- https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-files-required
- https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-no-npmignore

@Azure/azure-sdk-eng @bterlson @ramya-rao-a 