### PR TITLE
[Abort Controller] Updates version to 1.0.0-preview.1

### DIFF
--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/abort-controller",
   "sdk-type": "client",
-  "version": "1.0.0",
+  "version": "1.0.0-preview.1",
   "description": "Microsoft Azure SDK for JavaScript - Aborter",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/aborter.js",

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -45,7 +45,7 @@ describe("AbortController", () => {
   it("should abort when calling abort() after creation but before request finishes", async () => {
     const controller = new AbortController();
     const aborter = controller.signal;
-    const response = doAsyncOperation(aborter, 100);
+    const response = doAsyncOperation(aborter, 500);
     setTimeout(() => controller.abort(), 50);
     try {
       let r = await response;


### PR DESCRIPTION
Updates the `@azure/abort-controller` package to use the preview tag.
/cc @bterlson @ramya-rao-a 