### PR TITLE
[Event Hubs] Check if link exists before using them

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -478,11 +478,15 @@ export class EventHubSender extends LinkEntity {
           let onModified: Func<EventContext, void>;
           let onAccepted: Func<EventContext, void>;
           const removeListeners = (): void => {
-            clearTimeout(waitTimer);
-            this._sender!.removeListener(SenderEvents.rejected, onRejected);
-            this._sender!.removeListener(SenderEvents.accepted, onAccepted);
-            this._sender!.removeListener(SenderEvents.released, onReleased);
-            this._sender!.removeListener(SenderEvents.modified, onModified);
+           clearTimeout(waitTimer);
+           // When `removeListeners` is called on timeout, the sender might be closed and cleared
+           // So, check if it exists, before removing listeners from it.
+           if (this._sender) {
+            this._sender.removeListener(SenderEvents.rejected, onRejected);
+            this._sender.removeListener(SenderEvents.accepted, onAccepted);
+            this._sender.removeListener(SenderEvents.released, onReleased);
+            this._sender.removeListener(SenderEvents.modified, onModified);
+           }
           };
 
           onAccepted = (context: EventContext) => {


### PR DESCRIPTION
Check senders/receiver links exists before removing listeners from it.

For more context refer: https://github.com/Azure/azure-sdk-for-js/issues/2311