### PR TITLE
[Event Hubs] Ensure receiver is functional

### DIFF
--- a/sdk/eventhub/event-hubs/samples/receiveEventsLoop.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsLoop.ts
@@ -33,11 +33,11 @@ async function main(): Promise<void> {
       console.log(`Received events: ${events.map(event => event.body)}`);
     }
 
-    let receivedIteratorEvent = 0;
+    let iteratorCount = 0;
     for await (const events of receiver.getEventIterator({ preFetchCount: 5 })) {
-      receivedIteratorEvent++;
+      iteratorCount++;
       console.log(`Received event: ${events.body}`);
-      if (receivedIteratorEvent === 5) {
+      if (iteratorCount === 5) {
         break;
       }
     }

--- a/sdk/eventhub/event-hubs/samples/receiveEventsLoop.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsLoop.ts
@@ -22,7 +22,6 @@ async function main(): Promise<void> {
     consumerGroup: "$Default"
   });
   const batchSize = 1;
-  let messageLength = 0;
 
   try {
     for (let i = 0; i < 5; i++) {
@@ -34,10 +33,11 @@ async function main(): Promise<void> {
       console.log(`Received events: ${events.map(event => event.body)}`);
     }
 
+    let receivedIteratorEvent = 0;
     for await (const events of receiver.getEventIterator({ preFetchCount: 5 })) {
-      messageLength++;
+      receivedIteratorEvent++;
       console.log(`Received event: ${events.body}`);
-      if (messageLength === 5) {
+      if (receivedIteratorEvent === 5) {
         break;
       }
     }

--- a/sdk/eventhub/event-hubs/samples/receiveEventsLoop.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsLoop.ts
@@ -12,27 +12,40 @@ import { EventHubClient, EventPosition } from "@azure/event-hubs";
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = "";
-const eventHubsName = "";
+const eventHubName = "";
 
 async function main(): Promise<void> {
-  const client = EventHubClient.createFromConnectionString(connectionString, eventHubsName);
+  const client = EventHubClient.createFromConnectionString(connectionString, eventHubName);
   const partitionIds = await client.getPartitionIds();
-  let eventPosition = EventPosition.fromStart();
+  const receiver = client.createReceiver(partitionIds[0], {
+    eventPosition: EventPosition.fromFirstAvailableEvent(),
+    consumerGroup: "$Default"
+  });
   const batchSize = 1;
+  let messageLength = 0;
 
-  for (let i = 0; i < 10; i++) {
-    const events = await client.receiveBatch(partitionIds[0], batchSize, 5, {
-      eventPosition: eventPosition,
-      consumerGroup: "$Default"
-    });
-    if (!events.length) {
-      console.log("No more events to receive");
-      break;
+  try {
+    for (let i = 0; i < 5; i++) {
+      const events = await receiver.receiveBatch(batchSize, 5);
+      if (!events.length) {
+        console.log("No more events to receive");
+        break;
+      }
+      console.log(`Received events: ${events.map(event => event.body)}`);
     }
-    eventPosition = EventPosition.fromSequenceNumber(events[events.length - 1].sequenceNumber!);
-    console.log(`Received events #${i}: ${events.map(event => event.body)}`);
+
+    for await (const events of receiver.getEventIterator({ preFetchCount: 5 })) {
+      messageLength++;
+      console.log(`Received event: ${events.body}`);
+      if (messageLength === 5) {
+        break;
+      }
+    }
+
+    await receiver.close();
+  } finally {
+    await client.close();
   }
-  await client.close();
 }
 
 main().catch(err => {

--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -30,24 +30,26 @@ const listOfScientists = [
 async function main(): Promise<void> {
   const client = EventHubClient.createFromConnectionString(connectionString, eventHubName);
   const partitionIds = await client.getPartitionIds();
-  const sender = client.createSender(partitionIds[0]);
+  const sender = client.createSender({ partitionId: partitionIds[0] });
   const events: EventData[] = [];
-  // NOTE: For receiving events from Azure Stream Analytics, please send Events to an EventHub
-  // where the body is a JSON object/array.
-  // const events = [
-  //   { body: { "message": "Hello World 1" }, applicationProperties: { id: "Some id" }, partitionKey: "pk786" },
-  //   { body: { "message": "Hello World 2" } },
-  //   { body: { "message": "Hello World 3" } }
-  // ];
-  for (let index = 0; index < listOfScientists.length; index++) {
-    const scientist = listOfScientists[index];
-    events.push({ body: `${scientist.firstName} ${scientist.name}` });
+  try {
+    // NOTE: For receiving events from Azure Stream Analytics, please send Events to an EventHub
+    // where the body is a JSON object/array.
+    // const events = [
+    //   { body: { "message": "Hello World 1" }, applicationProperties: { id: "Some id" }, partitionKey: "pk786" },
+    //   { body: { "message": "Hello World 2" } },
+    //   { body: { "message": "Hello World 3" } }
+    // ];
+    for (let index = 0; index < listOfScientists.length; index++) {
+      const scientist = listOfScientists[index];
+      events.push({ body: `${scientist.firstName} ${scientist.name}` });
+    }
+    console.log("Sending batch events...");
+
+    await sender.send(events);
+  } finally {
+    await client.close();
   }
-  console.log("Sending batch events...");
-
-  await sender.send(events);
-
-  await client.close();
 }
 
 main().catch(err => {

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -27,5 +27,6 @@ export {
   TokenProvider,
   TokenInfo,
   AadTokenProvider,
-  SasTokenProvider
+  SasTokenProvider,
+  delay
 } from "@azure/amqp-common";

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -48,8 +48,8 @@ export class Receiver {
 
   private _partitionId: string;
   private _receiverOptions: ReceiverOptions;
-  private _streamingReceiver: StreamingReceiver;
-  private _batchingReceiver: BatchingReceiver;
+  private _streamingReceiver: StreamingReceiver | undefined;
+  private _batchingReceiver: BatchingReceiver | undefined;
 
   /**
    * @property Returns `true` if the receiver is closed. This can happen either because the receiver
@@ -93,8 +93,6 @@ export class Receiver {
     this._context = context;
     this._partitionId = partitionId;
     this._receiverOptions = options || {};
-    this._streamingReceiver = {} as StreamingReceiver;
-    this._batchingReceiver = {} as BatchingReceiver;
   }
   /**
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
@@ -111,7 +109,6 @@ export class Receiver {
     this._throwIfReceiverOrConnectionClosed();
     this._streamingReceiver = StreamingReceiver.create(this._context, this.partitionId, this._receiverOptions);
     this._streamingReceiver.prefetchCount = Constants.defaultPrefetchCount;
-    this._context.receivers[this._streamingReceiver.name] = this._streamingReceiver;
     return this._streamingReceiver.receive(onMessage, onError);
   }
 
@@ -185,7 +182,6 @@ export class Receiver {
   ): Promise<ReceivedEventData[]> {
     this._throwIfReceiverOrConnectionClosed();
     this._batchingReceiver = BatchingReceiver.create(this._context, this.partitionId, this._receiverOptions);
-    this._context.receivers[this._batchingReceiver.name] = this._batchingReceiver;
     let error: MessagingError | undefined;
     let result: ReceivedEventData[] = [];
     try {

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -10,6 +10,7 @@ import { MessagingError, Constants } from "@azure/amqp-common";
 import { StreamingReceiver, ReceiveHandler } from "./streamingReceiver";
 import { BatchingReceiver } from "./batchingReceiver";
 import { Aborter } from "./aborter";
+import { throwErrorIfConnectionClosed } from "./util/error";
 
 /**
  * Options to pass when creating an iterator to iterate over events
@@ -47,6 +48,8 @@ export class Receiver {
 
   private _partitionId: string;
   private _receiverOptions: ReceiverOptions;
+  private _streamingReceiver: StreamingReceiver;
+  private _batchingReceiver: BatchingReceiver;
 
   /**
    * @property Returns `true` if the receiver is closed. This can happen either because the receiver
@@ -90,6 +93,8 @@ export class Receiver {
     this._context = context;
     this._partitionId = partitionId;
     this._receiverOptions = options || {};
+    this._streamingReceiver = {} as StreamingReceiver;
+    this._batchingReceiver = {} as BatchingReceiver;
   }
   /**
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
@@ -103,10 +108,11 @@ export class Receiver {
    * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
    */
   receive(onMessage: OnMessage, onError: OnError, cancellationToken?: Aborter): ReceiveHandler {
-    const sReceiver = StreamingReceiver.create(this._context, this.partitionId, this._receiverOptions);
-    sReceiver.prefetchCount = Constants.defaultPrefetchCount;
-    this._context.receivers[sReceiver.name] = sReceiver;
-    return sReceiver.receive(onMessage, onError);
+    this._throwIfReceiverOrConnectionClosed();
+    this._streamingReceiver = StreamingReceiver.create(this._context, this.partitionId, this._receiverOptions);
+    this._streamingReceiver.prefetchCount = Constants.defaultPrefetchCount;
+    this._context.receivers[this._streamingReceiver.name] = this._streamingReceiver;
+    return this._streamingReceiver.receive(onMessage, onError);
   }
 
   /**
@@ -122,14 +128,37 @@ export class Receiver {
   /**
    * Closes the underlying AMQP receiver link.
    * Once closed, the receiver cannot be used for any further operations.
-   * Use the `createReceiver` function on the QueueClient or SubscriptionClient to instantiate
+   * Use the `createReceiver` function on the EventHubClient to instantiate
    * a new Receiver
    *
    * @returns {Promise<void>}
    */
   async close(): Promise<void> {
-    this._isClosed = true;
+    try {
+      if (this._context.connection && this._context.connection.isOpen()) {
+        // Close the streaming receiver.
+        if (this._streamingReceiver) {
+          await this._streamingReceiver.close();
+        }
+
+        // Close the batching receiver.
+        if (this._batchingReceiver) {
+          await this._batchingReceiver.close();
+        }
+      }
+    } catch (err) {
+      log.error(
+        "[%s] An error occurred while closing the Receiver for %s: %O",
+        this._context.connectionId,
+        this._context.config.entityPath,
+        err
+      );
+      throw err;
+    } finally {
+      this._isClosed = true;
+    }
   }
+
   /**
    * Indicates whether the receiver is currently receiving messages or not.
    * When this returns true, new `registerMessageHandler()` or `receiveMessages()` calls cannot be made.
@@ -154,25 +183,26 @@ export class Receiver {
     maxWaitTimeInSeconds?: number,
     cancellationToken?: Aborter
   ): Promise<ReceivedEventData[]> {
-    const bReceiver = BatchingReceiver.create(this._context, this.partitionId, this._receiverOptions);
-    this._context.receivers[bReceiver.name] = bReceiver;
+    this._throwIfReceiverOrConnectionClosed();
+    this._batchingReceiver = BatchingReceiver.create(this._context, this.partitionId, this._receiverOptions);
+    this._context.receivers[this._batchingReceiver.name] = this._batchingReceiver;
     let error: MessagingError | undefined;
     let result: ReceivedEventData[] = [];
     try {
-      result = await bReceiver.receive(maxMessageCount, maxWaitTimeInSeconds);
+      result = await this._batchingReceiver.receive(maxMessageCount, maxWaitTimeInSeconds);
     } catch (err) {
       error = err;
       log.error(
         "[%s] Receiver '%s', an error occurred while receiving %d messages for %d max time:\n %O",
         this._context.connectionId,
-        bReceiver.name,
+        this._batchingReceiver.name,
         maxMessageCount,
         maxWaitTimeInSeconds,
         err
       );
     }
     try {
-      await bReceiver.close();
+      await this._batchingReceiver.close();
     } catch (err) {
       // do nothing about it.
     }
@@ -180,5 +210,17 @@ export class Receiver {
       throw error;
     }
     return result;
+  }
+
+  private _throwIfReceiverOrConnectionClosed(): void {
+    throwErrorIfConnectionClosed(this._context);
+    if (this.isClosed) {
+      const errorMessage =
+        `The receiver for "${this._context.config.entityPath}" has been closed and can no longer be used. ` +
+        `Please create a new receiver using the "createReceiver" function on the EventHubClient.`;
+      const error = new Error(errorMessage);
+      log.error(`[${this._context.connectionId}] %O`, error);
+      throw error;
+    }
   }
 }

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -71,13 +71,8 @@ export class Sender {
    */
   async close(): Promise<void> {
     try {
-      if (
-        this._context.connection &&
-        this._context.connection.isOpen() &&
-        this._eventHubSender &&
-        this._context.senders[this._eventHubSender.name]
-      ) {
-        await this._context.senders[this._eventHubSender.name].close();
+      if (this._context.connection && this._context.connection.isOpen() && this._eventHubSender) {
+        await this._eventHubSender.close();
       }
       this._isClosed = true;
     } catch (err) {

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -1,0 +1,631 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import chai from "chai";
+import uuid from "uuid/v4";
+const should = chai.should();
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+import debugModule from "debug";
+const debug = debugModule("azure:event-hubs:receiver-spec");
+import { EventPosition, EventHubClient, EventData, MessagingError, delay, ReceivedEventData } from "../src";
+import { BatchingReceiver } from "../src/batchingReceiver";
+import { ReceiveHandler } from "../src/streamingReceiver";
+import dotenv from "dotenv";
+dotenv.config();
+
+describe("EventHub Receiver", function(): void {
+  const service = { connectionString: process.env.EVENTHUB_CONNECTION_STRING, path: process.env.EVENTHUB_NAME };
+  const client: EventHubClient = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+  let breceiver: BatchingReceiver;
+  let partitionIds: string[];
+  before("validate environment", async function(): Promise<void> {
+    should.exist(
+      process.env.EVENTHUB_CONNECTION_STRING,
+      "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
+    );
+    should.exist(
+      process.env.EVENTHUB_NAME,
+      "define EVENTHUB_NAME in your environment before running integration tests."
+    );
+    partitionIds = await client.getPartitionIds();
+  });
+
+  after("close the connection", async function(): Promise<void> {
+    await client.close();
+  });
+
+  afterEach("close the sender link", async function(): Promise<void> {
+    if (breceiver) {
+      await breceiver.close();
+      debug("After each - Batching Receiver closed.");
+    }
+  });
+
+  describe("with partitionId 0 as number", function(): void {
+    it("should work for receiveBatch", async function(): Promise<void> {
+      const result = await client
+        .createReceiver(partitionIds[0], { eventPosition: EventPosition.fromSequenceNumber(0) })
+        .receiveBatch(10, 20);
+      should.equal(true, Array.isArray(result));
+    });
+
+    it("should work for receive", function(done: Mocha.Done): void {
+      let rcvHandler: ReceiveHandler;
+      let stopCalled = false;
+      const onError = (error: MessagingError | Error) => {
+        debug(">>>> An error occurred: %O", error);
+      };
+      const onMsg = (data: ReceivedEventData) => {
+        debug(">>>> Received Data: %O", data);
+        if (!stopCalled) {
+          stopCalled = true;
+          rcvHandler
+            .stop()
+            .then(() => {
+              done();
+            })
+            .catch(() => {
+              done();
+            });
+        }
+      };
+      rcvHandler = client
+        .createReceiver(partitionIds[0], { exclusiveReceiverPriority: 1, eventPosition: EventPosition.fromOffset("0") })
+        .receive(onMsg, onError);
+    });
+  });
+
+  describe("with EventPosition specified as", function(): void {
+    it("'from end of stream' should receive messages correctly", async function(): Promise<void> {
+      const partitionId = partitionIds[0];
+      const events: EventData[] = [];
+      for (let i = 0; i < 10; i++) {
+        const ed: EventData = {
+          body: "Hello awesome world " + i
+        };
+        events.push(ed);
+      }
+      await client.createSender({ partitionId: partitionId }).send(events);
+      debug("Creating new receiver with offset EndOfStream");
+      breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
+        eventPosition: EventPosition.fromNewEventsOnly()
+      });
+      const data1 = await breceiver.receive(10, 10);
+      data1.length.should.equal(0, "Unexpected message received when using EventPosition.fromEnd()");
+      // send a new message. We should only receive this new message.
+      const uid = uuid();
+      const ed: EventData = {
+        body: "New message",
+        properties: {
+          stamp: uid
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed]);
+      debug(">>>>>>> Sent the new message after creating the receiver. We should only receive this message.");
+      const data2 = await breceiver.receive(10, 20);
+      debug("received messages: ", data2);
+      data2.length.should.equal(1, "Failed to receive the expected one single message");
+      data2[0].properties!.stamp.should.equal(uid, "Message received with unexpected uid");
+      debug("Next receive on this partition should not receive any messages.");
+      const data3 = await breceiver.receive(10, 10);
+      data3.length.should.equal(0, "Unexpected message received");
+    });
+
+    it("'after a particular offset' should receive messages correctly", async function(): Promise<void> {
+      const partitionId = partitionIds[0];
+      const pInfo = await client.getPartitionInformation(partitionId);
+      debug(`Creating new receiver with last enqueued offset: "${pInfo.lastEnqueuedOffset}".`);
+      breceiver = BatchingReceiver.create((client as any)._context, parseInt(partitionId), {
+        eventPosition: EventPosition.fromOffset(pInfo.lastEnqueuedOffset)
+      });
+      debug("Establishing the receiver link...");
+      const d = await breceiver.receive(10, 10);
+      d.length.should.equal(0);
+      // send a new message. We should only receive this new message.
+      const uid = uuid();
+      const ed: EventData = {
+        body: "New message after last enqueued offset",
+        properties: {
+          stamp: uid
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed]);
+      debug("Sent the new message after creating the receiver. We should only receive this message.");
+      const data = await breceiver.receive(10, 20);
+      debug("received messages: ", data);
+      data.length.should.equal(1);
+      data[0].properties!.stamp.should.equal(uid);
+      debug("Next receive on this partition should not receive any messages.");
+      const data2 = await breceiver.receive(10, 10);
+      data2.length.should.equal(0);
+    });
+
+    it("'after a particular offset with isInclusive true' should receive messages correctly", async function(): Promise<
+      void
+    > {
+      const partitionId = partitionIds[0];
+      const uid = uuid();
+      const ed: EventData = {
+        body: "New message after last enqueued offset",
+        properties: {
+          stamp: uid
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed]);
+      debug(`Sent message 1 with stamp: ${uid}.`);
+      const pInfo = await client.getPartitionInformation(partitionId);
+      const uid2 = uuid();
+      const ed2: EventData = {
+        body: "New message after last enqueued offset",
+        properties: {
+          stamp: uid2
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed2]);
+      debug(`Sent message 2 with stamp: ${uid} after getting the enqueued offset.`);
+      debug(`Creating new receiver with last enqueued offset: "${pInfo.lastEnqueuedOffset}".`);
+      breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
+        eventPosition: EventPosition.fromOffset(pInfo.lastEnqueuedOffset, true)
+      });
+      debug("We should receive the last 2 messages.");
+      const data = await breceiver.receive(10, 30);
+      debug("received messages: ", data);
+      data.length.should.equal(2, "Failed to receive the two expected messages");
+      data[0].properties!.stamp.should.equal(uid, "First message has unexpected uid");
+      data[1].properties!.stamp.should.equal(uid2, "Second message has unexpected uid");
+      debug("Next receive on this partition should not receive any messages.");
+      const data2 = await breceiver.receive(10, 10);
+      data2.length.should.equal(0, "Unexpected message received");
+    });
+
+    it("'from a particular enqueued time' should receive messages correctly", async function(): Promise<void> {
+      const partitionId = partitionIds[0];
+      const pInfo = await client.getPartitionInformation(partitionId);
+      debug(`Creating new receiver with last enqueued time: "${pInfo.lastEnqueuedTimeUtc}".`);
+      breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
+        eventPosition: EventPosition.fromEnqueuedTime(pInfo.lastEnqueuedTimeUtc)
+      });
+      debug("Establishing the receiver link...");
+      const d = await breceiver.receive(10, 10);
+      d.length.should.equal(0, "Unexpected message received before sending any message");
+      // send a new message. We should only receive this new message.
+      const uid = uuid();
+      const ed: EventData = {
+        body: "New message after last enqueued time " + pInfo.lastEnqueuedTimeUtc,
+        properties: {
+          stamp: uid
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed]);
+      debug("Sent the new message after creating the receiver. We should only receive this message.");
+      const data = await breceiver.receive(10, 20);
+      debug("received messages: ", data);
+      data.length.should.equal(1, "Failed to received the expected single message");
+      data[0].properties!.stamp.should.equal(uid);
+      debug("Next receive on this partition should not receive any messages.");
+      const data2 = await breceiver.receive(10, 10);
+      data2.length.should.equal(0, "Unexpected message received");
+    });
+
+    it("'after the particular sequence number' should receive messages correctly", async function(): Promise<void> {
+      const partitionId = partitionIds[0];
+      const pInfo = await client.getPartitionInformation(partitionId);
+      // send a new message. We should only receive this new message.
+      const uid = uuid();
+      const ed: EventData = {
+        body: "New message after last enqueued sequence number " + pInfo.lastEnqueuedSequenceNumber,
+        properties: {
+          stamp: uid
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed]);
+      debug(
+        "Sent the new message after getting the partition runtime information. We should only receive this message."
+      );
+      debug(`Creating new receiver with last enqueued sequence number: "${pInfo.lastEnqueuedSequenceNumber}".`);
+      breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
+        eventPosition: EventPosition.fromSequenceNumber(pInfo.lastEnqueuedSequenceNumber)
+      });
+      const data = await breceiver.receive(10, 20);
+      debug("received messages: ", data);
+      data.length.should.equal(1, "Failed to receive the expected single message");
+      data[0].properties!.stamp.should.equal(uid, "Received message has unexpected uid");
+      debug("Next receive on this partition should not receive any messages.");
+      const data2 = await breceiver.receive(10, 10);
+      data2.length.should.equal(0, "Unexpected message received");
+    });
+
+    it("'after the particular sequence number' with isInclusive true should receive messages correctly", async function(): Promise<
+      void
+    > {
+      const partitionId = partitionIds[0];
+      const uid = uuid();
+      const ed: EventData = {
+        body: "New message before getting the last sequence number",
+        properties: {
+          stamp: uid
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed]);
+      debug(`Sent message 1 with stamp: ${uid}.`);
+      const pInfo = await client.getPartitionInformation(partitionId);
+      const uid2 = uuid();
+      const ed2: EventData = {
+        body: "New message after the last enqueued offset",
+        properties: {
+          stamp: uid2
+        }
+      };
+      await client.createSender({ partitionId: partitionId }).send([ed2]);
+      debug(`Sent message 2 with stamp: ${uid}.`);
+      debug(`Creating new receiver with last sequence number: "${pInfo.lastEnqueuedSequenceNumber}".`);
+      breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
+        eventPosition: EventPosition.fromSequenceNumber(pInfo.lastEnqueuedSequenceNumber, true)
+      });
+      debug("We should receive the last 2 messages.");
+      const data = await breceiver.receive(10, 30);
+      debug("received messages: ", data);
+      data.length.should.equal(2, "Failed to received two expected messages");
+      data[0].properties!.stamp.should.equal(uid, "Message 1 has unexpected uid");
+      data[1].properties!.stamp.should.equal(uid2, "Message 2 has unexpected uid");
+      debug("Next receive on this partition should not receive any messages.");
+      const data2 = await breceiver.receive(10, 10);
+      data2.length.should.equal(0, "Unexpected message received");
+    });
+  });
+
+  describe("in batch mode", function(): void {
+    it("should receive messages correctly", async function(): Promise<void> {
+      const partitionId = partitionIds[0];
+      const data = await client.createReceiver(partitionId).receiveBatch(5, 10);
+      debug("received messages: ", data);
+      data.length.should.equal(5, "Failed to receive five expected messages");
+    });
+  });
+
+  // describe("with receiverRuntimeMetricEnabled", function (): void {
+  //   it("should have ReceiverRuntimeInfo populated", async function (): Promise<void> {
+  //     const partitionId = hubInfo.partitionIds[0];
+  //     sender = client.createSender(partitionId);
+  //     for (let i = 0; i < 10; i++) {
+  //       const ed: EventData = {
+  //         body: "Hello awesome world " + i
+  //       }
+  //       await sender.send(ed);
+  //       debug("sent message - " + i);
+  //     }
+  //     debug("Getting the partition information");
+  //     const pInfo = await client.getPartitionInformation(partitionId);
+  //     debug("partition info: ", pInfo);
+  //     debug("Creating new receiver with offset EndOfStream");
+  //     receiver = client.createReceiver(partitionId, { eventPosition: EventPosition.fromStart(), enableReceiverRuntimeMetric: true });
+  //     let data = await receiver.receive(1, 10);
+  //     debug("receiver.runtimeInfo ", receiver.runtimeInfo);
+  //     data.length.should.equal(1);
+  //     should.exist(receiver.runtimeInfo);
+  //     receiver.runtimeInfo!.lastEnqueuedOffset!.should.equal(pInfo.lastEnqueuedOffset);
+  //     receiver.runtimeInfo!.lastSequenceNumber!.should.equal(pInfo.lastSequenceNumber);
+  //     receiver.runtimeInfo!.lastEnqueuedTimeUtc!.getTime().should.equal(pInfo.lastEnqueuedTimeUtc.getTime());
+  //     receiver.runtimeInfo!.partitionId!.should.equal(pInfo.partitionId);
+  //     receiver.runtimeInfo!.retrievalTime!.getTime().should.be.greaterThan(Date.now() - 60000);
+  //   });
+  // });
+
+  describe("with epoch", function(): void {
+    it("should behave correctly when a receiver with lower epoch value is connected after a receiver with higher epoch value to a partition in a consumer group", function(done: Mocha.Done): void {
+      const partitionId = partitionIds[0];
+      let epochRcvr1: ReceiveHandler;
+      let epochRcvr2: ReceiveHandler;
+      const onError = (error: MessagingError | Error) => {
+        debug(">>>> epoch Receiver 1", error);
+        throw new Error("An Error should not have happened for epoch receiver with epoch value 2.");
+      };
+      const onMsg = (data: ReceivedEventData) => {
+        debug(">>>> epoch Receiver 1", data);
+      };
+      epochRcvr1 = client
+        .createReceiver(partitionId, { exclusiveReceiverPriority: 2, eventPosition: EventPosition.fromNewEventsOnly() })
+        .receive(onMsg, onError);
+      debug("Created epoch receiver 1 %s", epochRcvr1);
+      setTimeout(() => {
+        const onError2 = (error: MessagingError | Error) => {
+          debug(">>>> epoch Receiver 2", error);
+          should.exist(error);
+          should.equal(error.name, "ReceiverDisconnectedError");
+          epochRcvr2
+            .stop()
+            .then(() => epochRcvr1.stop())
+            .then(() => {
+              debug("Successfully closed the epoch receivers 1 and 2.");
+              done();
+            })
+            .catch(err => {
+              debug("error occurred while closing the receivers... ", err);
+              done();
+            });
+        };
+        const onMsg2 = (data: ReceivedEventData) => {
+          debug(">>>> epoch Receiver 2", data);
+        };
+        epochRcvr2 = client
+          .createReceiver(partitionId, {
+            exclusiveReceiverPriority: 1,
+            eventPosition: EventPosition.fromNewEventsOnly()
+          })
+          .receive(onMsg2, onError2);
+        debug("Created epoch receiver 2 %s", epochRcvr2);
+      }, 3000);
+    });
+
+    it("should behave correctly when a receiver with higher epoch value is connected after a receiver with lower epoch value to a partition in a consumer group", function(done: Mocha.Done): void {
+      const partitionId = partitionIds[0];
+      let epochRcvr1: ReceiveHandler;
+      let epochRcvr2: ReceiveHandler;
+      const onError = (error: MessagingError | Error) => {
+        debug(">>>> epoch Receiver 1", error);
+        should.exist(error);
+        should.equal(error.name, "ReceiverDisconnectedError");
+        epochRcvr1
+          .stop()
+          .then(() => epochRcvr2.stop())
+          .then(() => {
+            debug("Successfully closed the epoch receivers 1 and 2.");
+            done();
+          })
+          .catch(err => {
+            debug("error occurred while closing the receivers... ", err);
+            done();
+          });
+      };
+      const onMsg = (data: ReceivedEventData) => {
+        debug(">>>> epoch Receiver 1", data);
+      };
+      epochRcvr1 = client
+        .createReceiver(partitionId, {
+          exclusiveReceiverPriority: 1,
+          eventPosition: EventPosition.fromNewEventsOnly()
+        })
+        .receive(onMsg, onError);
+      debug("Created epoch receiver 1 %s", epochRcvr1);
+      setTimeout(() => {
+        const onError2 = (error: MessagingError | Error) => {
+          debug(">>>> epoch Receiver 2", error);
+          throw new Error("An Error should not have happened for epoch receiver with epoch value 2.");
+        };
+        const onMsg2 = (data: ReceivedEventData) => {
+          debug(">>>> epoch Receiver 2", data);
+        };
+        epochRcvr2 = client
+          .createReceiver(partitionId, {
+            exclusiveReceiverPriority: 2,
+            eventPosition: EventPosition.fromNewEventsOnly()
+          })
+          .receive(onMsg2, onError2);
+        debug("Created epoch receiver 2 %s", epochRcvr2);
+      }, 3000);
+    });
+
+    it("should behave correctly when a non epoch receiver is created after an epoch receiver", function(done: Mocha.Done): void {
+      const partitionId = partitionIds[0];
+      let epochRcvr: ReceiveHandler;
+      let nonEpochRcvr: ReceiveHandler;
+      const onerr1 = (error: MessagingError | Error) => {
+        debug(">>>> epoch Receiver ", error);
+        throw new Error("An Error should not have happened for epoch receiver with epoch value 1.");
+      };
+      const onmsg1 = (data: ReceivedEventData) => {
+        debug(">>>> epoch Receiver ", data);
+      };
+      epochRcvr = client
+        .createReceiver(partitionId, {
+          exclusiveReceiverPriority: 1,
+          eventPosition: EventPosition.fromNewEventsOnly()
+        })
+        .receive(onmsg1, onerr1);
+      debug("Created epoch receiver %s", epochRcvr);
+      const onerr2 = (error: MessagingError | Error) => {
+        debug(">>>> non epoch Receiver", error);
+        should.exist(error);
+        should.equal(error.name, "ReceiverDisconnectedError");
+        nonEpochRcvr
+          .stop()
+          .then(() => epochRcvr.stop())
+          .then(() => {
+            debug("Successfully closed the nonEpoch and epoch receivers");
+            done();
+          })
+          .catch(err => {
+            debug("error occurred while closing the receivers... ", err);
+            done();
+          });
+      };
+      const onmsg2 = (data: ReceivedEventData) => {
+        debug(">>>> non epoch Receiver", data);
+      };
+      nonEpochRcvr = client
+        .createReceiver(partitionId, {
+          eventPosition: EventPosition.fromNewEventsOnly()
+        })
+        .receive(onmsg2, onerr2);
+      debug("Created non epoch receiver %s", nonEpochRcvr);
+    });
+
+    it("should behave correctly when an epoch receiver is created after a non epoch receiver", function(done: Mocha.Done): void {
+      const partitionId = partitionIds[0];
+      let epochRcvr: ReceiveHandler;
+      let nonEpochRcvr: ReceiveHandler;
+      const onerr3 = (error: MessagingError | Error) => {
+        debug(">>>> non epoch Receiver", error);
+        should.exist(error);
+        should.equal(error.name, "ReceiverDisconnectedError");
+        nonEpochRcvr
+          .stop()
+          .then(() => epochRcvr.stop())
+          .then(() => {
+            debug("Successfully closed the nonEpoch and epoch receivers");
+            done();
+          })
+          .catch(err => {
+            debug("error occurred while closing the receivers... ", err);
+            done();
+          });
+      };
+      const onmsg3 = (data: ReceivedEventData) => {
+        debug(">>>> non epoch Receiver", data);
+      };
+      nonEpochRcvr = client
+        .createReceiver(partitionId, {
+          eventPosition: EventPosition.fromNewEventsOnly()
+        })
+        .receive(onmsg3, onerr3);
+      debug("Created non epoch receiver %s", nonEpochRcvr);
+      setTimeout(() => {
+        const onerr4 = (error: MessagingError | Error) => {
+          debug(">>>> epoch Receiver ", error);
+          throw new Error("OnErr4 >> An Error should not have happened for epoch receiver with epoch value 1.");
+        };
+        const onmsg4 = (data: ReceivedEventData) => {
+          debug(">>>> epoch Receiver ", data);
+        };
+        epochRcvr = client
+          .createReceiver(partitionId, {
+            exclusiveReceiverPriority: 1,
+            eventPosition: EventPosition.fromNewEventsOnly()
+          })
+          .receive(onmsg4, onerr4);
+        debug("Created epoch receiver %s", epochRcvr);
+      }, 3000);
+    });
+  });
+
+  describe("Negative scenarios", function(): void {
+    describe("on invalid partition ids like", function(): void {
+      const invalidIds = ["XYZ", "-1", "1000", "-"];
+      invalidIds.forEach(function(id: string): void {
+        it(`"${id}" should throw an error`, async function(): Promise<void> {
+          try {
+            debug("Created receiver and will be receiving messages from partition id ...", id);
+            const d = await client.createReceiver(id).receiveBatch(10, 3);
+            debug("received messages ", d.length);
+          } catch (err) {
+            debug("Receiver received an error", err);
+            should.exist(err);
+            err.message.should.match(
+              /.*The specified partition is invalid for an EventHub partition sender or receiver.*/gi
+            );
+          }
+        });
+      });
+
+      it(`" " should throw an invalid EventHub address error`, async function(): Promise<void> {
+        try {
+          const id = " ";
+          debug("Created receiver and will be receiving messages from partition id ...", id);
+          const d = await client.createReceiver(id).receiveBatch(10, 3);
+          debug("received messages ", d.length);
+        } catch (err) {
+          debug("Receiver received an error", err);
+          should.exist(err);
+          err.message.should.match(/.*Invalid EventHub address. It must be either of the following.*/gi);
+        }
+      });
+
+      const invalidIds2 = [""];
+      invalidIds2.forEach(function(id: string): void {
+        it(`"${id}" should throw an error`, async function(): Promise<void> {
+          try {
+            await client.createReceiver(id).receiveBatch(10, 3);
+          } catch (err) {
+            debug(`>>>> Received error - `, err);
+            should.exist(err);
+          }
+        });
+      });
+    });
+
+    it("should receive 'QuotaExceededError' when attempting to connect more than 5 receivers to a partition in a consumer group", function(done: Mocha.Done): void {
+      const partitionId = partitionIds[0];
+      const rcvHndlrs: ReceiveHandler[] = [];
+      const rcvrs: any[] = [];
+
+      // This test does not require recieving any messages.  Just attempting to connect the 6th receiver causes
+      // onerr2() to be called with QuotaExceededError.  So it's fastest to use EventPosition.fromEnd().
+      // Using EventPosition.fromStart() can cause timeouts or ServiceUnavailableException if the EventHub has
+      // a large number of messages.
+      const eventPosition = EventPosition.fromNewEventsOnly();
+
+      debug(">>> Receivers length: ", rcvHndlrs.length);
+      for (let i = 1; i <= 5; i++) {
+        const rcvrId = `rcvr-${i}`;
+        debug(rcvrId);
+        const onMsg = (data: ReceivedEventData) => {
+          if (!rcvrs[i]) {
+            rcvrs[i] = rcvrId;
+            debug("receiver id %s", rcvrId);
+          }
+        };
+        const onError = (err: MessagingError | Error) => {
+          debug("@@@@ Error received by receiver %s", rcvrId);
+          debug(err);
+        };
+        const rcvHndlr = client.createReceiver(partitionId, { eventPosition: eventPosition }).receive(onMsg, onError);
+        rcvHndlrs.push(rcvHndlr);
+      }
+      debug(">>> Attached message handlers to each receiver.");
+      setTimeout(() => {
+        debug(`Created 6th receiver - "rcvr-6"`);
+        const onmsg2 = (data: ReceivedEventData) => {
+          // debug(data);
+        };
+        const onerr2 = (err: MessagingError | Error) => {
+          debug("@@@@ Error received by receiver rcvr-6");
+          debug(err);
+          should.equal(err.name, "QuotaExceededError");
+          const promises = [];
+          for (const rcvr of rcvHndlrs) {
+            promises.push(rcvr.stop());
+          }
+          Promise.all(promises)
+            .then(() => {
+              debug("Successfully closed all the receivers..");
+              done();
+            })
+            .catch(err => {
+              debug("An error occurred while closing the receiver in the 'QuotaExceededError' test.", err);
+              done();
+            });
+        };
+        const failedRcvHandler = client
+          .createReceiver(partitionId, { eventPosition: eventPosition })
+          .receive(onmsg2, onerr2);
+        rcvHndlrs.push(failedRcvHandler);
+      }, 5000);
+    });
+  });
+  describe("Streaming - User Error", function(): void {
+    it("onError handler is called for user error", async function(): Promise<void> {
+      let caughtError: Error | undefined;
+      const data: EventData = {
+        body: "Hello World"
+      };
+      const partitionIds = await client.getPartitionIds();
+      await client.createSender({ partitionId: partitionIds[0] }).send([data]);
+      const errorMessage = "Will we see this error message?";
+
+      const onMessageHandler = (brokeredMessage: ReceivedEventData) => {
+        throw new Error(errorMessage);
+      };
+      const onErrorHandler = (err: MessagingError | Error) => {
+        caughtError = err;
+      };
+
+      client
+        .createReceiver(partitionIds[0], { eventPosition: EventPosition.fromFirstAvailableEvent() })
+        .receive(onMessageHandler, onErrorHandler);
+      await delay(5000);
+
+      should.equal(caughtError && caughtError.message, errorMessage, "User error did not surface.");
+    });
+  });
+}).timeout(90000);


### PR DESCRIPTION
As per the API proposal in #2718 (comment), we will now have a createReceiver() method on the Event Hub Client that returns a receiver.

This PR ensures that:

* `receive`, `receiveBatch`, `getEventIterator ` method works as expected.
* All tests in receiver.spec.ts are updated and pass
* receiver.close() closees all the underlying AMQP links. Further operations throw error.