### PR TITLE
[core-amqp] updates cancellation logic to directly use AbortError

### DIFF
--- a/sdk/core/core-amqp/src/errors.ts
+++ b/sdk/core/core-amqp/src/errors.ts
@@ -562,7 +562,14 @@ export function translate(err: AmqpError | Error): MessagingError {
 
   // Built-in errors like TypeError and RangeError should not be retryable as these indicate issues
   // with user input and not an issue with the Messaging process.
-  if (err instanceof TypeError || err instanceof RangeError) {
+  if (
+    err instanceof TypeError ||
+    err instanceof RangeError ||
+    // instanceof checks on custom Errors doesn't work without manually setting the prototype within the error.
+    // Must do a name check until AbortError is updated, and that doesn't break compatibility
+    // https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    (err as Error).name === "AbortError"
+  ) {
     error.retryable = false;
     return error;
   }

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { AbortSignal } from "@azure/abort-controller";
+import { AbortSignal, AbortError } from "@azure/abort-controller";
 import * as Constants from "./util/constants";
 import { retry, RetryConfig, RetryOperationType } from "./retry";
 import {
@@ -130,13 +130,9 @@ export class RequestResponseLink implements ReqResLink {
             `[${this.connection.id}] The request "${requestName}" ` +
             `to "${address}" has been cancelled by the user.`;
           log.error(desc);
-          const error = translate(
-            new Error(
-              `The ${requestName ? requestName + " " : ""}operation has been cancelled by the user.`
-            )
+          const error = new AbortError(
+            `The ${requestName ? requestName + " " : ""}operation has been cancelled by the user.`
           );
-          error.name = "AbortError";
-          error.retryable = false;
 
           reject(error);
         };


### PR DESCRIPTION
One thing to note is that I updated the `translate` method to check if the `err.name` was equal to `AbortError` instead of doing an `instanceof` check. This is because instanceof checks don't work on custom errors that extend `Error` unless you also set the error's prototype after it's instantiated. 

See https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work for more info.