### PR TITLE
[Event Hubs] Allow users to configure retry options in apis using the $management link

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -357,7 +357,7 @@ export class EventHubClient {
    */
   async getHubRuntimeInformation(options?: RequestOptions): Promise<EventHubRuntimeInformation> {
     try {
-      return await this._context.managementSession!.getHubRuntimeInformation();
+      return await this._context.managementSession!.getHubRuntimeInformation(options);
     } catch (err) {
       log.error("An error occurred while getting the hub runtime information: %O", err);
       throw err;
@@ -391,7 +391,7 @@ export class EventHubClient {
       throw new Error("'partitionId' is a required parameter and must be of type: 'string' | 'number'.");
     }
     try {
-      return await this._context.managementSession!.getPartitionInformation(partitionId);
+      return await this._context.managementSession!.getPartitionInformation(partitionId, options);
     } catch (err) {
       log.error("An error occurred while getting the partition information: %O", err);
       throw err;

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -177,11 +177,10 @@ export class ManagementClient extends LinkEntity {
       application_properties: {
         operation: Constants.readOperation,
         name: this.entityPath as string,
-        type: `${Constants.vendorString}:${Constants.partition}`
+        type: `${Constants.vendorString}:${Constants.partition}`,
+        partition: `${partitionId}`
       }
     };
-
-    request.application_properties!.partition = `${partitionId}`;
 
     const info: any = await this._makeManagementRequest(request, options);
     const partitionInfo: EventHubPartitionRuntimeInformation = {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -122,7 +122,18 @@ export class ManagementClient extends LinkEntity {
    * @returns {Promise<EventHubRuntimeInformation>}
    */
   async getHubRuntimeInformation(options?: RequestOptions): Promise<EventHubRuntimeInformation> {
-    const info: any = await this._makeManagementRequest(Constants.eventHub, options);
+    const request: Message = {
+      body: Buffer.from(JSON.stringify([])),
+      message_id: uuid(),
+      reply_to: this.replyTo,
+      application_properties: {
+        operation: Constants.readOperation,
+        name: this.entityPath as string,
+        type: `${Constants.vendorString}:${Constants.eventHub}`
+      }
+    };
+
+    const info: any = await this._makeManagementRequest(request, options);
     const runtimeInfo: EventHubRuntimeInformation = {
       path: info.name,
       createdAt: new Date(info.created_at),
@@ -158,7 +169,21 @@ export class ManagementClient extends LinkEntity {
     if (typeof partitionId !== "string" && typeof partitionId !== "number") {
       throw new Error("'partitionId' is a required parameter and must be of " + "type: 'string' | 'number'.");
     }
-    const info: any = await this._makeManagementRequest(Constants.partition, options, partitionId);
+
+    const request: Message = {
+      body: Buffer.from(JSON.stringify([])),
+      message_id: uuid(),
+      reply_to: this.replyTo,
+      application_properties: {
+        operation: Constants.readOperation,
+        name: this.entityPath as string,
+        type: `${Constants.vendorString}:${Constants.partition}`
+      }
+    };
+
+    request.application_properties!.partition = `${partitionId}`;
+
+    const info: any = await this._makeManagementRequest(request, options);
     const partitionInfo: EventHubPartitionRuntimeInformation = {
       beginningSequenceNumber: info.begin_sequence_number,
       hubPath: info.name,
@@ -253,28 +278,8 @@ export class ManagementClient extends LinkEntity {
    * @param {string} type - The type of entity requested for. Valid values are "eventhub", "partition"
    * @param {string | number} [partitionId] - The partitionId. Required only when type is "partition".
    */
-  private async _makeManagementRequest(
-    type: "eventhub" | "partition",
-    options?: RequestOptions,
-    partitionId?: string | number
-  ): Promise<any> {
-    if (partitionId != undefined && (typeof partitionId !== "string" && typeof partitionId !== "number")) {
-      throw new Error("'partitionId' is a required parameter and must be of type: 'string' | 'number'.");
-    }
+  private async _makeManagementRequest(request: Message, options?: RequestOptions): Promise<any> {
     try {
-      const request: Message = {
-        body: Buffer.from(JSON.stringify([])),
-        message_id: uuid(),
-        reply_to: this.replyTo,
-        application_properties: {
-          operation: Constants.readOperation,
-          name: this.entityPath as string,
-          type: `${Constants.vendorString}:${type}`
-        }
-      };
-      if (partitionId != undefined && type === Constants.partition) {
-        request.application_properties!.partition = `${partitionId}`;
-      }
       log.mgmt("[%s] Acquiring lock to get the management req res link.", this._context.connectionId);
       await defaultLock.acquire(this.managementLock, () => {
         return this._init();


### PR DESCRIPTION
Allow users to configure retry options in apis using the $management link as described in #2661 (comment) for the below 3 operations on EventHubClient

* getHubRuntimeInformation()
* getPartitionIds()
* getPartitionInformation()