### PR TITLE
Fixed the current secrets tests

### DIFF
--- a/sdk/keyvault/keyvault/package.json
+++ b/sdk/keyvault/keyvault/package.json
@@ -29,12 +29,15 @@
   },
   "devDependencies": {
     "@azure/ms-rest-nodeauth": "^0.9.2",
-    "@types/chai": "^4.1.6",
+    "@types/chai": "^4.1.7",
+    "@types/mocha": "^5.2.6",
     "chai": "^4.2.0",
+    "mocha": "^6.1.4",
     "prettier": "^1.16.4",
     "rimraf": "^2.6.2",
     "rollup": "^1.0.0",
     "rollup-plugin-node-resolve": "^4.2.0",
+    "ts-mocha": "^6.0.0",
     "typescript": "^3.2.2",
     "uglify-js": "^3.4.9"
   },


### PR DESCRIPTION
Addresses the first point of #3080: Fixes the current Secrets tests to work with the latest API.

To run this one has to `npm install` to make sure we have `@types/chai @types/mocha mocha ts-mocha`, then (with your own values):

```
CLIENT_ID="" \
CLIENT_SECRET="" \
TENANT_ID="" \
KEYVAULT_NAME="" \
 ./node_modules/.bin/ts-mocha -p tests/tsconfig.test.json tests/secrets.test.ts
```

Some questions:
- This is not part of any CI pipeline, so this is not going to run until manually executed.
- There are no documentation files about how to run this.
- I'm guessing I can do both points I just mentioned after we move the Secrets package into it's own, as required by https://github.com/Azure/azure-sdk-for-js/issues/3230 . Perhaps we should mention these in an issue/epic? I'm not sure where should these be.