### PR TITLE
[Event Hubs] Combine ClientOptionsBase and ClientOptions to simplify the EventHubClient creation experience

### DIFF
--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -11,7 +11,8 @@ import {
   delay,
   ConnectionContextBase,
   CreateConnectionContextBaseParameters,
-  EventHubConnectionConfig
+  EventHubConnectionConfig,
+  TokenProvider
 } from "@azure/amqp-common";
 import { ManagementClient, ManagementClientOptions } from "./managementClient";
 import { ClientOptions } from "./eventHubClient";
@@ -74,12 +75,12 @@ export namespace ConnectionContext {
     return finalUserAgent;
   }
 
-  export function create(config: EventHubConnectionConfig, options?: ConnectionContextOptions): ConnectionContext {
+  export function create(config: EventHubConnectionConfig,  tokenProvider: TokenProvider, options?: ConnectionContextOptions): ConnectionContext {
     if (!options) options = {};
 
     const parameters: CreateConnectionContextBaseParameters = {
       config: config,
-      tokenProvider: options.tokenProvider,
+      tokenProvider: tokenProvider,
       dataTransformer: options.dataTransformer,
       isEntityPathRequired: true,
       connectionProperties: {

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -322,12 +322,21 @@ export class EventHubClient {
    * @returns {EventHubClient} - An instance of the eventhub client.
    */
   static createFromConnectionString(connectionString: string, path?: string, options?: ClientOptions): EventHubClient {
+    if (!connectionString || (connectionString && typeof connectionString !== "string")) {
+      throw new Error("'connectionString' is a required parameter and must be of type: 'string'.");
+    }
     const config = EventHubConnectionConfig.create(connectionString, path);
-    EventHubConnectionConfig.validate(config);
 
     config.webSocket = options && options.webSocket;
     config.webSocketEndpointPath = "$servicebus/websocket";
     config.webSocketConstructorOptions = options && options.webSocketConstructorOptions;
+
+    if (!config.entityPath) {
+      throw new Error(
+        `Either the connectionString must have "EntityPath=<path-to-entity>" or ` +
+          `you must provide "path", while creating the client`
+      );
+    }
 
     const tokenProvider = new SasTokenProvider(
       config.endpoint,
@@ -370,12 +379,17 @@ export class EventHubClient {
     tokenProvider: TokenProvider,
     options?: ClientOptions
   ): EventHubClient {
-    host = String(host);
-    entityPath = String(entityPath);
-    if (!tokenProvider) {
-      throw new TypeError('Missing parameter "tokenProvider"');
+    if (!host || (host && typeof host !== "string")) {
+      throw new Error("'host' is a required parameter and must be of type: 'string'.");
     }
 
+    if (!entityPath || (entityPath && typeof entityPath !== "string")) {
+      throw new Error("'entityPath' is a required parameter and must be of type: 'string'.");
+    }
+
+     if (!tokenProvider || (tokenProvider && typeof tokenProvider !== "object")) {
+      throw new Error("'tokenProvider' is a required parameter and must be of type: 'object'.");
+    }
     if (!host.endsWith("/")) host += "/";
     const connectionString =
       `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;` + `SharedAccessKey=defaultKeyValue`;

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -323,12 +323,12 @@ export class EventHubClient {
    */
   static createFromConnectionString(connectionString: string, path?: string, options?: ClientOptions): EventHubClient {
     const config = EventHubConnectionConfig.create(connectionString, path);
+    EventHubConnectionConfig.validate(config);
 
     config.webSocket = options && options.webSocket;
     config.webSocketEndpointPath = "$servicebus/websocket";
     config.webSocketConstructorOptions = options && options.webSocketConstructorOptions;
 
-    EventHubConnectionConfig.validate(config);
     const tokenProvider = new SasTokenProvider(
       config.endpoint,
       config.sharedAccessKeyName,

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -5,7 +5,7 @@ export { EventData, EventHubDeliveryAnnotations, EventHubMessageAnnotations } fr
 export { Delivery, AmqpError, Message, MessageHeader, MessageProperties, Dictionary, WebSocketImpl } from "rhea-promise";
 export { ReceiverRuntimeInfo, OnMessage, OnError } from "./eventHubReceiver";
 export { ReceiveHandler } from "./streamingReceiver";
-export { EventHubClient, ReceiveOptions, ClientOptionsBase, ClientOptions } from "./eventHubClient";
+export { EventHubClient, ReceiveOptions, ClientOptions } from "./eventHubClient";
 export { EventPosition } from "./eventPosition";
 export { EventHubPartitionRuntimeInformation, EventHubRuntimeInformation } from "./managementClient";
 import { Constants } from "@azure/amqp-common";

--- a/sdk/eventhub/event-hubs/src/iothub/iothubClient.ts
+++ b/sdk/eventhub/event-hubs/src/iothub/iothubClient.ts
@@ -48,13 +48,13 @@ export class IotHubClient {
     const config = IotHubConnectionConfig.convertToEventHubConnectionConfig(iothubconfig);
     let result: string = "";
     if (!options) options = {};
-    options.tokenProvider = new IotSasTokenProvider(
+    const tokenProvider = new IotSasTokenProvider(
       config.endpoint,
       config.sharedAccessKeyName,
       config.sharedAccessKey
     );
     options.managementSessionAddress = `/messages/events/$management`;
-    const context = ConnectionContext.create(config, options);
+    const context = ConnectionContext.create(config, tokenProvider, options);
     try {
       log.iotClient("Getting the hub runtime info from the iothub connection string to get the redirect error.");
       await context.managementSession!.getHubRuntimeInformation();


### PR DESCRIPTION
This PR adds the following:

* Combines ClientOptionsBase and ClientOptions to simplify the EventHubClient creation experience.
* Remove duplicate connection string checks - `EventHubConnectionConfig.validate(config);` validates the properties of connection config, so no need to add extra checks.


For details see #1419