### PR TITLE
[Event Hubs] Adds tests for receiver

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -115,7 +115,6 @@ export class EventPosition {
   /**
    * Creates a position at the given enqueued time.
    * @param {Date | number} enqueuedTime The enqueue time. This value represents the actual time of enqueuing the message.
-   * @param {boolean} isInclusive If true, the specified event is included; otherwise the next event is returned.
    * @return {EventPosition} EventPosition
    */
   static fromEnqueuedTime(enqueuedTime: Date | number): EventPosition {


### PR DESCRIPTION
Adds tests for `receiver.getEventIterator()` and for mix-and-match receiver operation calls.

I did come across some unexpected behavior when passing a `cancellationToken` to the `getEventIterator` method, and logged #3597 to track.