### PR TITLE
[AutoPR hdinsight/resource-manager] [HDInsight] Fix specs not support subdomainsuffix parameter

### DIFF
--- a/sdk/hdinsight/arm-hdinsight/package.json
+++ b/sdk/hdinsight/arm-hdinsight/package.json
@@ -26,7 +26,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/hdinsight/arm-hdinsight",
+  "homepage": "https://github.com/azure/azure-sdk-for-js",
   "repository": {
     "type": "git",
     "url": "https://github.com/azure/azure-sdk-for-js.git"

--- a/sdk/hdinsight/arm-hdinsight/src/models/index.ts
+++ b/sdk/hdinsight/arm-hdinsight/src/models/index.ts
@@ -832,6 +832,14 @@ export interface ApplicationGetHttpsEndpoint {
    * The public port to connect to.
    */
   publicPort?: number;
+  /**
+   * The subDomainSuffix of the application and can not greater than 3 characters.
+   */
+  subDomainSuffix?: string;
+  /**
+   * The value indicates whether to disable GatewayAuth.
+   */
+  disableGatewayAuth?: boolean;
 }
 
 /**

--- a/sdk/hdinsight/arm-hdinsight/src/models/mappers.ts
+++ b/sdk/hdinsight/arm-hdinsight/src/models/mappers.ts
@@ -1435,6 +1435,18 @@ export const ApplicationGetHttpsEndpoint: msRest.CompositeMapper = {
         type: {
           name: "Number"
         }
+      },
+      subDomainSuffix: {
+        serializedName: "subDomainSuffix",
+        type: {
+          name: "String"
+        }
+      },
+      disableGatewayAuth: {
+        serializedName: "disableGatewayAuth",
+        type: {
+          name: "Boolean"
+        }
       }
     }
   }


### PR DESCRIPTION
Created to sync https://github.com/Azure/azure-rest-api-specs/pull/6150