### PR TITLE
[Event Hubs] Fix NYC code coverage breaking changes in 14.0.0

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -39,7 +39,7 @@
     "build": "tsc -p . && rollup -c 2>&1",
     "check-format": "prettier --list-different --config .prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log",
-    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 120000 test-dist/index.js",
+    "coverage": "npm run build-test && nyc --reporter=lcov --exclude-after-remap=false mocha -t 120000 test-dist/index.js",
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config .prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "lint": "tslint -p . -c tslint.json",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -38,7 +38,7 @@
     "build": "tsc -p . && rollup -c 2>&1",
     "check-format": "prettier --list-different --config .prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log",
-    "coverage": "npm run build-test && nyc --reporter=lcov mocha -t 120000 test-dist/index.js",
+    "coverage": "npm run build-test && nyc --reporter=lcov --exclude-after-remap=false mocha -t 120000 test-dist/index.js",
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config .prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "lint": "tslint -p . -c tslint.json",


### PR DESCRIPTION
**Description**
This PR attempts to fix improper functioning of nyc
nyc code coverage is not working after the update from ^13.3.0 to ^14.0.0 [ #2270 ]


**[Breaking Change in 14.0.0]**
https://github.com/istanbuljs/nyc/blob/master/CHANGELOG.md
https://github.com/istanbuljs/nyc#source-map-support-for-pre-instrumented-codebases

More reference - https://github.com/Azure/azure-sdk-for-js/pull/2627