### PR TITLE
adding connection string env var for storage live tests

### DIFF
--- a/sdk/storage/archetype-sdk-tests-storage.yml
+++ b/sdk/storage/archetype-sdk-tests-storage.yml
@@ -4,6 +4,7 @@ parameters:
     ACCOUNT_NAME: $(js-storage-test-account-name)
     ACCOUNT_KEY: $(js-storage-test-account-key)
     ACCOUNT_SAS: $(js-storage-test-account-sas)
+    CONNECTION_STRING: $(js-storage-test-connection-string)
   Matrix:
     Linux_Node8X:
       OSVmImage: "ubuntu-16.04"

--- a/sdk/storage/archetype-sdk-tests-storage.yml
+++ b/sdk/storage/archetype-sdk-tests-storage.yml
@@ -4,7 +4,7 @@ parameters:
     ACCOUNT_NAME: $(js-storage-test-account-name)
     ACCOUNT_KEY: $(js-storage-test-account-key)
     ACCOUNT_SAS: $(js-storage-test-account-sas)
-    CONNECTION_STRING: $(js-storage-test-connection-string)
+    STORAGE_CONNECTION_STRING: $(js-storage-test-connection-string)
   Matrix:
     Linux_Node8X:
       OSVmImage: "ubuntu-16.04"


### PR DESCRIPTION
- Adding connection string Environment variable for the storage live tests
- Required updates to devops and keyvault has been done

@Azure/azure-sdk-eng @HarshaNalluru 
