### PR TITLE
[Event Hubs] Create one AMQP sender link per Sender

### DIFF
--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -30,7 +30,7 @@ const listOfScientists = [
 async function main(): Promise<void> {
   const client = EventHubClient.createFromConnectionString(connectionString, eventHubName);
   const partitionIds = await client.getPartitionIds();
-  const sender = client.createSender();
+  const sender = client.createSender(partitionIds[0]);
   const events: EventData[] = [];
   // NOTE: For receiving events from Azure Stream Analytics, please send Events to an EventHub
   // where the body is a JSON object/array.
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
   }
   console.log("Sending batch events...");
 
-  await sender.send(events, partitionIds[0]);
+  await sender.send(events);
 
   await client.close();
 }

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -259,9 +259,32 @@ export class EventHubClient {
 
   /**
    * Creates a Sender
+   *
+   * @param options Options to create a Sender where you can control the send request via
+   * retry options and cancellation token.
+   *
+   * @return {Promise<void>} Promise<void>
    */
-  createSender(options?: RequestOptions): Sender {
-    return new Sender(this._context, options);
+  createSender(options?: RequestOptions): Sender;
+  /**
+   * Creates a Sender
+   *
+   * @param partitionId Partition ID to which the event data needs to be sent.
+   * @param options Options to create a Sender where you can control the send request via
+   * retry options and cancellation token.
+   *
+   * @return {Promise<void>} Promise<void>
+   */
+  createSender(partitionId: string, options?: RequestOptions): Sender;
+  createSender(partitionIdOrOptions?: string | RequestOptions, options?: RequestOptions): Sender {
+    let partitionId: string | undefined;
+    if (typeof partitionIdOrOptions === "string") {
+      partitionId = partitionIdOrOptions;
+    } else {
+      options = partitionIdOrOptions;
+    }
+
+    return new Sender(this._context, partitionId, options);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -300,6 +300,11 @@ export class EventHubSender extends LinkEntity {
    */
   async close(): Promise<void> {
     if (this._sender) {
+      log.sender(
+        "[%s] Closing the Sender for the entity '%s'.",
+        this._context.connectionId,
+        this._context.config.entityPath
+      );
       const senderLink = this._sender;
       this._deleteFromCache();
       await this._closeLink(senderLink);

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -391,7 +391,7 @@ export class EventHubSender extends LinkEntity {
 
   private _deleteFromCache(): void {
     this._sender = undefined;
-    delete this._context.senders[this.address];
+    delete this._context.senders[this.name];
     log.error(
       "[%s] Deleted the sender '%s' with address '%s' from the client cache.",
       this._context.connectionId,
@@ -624,7 +624,7 @@ export class EventHubSender extends LinkEntity {
         log.error("[%s] Sender '%s' created with sender options: %O", this._context.connectionId, this.name, options);
         // It is possible for someone to close the sender and then start it again.
         // Thus make sure that the sender is present in the client cache.
-        if (!this._context.senders[this.address]) this._context.senders[this.address] = this;
+        if (!this._context.senders[this.name]) this._context.senders[this.name] = this;
         await this._ensureTokenRenewal();
       } else {
         log.error(
@@ -658,9 +658,9 @@ export class EventHubSender extends LinkEntity {
     }
 
     const ehSender: EventHubSender = new EventHubSender(context, partitionId);
-    if (!context.senders[ehSender.address]) {
-      context.senders[ehSender.address] = ehSender;
+    if (!context.senders[ehSender.name]) {
+      context.senders[ehSender.name] = ehSender;
     }
-    return context.senders[ehSender.address];
+    return context.senders[ehSender.name];
   }
 }

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -6,9 +6,7 @@ import { EventHubSender } from "./eventHubSender";
 import { BatchingOptions, RequestOptions } from "./eventHubClient";
 import { ConnectionContext } from "./connectionContext";
 import * as log from "./log";
-import {
-  throwErrorIfConnectionClosed,
-} from "./util/error";
+import { throwErrorIfConnectionClosed } from "./util/error";
 
 /**
  * The Sender class can be used to send messages.
@@ -73,7 +71,12 @@ export class Sender {
    */
   async close(): Promise<void> {
     try {
-      if (this._context.connection && this._context.connection.isOpen() && this._eventHubSender) {
+      if (
+        this._context.connection &&
+        this._context.connection.isOpen() &&
+        this._eventHubSender &&
+        this._context.senders[this._eventHubSender.name]
+      ) {
         await this._context.senders[this._eventHubSender.name].close();
       }
       this._isClosed = true;

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as log from "../log";
+import { ConnectionContext } from "../connectionContext";
+
+/**
+ * @internal
+ * Logs and throws Error if the current AMQP connection is closed.
+ * @param context The ConnectionContext associated with the current AMQP connection.
+ */
+export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
+  if (context && context.wasConnectionCloseCalled) {
+    const errorMessage = "The underlying AMQP connection is closed.";
+    const error = new Error(errorMessage);
+    log.error(`[${context.connectionId}] %O`, error);
+    throw error;
+  }
+}

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -62,7 +62,7 @@ describe("EventHub Sender", function(): void {
           body: "Hello World 2"
         }
       ];
-      await client.createSender().send(data, "0");
+      await client.createSender("0").send(data);
     });
   });
 
@@ -81,10 +81,10 @@ describe("EventHub Sender", function(): void {
         for (let i = 0; i < senderCount; i++) {
           if (i === 0) {
             debug(">>>>> Sending a message to partition %d", i);
-            promises.push(client.createSender().send([{ body: `Hello World ${i}` }], "0"));
+            promises.push(client.createSender("0").send([{ body: `Hello World ${i}` }]));
           } else if (i === 1) {
             debug(">>>>> Sending a message to partition %d", i);
-            promises.push(client.createSender().send([{ body: `Hello World ${i}` }], "1"));
+            promises.push(client.createSender("1").send([{ body: `Hello World ${i}` }]));
           } else {
             debug(">>>>> Sending a message to the hub when i == %d", i);
             promises.push(client.createSender().send([{ body: `Hello World ${i}` }]));
@@ -105,7 +105,7 @@ describe("EventHub Sender", function(): void {
       };
       try {
         debug("Sendina message of 300KB...");
-        await client.createSender().send([data], "0");
+        await client.createSender("0").send([data]);
       } catch (err) {
         debug(err);
         should.exist(err);
@@ -114,7 +114,7 @@ describe("EventHub Sender", function(): void {
           /.*The received message \(delivery-id:(\d+), size:3000\d\d bytes\) exceeds the limit \(262144 bytes\) currently allowed on the link\..*/gi
         );
       }
-      await client.createSender().send([{ body: "Hello World EventHub!!" }], "0");
+      await client.createSender("0").send([{ body: "Hello World EventHub!!" }]);
       debug("Sent the message successfully on the same link..");
     });
   });
@@ -141,7 +141,7 @@ describe("EventHub Sender", function(): void {
         body: "Hello World"
       };
       try {
-        await client.createSender().send([data], "0", { batchLabel: 1 as any });
+        await client.createSender("0").send([data], { batchLabel: 1 as any });
       } catch (err) {
         debug(err);
         should.exist(err);


### PR DESCRIPTION
Each AMQP link tied to one partition and therefore cannot be used to send event to any other partition.

This PRs updates the following:

-  `createSender()` take `partitionId` as an optional parameter
-  `send()` method does not take `partitionId`
-  Create one AMQP link per sender
-  Every `send()` operation in the given sender uses the same AMQP link
-  If multiple senders are created for the same partition, each gets to have its own AMQP sender link