### PR TITLE
Update deprecated dependency "ms-rest-js"

### DIFF
--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -24,7 +24,7 @@
     "eslint-fix": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c .eslintrc.json --fix --fix-type [problem,suggestion]",
     "lint-and-test": "npm run eslint && npm run test"
   },
-  "files": [  
+  "files": [
     "dist/",
     "dist-esm/src/",
     "src/",
@@ -70,7 +70,7 @@
   "dependencies": {
     "assert": "^1.4.1",
     "events": "^3.0.0",
-    "ms-rest-js": "^1.0.455",
+    "@azure/ms-rest-js": "^1.8.2",
     "tslib": "^1.9.3"
   },
   "private": true

--- a/sdk/template/template/rollup.base.config.js
+++ b/sdk/template/template/rollup.base.config.js
@@ -52,13 +52,13 @@ export function nodeConfig(test = false) {
 export function browserConfig(test = false, production = false) {
   const baseConfig = {
     input: input,
-    external: ["ms-rest-js"],
+    external: ["@azure/ms-rest-js"],
     output: {
       file: "browser/azure-template.js",
       format: "umd",
       name: "ExampleClient",
       sourcemap: true,
-      globals: { "ms-rest-js": "msRest" }
+      globals: { "@azure/ms-rest-js": "msRest" }
     },
     plugins: [
       sourcemaps(),

--- a/sdk/template/template/src/index.ts
+++ b/sdk/template/template/src/index.ts
@@ -7,10 +7,10 @@ export { print };
 
 // this is a utility function from a library that should be external
 // for both node and web
-import { isNode } from "ms-rest-js";
+import { isNode } from "@azure/ms-rest-js";
 
 // exporting some value from a dependency
-export { URLBuilder } from "ms-rest-js";
+export { URLBuilder } from "@azure/ms-rest-js";
 
 export function createEventEmitter() {
   // use event emitter


### PR DESCRIPTION
Upgrade deprecated dependency `ms-rest-js` to latest version of `@azure/ms-rest-js`.  Addresses the following warning during `npm install`:

```
npm WARN deprecated ms-rest-js@1.0.465: Package has been renamed to @azure/ms-rest-js
```