### PR TITLE
[Service Bus] API reference doc updates

### DIFF
--- a/sdk/servicebus/service-bus/src/client.ts
+++ b/sdk/servicebus/service-bus/src/client.ts
@@ -8,15 +8,17 @@ import { AmqpError } from "rhea-promise";
  */
 export interface Client {
   /**
-   * @property {string} The entitypath for the Service Bus entity for which this client is created.
+   * @readonly
+   * @property The path for the Service Bus entity for which this client is created.
    */
   readonly entityPath: string;
   /**
-   * @property {string} A unique identifier for the client.
+   * @readonly
+   * @property A unique identifier for this client.
    */
   readonly id: string;
   /**
-   * Closes the client.
+   * Closes the client along with all senders and receivers created using the client.
    */
   close(): Promise<void>;
   /**

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -44,13 +44,14 @@ import { Typed } from "rhea-promise";
 import { max32BitNumber } from "../util/constants";
 
 /**
- * Represents a description of a rule.
+ * Represents a Rule on a Subscription that is used to filter the incoming message from the
+ * Subscription.
  */
 export interface RuleDescription {
   /**
    * Filter expression used to match messages. Supports 2 types:
-   * - `string`: SQL-like condition expression that is evaluated in the broker against the messages'
-   * user-defined properties and system properties. All system properties must be prefixed with
+   * - `string`: SQL-like condition expression that is evaluated against the messages'
+   * user-defined properties and system properties. All system properties will be prefixed with
    * `sys.` in the condition expression.
    * - `CorrelationFilter`: Properties of the filter will be used to match with the message properties.
    */
@@ -67,44 +68,44 @@ export interface RuleDescription {
 
 /**
  * Represents the correlation filter expression.
- * A CorrelationFilter holds a set of conditions that are matched against one of more of an
- * arriving message's user and system properties.
+ * A CorrelationFilter holds a set of conditions that are matched against user and system properties
+ * of incoming messages from a Subscription.
  */
 export interface CorrelationFilter {
   /**
-   * Identifier of the correlation.
+   * Value to be matched with the `correlationId` property of the incoming message.
    */
   correlationId?: string;
   /**
-   * Identifier of the message.
+   * Value to be matched with the `messageId` property of the incoming message.
    */
   messageId?: string;
   /**
-   * Address to send to.
+   * Value to be matched with the `to` property of the incoming message.
    */
   to?: string;
   /**
-   * Address of the queue to reply to.
+   * Value to be matched with the `replyTo` property of the incoming message.
    */
   replyTo?: string;
   /**
-   * Application specific label.
+   * Value to be matched with the `label` property of the incoming message.
    */
   label?: string;
   /**
-   * Session identifier.
+   * Value to be matched with the `sessionId` property of the incoming message.
    */
   sessionId?: string;
   /**
-   * Session identifier to reply to.
+   * Value to be matched with the `replyToSessionId` property of the incoming message.
    */
   replyToSessionId?: string;
   /**
-   * Content type of the message.
+   * Value to be matched with the `contentType` property of the incoming message.
    */
   contentType?: string;
   /**
-   * Application specific properties of the message.
+   * Value to be matched with the user properties of the incoming message.
    */
   userProperties?: any;
 }

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -82,7 +82,7 @@ export interface ReceiveOptions extends MessageHandlerOptions {
 }
 
 /**
- * Describes the message handler signature.
+ * Describes the signature of the message handler passed to `registerMessageHandler` method.
  */
 export interface OnMessage {
   /**
@@ -92,7 +92,7 @@ export interface OnMessage {
 }
 
 /**
- * Describes the error handler signature.
+ * Describes the signature of the error handler passed to `registerMessageHandler` method.
  */
 export interface OnError {
   /**

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -15,39 +15,41 @@ import * as log from "../log";
 import { throwErrorIfConnectionClosed } from "../util/errors";
 
 /**
- * Describes the options to control receiving of messages in streaming mode.
+ * Describes the options passed to `registerMessageHandler` method when receiving messages from a
+ * Queue/Subscription which does not have sessions enabled.
  */
 export interface MessageHandlerOptions {
   /**
-   * @property {boolean} [autoComplete] Indicates whether the message (if not settled by the user)
-   * should be automatically completed after the user provided onMessage handler has been executed.
-   * Completing a message, removes it from the Queue/Subscription.
+   * @property Indicates whether the `complete()` method on the message should automatically be
+   * called by the sdk after the user provided onMessage handler has been executed.
+   * Calling `complete()` on a message removes it from the Queue/Subscription.
    * - **Default**: `true`.
    */
   autoComplete?: boolean;
   /**
-   * @property {number} [maxMessageAutoRenewLockDurationInSeconds] The maximum duration in seconds until which
-   * the lock on the message will be renewed automatically before the message is settled.
+   * @property The maximum duration in seconds until which the lock on the message will be renewed
+   * by the sdk automatically. This auto renewal stops once the message is settled or once the user
+   * provided onMessage handler completes ite execution.
+   *
    * - **Default**: `300` seconds (5 minutes).
-   * - **To disable autolock renewal**, set `maxMessageAutoRenewLockDurationInSeconds` to `0`.
+   * - **To disable autolock renewal**, set this to `0`.
    */
   maxMessageAutoRenewLockDurationInSeconds?: number;
   /**
-   * @property {number} [newMessageWaitTimeoutInSeconds] The maximum amount of time the receiver
-   * will wait to receive a new message. If no new message is received in this time, then the
-   * receiver will be closed.
-   *
-   * Caution: When setting this value, take into account the time taken to process messages. Once
-   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
-   * invoked on messages.
+   * @property The maximum amount of time the receiver will wait to receive a new message. If no new
+   * message is received in this time, then the receiver will be closed.
    *
    * If this option is not provided, then receiver link will stay open until manually closed.
+   *
+   * **Caution**: When setting this value, take into account the time taken to process messages. Once
+   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
+   * invoked on messages.
    */
   newMessageWaitTimeoutInSeconds?: number;
   /**
-   * @property {number} [maxConcurrentCalls] The maximum number of concurrent calls that the library
-   * can make to the user's message handler. Once this limit has been reached, more messages will
-   * not be received until atleast one of the calls to the user's message handler has completed.
+   * @property The maximum number of concurrent calls that the sdk can make to the user's message
+   * handler. Once this limit has been reached, further messages will not be received until atleast
+   * one of the calls to the user's message handler has completed.
    * - **Default**: `1`.
    */
   maxConcurrentCalls?: number;

--- a/sdk/servicebus/service-bus/src/queueClient.ts
+++ b/sdk/servicebus/service-bus/src/queueClient.ts
@@ -20,24 +20,26 @@ import { ClientEntityContext } from "./clientEntityContext";
 
 /**
  * Describes the client that allows interacting with a Service Bus Queue.
- * Use the `createQueueClient` function on the Namespace object to instantiate a QueueClient
+ * Use the `createQueueClient` function on the ServiceBusClient object to instantiate a QueueClient
  * @class QueueClient
  */
 export class QueueClient implements Client {
   /**
-   * @property {string} The entitypath for the Service Bus Queue for which this client is created.
+   * @readonly
+   * @property The path for the Service Bus Queue for which this client is created.
    */
   readonly entityPath: string;
   /**
-   * @property {string} A unique identifier for the client.
+   * @readonly
+   * @property A unique identifier for this client.
    */
   readonly id: string;
   /**
-   * @property {boolean} _isClosed Denotes if close() was called on this client.
+   * @property Denotes if close() was called on this client.
    */
   private _isClosed: boolean = false;
   /**
-   * @property {ClientEntityContext} _context Describes the amqp connection context for the QueueClient.
+   * @property Describes the amqp connection context for the QueueClient.
    */
   private _context: ClientEntityContext;
 
@@ -47,7 +49,7 @@ export class QueueClient implements Client {
   /**
    * Constructor for QueueClient.
    * This is not meant for the user to call directly.
-   * The user should use the `createQueueClient` on the Namespace instead.
+   * The user should use the `createQueueClient` on the ServiceBusClient instead.
    *
    * @constructor
    * @internal
@@ -64,8 +66,7 @@ export class QueueClient implements Client {
   /**
    * Closes all the AMQP links for sender/receivers created by this client.
    * Once closed, neither the QueueClient nor its sender/receivers can be used for any
-   * further operations. Use the `createQueueClient` function on the Namespace object to
-   * instantiate a new QueueClient
+   * further operations.
    *
    * @returns {Promise<void>}
    */
@@ -137,9 +138,9 @@ export class QueueClient implements Client {
   }
 
   /**
-   * Creates a Sender to be used for sending messages, scheduling messages to be sent at a later time
+   * Creates a Sender for sending messages, scheduling messages to be sent at a later time
    * and cancelling such scheduled messages.
-   * Throws error if an open sender already exists for this QueueClient.
+   * - Throws error if an open sender already exists for this QueueClient.
    */
   createSender(): Sender {
     throwErrorIfClientOrConnectionClosed(this._context.namespace, this.entityPath, this._isClosed);
@@ -155,12 +156,16 @@ export class QueueClient implements Client {
 
   /**
    * Creates a Receiver for receiving messages from a Queue which does not have sessions enabled.
-   * Throws error if an open receiver already exists for this QueueClient.
-   *
-   * Throws error if the Queue has sessions enabled.
+   * - Throws error if an open receiver already exists for this QueueClient.
+   * - Throws error if the Queue has sessions enabled.
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
-   * values are `ReceiveMode.peekLock` and `ReceiveMode.receiveAndDelete`
+   * values are:
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * the message for a particular duration. If the message is not settled by this time, it lands back
+   * on Service Bus to be fetched by the next receive operation.
+   * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from
+   * Service Bus.
    *
    * @returns Receiver A receiver to receive messages from a Queue which does not have
    * sessions enabled.
@@ -169,12 +174,16 @@ export class QueueClient implements Client {
   /**
    * Creates a Receiver for receiving messages from a session enabled Queue. When no sessionId is
    * given, a random session among the available sessions is used.
-   *
-   * Throws error if an open receiver already exists for given sessionId.
-   * Throws error if the Queue does not have sessions enabled.
+   * - Throws error if an open receiver already exists for given sessionId.
+   * - Throws error if the Queue does not have sessions enabled.
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
-   * values are `ReceiveMode.peekLock` and `ReceiveMode.receiveAndDelete`
+   * values are:
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * the message for a particular duration. If the message is not settled by this time, it lands back
+   * on Service Bus to be fetched by the next receive operation.
+   * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from
+   * Service Bus.
    * @param sessionOptions Options to provide sessionId and duration of automatic lock renewal for
    * the session receiver.
    *
@@ -219,10 +228,9 @@ export class QueueClient implements Client {
 
   /**
    * Fetches the next batch of active messages (including deferred but not deadlettered messages).
-   * The first call to `peek()` fetches the first active message. Each subsequent call fetches the
+   * - The first call to `peek()` fetches the first active message. Each subsequent call fetches the
    * subsequent message.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * - Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
    * @param [maxMessageCount] The maximum number of messages to peek. Default value `1`.
@@ -236,8 +244,7 @@ export class QueueClient implements Client {
   /**
    * Peeks the desired number of active messages (including deferred but not deadlettered messages)
    * from the specified sequence number.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * - Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
    * @param fromSequenceNumber The sequence number from where to read the message.
@@ -277,8 +284,8 @@ export class QueueClient implements Client {
   /**
    * Returns the corresponding dead letter queue name for the queue represented by the given name.
    * Use this in the `createQueueClient` function on the `ServiceBusClient` instance to receive
-   * messages from the dead letter queue.
-   * @param queueName
+   * messages from a dead letter queue.
+   * @param queueName Name of the queue whose dead letter counterpart's name is being fetched
    */
   static getDeadLetterQueuePath(queueName: string): string {
     return `${queueName}/$DeadLetterQueue`;

--- a/sdk/servicebus/service-bus/src/queueClient.ts
+++ b/sdk/servicebus/service-bus/src/queueClient.ts
@@ -161,7 +161,7 @@ export class QueueClient implements Client {
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:
-   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the receiver has a lock on
    * the message for a particular duration. If the message is not settled by this time, it lands back
    * on Service Bus to be fetched by the next receive operation.
    * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from
@@ -179,7 +179,7 @@ export class QueueClient implements Client {
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:
-   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the receiver has a lock on
    * the message for a particular duration. If the message is not settled by this time, it lands back
    * on Service Bus to be fetched by the next receive operation.
    * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from

--- a/sdk/servicebus/service-bus/src/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receiver.ts
@@ -31,14 +31,14 @@ import {
  */
 export class Receiver {
   /**
-   * @property {ClientEntityContext} _context Describes the amqp connection context for the QueueClient.
+   * @property Describes the amqp connection context for the QueueClient.
    */
   private _context: ClientEntityContext;
   private _receiveMode: ReceiveMode;
   private _isClosed: boolean = false;
 
   /**
-   * @property {ReceiveMode} [receiveMode] Denotes receiveMode of this receiver.
+   * @property Denotes receiveMode of this receiver.
    * @readonly
    */
   public get receiveMode(): ReceiveMode {
@@ -46,7 +46,7 @@ export class Receiver {
   }
 
   /**
-   * @property {boolean} [isClosed] Denotes if close() was called on this receiver.
+   * @property Denotes if close() was called on this receiver.
    * @readonly
    */
   public get isClosed(): boolean {
@@ -116,8 +116,8 @@ export class Receiver {
   }
 
   /**
-   * Returns a batch of messages based on given count and timeout over an AMQP receiver link
-   * from a Queue/Subscription.
+   * Returns a promise that resolves to an array of messages based on given count and timeout over
+   * an AMQP receiver link from a Queue/Subscription.
    *
    * @param maxMessageCount      The maximum number of messages to receive from Queue/Subscription.
    * @param idleTimeoutInSeconds The maximum wait time in seconds for which the Receiver
@@ -159,9 +159,9 @@ export class Receiver {
 
   /**
    * Renews the lock on the message for the duration as specified during the Queue/Subscription
-   * creation. Check the `lockedUntilUtc` property on the message for the time when the lock expires.
-   *
-   * If a message is not settled (using either `complete()`, `defer()` or `deadletter()`,
+   * creation.
+   * - Check the `lockedUntilUtc` property on the message for the time when the lock expires.
+   * - If a message is not settled (using either `complete()`, `defer()` or `deadletter()`,
    * before its lock expires, then the message lands back in the Queue/Subscription for the next
    * receive operation.
    *
@@ -197,8 +197,8 @@ export class Receiver {
   }
 
   /**
-   * Receives a deferred message identified by the given `sequenceNumber`.
-   * @param sequenceNumber The sequence number of the message that will be received.
+   * Returns a promise that resolves to a deferred message identified by the given `sequenceNumber`.
+   * @param sequenceNumber The sequence number of the message that needs to be received.
    * @returns Promise<ServiceBusMessage | undefined>
    * - Returns `Message` identified by sequence number.
    * - Returns `undefined` if no such message is found.
@@ -225,8 +225,8 @@ export class Receiver {
   }
 
   /**
-   * Receives a list of deferred messages identified by given `sequenceNumbers`.
-   * @param sequenceNumbers A list containing the sequence numbers to receive.
+   * Returns a promise that resolves to an array of deferred messages identified by given `sequenceNumbers`.
+   * @param sequenceNumbers An array of sequence numbers for the messages that need to be received.
    * @returns Promise<ServiceBusMessage[]>
    * - Returns a list of messages identified by the given sequenceNumbers.
    * - Returns an empty list if no messages are found.
@@ -293,7 +293,7 @@ export class Receiver {
 
   /**
    * Indicates whether the receiver is currently receiving messages or not.
-   * When this returns true, registerMessageHandler() or receiveMessages() calls cannot be made.
+   * When this returns true, new `registerMessageHandler()` or `receiveMessages()` calls cannot be made.
    */
   isReceivingMessages(): boolean {
     if (this._context.streamingReceiver && this._context.streamingReceiver.isOpen()) {
@@ -353,7 +353,7 @@ export class SessionReceiver {
   private _sessionId: string | undefined;
 
   /**
-   * @property {ReceiveMode} [receiveMode] Denotes receiveMode of this receiver.
+   * @property Denotes receiveMode of this receiver.
    * @readonly
    */
   public get receiveMode(): ReceiveMode {
@@ -361,7 +361,7 @@ export class SessionReceiver {
   }
 
   /**
-   * @property {boolean} [isClosed] Denotes if close() was called on this receiver.
+   * @property Denotes if close() was called on this receiver.
    * @readonly
    */
   public get isClosed(): boolean {
@@ -371,7 +371,7 @@ export class SessionReceiver {
   }
 
   /**
-   * @property {string} [sessionId] The sessionId for the message session.
+   * @property The sessionId for the message session.
    * Will return undefined until a AMQP receiver link has been successfully set up for the session.
    * @readonly
    */
@@ -380,7 +380,7 @@ export class SessionReceiver {
   }
 
   /**
-   * @property {Date} [sessionLockedUntilUtc] The time in UTC until which the session is locked.
+   * @property The time in UTC until which the session is locked.
    * Everytime `renewSessionLock()` is called, this time gets updated to current time plus the lock
    * duration as specified during the Queue/Subscription creation.
    *
@@ -428,11 +428,11 @@ export class SessionReceiver {
 
   /**
    * Renews the lock on the session for the duration as specified during the Queue/Subscription
-   * creation. Check the `sessionLockedUntilUtc` property on the SessionReceiver for the time when the lock expires.
-   *
-   * When the lock on the session expires
-   * - No more messages can be received using this receiver
-   * - If a message is not settled (using either `complete()`, `defer()` or `deadletter()`,
+   * creation.
+   * - Check the `sessionLockedUntilUtc` property on the SessionReceiver for the time when the lock expires.
+   * - When the lock on the session expires
+   *     - No more messages can be received using this receiver
+   *     - If a message is not settled (using either `complete()`, `defer()` or `deadletter()`,
    *   before the session lock expires, then the message lands back in the Queue/Subscription for the next
    *   receive operation.
    *
@@ -450,7 +450,8 @@ export class SessionReceiver {
   }
 
   /**
-   * Sets the state of the MessageSession.
+   * Sets the state on the Session. For more on session states, see
+   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @param state The state that needs to be set.
    */
   async setState(state: any): Promise<void> {
@@ -460,7 +461,8 @@ export class SessionReceiver {
   }
 
   /**
-   * Gets the state of the MessageSession.
+   * Gets the state of the Session. For more on session states, see
+   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-sessions#message-session-state Session State}
    * @returns Promise<any> The state of that session
    */
   async getState(): Promise<any> {
@@ -471,10 +473,10 @@ export class SessionReceiver {
 
   /**
    * Fetches the next batch of active messages (including deferred but not deadlettered messages) in
-   * the current session. The first call to `peek()` fetches the first active message. Each
-   * subsequent call fetches the subsequent message.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * the current session.
+   * - The first call to `peek()` fetches the first active message. Each subsequent call fetches the
+   * subsequent message.
+   * - Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
    * @param maxMessageCount The maximum number of messages to peek. Default value `1`.
@@ -489,8 +491,7 @@ export class SessionReceiver {
   /**
    * Peeks the desired number of active messages (including deferred but not deadlettered messages)
    * from the specified sequence number in the current session.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * - Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
    * @param fromSequenceNumber The sequence number from where to read the message.
@@ -511,8 +512,8 @@ export class SessionReceiver {
   }
 
   /**
-   * Receives a deferred message identified by the given `sequenceNumber`.
-   * @param sequenceNumber The sequence number of the message that will be received.
+   * Returns a promise that resolves to a deferred message identified by the given `sequenceNumber`.
+   * @param sequenceNumber The sequence number of the message that needs to be received.
    * @returns Promise<ServiceBusMessage | undefined>
    * - Returns `Message` identified by sequence number.
    * - Returns `undefined` if no such message is found.
@@ -541,8 +542,8 @@ export class SessionReceiver {
   }
 
   /**
-   * Receives a list of deferred messages identified by given `sequenceNumbers`.
-   * @param sequenceNumbers A list containing the sequence numbers to receive.
+   * Returns a promise that resolves to an array of deferred messages identified by given `sequenceNumbers`.
+   * @param sequenceNumbers An array of sequence numbers for the messages that need to be received.
    * @returns Promise<ServiceBusMessage[]>
    * - Returns a list of messages identified by the given sequenceNumbers.
    * - Returns an empty list if no messages are found.
@@ -573,8 +574,8 @@ export class SessionReceiver {
   }
 
   /**
-   * Returns a batch of messages based on given count and timeout over an AMQP receiver link
-   * from a Queue/Subscription.
+   * Returns a promise that resolves to an array of messages based on given count and timeout over
+   * an AMQP receiver link from a Queue/Subscription.
    *
    * @param maxMessageCount      The maximum number of messages to receive from Queue/Subscription.
    * @param maxWaitTimeInSeconds The maximum wait time in seconds for which the Receiver
@@ -684,7 +685,7 @@ export class SessionReceiver {
 
   /**
    * Indicates whether the receiver is currently receiving messages or not.
-   * When this returns true, registerMessageHandler() or receiveMessages() calls cannot be made.
+   * When this returns true, new `registerMessageHandler()` or `receiveMessages()` calls cannot be made.
    */
   isReceivingMessages(): boolean {
     return this._messageSession ? this._messageSession.isReceivingMessages : false;

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -23,13 +23,13 @@ import {
  */
 export class Sender {
   /**
-   * @property {ClientEntityContext} _context Describes the amqp connection context for the Client.
+   * @property Describes the amqp connection context for the Client.
    */
   private _context: ClientEntityContext;
   private _isClosed: boolean = false;
 
   /**
-   * @property {boolean} [isClosed] Denotes if close() was called on this sender.
+   * @property Denotes if close() was called on this sender.
    * @readonly
    */
   public get isClosed(): boolean {
@@ -62,8 +62,9 @@ export class Sender {
    * Sends the given messages in a single batch i.e. in a single AMQP message after creating an AMQP
    * Sender link if it doesnt already exists.
    *
-   * To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
-   * and/or `partitionKey` properties respectively on the messages. When doing so, all
+   * - To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
+   * and/or `partitionKey` properties respectively on the messages.
+   * - When doing so, all
    * messages in the batch should have the same `sessionId` (if using sessions) and the same
    * `parititionKey` (if using paritions).
    *
@@ -155,8 +156,8 @@ export class Sender {
   }
 
   /**
-   * Cancels an array of messages that were scheduled to appear on a ServiceBus Queue/Subscription.
-   * @param sequenceNumbers - An Array of sequence numbers of the message to be cancelled.
+   * Cancels multiple messages that were scheduled to appear on a ServiceBus Queue/Subscription.
+   * @param sequenceNumbers - An Array of sequence numbers of the messages to be cancelled.
    * @returns Promise<void>
    */
   async cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void> {

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -26,7 +26,7 @@ import { SubscriptionClient } from "./subscriptionClient";
  */
 export interface ServiceBusClientOptions {
   /**
-   * @property {DataTransformer} [dataTransformer] The data transformer that will be used to encode
+   * @property The data transformer that will be used to encode
    * and decode the sent and received messages respectively. If not provided then we will use the
    * DefaultDataTransformer. The default transformer should handle majority of the cases. This
    * option needs to be used only for specialized scenarios.
@@ -41,11 +41,12 @@ export interface ServiceBusClientOptions {
  */
 export class ServiceBusClient {
   /**
-   * @property {string} name The namespace name of the Service Bus instance.
+   * @readonly
+   * @property The namespace name of the Service Bus instance.
    */
   readonly name: string;
   /**
-   * @property {ConnectionContext} _context Describes the amqp connection context for the Namespace.
+   * @property Describes the amqp connection context for the Namespace.
    * @private
    */
   private _context: ConnectionContext;

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -16,17 +16,19 @@ import { reorderLockToken } from "../src/util/utils";
 import { throwIfMessageCannotBeSettled } from "../src/util/errors";
 
 /**
- * The mode in which messages should be received
+ * The mode in which messages should be received. The 2 modes are `peekLock` and `receiveAndDelete`.
  */
 export enum ReceiveMode {
   /**
-   * Peek the message and lock it until it is settled or times out.
+   * Once a message is received in this mode, the reciever has a lock on the message for a
+   * particular duration. If the message is not settled by this time, it lands back on Service Bus
+   * to be fetched by the next receive operation.
    * @type {Number}
    */
   peekLock = 1,
 
   /**
-   * Remove the message from the service bus upon delivery.
+   * Messages received in this mode get automatically removed from Service Bus.
    * @type {Number}
    */
   receiveAndDelete = 2
@@ -55,7 +57,7 @@ export enum DispositionStatus {
 
 /**
  * @internal
- * Describes the delivery annotations for ServiceBus.
+ * Describes the delivery annotations for Service Bus.
  * @interface
  */
 export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
@@ -83,7 +85,7 @@ export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
 
 /**
  * @internal
- * Describes the message annotations for ServiceBus.
+ * Describes the message annotations for Service Bus.
  * @interface ServiceBusMessageAnnotations
  */
 export interface ServiceBusMessageAnnotations extends MessageAnnotations {
@@ -110,60 +112,63 @@ export interface ServiceBusMessageAnnotations extends MessageAnnotations {
 }
 
 /**
- * Describes the reason and error description for dead lettering a message.
+ * Describes the reason and error description for dead lettering a message using the `deadLetter()`
+ * method on the message received from Service Bus.
  * @interface DeadLetterOptions
  */
 export interface DeadLetterOptions {
   /**
-   * @property {string} [deadletterReason] The reason for deadlettering the message.
+   * @property The reason for deadlettering the message.
    */
   deadletterReason: string;
   /**
-   * @property {string} [deadLetterErrorDescription] The error description for deadlettering the message.
+   * @property The error description for deadlettering the message.
    */
   deadLetterErrorDescription: string;
 }
 
 /**
- * Describes the message to be sent to ServiceBus.
+ * Describes the message to be sent to Service Bus.
  * @interface SendableMessageInfo.
  */
 export interface SendableMessageInfo {
   /**
-   * @property {any} body - The message body that needs to be sent or is received.
+   * @property The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property {string | number | Buffer} [messageId] The message identifier is an
+   * @property The message identifier is an
    * application-defined value that uniquely identifies the message and its payload.
    *
    * Note: Numbers that are not whole integers are not allowed.
    */
   messageId?: string | number | Buffer;
   /**
-   * @property {string} [contentType] The content type of the message. Optionally describes
+   * @property The content type of the message. Optionally describes
    * the payload of the message, with a descriptor following the format of RFC2045, Section 5, for
    * example "application/json".
    */
   contentType?: string;
   /**
-   * @property {string | number | Buffer} [correlationId] The correlation identifier that allows an
+   * @property The correlation identifier that allows an
    * application to specify a context for the message for the purposes of correlation, for example
    * reflecting the MessageId of a message that is being replied to.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   correlationId?: string | number | Buffer;
   /**
-   * @property {string} [partitionKey] The partition key for sending a message to a
-   * partitioned entity. Maximum length is 128 characters. For {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning partitioned entities},
-   * etting this value enables assigning related messages to the same internal partition,
+   * @property The partition key for sending a message to a partitioned entity.
+   * Maximum length is 128 characters. For {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning partitioned entities},
+   * setting this value enables assigning related messages to the same internal partition,
    * so that submission sequence order is correctly recorded. The partition is chosen by a hash
-   * function over this value and cannot be chosen directly. For session-aware entities,
-   * the `sessionId` property overrides this value.
+   * function over this value and cannot be chosen directly.
+   * - For session-aware entities, the `sessionId` property overrides this value.
+   * - For non partitioned entities, partition key will be ignored
+   *
    */
   partitionKey?: string;
   /**
-   * @property {string} [viaPartitionKey] The partition key for sending a message into an entity
+   * @property The partition key for sending a message into an entity
    * via a partitioned transfer queue. Maximum length is 128 characters. If a message is sent via a
    * transfer queue in the scope of a transaction, this value selects the transfer queue partition:
    * This is functionally equivalent to `partitionKey` property and ensures that messages are kept
@@ -172,7 +177,7 @@ export interface SendableMessageInfo {
    */
   viaPartitionKey?: string;
   /**
-   * @property {string} [sessionId] The session identifier for a session-aware entity. Maximum
+   * @property The session identifier for a session-aware entity. Maximum
    * length is 128 characters. For session-aware entities, this application-defined value specifies
    * the session affiliation of the message. Messages with the same session identifier are subject
    * to summary locking and enable exact in-order processing and demultiplexing. For
@@ -181,14 +186,14 @@ export interface SendableMessageInfo {
    */
   sessionId?: string;
   /**
-   * @property {string} [replyToSessionId] The session identifier augmenting the `replyTo` address.
+   * @property The session identifier augmenting the `replyTo` address.
    * Maximum length is 128 characters. This value augments the ReplyTo information and specifies
    * which SessionId should be set for the reply when sent to the reply entity.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   replyToSessionId?: string;
   /**
-   * @property {number} [timeToLive] The message’s time to live value. This value is the relative
+   * @property The message’s time to live value. This value is the relative
    * duration after which the message expires, starting from the instant the message has been
    * accepted and stored by the broker, as captured in `enqueuedTimeUtc`. When not set explicitly,
    * the assumed value is the DefaultTimeToLive for the respective queue or topic. A message-level
@@ -198,20 +203,20 @@ export interface SendableMessageInfo {
    */
   timeToLive?: number;
   /**
-   * @property {string} [label] The application specific label. This property enables the
+   * @property The application specific label. This property enables the
    * application to indicate the purpose of the message to the receiver in a standardized. fashion,
    * similar to an email subject line. The mapped AMQP property is "subject".
    */
   label?: string;
   /**
-   * @property {string} [to] The "to" address. This property is reserved for future use in routing
+   * @property The "to" address. This property is reserved for future use in routing
    * scenarios and presently ignored by the broker itself. Applications can use this value in
    * rule-driven {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-auto-forwarding auto-forward chaining}
    * scenarios to indicate the intended logical destination of the message.
    */
   to?: string;
   /**
-   * @property {string} [replyTo] The address of an entity to send replies to. This optional and
+   * @property The address of an entity to send replies to. This optional and
    * application-defined value is a standard way to express a reply path to the receiver of the
    * message. When a sender expects a reply, it sets the value to the absolute or relative path of
    * the queue or topic it expects the reply to be sent to. See
@@ -219,7 +224,7 @@ export interface SendableMessageInfo {
    */
   replyTo?: string;
   /**
-   * @property {Date} [scheduledEnqueueTimeUtc] The date and time in UTC at which the message will
+   * @property The date and time in UTC at which the message will
    * be enqueued. This property returns the time in UTC; when setting the property, the
    * supplied DateTime value must also be in UTC. This value is for delayed message sending.
    * It is utilized to delay messages sending to a specific time in the future. Message enqueuing
@@ -228,14 +233,14 @@ export interface SendableMessageInfo {
    */
   scheduledEnqueueTimeUtc?: Date;
   /**
-   * @property {{ [key: string]: any }} [userProperties] The application specific properties which can be
+   * @property The application specific properties which can be
    * used for custom message metadata.
    */
   userProperties?: { [key: string]: any };
 }
 
 /**
- * Describes the message to be sent to ServiceBus.
+ * Describes the message to be sent to Service Bus.
  */
 export module SendableMessageInfo {
   /**
@@ -464,58 +469,54 @@ export module SendableMessageInfo {
 }
 
 /**
- * Describes the message received from ServiceBus.
+ * Describes the message received from Service Bus.
  * @class ReceivedSBMessage
  */
 export interface ReceivedMessageInfo extends SendableMessageInfo {
   /**
-   * @property {string} [lockToken] The lock token for the current message. The lock token is a
-   * reference to the lock that is being held by the broker in `ReceiveMode.PeekLock` mode. Locks
-   * are used to explicitly settle messages as explained in the {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
-   * The token can also be used to pin the lock permanently through the {@link https://docs.microsoft.com/azure/service-bus-messaging/message-deferral Deferral API}
-   * and, with that, take the message out of the regular delivery state flow.
+   * @property The lock token is a reference to the lock that is being held by the broker in
+   * `ReceiveMode.PeekLock` mode. Locks are used internally settle messages as explained in the
+   * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
+   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * mode.
    * @readonly
    */
   readonly lockToken?: string;
   /**
-   * @property {number} [deliveryCount] The current delivery count. The value start from 1. Number
-   * of deliveries that have been attempted for this message. The count is incremented when a
-   * message lock expires, or the message is explicitly abandoned by the receiver.
+   * @property Number of deliveries that have been attempted for this message. The count is
+   * incremented when a message lock expires, or the message is explicitly abandoned using the
+   * `abandon()` method on the message.
    * @readonly
    */
   readonly deliveryCount?: number;
   /**
-   * @property {Date} [enqueuedTimeUtc] The date and time of the sent message in UTC. The UTC
-   * instant at which the message has been accepted and stored in the entity. This value can be
-   * used as an authoritative and neutral arrival time indicator when the receiver does not
-   * want to trust the sender's clock.
+   * @property The UTC instant at which the message has been accepted and stored in Service Bus.
    * @readonly
    */
   readonly enqueuedTimeUtc?: Date;
   /**
-   * @property {Date} [expiresAtUtc] The date and time in UTC at which the message is set to expire.
-   * The UTC instant at which the message is marked for removal and no longer available for
-   * retrieval from the entity due to expiration. Expiry is controlled by the `timeToLive` property
-   * and this property is computed from `enqueuedTimeUtc` + `timeToLive`.
+   * @property The UTC instant at which the message is marked for removal and no longer available for
+   * retrieval from the entity due to expiration. This property is computed from 2 other properties
+   * on the message: `enqueuedTimeUtc` + `timeToLive`.
    */
   readonly expiresAtUtc?: Date;
   /**
-   * @property {Date} [lockedUntilUtc] The date and time in UTC until which the message will be
-   * locked in the queue/subscription. For messages retrieved under a lock (peek-lock receive mode,
-   * not pre-settled) this property reflects the UTC instant until which the message is held
-   * locked in the queue/subscription. When the lock expires, the `deliveryCount` is incremented
-   * and the message is again available for retrieval.
+   * @property The UTC instant until which the message is held locked in the queue/subscription.
+   * When the lock expires, the `deliveryCount` is incremented and the message is again available
+   * for retrieval.
+   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * mode.
    */
   lockedUntilUtc?: Date;
   /**
-   * @property {number} [enqueuedSequenceNumber] The original sequence number of the message. For
+   * @property The original sequence number of the message. For
    * messages that have been auto-forwarded, this property reflects the sequence number that had
    * first been assigned to the message at its original point of submission.
    * @readonly
    */
   readonly enqueuedSequenceNumber?: number;
   /**
-   * @property {number} [sequenceNumber] The unique number assigned to a message by Service Bus.
+   * @property The unique number assigned to a message by Service Bus.
    * The sequence number is a unique 64-bit integer assigned to a message as it is accepted
    * and stored by the broker and functions as its true identifier. For partitioned entities,
    * the topmost 16 bits reflect the partition identifier. Sequence numbers monotonically increase.
@@ -544,7 +545,7 @@ export interface ReceivedMessageInfo extends SendableMessageInfo {
 }
 
 /**
- * Describes the module that is responsible for converting the message received from ServiceBus
+ * Describes the module that is responsible for converting the message received from Service Bus
  * to/from AmqpMessage.
  */
 export module ReceivedMessageInfo {
@@ -695,34 +696,60 @@ export module ReceivedMessageInfo {
 }
 
 /**
- * Describes the message received from ServiceBus.
+ * Describes the message received from Service Bus.
  * @interface ReceivedMessage
  */
 interface ReceivedMessage extends ReceivedMessageInfo {
+  /**
+   * Removes the message from Service Bus.
+   * @returns Promise<void>.
+   */
   complete(): Promise<void>;
 
+  /**
+   * The lock held on the message by the receiver is let go, making the message available again in
+   * Service Bus for another receive operation.
+   * @param propertiesToModify The properties of the message to modify while abandoning the message.
+   *
+   * @return Promise<void>.
+   */
   abandon(propertiesToModify?: { [key: string]: any }): Promise<void>;
 
+  /**
+   * Defers the processing of the message. Save the `sequenceNumber` of the message, in order to
+   * receive it message again in the future using the `receiveDeferredMessage` method.
+   * @param propertiesToModify The properties of the message to modify while deferring the message
+   *
+   * @returns Promise<void>
+   */
   defer(propertiesToModify?: { [key: string]: any }): Promise<void>;
 
+  /**
+   * Moves the message to the deadletter sub-queue. To receive a deadletted message, create a new
+   * QueueClient/SubscriptionClient using the path for the deadletter sub-queue.
+   * @param options The DeadLetter options that can be provided while
+   * rejecting the message.
+   *
+   * @returns Promise<void>
+   */
   deadLetter(options?: DeadLetterOptions): Promise<void>;
 }
 
 /**
- * Describes the message received from ServiceBus.
+ * Describes the message received from Service Bus.
  * @class ServiceBusMessage
  */
 export class ServiceBusMessage implements ReceivedMessage {
   /**
-   * @property {any} body - The message body that needs to be sent or is received.
+   * @property The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property {{ [key: string]: any }} [userProperties] The application specific properties.
+   * @property The application specific properties.
    */
   userProperties?: { [key: string]: any };
   /**
-   * @property {string | number | Buffer} [messageId] The message identifier is an
+   * @property The message identifier is an
    * application-defined value that uniquely identifies the message and its payload. The identifier
    * is a free-form string and can reflect a GUID or an identifier derived from the application
    * context. If enabled, the
@@ -731,29 +758,29 @@ export class ServiceBusMessage implements ReceivedMessage {
    */
   messageId?: string | number | Buffer;
   /**
-   * @property {string} [contentType] The content type of the message. Optionally describes
+   * @property The content type of the message. Optionally describes
    * the payload of the message, with a descriptor following the format of RFC2045, Section 5, for
    * example "application/json".
    */
   contentType?: string;
   /**
-   * @property {string | number | Buffer} [correlationId] The correlation identifier that allows an
+   * @property The correlation identifier that allows an
    * application to specify a context for the message for the purposes of correlation, for example
    * reflecting the MessageId of a message that is being replied to.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   correlationId?: string | number | Buffer;
   /**
-   * @property {string} [partitionKey] The partition key for sending a message to a
+   * @property The partition key for sending a message to a
    * partitioned entity. Maximum length is 128 characters. For {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-partitioning partitioned entities},
-   * etting this value enables assigning related messages to the same internal partition,
+   * setting this value enables assigning related messages to the same internal partition,
    * so that submission sequence order is correctly recorded. The partition is chosen by a hash
    * function over this value and cannot be chosen directly. For session-aware entities,
    * the `sessionId` property overrides this value.
    */
   partitionKey?: string;
   /**
-   * @property {string} [viaPartitionKey] The partition key for sending a message into an entity
+   * @property The partition key for sending a message into an entity
    * via a partitioned transfer queue. Maximum length is 128 characters. If a message is sent via a
    * transfer queue in the scope of a transaction, this value selects the transfer queue partition:
    * This is functionally equivalent to `partitionKey` property and ensures that messages are kept
@@ -762,7 +789,7 @@ export class ServiceBusMessage implements ReceivedMessage {
    */
   viaPartitionKey?: string;
   /**
-   * @property {string} [sessionId] The session identifier for a session-aware entity. Maximum
+   * @property The session identifier for a session-aware entity. Maximum
    * length is 128 characters. For session-aware entities, this application-defined value specifies
    * the session affiliation of the message. Messages with the same session identifier are subject
    * to summary locking and enable exact in-order processing and demultiplexing. For
@@ -771,14 +798,14 @@ export class ServiceBusMessage implements ReceivedMessage {
    */
   sessionId?: string;
   /**
-   * @property {string} [replyToSessionId] The session identifier augmenting the `replyTo` address.
+   * @property The session identifier augmenting the `replyTo` address.
    * Maximum length is 128 characters. This value augments the ReplyTo information and specifies
    * which SessionId should be set for the reply when sent to the reply entity.
    * See {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messages-payloads?#message-routing-and-correlation Message Routing and Correlation}.
    */
   replyToSessionId?: string;
   /**
-   * @property {number} [timeToLive] The message’s time to live value. This value is the relative
+   * @property The message’s time to live value. This value is the relative
    * duration after which the message expires, starting from the instant the message has been
    * accepted and stored by the broker, as captured in `enqueuedTimeUtc`. When not set explicitly,
    * the assumed value is the DefaultTimeToLive for the respective queue or topic. A message-level
@@ -788,20 +815,20 @@ export class ServiceBusMessage implements ReceivedMessage {
    */
   timeToLive?: number;
   /**
-   * @property {string} [label] The application specific label. This property enables the
+   * @property The application specific label. This property enables the
    * application to indicate the purpose of the message to the receiver in a standardized. fashion,
    * similar to an email subject line. The mapped AMQP property is "subject".
    */
   label?: string;
   /**
-   * @property {string} [to] The "to" address. This property is reserved for future use in routing
+   * @property The "to" address. This property is reserved for future use in routing
    * scenarios and presently ignored by the broker itself. Applications can use this value in
    * rule-driven {@link https://docs.microsoft.com/azure/service-bus-messaging/service-bus-auto-forwarding auto-forward chaining}
    * scenarios to indicate the intended logical destination of the message.
    */
   to?: string;
   /**
-   * @property {string} [replyTo] The address of an entity to send replies to. This optional and
+   * @property The address of an entity to send replies to. This optional and
    * application-defined value is a standard way to express a reply path to the receiver of the
    * message. When a sender expects a reply, it sets the value to the absolute or relative path of
    * the queue or topic it expects the reply to be sent to. See
@@ -809,7 +836,7 @@ export class ServiceBusMessage implements ReceivedMessage {
    */
   replyTo?: string;
   /**
-   * @property {Date} [scheduledEnqueueTimeUtc] The date and time in UTC at which the message will
+   * @property The date and time in UTC at which the message will
    * be enqueued. This property returns the time in UTC; when setting the property, the
    * supplied DateTime value must also be in UTC. This value is for delayed message sending.
    * It is utilized to delay messages sending to a specific time in the future. Message enqueuing
@@ -818,53 +845,49 @@ export class ServiceBusMessage implements ReceivedMessage {
    */
   scheduledEnqueueTimeUtc?: Date;
   /**
-   * @property {string} [lockToken] The lock token for the current message. The lock token is a
-   * reference to the lock that is being held by the broker in `ReceiveMode.PeekLock` mode. Locks
-   * are used to explicitly settle messages as explained in the {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
-   * The token can also be used to pin the lock permanently through the {@link https://docs.microsoft.com/azure/service-bus-messaging/message-deferral Deferral API}
-   * and, with that, take the message out of the regular delivery state flow.
+   * @property The lock token is a reference to the lock that is being held by the broker in
+   * `ReceiveMode.PeekLock` mode. Locks are used internally settle messages as explained in the
+   * {@link https://docs.microsoft.com/azure/service-bus-messaging/message-transfers-locks-settlement product documentation in more detail}
+   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * mode.
    * @readonly
    */
   readonly lockToken?: string;
   /**
-   * @property {number} [deliveryCount] The current delivery count. The value start from 1. Number
-   * of deliveries that have been attempted for this message. The count is incremented when a
-   * message lock expires, or the message is explicitly abandoned by the receiver.
+   * @property Number of deliveries that have been attempted for this message. The count is
+   * incremented when a message lock expires, or the message is explicitly abandoned using the
+   * `abandon()` method on the message.
    * @readonly
    */
   readonly deliveryCount?: number;
   /**
-   * @property {Date} [enqueuedTimeUtc] The date and time of the sent message in UTC. The UTC
-   * instant at which the message has been accepted and stored in the entity. This value can be
-   * used as an authoritative and neutral arrival time indicator when the receiver does not
-   * want to trust the sender's clock.
+   * @property The UTC instant at which the message has been accepted and stored in Service Bus.
    * @readonly
    */
   readonly enqueuedTimeUtc?: Date;
   /**
-   * @property {Date} [expiresAtUtc] The date and time in UTC at which the message is set to expire.
-   * The UTC instant at which the message is marked for removal and no longer available for
-   * retrieval from the entity due to expiration. Expiry is controlled by the `timeToLive` property
-   * and this property is computed from `enqueuedTimeUtc` + `timeToLive`.
+   * @property The UTC instant at which the message is marked for removal and no longer available for
+   * retrieval from the entity due to expiration. This property is computed from 2 other properties
+   * on the message: `enqueuedTimeUtc` + `timeToLive`.
    */
   readonly expiresAtUtc?: Date;
   /**
-   * @property {Date} [lockedUntilUtc] The date and time in UTC until which the message will be
-   * locked in the queue/subscription. For messages retrieved under a lock (peek-lock receive mode,
-   * not pre-settled) this property reflects the UTC instant until which the message is held
-   * locked in the queue/subscription. When the lock expires, the `deliveryCount` is incremented
-   * and the message is again available for retrieval.
+   * @property The UTC instant until which the message is held locked in the queue/subscription.
+   * When the lock expires, the `deliveryCount` is incremented and the message is again available
+   * for retrieval.
+   * - Not applicable when the message is received in `ReceiveMode.receiveAndDelete`
+   * mode.
    */
   lockedUntilUtc?: Date;
   /**
-   * @property {number} [enqueuedSequenceNumber] The original sequence number of the message. For
+   * @property The original sequence number of the message. For
    * messages that have been auto-forwarded, this property reflects the sequence number that had
    * first been assigned to the message at its original point of submission.
    * @readonly
    */
   readonly enqueuedSequenceNumber?: number;
   /**
-   * @property {number} [sequenceNumber] The unique number assigned to a message by Service Bus.
+   * @property The unique number assigned to a message by Service Bus.
    * The sequence number is a unique 64-bit integer assigned to a message as it is accepted
    * and stored by the broker and functions as its true identifier. For partitioned entities,
    * the topmost 16 bits reflect the partition identifier. Sequence numbers monotonically increase.
@@ -873,7 +896,7 @@ export class ServiceBusMessage implements ReceivedMessage {
    */
   readonly sequenceNumber?: Long;
   /**
-   * @property {string} [deadLetterSource] The name of the queue or subscription that this message
+   * @property The name of the queue or subscription that this message
    * was enqueued on, before it was deadlettered. Only set in messages that have been dead-lettered
    * and subsequently auto-forwarded from the dead-letter queue to another entity. Indicates the
    * entity in which the message was dead-lettered.
@@ -914,7 +937,7 @@ export class ServiceBusMessage implements ReceivedMessage {
   }
 
   /**
-   * Completes a message using it's lock token. This will delete the message from ServiceBus.
+   * Removes the message from Service Bus.
    * @returns Promise<void>.
    */
   async complete(): Promise<void> {
@@ -942,10 +965,10 @@ export class ServiceBusMessage implements ReceivedMessage {
     return receiver!.settleMessage(this, DispositionType.complete);
   }
   /**
-   * Abandons a message using it's lock token. This will make the message available again in
-   * Service Bus for processing.
-   * @param {{ [key: string]: any }} propertiesToModify The properties of the message to modify while
-   * abandoning the message. Abandoning a message will increase the delivery count on the message.
+   * The lock held on the message by the receiver is let go, making the message available again in
+   * Service Bus for another receive operation.
+   * @param propertiesToModify The properties of the message to modify while abandoning the message.
+   *
    * @return Promise<void>.
    */
   async abandon(propertiesToModify?: { [key: string]: any }): Promise<void> {
@@ -975,12 +998,10 @@ export class ServiceBusMessage implements ReceivedMessage {
   }
 
   /**
-   * Defers the processing of the message. In order to receive this message again in the future,
-   * you will need to save the `sequenceNumber` and receive it
-   * using `receiveDeferredMessage(sequenceNumber)`. Deferring messages does not impact message's
-   * expiration, meaning that deferred messages can still expire.
-   * @param [propertiesToModify] The properties of the message to modify while
-   * deferring the message
+   * Defers the processing of the message. Save the `sequenceNumber` of the message, in order to
+   * receive it message again in the future using the `receiveDeferredMessage` method.
+   * @param propertiesToModify The properties of the message to modify while deferring the message
+   *
    * @returns Promise<void>
    */
   async defer(propertiesToModify?: { [key: string]: any }): Promise<void> {
@@ -1009,9 +1030,11 @@ export class ServiceBusMessage implements ReceivedMessage {
   }
 
   /**
-   * Moves the message to the deadletter sub-queue.
-   * @param [options] The DeadLetter options that can be provided while
+   * Moves the message to the deadletter sub-queue. To receive a deadletted message, create a new
+   * QueueClient/SubscriptionClient using the path for the deadletter sub-queue.
+   * @param options The DeadLetter options that can be provided while
    * rejecting the message.
+   *
    * @returns Promise<void>
    */
   async deadLetter(options?: DeadLetterOptions): Promise<void> {
@@ -1061,7 +1084,7 @@ export class ServiceBusMessage implements ReceivedMessage {
    * @returns ServiceBusMessage
    */
   clone(): SendableMessageInfo {
-    // We are returning a SendableMessageInfo object because that object can then be sent to ServiceBus
+    // We are returning a SendableMessageInfo object because that object can then be sent to Service Bus
     const clone: SendableMessageInfo = {
       body: this.body,
       contentType: this.contentType,

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -20,7 +20,7 @@ import { throwIfMessageCannotBeSettled } from "../src/util/errors";
  */
 export enum ReceiveMode {
   /**
-   * Once a message is received in this mode, the reciever has a lock on the message for a
+   * Once a message is received in this mode, the receiver has a lock on the message for a
    * particular duration. If the message is not settled by this time, it lands back on Service Bus
    * to be fetched by the next receive operation.
    * @type {Number}
@@ -677,14 +677,14 @@ export module ReceivedMessageInfo {
       lockToken:
         delivery && delivery.tag && delivery.tag.length !== 0
           ? uuid_to_string(
-              shouldReorderLockToken === true
-                ? reorderLockToken(
-                    typeof delivery.tag === "string" ? Buffer.from(delivery.tag) : delivery.tag
-                  )
-                : typeof delivery.tag === "string"
+            shouldReorderLockToken === true
+              ? reorderLockToken(
+                typeof delivery.tag === "string" ? Buffer.from(delivery.tag) : delivery.tag
+              )
+              : typeof delivery.tag === "string"
                 ? Buffer.from(delivery.tag)
                 : delivery.tag
-            )
+          )
           : undefined,
       ...sbmsg,
       ...props

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -54,44 +54,45 @@ export interface CreateMessageSessionReceiverLinkOptions {
 }
 
 /**
- * Describes the options for creating a SessionReceiver.
+ * Describes the options passed to the `createReceiver` method when using a Queue/Subscription that
+ * has sessions enabled.
  */
 export interface SessionReceiverOptions {
   /**
-   * @property {string} [sessionId] The sessionId for the message session. If null or undefined is
+   * @property The sessionId for the message session. If null or undefined is
    * provided, the SessionReceiver gets created for a randomly chosen session from available sessions
    */
   sessionId: string | undefined;
   /**
-   * @property {number} [maxSessionAutoRenewLockDurationInSeconds] The maximum duration in seconds
-   * until which, the lock on the session will be renewed automatically.
+   * @property The maximum duration in seconds
+   * until which, the lock on the session will be renewed automatically by the sdk.
    * - **Default**: `300` seconds (5 minutes).
-   * - **To disable autolock renewal**, set `maxSessionAutoRenewLockDurationInSeconds` to `0`.
+   * - **To disable autolock renewal**, set this to `0`.
    */
   maxSessionAutoRenewLockDurationInSeconds?: number;
 }
 
 /**
- * Describes the options to control receiving of messages in streaming mode.
+ * Describes the options passed to `registerMessageHandler` method when receiving messages from a
+ * Queue/Subscription which has sessions enabled.
  */
 export interface SessionMessageHandlerOptions {
   /**
-   * @property {boolean} [autoComplete] Indicates whether the message (if not settled by the user)
-   * should be automatically completed after the user provided onMessage handler has been executed.
-   * Completing a message, removes it from the Queue/Subscription.
+   * @property Indicates whether the `complete()` method on the message should automatically be
+   * called by the sdk after the user provided onMessage handler has been executed.
+   * Calling `complete()` on a message removes it from the Queue/Subscription.
    * - **Default**: `true`.
    */
   autoComplete?: boolean;
   /**
-   * @property {number} [newMessageWaitTimeoutInSeconds] The maximum amount of time the receiver
-   * will wait to receive a new message. If no new message is received in this time, then the
-   * receiver will be closed.
-   *
-   * Caution: When setting this value, take into account the time taken to process messages. Once
-   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
-   * invoked on messages.
+   * @property The maximum amount of time the receiver will wait to receive a new message. If no new
+   * message is received in this time, then the receiver will be closed.
    *
    * If this option is not provided, then receiver link will stay open until manually closed.
+   *
+   * **Caution**: When setting this value, take into account the time taken to process messages. Once
+   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
+   * invoked on messages.
    */
   newMessageWaitTimeoutInSeconds?: number;
   /**

--- a/sdk/servicebus/service-bus/src/subscriptionClient.ts
+++ b/sdk/servicebus/service-bus/src/subscriptionClient.ts
@@ -18,39 +18,44 @@ import { ClientEntityContext } from "./clientEntityContext";
 
 /**
  * Describes the client that allows interacting with a Service Bus Subscription.
- * Use the `createSubscriptionClient` function on the Namespace object to instantiate a
+ * Use the `createSubscriptionClient` function on the ServiceBusClient object to instantiate a
  * SubscriptionClient
  * @class SubscriptionClient
  */
 export class SubscriptionClient implements Client {
   /**
-   * @property {string}  The topic name.
+   * @readonly
+   * @property The topic name.
    */
   readonly topicName: string;
   /**
-   * @property {string}  The subscription name.
+   * @readonly
+   * @property The subscription name.
    */
   readonly subscriptionName: string;
 
   /**
-   * @property {string} defaultRuleName Name of the default rule on the subscription.
+   * @readonly
+   * @property defaultRuleName Name of the default rule on the subscription.
    */
   readonly defaultRuleName: string = "$Default";
 
   /**
-   * @property {string} The entitypath for the Service Bus Subscription for which this client is created.
+   * @readonly
+   * @property The path for the Service Bus Subscription for which this client is created.
    */
   readonly entityPath: string;
   /**
-   * @property {string} A unique identifier for the client.
+   * @readonly
+   * @property A unique identifier for this client.
    */
   readonly id: string;
   /**
-   * @property {boolean} _isClosed Denotes if close() was called on this client.
+   * @property Denotes if close() was called on this client.
    */
   private _isClosed: boolean = false;
   /**
-   * @property {ClientEntityContext} _context Describes the amqp connection context for the SubscriptionClient.
+   * @property Describes the amqp connection context for the SubscriptionClient.
    */
   private _context: ClientEntityContext;
 
@@ -85,8 +90,7 @@ export class SubscriptionClient implements Client {
   /**
    * Closes the AMQP link for the receivers created by this client.
    * Once closed, neither the SubscriptionClient nor its receivers can be used for any
-   * further operations. Use the `createSubscriptionClient` function on the Namespace object to
-   * instantiate a new SubscriptionClient.
+   * further operations.
    *
    * @returns {Promise<void>}
    */
@@ -153,13 +157,17 @@ export class SubscriptionClient implements Client {
   }
 
   /**
-   * Creates a Receiver for receiving messages from a Subscription which does not have sessions enabled.
-   * Throws error if an open receiver already exists for this SubscriptionClient.
-   *
-   * Throws error if the Subscription has sessions enabled.
+   * Creates a Receiver for receiving messages from a Queue which does not have sessions enabled.
+   * - Throws error if an open receiver already exists for this QueueClient.
+   * - Throws error if the Queue has sessions enabled.
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
-   * values are `ReceiveMode.peekLock` and `ReceiveMode.receiveAndDelete`
+   * values are:
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * the message for a particular duration. If the message is not settled by this time, it lands back
+   * on Service Bus to be fetched by the next receive operation.
+   * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from
+   * Service Bus.
    *
    * @returns Receiver A receiver to receive messages from a Subscription which does not have
    * sessions enabled.
@@ -168,12 +176,16 @@ export class SubscriptionClient implements Client {
   /**
    * Creates a Receiver for receiving messages from a session enabled Subscription. When no sessionId is
    * given, a random session among the available sessions is used.
-   *
-   * Throws error if an open receiver already exists for given sessionId.
-   * Throws error if the Subscription does not have sessions enabled.
+   * - Throws error if an open receiver already exists for given sessionId.
+   * - Throws error if the Queue does not have sessions enabled.
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
-   * values are `ReceiveMode.peekLock` and `ReceiveMode.receiveAndDelete`
+   * values are:
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * the message for a particular duration. If the message is not settled by this time, it lands back
+   * on Service Bus to be fetched by the next receive operation.
+   * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from
+   * Service Bus.
    * @param sessionOptions Options to provide sessionId and duration of automatic lock renewal for
    * the session receiver.
    *
@@ -218,10 +230,9 @@ export class SubscriptionClient implements Client {
 
   /**
    * Fetches the next batch of active messages (including deferred but not deadlettered messages).
-   * The first call to `peek()` fetches the first active message. Each subsequent call fetches the
+   * - The first call to `peek()` fetches the first active message. Each subsequent call fetches the
    * subsequent message.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * - Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
    * @param [maxMessageCount] The maximum number of messages to peek. Default value `1`.
@@ -235,8 +246,7 @@ export class SubscriptionClient implements Client {
   /**
    * Peeks the desired number of active messages (including deferred but not deadlettered messages)
    * from the specified sequence number.
-   *
-   * Unlike a `received` message, `peeked` message is a read-only version of the message.
+   * - Unlike a `received` message, `peeked` message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`. The lock on it cannot be renewed.
    *
    * @param fromSequenceNumber The sequence number from where to read the message.
@@ -266,6 +276,8 @@ export class SubscriptionClient implements Client {
 
   /**
    * Removes the rule on the subscription identified by the given rule name.
+   * **Note**: If all rules on a subscription are removed, then the subscription will not receive
+   * any more messages.
    * @param ruleName
    */
   async removeRule(ruleName: string): Promise<void> {
@@ -275,7 +287,7 @@ export class SubscriptionClient implements Client {
 
   /**
    * Adds a rule on the subscription as defined by the given rule name, filter and action.
-   * Remember to remove the default true filter on the subscription before adding a rule,
+   * **Note**: Remove the default true filter on the subscription before adding a rule,
    * otherwise, the added rule will have no affect as the true filter will always result in
    * the subscription receiving all messages.
    * @param ruleName Name of the rule

--- a/sdk/servicebus/service-bus/src/subscriptionClient.ts
+++ b/sdk/servicebus/service-bus/src/subscriptionClient.ts
@@ -163,7 +163,7 @@ export class SubscriptionClient implements Client {
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:
-   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the receiver has a lock on
    * the message for a particular duration. If the message is not settled by this time, it lands back
    * on Service Bus to be fetched by the next receive operation.
    * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from
@@ -181,7 +181,7 @@ export class SubscriptionClient implements Client {
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:
-   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the reciever has a lock on
+   * - `ReceiveMode.peekLock`: Once a message is received in this mode, the receiver has a lock on
    * the message for a particular duration. If the message is not settled by this time, it lands back
    * on Service Bus to be fetched by the next receive operation.
    * - `ReceiveMode.receiveAndDelete`: Messages received in this mode get automatically removed from

--- a/sdk/servicebus/service-bus/src/topicClient.ts
+++ b/sdk/servicebus/service-bus/src/topicClient.ts
@@ -15,24 +15,26 @@ import { ClientEntityContext } from "./clientEntityContext";
 
 /**
  * Describes the client that allows interacting with a Service Bus Topic.
- * Use the `createTopicClient` function on the Namespace object to instantiate a TopicClient
+ * Use the `createTopicClient` function on the ServiceBusClient object to instantiate a TopicClient
  * @class TopicClient
  */
 export class TopicClient implements Client {
   /**
-   * @property {string} The entitypath for the Service Bus Topic for which this client is created.
+   * @readonly
+   * @property The path for the Service Bus Topic for which this client is created.
    */
   readonly entityPath: string;
   /**
-   * @property {string} A unique identifier for the client.
+   * @readonly
+   * @property A unique identifier for this client.
    */
   readonly id: string;
   /**
-   * @property {boolean} _isClosed Denotes if close() was called on this client.
+   * @property Denotes if close() was called on this client.
    */
   private _isClosed: boolean = false;
   /**
-   * @property {ClientEntityContext} _context Describes the amqp connection context for the QueueClient.
+   * @property  Describes the amqp connection context for the QueueClient.
    */
   private _context: ClientEntityContext;
 
@@ -58,8 +60,7 @@ export class TopicClient implements Client {
   /**
    * Closes the AMQP link for the sender created by this client.
    * Once closed, neither the TopicClient nor its senders can be used for any
-   * further operations. Use the `createTopicClient` function on the Namespace object to
-   * instantiate a new TopicClient
+   * further operations.
    *
    * @returns {Promise<void>}
    */
@@ -115,7 +116,7 @@ export class TopicClient implements Client {
   /**
    * Creates a Sender to be used for sending messages, scheduling messages to be sent at a later time
    * and cancelling such scheduled messages.
-   * Throws error if an open sender already exists for this TopicClient.
+   * - Throws error if an open sender already exists for this TopicClient.
    *
    * If the Topic has session enabled Subscriptions, then messages sent without the `sessionId`
    * property will go to the dead letter queue of such subscriptions.
@@ -137,8 +138,8 @@ export class TopicClient implements Client {
    * Returns the corresponding dead letter topic name for the given topic and subscription names.
    * Use this in the `createSubscriptionClient` function of the `ServiceBusClient` instance to
    * receive messages from dead letter queue for given subscription.
-   * @param topicName
-   * @param subscriptionName
+   * @param topicName Name of the topic whose dead letter counterpart's name is being fetched
+   * @param subscriptionName Name of the subscription whose dead letter counterpart's name is being fetched
    */
   static getDeadLetterTopicPath(topicName: string, subscriptionName: string): string {
     return `${topicName}/Subscriptions/${subscriptionName}/$DeadLetterQueue`;

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -269,7 +269,7 @@ export function throwIfMessageCannotBeSettled(
   const error = new Error(errorMessage);
   if (receiver) {
     log.error(
-      "An error occured when settling a message using the reciever %s: %O",
+      "An error occured when settling a message using the receiver %s: %O",
       receiver.name,
       error
     );

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -29,6 +29,7 @@ export function getUniqueName(name: string): string {
 }
 
 /**
+ * @internal
  * If you try to turn a Guid into a Buffer in .NET, the bytes of the first three groups get
  * flipped within the group, but the last two groups don't get flipped, so we end up with a
  * different byte order. This is the order of bytes needed to make Service Bus recognize the token.

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -428,7 +428,7 @@ describe("Peek session", function(): void {
       sessionId: useSessionId ? testMessage.sessionId : undefined
     });
 
-    // At this point AMQP reciever link has not been established.
+    // At this point AMQP receiver link has not been established.
     // peek() will not establish the link if sessionId was provided
     const peekedMsgs = await receiver.peek(1);
     should.equal(peekedMsgs.length, 1, "Unexpected number of messages");


### PR DESCRIPTION
We now have our API reference docs published at https://docs.microsoft.com/en-us/javascript/api/%40azure/service-bus/?view=azure-node-preview

This PR is for slight changes across the board to improve the documentation. Some common changes:
- Remove the pattern of `{propertyType} [propertyName]` in the property descriptions, they get printed as is, and therefore are not helpful
<img width="845" alt="Screen Shot 2019-04-21 at 4 51 11 PM" src="https://user-images.githubusercontent.com/16890566/56477049-df212580-6455-11e9-9885-92f92dd72c16.png">

- Add @readonly attributes to properties that are not meant to be updated by the user. This has no affect on docs today, but the hope is that future features in doc generation process picks up on this attribute and shows a readonly tag in the docs

