### PR TITLE
[Event Hubs] Add retry logic on receive batch

### DIFF
--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -209,7 +209,7 @@ export class Receiver {
 
     let result: ReceivedEventData[] = [];
     try {
-      result = await this._batchingReceiver.receive(maxMessageCount, maxWaitTimeInSeconds, cancellationToken);
+      result = await this._batchingReceiver.receive(maxMessageCount, maxWaitTimeInSeconds, this._receiverOptions.retryOptions, cancellationToken);
     } catch (err) {
       log.error(
         "[%s] Receiver '%s', an error occurred while receiving %d messages for %d max time:\n %O",


### PR DESCRIPTION
* The work to re-establish the AMQP receiver link is already covered in #3310. This is an internal feature and the user provided retry options will not be touching this.
* The receiveBatch() respect the retry options and passes to receive() method and uses the retry function directly on the receive() operation of the batching receiver.