### PR TITLE
[Service Bus] Include Copyright text in all the samples

### DIFF
--- a/sdk/servicebus/service-bus/samples/browserSample.html
+++ b/sdk/servicebus/service-bus/samples/browserSample.html
@@ -1,4 +1,8 @@
-<!-- This sample demonstrates a simple send message operation.  
+<!-- 
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT Licence.
+  
+This sample demonstrates a simple send message operation.  
 Refer to other Javascript samples and replace code in main() to try them out -->
 
 <!-- Line that imports the SDK source script for use in browser -->

--- a/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/deferral.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/deferral.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how the defer() function can be used to defer a message for later processing.
 
   In this sample, we have an application that gets cooking instructions out of order. It uses

--- a/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/movingMessagesToDLQ.js
@@ -1,9 +1,12 @@
 /*
-    This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
-    the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
-    https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
 
-    Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
+  This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
+  the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
+  https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+
+  Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
 */
 
 const { ServiceBusClient, ReceiveMode } = require("@azure/service-bus");

--- a/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/processMessageFromDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/processMessageFromDLQ.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates retrieving a message from a dead letter queue, editing it and
   sending it back to the main queue.
 

--- a/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/sessionState.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates usage of SessionState.
 
   We take for example the context of an online shopping app and see how we can use Session State

--- a/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/topicFilters.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advancedFeatures/topicFilters.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample illustrates how to use topic subscriptions and filters for splitting
   up a message stream into multiple streams based on message properties.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/browseMessages.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how the peek() function can be used to browse a Service Bus message.
 
   See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/interactiveLogin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/interactiveLogin.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how to create a namespace using AAD token credentials
   obtained from interactive login.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/loginWithAzureAccount.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/loginWithAzureAccount.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how to create a namespace using AAD token credentials
   obtained from signing in through your Azure account.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/receiveMessagesLoop.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/receiveMessagesLoop.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how the receiveMessages() function can be used to receive Service Bus
   messages in a loop.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/receiveMessagesStreaming.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how the receive() function can be used to receive Service Bus messages
   in a stream.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/scheduledMessages.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how the scheduleMessage() function can be used to schedule messages to
   appear on a Service Bus Queue/Subscription at a later time.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/sendMessages.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how the send() function can be used to send messages to Service Bus
   Queue/Topic.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/servicePrincipalLogin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/servicePrincipalLogin.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how to create a namespace using AAD token credentials
   obtained from using Service Principal Secrets.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/session.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how to send/receive messages to/from session enabled queues/subscriptions
   in Service Bus.
 

--- a/sdk/servicebus/service-bus/samples/javascript/gettingStarted/useProxy.js
+++ b/sdk/servicebus/service-bus/samples/javascript/gettingStarted/useProxy.js
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+  
   This sample demonstrates how to create a ServiceBusClient meant to be used in an environment
   where outgoing network requests have to go through a proxy server
 */

--- a/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/deferral.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the defer() function can be used to defer a message for later processing.
 
   In this sample, we have an application that gets cooking instructions out of order. It uses

--- a/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/movingMessagesToDLQ.ts
@@ -1,9 +1,12 @@
 /*
-    This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
-    the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
-    https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
 
-    Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
+  This sample demonstrates scenarios as to how a Service Bus message can be explicitly moved to
+  the DLQ. For other implicit ways when Service Bus messages get moved to DLQ, refer to -
+  https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+
+  Run processMessagesInDLQ example after this to see how the messages in DLQ can be reprocessed.
 */
 
 import { ServiceBusClient, ReceiveMode } from "@azure/service-bus";

--- a/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/processMessageFromDLQ.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates retrieving a message from a dead letter queue, editing it and
   sending it back to the main queue.
 

--- a/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/sessionState.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates usage of SessionState.
 
   We take for example the context of an online shopping app and see how we can use Session State

--- a/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/topicFilters.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/advancedFeatures/topicFilters.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample illustrates how to use topic subscriptions and filters for splitting
   up a message stream into multiple streams based on message properties.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/browseMessages.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the peek() function can be used to browse a Service Bus message.
 
   See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/interactiveLogin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/interactiveLogin.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to create a namespace using AAD token credentials
   obtained from interactive login.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/loginWithAzureAccount.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/loginWithAzureAccount.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to create a namespace using AAD token credentials
   obtained from signing in through your Azure account.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/receiveMessagesLoop.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the receiveMessages() function can be used to receive Service Bus
   messages in a loop.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/receiveMessagesStreaming.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the receive() function can be used to receive Service Bus messages
   in a stream.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/scheduledMessages.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the scheduleMessage() function can be used to schedule messages to
   appear on a Service Bus Queue/Subscription at a later time.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/sendMessages.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the send() function can be used to send messages to Service Bus
   Queue/Topic.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/servicePrincipalLogin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/servicePrincipalLogin.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to create a namespace using AAD token credentials
   obtained from using Service Principal Secrets.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/session.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/session.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to send/receive messages to/from session enabled queues/subscriptions
   in Service Bus.
 

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/useProxy.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to create a ServiceBusClient meant to be used in an environment
   where outgoing network requests have to go through a proxy server
 */


### PR DESCRIPTION
Updated all the samples and included the Copyright text:
```
/*
  Copyright (c) Microsoft Corporation. All rights reserved.
  Licensed under the MIT Licence.
..
..
*/
```