### PR TITLE
[Service Bus] Better error message when session cannot be locked

### DIFF
--- a/sdk/servicebus/service-bus/src/queueClient.ts
+++ b/sdk/servicebus/service-bus/src/queueClient.ts
@@ -111,7 +111,8 @@ export class QueueClient implements Client {
   /**
    * Creates a Receiver for receiving messages from a Queue which does not have sessions enabled.
    * - Throws error if an open receiver already exists for this QueueClient.
-   * - Throws error if the Queue has sessions enabled.
+   * - Throws `InvalidOperationError` if the Queue has sessions enabled (in which case, use the
+   * overload of this method which takes `sessionOptions` argument)
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:
@@ -129,7 +130,9 @@ export class QueueClient implements Client {
    * Creates a Receiver for receiving messages from a session enabled Queue. When no sessionId is
    * given, a random session among the available sessions is used.
    * - Throws error if an open receiver already exists for given sessionId.
-   * - Throws error if the Queue does not have sessions enabled.
+   * - Throws `SessionCannotBeLockedError` if the Queue does not have sessions enabled (in which
+   * case do not pass the `sessionOptions` argument) or if Service Bus is not able to get a lock on
+   * the session (in which case try again after some time)
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -1016,16 +1016,20 @@ export class MessageSession extends LinkEntity {
           this._receiver.source.filter &&
           this._receiver.source.filter[Constants.sessionFilterName];
         let errorMessage: string = "";
-        // SB allows a sessionId with empty string value :)
+        // Service Bus creates receiver successfully with no sessionId if it fails to get a lock on
+        // the session instead of throwing the SessionCannotBeLockedError. So, we throw it instead.
         if (receivedSessionId == undefined) {
-          errorMessage =
-            `Received an incorrect sessionId '${receivedSessionId}' while creating ` +
-            `the receiver '${this.name}'.`;
-        }
-        if (this.sessionId != undefined && receivedSessionId !== this.sessionId) {
-          errorMessage =
-            `Received sessionId '${receivedSessionId}' does not match the provided ` +
-            `sessionId '${this.sessionId}' while creating the receiver '${this.name}'.`;
+          if (this.sessionId == undefined) {
+            // User asked for a random session to be picked, but there are no sessions free to take
+            // a lock on or the Queue/Subscription doesnt have sessions enabled.
+            errorMessage = `There are no sessions available for receiving messages.`;
+          } else {
+            // User passed a sessionId, but cannot get a lock on it either because somebody else
+            // has a lock on it or the Queue/Subscription doesnt have sessions enabled.
+            errorMessage = `The session with id '${
+              this.sessionId
+            }' is not available for receiving messages.`;
+          }
         }
         if (errorMessage) {
           const error = translate({

--- a/sdk/servicebus/service-bus/src/subscriptionClient.ts
+++ b/sdk/servicebus/service-bus/src/subscriptionClient.ts
@@ -109,9 +109,9 @@ export class SubscriptionClient implements Client {
 
   /**
    * Creates a Receiver for receiving messages from a Subscription which does not have sessions enabled.
-   * Throws error if an open receiver already exists for this SubscriptionClient.
-   *
-   * Throws error if the Subscription has sessions enabled.
+   * - Throws error if an open receiver already exists for this SubscriptionClient.
+   * - Throws `InvalidOperationError` if the Subscription has sessions enabled (in which case, use the
+   * overload of this method which takes `sessionOptions` argument)
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:
@@ -129,7 +129,9 @@ export class SubscriptionClient implements Client {
    * Creates a Receiver for receiving messages from a session enabled Subscription. When no sessionId is
    * given, a random session among the available sessions is used.
    * - Throws error if an open receiver already exists for given sessionId.
-   * - Throws error if the Queue does not have sessions enabled.
+   * - Throws `SessionCannotBeLockedError` if the Subscription does not have sessions enabled (in which
+   * case do not pass the `sessionOptions` argument) or if Service Bus is not able to get a lock on
+   * the session (in which case try again after some time)
    *
    * @param receiveMode An enum indicating the mode in which messages should be received. Possible
    * values are:


### PR DESCRIPTION
When creating a receiver for a session enabled Queue/Subscription, and Service Bus cannot get a lock on the session, it sometimes creates receiver nevertheless but with no sessionId set on it. We have been throwing `SessionCannotBeLockedError` in such cases.

The same error is thrown when user attempts to create a session receiver for a Queue/Subscription with sessions not enabled.

As part of the work being done for #2658, this PR updates the corresponding error message to be more clear