### PR TITLE
[AutoPR cognitiveservices/data-plane/ComputerVision] [Cogs OCR] Remove optional `mode` parameter from CognitiveService OCR preview API for GA preparation

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-computervision/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/package.json
@@ -4,7 +4,7 @@
   "description": "ComputerVisionClient Library with typescript type definitions for node.js and browser.",
   "version": "4.0.0",
   "dependencies": {
-    "@azure/ms-rest-js": "^1.6.0",
+    "@azure/ms-rest-js": "^1.8.1",
     "tslib": "^1.9.3"
   },
   "keywords": [
@@ -25,7 +25,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/cognitiveservices/cognitiveservices-computervision",
+  "homepage": "https://github.com/azure/azure-sdk-for-js",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClient.ts
@@ -418,32 +418,28 @@ class ComputerVisionClient extends ComputerVisionClientContext {
   /**
    * Use this interface to get the result of a Read operation, employing the state-of-the-art Optical
    * Character Recognition (OCR) algorithms optimized for text-heavy documents. When you use the Read
-   * File interface, the response contains a field called "Operation-Location". The
-   * "Operation-Location" field contains the URL that you must use for your "Read Operation Result"
+   * File interface, the response contains a field called 'Operation-Location'. The
+   * 'Operation-Location' field contains the URL that you must use for your 'GetReadOperationResult'
    * operation to access OCR results.​
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
    * @param url Publicly reachable URL of an image.
    * @param [options] The optional parameters
    * @returns Promise<Models.BatchReadFileResponse>
    */
-  batchReadFile(mode: Models.TextRecognitionMode, url: string, options?: msRest.RequestOptionsBase): Promise<Models.BatchReadFileResponse>;
+  batchReadFile(url: string, options?: msRest.RequestOptionsBase): Promise<Models.BatchReadFileResponse>;
   /**
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
    * @param url Publicly reachable URL of an image.
    * @param callback The callback
    */
-  batchReadFile(mode: Models.TextRecognitionMode, url: string, callback: msRest.ServiceCallback<void>): void;
+  batchReadFile(url: string, callback: msRest.ServiceCallback<void>): void;
   /**
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
    * @param url Publicly reachable URL of an image.
    * @param options The optional parameters
    * @param callback The callback
    */
-  batchReadFile(mode: Models.TextRecognitionMode, url: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  batchReadFile(mode: Models.TextRecognitionMode, url: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.BatchReadFileResponse> {
+  batchReadFile(url: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  batchReadFile(url: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.BatchReadFileResponse> {
     return this.sendOperationRequest(
       {
-        mode,
         url,
         options
       },
@@ -453,21 +449,21 @@ class ComputerVisionClient extends ComputerVisionClientContext {
 
   /**
    * This interface is used for getting OCR results of Read operation. The URL to this interface
-   * should be retrieved from "Operation-Location" field returned from Batch Read File interface.
-   * @param operationId Id of read operation returned in the response of the "Batch Read File"
+   * should be retrieved from 'Operation-Location' field returned from Batch Read File interface.
+   * @param operationId Id of read operation returned in the response of the 'Batch Read File'
    * interface.
    * @param [options] The optional parameters
    * @returns Promise<Models.GetReadOperationResultResponse>
    */
   getReadOperationResult(operationId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetReadOperationResultResponse>;
   /**
-   * @param operationId Id of read operation returned in the response of the "Batch Read File"
+   * @param operationId Id of read operation returned in the response of the 'Batch Read File'
    * interface.
    * @param callback The callback
    */
   getReadOperationResult(operationId: string, callback: msRest.ServiceCallback<Models.ReadOperationResult>): void;
   /**
-   * @param operationId Id of read operation returned in the response of the "Batch Read File"
+   * @param operationId Id of read operation returned in the response of the 'Batch Read File'
    * interface.
    * @param options The optional parameters
    * @param callback The callback
@@ -820,32 +816,28 @@ class ComputerVisionClient extends ComputerVisionClientContext {
    * Use this interface to get the result of a Read Document operation, employing the
    * state-of-the-art Optical Character Recognition (OCR) algorithms optimized for text-heavy
    * documents. When you use the Read Document interface, the response contains a field called
-   * "Operation-Location". The "Operation-Location" field contains the URL that you must use for your
-   * "Get Read Result operation" to access OCR results.​
+   * 'Operation-Location'. The 'Operation-Location' field contains the URL that you must use for your
+   * 'Get Read Result operation' to access OCR results.​
    * @param image An image stream.
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
    * @param [options] The optional parameters
    * @returns Promise<Models.BatchReadFileInStreamResponse>
    */
-  batchReadFileInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, options?: msRest.RequestOptionsBase): Promise<Models.BatchReadFileInStreamResponse>;
+  batchReadFileInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase): Promise<Models.BatchReadFileInStreamResponse>;
   /**
    * @param image An image stream.
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
    * @param callback The callback
    */
-  batchReadFileInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, callback: msRest.ServiceCallback<void>): void;
+  batchReadFileInStream(image: msRest.HttpRequestBody, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param image An image stream.
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
    * @param options The optional parameters
    * @param callback The callback
    */
-  batchReadFileInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  batchReadFileInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.BatchReadFileInStreamResponse> {
+  batchReadFileInStream(image: msRest.HttpRequestBody, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  batchReadFileInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.BatchReadFileInStreamResponse> {
     return this.sendOperationRequest(
       {
         image,
-        mode,
         options
       },
       batchReadFileInStreamOperationSpec,
@@ -1160,9 +1152,6 @@ const batchReadFileOperationSpec: msRest.OperationSpec = {
   path: "read/core/asyncBatchAnalyze",
   urlParameters: [
     Parameters.endpoint
-  ],
-  queryParameters: [
-    Parameters.mode
   ],
   requestBody: {
     parameterPath: {
@@ -1490,9 +1479,6 @@ const batchReadFileInStreamOperationSpec: msRest.OperationSpec = {
   path: "read/core/asyncBatchAnalyze",
   urlParameters: [
     Parameters.endpoint
-  ],
-  queryParameters: [
-    Parameters.mode
   ],
   requestBody: {
     parameterPath: "image",

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-computervision";
-const packageVersion = "3.2.0";
+const packageVersion = "4.0.0";
 
 export class ComputerVisionClientContext extends msRest.ServiceClient {
   endpoint: string;

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
@@ -627,7 +627,7 @@ export interface CelebrityResults {
 }
 
 /**
- * Json object representing a recognized word.
+ * An object representing a recognized word.
  */
 export interface Word {
   /**
@@ -645,7 +645,7 @@ export interface Word {
 }
 
 /**
- * Json object representing a recognized text line.
+ * An object representing a recognized text line.
  */
 export interface Line {
   /**
@@ -663,7 +663,7 @@ export interface Line {
 }
 
 /**
- * Json object representing a recognized text region
+ * An object representing a recognized text region
  */
 export interface TextRecognitionResult {
   /**
@@ -683,8 +683,8 @@ export interface TextRecognitionResult {
    */
   height?: number;
   /**
-   * The unit used in the Width, Height and BoundingBox. For images, the unit is "pixel". For PDF,
-   * the unit is "inch". Possible values include: 'pixel', 'inch'
+   * The unit used in the Width, Height and BoundingBox. For images, the unit is 'pixel'. For PDF,
+   * the unit is 'inch'. Possible values include: 'pixel', 'inch'
    */
   unit?: TextRecognitionResultDimensionUnit;
   /**
@@ -718,7 +718,7 @@ export interface ReadOperationResult {
    */
   status?: TextOperationStatusCodes;
   /**
-   * A array of text recognition result of the read operation.
+   * An array of text recognition result of the read operation.
    */
   recognitionResults?: TextRecognitionResult[];
 }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/5931