### PR TITLE
Remove prepack scripts from Rush-managed packages

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -75,7 +75,6 @@
     "lint:fix": "tslint -p . --fix",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
-    "prepack": "npm i && npm run build",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -70,7 +70,6 @@
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "echo skipped",
     "lint": "echo skipped",
-    "prepack": "npm install && npm run build",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -75,7 +75,6 @@
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "echo skipped",
     "lint": "echo skipped",
-    "prepack": "npm install && npm run build",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -74,7 +74,6 @@
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "echo skipped",
     "lint": "echo skipped",
-    "prepack": "npm install && npm run build",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",


### PR DESCRIPTION
NPM install should never be used within scripts for packages that are part of the Rush workspace. Should be a fix for #3482.