### PR TITLE
[Event Hubs] Improve EventPosition class

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -10,6 +10,7 @@ import { ReceiveOptions } from "./eventHubClient";
 import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
 import { EventPosition } from "./eventPosition";
+import { getExpression } from "./util/utils";
 
 interface CreateReceiverOptions {
   onMessage: OnAmqpEvent;
@@ -181,9 +182,7 @@ export class EventHubReceiver extends LinkEntity {
     this.epoch = options.epoch;
     this.options = options;
     this.receiverRuntimeMetricEnabled = options.enableReceiverRuntimeMetric || false;
-    this.runtimeInfo = {
-      
-    };
+    this.runtimeInfo = {};
     this._checkpoint = {
       enqueuedTimeUtc: new Date(),
       offset: "0",
@@ -611,7 +610,7 @@ export class EventHubReceiver extends LinkEntity {
     const eventPosition = options.eventPosition || this.options.eventPosition;
     if (eventPosition) {
       // Set filter on the receiver if event position is specified.
-      const filterClause = eventPosition.getExpression();
+      const filterClause = getExpression(eventPosition);
       if (filterClause) {
         (rcvrOptions.source as any).filter = {
           "apache.org:selector-filter:string": types.wrap_described(filterClause, 0x468c00000004)

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -10,7 +10,7 @@ import { ReceiveOptions } from "./eventHubClient";
 import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
 import { EventPosition } from "./eventPosition";
-import { getExpression } from "./util/utils";
+import { getEventPositionFilter } from "./util/utils";
 
 interface CreateReceiverOptions {
   onMessage: OnAmqpEvent;
@@ -610,7 +610,7 @@ export class EventHubReceiver extends LinkEntity {
     const eventPosition = options.eventPosition || this.options.eventPosition;
     if (eventPosition) {
       // Set filter on the receiver if event position is specified.
-      const filterClause = getExpression(eventPosition);
+      const filterClause = getEventPositionFilter(eventPosition);
       if (filterClause) {
         (rcvrOptions.source as any).filter = {
           "apache.org:selector-filter:string": types.wrap_described(filterClause, 0x468c00000004)

--- a/sdk/eventhub/event-hubs/src/util/utils.ts
+++ b/sdk/eventhub/event-hubs/src/util/utils.ts
@@ -1,0 +1,33 @@
+import { EventPosition } from "../eventPosition";
+import { translate, Constants, ErrorNameConditionMapper } from "@azure/amqp-common";
+
+/**
+ * @internal
+ * Gets the expression (filter clause) that needs to be set on the source.
+ * @return {string} filterExpression
+ */
+export function getExpression(eventPosition: EventPosition): string {
+  let result;
+  // order of preference
+  if (eventPosition.offset != undefined) {
+    result = eventPosition.isInclusive
+      ? `${Constants.offsetAnnotation} >= '${eventPosition.offset}'`
+      : `${Constants.offsetAnnotation} > '${eventPosition.offset}'`;
+  } else if (eventPosition.sequenceNumber != undefined) {
+    result = eventPosition.isInclusive
+      ? `${Constants.sequenceNumberAnnotation} >= '${eventPosition.sequenceNumber}'`
+      : `${Constants.sequenceNumberAnnotation} > '${eventPosition.sequenceNumber}'`;
+  } else if (eventPosition.enqueuedTime != undefined) {
+    const time =
+      eventPosition.enqueuedTime instanceof Date ? eventPosition.enqueuedTime.getTime() : eventPosition.enqueuedTime;
+    result = `${Constants.enqueuedTimeAnnotation} > '${time}'`;
+  }
+
+  if (!result) {
+    throw translate({
+      condition: ErrorNameConditionMapper.ArgumentError,
+      description: "No starting position was set in the EventPosition."
+    });
+  }
+  return result;
+}

--- a/sdk/eventhub/event-hubs/src/util/utils.ts
+++ b/sdk/eventhub/event-hubs/src/util/utils.ts
@@ -3,10 +3,10 @@ import { translate, Constants, ErrorNameConditionMapper } from "@azure/amqp-comm
 
 /**
  * @internal
- * Gets the expression (filter clause) that needs to be set on the source.
+ * Gets the expression to be set as the filter clause when creating the receiver
  * @return {string} filterExpression
  */
-export function getExpression(eventPosition: EventPosition): string {
+export function getEventPositionFilter(eventPosition: EventPosition): string {
   let result;
   // order of preference
   if (eventPosition.offset != undefined) {


### PR DESCRIPTION
As per the API proposal in #2718 (comment), Improve EventPosition class.

This PR updates the following:
* Move getExpression() out of EventPosition class.
* change startOfStream -> firstAvailableEvent and endOfStream -> newEventsOnly
* firstAvailableEvent and endOfStream  return as a static properties on the class.