### PR TITLE
[Event Hubs] updates send method to also accept a single EventData object

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -75,7 +75,7 @@ export interface EventSenderOptions {
 /**
  * Options that can be passed when sending a batch of events using the EventHubsClient
  */
-export interface EventBatchingOptions {
+export interface SendOptions {
   /**
    * @property
    * If specified EventHub will hash this string to map to a partitionId.

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -28,7 +28,7 @@ import {
 import { EventData, toAmqpMessage } from "./eventData";
 import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
-import { EventBatchingOptions, EventSenderOptions } from "./eventHubClient";
+import { SendOptions, EventSenderOptions } from "./eventHubClient";
 import { AbortSignal, AbortError } from "@azure/abort-controller";
 
 interface CreateSenderOptions {
@@ -338,7 +338,7 @@ export class EventHubSender extends LinkEntity {
    * @param options Options to control the way the events are batched along with request options
    * @return Promise<void>
    */
-  async send(events: EventData[], options?: EventBatchingOptions & EventSenderOptions): Promise<void> {
+  async send(events: EventData[], options?: SendOptions & EventSenderOptions): Promise<void> {
     try {
       if (!this.isOpen()) {
         log.sender(
@@ -431,7 +431,7 @@ export class EventHubSender extends LinkEntity {
   private _trySendBatch(
     message: AmqpMessage | Buffer,
     tag: any,
-    options?: EventBatchingOptions & EventSenderOptions,
+    options?: SendOptions & EventSenderOptions,
     format?: number
   ): Promise<void> {
     if (!options) {

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -9,11 +9,11 @@ export { OnMessage, OnError } from "./eventHubReceiver";
 export { ReceiveHandler } from "./streamingReceiver";
 export {
   EventHubClient,
-  EventReceiverOptions,
   EventHubClientOptions,
-  EventBatchingOptions,
+  EventReceiverOptions,
+  EventSenderOptions,
   RetryOptions,
-  EventSenderOptions
+  SendOptions
 } from "./eventHubClient";
 export { EventPosition, EventPositionOptions } from "./eventPosition";
 export { PartitionProperties, EventHubProperties } from "./managementClient";

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -3,7 +3,7 @@
 
 import { EventData } from "./eventData";
 import { EventHubSender } from "./eventHubSender";
-import { EventBatchingOptions, EventSenderOptions } from "./eventHubClient";
+import { EventSenderOptions, SendOptions } from "./eventHubClient";
 import { ConnectionContext } from "./connectionContext";
 import * as log from "./log";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
@@ -42,26 +42,27 @@ export class EventSender {
   constructor(context: ConnectionContext, options?: EventSenderOptions) {
     this._context = context;
     this._senderOptions = options || {};
-    const partitionId = this._senderOptions.partitionId != undefined ? String(this._senderOptions.partitionId) : undefined;
+    const partitionId =
+      this._senderOptions.partitionId != undefined ? String(this._senderOptions.partitionId) : undefined;
     this._eventHubSender = EventHubSender.create(this._context, partitionId);
   }
 
   /**
    * Send a batch of EventData to the EventHub using the options provided.
    *
-   * @param events  An array of EventData objects to be sent in a Batch message.
+   * @param eventData  An individual EventData or array of EventData objects to be sent in a Batch message.
    * @param options Options where you can specifiy the partition to send the message to along with controlling the send
    * request via retry options, log level and cancellation token.
    *
    * @return {Promise<void>} Promise<void>
    */
-  async send(events: EventData[], options?: EventBatchingOptions): Promise<void> {
+  async send(eventData: EventData | EventData[], options?: SendOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
-    throwTypeErrorIfParameterMissing(this._context.connectionId, 'events', events);
-    if (!Array.isArray(events)) {
-      events = [events];
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "events", eventData);
+    if (!Array.isArray(eventData)) {
+      eventData = [eventData];
     }
-    return this._eventHubSender.send(events, { ...this._senderOptions, ...options });
+    return this._eventHubSender.send(eventData, { ...this._senderOptions, ...options });
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -58,7 +58,7 @@ export class EventSender {
    */
   async send(eventData: EventData | EventData[], options?: SendOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
-    throwTypeErrorIfParameterMissing(this._context.connectionId, "events", eventData);
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "eventData", eventData);
     if (!Array.isArray(eventData)) {
       eventData = [eventData];
     }

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -33,6 +33,18 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
     await client.close();
   });
 
+  describe("Single message", function(): void {
+    it("should be sent successfully.", async function(): Promise<void> {
+      const data: EventData = { body: "Hello World 1" };
+      await client.createSender().send(data);
+    });
+
+    it("with partition key should be sent successfully.", async function(): Promise<void> {
+      const data: EventData = { body: "Hello World 1" };
+      await client.createSender().send(data, { partitionKey: "1" });
+    });
+  });
+
   describe("Batch message", function(): void {
     it("should be sent successfully.", async function(): Promise<void> {
       const data: EventData[] = [


### PR DESCRIPTION
Fixes #3821 

The `send` method already accepted a single `EventData` object in JavaScript, so this change is just renaming a few interfaces/variables to support TypeScript. Also adds tests to verify sending a single event works.