### PR TITLE
Make visibilityTimeout parameter optional with default value of zero

### DIFF
--- a/sdk/storage/storage-queue/src/MessageIdClient.ts
+++ b/sdk/storage/storage-queue/src/MessageIdClient.ts
@@ -101,20 +101,20 @@ export class MessageIdClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/update-message
    *
    * @param {string} popReceipt A valid pop receipt value returned from an earlier call to the dequeue messages or update message operation.
+   * @param {string} message Message to update.
    * @param {number} visibilityTimeout Specifies the new visibility timeout value, in seconds,
    *                                   relative to server time. The new value must be larger than or equal to 0,
    *                                   and cannot be larger than 7 days. The visibility timeout of a message cannot
    *                                   be set to a value later than the expiry time.
    *                                   A message can be updated until it has been deleted or has expired.
-   * @param {string} message Message to update.
    * @param {MessageIdUpdateOptions} [options] Optional options to MessageId Update operation.
    * @returns {Promise<Models.MessageIdUpdateResponse>}
    * @memberof MessageIdClient
    */
   public async update(
     popReceipt: string,
-    visibilityTimeout: number,
     message: string,
+    visibilityTimeout?: number,
     options: MessageIdUpdateOptions = {}
   ): Promise<Models.MessageIdUpdateResponse> {
     const aborter = options.abortSignal || Aborter.none;
@@ -123,7 +123,7 @@ export class MessageIdClient extends StorageClient {
         messageText: message
       },
       popReceipt,
-      visibilityTimeout,
+      visibilityTimeout || 0,
       {
         abortSignal: aborter
       }

--- a/sdk/storage/storage-queue/test/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/messageidclient.spec.ts
@@ -34,7 +34,7 @@ describe("MessageIdClient", () => {
 
     let newMessage = "";
     let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
-    let uResult = await messageIdClient.update(eResult.popReceipt, 0, newMessage);
+    let uResult = await messageIdClient.update(eResult.popReceipt, newMessage);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
     assert.ok(uResult.date);
@@ -68,7 +68,7 @@ describe("MessageIdClient", () => {
 
     let newMessage = "New Message";
     let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
-    let uResult = await messageIdClient.update(eResult.popReceipt, 10, newMessage);
+    let uResult = await messageIdClient.update(eResult.popReceipt, newMessage, 10);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
     assert.ok(uResult.date);
@@ -99,7 +99,7 @@ describe("MessageIdClient", () => {
 
     let newMessage = new Array(64 * 1024 + 1).join("a");
     let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
-    let uResult = await messageIdClient.update(eResult.popReceipt, 0, newMessage);
+    let uResult = await messageIdClient.update(eResult.popReceipt, newMessage);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
     assert.ok(uResult.date);
@@ -129,7 +129,7 @@ describe("MessageIdClient", () => {
 
     let error;
     try {
-      await messageIdClient.update(eResult.popReceipt, 0, newMessage);
+      await messageIdClient.update(eResult.popReceipt, newMessage);
     } catch (err) {
       error = err;
     }

--- a/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
@@ -37,7 +37,7 @@ describe("MessageIdClient Node", () => {
     buffer.write(specialChars, 0);
     let newMessage = buffer.toString();
     let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
-    let uResult = await messageIdClient.update(eResult.popReceipt, 0, newMessage);
+    let uResult = await messageIdClient.update(eResult.popReceipt, newMessage);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
     assert.ok(uResult.date);
@@ -71,7 +71,7 @@ describe("MessageIdClient Node", () => {
 
     let error;
     try {
-      await messageIdClient.update(eResult.popReceipt, 0, newMessage);
+      await messageIdClient.update(eResult.popReceipt, newMessage);
     } catch (err) {
       error = err;
     }


### PR DESCRIPTION
for `MessageIdClient.update()` function.

Fixes #3489.