### PR TITLE
Fix broken test rollup script

### DIFF
--- a/sdk/servicebus/service-bus/rollup.test.config.js
+++ b/sdk/servicebus/service-bus/rollup.test.config.js
@@ -3,4 +3,4 @@
 
 import * as base from "./rollup.base.config";
 
-export default [base.nodeConfig(true) /*, base.browserConfig(true)*/];
+export default [base.nodeConfig({ test: true }) /*, base.browserConfig({ test: true })*/];


### PR DESCRIPTION
As part of #2555 the format of input parameters to the rollup script was changed.
Since the change didn't make it to the rollup script used for test files, no test files were rolled up and so no tests were run in last night's CI
