### PR TITLE
Fix rollup module resolution with pnpm

### DIFF
--- a/sdk/core/amqp/rollup.base.config.js
+++ b/sdk/core/amqp/rollup.base.config.js
@@ -49,6 +49,7 @@ export function nodeConfig(test = false) {
     input: input,
     external: depNames.concat(externalNodeBuiltins),
     output: { file: "dist/index.js", format: "cjs", sourcemap: true },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace({
@@ -91,6 +92,7 @@ export function browserConfig(test = false) {
       name: "Azure.AMQPCommon",
       sourcemap: true
     },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
 
@@ -122,8 +124,8 @@ export function browserConfig(test = false) {
       }),
 
       nodeResolve({
-        preferBuiltins: false,
-        mainFields: ["module", "browser"]
+        mainFields: ["module", "browser"],
+        preferBuiltins: false
       }),
 
       cjs({

--- a/sdk/eventhub/event-hubs/rollup.base.config.js
+++ b/sdk/eventhub/event-hubs/rollup.base.config.js
@@ -22,6 +22,7 @@ export function nodeConfig(test = false) {
     input: input,
     external: depNames.concat(externalNodeBuiltins),
     output: { file: "dist/index.js", format: "cjs", sourcemap: true },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace({
@@ -80,6 +81,7 @@ export function browserConfig(test = false) {
       sourcemap: true,
       globals: { "ms-rest-js": "msRest" }
     },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace(
@@ -95,8 +97,8 @@ export function browserConfig(test = false) {
         }
       ),
       nodeResolve({
-        preferBuiltins: false,
-        browser: true
+        mainFields: ['module', 'browser'],
+        preferBuiltins: false
       }),
       cjs({
         namedExports: { events: ["EventEmitter"] }

--- a/sdk/eventhub/event-processor-host/rollup.base.config.js
+++ b/sdk/eventhub/event-processor-host/rollup.base.config.js
@@ -22,6 +22,7 @@ export function nodeConfig(test = false) {
     input: input,
     external: depNames.concat(externalNodeBuiltins),
     output: { file: "dist/index.js", format: "cjs", sourcemap: true },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace({
@@ -80,6 +81,7 @@ export function browserConfig(test = false) {
       sourcemap: true,
       globals: { "ms-rest-js": "msRest" }
     },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace(
@@ -95,8 +97,8 @@ export function browserConfig(test = false) {
         }
       ),
       nodeResolve({
-        preferBuiltins: false,
-        browser: true
+        mainFields: ['module', 'browser'],
+        preferBuiltins: false
       }),
       cjs({
         namedExports: { events: ["EventEmitter"] }

--- a/sdk/keyvault/keyvault/rollup.config.js
+++ b/sdk/keyvault/keyvault/rollup.config.js
@@ -24,6 +24,7 @@ const config = {
  * regenerated.
  */`
   },
+  preserveSymlinks: false,
   plugins: [
     nodeResolve({ module: true })
   ]

--- a/sdk/servicebus/service-bus/rollup.base.config.js
+++ b/sdk/servicebus/service-bus/rollup.base.config.js
@@ -41,6 +41,7 @@ export function nodeConfig({ test = false, production = false } = {}) {
     input: input,
     external: depNames.concat(externalNodeBuiltins),
     output: { file: "dist/index.js", format: "cjs", sourcemap: true },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace({
@@ -92,6 +93,7 @@ export function browserConfig({ test = false, production = false } = {}) {
       name: "Azure.Messaging.ServiceBus",
       sourcemap: true
     },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace(
@@ -123,8 +125,8 @@ export function browserConfig({ test = false, production = false } = {}) {
       }),
 
       nodeResolve({
-        preferBuiltins: false,
-        browser: true
+        mainFields: ['module', 'browser'],
+        preferBuiltins: false
       }),
       cjs({
         namedExports: { events: ["EventEmitter"] }

--- a/sdk/storage/storage-blob/rollup.config.js
+++ b/sdk/storage/storage-blob/rollup.config.js
@@ -22,6 +22,7 @@ const nodeRollupConfigFactory = () => {
       format: "cjs",
       sourcemap: true
     },
+    preserveSymlinks: false,
     plugins: [nodeResolve(), uglify()]
   };
 };
@@ -36,6 +37,7 @@ const browserRollupConfigFactory = isProduction => {
       name: "azblob",
       sourcemap: true
     },
+    preserveSymlinks: false,
     plugins: [
       replace({
         delimiters: ["", ""],

--- a/sdk/storage/storage-file/rollup.config.js
+++ b/sdk/storage/storage-file/rollup.config.js
@@ -22,6 +22,7 @@ const nodeRollupConfigFactory = () => {
       format: "cjs",
       sourcemap: true
     },
+    preserveSymlinks: false,
     plugins: [nodeResolve(), uglify()]
   };
 };
@@ -36,6 +37,7 @@ const browserRollupConfigFactory = isProduction => {
       name: "azfile",
       sourcemap: true
     },
+    preserveSymlinks: false,
     plugins: [
       replace({
         delimiters: ["", ""],

--- a/sdk/storage/storage-queue/rollup.config.js
+++ b/sdk/storage/storage-queue/rollup.config.js
@@ -22,6 +22,7 @@ const nodeRollupConfigFactory = () => {
             format: "cjs",
             sourcemap: true
         },
+        preserveSymlinks: false,
         plugins: [nodeResolve(), uglify()]
     };
 };
@@ -36,6 +37,7 @@ const browserRollupConfigFactory = isProduction => {
             name: "azqueue",
             sourcemap: true
         },
+        preserveSymlinks: false,
         plugins: [
             replace({
                 delimiters: ["", ""],

--- a/sdk/template/template/rollup.base.config.js
+++ b/sdk/template/template/rollup.base.config.js
@@ -17,6 +17,7 @@ export function nodeConfig(test = false) {
     input: input,
     external: depNames.concat(externalNodeBuiltins),
     output: { file: "dist/index.js", format: "cjs", sourcemap: true },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace({
@@ -60,6 +61,7 @@ export function browserConfig(test = false, production = false) {
       sourcemap: true,
       globals: { "@azure/ms-rest-js": "msRest" }
     },
+    preserveSymlinks: false,
     plugins: [
       sourcemaps(),
       replace({


### PR DESCRIPTION
Because PNPM uses symlinks, Rollup (via the node-resolve plugin) was unable to resolve a lot of modules. The browser bundles likely never worked right under PNPM. This fixes the issue so that node-resolve is able to pull in modules across symlinks.