### PR TITLE
[Storage-blob] Add creation/deletion functions to parent client

### DIFF
--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -904,11 +904,11 @@ export class BlobClient extends StorageClient {
   }
 
   /**
-   * Get a LeaseClient that manages leases on the container.
+   * Get a LeaseClient that manages leases on the blob.
    *
    * @param {string} [proposeLeaseId] Initial proposed lease Id.
    * @returns
-   * @memberof ContainerClient
+   * @memberof BlobClient
    */
   public getLeaseClient(proposeLeaseId?: string) {
     return new LeaseClient(this, proposeLeaseId);

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -6,7 +6,11 @@ import { Aborter } from "./Aborter";
 import { ListContainersIncludeType } from "./generated/lib/models/index";
 import { Service } from "./generated/lib/operations";
 import { newPipeline, NewPipelineOptions, Pipeline } from "./Pipeline";
-import { ContainerClient } from "./ContainerClient";
+import {
+    ContainerClient,
+    ContainerCreateOptions,
+    ContainerDeleteMethodOptions
+} from "./ContainerClient";
 import { appendToURLPath, extractConnectionStringParts } from "./utils/utils.common";
 import { Credential } from "./credentials/Credential";
 import { SharedKeyCredential } from "./credentials/SharedKeyCredential";
@@ -211,6 +215,42 @@ export class BlobServiceClient extends StorageClient {
       appendToURLPath(this.url, encodeURIComponent(containerName)),
       this.pipeline
     );
+  }
+
+  /**
+   * Create a Blob container.
+   *
+   * @param {string} containerName Name of the container to create.
+   * @param {ContainerCreateOptions} [options] Options to configure Container Create operation.
+   * @returns {Promise<{ containerClient: ContainerClient; response: Models.ContainerCreateResponse }>} Container creation response and the corresponding container client.
+   * @memberof BlobServiceClient
+   */
+  public async createBlobContainer(
+    containerName: string,
+    options?: ContainerCreateOptions
+  ): Promise<{ containerClient: ContainerClient; response: Models.ContainerCreateResponse }> {
+    const containerClient = this.createContainerClient(containerName);
+    const response = await containerClient.create(options);
+    return {
+      containerClient,
+      response
+    };
+  }
+
+  /**
+   * Deletes a Blob container.
+   *
+   * @param {string} containerName Name of the container to delete.
+   * @param {ContainerDeleteMethodOptions} [options] Options to configure Container Delete operation.
+   * @returns {Promise<Models.ContainerDeleteResponse>} Container deletion response.
+   * @memberof BlobServiceClient
+   */
+  public async deleteBlobContainer(
+    containerName: string,
+    options?: ContainerDeleteMethodOptions
+  ): Promise<Models.ContainerDeleteResponse> {
+    const containerClient = this.createContainerClient(containerName);
+    return await containerClient.delete(options);
   }
 
   /**

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -222,18 +222,21 @@ export class BlobServiceClient extends StorageClient {
    *
    * @param {string} containerName Name of the container to create.
    * @param {ContainerCreateOptions} [options] Options to configure Container Create operation.
-   * @returns {Promise<{ containerClient: ContainerClient; response: Models.ContainerCreateResponse }>} Container creation response and the corresponding container client.
+   * @returns {Promise<{ containerClient: ContainerClient; containerCreateResponse: Models.ContainerCreateResponse }>} Container creation response and the corresponding container client.
    * @memberof BlobServiceClient
    */
-  public async createBlobContainer(
+  public async createContainer(
     containerName: string,
     options?: ContainerCreateOptions
-  ): Promise<{ containerClient: ContainerClient; response: Models.ContainerCreateResponse }> {
+  ): Promise<{
+    containerClient: ContainerClient;
+    containerCreateResponse: Models.ContainerCreateResponse;
+  }> {
     const containerClient = this.createContainerClient(containerName);
-    const response = await containerClient.create(options);
+    const containerCreateResponse = await containerClient.create(options);
     return {
       containerClient,
-      response
+      containerCreateResponse
     };
   }
 
@@ -245,7 +248,7 @@ export class BlobServiceClient extends StorageClient {
    * @returns {Promise<Models.ContainerDeleteResponse>} Container deletion response.
    * @memberof BlobServiceClient
    */
-  public async deleteBlobContainer(
+  public async deleteContainer(
     containerName: string,
     options?: ContainerDeleteMethodOptions
   ): Promise<Models.ContainerDeleteResponse> {

--- a/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
@@ -265,6 +265,31 @@ describe("BlobServiceClient", () => {
     assert.ok(accountInfo.skuName);
   });
 
+  it("createContainer and deleteContainer", async () => {
+    const blobServiceClient = getBSU();
+    const containerName = getUniqueName("container");
+    const access = "container";
+    const metadata = { key: "value" };
+
+    const { containerClient } = await blobServiceClient.createBlobContainer(containerName, {
+      access,
+      metadata
+    });
+    const result = await containerClient.getProperties();
+    assert.deepEqual(result.blobPublicAccess, access);
+    assert.deepEqual(result.metadata, metadata);
+
+    await blobServiceClient.deleteBlobContainer(containerName);
+    try {
+      await containerClient.getProperties();
+      assert.fail(
+        "Expecting an error in getting properties from a deleted block blob but didn't get one."
+      );
+    } catch (error) {
+      assert.ok((error.statusCode as number) === 404);
+    }
+  });
+
   it("can be created with a url and a credential", async () => {
     const serviceClient = getBSU();
     const factories = serviceClient.pipeline.factories;

--- a/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
@@ -271,7 +271,7 @@ describe("BlobServiceClient", () => {
     const access = "container";
     const metadata = { key: "value" };
 
-    const { containerClient } = await blobServiceClient.createBlobContainer(containerName, {
+    const { containerClient } = await blobServiceClient.createContainer(containerName, {
       access,
       metadata
     });
@@ -279,7 +279,7 @@ describe("BlobServiceClient", () => {
     assert.deepEqual(result.blobPublicAccess, access);
     assert.deepEqual(result.metadata, metadata);
 
-    await blobServiceClient.deleteBlobContainer(containerName);
+    await blobServiceClient.deleteContainer(containerName);
     try {
       await containerClient.getProperties();
       assert.fail(

--- a/sdk/storage/storage-file/src/DirectoryClient.ts
+++ b/sdk/storage/storage-file/src/DirectoryClient.ts
@@ -205,10 +205,10 @@ export class DirectoryClient extends StorageClient {
    */
   public async createSubdirectory(directoryName: string, options?: DirectoryCreateOptions) {
     const directoryClient = this.createDirectoryClient(directoryName);
-    const response = await directoryClient.create(options);
+    const directoryCreateResponse = await directoryClient.create(options);
     return {
       directoryClient,
-      response
+      directoryCreateResponse
     };
   }
 
@@ -239,10 +239,10 @@ export class DirectoryClient extends StorageClient {
    */
   public async createFile(fileName: string, size: number, options?: FileCreateOptions) {
     const fileClient = this.createFileClient(fileName);
-    const response = await fileClient.create(size, options);
+    const fileCreateResponse = await fileClient.create(size, options);
     return {
       fileClient,
-      response
+      fileCreateResponse
     };
   }
 

--- a/sdk/storage/storage-file/src/DirectoryClient.ts
+++ b/sdk/storage/storage-file/src/DirectoryClient.ts
@@ -8,7 +8,7 @@ import { Metadata } from "./models";
 import { Pipeline } from "./Pipeline";
 import { StorageClient } from "./StorageClient";
 import { appendToURLPath } from "./utils/utils.common";
-import { FileClient } from "./FileClient";
+import { FileClient, FileCreateOptions, FileDeleteOptions } from "./FileClient";
 
 /**
  * Options to configure Directory - Create operation.
@@ -191,6 +191,83 @@ export class DirectoryClient extends StorageClient {
       appendToURLPath(this.url, encodeURIComponent(subDirectoryName)),
       this.pipeline
     );
+  }
+
+  /**
+   * Creates a new subdirectory under this directory.
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
+   *
+   *
+   * @param {string} directoryName
+   * @param {DirectoryCreateOptions} [options] Options to Directory Create operation.
+   * @returns Directory creation response data and the corresponding directory client.
+   * @memberof DirectoryClient
+   */
+  public async createSubdirectory(directoryName: string, options?: DirectoryCreateOptions) {
+    const directoryClient = this.createDirectoryClient(directoryName);
+    const response = await directoryClient.create(options);
+    return {
+      directoryClient,
+      response
+    };
+  }
+
+  /**
+   * Removes the specified empty sub directory under this directory.
+   * Note that the directory must be empty before it can be deleted.
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
+   *
+   * @param {string} directoryName
+   * @param {DirectoryDeleteOptions} [options] Options to Directory Delete operation.
+   * @returns Directory deletion response data.
+   * @memberof DirectoryClient
+   */
+  public async deleteSubdirectory(directoryName: string, options?: DirectoryDeleteOptions) {
+    const directoryClient = this.createDirectoryClient(directoryName);
+    return await directoryClient.delete(options);
+  }
+
+  /**
+   * Creates a new file or replaces a file under this directory. Note it only initializes the file with no content.
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
+   *
+   * @param {string} fileName
+   * @param {number} size Specifies the maximum size in bytes for the file, up to 1 TB.
+   * @param {FileCreateOptions} [options] Options to File Create operation.
+   * @returns File creation response data and the corresponding file client.
+   * @memberof DirectoryClient
+   */
+  public async createFile(fileName: string, size: number, options?: FileCreateOptions) {
+    const fileClient = this.createFileClient(fileName);
+    const response = await fileClient.create(size, options);
+    return {
+      fileClient,
+      response
+    };
+  }
+
+  /**
+   * Removes the specified file under this directory from the storage account.
+   * When a file is successfully deleted, it is immediately removed from the storage
+   * account's index and is no longer accessible to clients. The file's data is later
+   * removed from the service during garbage collection.
+   *
+   * Delete File will fail with status code 409 (Conflict) and error code SharingViolation
+   * if the file is open on an SMB client.
+   *
+   * Delete File is not supported on a share snapshot, which is a read-only copy of
+   * a share. An attempt to perform this operation on a share snapshot will fail with 400 (InvalidQueryParameterValue)
+   *
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
+   *
+   * @param {string} fileName Name of the file to delete
+   * @param {FileDeleteOptions} [options] Options to File Delete operation.
+   * @returns File deletion response data.
+   * @memberof DirectoryClient
+   */
+  public async deleteFile(fileName: string, options?: FileDeleteOptions) {
+    const fileClient = this.createFileClient(fileName);
+    return await fileClient.delete(options);
   }
 
   /**

--- a/sdk/storage/storage-file/src/FileServiceClient.ts
+++ b/sdk/storage/storage-file/src/FileServiceClient.ts
@@ -6,7 +6,7 @@ import { Aborter } from "./Aborter";
 import { Service } from "./generated/lib/operations";
 import { Pipeline } from "./Pipeline";
 import { StorageClient } from "./StorageClient";
-import { ShareClient } from "./ShareClient";
+import { ShareClient, ShareCreateOptions, ShareDeleteMethodOptions } from "./ShareClient";
 import { appendToURLPath } from "./utils/utils.common";
 
 /**
@@ -131,6 +131,36 @@ export class FileServiceClient extends StorageClient {
    */
   public createShareClient(shareName: string): ShareClient {
     return new ShareClient(appendToURLPath(this.url, shareName), this.pipeline);
+  }
+
+  /**
+   * Creates a Share.
+   *
+   * @param {string} shareName
+   * @param {ShareCreateOptions} [options]
+   * @returns Share creation response and the corresponding share client.
+   * @memberof FileServiceClient
+   */
+  public async createShare(shareName: string, options?: ShareCreateOptions) {
+    const shareClient = this.createShareClient(shareName);
+    const response = await shareClient.create(options);
+    return {
+      response,
+      shareClient
+    };
+  }
+
+  /**
+   * Deletes a Share.
+   *
+   * @param {string} shareName
+   * @param {ShareDeleteMethodOptions} [options]
+   * @returns Share deletion response and the corresponding share client.
+   * @memberof FileServiceClient
+   */
+  public async deleteShare(shareName: string, options?: ShareDeleteMethodOptions) {
+    const shareClient = this.createShareClient(shareName);
+    return await shareClient.delete(options);
   }
 
   /**

--- a/sdk/storage/storage-file/src/FileServiceClient.ts
+++ b/sdk/storage/storage-file/src/FileServiceClient.ts
@@ -143,9 +143,9 @@ export class FileServiceClient extends StorageClient {
    */
   public async createShare(shareName: string, options?: ShareCreateOptions) {
     const shareClient = this.createShareClient(shareName);
-    const response = await shareClient.create(options);
+    const shareCreateResponse = await shareClient.create(options);
     return {
-      response,
+      shareCreateResponse,
       shareClient
     };
   }

--- a/sdk/storage/storage-file/src/ShareClient.ts
+++ b/sdk/storage/storage-file/src/ShareClient.ts
@@ -11,7 +11,8 @@ import { Pipeline } from "./Pipeline";
 import { StorageClient } from "./StorageClient";
 import { URLConstants } from "./utils/constants";
 import { appendToURLPath, setURLParameter, truncatedISO8061Date } from "./utils/utils.common";
-import { DirectoryClient } from "./DirectoryClient";
+import { DirectoryClient, DirectoryCreateOptions, DirectoryDeleteOptions } from "./DirectoryClient";
+import { FileCreateOptions, FileDeleteOptions } from "./FileClient";
 
 /**
  * Options to configure Share - Create operation.
@@ -340,6 +341,92 @@ export class ShareClient extends StorageClient {
       appendToURLPath(this.url, encodeURIComponent(directoryName)),
       this.pipeline
     );
+  }
+
+  /**
+   * Creates a new subdirectory under this share.
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
+   *
+   *
+   * @param {string} directoryName
+   * @param {DirectoryCreateOptions} [options] Options to Directory Create operation.
+   * @returns Directory creation response data and the corresponding directory client.
+   * @memberof ShareClient
+   */
+  public async createDirectory(directoryName: string, options?: DirectoryCreateOptions) {
+    const directoryClient = this.createDirectoryClient(directoryName);
+    const response = await directoryClient.create(options);
+    return {
+      directoryClient,
+      response
+    };
+  }
+
+  /**
+   * Removes the specified empty sub directory under this share.
+   * Note that the directory must be empty before it can be deleted.
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-directory
+   *
+   * @param {string} directoryName
+   * @param {DirectoryDeleteOptions} [options] Options to Directory Delete operation.
+   * @returns Directory deletion response data.
+   * @memberof ShareClient
+   */
+  public async deleteDirectory(directoryName: string, options?: DirectoryDeleteOptions) {
+    const directoryClient = this.createDirectoryClient(directoryName);
+    return await directoryClient.delete(options);
+  }
+
+  /**
+   * Creates a new file or replaces a file under an existing directory in this share.
+   * Note it only initializes the file with no content.
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
+   *
+   * @param {string} fileName
+   * @param {number} size Specifies the maximum size in bytes for the file, up to 1 TB.
+   * @param {FileCreateOptions} [options] Options to File Create operation.
+   * @returns File creation response data and the corresponding file client.
+   * @memberof ShareClient
+   */
+  public async createFile(
+    directoryName: string,
+    fileName: string,
+    size: number,
+    options?: FileCreateOptions
+  ) {
+    const directoryClient = this.createDirectoryClient(directoryName);
+    const fileClient = directoryClient.createFileClient(fileName);
+    const response = await fileClient.create(size, options);
+    return {
+      fileClient,
+      response
+    };
+  }
+
+  /**
+   * Removes a file under an existing directory in this share from the storage account.
+   * When a file is successfully deleted, it is immediately removed from the storage
+   * account's index and is no longer accessible to clients. The file's data is later
+   * removed from the service during garbage collection.
+   *
+   * Delete File will fail with status code 409 (Conflict) and error code SharingViolation
+   * if the file is open on an SMB client.
+   *
+   * Delete File is not supported on a share snapshot, which is a read-only copy of
+   * a share. An attempt to perform this operation on a share snapshot will fail with 400 (InvalidQueryParameterValue)
+   *
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
+   *
+   * @param {string} directoryName
+   * @param {string} fileName
+   * @param {FileDeleteOptions} [options] Options to File Delete operation.
+   * @returns
+   * @memberof ShareClient
+   */
+  public async deleteFile(directoryName: string, fileName: string, options?: FileDeleteOptions) {
+    const directoryClient = this.createDirectoryClient(directoryName);
+    const fileClient = directoryClient.createFileClient(fileName);
+    return await fileClient.delete(options);
   }
 
   /**

--- a/sdk/storage/storage-file/src/ShareClient.ts
+++ b/sdk/storage/storage-file/src/ShareClient.ts
@@ -344,6 +344,18 @@ export class ShareClient extends StorageClient {
   }
 
   /**
+   * Gets the directory client for the root directory of this share.
+   * Note that the root directory always exists and cannot be deleted.
+   *
+   * @readonly
+   * @type {DirectoryClient}
+   * @memberof ShareClient
+   */
+  public get rootDirectoryClient(): DirectoryClient {
+    return this.createDirectoryClient("");
+  }
+
+  /**
    * Creates a new subdirectory under this share.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-directory
    *
@@ -378,7 +390,7 @@ export class ShareClient extends StorageClient {
   }
 
   /**
-   * Creates a new file or replaces a file under an existing directory in this share.
+   * Creates a new file or replaces a file under the root directory of this share.
    * Note it only initializes the file with no content.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/create-file
    *
@@ -388,13 +400,8 @@ export class ShareClient extends StorageClient {
    * @returns File creation response data and the corresponding file client.
    * @memberof ShareClient
    */
-  public async createFile(
-    directoryName: string,
-    fileName: string,
-    size: number,
-    options?: FileCreateOptions
-  ) {
-    const directoryClient = this.createDirectoryClient(directoryName);
+  public async createFile(fileName: string, size: number, options?: FileCreateOptions) {
+    const directoryClient = this.rootDirectoryClient;
     const fileClient = directoryClient.createFileClient(fileName);
     const response = await fileClient.create(size, options);
     return {
@@ -404,7 +411,7 @@ export class ShareClient extends StorageClient {
   }
 
   /**
-   * Removes a file under an existing directory in this share from the storage account.
+   * Removes a file under the root directory of this share from the storage account.
    * When a file is successfully deleted, it is immediately removed from the storage
    * account's index and is no longer accessible to clients. The file's data is later
    * removed from the service during garbage collection.
@@ -423,8 +430,8 @@ export class ShareClient extends StorageClient {
    * @returns
    * @memberof ShareClient
    */
-  public async deleteFile(directoryName: string, fileName: string, options?: FileDeleteOptions) {
-    const directoryClient = this.createDirectoryClient(directoryName);
+  public async deleteFile(fileName: string, options?: FileDeleteOptions) {
+    const directoryClient = this.rootDirectoryClient;
     const fileClient = directoryClient.createFileClient(fileName);
     return await fileClient.delete(options);
   }

--- a/sdk/storage/storage-file/src/ShareClient.ts
+++ b/sdk/storage/storage-file/src/ShareClient.ts
@@ -367,10 +367,10 @@ export class ShareClient extends StorageClient {
    */
   public async createDirectory(directoryName: string, options?: DirectoryCreateOptions) {
     const directoryClient = this.createDirectoryClient(directoryName);
-    const response = await directoryClient.create(options);
+    const directoryCreateResponse = await directoryClient.create(options);
     return {
       directoryClient,
-      response
+      directoryCreateResponse
     };
   }
 
@@ -403,10 +403,10 @@ export class ShareClient extends StorageClient {
   public async createFile(fileName: string, size: number, options?: FileCreateOptions) {
     const directoryClient = this.rootDirectoryClient;
     const fileClient = directoryClient.createFileClient(fileName);
-    const response = await fileClient.create(size, options);
+    const fileCreateResponse = await fileClient.create(size, options);
     return {
       fileClient,
-      response
+      fileCreateResponse
     };
   }
 

--- a/sdk/storage/storage-file/test/fileserviceclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileserviceclient.spec.ts
@@ -131,4 +131,24 @@ describe("FileServiceClient", () => {
     assert.ok(result.version!.length > 0);
     assert.deepEqual(result.hourMetrics, serviceProperties.hourMetrics);
   });
+
+  it("createShare and deleteShare", async () => {
+    const serviceClient = getBSU();
+    const shareName = getUniqueName("share");
+    const metadata = { key: "value" };
+
+    const { shareClient } = await serviceClient.createShare(shareName, { metadata });
+    const result = await shareClient.getProperties();
+    assert.deepEqual(result.metadata, metadata);
+
+    await serviceClient.deleteShare(shareName);
+    try {
+      await shareClient.getProperties();
+      assert.fail(
+        "Expecting an error in getting properties from a deleted block blob but didn't get one."
+      );
+    } catch (error) {
+      assert.ok((error.statusCode as number) === 404);
+    }
+  });
 });

--- a/sdk/storage/storage-file/test/shareclient.spec.ts
+++ b/sdk/storage/storage-file/test/shareclient.spec.ts
@@ -107,16 +107,14 @@ describe("ShareClient", () => {
     }
   });
 
-  it("createFile and deleteFile", async () => {
-    const dirName = getUniqueName("directory");
-    const { directoryClient } = await shareClient.createDirectory(dirName);
+  it("createFile and deleteFile under root directory", async () => {
     const fileName = getUniqueName("file");
     const metadata = { key: "value" };
-    const { fileClient } = await shareClient.createFile(dirName, fileName, 256, { metadata });
+    const { fileClient } = await shareClient.createFile(fileName, 256, { metadata });
     const result = await fileClient.getProperties();
     assert.deepEqual(result.metadata, metadata);
 
-    await shareClient.deleteFile(dirName, fileName);
+    await shareClient.deleteFile(fileName);
     try {
       await fileClient.getProperties();
       assert.fail(
@@ -125,6 +123,11 @@ describe("ShareClient", () => {
     } catch (error) {
       assert.ok((error.statusCode as number) === 404);
     }
-    await directoryClient.delete();
+  });
+
+  it("can get a directory client for root directory", async () => {
+    const root = await shareClient.rootDirectoryClient;
+    const result = await root.getProperties();
+    assert.ok(result, "Expecting valid properties for the root directory.");
   });
 });

--- a/sdk/storage/storage-file/test/shareclient.spec.ts
+++ b/sdk/storage/storage-file/test/shareclient.spec.ts
@@ -87,4 +87,44 @@ describe("ShareClient", () => {
 
     await snapshotShareClient.delete({});
   });
+
+  it("createDirectory and deleteDirectory", async () => {
+    const dirName = getUniqueName("directory");
+    const metadata = { key: "value" };
+
+    const { directoryClient } = await shareClient.createDirectory(dirName, { metadata });
+    const result = await directoryClient.getProperties();
+    assert.deepEqual(result.metadata, metadata);
+
+    await shareClient.deleteDirectory(dirName);
+    try {
+      await directoryClient.getProperties();
+      assert.fail(
+        "Expecting an error in getting properties from a deleted block blob but didn't get one."
+      );
+    } catch (error) {
+      assert.ok((error.statusCode as number) === 404);
+    }
+  });
+
+  it("createFile and deleteFile", async () => {
+    const dirName = getUniqueName("directory");
+    const { directoryClient } = await shareClient.createDirectory(dirName);
+    const fileName = getUniqueName("file");
+    const metadata = { key: "value" };
+    const { fileClient } = await shareClient.createFile(dirName, fileName, 256, { metadata });
+    const result = await fileClient.getProperties();
+    assert.deepEqual(result.metadata, metadata);
+
+    await shareClient.deleteFile(dirName, fileName);
+    try {
+      await fileClient.getProperties();
+      assert.fail(
+        "Expecting an error in getting properties from a deleted block blob but didn't get one."
+      );
+    } catch (error) {
+      assert.ok((error.statusCode as number) === 404);
+    }
+    await directoryClient.delete();
+  });
 });


### PR DESCRIPTION
- Add `createContainer()` and `deleteContainer()` to `BlobServiceClient`.

- Add `uploadBlockBlob()` and `deleteBlob()` to `ContainerClient`. This is the
  most used Blob type. We don't add similar creation functions for the other two
  blob types as they are used less frequently.