### PR TITLE
[JS] [Service Bus] package.json in the samples folder

### DIFF
--- a/sdk/servicebus/service-bus/samples/README.md
+++ b/sdk/servicebus/service-bus/samples/README.md
@@ -2,10 +2,13 @@
 
 ## Install the library
 
-Run the below in your samples folder to install the npm package for Azure Service Bus library.
-```bash
-npm install @azure/service-bus
-```
+Copy the samples folder, then run npm install inside it in order to
+install the npm package for Azure Service Bus library.
+
+If you want to copy individual sample files and run them outside,
+remember to install the service-bus package with:
+
+    npm install @azure/service-bus
 
 ## Get connection string for Service Bus & names for Queues/Topics/Subscriptions
 - In the [Azure Portal](https://portal.azure.com), go to **Dashboard > Service Bus > _your-servicebus-namespace_**.
@@ -16,18 +19,6 @@ npm install @azure/service-bus
 > _Note : **RootManageSharedAccessKey** is automatically created for the namespace and has permissions for the entire namespace. If you want to use restricted access, refer [Shared Access Signatures](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-sas), create the Access Keys exclusive to the specific created Queue/Topic._
 
 Before running any of the samples, update it with the connection string and the queue/topic/subscription names you have noted down above.
-
-## Initializing the samples folder
-
-Copy the samples folder somewhere in your computer, then run `npm
-install` inside of it.
-
-If you want to run just a specific sample, copy that file into a
-separate folder and continue with the steps below. Remember to
-install the library with `npm install @azure/service-bus`. Read the
-sample's source code to verify any other dependency that you might
-need (dependencies will be visible within the first lines of each
-sample file).
 
 ## Running a Javascript sample
 

--- a/sdk/servicebus/service-bus/samples/README.md
+++ b/sdk/servicebus/service-bus/samples/README.md
@@ -17,6 +17,16 @@ npm install @azure/service-bus
 
 Before running any of the samples, update it with the connection string and the queue/topic/subscription names you have noted down above.
 
+## Initializing the samples folder
+
+Once you clone this repository, make sure you're in this samples folder. If you're already in this folder you might ignore this step, otherwise do as follows:
+```bash
+git clone https://github.com/Azure/azure-sdk-for-js
+cd azure-sdk-for-js/sdk/servicebus/service-bus/samples/
+```
+
+Inside of this folder, run `npm install`.
+
 ## Running a Javascript sample
 
 Copy the sample to your samples folder and use `node` to run it.

--- a/sdk/servicebus/service-bus/samples/README.md
+++ b/sdk/servicebus/service-bus/samples/README.md
@@ -1,4 +1,4 @@
-# Getting started with samples #
+﻿# Getting started with samples #
 
 ## Install the library
 
@@ -19,13 +19,15 @@ Before running any of the samples, update it with the connection string and the 
 
 ## Initializing the samples folder
 
-Once you clone this repository, make sure you're in this samples folder. If you're already in this folder you might ignore this step, otherwise do as follows:
-```bash
-git clone https://github.com/Azure/azure-sdk-for-js
-cd azure-sdk-for-js/sdk/servicebus/service-bus/samples/
-```
+Copy the samples folder somewhere in your computer, then run `npm
+install` inside of it.
 
-Inside of this folder, run `npm install`.
+If you want to run just a specific sample, copy that file into a
+separate folder and continue with the steps below. Remember to
+install the library with `npm install @azure/service-bus`. Read the
+sample's source code to verify any other dependency that you might
+need (dependencies will be visible within the first lines of each
+sample file).
 
 ## Running a Javascript sample
 

--- a/sdk/servicebus/service-bus/samples/README.md
+++ b/sdk/servicebus/service-bus/samples/README.md
@@ -2,13 +2,12 @@
 
 ## Install the library
 
-Copy the samples folder, then run npm install inside it in order to
-install the npm package for Azure Service Bus library.
-
-If you want to copy individual sample files and run them outside,
-remember to install the service-bus package with:
-
-    npm install @azure/service-bus
+There are 2 ways you can work with the samples.
+- Copy the sample file you want to a folder of your choice and run `npm install @azure/service-bus`
+to install the library
+- Or, in case you have cloned this repo, then run `npm install` in the `samples` folder to install the
+library. This will install the library as well as other dependencies that are required by some of the
+samples.
 
 ## Get connection string for Service Bus & names for Queues/Topics/Subscriptions
 - In the [Azure Portal](https://portal.azure.com), go to **Dashboard > Service Bus > _your-servicebus-namespace_**.

--- a/sdk/servicebus/service-bus/samples/README.md
+++ b/sdk/servicebus/service-bus/samples/README.md
@@ -1,4 +1,4 @@
-﻿# Getting started with samples #
+# Getting started with samples #
 
 ## Install the library
 

--- a/sdk/servicebus/service-bus/samples/package.json
+++ b/sdk/servicebus/service-bus/samples/package.json
@@ -1,7 +1,21 @@
 {
   "name": "@azure/service-bus-samples",
-  "version": "0.0.0",
-  "description": "@azure/service-bus samples",
+  "version": "0.0.1",
+  "description": "@0azure/service-bus samples",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
+  "repository": "github:Azure/azure-sdk-for-js",
   "author": "Microsoft",
-  "license": "ISC"
+  "license": "MIT",
+  "dependencies": {
+    "@azure/ms-rest-nodeauth": "^2.0.1",
+    "@azure/service-bus": "^1.0.2",
+    "https-proxy-agent": "^2.2.1",
+    "rhea-promise": "^0.2.0",
+    "ws": "^7.0.0"
+  },
+  "devDependencies": {
+    "@azure/arm-servicebus": "^0.1.0",
+    "@types/node": "^8.0.0",
+    "@types/ws": "^6.0.1"
+  }
 }

--- a/sdk/servicebus/service-bus/samples/package.json
+++ b/sdk/servicebus/service-bus/samples/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus-samples",
   "version": "0.0.1",
   "description": "@0azure/service-bus samples",
-  "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
   "author": "Microsoft",
   "license": "MIT",
@@ -10,11 +10,9 @@
     "@azure/ms-rest-nodeauth": "^2.0.1",
     "@azure/service-bus": "^1.0.2",
     "https-proxy-agent": "^2.2.1",
-    "rhea-promise": "^0.2.0",
     "ws": "^7.0.0"
   },
   "devDependencies": {
-    "@azure/arm-servicebus": "^0.1.0",
     "@types/node": "^8.0.0",
     "@types/ws": "^6.0.1"
   }

--- a/sdk/servicebus/service-bus/samples/package.json
+++ b/sdk/servicebus/service-bus/samples/package.json
@@ -3,8 +3,5 @@
   "version": "0.0.0",
   "description": "@azure/service-bus samples",
   "author": "Microsoft",
-  "license": "ISC",
-  "dependencies": {
-    "@azure/service-bus": "^1.0.2"
-  }
+  "license": "ISC"
 }

--- a/sdk/servicebus/service-bus/samples/package.json
+++ b/sdk/servicebus/service-bus/samples/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "samples",
+  "version": "0.0.0",
+  "description": "@azure/service-bus samples",
+  "author": "Microsoft",
+  "license": "ISC",
+  "dependencies": {
+    "@azure/service-bus": "^1.0.2"
+  }
+}

--- a/sdk/servicebus/service-bus/samples/package.json
+++ b/sdk/servicebus/service-bus/samples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "samples",
+  "name": "@azure/service-bus-samples",
   "version": "0.0.0",
   "description": "@azure/service-bus samples",
   "author": "Microsoft",

--- a/sdk/servicebus/service-bus/samples/typescript/gettingStarted/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/gettingStarted/scheduledMessages.ts
@@ -10,13 +10,13 @@
 */
 
 import {
+  delay,
   ServiceBusClient,
   ReceiveMode,
   SendableMessageInfo,
   OnMessage,
   OnError
 } from "@azure/service-bus";
-import { delay } from "rhea-promise";
 
 // Define connection string and related Service Bus entity names here
 const connectionString = "";


### PR DESCRIPTION
The samples in the `samples` folder fail to run because they require users to install `@azure/service-bus` while they are inside of the source code of `@azure/service-bus`. NPM does this distinction by finding the nearest `package.json`. A rather simple fix for this is to add a `package.json` inside of the `samples` folder.

Some notes:
- I'm not adding dependencies yet because they vary considerably from example to example.
- If we decide to list all the dependencies, we might want to also publish this as an NPM package. This would require changes to the available documentation to reflect that users can install the package and try the examples from there.

Closes #3063