### PR TITLE
[Service Bus] Adjust test duration for manual lock renewal usecases

### DIFF
--- a/sdk/servicebus/service-bus/test/stress/stress_messageManualLockRenewal.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_messageManualLockRenewal.ts
@@ -103,7 +103,7 @@ async function receiveMessage(): Promise<void> {
       maxMessageAutoRenewLockDurationInSeconds: 0
     });
 
-    await delay(testDurationInMilliseconds + 5000);
+    await delay(testDurationInMilliseconds + 30000);
     await receiver.close();
   } finally {
     await client.close();

--- a/sdk/servicebus/service-bus/test/stress/stress_sessionManualLockRenewal.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_sessionManualLockRenewal.ts
@@ -110,7 +110,7 @@ async function receiveMessage(sessionId: string): Promise<void> {
       autoComplete: false
     });
 
-    await delay(testDurationInMilliseconds + 5000);
+    await delay(testDurationInMilliseconds + 30000);
     await receiver.close();
   } finally {
     await client.close();


### PR DESCRIPTION
To refer to https://github.com/Azure/azure-sdk-for-js/issues/2398#issuecomment-486447631 for more details.