### PR TITLE
update service-bus package.json to whitelist files

### DIFF
--- a/sdk/servicebus/service-bus/.npmignore
+++ b/sdk/servicebus/service-bus/.npmignore
@@ -41,8 +41,6 @@ sample.env
 # misc #
 contribute.md
 src/
-tsconfig.json
-tslint.json
 webpack.config.ts
 .idea/
 changelog.md

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -64,13 +64,10 @@
     "typescript": "^3.2.1"
   },
   "files": [
-    "LICENSE",
-    "changelog.md",
-    "Readme.md",
     "dist/",
     "dist-esm/src/",
     "src/",
-    "typings/"
+    "typings/src"
   ],
   "scripts": {
     "tslint": "tslint -p . -c tslint.json",


### PR DESCRIPTION
This PR involves modifying the package.json for each of the following services to restrict what files are part of the published packages by whitelisting them in files array in package.json, instead of blacklisting the files not required in .npmignore. 
- service-bus

The default files (like license, readme, changelog) get included in the package without needing to specify them in `files`. Referencing : https://docs.npmjs.com/files/package.json#files
This PR changes what contents will be part of the package
This is done as part of the guidelines:
- https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-files-required
- https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-no-npmignore

@Azure/azure-sdk-eng @bterlson @ramya-rao-a 