### PR TITLE
 [Event Hubs] Allow users to configure retry options in send requests

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -245,7 +245,7 @@ export class EventHubClient {
       partitionId = partitionIdOrptions.partitionId;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return sender.send(data);
+    return typeof partitionIdOrptions === "object" ? sender.send(data, partitionIdOrptions) :  sender.send(data);
   }
 
   /**
@@ -259,9 +259,9 @@ export class EventHubClient {
    *
    * @return {Promise<Delivery>} Promise<Delivery>
    */
-  async sendBatch(datas: EventData[], partitionId?: string | number): Promise<Delivery>;
-  async sendBatch(datas: EventData[], options?: SendOptions): Promise<Delivery>;
-  async sendBatch(datas: EventData[], partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
+  async sendBatch(data: EventData[], partitionId?: string | number): Promise<Delivery>;
+  async sendBatch(data: EventData[], options?: SendOptions): Promise<Delivery>;
+  async sendBatch(data: EventData[], partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
@@ -269,7 +269,7 @@ export class EventHubClient {
       partitionId = partitionIdOrptions.partitionId;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return sender.sendBatch(datas);
+    return typeof partitionIdOrptions === "object" ? sender.sendBatch(data, partitionIdOrptions) :  sender.sendBatch(data);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -239,13 +239,15 @@ export class EventHubClient {
   async send(data: EventData, options?: SendOptions): Promise<Delivery>;
   async send(data: EventData, partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
+    let sendOptions: SendOptions = {};
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
-    } else if (partitionIdOrptions && partitionIdOrptions.hasOwnProperty("partitionId")) {
+    } else if (partitionIdOrptions && typeof partitionIdOrptions === "object") {
       partitionId = partitionIdOrptions.partitionId;
+      sendOptions = partitionIdOrptions;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return typeof partitionIdOrptions === "object" ? sender.send(data, partitionIdOrptions) :  sender.send(data);
+    return sender.send(data, sendOptions);
   }
 
   /**
@@ -263,13 +265,15 @@ export class EventHubClient {
   async sendBatch(data: EventData[], options?: SendOptions): Promise<Delivery>;
   async sendBatch(data: EventData[], partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
+    let sendOptions: SendOptions = {};
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
     } else if (partitionIdOrptions && partitionIdOrptions.hasOwnProperty("partitionId")) {
       partitionId = partitionIdOrptions.partitionId;
+      sendOptions = partitionIdOrptions;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return typeof partitionIdOrptions === "object" ? sender.sendBatch(data, partitionIdOrptions) :  sender.sendBatch(data);
+    return sender.sendBatch(data, sendOptions);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -478,11 +478,15 @@ export class EventHubSender extends LinkEntity {
           let onModified: Func<EventContext, void>;
           let onAccepted: Func<EventContext, void>;
           const removeListeners = (): void => {
-            clearTimeout(waitTimer);
-            this._sender!.removeListener(SenderEvents.rejected, onRejected);
-            this._sender!.removeListener(SenderEvents.accepted, onAccepted);
-            this._sender!.removeListener(SenderEvents.released, onReleased);
-            this._sender!.removeListener(SenderEvents.modified, onModified);
+           clearTimeout(waitTimer);
+           // When `removeListeners` is called on timeout, the sender might be closed and cleared
+           // So, check if it exists, before removing listeners from it.
+           if (this._sender) {
+            this._sender.removeListener(SenderEvents.rejected, onRejected);
+            this._sender.removeListener(SenderEvents.accepted, onAccepted);
+            this._sender.removeListener(SenderEvents.released, onReleased);
+            this._sender.removeListener(SenderEvents.modified, onModified);
+           }
           };
 
           onAccepted = (context: EventContext) => {

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -479,15 +479,15 @@ export class EventHubSender extends LinkEntity {
           let onModified: Func<EventContext, void>;
           let onAccepted: Func<EventContext, void>;
           const removeListeners = (): void => {
-           clearTimeout(waitTimer);
-           // When `removeListeners` is called on timeout, the sender might be closed and cleared
-           // So, check if it exists, before removing listeners from it.
-           if (this._sender) {
-            this._sender.removeListener(SenderEvents.rejected, onRejected);
-            this._sender.removeListener(SenderEvents.accepted, onAccepted);
-            this._sender.removeListener(SenderEvents.released, onReleased);
-            this._sender.removeListener(SenderEvents.modified, onModified);
-           }
+            clearTimeout(waitTimer);
+            // When `removeListeners` is called on timeout, the sender might be closed and cleared
+            // So, check if it exists, before removing listeners from it.
+            if (this._sender) {
+              this._sender.removeListener(SenderEvents.rejected, onRejected);
+              this._sender.removeListener(SenderEvents.accepted, onAccepted);
+              this._sender.removeListener(SenderEvents.released, onReleased);
+              this._sender.removeListener(SenderEvents.modified, onModified);
+            }
           };
 
           onAccepted = (context: EventContext) => {
@@ -554,7 +554,10 @@ export class EventHubSender extends LinkEntity {
           this._sender!.on(SenderEvents.rejected, onRejected);
           this._sender!.on(SenderEvents.modified, onModified);
           this._sender!.on(SenderEvents.released, onReleased);
-          waitTimer = setTimeout(actionAfterTimeout, options && options.idleTimeout ? options.idleTimeout : Constants.defaultOperationTimeoutInSeconds * 1000);
+          waitTimer = setTimeout(
+            actionAfterTimeout,
+            options && options.idleTimeout ? options.idleTimeout : Constants.defaultOperationTimeoutInSeconds * 1000
+          );
           const delivery = this._sender!.send(message, tag, format);
           log.sender(
             "[%s] Sender '%s', sent message with delivery id: %d and tag: %s",
@@ -583,7 +586,10 @@ export class EventHubSender extends LinkEntity {
       connectionId: this._context.connectionId,
       operationType: RetryOperationType.sendMessage,
       times: options && options.retryAttempts ? options.retryAttempts : Constants.defaultRetryAttempts,
-      delayInSeconds:  options && options.delayBetweenRetries ? options.delayBetweenRetries : Constants.defaultDelayBetweenOperationRetriesInSeconds + jitterInSeconds
+      delayInSeconds:
+        options && options.delayBetweenRetries
+          ? options.delayBetweenRetries
+          : Constants.defaultDelayBetweenOperationRetriesInSeconds + jitterInSeconds
     };
     return retry<Delivery>(config);
   }

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -84,6 +84,7 @@
   },
   "files": [
     "dist/",
+    "dist-esm/package.json",
     "dist-esm/src/",
     "src/",
     "typings/src",


### PR DESCRIPTION
Allow users to configure retry options in send requests as described in #2661 (comment) for send operations on `EventHubClient`.