### PR TITLE
Disable PR validation for nightly emulator for now

### DIFF
--- a/sdk/cosmosdb/cosmos/.azure-pipelines/cosmos.test.nightly.emulator.yml
+++ b/sdk/cosmosdb/cosmos/.azure-pipelines/cosmos.test.nightly.emulator.yml
@@ -11,13 +11,13 @@ trigger:
     include:
     - sdk/cosmosdb/cosmos
 
-pr:
-  branches:
-    include:
-    - master
-  paths:
-    include:
-    - sdk/cosmosdb/cosmos
+# pr:
+#   branches:
+#     include:
+#     - master
+#   paths:
+#     include:
+#     - sdk/cosmosdb/cosmos
 
 jobs:
   - job: NightlyEmulator


### PR DESCRIPTION
It requires test secrets that are not available to PR from public forks.
Disabling until we have a resolution from ongoing discussion.