### PR TITLE
[Event Hubs] Revisit parameter validations as per guidelines

### DIFF
--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -63,7 +63,7 @@ export class EventHubClient {
     createSender(options?: EventSenderOptions): EventSender;
     readonly eventHubName: string;
     getPartitionIds(cancellationToken?: Aborter): Promise<Array<string>>;
-    getPartitionInformation(partitionId: string | number, cancellationToken?: Aborter): Promise<PartitionProperties>;
+    getPartitionInformation(partitionId: string, cancellationToken?: Aborter): Promise<PartitionProperties>;
     getProperties(cancellationToken?: Aborter): Promise<EventHubProperties>;
 }
 

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -18,6 +18,7 @@ import { EventHubReceiver } from "./eventHubReceiver";
 import { ConnectionContext } from "./connectionContext";
 import { Aborter } from "./aborter";
 import * as log from "./log";
+import { throwAbortError } from './util/error';
 
 /**
  * Describes the batching receiver where the user can receive a specified number of messages for a predefined time.
@@ -61,10 +62,6 @@ export class BatchingReceiver extends EventHubReceiver {
     retryOptions?: RetryOptions,
     cancellationToken?: Aborter
   ): Promise<ReceivedEventData[]> {
-    if (!maxMessageCount || (maxMessageCount && typeof maxMessageCount !== "number")) {
-      throw new Error("'maxMessageCount' is a required parameter of type number with a value greater than 0.");
-    }
-
     if (maxWaitTimeInSeconds == undefined) {
       maxWaitTimeInSeconds = Constants.defaultOperationTimeoutInSeconds;
     }
@@ -164,7 +161,7 @@ export class BatchingReceiver extends EventHubReceiver {
             `[${this._context.connectionId}] The receive operation on the Receiver "${this.name}" with ` +
             `address "${this.address}" has been cancelled by the user.`;
           log.error(desc);
-          throw new Error(desc);
+          throwAbortError('The receive operation has been cancelled by the user.');
         };
 
         // Action to be taken when an error is received.

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -256,7 +256,7 @@ export class EventHubClient {
       }
       tokenProvider = new SasTokenProvider(parsedCS.Endpoint, parsedCS.SharedAccessKeyName, parsedCS.SharedAccessKey);
     } else {
-      const eventHubPath = String(eventHubPathOrOptions);
+      const eventHubPath = eventHubPathOrOptions;
       let sharedAccessKeyName = "defaultKeyName";
       let sharedAccessKey = "defaultKeyValue";
 

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -28,6 +28,7 @@ import { IotHubClient } from "./iothub/iothubClient";
 import { Aborter } from "./aborter";
 import { EventSender } from "./sender";
 import { EventReceiver } from "./receiver";
+import { throwTypeErrorIfParameterMissing } from "./util/error";
 
 /**
  * Retry policy options for operations on the EventHubClient
@@ -76,7 +77,7 @@ export interface EventSenderOptions {
  */
 export interface EventBatchingOptions {
   /**
-   * @property 
+   * @property
    * If specified EventHub will hash this string to map to a partitionId.
    * It guarantees that messages with the same partitionKey end up in the same partition.
    * This will be ignored if the sender was created using a `paritionId`.
@@ -95,7 +96,7 @@ export interface EventBatchingOptions {
  */
 export interface EventReceiverOptions {
   /**
-   * @property 
+   * @property
    * The event position in the partition at which to start receiving messages.
    */
   beginReceivingAt?: EventPosition;
@@ -106,7 +107,7 @@ export interface EventReceiverOptions {
    */
   consumerGroup?: string;
   /**
-   * @property 
+   * @property
    * The priority value that this receiver is currently using for partition ownership.
    * If another receiver is currently active for the same partition with no or lesser
    * priority, then it will get disconnected.
@@ -115,7 +116,7 @@ export interface EventReceiverOptions {
    */
   exclusiveReceiverPriority?: number;
   /**
-   * @property 
+   * @property
    * Retry options for the receive operation on the receiver. If no value is provided here, the
    * retry options set when creating the `EventHubClient` is used.
    */
@@ -128,10 +129,10 @@ export interface EventReceiverOptions {
  */
 export interface EventHubClientOptions {
   /**
-   * @property 
+   * @property
    * The data transformer that will be used to encode and decode the sent and received messages respectively.
-   * If not provided then the `DefaultDataTransformer` is used which has the below `encode` & `decode` features 
-   * - `encode`: 
+   * If not provided then the `DefaultDataTransformer` is used which has the below `encode` & `decode` features
+   * - `encode`:
    *    - If event body is a Buffer, then the event is sent without any data transformation
    *    - Else, JSON.stringfy() is run on the body, and then converted to Buffer before sending the event
    *    - If JSON.stringify() fails at this point, the send operation fails too.
@@ -142,13 +143,13 @@ export interface EventHubClientOptions {
    */
   dataTransformer?: DataTransformer;
   /**
-   * @property 
+   * @property
    * The user agent that will be appended to the built in user agent string that is passed as a
-   * connection property to the Event Hubs service 
+   * connection property to the Event Hubs service
    */
   userAgent?: string;
   /**
-   * @property 
+   * @property
    * The WebSocket constructor used to create an AMQP connection over a WebSocket.
    * This option should be provided in the below scenarios
    * - The TCP port 5671 which is what is used by the AMQP connection to Event Hubs is blocked in your environment.
@@ -187,7 +188,7 @@ export class EventHubClient {
   private _clientOptions: EventHubClientOptions;
 
   /**
-   * @property 
+   * @property
    * @readonly
    * The name of the Event Hub instance for which this client is created
    */
@@ -248,24 +249,18 @@ export class EventHubClient {
       options = eventHubPathOrOptions;
       const parsedCS = parseConnectionString<EventHubConnectionStringModel>(connectionString);
       if (!parsedCS.EntityPath) {
-        throw new TypeError(
-          `"connectionString": "${connectionString}", ` + `must contain EntityPath="<path-to-the-entity>".`
+        throw new Error(
+          'EntityPath is missing in the connection string. The value for the "connectionString" parameter must be of the form ' +
+            '"Endpoint=sb://fully-qualified-host-name/;SharedAccessKeyName=shared-access-policy-name;SharedAccessKey=shared-access-key;EntityPath=event-hub-name"'
         );
       }
       tokenProvider = new SasTokenProvider(parsedCS.Endpoint, parsedCS.SharedAccessKeyName, parsedCS.SharedAccessKey);
     } else {
-      let host = hostOrConnectionString;
-      const eventHubPath = eventHubPathOrOptions;
+      const eventHubPath = String(eventHubPathOrOptions);
       let sharedAccessKeyName = "defaultKeyName";
       let sharedAccessKey = "defaultKeyValue";
-      if (!host) {
-        throw new Error(
-          "Please provide a fully qualified domain name of your Event Hub instance for the 'host' parameter."
-        );
-      }
-      if (!eventHubPath) {
-        throw new Error("Please provide a value for the 'entityPath' parameter.");
-      }
+
+      // TODO: Update this when we move to Azure Identity
       if (!tokenProviderOrCredentials) {
         throw new Error("Please provide either a token provider or a valid credentials object.");
       }
@@ -283,6 +278,8 @@ export class EventHubClient {
           sharedAccessKey = tokenProvider.key;
         }
       }
+
+      let host = String(hostOrConnectionString);
       if (!host.endsWith("/")) host += "/";
       connectionString = `Endpoint=sb://${host};SharedAccessKeyName=${sharedAccessKeyName};SharedAccessKey=${sharedAccessKey};EntityPath=${eventHubPath}`;
     }
@@ -319,18 +316,18 @@ export class EventHubClient {
         log.client("Closed the amqp connection '%s' on the client.", this._context.connectionId);
       }
     } catch (err) {
-      const msg = `An error occurred while closing the connection "${this._context.connectionId}": ${JSON.stringify(err)}`;
-      log.error(msg);
-      throw new Error(msg);
+      err = err instanceof Error ? err : JSON.stringify(err);
+      log.error(`An error occurred while closing the connection "${this._context.connectionId}":\n${err}`);
+      throw err;
     }
   }
 
   /**
-   * Creates a Sender that can be used to send events to the Event Hub for which this client 
+   * Creates a Sender that can be used to send events to the Event Hub for which this client
    * was created.
    *
    * @param options Options to create a Sender where you can specify the id of the partition
-   * to which events need to be sent to and retry options. 
+   * to which events need to be sent to and retry options.
    *
    * @return {Promise<void>} Promise<void>
    */
@@ -339,15 +336,17 @@ export class EventHubClient {
   }
 
   /**
-   * Creates a Receiver that can be used to receive events from the Event Hub for which this 
+   * Creates a Receiver that can be used to receive events from the Event Hub for which this
    * client was created.
-   * 
+   *
    * @param partitionId The id of the partition from which to receive events
    * @param options Options to create the Receiver where you can specify the position from
    * which to start receiving events, the consumer group to receive events from, retry options
    * and more.
    */
   createReceiver(partitionId: string, options?: EventReceiverOptions): EventReceiver {
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
+    partitionId = String(partitionId);
     return new EventReceiver(this._context, partitionId, options);
   }
 
@@ -383,13 +382,12 @@ export class EventHubClient {
 
   /**
    * Provides information about the specified partition.
-   * @param {(string|number)} partitionId Partition ID for which partition information is required.
+   * @param {string} partitionId Partition ID for which partition information is required.
    * @returns {Promise<PartitionProperties>} A promise that resoloves with EventHubPartitionRuntimeInformation.
    */
-  async getPartitionInformation(partitionId: string|number, cancellationToken?: Aborter): Promise<PartitionProperties> {
-    if (typeof partitionId !== "string" && typeof partitionId !== "number") {
-      throw new Error("'partitionId' is a required parameter and must be of type: 'string' | 'number'.");
-    }
+  async getPartitionInformation(partitionId: string, cancellationToken?: Aborter): Promise<PartitionProperties> {
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
+    partitionId = String(partitionId);
     try {
       return await this._context.managementSession!.getPartitionInformation(partitionId, {
         retryOptions: this._clientOptions.retryOptions,
@@ -415,12 +413,9 @@ export class EventHubClient {
     entityPath?: string,
     options?: EventHubClientOptions
   ): EventHubClient {
-    if (!connectionString || (connectionString && typeof connectionString !== "string")) {
-      throw new Error("'connectionString' is a required parameter and must be of type: 'string'.");
-    }
     const config = ConnectionConfig.create(connectionString, entityPath);
     if (!config.entityPath) {
-      throw new TypeError(
+      throw new Error(
         `Either provide "path" or the "connectionString": "${connectionString}", ` +
           `must contain EntityPath="<path-to-the-entity>".`
       );

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -92,10 +92,10 @@ export class EventPosition {
    * @return {EventPosition} EventPosition
    */
   static fromOffset(offset: string, isInclusive?: boolean): EventPosition {
-    if (!offset || typeof offset !== "string") {
-      throw new Error("'offset' is a required parameter and must be a non-empty string.");
+    if (offset == undefined) {
+      throw new Error('Missing parameter "offset"');
     }
-    return new EventPosition({ offset: offset, isInclusive: isInclusive });
+    return new EventPosition({ offset: String(offset), isInclusive: isInclusive });
   }
 
   /**
@@ -106,8 +106,11 @@ export class EventPosition {
    * @return {EventPosition} EventPosition
    */
   static fromSequenceNumber(sequenceNumber: number, isInclusive?: boolean): EventPosition {
-    if (sequenceNumber == undefined || typeof sequenceNumber !== "number") {
-      throw new Error("'sequenceNumber' is a required parameter and must be of type 'number'.");
+    if (sequenceNumber == undefined) {
+      throw new Error('Missing parameter "sequenceNumber"');
+    }
+    if (typeof sequenceNumber !== "number") {
+      throw new Error('The parameter "sequenceNumber" should be of type "number"');
     }
     return new EventPosition({ sequenceNumber: sequenceNumber, isInclusive: isInclusive });
   }
@@ -118,8 +121,8 @@ export class EventPosition {
    * @return {EventPosition} EventPosition
    */
   static fromEnqueuedTime(enqueuedTime: Date | number): EventPosition {
-    if (enqueuedTime == undefined || (typeof enqueuedTime !== "number" && !(enqueuedTime instanceof Date))) {
-      throw new Error("'enqueuedTime' is a required parameter and must be an instance of 'Date' or of type 'number'.");
+    if (enqueuedTime == undefined) {
+      throw new Error('Missing parameter "enqueuedTime"');
     }
     return new EventPosition({ enqueuedTime: enqueuedTime });
   }

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -156,10 +156,6 @@ export class ManagementClient extends LinkEntity {
     partitionId: string | number,
     options?: { retryOptions?: RetryOptions; cancellationToken?: Aborter }
   ): Promise<PartitionProperties> {
-    if (typeof partitionId !== "string" && typeof partitionId !== "number") {
-      throw new Error("'partitionId' is a required parameter and must be of " + "type: 'string' | 'number'.");
-    }
-
     const request: Message = {
       body: Buffer.from(JSON.stringify([])),
       message_id: uuid(),

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -105,6 +105,12 @@ export class EventReceiver {
   receive(onMessage: OnMessage, onError: OnError, cancellationToken?: Aborter): ReceiveHandler {
     this._throwIfReceiverOrConnectionClosed();
     this._throwIfAlreadyReceiving();
+    if (typeof onMessage !== "function") {
+      throw new TypeError("The parameter 'onMessage' must be of type 'function'.");
+    }
+    if (typeof onError !== "function") {
+      throw new TypeError("The parameter 'onError' must be of type 'function'.");
+    }
     const checkpoint = this.getCheckpoint();
     if (checkpoint) {
       this._receiverOptions.beginReceivingAt = EventPosition.fromSequenceNumber(checkpoint);

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -6,7 +6,7 @@ import { EventHubSender } from "./eventHubSender";
 import { EventBatchingOptions, EventSenderOptions } from "./eventHubClient";
 import { ConnectionContext } from "./connectionContext";
 import * as log from "./log";
-import { throwErrorIfConnectionClosed } from "./util/error";
+import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
 
 /**
  * The Sender class can be used to send messages.
@@ -42,7 +42,8 @@ export class EventSender {
   constructor(context: ConnectionContext, options?: EventSenderOptions) {
     this._context = context;
     this._senderOptions = options || {};
-    this._eventHubSender = EventHubSender.create(this._context, this._senderOptions.partitionId);
+    const partitionId = this._senderOptions.partitionId != undefined ? String(this._senderOptions.partitionId) : undefined;
+    this._eventHubSender = EventHubSender.create(this._context, partitionId);
   }
 
   /**
@@ -56,6 +57,7 @@ export class EventSender {
    */
   async send(events: EventData[], options?: EventBatchingOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
+    throwTypeErrorIfParameterMissing(this._context.connectionId, 'events', events);
     if (!Array.isArray(events)) {
       events = [events];
     }

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -110,12 +110,6 @@ export class StreamingReceiver extends EventHubReceiver {
    * @param {Aborter} cancellationToken Cancel current operation.
    */
   receive(onMessage: OnMessage, onError: OnError, cancellationToken?: Aborter): ReceiveHandler {
-    if (!onMessage || typeof onMessage !== "function") {
-      throw new Error("'onMessage' is a required parameter and must be of type 'function'.");
-    }
-    if (!onError || typeof onError !== "function") {
-      throw new Error("'onError' is a required parameter and must be of type 'function'.");
-    }
     this._onMessage = onMessage;
     this._onError = onError;
     if (cancellationToken) {

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -17,3 +17,33 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
     throw error;
   }
 }
+
+/**
+ * @internal
+ * Logs and Throws TypeError if given parameter is undefined or null
+ * @param connectionId Id of the underlying AMQP connection used for logging
+ * @param parameterName Name of the parameter to check
+ * @param parameterValue Value of the parameter to check
+ */
+export function throwTypeErrorIfParameterMissing(
+  connectionId: string,
+  parameterName: string,
+  parameterValue: any
+): void {
+  if (parameterValue === undefined || parameterValue === null) {
+    const error = new TypeError(`Missing parameter "${parameterName}"`);
+    log.error(`[${connectionId}] %O`, error);
+    throw error;
+  }
+}
+
+/**
+ * @internal
+ * Throws AbortError with the given error message
+ * @param message Error message to be set on the AbortError
+ */
+export function throwAbortError(message?: string): void {
+  const abortError = new Error(message);
+  abortError.name = 'AbortError';
+  throw abortError;
+}

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -15,24 +15,10 @@ const debug = debugModule("azure:event-hubs:client-spec");
 import { EventHubClient } from "../src";
 import { packageJsonInfo } from "../src/util/constants";
 
-function testFalsyValues(testFn: Function): void {
-  // tslint:disable-next-line: no-null-keyword
-  [null, undefined, "", 0].forEach(function(value: string | number | null | undefined): void {
-    testFn(value);
-  });
-}
 
 describe("EventHubClient", function(): void {
   describe(".fromConnectionString", function(): void {
-    it("throws when there is no connection string", function(): void {
-      testFalsyValues(function(value: any): void {
-        const test = function(): EventHubClient {
-          return EventHubClient.createFromConnectionString(value);
-        };
-        test.should.throw(Error, "'connectionString' is a required parameter and must be of type: 'string'.");
-      });
-    });
-
+ 
     it("throws when it cannot find the Event Hub path", function(): void {
       const endpoint = "Endpoint=sb://abc";
       const test = function(): EventHubClient {

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -63,7 +63,7 @@ describe("RuntimeInformation", function(): void {
 
   it("gets the partition runtime information with partitionId as a number", async function(): Promise<void> {
     client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
-    const partitionRuntimeInfo = await client.getPartitionInformation(0);
+    const partitionRuntimeInfo = await client.getPartitionInformation(0 as any);
     debug(partitionRuntimeInfo);
     partitionRuntimeInfo.id.should.equal("0");
     partitionRuntimeInfo.eventHubPath.should.equal(service.path);

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -72,17 +72,6 @@ describe("RuntimeInformation", function(): void {
     should.exist(partitionRuntimeInfo.lastEnqueuedOffset);
   });
 
-  it("should fail the partition runtime information when partitionId is not a number or string", async function(): Promise<
-    void
-  > {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
-    try {
-      await client.getPartitionInformation(true as any);
-    } catch (err) {
-      err.message.should.equal("'partitionId' is a required parameter and must be of type: 'string' | 'number'.");
-    }
-  });
-
   it("should fail the partition runtime information when partitionId is empty string", async function(): Promise<void> {
     client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
     try {


### PR DESCRIPTION
This PR revisits parameter validations as per the guidelines in #2660

Other than what is covered in https://github.com/Azure/azure-sdk-for-js/issues/2660#issuecomment-500561507, this PR covers
- Avoid checks on connection string or host when `Connection.create()` can throw required error
- Check on `maxMessageCount` in receive operation removed. This value is used to add credits in rhea and rhea treats all invalid values as 0, therefore user gets no events
- `AbortError` is the name used when operation is cancelled
- Parameter validations that do not perform type check or existence checks should be normal "Error" not "TypeError"
