### PR TITLE
[Service Bus] Skip unnecessary error in fromAmqpMessage

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -461,7 +461,9 @@ export function fromAmqpMessage(
   shouldReorderLockToken?: boolean
 ): ReceivedMessageInfo {
   if (!msg) {
-    throw new Error("'msg' cannot be null or undefined.");
+    msg = {
+      body: undefined
+    };
   }
   const sbmsg: SendableMessageInfo = {
     body: msg.body


### PR DESCRIPTION
_Offshoot from #2761_

`fromAmqpMessage` is an helper method used by the library to convert a message received over an AMQP link to a type that we want to expose to our users
- When a message is received over AMQP receiver link, for eg: `receiveMessages` or `registerMessageHandler`
- When a message is received over the $management link, for eg: `peek` or `receiveDeferredMessages`

We currently throw an error when the input parameter to this helper method is not provided.

While these kind of parameter validations are helpful for user facing apis to validate user input, this particular check and error is an overkill for an internal function.

This PR removes the error being thrown and replaces it with an empty message.

This work is being done as part of #2658 where we are removing the errors that are not actionable by the user.