### PR TITLE
Add types to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,7 @@ browser
 test-browser
 typings
 typedoc
+types
 
 # autorest generated files
 swagger/*.json


### PR DESCRIPTION
We're using `types` in KeyVault's packages. We should ignore them.

I'm not sure how to label this PR :thinking: