### PR TITLE
Fix the getAll names to be just get with plural

### DIFF
--- a/sdk/keyvault/keyvault-keys/samples/singleKey.ts
+++ b/sdk/keyvault/keyvault-keys/samples/singleKey.ts
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
   console.log("getResult: ", getResult);
   let encoded = Buffer.from("Hello World");
 
-  for await (let x of client.getAllKeys()) {
+  for await (let x of client.getKeys()) {
     console.log(">> ", x);
   }
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -32,7 +32,7 @@ import {
   ImportKeyOptions,
   UpdateKeyOptions,
   GetKeyOptions,
-  GetAllKeysOptions,
+  GetKeysOptions,
   KeyAttributes,
   RequestOptions
 } from "./keysModels";
@@ -424,7 +424,7 @@ export class KeysClient {
 
   public async *getKeyVersions(
     name: string,
-    options?: GetAllKeysOptions
+    options?: GetKeysOptions
   ): AsyncIterableIterator<KeyAttributes> {
     let currentSetResponse = await this.client.getKeyVersions(
       this.vaultBaseUrl,
@@ -452,7 +452,7 @@ export class KeysClient {
    * @param [options] The optional parameters
    * @returns AsyncIterableIterator<Key>
    */
-  public async *getAllKeys(options?: GetAllKeysOptions): AsyncIterableIterator<KeyAttributes> {
+  public async *getKeys(options?: GetKeysOptions): AsyncIterableIterator<KeyAttributes> {
     let currentSetResponse = await this.client.getKeys(
       this.vaultBaseUrl,
       {
@@ -478,7 +478,7 @@ export class KeysClient {
    * @param [options] The optional parameters
    * @returns AsyncIterableIterator<Key>
    */
-  public async *getAllDeletedKeys(options?: GetAllKeysOptions): AsyncIterableIterator<Key> {
+  public async *getDeletedKeys(options?: GetKeysOptions): AsyncIterableIterator<Key> {
     let currentSetResponse = await this.client.getDeletedKeys(
       this.vaultBaseUrl,
       {

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -239,7 +239,7 @@ export interface GetKeyOptions {
  * An interface representing optional parameters for KeyClient paged operations.
  * Optional Parameters.
  */
-export interface GetAllKeysOptions {
+export interface GetKeysOptions {
   /**
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */

--- a/sdk/keyvault/keyvault-secrets/samples/secrets.pipeline.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/secrets.pipeline.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { SecretsClient, Pipeline, RestError } from "../src";
+import { Pipeline, RestError } from "../src/core";
+import { SecretsClient } from "../src";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { signingPolicy, exponentialRetryPolicy, deserializationPolicy } from "@azure/ms-rest-js";
 

--- a/sdk/keyvault/keyvault-secrets/samples/singleSecret.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/singleSecret.ts
@@ -22,7 +22,7 @@ async function main(): Promise<void> {
   const secretName = "MySecretName";
   const result = await client.setSecret("MySecretName", "MySecretValue");
 
-  for await (let secretAttr of client.getAllSecrets()) {
+  for await (let secretAttr of client.getSecrets()) {
     const secret = await client.getSecret(secretAttr.name);
     console.log("secret: ", secret);
   }

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -26,7 +26,7 @@ import {
   SetSecretOptions,
   UpdateSecretOptions,
   GetSecretOptions,
-  GetAllSecretsOptions,
+  GetSecretsOptions,
   SecretAttributes
 } from "./secretsModels";
 import { parseKeyvaultIdentifier as parseKeyvaultEntityIdentifier } from "./core/utils";
@@ -326,7 +326,7 @@ export class SecretsClient {
 
   public async *getSecretVersions(
     secretName: string,
-    options?: GetAllSecretsOptions
+    options?: GetSecretsOptions
   ): AsyncIterableIterator<SecretAttributes> {
     let currentSetResponse = await this.client.getSecretVersions(
       this.vaultBaseUrl,
@@ -353,7 +353,7 @@ export class SecretsClient {
    * @param [options] The optional parameters
    * @returns AsyncIterableIterator<Secret>
    */
-  public async *getAllSecrets(options?: GetAllSecretsOptions): AsyncIterableIterator<SecretAttributes> {
+  public async *getSecrets(options?: GetSecretsOptions): AsyncIterableIterator<SecretAttributes> {
     let currentSetResponse = await this.client.getSecrets(
       this.vaultBaseUrl,
       {
@@ -379,7 +379,7 @@ export class SecretsClient {
    * @param [options] The optional parameters
    * @returns AsyncIterableIterator<Secret>
    */
-  public async *getAllDeletedSecrets(options?: GetAllSecretsOptions): AsyncIterableIterator<Secret> {
+  public async *getDeletedSecrets(options?: GetSecretsOptions): AsyncIterableIterator<Secret> {
     let currentSetResponse = await this.client.getDeletedSecrets(
       this.vaultBaseUrl,
       {

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -187,7 +187,7 @@ export interface GetSecretOptions {
  * An interface representing optional parameters for SecretClient paged operations.
  * Optional Parameters.
  */
-export interface GetAllSecretsOptions {
+export interface GetSecretsOptions {
   /**
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */


### PR DESCRIPTION
This should fix the names that are currently getAll* to be just get with a plural. This better aligns with the agreed upon naming conventions.