### PR TITLE
[Service Bus] Throw LockLostError when AMQP link not alive

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -1076,9 +1076,7 @@ export function throwIfMessageCannotBeSettled(
       getErrorMessageNotSupportedInReceiveAndDeleteMode(`${operation} the message`)
     );
   } else if (isRemoteSettled) {
-    error = new Error(
-      `Failed to ${operation} the message as this message has been already settled.`
-    );
+    error = new Error(`Failed to ${operation} the message as this message is already settled.`);
   } else if (!receiver || !receiver.isOpen()) {
     const errorMessage =
       `Failed to ${operation} the message as the AMQP link with which the message was ` +

--- a/sdk/servicebus/service-bus/src/util/errors.ts
+++ b/sdk/servicebus/service-bus/src/util/errors.ts
@@ -261,6 +261,7 @@ export function throwTypeErrorIfParameterIsEmptyString(
 }
 
 /**
+ * @internal
  * Gets error message for when an operation is not supported in ReceiveAndDelete mode
  * @param failedToDo A string to add to the placeholder in the error message. Denotes the action
  * that is not supported in ReceiveAndDelete mode

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -703,7 +703,7 @@ describe("Streaming - Settle an already Settled message throws error", () => {
   const testError = (err: Error, operation: DispositionType) => {
     should.equal(
       err.message,
-      `Failed to ${operation} the message as this message has been already settled.`,
+      `Failed to ${operation} the message as this message is already settled.`,
       "ErrorMessage is different than expected"
     );
     errorWasThrown = true;

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -830,7 +830,7 @@ describe("Sessions Streaming - Settle an already Settled message throws error", 
   const testError = (err: Error, operation: DispositionType) => {
     should.equal(
       err.message,
-      `Failed to ${operation} the message as this message has been already settled.`,
+      `Failed to ${operation} the message as this message is already settled.`,
       "ErrorMessage is different than expected"
     );
     errorWasThrown = true;


### PR DESCRIPTION
Offshoot from #2761

An AMQP receiver link may die due to errors from service or network loss or due to user closing the receiver object. Messages received from such links can no longer be settled. We throw a generic error for such cases.

In the spirit of #2658, this PR makes the below changes
- Use `SesisonLockLostError` or `MessageLockLostError` for above cases
- Improve the error message for above cases
- Document all errors thrown by the library when settling messages

The reason to chose the LockLostError is because the minute the AMQP receiver link dies, the service releases the lock on the message/session
