### PR TITLE
[Service Bus] Remove support for newMessageWaitTimeoutInSeconds

### DIFF
--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -45,6 +45,7 @@ export class BatchingReceiver extends MessageReceiver {
    */
   constructor(context: ClientEntityContext, options?: ReceiveOptions) {
     super(context, ReceiverType.batching, options);
+    this.newMessageWaitTimeoutInSeconds = 1;
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -258,7 +258,6 @@ export class MessageReceiver extends LinkEntity {
     if (typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0) {
       this.maxConcurrentCalls = options.maxConcurrentCalls;
     }
-    this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
     this.resetTimerOnNewMessageReceived = () => {
       /** */
     };

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -36,17 +36,6 @@ export interface MessageHandlerOptions {
    */
   maxMessageAutoRenewLockDurationInSeconds?: number;
   /**
-   * @property The maximum amount of time the receiver will wait to receive a new message. If no new
-   * message is received in this time, then the receiver will be closed.
-   *
-   * If this option is not provided, then receiver link will stay open until manually closed.
-   *
-   * **Caution**: When setting this value, take into account the time taken to process messages. Once
-   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
-   * invoked on messages.
-   */
-  newMessageWaitTimeoutInSeconds?: number;
-  /**
    * @property The maximum number of concurrent calls that the sdk can make to the user's message
    * handler. Once this limit has been reached, further messages will not be received until atleast
    * one of the calls to the user's message handler has completed.

--- a/sdk/servicebus/service-bus/src/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receiver.ts
@@ -70,8 +70,7 @@ export class Receiver {
   /**
    * Registers handlers to deal with the incoming stream of messages over an AMQP receiver link
    * from a Queue/Subscription.
-   * To stop receiving messages, call `close()` on the Receiver or set the property
-   * `newMessageWaitTimeoutInSeconds` in the options to provide a timeout.
+   * To stop receiving messages, call `close()` on the Receiver.
    *
    * @param onMessage - Handler for processing each incoming message.
    * @param onError - Handler for any error that occurs while receiving or processing messages.
@@ -139,8 +138,7 @@ export class Receiver {
     if (!this._context.batchingReceiver || !this._context.batchingReceiver.isOpen()) {
       const options: ReceiveOptions = {
         maxConcurrentCalls: 0,
-        receiveMode: this._receiveMode,
-        newMessageWaitTimeoutInSeconds: 1
+        receiveMode: this._receiveMode
       };
       this._context.batchingReceiver = BatchingReceiver.create(this._context, options);
     }
@@ -616,8 +614,7 @@ export class SessionReceiver {
   /**
    * Registers handlers to deal with the incoming stream of messages over an AMQP receiver link
    * from a Queue/Subscription.
-   * To stop receiving messages, call `close()` on the SessionReceiver or set the property
-   * `newMessageWaitTimeoutInSeconds` in the options to provide a timeout.
+   * To stop receiving messages, call `close()` on the SessionReceiver.
    *
    * @param onMessage - Handler for processing each incoming message.
    * @param onError - Handler for any error that occurs while receiving or processing messages.

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -85,17 +85,6 @@ export interface SessionMessageHandlerOptions {
    */
   autoComplete?: boolean;
   /**
-   * @property The maximum amount of time the receiver will wait to receive a new message. If no new
-   * message is received in this time, then the receiver will be closed.
-   *
-   * If this option is not provided, then receiver link will stay open until manually closed.
-   *
-   * **Caution**: When setting this value, take into account the time taken to process messages. Once
-   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
-   * invoked on messages.
-   */
-  newMessageWaitTimeoutInSeconds?: number;
-  /**
    * @property {number} [maxConcurrentCalls] The maximum number of concurrent calls that the library
    * can make to the user's message handler. Once this limit has been reached, more messages will
    * not be received until atleast one of the calls to the user's message handler has completed.
@@ -114,6 +103,17 @@ export interface SessionManagerOptions extends SessionMessageHandlerOptions {
    * - **Default**: `2000`.
    */
   maxConcurrentSessions?: number;
+  /**
+   * @property The maximum amount of time the receiver will wait to receive a new message. If no new
+   * message is received in this time, then the receiver will be closed.
+   *
+   * If this option is not provided, then receiver link will stay open until manually closed.
+   *
+   * **Caution**: When setting this value, take into account the time taken to process messages. Once
+   * the receiver is closed, operations like complete()/abandon()/defer()/deadletter() cannot be
+   * invoked on messages.
+   */
+  newMessageWaitTimeoutInSeconds?: number;
 }
 
 /**
@@ -541,7 +541,6 @@ export class MessageSession extends LinkEntity {
     if (typeof options.maxConcurrentCalls === "number" && options.maxConcurrentCalls > 0) {
       this.maxConcurrentCalls = options.maxConcurrentCalls;
     }
-    this.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
 
     // If explicitly set to false then autoComplete is false else true (default).
     this.autoComplete = options.autoComplete === false ? options.autoComplete : true;

--- a/sdk/servicebus/service-bus/src/session/sessionManager.ts
+++ b/sdk/servicebus/service-bus/src/session/sessionManager.ts
@@ -130,6 +130,9 @@ export class SessionManager {
     onError: OnError,
     options?: SessionManagerOptions
   ): Promise<void> {
+    if (!options) {
+      options = {};
+    }
     const connectionId = this._context.namespace.connectionId;
     const noActiveSessionBackOffInSeconds = 10;
     while (!this._isCancelRequested) {
@@ -178,6 +181,9 @@ export class SessionManager {
           callee: SessionCallee.sessionManager,
           ...options
         });
+
+        messageSession.newMessageWaitTimeoutInSeconds = options.newMessageWaitTimeoutInSeconds;
+
         if (this._isCancelRequested) {
           log.sessionManager(
             "[%s] Since cancellation was requested, we will close the messageSession with id '%s'.",


### PR DESCRIPTION
This PR removes support for `newMessageWaitTimeoutInSeconds` option in `registerMessageHandler` method.

We will be adding timeouts and cancellations in the future updates based on the work done for Event Hubs as part of #2641. Having this feature can result in breaking changes in the future. Since this feature was more of a "good to have" than customer driven or requirements driven, removing this for now.

For more details, please see #2764