### PR TITLE
[Event Hubs] Add support for token cancellation in streaming and batching receiver

### DIFF
--- a/sdk/eventhub/event-hubs/samples/receiveEventsStreaming.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsStreaming.ts
@@ -8,7 +8,7 @@
   to populate Event Hubs before running this sample.
 */
 
-import { EventHubClient, OnMessage, OnError, MessagingError, delay, EventData, EventPosition } from "../SRC";
+import { EventHubClient, OnMessage, OnError, MessagingError, delay, EventData, EventPosition } from "@azure/event-hubs";
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = "";

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -38,7 +38,7 @@ export class BatchingReceiver extends EventHubReceiver {
    * @param {number} [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver
    * should wait to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
    * @property {Aborter} cancellationToken Cancel current operation.
-   * @returns {Promise<EventData[]>} A promise that resolves with an array of EventData objects.
+   * @returns {Promise<ReceivedEventData[]>} A promise that resolves with an array of ReceivedEventData objects.
    */
   receive(
     maxMessageCount: number,

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -37,7 +37,7 @@ export class BatchingReceiver extends EventHubReceiver {
    * @param {number} maxMessageCount The maximum message count. Must be a value greater than 0.
    * @param {number} [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver
    * should wait to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
-   * @property {Aborter} cancellationToken Cancel current operation.
+   * @param {Aborter} cancellationToken Cancel current operation.
    * @returns {Promise<ReceivedEventData[]>} A promise that resolves with an array of ReceivedEventData objects.
    */
   receive(

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -257,8 +257,8 @@ export class EventHubReceiver extends LinkEntity {
         `[${this._context.connectionId}] The receive operation on the Receiver "${this.name}" with ` +
         `address "${this.address}" has been cancelled by the user.`;
       log.error(desc);
-     await this.close();
-     this._onError!(new Error(desc));
+      await this.close();
+      this._onError!(new Error(desc));
     };
 
     this._onAmqpError = (context: EventContext) => {
@@ -438,9 +438,6 @@ export class EventHubReceiver extends LinkEntity {
             this.address
           );
         } else {
-          if (this._aborter) {
-            this._aborter.removeEventListener("abort", this._onAbort);
-          }
           log.error(
             "[%s] close() method of Receiver '%s' with address '%s' was not called. There " +
               "was an accompanying error and it is NOT retryable. Hence NOT re-establishing " +
@@ -461,9 +458,6 @@ export class EventHubReceiver extends LinkEntity {
           this.address
         );
       } else {
-        if (this._aborter) {
-          this._aborter.removeEventListener("abort", this._onAbort);
-        }
         const state: any = {
           wasCloseInitiated: wasCloseInitiated,
           receiverError: receiverError,
@@ -504,6 +498,10 @@ export class EventHubReceiver extends LinkEntity {
           delayInSeconds: 15
         };
         await retry<void>(config);
+      } else {
+        if (this._aborter) {
+          this._aborter.removeEventListener("abort", this._onAbort);
+        }
       }
     } catch (err) {
       log.error(

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -337,9 +337,6 @@ export class EventHubReceiver extends LinkEntity {
           );
           await this.detached(receiverError);
         } else {
-          if (this._aborter) {
-            this._aborter.removeEventListener("abort", this._onAbort);
-          }
           log.error(
             "[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
               "and the sdk did not initate this. Moreover the receiver is already re-connecting. " +
@@ -389,9 +386,6 @@ export class EventHubReceiver extends LinkEntity {
           );
           await this.detached(sessionError);
         } else {
-          if (this._aborter) {
-            this._aborter.removeEventListener("abort", this._onAbort);
-          }
           log.error(
             "[%s] 'session_close' event occurred on the session of receiver '%s' with " +
               "address '%s' and the sdk did not initiate this. Moreover the receiver is already " +

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -258,7 +258,7 @@ export class EventHubReceiver extends LinkEntity {
         `address "${this.address}" has been cancelled by the user.`;
       log.error(desc);
      await this.close();
-     throw new Error(desc);
+     this._onError!(new Error(desc));
     };
 
     this._onAmqpError = (context: EventContext) => {

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -438,6 +438,9 @@ export class EventHubReceiver extends LinkEntity {
             this.address
           );
         } else {
+          if (this._aborter) {
+            this._aborter.removeEventListener("abort", this._onAbort);
+          }
           log.error(
             "[%s] close() method of Receiver '%s' with address '%s' was not called. There " +
               "was an accompanying error and it is NOT retryable. Hence NOT re-establishing " +
@@ -458,6 +461,9 @@ export class EventHubReceiver extends LinkEntity {
           this.address
         );
       } else {
+        if (this._aborter) {
+          this._aborter.removeEventListener("abort", this._onAbort);
+        }
         const state: any = {
           wasCloseInitiated: wasCloseInitiated,
           receiverError: receiverError,

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -173,7 +173,7 @@ export class Receiver {
    * to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
    * @property {Aborter} cancellationToken Cancel current operation.
    *
-   * @returns {Promise<Array<EventData>>} Promise<Array<EventData>>.
+   * @returns {Promise<ReceivedEventData[]>} Promise<ReceivedEventData[]>.
    */
   async receiveBatch(
     maxMessageCount: number,

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -171,7 +171,7 @@ export class Receiver {
    * @param {number} maxMessageCount The maximum message count. Must be a value greater than 0.
    * @param {number} [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver should wait
    * to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
-   * @property {Aborter} cancellationToken Cancel current operation.
+   * @param {Aborter} cancellationToken Cancel current operation.
    *
    * @returns {Promise<ReceivedEventData[]>} Promise<ReceivedEventData[]>.
    */

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -109,7 +109,7 @@ export class Receiver {
     this._throwIfReceiverOrConnectionClosed();
     this._streamingReceiver = StreamingReceiver.create(this._context, this.partitionId, this._receiverOptions);
     this._streamingReceiver.prefetchCount = Constants.defaultPrefetchCount;
-    return this._streamingReceiver.receive(onMessage, onError);
+    return this._streamingReceiver.receive(onMessage, onError, cancellationToken);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -98,10 +98,10 @@ export class Receiver {
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
    * the provided onMessage handler and error will be passed to the provided onError handler.
    *
-   * @param {OnMessage} onMessage                              The message handler to receive event data objects.
-   * @param {OnError} onError                                  The error handler to receive an error that occurs
+   * @param {OnMessage} onMessage The message handler to receive event data objects.
+   * @param {OnError} onError The error handler to receive an error that occurs
    * while receiving messages.
-   * @param {ReceiverOptions} [options]                         Options for how you'd like to receive messages.
+   * @property {Aborter} cancellationToken Cancel current operation.
    *
    * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
    */
@@ -168,10 +168,10 @@ export class Receiver {
    * Receives a batch of EventData objects from an EventHub partition for a given count and a given max wait time in seconds, whichever
    * happens first. This method can be used directly after creating the receiver object and **MUST NOT** be used along with the `start()` method.
    *
-   * @param {number} maxMessageCount                           The maximum message count. Must be a value greater than 0.
-   * @param {number} [maxWaitTimeInSeconds]                    The maximum wait time in seconds for which the Receiver should wait
+   * @param {number} maxMessageCount The maximum message count. Must be a value greater than 0.
+   * @param {number} [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver should wait
    * to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
-   * @param {ReceiverOptions} [options]                         Options for how you'd like to receive messages.
+   * @property {Aborter} cancellationToken Cancel current operation.
    *
    * @returns {Promise<Array<EventData>>} Promise<Array<EventData>>.
    */

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -185,7 +185,7 @@ export class Receiver {
     let error: MessagingError | undefined;
     let result: ReceivedEventData[] = [];
     try {
-      result = await this._batchingReceiver.receive(maxMessageCount, maxWaitTimeInSeconds);
+      result = await this._batchingReceiver.receive(maxMessageCount, maxWaitTimeInSeconds, cancellationToken);
     } catch (err) {
       error = err;
       log.error(

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -101,7 +101,7 @@ export class Receiver {
    * @param {OnMessage} onMessage The message handler to receive event data objects.
    * @param {OnError} onError The error handler to receive an error that occurs
    * while receiving messages.
-   * @property {Aborter} cancellationToken Cancel current operation.
+   * @param {Aborter} cancellationToken Cancel current operation.
    *
    * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
    */

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -107,6 +107,7 @@ export class StreamingReceiver extends EventHubReceiver {
    * @ignore
    * @param {OnMessage} onMessage The message handler to receive event data objects.
    * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
+   * @property {Aborter} cancellationToken Cancel current operation.
    */
   receive(onMessage: OnMessage, onError: OnError, cancellationToken?: Aborter): ReceiveHandler {
     if (!onMessage || typeof onMessage !== "function") {

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -107,7 +107,7 @@ export class StreamingReceiver extends EventHubReceiver {
    * @ignore
    * @param {OnMessage} onMessage The message handler to receive event data objects.
    * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
-   * @property {Aborter} cancellationToken Cancel current operation.
+   * @param {Aborter} cancellationToken Cancel current operation.
    */
   receive(onMessage: OnMessage, onError: OnError, cancellationToken?: Aborter): ReceiveHandler {
     if (!onMessage || typeof onMessage !== "function") {


### PR DESCRIPTION
Allow users to cancel a receive() call as described in #2641 (comment)

This PR uses addEventListener and removeEventListener of Aborter class.

Added `onAbort` listener using addEventListener method that listens aborted request and throws error when user calls aborter.abort(). It means that at any time if user wants to cancel the receive request they can create an instance of an Aborter class and call abort().

https://github.com/Azure/azure-sdk-for-js/issues/2837
https://github.com/Azure/azure-sdk-for-js/issues/2838