### PR TITLE
[Event Hubs] updates APIs to accept AbortSignalLike instead of AbortSignal

### DIFF
--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -16,7 +16,7 @@ import { ReceivedEventData, EventDataInternal, fromAmqpMessage } from "./eventDa
 import { EventReceiverOptions, RetryOptions } from "./eventHubClient";
 import { EventHubReceiver } from "./eventHubReceiver";
 import { ConnectionContext } from "./connectionContext";
-import { AbortSignal, AbortError } from "@azure/abort-controller";
+import { AbortSignalLike, AbortError } from "@azure/abort-controller";
 import * as log from "./log";
 
 /**
@@ -52,14 +52,14 @@ export class BatchingReceiver extends EventHubReceiver {
    * @param {number} [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver
    * should wait to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
    * @param {RetryOptions} [retryOptions] Retry options for the receive operation
-   * @param {AbortSignal} abortSignal Signal to cancel current operation.
+   * @param {AbortSignalLike} abortSignal Signal to cancel current operation.
    * @returns {Promise<ReceivedEventData[]>} A promise that resolves with an array of ReceivedEventData objects.
    */
   receive(
     maxMessageCount: number,
     maxWaitTimeInSeconds?: number,
     retryOptions?: RetryOptions,
-    abortSignal?: AbortSignal
+    abortSignal?: AbortSignalLike
   ): Promise<ReceivedEventData[]> {
     if (maxWaitTimeInSeconds == undefined) {
       maxWaitTimeInSeconds = Constants.defaultOperationTimeoutInSeconds;

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -25,7 +25,7 @@ import { PartitionProperties, EventHubProperties } from "./managementClient";
 import { EventPosition } from "./eventPosition";
 
 import { IotHubClient } from "./iothub/iothubClient";
-import { AbortSignal } from "@azure/abort-controller";
+import { AbortSignalLike } from "@azure/abort-controller";
 import { EventSender } from "./sender";
 import { EventReceiver } from "./receiver";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
@@ -87,7 +87,7 @@ export interface SendOptions {
    * @property
    * Cancel current operation
    */
-  abortSignal?: AbortSignal;
+  abortSignal?: AbortSignalLike;
 }
 
 /**
@@ -354,7 +354,7 @@ export class EventHubClient {
    * Provides the eventhub runtime information.
    * @returns {Promise<EventHubProperties>} A promise that resolves with HubInformation.
    */
-  async getProperties(abortSignal?: AbortSignal): Promise<EventHubProperties> {
+  async getProperties(abortSignal?: AbortSignalLike): Promise<EventHubProperties> {
     try {
       return await this._context.managementSession!.getHubRuntimeInformation({
         retryOptions: this._clientOptions.retryOptions,
@@ -370,7 +370,7 @@ export class EventHubClient {
    * Provides an array of partitionIds.
    * @returns {Promise<Array<string>>} A promise that resolves with an Array of strings.
    */
-  async getPartitionIds(abortSignal?: AbortSignal): Promise<Array<string>> {
+  async getPartitionIds(abortSignal?: AbortSignalLike): Promise<Array<string>> {
     try {
       const runtimeInfo = await this.getProperties(abortSignal);
       return runtimeInfo.partitionIds;
@@ -385,7 +385,7 @@ export class EventHubClient {
    * @param {string} partitionId Partition ID for which partition information is required.
    * @returns {Promise<PartitionProperties>} A promise that resoloves with EventHubPartitionRuntimeInformation.
    */
-  async getPartitionInformation(partitionId: string, abortSignal?: AbortSignal): Promise<PartitionProperties> {
+  async getPartitionInformation(partitionId: string, abortSignal?: AbortSignalLike): Promise<PartitionProperties> {
     throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
     partitionId = String(partitionId);
     try {

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -3,7 +3,14 @@
 
 import uuid from "uuid/v4";
 import * as log from "./log";
-import { Receiver, OnAmqpEvent, EventContext, ReceiverOptions as RheaReceiverOptions, types, AmqpError } from "rhea-promise";
+import {
+  Receiver,
+  OnAmqpEvent,
+  EventContext,
+  ReceiverOptions as RheaReceiverOptions,
+  types,
+  AmqpError
+} from "rhea-promise";
 import { translate, Constants, MessagingError, retry, RetryOperationType, RetryConfig } from "@azure/core-amqp";
 import { ReceivedEventData, EventDataInternal, fromAmqpMessage } from "./eventData";
 import { EventReceiverOptions } from "./eventHubClient";
@@ -11,7 +18,7 @@ import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
 import { EventPosition } from "./eventPosition";
 import { getEventPositionFilter } from "./util/utils";
-import { AbortSignal } from "@azure/abort-controller";
+import { AbortSignalLike } from "@azure/abort-controller";
 
 interface CreateReceiverOptions {
   onMessage: OnAmqpEvent;
@@ -171,7 +178,7 @@ export class EventHubReceiver extends LinkEntity {
    * @property {Aborter | undefined} _aborter Describes Aborter instance that will be set by the user
    * to cancel the request.
    */
-  protected _abortSignal: AbortSignal | undefined;
+  protected _abortSignal: AbortSignalLike | undefined;
 
   /**
    * @property {number} Returns sequenceNumber of the last event received.

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -29,7 +29,7 @@ import { EventData, toAmqpMessage } from "./eventData";
 import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
 import { SendOptions, EventSenderOptions } from "./eventHubClient";
-import { AbortSignal, AbortError } from "@azure/abort-controller";
+import { AbortSignalLike, AbortError } from "@azure/abort-controller";
 
 interface CreateSenderOptions {
   newName?: boolean;
@@ -458,7 +458,7 @@ export class EventHubSender extends LinkEntity {
           let onReleased: Func<EventContext, void>;
           let onModified: Func<EventContext, void>;
           let onAccepted: Func<EventContext, void>;
-          let abortSignal: AbortSignal;
+          let abortSignal: AbortSignalLike;
           let onAborted: () => void;
 
           const removeListeners = (): void => {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -8,7 +8,7 @@ import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
 import * as log from "./log";
 import { RetryOptions } from "./eventHubClient";
-import { AbortSignal } from "@azure/abort-controller";
+import { AbortSignalLike } from "@azure/abort-controller";
 /**
  * Describes the runtime information of an EventHub.
  * @interface HubRuntimeInformation
@@ -112,7 +112,7 @@ export class ManagementClient extends LinkEntity {
    */
   async getHubRuntimeInformation(options?: {
     retryOptions?: RetryOptions;
-    abortSignal?: AbortSignal;
+    abortSignal?: AbortSignalLike;
   }): Promise<EventHubProperties> {
     if (!options) {
       options = {};
@@ -160,7 +160,7 @@ export class ManagementClient extends LinkEntity {
    */
   async getPartitionInformation(
     partitionId: string | number,
-    options?: { retryOptions?: RetryOptions; abortSignal?: AbortSignal }
+    options?: { retryOptions?: RetryOptions; abortSignal?: AbortSignalLike }
   ): Promise<PartitionProperties> {
     if (!options) {
       options = {};
@@ -276,7 +276,7 @@ export class ManagementClient extends LinkEntity {
    */
   private async _makeManagementRequest(
     request: Message,
-    options?: { retryOptions?: RetryOptions; timeout?: number; abortSignal?: AbortSignal; requestName?: string }
+    options?: { retryOptions?: RetryOptions; timeout?: number; abortSignal?: AbortSignalLike; requestName?: string }
   ): Promise<any> {
     try {
       log.mgmt("[%s] Acquiring lock to get the management req res link.", this._context.connectionId);

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -7,7 +7,7 @@ import { EventReceiverOptions } from "./eventHubClient";
 import { EventHubReceiver, OnMessage, OnError } from "./eventHubReceiver";
 import { ConnectionContext } from "./connectionContext";
 import * as log from "./log";
-import { AbortSignal } from "@azure/abort-controller";
+import { AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * Describes the receive handler object that is returned from the receive() method with handlers is
@@ -107,9 +107,9 @@ export class StreamingReceiver extends EventHubReceiver {
    * @ignore
    * @param {OnMessage} onMessage The message handler to receive event data objects.
    * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
-   * @param {AbortSignal} abortSignal Signal to cancel current operation.
+   * @param {AbortSignalLike} abortSignal Signal to cancel current operation.
    */
-  receive(onMessage: OnMessage, onError: OnError, abortSignal?: AbortSignal): ReceiveHandler {
+  receive(onMessage: OnMessage, onError: OnError, abortSignal?: AbortSignalLike): ReceiveHandler {
     this._onMessage = onMessage;
     this._onError = onError;
     if (abortSignal) {


### PR DESCRIPTION
Updates event-hubs to accept AbortSignalLike instead of AbortSignal. This will allow the package to accept any AbortSignal that implements the interface, including the native DOM AbortSignal in modern web browsers.