### PR TITLE
[Cosmos] Downcast to ItemDefinition

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -211,7 +211,7 @@ export class Items {
     // Generate random document id if the id is missing in the payload and
     // options.disableAutomaticIdGeneration != true
     if ((body.id === undefined || body.id === "") && !options.disableAutomaticIdGeneration) {
-      body.id = Helper.generateGuidId();
+      (body as ItemDefinition).id = Helper.generateGuidId();
     }
 
     const err = {};
@@ -268,7 +268,7 @@ export class Items {
     // Generate random document id if the id is missing in the payload and
     // options.disableAutomaticIdGeneration != true
     if ((body.id === undefined || body.id === "") && !options.disableAutomaticIdGeneration) {
-      body.id = Helper.generateGuidId();
+      (body as ItemDefinition).id = Helper.generateGuidId();
     }
 
     const err = {};


### PR DESCRIPTION
- Required by improved soundness check introduced in TS 3.5.1
- https://github.com/microsoft/TypeScript/issues/31661

This is one way we could address the compiler errors, but I'm not sure if it's the best way.