### PR TITLE
[Service Bus] Allow empty string as sessionId

### DIFF
--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -147,7 +147,7 @@ export namespace ClientEntityContext {
     );
 
     (entityContext as ClientEntityContext).getReceiver = (name: string, sessionId?: string) => {
-      if (sessionId && entityContext.expiredMessageSessions[sessionId]) {
+      if (sessionId != undefined && entityContext.expiredMessageSessions[sessionId]) {
         const error = new Error(
           `The session lock has expired on the session with id ${sessionId}.`
         );

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -314,7 +314,7 @@ export class ManagementClient extends LinkEntity {
         Buffer.from(fromSequenceNumber.toBytesBE())
       );
       messageBody[Constants.messageCount] = types.wrap_int(maxMessageCount);
-      if (sessionId) {
+      if (sessionId != undefined) {
         messageBody[Constants.sessionIdMapKey] = sessionId;
       }
       const request: AmqpMessage = {

--- a/sdk/servicebus/service-bus/src/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receiver.ts
@@ -429,7 +429,7 @@ export class SessionReceiver {
       receiveMode === ReceiveMode.receiveAndDelete ? receiveMode : ReceiveMode.peekLock;
     this._sessionOptions = sessionOptions;
 
-    if (sessionOptions.sessionId) {
+    if (sessionOptions.sessionId != undefined) {
       sessionOptions.sessionId = String(sessionOptions.sessionId);
 
       // Check if receiver for given session already exists
@@ -753,15 +753,8 @@ export class SessionReceiver {
         .maxSessionAutoRenewLockDurationInSeconds,
       receiveMode: this._receiveMode
     });
-    // By this point, we should have a valid sessionId on the messageSession
-    // If not, the receiver cannot be used, so throw error.
-    if (!this._messageSession.sessionId) {
-      const error = new Error("Something went wrong. Cannot lock a session.");
-      log.error(`[${this._context.namespace.connectionId}] %O`, error);
-      throw error;
-    }
     this._sessionId = this._messageSession.sessionId;
-    delete this._context.expiredMessageSessions[this._messageSession.sessionId];
+    delete this._context.expiredMessageSessions[this._messageSession.sessionId!];
   }
 
   private _throwIfAlreadyReceiving(): void {

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -136,7 +136,7 @@ export class MessageSession extends LinkEntity {
    */
   sessionLockedUntilUtc?: Date;
   /**
-   * @property {string} [sessionId] The sessionId for the message session.
+   * @property {string} [sessionId] The sessionId for the message session. Empty string is valid sessionId
    */
   sessionId?: string;
   /**

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -134,7 +134,7 @@ export function getReceiverClosedErrorMsg(
       `Please create a new client using an instance of ServiceBusClient.`
     );
   }
-  if (!sessionId) {
+  if (sessionId == undefined) {
     return (
       `The receiver for "${entityPath}" has been closed and can no longer be used. ` +
       `Please create a new receiver using the "createReceiver" function on the ${clientType}.`
@@ -152,7 +152,7 @@ export function getReceiverClosedErrorMsg(
  * @param sessionId If using session receiver, then the id of the session
  */
 export function getAlreadyReceivingErrorMsg(entityPath: string, sessionId?: string): string {
-  if (!sessionId) {
+  if (sessionId == undefined) {
     return `The receiver for "${entityPath}" is already receiving messages.`;
   }
   return `The receiver for session "${sessionId}" for "${entityPath}" is already receiving messages.`;


### PR DESCRIPTION
_Offshoot from #2761_

Service Bus considers empty string to be a valid sessionId

This PR updates places in our library that considers a session id with empty string as invalid value.

- `if (sesisonId)` is replaced with `if (sessionId != undefined)`
- `if (!sessionId)` is replaced with `if (sessionId == undefined)`

Please note that `a == undefined` is the same as `a === undefined || a === null`
and `a != undefined` is the same as `a !== undefined && a !== null`