### PR TITLE
[Event Hubs] Create one AMQP batching receiver link per Receiver

### DIFF
--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -180,13 +180,13 @@ export class Receiver {
     cancellationToken?: Aborter
   ): Promise<ReceivedEventData[]> {
     this._throwIfReceiverOrConnectionClosed();
+    if (!this._batchingReceiver){
     this._batchingReceiver = BatchingReceiver.create(this._context, this.partitionId, this._receiverOptions);
-    let error: MessagingError | undefined;
+    }
     let result: ReceivedEventData[] = [];
     try {
       result = await this._batchingReceiver.receive(maxMessageCount, maxWaitTimeInSeconds, cancellationToken);
     } catch (err) {
-      error = err;
       log.error(
         "[%s] Receiver '%s', an error occurred while receiving %d messages for %d max time:\n %O",
         this._context.connectionId,
@@ -195,14 +195,7 @@ export class Receiver {
         maxWaitTimeInSeconds,
         err
       );
-    }
-    try {
-      await this._batchingReceiver.close();
-    } catch (err) {
-      // do nothing about it.
-    }
-    if (error) {
-      throw error;
+      throw err;
     }
     return result;
   }

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -6,7 +6,7 @@ import { ConnectionContext } from "./connectionContext";
 import { ReceiverOptions } from "./eventHubClient";
 import { OnMessage, OnError } from "./eventHubReceiver";
 import { ReceivedEventData } from "./eventData";
-import { MessagingError, Constants } from "@azure/amqp-common";
+import { Constants } from "@azure/amqp-common";
 import { StreamingReceiver, ReceiveHandler } from "./streamingReceiver";
 import { BatchingReceiver } from "./batchingReceiver";
 import { Aborter } from "./aborter";
@@ -180,8 +180,8 @@ export class Receiver {
     cancellationToken?: Aborter
   ): Promise<ReceivedEventData[]> {
     this._throwIfReceiverOrConnectionClosed();
-    if (!this._batchingReceiver){
-    this._batchingReceiver = BatchingReceiver.create(this._context, this.partitionId, this._receiverOptions);
+    if (!this._batchingReceiver) {
+      this._batchingReceiver = BatchingReceiver.create(this._context, this.partitionId, this._receiverOptions);
     }
     let result: ReceivedEventData[] = [];
     try {


### PR DESCRIPTION
Today, each call to receiveBatch() creates a new AMQP receiver link and closes it at the end of the operation.

The new API proposal in #2718 (comment) introduces the concept of dedicated receivers.
This PRs updates the following:

-  Create one AMQP link per batching receiver.
-  Every `receiveBatch()` operation in the given receiver uses the same AMQP link