### PR TITLE
[Event Hubs] Include Copyright text in all the samples

### DIFF
--- a/sdk/eventhub/event-hubs/samples/getHubRuntimeInfo.ts
+++ b/sdk/eventhub/event-hubs/samples/getHubRuntimeInfo.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to use getHubRuntimeInformation() and
   getPartitionInformation() to get information about the Event Hubs instance.
 */

--- a/sdk/eventhub/event-hubs/samples/interactiveLogin.ts
+++ b/sdk/eventhub/event-hubs/samples/interactiveLogin.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to instantiate EventHubsClien using AAD token credentials
   obtained from interactive login.
 

--- a/sdk/eventhub/event-hubs/samples/iotGetHubRuntimeInfo.ts
+++ b/sdk/eventhub/event-hubs/samples/iotGetHubRuntimeInfo.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
  This sample demonstrates how to use getHubRuntimeInformation() and
  getPartitionInformation() to get information about the Iot Hub instance.
 */

--- a/sdk/eventhub/event-hubs/samples/loginWithAzureAccount.ts
+++ b/sdk/eventhub/event-hubs/samples/loginWithAzureAccount.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to instantiate EventHubsClient using AAD token credentials
   obtained from signing in through your Azure account.
 

--- a/sdk/eventhub/event-hubs/samples/receiveMessagesLoop.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveMessagesLoop.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the receiveBatch() function can be used to receive Event Hubs
   messages in a loop.
 

--- a/sdk/eventhub/event-hubs/samples/receiveMessagesStreaming.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveMessagesStreaming.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the receive() function can be used to receive Event Hubs messages
   in a stream.
 

--- a/sdk/eventhub/event-hubs/samples/sendMessages.ts
+++ b/sdk/eventhub/event-hubs/samples/sendMessages.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how the send() function can be used to send messages to Event Hubs.
 
   See https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-about

--- a/sdk/eventhub/event-hubs/samples/servicePrincipalLogin.ts
+++ b/sdk/eventhub/event-hubs/samples/servicePrincipalLogin.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to instantiate EventHubsClient using AAD token credentials
   obtained from using Service Principal Secrets.
 

--- a/sdk/eventhub/event-hubs/samples/useProxy.ts
+++ b/sdk/eventhub/event-hubs/samples/useProxy.ts
@@ -1,4 +1,7 @@
 /*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
   This sample demonstrates how to create a EventHubsClient meant to be used in an environment
   where outgoing network requests have to go through a proxy server
 */


### PR DESCRIPTION
Updated all the samples and included the Copyright text:
```
/*
  Copyright (c) Microsoft Corporation. All rights reserved.
  Licensed under the MIT Licence.
..
..
*/
```