### PR TITLE
Revert "Add preinstall message to Rush projects"

### DIFF
--- a/sdk/core/amqp-common/package.json
+++ b/sdk/core/amqp-common/package.json
@@ -97,7 +97,6 @@
     "lint": "tslint -p . -c tslint.json --exclude samples/**/*.ts --exclude test/**/*.ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -35,7 +35,6 @@
     "lint": "tslint --project tsconfig.json",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "smoke-test": "node ts-test.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -51,7 +51,6 @@
     "lint": "tslint -p . -c tslint.json",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -49,7 +49,6 @@
     "lint": "tslint -p . -c tslint.json",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -42,7 +42,6 @@
     "lint": "echo skipped",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "prepare": "npm run build",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",

--- a/sdk/keyvault/keyvault/package.json
+++ b/sdk/keyvault/keyvault/package.json
@@ -55,7 +55,6 @@
     "lint": "echo skipped",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -108,7 +108,6 @@
     "lint-fix": "eslint -c ../../.eslintrc.json src test samples --ext .ts --fix --fix-type [problem,suggestion]",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -84,7 +84,6 @@
     "lint": "echo skipped",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -84,7 +84,6 @@
     "lint": "echo skipped",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -82,7 +82,6 @@
     "lint": "echo skipped",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -27,7 +27,6 @@
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c ../../.eslintrc.json",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "preinstall": "node ../../../common/scripts/rush-welcome.js",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",


### PR DESCRIPTION
The preinstall script gets packaged into the release which breaks the released package. It was a nice idea (to show a helpful message if a dev runs `npm install` inside a package directory) but there's no hook that ONLY triggers when installing locally.

The error that occurs when trying to install a released package with this commit is:

```
> @azure/amqp-common@1.0.0-preview.4 preinstall D:\Git\js\sdk\servicebus\service-bus\node_modules\@azure\amqp-common
> node ../../../common/scripts/rush-welcome.js

internal/modules/cjs/loader.js:584
    throw err;
    ^

Error: Cannot find module 'D:\Git\js\sdk\servicebus\service-bus\common\scripts\rush-welcome.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
    at Function.Module._load (internal/modules/cjs/loader.js:508:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @azure/amqp-common@1.0.0-preview.4 preinstall: `node ../../../common/scripts/rush-welcome.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @azure/amqp-common@1.0.0-preview.4 preinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\mharder\AppData\Roaming\npm-cache\_logs\2019-05-09T17_31_15_375Z-debug.log
```
