### PR TITLE
[core-amqp] Move @types/async-lock to a normal dependency

### DIFF
--- a/sdk/core/amqp/package.json
+++ b/sdk/core/amqp/package.json
@@ -9,6 +9,7 @@
   "types": "./typings/src/index.d.ts",
   "dependencies": {
     "@azure/ms-rest-nodeauth": "^0.9.2",
+    "@types/async-lock": "^1.1.0",
     "@types/is-buffer": "^2.0.0",
     "async-lock": "^1.1.3",
     "buffer": "^5.2.1",
@@ -32,7 +33,6 @@
     "rhea-promise": "^0.1.15"
   },
   "devDependencies": {
-    "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/debug": "^0.0.31",


### PR DESCRIPTION
Because we export types from the async-lock library, the types for async-lock need to be a regular dependency instead of a dev dependency.

Fixes part of azure/amqp-common-js#59.