### PR TITLE
[Event Hubs] Allow users to configure retry options in send requests 

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -245,7 +245,7 @@ export class EventHubClient {
       partitionId = partitionIdOrptions.partitionId;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return sender.send(data);
+    return typeof partitionIdOrptions === "object" ? sender.send(data, partitionIdOrptions) :  sender.send(data);
   }
 
   /**
@@ -259,9 +259,9 @@ export class EventHubClient {
    *
    * @return {Promise<Delivery>} Promise<Delivery>
    */
-  async sendBatch(datas: EventData[], partitionId?: string | number): Promise<Delivery>;
-  async sendBatch(datas: EventData[], options?: SendOptions): Promise<Delivery>;
-  async sendBatch(datas: EventData[], partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
+  async sendBatch(data: EventData[], partitionId?: string | number): Promise<Delivery>;
+  async sendBatch(data: EventData[], options?: SendOptions): Promise<Delivery>;
+  async sendBatch(data: EventData[], partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
@@ -269,7 +269,7 @@ export class EventHubClient {
       partitionId = partitionIdOrptions.partitionId;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return sender.sendBatch(datas);
+    return typeof partitionIdOrptions === "object" ? sender.sendBatch(data, partitionIdOrptions) :  sender.sendBatch(data);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -46,13 +46,13 @@ export interface RequestOptions {
    */
   retryAttempts?: number;
   /**
-   * Number of milliseconds to wait between retries
+   * Number of seconds to wait between retries
    */
-  delayBetweenRetries?: number;
+  delayBetweenRetriesInSeconds?: number;
   /**
-   * Number of milliseconds to wait before declaring an opetration to have timed out
+   * Number of seconds to wait before declaring an opetration to have timed out
    */
-  idleTimeout?: number;
+  idleTimeoutInSeconds?: number;
   /**
    * The cancellation token used to cancel the current request
    */

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -242,7 +242,7 @@ export class EventHubClient {
     let sendOptions: SendOptions = {};
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
-    } else if (partitionIdOrptions && typeof partitionIdOrptions === "object") {
+    } else if (partitionIdOrptions) {
       partitionId = partitionIdOrptions.partitionId;
       sendOptions = partitionIdOrptions;
     }
@@ -268,7 +268,7 @@ export class EventHubClient {
     let sendOptions: SendOptions = {};
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
-    } else if (partitionIdOrptions && partitionIdOrptions.hasOwnProperty("partitionId")) {
+    } else if (partitionIdOrptions) {
       partitionId = partitionIdOrptions.partitionId;
       sendOptions = partitionIdOrptions;
     }

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -237,14 +237,14 @@ export class EventHubClient {
    */
   async send(data: EventData, partitionId?: string | number): Promise<Delivery>;
   async send(data: EventData, options?: SendOptions): Promise<Delivery>;
-  async send(data: EventData, partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
+  async send(data: EventData, partitionIdOrOptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
     let sendOptions: SendOptions = {};
-    if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
-      partitionId = partitionIdOrptions;
-    } else if (partitionIdOrptions) {
-      partitionId = partitionIdOrptions.partitionId;
-      sendOptions = partitionIdOrptions;
+    if (typeof partitionIdOrOptions === "string" || typeof partitionIdOrOptions === "number") {
+      partitionId = partitionIdOrOptions;
+    } else if (partitionIdOrOptions) {
+      partitionId = partitionIdOrOptions.partitionId;
+      sendOptions = partitionIdOrOptions;
     }
     const sender = EventHubSender.create(this._context, partitionId);
     return sender.send(data, sendOptions);
@@ -263,14 +263,14 @@ export class EventHubClient {
    */
   async sendBatch(data: EventData[], partitionId?: string | number): Promise<Delivery>;
   async sendBatch(data: EventData[], options?: SendOptions): Promise<Delivery>;
-  async sendBatch(data: EventData[], partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
+  async sendBatch(data: EventData[], partitionIdOrOptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
     let sendOptions: SendOptions = {};
-    if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
-      partitionId = partitionIdOrptions;
-    } else if (partitionIdOrptions) {
-      partitionId = partitionIdOrptions.partitionId;
-      sendOptions = partitionIdOrptions;
+    if (typeof partitionIdOrOptions === "string" || typeof partitionIdOrOptions === "number") {
+      partitionId = partitionIdOrOptions;
+    } else if (partitionIdOrOptions) {
+      partitionId = partitionIdOrOptions.partitionId;
+      sendOptions = partitionIdOrOptions;
     }
     const sender = EventHubSender.create(this._context, partitionId);
     return sender.sendBatch(data, sendOptions);

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -239,13 +239,15 @@ export class EventHubClient {
   async send(data: EventData, options?: SendOptions): Promise<Delivery>;
   async send(data: EventData, partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
+    let sendOptions: SendOptions = {};
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
-    } else if (partitionIdOrptions && partitionIdOrptions.hasOwnProperty("partitionId")) {
+    } else if (partitionIdOrptions && typeof partitionIdOrptions === "object") {
       partitionId = partitionIdOrptions.partitionId;
+      sendOptions = partitionIdOrptions;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return typeof partitionIdOrptions === "object" ? sender.send(data, partitionIdOrptions) :  sender.send(data);
+    return sender.send(data, sendOptions);
   }
 
   /**
@@ -263,13 +265,15 @@ export class EventHubClient {
   async sendBatch(data: EventData[], options?: SendOptions): Promise<Delivery>;
   async sendBatch(data: EventData[], partitionIdOrptions?: string | number | SendOptions): Promise<Delivery> {
     let partitionId: string | number | undefined;
+    let sendOptions: SendOptions = {};
     if (typeof partitionIdOrptions === "string" || typeof partitionIdOrptions === "number") {
       partitionId = partitionIdOrptions;
     } else if (partitionIdOrptions && partitionIdOrptions.hasOwnProperty("partitionId")) {
       partitionId = partitionIdOrptions.partitionId;
+      sendOptions = partitionIdOrptions;
     }
     const sender = EventHubSender.create(this._context, partitionId);
-    return typeof partitionIdOrptions === "object" ? sender.sendBatch(data, partitionIdOrptions) :  sender.sendBatch(data);
+    return sender.sendBatch(data, sendOptions);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -556,9 +556,9 @@ export class EventHubSender extends LinkEntity {
           this._sender!.on(SenderEvents.released, onReleased);
           waitTimer = setTimeout(
             actionAfterTimeout,
-            options && options.idleTimeoutInSeconds && options.idleTimeoutInSeconds > 0
+            (options && options.idleTimeoutInSeconds && options.idleTimeoutInSeconds > 0
               ? options.idleTimeoutInSeconds
-              : Constants.defaultOperationTimeoutInSeconds * 1000
+              : Constants.defaultOperationTimeoutInSeconds) * 1000
           );
           const delivery = this._sender!.send(message, tag, format);
           log.sender(

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -556,7 +556,9 @@ export class EventHubSender extends LinkEntity {
           this._sender!.on(SenderEvents.released, onReleased);
           waitTimer = setTimeout(
             actionAfterTimeout,
-            options && options.idleTimeout ? options.idleTimeout : Constants.defaultOperationTimeoutInSeconds * 1000
+            options && options.idleTimeout && options.idleTimeout > 0
+              ? options.idleTimeout
+              : Constants.defaultOperationTimeoutInSeconds * 1000
           );
           const delivery = this._sender!.send(message, tag, format);
           log.sender(
@@ -585,7 +587,10 @@ export class EventHubSender extends LinkEntity {
       operation: sendEventPromise,
       connectionId: this._context.connectionId,
       operationType: RetryOperationType.sendMessage,
-      times: options && options.retryAttempts ? options.retryAttempts : Constants.defaultRetryAttempts,
+      times:
+        options && options.retryAttempts && options.retryAttempts > 0
+          ? options.retryAttempts
+          : Constants.defaultRetryAttempts,
       delayInSeconds:
         options && options.delayBetweenRetries
           ? options.delayBetweenRetries

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -556,8 +556,8 @@ export class EventHubSender extends LinkEntity {
           this._sender!.on(SenderEvents.released, onReleased);
           waitTimer = setTimeout(
             actionAfterTimeout,
-            options && options.idleTimeout && options.idleTimeout > 0
-              ? options.idleTimeout
+            options && options.idleTimeoutInSeconds && options.idleTimeoutInSeconds > 0
+              ? options.idleTimeoutInSeconds
               : Constants.defaultOperationTimeoutInSeconds * 1000
           );
           const delivery = this._sender!.send(message, tag, format);
@@ -583,18 +583,20 @@ export class EventHubSender extends LinkEntity {
       });
 
     const jitterInSeconds = randomNumberFromInterval(1, 4);
+    const times =
+      options && options.retryAttempts && options.retryAttempts > 0
+        ? options.retryAttempts
+        : Constants.defaultRetryAttempts;
+    const delayInSeconds =
+      options && options.delayBetweenRetriesInSeconds && options.delayBetweenRetriesInSeconds > 0
+        ? options.delayBetweenRetriesInSeconds
+        : Constants.defaultDelayBetweenOperationRetriesInSeconds;
     const config: RetryConfig<Delivery> = {
       operation: sendEventPromise,
       connectionId: this._context.connectionId,
       operationType: RetryOperationType.sendMessage,
-      times:
-        options && options.retryAttempts && options.retryAttempts > 0
-          ? options.retryAttempts
-          : Constants.defaultRetryAttempts,
-      delayInSeconds:
-        options && options.delayBetweenRetries
-          ? options.delayBetweenRetries
-          : Constants.defaultDelayBetweenOperationRetriesInSeconds + jitterInSeconds
+      times: times,
+      delayInSeconds: delayInSeconds + jitterInSeconds
     };
     return retry<Delivery>(config);
   }

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -479,15 +479,15 @@ export class EventHubSender extends LinkEntity {
           let onModified: Func<EventContext, void>;
           let onAccepted: Func<EventContext, void>;
           const removeListeners = (): void => {
-           clearTimeout(waitTimer);
-           // When `removeListeners` is called on timeout, the sender might be closed and cleared
-           // So, check if it exists, before removing listeners from it.
-           if (this._sender) {
-            this._sender.removeListener(SenderEvents.rejected, onRejected);
-            this._sender.removeListener(SenderEvents.accepted, onAccepted);
-            this._sender.removeListener(SenderEvents.released, onReleased);
-            this._sender.removeListener(SenderEvents.modified, onModified);
-           }
+            clearTimeout(waitTimer);
+            // When `removeListeners` is called on timeout, the sender might be closed and cleared
+            // So, check if it exists, before removing listeners from it.
+            if (this._sender) {
+              this._sender.removeListener(SenderEvents.rejected, onRejected);
+              this._sender.removeListener(SenderEvents.accepted, onAccepted);
+              this._sender.removeListener(SenderEvents.released, onReleased);
+              this._sender.removeListener(SenderEvents.modified, onModified);
+            }
           };
 
           onAccepted = (context: EventContext) => {
@@ -554,7 +554,10 @@ export class EventHubSender extends LinkEntity {
           this._sender!.on(SenderEvents.rejected, onRejected);
           this._sender!.on(SenderEvents.modified, onModified);
           this._sender!.on(SenderEvents.released, onReleased);
-          waitTimer = setTimeout(actionAfterTimeout, options && options.idleTimeout ? options.idleTimeout : Constants.defaultOperationTimeoutInSeconds * 1000);
+          waitTimer = setTimeout(
+            actionAfterTimeout,
+            options && options.idleTimeout ? options.idleTimeout : Constants.defaultOperationTimeoutInSeconds * 1000
+          );
           const delivery = this._sender!.send(message, tag, format);
           log.sender(
             "[%s] Sender '%s', sent message with delivery id: %d and tag: %s",
@@ -583,7 +586,10 @@ export class EventHubSender extends LinkEntity {
       connectionId: this._context.connectionId,
       operationType: RetryOperationType.sendMessage,
       times: options && options.retryAttempts ? options.retryAttempts : Constants.defaultRetryAttempts,
-      delayInSeconds:  options && options.delayBetweenRetries ? options.delayBetweenRetries : Constants.defaultDelayBetweenOperationRetriesInSeconds + jitterInSeconds
+      delayInSeconds:
+        options && options.delayBetweenRetries
+          ? options.delayBetweenRetries
+          : Constants.defaultDelayBetweenOperationRetriesInSeconds + jitterInSeconds
     };
     return retry<Delivery>(config);
   }


### PR DESCRIPTION
Allow users to configure retry options in send requests as described in #2661 (comment) for send operations on `EventHubClient`.