### PR TITLE
[ServiceBus] include tsconfig.json in service-bus package

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -72,7 +72,8 @@
     "dist/",
     "dist-esm/src/",
     "src/",
-    "typings/src"
+    "typings/src",
+    "tsconfig.json"
   ],
   "scripts": {
     "tslint": "tslint -p . -c tslint.json",


### PR DESCRIPTION
Including tsconfig.json in list of allowed files in package.json. VSCode users may likely see errors if tsconfig.json is not present. 

@bterlson @mikeharder @ramya-rao-a 