### PR TITLE
Added support for domainCredentials for authenticating to EventGrid domains.

### DIFF
--- a/sdk/core/core-http/lib/coreHttp.ts
+++ b/sdk/core/core-http/lib/coreHttp.ts
@@ -49,4 +49,5 @@ export { BasicAuthenticationCredentials } from "./credentials/basicAuthenticatio
 export { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKeyCredentials";
 export { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 export { TopicCredentials } from "./credentials/topicCredentials";
+export { DomainCredentials } from "./credentials/domainCredentials";
 export { Authenticator } from "./credentials/credentials";

--- a/sdk/core/core-http/lib/credentials/domainCredentials.ts
+++ b/sdk/core/core-http/lib/credentials/domainCredentials.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import { ApiKeyCredentials, ApiKeyCredentialOptions } from "./apiKeyCredentials";
+
+export class DomainCredentials extends ApiKeyCredentials {
+  /**
+   * Creates a new EventGrid DomainCredentials object.
+   *
+   * @constructor
+   * @param {string} domainKey   The EventGrid domain key
+   */
+  constructor(domainKey: string) {
+    if (!domainKey || (domainKey && typeof domainKey !== "string")) {
+      throw new Error("domainKey cannot be null or undefined and must be of type string.");
+    }
+    const options: ApiKeyCredentialOptions = {
+      inHeader: {
+        "aeg-sas-key": domainKey
+      }
+    };
+    super(options);
+  }
+}

--- a/sdk/core/core-http/lib/msRest.ts
+++ b/sdk/core/core-http/lib/msRest.ts
@@ -47,4 +47,5 @@ export { BasicAuthenticationCredentials } from "./credentials/basicAuthenticatio
 export { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKeyCredentials";
 export { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 export { TopicCredentials } from "./credentials/topicCredentials";
+export { DomainCredentials } from "./credentials/domainCredentials";
 export { Authenticator } from "./credentials/credentials";


### PR DESCRIPTION
Added a new DomainCredentials class for make it easier to supply EventGrid domain credentials. Event Grid domain is a recently introduced concept/resource and applications can publish events to an EventGrid domain for which an api key needs to be provided, and this newly introduced DomainCredentials class makes it easy to do so.