### PR TITLE
[Event Hubs] Ensure createSender() works end to end

### DIFF
--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -12,7 +12,7 @@ import { EventHubClient, EventData } from "@azure/event-hubs";
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = "";
-const eventHubsName = "";
+const eventHubName = "";
 
 const listOfScientists = [
   { name: "Einstein", firstName: "Albert" },
@@ -28,20 +28,24 @@ const listOfScientists = [
 ];
 
 async function main(): Promise<void> {
-  const client = EventHubClient.createFromConnectionString(connectionString, eventHubsName);
+  const client = EventHubClient.createFromConnectionString(connectionString, eventHubName);
   const partitionIds = await client.getPartitionIds();
-
+  const sender = client.createSender();
+  const events: EventData[] = [];
+  // NOTE: For receiving events from Azure Stream Analytics, please send Events to an EventHub
+  // where the body is a JSON object/array.
+  // const events = [
+  //   { body: { "message": "Hello World 1" }, applicationProperties: { id: "Some id" }, partitionKey: "pk786" },
+  //   { body: { "message": "Hello World 2" } },
+  //   { body: { "message": "Hello World 3" } }
+  // ];
   for (let index = 0; index < listOfScientists.length; index++) {
     const scientist = listOfScientists[index];
-    const eventData: EventData = {
-      body: `${scientist.firstName} ${scientist.name}`
-    };
-    // NOTE: For receiving events from Azure Stream Analytics, please send Events to an EventHub
-    // where the body is a JSON object/array.
-    // const eventData = { body: { "message": `${scientist.firstName} ${scientist.name}` } };
-    console.log(`Sending event: ${eventData.body}`);
-    await client.send(eventData, partitionIds[0]);
+    events.push({ body: `${scientist.firstName} ${scientist.name}` });
   }
+  console.log("Sending batch events...");
+
+  await sender.send(events, partitionIds[0]);
 
   await client.close();
 }

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -192,9 +192,10 @@ export namespace EventDataInternal {
 
   /**
    * Converts an EventData object to an AMQP message.
-   * @param {EventDataInternal} data The EventData object that needs to be converted to an AMQP message.
+   * @param data The EventData object that needs to be converted to an AMQP message.
+   * @param partitionKey An optional key to determine the partition that this event should land in.
    */
-  export function toAmqpMessage(data: EventDataInternal, batchLabel?: string): Message {
+  export function toAmqpMessage(data: EventDataInternal, partitionKey?: string): Message {
     const msg: Message = {
       body: data.body
     };
@@ -214,8 +215,8 @@ export namespace EventDataInternal {
     if (data.applicationProperties) {
       msg.application_properties = data.applicationProperties;
     }
-    if (batchLabel != undefined) {
-      msg.message_annotations[Constants.partitionKey] = batchLabel;
+    if (partitionKey != undefined) {
+      msg.message_annotations[Constants.partitionKey] = partitionKey;
       // Event Hub service cannot route messages to a specific partition based on the partition key
       // if AMQP message header is an empty object. Hence we make sure that header is always present
       // with atleast one property. Setting durable to true, helps us achieve that.

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -194,7 +194,7 @@ export namespace EventDataInternal {
    * Converts an EventData object to an AMQP message.
    * @param {EventDataInternal} data The EventData object that needs to be converted to an AMQP message.
    */
-  export function toAmqpMessage(data: EventDataInternal): Message {
+  export function toAmqpMessage(data: EventDataInternal, batchLabel?: string): Message {
     const msg: Message = {
       body: data.body
     };
@@ -214,8 +214,8 @@ export namespace EventDataInternal {
     if (data.applicationProperties) {
       msg.application_properties = data.applicationProperties;
     }
-    if (data.partitionKey != undefined) {
-      msg.message_annotations[Constants.partitionKey] = data.partitionKey;
+    if (batchLabel != undefined) {
+      msg.message_annotations[Constants.partitionKey] = batchLabel;
       // Event Hub service cannot route messages to a specific partition based on the partition key
       // if AMQP message header is an empty object. Hence we make sure that header is always present
       // with atleast one property. Setting durable to true, helps us achieve that.

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -24,34 +24,8 @@ import { EventPosition } from "./eventPosition";
 
 import { IotHubClient } from "./iothub/iothubClient";
 import { Aborter } from "./aborter";
-import { Sender } from './sender';
-import { Receiver } from './receiver';
-
-/**
- * LogLevel that defines the level of logging to be used
- */
-export enum LogLevel {
-  /**
-   * No logging will be done
-   */
-  None,
-  /**
-   * Only logs pertaining to errors will be presented
-   */
-  Error,
-  /**
-   * Only logs pertaining to warnings and errors will be presented
-   */
-  Warning,
-  /**
-   * Only informational logs along with errors and warnings will be presented
-   */
-  Info,
-  /**
-   * All possible logs will be presented
-   */
-  Verbose
-}
+import { Sender } from "./sender";
+import { Receiver } from "./receiver";
 
 /**
  * Retry policy options for operations on the EventHubClient
@@ -83,10 +57,6 @@ export interface RequestOptions {
    * The cancellation token used to cancel the current request
    */
   cancellationToken?: Aborter;
-  /**
-   * Log level to use for the current operation. This overrides the value set when creating the EventHubsClient
-   */
-  logLevel?: LogLevel;
 }
 
 /**
@@ -102,7 +72,7 @@ export interface BatchingOptions {
   /**
    * Cancel current operation
    */
-  cancellationToken? : Aborter;
+  cancellationToken?: Aborter;
 }
 
 /**
@@ -157,11 +127,6 @@ export interface ClientOptions {
    * @property {webSocketConstructorOptions} - Options to be passed to the WebSocket constructor
    */
   webSocketConstructorOptions?: any;
-  /**
-   * LogLevel that defines the level of logging to be used. The logLevel set on each operation of the
-   * EventHubsClient will override this value
-   */
-  logLevel?: LogLevel;
 }
 
 /**
@@ -293,15 +258,15 @@ export class EventHubClient {
   }
 
   /**
-  * Creates a Sender 
-  */
+   * Creates a Sender
+   */
   createSender(options?: RequestOptions): Sender {
     return new Sender(this._context, options);
   }
 
   /**
-  * Creates a Receiver 
-  */
+   * Creates a Receiver
+   */
   createReceiver(partitionId: string, options?: ReceiveOptions): Receiver {
     return new Receiver(this._context, partitionId, options);
   }
@@ -369,7 +334,7 @@ export class EventHubClient {
     if (!config.entityPath) {
       throw new TypeError(
         `Either provide "path" or the "connectionString": "${connectionString}", ` +
-        `must contain EntityPath="<path-to-the-entity>".`
+          `must contain EntityPath="<path-to-the-entity>".`
       );
     }
     const tokenProvider = new SasTokenProvider(config.endpoint, config.sharedAccessKeyName, config.sharedAccessKey);

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -181,9 +181,7 @@ export class EventHubReceiver extends LinkEntity {
     this.epoch = options.epoch;
     this.options = options;
     this.receiverRuntimeMetricEnabled = options.enableReceiverRuntimeMetric || false;
-    this.runtimeInfo = {
-      
-    };
+    this.runtimeInfo = {};
     this._checkpoint = {
       enqueuedTimeUtc: new Date(),
       offset: "0",

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -328,8 +328,9 @@ export class EventHubSender extends LinkEntity {
    * "application_properties" and "properties" of the first message will be set as that
    * of the envelope (batch message).
    * @ignore
-   * @param {Array<EventData>} events  An array of EventData objects to be sent in a Batch message.
-   * @return {Promise<void>} Promise<void>
+   * @param events  An array of EventData objects to be sent in a Batch message.
+   * @param options Options to control the way the events are batched along with request options
+   * @return Promise<void>
    */
   async send(events: EventData[], options?: BatchingOptions & RequestOptions): Promise<void> {
     try {
@@ -347,10 +348,10 @@ export class EventHubSender extends LinkEntity {
         });
       }
       log.sender("[%s] Sender '%s', trying to send EventData[].", this._context.connectionId, this.name);
+      const batchLabel = (options && options.batchLabel) || undefined;
       const messages: AmqpMessage[] = [];
       // Convert EventData to AmqpMessage.
       for (let i = 0; i < events.length; i++) {
-        const batchLabel = options && options.batchLabel!;
         const message = EventDataInternal.toAmqpMessage(events[i], batchLabel);
         message.body = this._context.dataTransformer.encode(events[i].body);
         messages[i] = message;

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -129,8 +129,8 @@ export class EventHubSender extends LinkEntity {
         if (!this.isConnecting) {
           log.error(
             "[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
-            "and the sdk did not initiate this. The sender is not reconnecting. Hence, calling " +
-            "detached from the _onAmqpClose() handler.",
+              "and the sdk did not initiate this. The sender is not reconnecting. Hence, calling " +
+              "detached from the _onAmqpClose() handler.",
             this._context.connectionId,
             this.name,
             this.address
@@ -139,8 +139,8 @@ export class EventHubSender extends LinkEntity {
         } else {
           log.error(
             "[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
-            "and the sdk did not initate this. Moreover the sender is already re-connecting. " +
-            "Hence not calling detached from the _onAmqpClose() handler.",
+              "and the sdk did not initate this. Moreover the sender is already re-connecting. " +
+              "Hence not calling detached from the _onAmqpClose() handler.",
             this._context.connectionId,
             this.name,
             this.address
@@ -149,8 +149,8 @@ export class EventHubSender extends LinkEntity {
       } else {
         log.error(
           "[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
-          "because the sdk initiated it. Hence not calling detached from the _onAmqpClose" +
-          "() handler.",
+            "because the sdk initiated it. Hence not calling detached from the _onAmqpClose" +
+            "() handler.",
           this._context.connectionId,
           this.name,
           this.address
@@ -174,8 +174,8 @@ export class EventHubSender extends LinkEntity {
         if (!this.isConnecting) {
           log.error(
             "[%s] 'session_close' event occurred on the session of sender '%s' with " +
-            "address '%s' and the sdk did not initiate this. Hence calling detached from the " +
-            "_onSessionClose() handler.",
+              "address '%s' and the sdk did not initiate this. Hence calling detached from the " +
+              "_onSessionClose() handler.",
             this._context.connectionId,
             this.name,
             this.address
@@ -184,8 +184,8 @@ export class EventHubSender extends LinkEntity {
         } else {
           log.error(
             "[%s] 'session_close' event occurred on the session of sender '%s' with " +
-            "address '%s' and the sdk did not initiate this. Moreover the sender is already " +
-            "re-connecting. Hence not calling detached from the _onSessionClose() handler.",
+              "address '%s' and the sdk did not initiate this. Moreover the sender is already " +
+              "re-connecting. Hence not calling detached from the _onSessionClose() handler.",
             this._context.connectionId,
             this.name,
             this.address
@@ -194,8 +194,8 @@ export class EventHubSender extends LinkEntity {
       } else {
         log.error(
           "[%s] 'session_close' event occurred on the session of sender '%s' with address " +
-          "'%s' because the sdk initiated it. Hence not calling detached from the _onSessionClose" +
-          "() handler.",
+            "'%s' because the sdk initiated it. Hence not calling detached from the _onSessionClose" +
+            "() handler.",
           this._context.connectionId,
           this.name,
           this.address
@@ -224,8 +224,8 @@ export class EventHubSender extends LinkEntity {
           shouldReopen = true;
           log.error(
             "[%s] close() method of Sender '%s' with address '%s' was not called. There " +
-            "was an accompanying error an it is retryable. This is a candidate for re-establishing " +
-            "the sender link.",
+              "was an accompanying error an it is retryable. This is a candidate for re-establishing " +
+              "the sender link.",
             this._context.connectionId,
             this.name,
             this.address
@@ -233,8 +233,8 @@ export class EventHubSender extends LinkEntity {
         } else {
           log.error(
             "[%s] close() method of Sender '%s' with address '%s' was not called. There " +
-            "was an accompanying error and it is NOT retryable. Hence NOT re-establishing " +
-            "the sender link.",
+              "was an accompanying error and it is NOT retryable. Hence NOT re-establishing " +
+              "the sender link.",
             this._context.connectionId,
             this.name,
             this.address
@@ -244,8 +244,8 @@ export class EventHubSender extends LinkEntity {
         shouldReopen = true;
         log.error(
           "[%s] close() method of Sender '%s' with address '%s' was not called. There " +
-          "was no accompanying error as well. This is a candidate for re-establishing " +
-          "the sender link.",
+            "was no accompanying error as well. This is a candidate for re-establishing " +
+            "the sender link.",
           this._context.connectionId,
           this.name,
           this.address
@@ -328,12 +328,12 @@ export class EventHubSender extends LinkEntity {
    * "application_properties" and "properties" of the first message will be set as that
    * of the envelope (batch message).
    * @ignore
-   * @param {Array<EventData>} datas  An array of EventData objects to be sent in a Batch message.
+   * @param {Array<EventData>} events  An array of EventData objects to be sent in a Batch message.
    * @return {Promise<void>} Promise<void>
    */
-  async send(data: EventData[], options?: BatchingOptions & RequestOptions): Promise<void> {
+  async send(events: EventData[], options?: BatchingOptions & RequestOptions): Promise<void> {
     try {
-      if (!data || (data && !Array.isArray(data))) {
+      if (!events || (events && !Array.isArray(events))) {
         throw new Error("data is required and it must be an Array.");
       }
 
@@ -349,9 +349,10 @@ export class EventHubSender extends LinkEntity {
       log.sender("[%s] Sender '%s', trying to send EventData[].", this._context.connectionId, this.name);
       const messages: AmqpMessage[] = [];
       // Convert EventData to AmqpMessage.
-      for (let i = 0; i < data.length; i++) {
-        const message = EventDataInternal.toAmqpMessage(data[i]);
-        message.body = this._context.dataTransformer.encode(data[i].body);
+      for (let i = 0; i < events.length; i++) {
+        const batchLabel = options && options.batchLabel!;
+        const message = EventDataInternal.toAmqpMessage(events[i], batchLabel);
+        message.body = this._context.dataTransformer.encode(events[i].body);
         messages[i] = message;
       }
       // Encode every amqp message and then convert every encoded message to amqp data section
@@ -424,7 +425,12 @@ export class EventHubSender extends LinkEntity {
    * @param message The message to be sent to EventHub.
    * @return {Promise<void>} Promise<void>
    */
-  private _trySend(message: AmqpMessage | Buffer, tag: any, options?: BatchingOptions & RequestOptions, format?: number): Promise<void> {
+  private _trySend(
+    message: AmqpMessage | Buffer,
+    tag: any,
+    options?: BatchingOptions & RequestOptions,
+    format?: number
+  ): Promise<void> {
     if (!options) {
       options = {};
     }
@@ -485,7 +491,7 @@ export class EventHubSender extends LinkEntity {
             } else {
               err = new Error(
                 `[${this._context.connectionId}] Sender '${this.name}', ` +
-                `received a release disposition.Hence we are rejecting the promise.`
+                  `received a release disposition.Hence we are rejecting the promise.`
               );
             }
             log.error(err);
@@ -500,7 +506,7 @@ export class EventHubSender extends LinkEntity {
             } else {
               err = new Error(
                 `[${this._context.connectionId}] Sender "${this.name}", ` +
-                `received a modified disposition.Hence we are rejecting the promise.`
+                  `received a modified disposition.Hence we are rejecting the promise.`
               );
             }
             log.error(err);
@@ -560,8 +566,8 @@ export class EventHubSender extends LinkEntity {
         : Constants.defaultRetryAttempts;
     const delayInSeconds =
       options.retryOptions &&
-        options.retryOptions.delayBetweenRetriesInSeconds &&
-        options.retryOptions.delayBetweenRetriesInSeconds > 0
+      options.retryOptions.delayBetweenRetriesInSeconds &&
+      options.retryOptions.delayBetweenRetriesInSeconds > 0
         ? options.retryOptions.delayBetweenRetriesInSeconds
         : Constants.defaultDelayBetweenOperationRetriesInSeconds;
     const config: RetryConfig<void> = {
@@ -589,7 +595,7 @@ export class EventHubSender extends LinkEntity {
       if (!this.isOpen() && !this.isConnecting) {
         log.error(
           "[%s] The sender '%s' with address '%s' is not open and is not currently " +
-          "establishing itself. Hence let's try to connect.",
+            "establishing itself. Hence let's try to connect.",
           this._context.connectionId,
           this.name,
           this.address

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -7,7 +7,7 @@ export { EventData, ReceivedEventData } from "./eventData";
 export { WebSocketImpl } from "rhea-promise";
 export { LastEnqueuedInfo, OnMessage, OnError } from "./eventHubReceiver";
 export { ReceiveHandler } from "./streamingReceiver";
-export { EventHubClient, ReceiveOptions, ClientOptions, BatchingOptions, RequestOptions, LogLevel, RetryOptions } from "./eventHubClient";
+export { EventHubClient, ReceiveOptions, ClientOptions, BatchingOptions, RequestOptions, RetryOptions } from "./eventHubClient";
 export { EventPosition } from "./eventPosition";
 export { PartitionInformation, HubInformation } from "./managementClient";
 export { Sender } from "./sender";

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 import * as log from "./log";
-import { ConnectionContext } from './connectionContext';
-import { ReceiveOptions } from './eventHubClient';
+import { ConnectionContext } from "./connectionContext";
+import { ReceiveOptions } from "./eventHubClient";
 import { OnMessage, OnError, LastEnqueuedInfo } from "./eventHubReceiver";
 import { ReceivedEventData } from "./eventData";
 import { MessagingError, Constants } from "@azure/amqp-common";
 import { StreamingReceiver, ReceiveHandler } from "./streamingReceiver";
 import { BatchingReceiver } from "./batchingReceiver";
-import { Aborter } from './aborter';
+import { Aborter } from "./aborter";
 
 /**
  * The Receiver class can be used to receive messages in a batch or by registering handlers.
@@ -40,37 +40,37 @@ export class Receiver {
   }
 
   /**
-  * @property Returns `true` if the receiver is closed. This can happen either because the receiver
-  * itself has been closed or the client that created it has been closed.
-  * @readonly
-  */
+   * @property Returns `true` if the receiver is closed. This can happen either because the receiver
+   * itself has been closed or the client that created it has been closed.
+   * @readonly
+   */
   public get partitionId(): string {
     return this._partitionId;
   }
 
   /**
-  * @property {string} [consumerGroup] The consumer group from which the handler is receiving
-  * events from.
-  * @readonly
-  */
+   * @property {string} [consumerGroup] The consumer group from which the handler is receiving
+   * events from.
+   * @readonly
+   */
   get consumerGroup(): string | undefined {
-    return this._receiveOptions && this._receiveOptions.consumerGroup
+    return this._receiveOptions && this._receiveOptions.consumerGroup;
   }
 
   /**
    * @property {number} [epoch] The epoch value of the underlying receiver, if present.
-  * @readonly
-  */
+   * @readonly
+   */
   get epoch(): number | undefined {
-    return this._receiveOptions && this._receiveOptions.epoch
+    return this._receiveOptions && this._receiveOptions.epoch;
   }
 
   /**
-  * @property {ReceiverRuntimeInfo} [runtimeInfo] The receiver runtime info. This property will only
-  * be enabled when `enableReceiverRuntimeMetric` option is set to true in the
-  * `client.receive()` method.
-  * @readonly
-  */
+   * @property {ReceiverRuntimeInfo} [runtimeInfo] The receiver runtime info. This property will only
+   * be enabled when `enableReceiverRuntimeMetric` option is set to true in the
+   * `client.receive()` method.
+   * @readonly
+   */
   get lastEnqueuedInfo(): LastEnqueuedInfo | undefined {
     return undefined;
   }
@@ -84,17 +84,17 @@ export class Receiver {
     this._receiveOptions = options || {};
   }
   /**
-    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
-    * the provided onMessage handler and error will be passed to the provided onError handler.
-    *
-    * @param {string|number} partitionId                        Partition ID from which to receive.
-    * @param {OnMessage} onMessage                              The message handler to receive event data objects.
-    * @param {OnError} onError                                  The error handler to receive an error that occurs
-    * while receiving messages.
-    * @param {ReceiveOptions} [options]                         Options for how you'd like to receive messages.
-    *
-    * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
-    */
+   * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
+   * the provided onMessage handler and error will be passed to the provided onError handler.
+   *
+   * @param {string|number} partitionId                        Partition ID from which to receive.
+   * @param {OnMessage} onMessage                              The message handler to receive event data objects.
+   * @param {OnError} onError                                  The error handler to receive an error that occurs
+   * while receiving messages.
+   * @param {ReceiveOptions} [options]                         Options for how you'd like to receive messages.
+   *
+   * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
+   */
   receive(partitionId: string, onMessage: OnMessage, onError: OnError, cancellationToken?: Aborter): ReceiveHandler {
     if (typeof partitionId !== "string" && typeof partitionId !== "number") {
       throw new Error("'partitionId' is a required parameter and must be of type: 'string' | 'number'.");
@@ -105,11 +105,47 @@ export class Receiver {
     return sReceiver.receive(onMessage, onError);
   }
 
+  /**
+   * Gets an async iterator over events from the receiver.
+   */
+  async *getEventIterator(
+    partitionId: string,
+    batchSize: number,
+    maxWaitTimeInSeconds: number,
+    cancellationToken?: Aborter
+  ): AsyncIterableIterator<ReceivedEventData[]> {
+    // TODO: Create batching receiver using the options here
+    // Update `receiveBatch` call to use the above receiver
+    // Don't export `receiveBatch` from user
+    while (true) {
+      const currentBatch = await this.receiveBatch(partitionId, batchSize, maxWaitTimeInSeconds, cancellationToken);
+      yield currentBatch;
+    }
+  }
+
+  /**
+   * Closes the underlying AMQP receiver link.
+   * Once closed, the receiver cannot be used for any further operations.
+   * Use the `createReceiver` function on the QueueClient or SubscriptionClient to instantiate
+   * a new Receiver
+   *
+   * @returns {Promise<void>}
+   */
+  async close(): Promise<void> {
+    this._isClosed = true;
+  }
+  /**
+   * Indicates whether the receiver is currently receiving messages or not.
+   * When this returns true, new `registerMessageHandler()` or `receiveMessages()` calls cannot be made.
+   */
+  isReceivingMessages(): boolean {
+    return false;
+  }
 
   /**
    * Receives a batch of EventData objects from an EventHub partition for a given count and a given max wait time in seconds, whichever
    * happens first. This method can be used directly after creating the receiver object and **MUST NOT** be used along with the `start()` method.
-   * 
+   *
    * @private
    * @param {string|number} partitionId                        Partition ID from which to receive.
    * @param {number} maxMessageCount                           The maximum message count. Must be a value greater than 0.
@@ -155,46 +191,4 @@ export class Receiver {
     }
     return result;
   }
-
-  /**
-   * Gets an async iterator over events from the receiver.
-   */
-  async *getEventIterator(
-    partitionId: string,
-    batchSize: number,
-    maxWaitTimeInSeconds: number,
-    cancellationToken?: Aborter
-  ): AsyncIterableIterator<ReceivedEventData[]> {
-    // TODO: Create batching receiver using the options here
-    // Update `receiveBatch` call to use the above receiver
-    // Don't export `receiveBatch` from user
-    while (true) {
-      const currentBatch = await this.receiveBatch(partitionId, batchSize, maxWaitTimeInSeconds, cancellationToken);
-      yield currentBatch;
-    }
-  }
-
-  /**
-   * Closes the underlying AMQP receiver link.
-   * Once closed, the receiver cannot be used for any further operations.
-   * Use the `createReceiver` function on the QueueClient or SubscriptionClient to instantiate
-   * a new Receiver
-   *
-   * @returns {Promise<void>}
-   */
-  async close(): Promise<void> {
-    this._isClosed = true;
-  }
-
-  /**
-   * Indicates whether the receiver is currently receiving messages or not.
-   * When this returns true, new `registerMessageHandler()` or `receiveMessages()` calls cannot be made.
-   */
-  isReceivingMessages(): boolean {
-    return false;
-  }
-
-
 }
-
-

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -4,8 +4,7 @@
 import { EventData } from "./eventData";
 import { EventHubSender } from "./eventHubSender";
 import { BatchingOptions, RequestOptions } from "./eventHubClient";
-import { ConnectionContext } from './connectionContext';
-
+import { ConnectionContext } from "./connectionContext";
 
 /**
  * The Sender class can be used to send messages, schedule messages to be sent at a later time
@@ -41,28 +40,28 @@ export class Sender {
     this._context = context;
     this._requestOptions = options || {};
   }
-  
-    /**
+
+  /**
    * Send a batch of EventData to the EventHub using the options provided.
    *
-   * @param data  An array of EventData objects to be sent in a Batch message.
+   * @param events  An array of EventData objects to be sent in a Batch message.
    * @param options Options where you can specifiy the partition to send the message to along with controlling the send
    * request via retry options, log level and cancellation token.
    *
    * @return {Promise<void>} Promise<void>
    */
-  async send(data: EventData[], options?: BatchingOptions): Promise<void>;
+  async send(events: EventData[], options?: BatchingOptions): Promise<void>;
   /**
    * Send a batch of EventData to specified partition of the EventHub using the options provided.
    *
-   * @param data  An array of EventData objects to be sent in a Batch message.
+   * @param events  An array of EventData objects to be sent in a Batch message.
    * @param partitionId Partition ID to which the event data needs to be sent.
    *
    * @return Promise<void>
    */
-  async send(data: EventData[], partitionId: string, options?: BatchingOptions): Promise<void>;
+  async send(events: EventData[], partitionId: string, options?: BatchingOptions): Promise<void>;
   async send(
-    data: EventData[],
+    events: EventData[],
     partitionIdOrOptions?: string | BatchingOptions,
     options?: BatchingOptions
   ): Promise<void> {
@@ -72,9 +71,12 @@ export class Sender {
     } else {
       options = partitionIdOrOptions;
     }
+    if (!Array.isArray(events)) {
+      events = [events];
+    }
 
     const sender = EventHubSender.create(this._context, partitionId);
-    return sender.send(data, {...this._requestOptions, ...options});
+    return sender.send(events, { ...this._requestOptions, ...options });
   }
 
   /**
@@ -87,6 +89,4 @@ export class Sender {
   async close(): Promise<void> {
     this._isClosed = true;
   }
-
- 
 }

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import chai from "chai";
+const should = chai.should();
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+import debugModule from "debug";
+const debug = debugModule("azure:event-hubs:sender-spec");
+import { EventHubClient, EventData } from "../src";
+import dotenv from "dotenv";
+dotenv.config();
+
+describe("EventHub Sender", function(): void {
+  const service = { connectionString: process.env.EVENTHUB_CONNECTION_STRING, path: process.env.EVENTHUB_NAME };
+  const client: EventHubClient = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+  before("validate environment", function(): void {
+    should.exist(
+      process.env.EVENTHUB_CONNECTION_STRING,
+      "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
+    );
+    should.exist(
+      process.env.EVENTHUB_NAME,
+      "define EVENTHUB_NAME in your environment before running integration tests."
+    );
+  });
+
+  after("close the connection", async function(): Promise<void> {
+    debug("Closing the client..");
+    await client.close();
+  });
+
+  describe("Batch message", function(): void {
+    it("should be sent successfully.", async function(): Promise<void> {
+      const data: EventData[] = [
+        {
+          body: "Hello World 1"
+        },
+        {
+          body: "Hello World 2"
+        }
+      ];
+      await client.createSender().send(data);
+    });
+    it("with partition key should be sent successfully.", async function(): Promise<void> {
+      const data: EventData[] = [
+        {
+          body: "Hello World 1"
+          // partitionKey: "p1234"
+        },
+        {
+          body: "Hello World 2"
+        }
+      ];
+      await client.createSender().send(data);
+    });
+    it("should be sent successfully to a specific partition.", async function(): Promise<void> {
+      const data: EventData[] = [
+        {
+          body: "Hello World 1"
+        },
+        {
+          body: "Hello World 2"
+        }
+      ];
+      await client.createSender().send(data, "0");
+    });
+  });
+
+  describe("Multiple messages", function(): void {
+    it("should be sent successfully in parallel", async function(): Promise<void> {
+      const promises = [];
+      for (let i = 0; i < 5; i++) {
+        promises.push(client.createSender().send([{ body: `Hello World ${i}` }]));
+      }
+      await Promise.all(promises);
+    });
+    it("should be sent successfully in parallel by multiple senders", async function(): Promise<void> {
+      const senderCount = 3;
+      try {
+        const promises = [];
+        for (let i = 0; i < senderCount; i++) {
+          if (i === 0) {
+            debug(">>>>> Sending a message to partition %d", i);
+            promises.push(client.createSender().send([{ body: `Hello World ${i}` }], "0"));
+          } else if (i === 1) {
+            debug(">>>>> Sending a message to partition %d", i);
+            promises.push(client.createSender().send([{ body: `Hello World ${i}` }], "1"));
+          } else {
+            debug(">>>>> Sending a message to the hub when i == %d", i);
+            promises.push(client.createSender().send([{ body: `Hello World ${i}` }]));
+          }
+        }
+        await Promise.all(promises);
+      } catch (err) {
+        debug("An error occurred while running the test: ", err);
+        throw err;
+      }
+    });
+
+    it("should fail when a message greater than 256 KB is sent and succeed when a normal message is sent after that on the same link.", async function(): Promise<
+      void
+    > {
+      const data: EventData = {
+        body: Buffer.from("Z".repeat(300000))
+      };
+      try {
+        debug("Sendina message of 300KB...");
+        await client.createSender().send([data], "0");
+      } catch (err) {
+        debug(err);
+        should.exist(err);
+        should.equal(err.name, "MessageTooLargeError");
+        err.message.should.match(
+          /.*The received message \(delivery-id:(\d+), size:3000\d\d bytes\) exceeds the limit \(262144 bytes\) currently allowed on the link\..*/gi
+        );
+      }
+      await client.createSender().send([{ body: "Hello World EventHub!!" }], "0");
+      debug("Sent the message successfully on the same link..");
+    });
+  });
+
+  describe("Negative scenarios", function(): void {
+    it("a message greater than 256 KB should fail.", async function(): Promise<void> {
+      const data: EventData = {
+        body: Buffer.from("Z".repeat(300000))
+      };
+      try {
+        await client.createSender().send([data]);
+      } catch (err) {
+        debug(err);
+        should.exist(err);
+        should.equal(err.name, "MessageTooLargeError");
+        err.message.should.match(
+          /.*The received message \(delivery-id:(\d+), size:3000\d\d bytes\) exceeds the limit \(262144 bytes\) currently allowed on the link\..*/gi
+        );
+      }
+    });
+
+    it("Error thrown when the 'partitionKey' is not of type 'string'", async function(): Promise<void> {
+      const data: EventData = {
+        body: "Hello World"
+        // partitionKey: 1 as any
+      };
+      try {
+        await client.createSender().send([data], "0");
+      } catch (err) {
+        debug(err);
+        should.exist(err);
+        err.message.should.match(/.*'partitionKey' must be of type 'string'.*/gi);
+      }
+    });
+
+    describe("on invalid partition ids like", function(): void {
+      // tslint:disable-next-line: no-null-keyword
+      const invalidIds = ["XYZ", "-1", "1000", "-", null];
+      invalidIds.forEach(function(id: string | null): void {
+        it(`"${id}" should throw an error`, async function(): Promise<void> {
+          try {
+            debug("Created sender and will be sending a message to partition id ...", id);
+            await client.createSender().send([{ body: "Hello world!" }], id as any);
+            debug("sent the message.");
+          } catch (err) {
+            debug(`>>>> Received error for invalid partition id "${id}" - `, err);
+            should.exist(err);
+            err.message.should.match(
+              /.*The specified partition is invalid for an EventHub partition sender or receiver.*/gi
+            );
+          }
+        });
+      });
+
+      const invalidIds2 = ["", " "];
+      invalidIds2.forEach(function(id: string): void {
+        it(`"${id}" should throw an invalid EventHub address error`, async function(): Promise<void> {
+          try {
+            debug("Created sender and will be sending a message to partition id ...", id);
+            await client.createSender().send([{ body: "Hello world!" }], id as any);
+            debug("sent the message.");
+          } catch (err) {
+            debug(`>>>> Received invalid EventHub address error for partition id "${id}" - `, err);
+            should.exist(err);
+            err.message.should.match(/.*Invalid EventHub address. It must be either of the following.*/gi);
+          }
+        });
+      });
+    });
+  });
+}).timeout(20000);


### PR DESCRIPTION
Updating `Send` API as per the API proposal in #2718 (comment). Now we have createSender() method that returns a sender. This PR updates the following:

* send method and all its overloads work as expected
* sender.spec.ts are updated
* send sample is updated
* Remove logLevel from all the receiveOptions
* if user sends 1 event, converted to an array


