### PR TITLE
[Event Hubs] Re-establish links on retryable errors for batching receiver

### DIFF
--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -78,7 +78,7 @@ export class BatchingReceiver extends EventHubReceiver {
           clearTimeout(waitTimer);
         }
 
-        if (this._receiver && this._receiver.credit === 0) {
+        if (this._receiver && this._receiver.credit === 0 || eventData.length === 0) {
           this.isReceivingMessages = false;
           if (this._aborter) {
             this._aborter.removeEventListener("abort", this._onAbort);

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -183,7 +183,6 @@ export class BatchingReceiver extends EventHubReceiver {
             if (this._aborter) {
               this._aborter.removeEventListener("abort", this._onAbort);
             }
-
             this.isReceivingMessages = false;
             if (waitTimer) {
               clearTimeout(waitTimer);

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -3,7 +3,14 @@
 
 import uuid from "uuid/v4";
 import * as log from "./log";
-import { Receiver, OnAmqpEvent, EventContext, ReceiverOptions as RheaReceiverOptions, types, AmqpError } from "rhea-promise";
+import {
+  Receiver,
+  OnAmqpEvent,
+  EventContext,
+  ReceiverOptions as RheaReceiverOptions,
+  types,
+  AmqpError
+} from "rhea-promise";
 import { translate, Constants, MessagingError, retry, RetryOperationType, RetryConfig } from "@azure/amqp-common";
 import { ReceivedEventData, EventDataInternal, fromAmqpMessage } from "./eventData";
 import { ReceiverOptions } from "./eventHubClient";
@@ -173,7 +180,8 @@ export class EventHubReceiver extends LinkEntity {
    */
   protected _aborter: Aborter | undefined;
   /**
-   * @property {number| undefined} _messageRecoveryCount This is used to add credits from incase of recovery.
+   * @property {number| undefined} _messageRecoveryCount The message recovery count.
+   * This is used to add credits from incase of recovery.
    */
   protected _messageRecoveryCount: number | undefined;
 
@@ -475,7 +483,7 @@ export class EventHubReceiver extends LinkEntity {
           operation: () =>
             this._init(options).then(async () => {
               if (this._receiver && this._type === "BatchingReceiver") {
-                this._receiver.addCredit(this._maxMessageCount!);
+                this._receiver.addCredit(this._messageRecoveryCount!);
               }
             }),
           connectionId: this._context.connectionId,

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -228,7 +228,7 @@ export class LinkEntity {
    * Provides the current type of the LinkEntity.
    * @return {string} The entity type.
    */
-  private get _type(): string {
+  protected get _type(): string {
     let result = "LinkEntity";
     if ((this as any).constructor && (this as any).constructor.name) {
       result = (this as any).constructor.name;


### PR DESCRIPTION
Retry establishing the AMQP receiver link in the below cases. The re-established link starts from the checkpoint i.e the last received event

* retryable receiver error
* retryable session error
* retryable connection error