### PR TITLE
run service bus live-tests in parallel

### DIFF
--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -21,4 +21,4 @@ jobs:
         RESOURCE_GROUP: $(service-bus-test-resource-group)
         SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
       # Service Bus tests do not support concurrent execution
-      MaxParallel: 1
+      MaxParallel: 0

--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -20,5 +20,3 @@ jobs:
         CLEAN_NAMESPACE: "true"
         RESOURCE_GROUP: $(service-bus-test-resource-group)
         SERVICEBUS_CONNECTION_STRING: $(service-bus-test-connection-string)
-      # Service Bus tests do not support concurrent execution
-      MaxParallel: 0


### PR DESCRIPTION
- Enabling the browser tests and node tests to run in parallel
- This can be merged after the other PRs for the issue 3419 is resolved

@Azure/azure-sdk-eng 