### PR TITLE
[Service-bus] enabling browser tests for nightly

### DIFF
--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -15,16 +15,16 @@ jobs:
       # Service Bus tests do not support concurrent execution
       MaxParallel: 1
 
- - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-tests-browser.yml
-    parameters:
-      PackageName: "@azure/service-bus"
-      EnvVars:
-        AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AAD_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AAD_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
-        CLEAN_NAMESPACE: "true"
-        RESOURCE_GROUP: $(service-bus-test-resource-group)
-        SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
-      # Service Bus tests do not support concurrent execution
-      MaxParallel: 1
+  - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-tests-browser.yml
+      parameters:
+        PackageName: "@azure/service-bus"
+        EnvVars:
+          AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+          AAD_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+          AAD_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+          AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
+          CLEAN_NAMESPACE: "true"
+          RESOURCE_GROUP: $(service-bus-test-resource-group)
+          SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
+        # Service Bus tests do not support concurrent execution
+        MaxParallel: 1

--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -16,15 +16,15 @@ jobs:
       MaxParallel: 1
 
   - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-tests-browser.yml
-      parameters:
-        PackageName: "@azure/service-bus"
-        EnvVars:
-          AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-          AAD_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-          AAD_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-          AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
-          CLEAN_NAMESPACE: "true"
-          RESOURCE_GROUP: $(service-bus-test-resource-group)
-          SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
-        # Service Bus tests do not support concurrent execution
-        MaxParallel: 1
+    parameters:
+      PackageName: "@azure/service-bus"
+      EnvVars:
+        AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AAD_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AAD_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
+        CLEAN_NAMESPACE: "true"
+        RESOURCE_GROUP: $(service-bus-test-resource-group)
+        SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
+      # Service Bus tests do not support concurrent execution
+      MaxParallel: 1

--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -14,3 +14,17 @@ jobs:
         SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
       # Service Bus tests do not support concurrent execution
       MaxParallel: 1
+
+ - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-tests-browser.yml
+    parameters:
+      PackageName: "@azure/service-bus"
+      EnvVars:
+        AAD_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AAD_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AAD_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+        AZURE_SUBSCRIPTION_ID: $(test-subscription-id)
+        CLEAN_NAMESPACE: "true"
+        RESOURCE_GROUP: $(service-bus-test-resource-group)
+        SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
+      # Service Bus tests do not support concurrent execution
+      MaxParallel: 1


### PR DESCRIPTION
- Enabling browser tests for nightly for service-bus

We missed adding the browser tests for service-bus while porting to the new yaml file structure. This PR is for adding them back and trying to run the browser tests for service-bus efficiently, taking into account that node tests and browser tests cannot run in parallel for now, with the current way the tests are set up.
Node tests have to run before browser tests.
@Azure/azure-sdk-eng 