### PR TITLE
[AutoPR containerservice/resource-manager] Add identity property in managedCluster definition and add an example

### DIFF
--- a/packages/@azure/arm-containerservice/lib/models/agentPoolsMappers.ts
+++ b/packages/@azure/arm-containerservice/lib/models/agentPoolsMappers.ts
@@ -47,6 +47,7 @@ export {
   ManagedClusterAddonProfile,
   ContainerServiceNetworkProfile,
   ManagedClusterAADProfile,
+  ManagedClusterIdentity,
   ManagedClusterAccessProfile
 } from "../models/mappers";
 

--- a/packages/@azure/arm-containerservice/lib/models/containerServicesMappers.ts
+++ b/packages/@azure/arm-containerservice/lib/models/containerServicesMappers.ts
@@ -50,6 +50,7 @@ export {
   ManagedClusterAddonProfile,
   ContainerServiceNetworkProfile,
   ManagedClusterAADProfile,
+  ManagedClusterIdentity,
   ManagedClusterAccessProfile
 } from "../models/mappers";
 

--- a/packages/@azure/arm-containerservice/lib/models/index.ts
+++ b/packages/@azure/arm-containerservice/lib/models/index.ts
@@ -1331,7 +1331,7 @@ export interface ManagedClusterIdentity {
   readonly tenantId?: string;
   /**
    * @member {ResourceIdentityType} [type] The type of identity used for the
-   * managed cluster. Type 'SystemAssigned' will use an implicityly created
+   * managed cluster. Type 'SystemAssigned' will use an implicitly created
    * identity in master components and an auto-created user assigned identity
    * in MC_ resource group in agent nodes. Type 'None' will not use MSI for the
    * managed cluster, service principal will be used instead. Possible values

--- a/packages/@azure/arm-containerservice/lib/models/index.ts
+++ b/packages/@azure/arm-containerservice/lib/models/index.ts
@@ -1310,6 +1310,38 @@ export interface ManagedClusterAADProfile {
 
 /**
  * @interface
+ * An interface representing ManagedClusterIdentity.
+ * Identity for the managed cluster.
+ *
+ */
+export interface ManagedClusterIdentity {
+  /**
+   * @member {string} [principalId] The principal id of the system assigned
+   * identity which is used by master components.
+   * **NOTE: This property will not be serialized. It can only be populated by
+   * the server.**
+   */
+  readonly principalId?: string;
+  /**
+   * @member {string} [tenantId] The tenant id of the system assigned identity
+   * which is used by master components.
+   * **NOTE: This property will not be serialized. It can only be populated by
+   * the server.**
+   */
+  readonly tenantId?: string;
+  /**
+   * @member {ResourceIdentityType} [type] The type of identity used for the
+   * managed cluster. Type 'SystemAssigned' will use an implicityly created
+   * identity in master components and an auto-created user assigned identity
+   * in MC_ resource group in agent nodes. Type 'None' will not use MSI for the
+   * managed cluster, service principal will be used instead. Possible values
+   * include: 'SystemAssigned', 'None'
+   */
+  type?: ResourceIdentityType;
+}
+
+/**
+ * @interface
  * An interface representing ManagedCluster.
  * Managed cluster.
  *
@@ -1404,6 +1436,11 @@ export interface ManagedCluster extends Resource {
    * Ranges to kubernetes API server.
    */
   apiServerAuthorizedIPRanges?: string[];
+  /**
+   * @member {ManagedClusterIdentity} [identity] The identity of the managed
+   * cluster, if configured.
+   */
+  identity?: ManagedClusterIdentity;
 }
 
 /**
@@ -1833,6 +1870,14 @@ export type NetworkPolicy = 'calico' | 'azure';
  * @enum {string}
  */
 export type LoadBalancerSku = 'standard' | 'basic';
+
+/**
+ * Defines values for ResourceIdentityType.
+ * Possible values include: 'SystemAssigned', 'None'
+ * @readonly
+ * @enum {string}
+ */
+export type ResourceIdentityType = 'SystemAssigned' | 'None';
 
 /**
  * Contains response data for the list operation.

--- a/packages/@azure/arm-containerservice/lib/models/managedClustersMappers.ts
+++ b/packages/@azure/arm-containerservice/lib/models/managedClustersMappers.ts
@@ -24,6 +24,7 @@ export {
   ManagedClusterAddonProfile,
   ContainerServiceNetworkProfile,
   ManagedClusterAADProfile,
+  ManagedClusterIdentity,
   CloudError,
   ManagedClusterUpgradeProfile,
   ManagedClusterPoolUpgradeProfile,

--- a/packages/@azure/arm-containerservice/lib/models/mappers.ts
+++ b/packages/@azure/arm-containerservice/lib/models/mappers.ts
@@ -1414,6 +1414,40 @@ export const ManagedClusterAADProfile: msRest.CompositeMapper = {
   }
 };
 
+export const ManagedClusterIdentity: msRest.CompositeMapper = {
+  serializedName: "ManagedClusterIdentity",
+  type: {
+    name: "Composite",
+    className: "ManagedClusterIdentity",
+    modelProperties: {
+      principalId: {
+        readOnly: true,
+        serializedName: "principalId",
+        type: {
+          name: "String"
+        }
+      },
+      tenantId: {
+        readOnly: true,
+        serializedName: "tenantId",
+        type: {
+          name: "String"
+        }
+      },
+      type: {
+        serializedName: "type",
+        type: {
+          name: "Enum",
+          allowedValues: [
+            "SystemAssigned",
+            "None"
+          ]
+        }
+      }
+    }
+  }
+};
+
 export const ManagedCluster: msRest.CompositeMapper = {
   serializedName: "ManagedCluster",
   type: {
@@ -1541,6 +1575,13 @@ export const ManagedCluster: msRest.CompositeMapper = {
               name: "String"
             }
           }
+        }
+      },
+      identity: {
+        serializedName: "identity",
+        type: {
+          name: "Composite",
+          className: "ManagedClusterIdentity"
         }
       }
     }

--- a/packages/@azure/arm-containerservice/lib/models/openShiftManagedClustersMappers.ts
+++ b/packages/@azure/arm-containerservice/lib/models/openShiftManagedClustersMappers.ts
@@ -48,6 +48,7 @@ export {
   ManagedClusterAddonProfile,
   ContainerServiceNetworkProfile,
   ManagedClusterAADProfile,
+  ManagedClusterIdentity,
   ManagedClusterAccessProfile
 } from "../models/mappers";
 


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5709