### PR TITLE
[Event Hubs] Iterator for receiver receive events in the background

### DIFF
--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -126,9 +126,11 @@ export class Receiver {
       options = {};
     }
     let nextBatch: Promise<ReceivedEventData[]> | undefined;
-    let currentBatch = await this.receiveBatch(options.prefetchCount || 1, 60, options.cancellationToken);
+    const prefetchCount = options.prefetchCount || 1;
+    const maxWaitTimeInSeconds = 60;
+    let currentBatch = await this.receiveBatch( prefetchCount, maxWaitTimeInSeconds, options.cancellationToken);
     while (true) {
-      nextBatch = this.receiveBatch(options.prefetchCount || 1, 60, options.cancellationToken);
+      nextBatch = this.receiveBatch(prefetchCount, maxWaitTimeInSeconds, options.cancellationToken);
       for (const event of currentBatch) {
         yield event;
       }


### PR DESCRIPTION
Now we have getEventIterator() that returns an async iterator that can be used to iterate over the events. Internally it calls receiveBatch().

This PR updates:
- a batch of events is fetched upfront
- while the user iterates over this batch, the next batch is already requested.

This way, each iteration does not have to wait for the event to be sent from the service.

**DO NOT MERGE THIS PR**
We also need to support multiple receive operations . 

For examples: If user will call the `receiveBatch()/receive()` after the `getAsyncIterator`, then they will not get the next event because while the user iterates over the batch, the next batch is already requested with the updated checkpoint.