### PR TITLE
[Identity] Add ManagedIdentityCredential implementation

### DIFF
--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -2,10 +2,13 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import qs from "qs";
-import { AccessToken, ServiceClient, ServiceClientOptions, GetTokenOptions } from "@azure/core-http";
+import { AccessToken, ServiceClient, ServiceClientOptions, GetTokenOptions, WebResource, RequestPrepareOptions } from "@azure/core-http";
 
 export class IdentityClient extends ServiceClient {
   private static readonly DefaultAuthorityHost = "https://login.microsoftonline.com/";
+  private static readonly ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
+  private static readonly MsiApiVersion = "2018-02-01";
+  private static readonly DefaultScopeSuffix = "/.default";
 
   constructor(options?: IdentityClientOptions) {
     super(undefined, options);
@@ -15,6 +18,48 @@ export class IdentityClient extends ServiceClient {
     }
   }
 
+  private createWebResource(
+    requestOptions: RequestPrepareOptions
+  ): WebResource {
+    const webResource = new WebResource();
+    webResource.prepare(requestOptions);
+    return webResource;
+  }
+
+  private async sendTokenRequest(requestOptions: RequestPrepareOptions): Promise<AccessToken | null> {
+    const response = await this.sendRequest(requestOptions);
+    if (response.status === 200 || response.status === 201) {
+      const expiresOn = new Date();
+      expiresOn.setSeconds(expiresOn.getSeconds() + response.parsedBody.expires_in);
+
+      return {
+        token: response.parsedBody.access_token,
+        expiresOn: expiresOn
+      };
+    }
+
+    return null;
+  }
+
+  private mapScopesToResource(scopes: string | string[]): string {
+    let scope = ""
+    if (Array.isArray(scopes)) {
+      if (scopes.length !== 1) {
+        throw "To convert to a resource string the specified array must be exactly length 1"
+      }
+
+      scope = scopes[0];
+    } else if (typeof scopes === 'string') {
+      scope = scopes;
+    }
+
+    if (!scope.endsWith(IdentityClient.DefaultScopeSuffix)) {
+      return scope;
+    }
+
+    return scope.substr(0, scope.lastIndexOf(IdentityClient.DefaultScopeSuffix));
+  }
+
   async authenticate(
     tenantId: string,
     clientId: string,
@@ -22,7 +67,7 @@ export class IdentityClient extends ServiceClient {
     scopes: string | string[],
     getTokenOptions?: GetTokenOptions
   ): Promise<AccessToken | null> {
-    const response = await this.sendRequest({
+    const webResource = this.createWebResource({
       url: `${this.baseUri}/${tenantId}/oauth2/v2.0/token`,
       method: "POST",
       disableJsonStringifyOnBody: true,
@@ -38,21 +83,42 @@ export class IdentityClient extends ServiceClient {
         Accept: "application/json",
         "Content-Type": "application/x-www-form-urlencoded"
       },
+      abortSignal: getTokenOptions && getTokenOptions.abortSignal
+    });
+
+    return this.sendTokenRequest(webResource);
+  }
+
+  authenticateManagedIdentity(
+    scopes: string | string[],
+    clientId?: string,
+    getTokenOptions?: GetTokenOptions
+  ): Promise<AccessToken | null> {
+    const queryParameters: any = {
+      resource: this.mapScopesToResource(scopes),
+      "api-version": IdentityClient.MsiApiVersion
+    }
+
+    if (clientId) {
+      queryParameters.client_id = clientId;
+    }
+
+    const webResource = this.createWebResource({
+      url: IdentityClient.ImdsEndpoint,
+      method: "GET",
+      disableJsonStringifyOnBody: true,
+      deserializationMapper: undefined,
+      queryParameters,
+      headers: {
+        Accept: "application/json",
+        Metadata: true
+      },
       abortSignal: getTokenOptions && getTokenOptions.abortSignal,
     });
 
-    if (response.status === 200 || response.status === 201) {
-      const expiresOn = new Date();
-      expiresOn.setSeconds(expiresOn.getSeconds() + response.parsedBody.expires_in);
-
-      return {
-        token: response.parsedBody.access_token,
-        expiresOn: expiresOn
-      };
-    }
-
-    return null;
+    return this.sendTokenRequest(webResource);
   }
+
 
   static getDefaultOptions(): IdentityClientOptions {
     return {

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -2,7 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import qs from "qs";
-import { AccessToken, ServiceClient, ServiceClientOptions, GetTokenOptions, WebResource, RequestPrepareOptions } from "@azure/core-http";
+import {
+  AccessToken,
+  ServiceClient,
+  ServiceClientOptions,
+  GetTokenOptions,
+  WebResource,
+  RequestPrepareOptions
+} from "@azure/core-http";
 
 export class IdentityClient extends ServiceClient {
   private static readonly DefaultAuthorityHost = "https://login.microsoftonline.com/";
@@ -18,15 +25,15 @@ export class IdentityClient extends ServiceClient {
     }
   }
 
-  private createWebResource(
-    requestOptions: RequestPrepareOptions
-  ): WebResource {
+  private createWebResource(requestOptions: RequestPrepareOptions): WebResource {
     const webResource = new WebResource();
     webResource.prepare(requestOptions);
     return webResource;
   }
 
-  private async sendTokenRequest(requestOptions: RequestPrepareOptions): Promise<AccessToken | null> {
+  private async sendTokenRequest(
+    requestOptions: RequestPrepareOptions
+  ): Promise<AccessToken | null> {
     const response = await this.sendRequest(requestOptions);
     if (response.status === 200 || response.status === 201) {
       const expiresOn = new Date();
@@ -42,14 +49,14 @@ export class IdentityClient extends ServiceClient {
   }
 
   private mapScopesToResource(scopes: string | string[]): string {
-    let scope = ""
+    let scope = "";
     if (Array.isArray(scopes)) {
       if (scopes.length !== 1) {
-        throw "To convert to a resource string the specified array must be exactly length 1"
+        throw "To convert to a resource string the specified array must be exactly length 1";
       }
 
       scope = scopes[0];
-    } else if (typeof scopes === 'string') {
+    } else if (typeof scopes === "string") {
       scope = scopes;
     }
 
@@ -97,7 +104,7 @@ export class IdentityClient extends ServiceClient {
     const queryParameters: any = {
       resource: this.mapScopesToResource(scopes),
       "api-version": IdentityClient.MsiApiVersion
-    }
+    };
 
     if (clientId) {
       queryParameters.client_id = clientId;
@@ -113,12 +120,11 @@ export class IdentityClient extends ServiceClient {
         Accept: "application/json",
         Metadata: true
       },
-      abortSignal: getTokenOptions && getTokenOptions.abortSignal,
+      abortSignal: getTokenOptions && getTokenOptions.abortSignal
     });
 
     return this.sendTokenRequest(webResource);
   }
-
 
   static getDefaultOptions(): IdentityClientOptions {
     return {

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -8,10 +8,7 @@ export class ManagedIdentityCredential implements TokenCredential {
   private identityClient: IdentityClient;
   private _clientId: string | undefined;
 
-  constructor(
-    clientId?: string,
-    options?: IdentityClientOptions
-  ) {
+  constructor(clientId?: string, options?: IdentityClientOptions) {
     this.identityClient = new IdentityClient(options);
     this._clientId = clientId;
   }
@@ -20,11 +17,6 @@ export class ManagedIdentityCredential implements TokenCredential {
     scopes: string | string[],
     options?: GetTokenOptions
   ): Promise<AccessToken | null> {
-
-    return this.identityClient.authenticateManagedIdentity(
-      scopes,
-      this._clientId,
-      options
-    );
+    return this.identityClient.authenticateManagedIdentity(scopes, this._clientId, options);
   }
 }

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-http";
+import { IdentityClientOptions, IdentityClient } from "../client/identityClient";
+
+export class ManagedIdentityCredential implements TokenCredential {
+  private identityClient: IdentityClient;
+  private _clientId: string | undefined;
+
+  constructor(
+    clientId?: string,
+    options?: IdentityClientOptions
+  ) {
+    this.identityClient = new IdentityClient(options);
+    this._clientId = clientId;
+  }
+
+  public getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions
+  ): Promise<AccessToken | null> {
+
+    return this.identityClient.authenticateManagedIdentity(
+      scopes,
+      this._clientId,
+      options
+    );
+  }
+}

--- a/sdk/identity/identity/src/credentials/systemCredential.ts
+++ b/sdk/identity/identity/src/credentials/systemCredential.ts
@@ -4,9 +4,13 @@
 import { IdentityClientOptions } from "../client/identityClient";
 import { AggregateCredential } from "./aggregateCredential";
 import { EnvironmentCredential } from "./environmentCredential";
+import { ManagedIdentityCredential } from "./managedIdentityCredential";
 
 export class SystemCredential extends AggregateCredential {
   constructor(identityClientOptions?: IdentityClientOptions) {
-    super(new EnvironmentCredential(identityClientOptions));
+    super(
+      new EnvironmentCredential(identityClientOptions),
+      new ManagedIdentityCredential(undefined, identityClientOptions)
+    );
   }
 }

--- a/sdk/identity/identity/src/credentials/systemCredential.ts
+++ b/sdk/identity/identity/src/credentials/systemCredential.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { IdentityClientOptions } from '../client/identityClient';
-import { AggregateCredential } from './aggregateCredential';
-import { EnvironmentCredential } from './environmentCredential';
+import { IdentityClientOptions } from "../client/identityClient";
+import { AggregateCredential } from "./aggregateCredential";
+import { EnvironmentCredential } from "./environmentCredential";
 
 export class SystemCredential extends AggregateCredential {
   constructor(identityClientOptions?: IdentityClientOptions) {

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -8,6 +8,7 @@ export { AggregateCredential } from "./credentials/aggregateCredential";
 export { IdentityClientOptions } from "./client/identityClient";
 export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
+export { ManagedIdentityCredential } from "./credentials/managedIdentityCredential";
 export { SystemCredential } from "./credentials/systemCredential";
 
 export { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";

--- a/sdk/identity/identity/test/credentials/authTestUtils.ts
+++ b/sdk/identity/identity/test/credentials/authTestUtils.ts
@@ -12,7 +12,7 @@ export class MockAuthHttpClient implements HttpClient {
   public identityClientOptions: IdentityClientOptions;
 
   constructor() {
-    this.requestResolve = (r) => {};
+    this.requestResolve = () => { };
     this.requestPromise = new Promise((resolve) => {
       this.requestResolve = resolve;
     });
@@ -46,7 +46,7 @@ export function assertClientCredentials(
   expectedTenantId: string,
   expectedClientId: string,
   expectedClientSecret: string
-) {
+): void {
   if (!authRequest) {
     assert.fail("No authentication request was intercepted");
   } else {

--- a/sdk/identity/identity/test/credentials/authTestUtils.ts
+++ b/sdk/identity/identity/test/credentials/authTestUtils.ts
@@ -12,7 +12,7 @@ export class MockAuthHttpClient implements HttpClient {
   public identityClientOptions: IdentityClientOptions;
 
   constructor() {
-    this.requestResolve = () => { };
+    this.requestResolve = () => {};
     this.requestPromise = new Promise((resolve) => {
       this.requestResolve = resolve;
     });

--- a/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import assert from "assert";
+import { ManagedIdentityCredential } from "../../src";
+import { MockAuthHttpClient } from "./authTestUtils";
+import { WebResource } from '@azure/core-http';
+
+describe("ManagedIdentityCredential", function () {
+  it("sends an authorization request with a modified resource name", async () => {
+    const authRequest = await getMsiTokenAuthRequest(["https://service/.default"], "client");
+    assert.ok(authRequest.query, "No query string parameters on request")
+    if (authRequest.query) {
+      assert.equal(authRequest.query["client_id"], "client")
+      assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service")
+    }
+  });
+
+  it("sends an authorization request with an unmodified resource name", async () => {
+    const authRequest = await getMsiTokenAuthRequest("someResource");
+    assert.ok(authRequest.query, "No query string parameters on request")
+    if (authRequest.query) {
+      assert.equal(authRequest.query["client_id"], undefined)
+      assert.equal(decodeURIComponent(authRequest.query["resource"]), "someResource")
+    }
+  });
+
+  async function getMsiTokenAuthRequest(scopes: string | string[], clientId?: string): Promise<WebResource> {
+    const mockHttpClient = new MockAuthHttpClient();
+    const credential = new ManagedIdentityCredential(
+      clientId,
+      mockHttpClient.identityClientOptions
+    );
+
+    await credential.getToken(scopes);
+    return mockHttpClient.getAuthRequest();
+  }
+});

--- a/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
@@ -4,28 +4,31 @@
 import assert from "assert";
 import { ManagedIdentityCredential } from "../../src";
 import { MockAuthHttpClient } from "./authTestUtils";
-import { WebResource } from '@azure/core-http';
+import { WebResource } from "@azure/core-http";
 
-describe("ManagedIdentityCredential", function () {
+describe("ManagedIdentityCredential", function() {
   it("sends an authorization request with a modified resource name", async () => {
     const authRequest = await getMsiTokenAuthRequest(["https://service/.default"], "client");
-    assert.ok(authRequest.query, "No query string parameters on request")
+    assert.ok(authRequest.query, "No query string parameters on request");
     if (authRequest.query) {
-      assert.equal(authRequest.query["client_id"], "client")
-      assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service")
+      assert.equal(authRequest.query["client_id"], "client");
+      assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
     }
   });
 
   it("sends an authorization request with an unmodified resource name", async () => {
     const authRequest = await getMsiTokenAuthRequest("someResource");
-    assert.ok(authRequest.query, "No query string parameters on request")
+    assert.ok(authRequest.query, "No query string parameters on request");
     if (authRequest.query) {
-      assert.equal(authRequest.query["client_id"], undefined)
-      assert.equal(decodeURIComponent(authRequest.query["resource"]), "someResource")
+      assert.equal(authRequest.query["client_id"], undefined);
+      assert.equal(decodeURIComponent(authRequest.query["resource"]), "someResource");
     }
   });
 
-  async function getMsiTokenAuthRequest(scopes: string | string[], clientId?: string): Promise<WebResource> {
+  async function getMsiTokenAuthRequest(
+    scopes: string | string[],
+    clientId?: string
+  ): Promise<WebResource> {
     const mockHttpClient = new MockAuthHttpClient();
     const credential = new ManagedIdentityCredential(
       clientId,


### PR DESCRIPTION
This change adds an `MsiCredential` implementation of `TokenCredential` which can authenticate against Azure AD using a managed service identity configured for the deployment environment.  I tested that I was able to retrieve a token from the MSI endpoint in a VM that I created in Azure.

I'll rebase this PR on top of #3681 after it gets merged.

/cc @AlexGhiondea