### PR TITLE
[Identity] Rename 'expiresOn' and other small tweaks to @azure/core-http

### DIFF
--- a/sdk/core/core-http/lib/credentials/tokenCredential.ts
+++ b/sdk/core/core-http/lib/credentials/tokenCredential.ts
@@ -41,7 +41,7 @@ export interface AccessToken {
   token: string;
 
   /**
-   * The access token's expiration date and time.
+   * The access token's expiration timestamp.
    */
-  expiresOn: Date;
+  expiresOnTimestamp: number;
 }

--- a/sdk/core/core-http/lib/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/bearerTokenAuthenticationPolicy.ts
@@ -72,7 +72,7 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
   private async getToken(options: GetTokenOptions): Promise<string | undefined> {
     if (
       this.cachedToken &&
-      new Date(Date.now() + TokenRefreshBufferMs) < this.cachedToken.expiresOn
+      Date.now() + TokenRefreshBufferMs < this.cachedToken.expiresOnTimestamp
     ) {
       return this.cachedToken.token;
     }

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -63,7 +63,7 @@
     "build:scripts": "tsc -p ./.scripts/",
     "build:test": "run-s build build:test-browser",
     "build:tsc": "tsc -p tsconfig.es.json",
-    "build:rollup": "rollup -c rollup.config.ts",
+    "build:rollup": "rollup -c rollup.config.ts 2>&1",
     "build:minify-browser": "uglifyjs -c -m --comments --source-map \"content='./dist/coreHttp.browser.js.map'\" -o ./dist/coreHttp.browser.min.js ./dist/coreHttp.browser.js",
     "build:test-browser": "webpack --config webpack.testconfig.ts",
     "check-format": "prettier --list-different --config .prettierrc.json \"src/**/*.ts\"",

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -44,10 +44,10 @@ describe("BearerTokenAuthenticationPolicy", function () {
 
   it("refreshes access tokens when they expire", async () => {
     const now = Date.now();
-    const refreshCred1 = new MockRefreshAzureCredential(new Date(now));
-    const refreshCred2 = new MockRefreshAzureCredential(new Date(now + TokenRefreshBufferMs));
+    const refreshCred1 = new MockRefreshAzureCredential(now);
+    const refreshCred2 = new MockRefreshAzureCredential(now + TokenRefreshBufferMs);
     const notRefreshCred1 = new MockRefreshAzureCredential(
-      new Date(now + TokenRefreshBufferMs + 5000)
+      now + TokenRefreshBufferMs + 5000
     );
 
     const credentialsToTest: [MockRefreshAzureCredential, number][] = [
@@ -81,11 +81,11 @@ describe("BearerTokenAuthenticationPolicy", function () {
 });
 
 class MockRefreshAzureCredential implements TokenCredential {
-  private _expiresOn: Date;
+  private _expiresOnTimestamp: number;
   public authCount = 0;
 
-  constructor(expiresOn: Date) {
-    this._expiresOn = expiresOn;
+  constructor(expiresOnTimestamp: number) {
+    this._expiresOnTimestamp = expiresOnTimestamp;
   }
 
   public getToken(
@@ -93,6 +93,6 @@ class MockRefreshAzureCredential implements TokenCredential {
     _options?: GetTokenOptions
   ): Promise<AccessToken | null> {
     this.authCount++;
-    return Promise.resolve({ token: "mocktoken", expiresOn: this._expiresOn });
+    return Promise.resolve({ token: "mocktoken", expiresOnTimestamp: this._expiresOnTimestamp });
   }
 }

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -5,11 +5,11 @@
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
+  "types": "dist-esm/src/index.d.ts",
   "browser": {
     "stream": "./node_modules/stream-browserify/index.js",
     "./dist/index.js": "./browser/index.js"
   },
-  "types": "dist-esm/index.d.ts",
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -18,11 +18,10 @@ export class IdentityClient extends ServiceClient {
   private static readonly DefaultScopeSuffix = "/.default";
 
   constructor(options?: IdentityClientOptions) {
+    options = options || IdentityClient.getDefaultOptions();
     super(undefined, options);
 
-    if (options !== undefined) {
-      this.baseUri = options.authorityHost;
-    }
+    this.baseUri = options.authorityHost;
   }
 
   private createWebResource(requestOptions: RequestPrepareOptions): WebResource {

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -36,12 +36,9 @@ export class IdentityClient extends ServiceClient {
   ): Promise<AccessToken | null> {
     const response = await this.sendRequest(requestOptions);
     if (response.status === 200 || response.status === 201) {
-      const expiresOn = new Date();
-      expiresOn.setSeconds(expiresOn.getSeconds() + response.parsedBody.expires_in);
-
       return {
         token: response.parsedBody.access_token,
-        expiresOn: expiresOn
+        expiresOnTimestamp: Date.now() + response.parsedBody.expires_in * 1000
       };
     }
 


### PR DESCRIPTION
This change fixes a few issues:

- Fixes #3796: Warnings are written when building `@azure/core-http`
- Fixes #3716: `expiresOn` should be renamed to `expiresOnTimestamp` and changed to a `number`
- Fixes an issue where the default authority host URL isn't applied when `IdentityClientOptions` aren't passed to `IdentityClient`
- Fixes the `types` path in `identity`'s `package.json` so that it points to the correct path

/cc @ShivangiReja 