### PR TITLE
[Identity] Throw AuthenticationError when any authentication request fails

### DIFF
--- a/sdk/identity/identity/src/client/errors.ts
+++ b/sdk/identity/identity/src/client/errors.ts
@@ -60,8 +60,8 @@ export class AuthenticationError extends Error {
     this.statusCode = statusCode;
     this.errorResponse = errorResponse;
 
-    // Restore the object prototype since Error's constructor futzes with it
-    Object.setPrototypeOf(this, new.target.prototype);
+    // Ensure that this type reports the correct name
+    this.name = "AuthenticationError";
   }
 }
 
@@ -71,7 +71,7 @@ export class AggregateAuthenticationError extends Error {
     super("Authentication failed to complete due to errors");
     this.errors = errors;
 
-    // Restore the object prototype since Error's constructor futzes with it
-    Object.setPrototypeOf(this, new.target.prototype);
+    // Ensure that this type reports the correct name
+    this.name = "AggregateAuthenticationError";
   }
 }

--- a/sdk/identity/identity/src/client/errors.ts
+++ b/sdk/identity/identity/src/client/errors.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+/**
+ * See the official documentation for more details:
+ *
+ * https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code#error-response-1
+ */
+export interface ErrorResponse {
+  error: string;
+  error_description: string;
+  error_codes?: number[];
+  timestamp?: string;
+  trace_id?: string;
+  correlation_id?: string;
+}
+
+export class AuthenticationError extends Error {
+  public readonly statusCode: number;
+  public readonly errorResponse: ErrorResponse;
+
+  constructor(statusCode: number, errorBody: string | undefined | null) {
+    let errorResponse = {
+      error: "unknown",
+      error_description: "An unknown error occurred and no additional details are available."
+    };
+
+    if (errorBody) {
+      try {
+        // Most error responses will contain JSON-formatted error details
+        // in the response body
+        errorResponse = JSON.parse(errorBody);
+      } catch (e) {
+        if (statusCode === 400) {
+          errorResponse = {
+            error: "authority_not_found",
+            error_description: "The specified authority URL was not found."
+          };
+        } else {
+          errorResponse = {
+            error: "unknown_error",
+            error_description: `An unknown error has occurred. Response body:\n\n${errorBody}`
+          };
+        }
+      }
+    } else {
+      errorResponse = {
+        error: "unknown_error",
+        error_description: "An unknown error occurred and no additional details are available."
+      };
+    }
+
+    super(
+      `An error was returned while authenticating to Azure Active Directory (status code ${statusCode}).\n\nMore details:\n\n${JSON.stringify(
+        errorResponse,
+        null,
+        "  "
+      )}`
+    );
+    this.statusCode = statusCode;
+    this.errorResponse = errorResponse;
+
+    // Restore the object prototype since Error's constructor futzes with it
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class AggregateAuthenticationError extends Error {
+  public errors: any[];
+  constructor(errors: any[]) {
+    super("Authentication failed to complete due to errors");
+    this.errors = errors;
+
+    // Restore the object prototype since Error's constructor futzes with it
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/sdk/identity/identity/src/client/errors.ts
+++ b/sdk/identity/identity/src/client/errors.ts
@@ -5,6 +5,9 @@
  * See the official documentation for more details:
  *
  * https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code#error-response-1
+ * 
+ * NOTE: This documentation is for v1 OAuth support but the same error
+ * response details still apply to v2.
  */
 export interface ErrorResponse {
   error: string;

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -67,7 +67,7 @@ export class IdentityClient extends ServiceClient {
     return scope.substr(0, scope.lastIndexOf(DefaultScopeSuffix));
   }
 
-  private dateInSeconds(date: Date) {
+  private dateInSeconds(date: Date): number {
     return Math.floor(date.getTime() / 1000);
   }
 

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -12,6 +12,7 @@ import {
   WebResource,
   RequestPrepareOptions
 } from "@azure/core-http";
+import { AuthenticationError } from "./errors";
 
 const SelfSignedJwtLifetimeMins = 10;
 const DefaultAuthorityHost = "https://login.microsoftonline.com";
@@ -42,9 +43,9 @@ export class IdentityClient extends ServiceClient {
         token: response.parsedBody.access_token,
         expiresOnTimestamp: Date.now() + response.parsedBody.expires_in * 1000
       };
+    } else {
+      throw new AuthenticationError(response.status, response.bodyAsText);
     }
-
-    return null;
   }
 
   private mapScopesToResource(scopes: string | string[]): string {

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
+import { AggregateAuthenticationError } from "../client/errors";
 
 export class ChainedTokenCredential implements TokenCredential {
   private _sources: TokenCredential[] = [];
@@ -15,9 +16,18 @@ export class ChainedTokenCredential implements TokenCredential {
     options?: GetTokenOptions
   ): Promise<AccessToken | null> {
     let token = null;
+    const errors = [];
 
     for (let i = 0; i < this._sources.length && token === null; i++) {
-      token = await this._sources[i].getToken(scopes, options);
+      try {
+        token = await this._sources[i].getToken(scopes, options);
+      } catch (err) {
+        errors.push(err);
+      }
+    }
+
+    if (!token && errors.length > 0) {
+      throw new AggregateAuthenticationError(errors);
     }
 
     return token;

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -11,6 +11,7 @@ export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { ManagedIdentityCredential } from "./credentials/managedIdentityCredential";
 export { DefaultAzureCredential } from "./credentials/defaultAzureCredential";
+export { AuthenticationError, AggregateAuthenticationError } from "./client/errors";
 
 export { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 

--- a/sdk/identity/identity/test/client/identityClient.spec.ts
+++ b/sdk/identity/identity/test/client/identityClient.spec.ts
@@ -2,23 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import assert from "assert";
+import { assertRejects } from "../credentials/authTestUtils";
 import { IdentityClient } from "../../src/client/identityClient";
 import { MockAuthHttpClient } from "../credentials/authTestUtils";
 import { AuthenticationError } from "../../src/";
-
-// Node's `assert.rejects` doesn't appear until 8.13.0 so we'll
-// use our own simple implementation here
-async function assertRejects(
-  promise: Promise<any>,
-  expected: (error: any) => boolean,
-  message?: string
-) {
-  try {
-    await promise;
-  } catch (error) {
-    assert.ok(expected(error), message || "The error didn't pass the assertion predicate.")
-  }
-}
 
 function isExpectedError(expectedErrorName: string): (error: any) => boolean {
   return (error: any) => {

--- a/sdk/identity/identity/test/client/identityClient.spec.ts
+++ b/sdk/identity/identity/test/client/identityClient.spec.ts
@@ -39,7 +39,10 @@ describe("IdentityClient", function () {
 
     await assertRejects(
       client.authenticateClientSecret("tenant", "client", "secret", "https://test/.default"),
-      error => error instanceof AuthenticationError
+      error => {
+        assert.strictEqual(error.name, 'AuthenticationError')
+        return true;
+      }
     );
   });
 

--- a/sdk/identity/identity/test/client/identityClient.spec.ts
+++ b/sdk/identity/identity/test/client/identityClient.spec.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import assert from "assert";
+import { IdentityClient } from "../../src/client/identityClient";
+import { MockAuthHttpClient } from "../credentials/authTestUtils";
+import { AuthenticationError } from "../../src/";
+
+describe("IdentityClient", function () {
+  it("throws an exception when an authentication request fails", async () => {
+    const mockHttp = new MockAuthHttpClient({
+      status: 400,
+      bodyAsText: `{ "error": "test_error", "error_description": "This is a test error" }`
+    });
+    const client = new IdentityClient(mockHttp.identityClientOptions);
+
+    await (assert as any).rejects(
+      () => client.authenticateClientSecret("tenant", "client", "secret", "https://test/.default"),
+      AuthenticationError
+    );
+  });
+
+  it("returns a usable error when the authentication response body doesn't contain parseable JSON", async () => {
+    const client = new IdentityClient({ authorityHost: "bogus" });
+    await (assert as any).rejects(
+      () => client.authenticateClientSecret("tenant", "client", "secret", "https://test/.default"),
+      (err: AuthenticationError) => err.errorResponse.error === "authority_not_found"
+    );
+  });
+});

--- a/sdk/identity/identity/test/credentials/aggregateCredential.spec.ts
+++ b/sdk/identity/identity/test/credentials/aggregateCredential.spec.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+import assert from "assert";
+import {
+  AggregateCredential,
+  TokenCredential,
+  AccessToken,
+  AggregateAuthenticationError
+} from "../../src";
+
+function mockCredential(returnPromise: Promise<AccessToken | null>): TokenCredential {
+  return {
+    getToken: () => returnPromise
+  };
+}
+
+describe("AggregateCredential", function() {
+  it("returns the first token received from a credential", async () => {
+    const aggregateCredential = new AggregateCredential(
+      mockCredential(Promise.resolve(null)),
+      mockCredential(Promise.resolve({ token: "firstToken", expiresOnTimestamp: 0 })),
+      mockCredential(Promise.resolve({ token: "secondToken", expiresOnTimestamp: 0 }))
+    );
+    const accessToken = await aggregateCredential.getToken("scope");
+    assert.notStrictEqual(accessToken, null);
+    assert.strictEqual(accessToken && accessToken.token, "firstToken");
+  });
+
+  it("returns an AggregateAuthenticationError when no token is returned and one credential returned an error", async () => {
+    const aggregateCredential = new AggregateCredential(
+      mockCredential(Promise.reject(new Error("Boom."))),
+      mockCredential(Promise.resolve(null)),
+      mockCredential(Promise.reject(new Error("Boom.")))
+    );
+
+    await (assert as any).rejects(
+      () => aggregateCredential.getToken("scope"),
+      (err: AggregateAuthenticationError) => err.errors.length === 2
+    );
+  });
+});

--- a/sdk/identity/identity/test/credentials/authTestUtils.ts
+++ b/sdk/identity/identity/test/credentials/authTestUtils.ts
@@ -20,7 +20,7 @@ export class MockAuthHttpClient implements HttpClient {
   public identityClientOptions: IdentityClientOptions;
 
   constructor(authResponse?: MockAuthResponse) {
-    this.requestResolve = () => {};
+    this.requestResolve = () => { };
     this.requestPromise = new Promise((resolve) => {
       this.requestResolve = resolve;
     });
@@ -79,5 +79,19 @@ export function assertClientCredentials(
       true,
       "Request body doesn't contain expected clientSecret"
     );
+  }
+}
+
+// Node's `assert.rejects` doesn't appear until 8.13.0 so we'll
+// use our own simple implementation here
+export async function assertRejects(
+  promise: Promise<any>,
+  expected: (error: any) => boolean,
+  message?: string
+): Promise<any> {
+  try {
+    await promise;
+  } catch (error) {
+    assert.ok(expected(error), message || "The error didn't pass the assertion predicate.")
   }
 }

--- a/sdk/identity/identity/test/credentials/chainedTokenCredential.spec.ts
+++ b/sdk/identity/identity/test/credentials/chainedTokenCredential.spec.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import assert from "assert";
+import { assertRejects } from "./authTestUtils";
 import {
   ChainedTokenCredential,
   TokenCredential,
@@ -34,8 +35,8 @@ describe("ChainedTokenCredential", function () {
       mockCredential(Promise.reject(new Error("Boom.")))
     );
 
-    await (assert as any).rejects(
-      () => chainedTokenCredential.getToken("scope"),
+    await assertRejects(
+      chainedTokenCredential.getToken("scope"),
       (err: AggregateAuthenticationError) => err.errors.length === 2
     );
   });

--- a/sdk/identity/identity/test/credentials/chainedTokenCredential.spec.ts
+++ b/sdk/identity/identity/test/credentials/chainedTokenCredential.spec.ts
@@ -3,7 +3,7 @@
 
 import assert from "assert";
 import {
-  AggregateCredential,
+  ChainedTokenCredential,
   TokenCredential,
   AccessToken,
   AggregateAuthenticationError
@@ -15,27 +15,27 @@ function mockCredential(returnPromise: Promise<AccessToken | null>): TokenCreden
   };
 }
 
-describe("AggregateCredential", function() {
+describe("ChainedTokenCredential", function () {
   it("returns the first token received from a credential", async () => {
-    const aggregateCredential = new AggregateCredential(
+    const chainedTokenCredential = new ChainedTokenCredential(
       mockCredential(Promise.resolve(null)),
       mockCredential(Promise.resolve({ token: "firstToken", expiresOnTimestamp: 0 })),
       mockCredential(Promise.resolve({ token: "secondToken", expiresOnTimestamp: 0 }))
     );
-    const accessToken = await aggregateCredential.getToken("scope");
+    const accessToken = await chainedTokenCredential.getToken("scope");
     assert.notStrictEqual(accessToken, null);
     assert.strictEqual(accessToken && accessToken.token, "firstToken");
   });
 
   it("returns an AggregateAuthenticationError when no token is returned and one credential returned an error", async () => {
-    const aggregateCredential = new AggregateCredential(
+    const chainedTokenCredential = new ChainedTokenCredential(
       mockCredential(Promise.reject(new Error("Boom."))),
       mockCredential(Promise.resolve(null)),
       mockCredential(Promise.reject(new Error("Boom.")))
     );
 
     await (assert as any).rejects(
-      () => aggregateCredential.getToken("scope"),
+      () => chainedTokenCredential.getToken("scope"),
       (err: AggregateAuthenticationError) => err.errors.length === 2
     );
   });

--- a/sdk/identity/identity/tsconfig.json
+++ b/sdk/identity/identity/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "es6" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
@@ -19,7 +19,6 @@
     "importHelpers": true /* Import emit helpers from 'tslib'. */,
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
@@ -28,13 +27,11 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
     /* Additional Checks */
     // "noUnusedLocals": true,                /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
     /* Module Resolution Options */
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
@@ -45,13 +42,11 @@
     "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */


### PR DESCRIPTION
This change introduces a couple of error types that will be thrown from `TokenCredential.getToken` (ultimately from within `IdentityClient`) when an authentication request fails.  While working with @ShivangiReja it became clear that having no real errors made it very hard to diagnose why credential requests failed.

For individual `TokenCredential` implementations, an `AuthenticationError` will be thrown when the authentication service returns an error, making sure to pass along the "error response" as documented [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/v1-protocols-oauth-code#error-response-1).

When the `AggregateCredential` is used, an `AggregateAuthenticationError` will be thrown _only_ when no token is returned by another credential in the chain.  I've added tests to verify this behavior.

@schaabs - I seem to recall that you weren't in favor of throwing exceptions when a credential isn't available.  Is there anything I can change about this approach to be more in line with what you had in mind?