### PR TITLE
Fixes a typo in the ci.yml file.

### DIFF
--- a/sdk/servicebus/service-bus/ci.yml
+++ b/sdk/servicebus/service-bus/ci.yml
@@ -14,4 +14,4 @@ pr:
 jobs:
   - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-client.yml
     parameters:
-      - PackageName: "@azure/service-bus"
+      PackageName: "@azure/service-bus"


### PR DESCRIPTION
There is an error in the YAML file in the client libs for service-bus. This fixes it so that the pipeline is unstuck.