### PR TITLE
Remove duplicate Buffer module references from node-resolve plugin

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -122,7 +122,7 @@
     "coverage": "nyc --reporter=lcov --exclude-after-remap=false mocha -t 120000 test-dist/index.js --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
-    "integration-test:browser": "echo skipped",
+    "integration-test:browser": "karma start --single-run",
     "integration-test:node": "mocha -t 120000 test-dist/index.js --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint": "eslint -c ../../.eslintrc.json src test samples --ext .ts -f node_modules/eslint-detailed-reporter/lib/detailed.js -o service-bus-lintReport.html || exit 0",

--- a/sdk/servicebus/service-bus/rollup.base.config.js
+++ b/sdk/servicebus/service-bus/rollup.base.config.js
@@ -134,7 +134,8 @@ export function browserConfig({ test = false, production = false } = {}) {
 
       nodeResolve({
         mainFields: ["module", "browser"],
-        preferBuiltins: false
+        preferBuiltins: false,
+        dedupe: ["buffer"]
       }),
       cjs({
         namedExports: { events: ["EventEmitter"], long: ["ZERO"] }


### PR DESCRIPTION
For more context refer to #3119 

@bterlson and I had troubleshooted this offline and found that removing duplicate Buffer module references from the rolled up file fixes the issue!