### PR TITLE
[Service Bus] Readme updated to remove preview status

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -9,10 +9,6 @@ Use the client library for Azure Service Bus in your Node.js application to
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus) | [Package (npm)](https://www.npmjs.com/package/@azure/service-bus) | [API Reference Documentation](https://docs.microsoft.com/en-us/javascript/api/%40azure/service-bus/) | [Product documentation](https://azure.microsoft.com/en-us/services/service-bus/)
 
-## Status
-
-This library is currently in preview and the APIs may change prior to release.
-
 ## Getting Started
 
 ### Install the package

--- a/sdk/servicebus/service-bus/changelog.md
+++ b/sdk/servicebus/service-bus/changelog.md
@@ -1,3 +1,8 @@
+# 2019-05-16 1.0.1
+
+- Readme updated to remove the status about this library being in preview. This library is now out
+of preview.
+
 # 2019-05-16 1.0.0
 
 - `receiveMessages()` now returns rejected promise when network connection is lost.

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/service-bus",
   "author": "Microsoft Corporation",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "description": "Azure Service Bus SDK for Node.js",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus",


### PR DESCRIPTION
Readme updated to remove preview status and version updated to 1.0.1 so that the readme in npmjs.com doesn't reflect the wrong state