### PR TITLE
Fix browser test failures

### DIFF
--- a/sdk/storage/storage-blob/src/AppendBlobClient.ts
+++ b/sdk/storage/storage-blob/src/AppendBlobClient.ts
@@ -113,6 +113,8 @@ export class AppendBlobClient extends BlobClient {
   private appendBlobContext: AppendBlob;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of AppendBlobClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -550,7 +550,9 @@ export class BlobClient extends StorageClient {
   private blobContext: Blob;
 
   /**
-   * Creates an instance of BlobClient.
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
+   * Creates an instance of BlobClient from connection string.
    *
    * @param {string} connectionString Connection string for an Azure storage account.
    * @param {string} containerName Container name.

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -7,9 +7,9 @@ import { ListContainersIncludeType } from "./generated/lib/models/index";
 import { Service } from "./generated/lib/operations";
 import { newPipeline, NewPipelineOptions, Pipeline } from "./Pipeline";
 import {
-    ContainerClient,
-    ContainerCreateOptions,
-    ContainerDeleteMethodOptions
+  ContainerClient,
+  ContainerCreateOptions,
+  ContainerDeleteMethodOptions
 } from "./ContainerClient";
 import { appendToURLPath, extractConnectionStringParts } from "./utils/utils.common";
 import { Credential } from "./credentials/Credential";
@@ -146,6 +146,8 @@ export class BlobServiceClient extends StorageClient {
   private serviceContext: Service;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of BlobServiceClient from connection string.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-blob/src/BlockBlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlockBlobClient.ts
@@ -393,6 +393,8 @@ export class BlockBlobClient extends BlobClient {
   private blockBlobContext: BlockBlob;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of BlockBlobClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -422,6 +422,8 @@ export class ContainerClient extends StorageClient {
   private containerContext: Container;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of ContainerClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-blob/src/PageBlobClient.ts
+++ b/sdk/storage/storage-blob/src/PageBlobClient.ts
@@ -278,6 +278,8 @@ export class PageBlobClient extends BlobClient {
   private pageBlobContext: PageBlob;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of PageBlobClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -71,6 +71,8 @@ export function escapeURLPath(url: string): string {
 }
 
 /**
+ * ONLY AVAILABLE IN NODE.JS RUNTIME.
+ *
  * Extracts the parts of an Azure Storage account connection string.
  *
  * @export

--- a/sdk/storage/storage-blob/test/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/appendblobclient.spec.ts
@@ -1,9 +1,7 @@
 import * as assert from "assert";
 
 import * as dotenv from "dotenv";
-import { newPipeline, SharedKeyCredential } from "../src";
-import { AppendBlobClient } from "../src/AppendBlobClient";
-import { bodyToString, getBSU, getConnectionStringFromEnvironment, getUniqueName } from "./utils";
+import { bodyToString, getBSU, getUniqueName } from "./utils";
 dotenv.config({ path: "../.env" });
 
 describe("AppendBlobClient", () => {
@@ -64,74 +62,5 @@ describe("AppendBlobClient", () => {
     const downloadResponse = await appendBlobClient.download(0);
     assert.equal(await bodyToString(downloadResponse, content.length), content);
     assert.equal(downloadResponse.contentLength!, content.length);
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const factories = appendBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new AppendBlobClient(appendBlobClient.url, credential);
-
-    await newClient.create();
-    await newClient.download();
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const factories = appendBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new AppendBlobClient(appendBlobClient.url, credential, {
-      telemetry: { value: "test/1.0" }
-    });
-
-    await newClient.create();
-    await newClient.download();
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const factories = appendBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new AppendBlobClient(appendBlobClient.url, pipeline);
-
-    await newClient.create();
-    await newClient.download();
-  });
-
-  it("can be created with a connection string", async () => {
-    const newClient = new AppendBlobClient(
-      getConnectionStringFromEnvironment(),
-      containerName,
-      blobName
-    );
-
-    await newClient.create();
-    await newClient.download();
-  });
-
-  it("throws error if constructor containerName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new AppendBlobClient(getConnectionStringFromEnvironment(), "", "blobName");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for containerName and blobName parameters",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
-  });
-
-  it("throws error if constructor blobName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new AppendBlobClient(getConnectionStringFromEnvironment(), "containerName", "");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for containerName and blobName parameters",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
   });
 });

--- a/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
@@ -1,15 +1,8 @@
 import * as assert from "assert";
 
 import * as dotenv from "dotenv";
-import { newPipeline, SharedKeyCredential } from "../src";
 import { BlobServiceClient } from "../src/BlobServiceClient";
-import {
-  getAlternateBSU,
-  getBSU,
-  getConnectionStringFromEnvironment,
-  getUniqueName,
-  wait
-} from "./utils";
+import { getAlternateBSU, getBSU, getUniqueName, wait } from "./utils";
 dotenv.config({ path: "../.env" });
 
 describe("BlobServiceClient", () => {
@@ -288,61 +281,5 @@ describe("BlobServiceClient", () => {
     } catch (error) {
       assert.ok((error.statusCode as number) === 404);
     }
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const serviceClient = getBSU();
-    const factories = serviceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new BlobServiceClient(serviceClient.url, credential);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const serviceClient = getBSU();
-    const factories = serviceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new BlobServiceClient(serviceClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const serviceClient = getBSU();
-    const factories = serviceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new BlobServiceClient(serviceClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created from a connection string", async () => {
-    const newClient = BlobServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
   });
 });

--- a/sdk/storage/storage-blob/test/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blockblobclient.spec.ts
@@ -1,15 +1,7 @@
 import * as assert from "assert";
 
 import * as dotenv from "dotenv";
-import { newPipeline, SharedKeyCredential } from "../src";
-import { BlockBlobClient } from "../src/BlockBlobClient";
-import {
-  base64encode,
-  bodyToString,
-  getBSU,
-  getConnectionStringFromEnvironment,
-  getUniqueName
-} from "./utils";
+import { base64encode, bodyToString, getBSU, getUniqueName } from "./utils";
 dotenv.config({ path: "../.env" });
 
 describe("BlockBlobClient", () => {
@@ -195,84 +187,5 @@ describe("BlockBlobClient", () => {
     assert.equal(listResponse.uncommittedBlocks!.length, 0);
     assert.equal(listResponse.committedBlocks![0].name, base64encode("2"));
     assert.equal(listResponse.committedBlocks![0].size, body.length);
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const factories = blockBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new BlockBlobClient(blockBlobClient.url, credential);
-
-    const body: string = getUniqueName("randomstring");
-    await newClient.upload(body, body.length);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, body.length), body);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const factories = blockBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new BlockBlobClient(blockBlobClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const body: string = getUniqueName("randomstring");
-    await newClient.upload(body, body.length);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, body.length), body);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const factories = blockBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new BlockBlobClient(blockBlobClient.url, pipeline);
-
-    const body: string = getUniqueName("randomstring");
-    await newClient.upload(body, body.length);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, body.length), body);
-  });
-
-  it("can be created with a connection string", async () => {
-    const newClient = new BlockBlobClient(
-      getConnectionStringFromEnvironment(),
-      containerName,
-      blobName
-    );
-
-    const body: string = getUniqueName("randomstring");
-    await newClient.upload(body, body.length);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, body.length), body);
-  });
-
-  it("throws error if constructor containerName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new BlockBlobClient(getConnectionStringFromEnvironment(), "", "blobName");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for containerName and blobName parameters",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
-  });
-
-  it("throws error if constructor blobName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new BlockBlobClient(getConnectionStringFromEnvironment(), "containerName", "");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for containerName and blobName parameters",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
   });
 });

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -1,8 +1,6 @@
 import * as assert from "assert";
 import * as dotenv from "dotenv";
-import { newPipeline, SharedKeyCredential } from "../src";
-import { ContainerClient } from "../src/ContainerClient";
-import { bodyToString, getBSU, getConnectionStringFromEnvironment, getUniqueName } from "./utils";
+import { bodyToString, getBSU, getUniqueName } from "./utils";
 dotenv.config({ path: "../.env" });
 
 describe("ContainerClient", () => {
@@ -312,115 +310,6 @@ describe("ContainerClient", () => {
       );
     } catch (error) {
       assert.ok((error.statusCode as number) === 404);
-    }
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const factories = containerClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new ContainerClient(containerClient.url, credential);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(!result.leaseDuration);
-    assert.equal(result.leaseState, "available");
-    assert.equal(result.leaseStatus, "unlocked");
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-    assert.ok(!result.blobPublicAccess);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const factories = containerClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new ContainerClient(containerClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(!result.leaseDuration);
-    assert.equal(result.leaseState, "available");
-    assert.equal(result.leaseStatus, "unlocked");
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-    assert.ok(!result.blobPublicAccess);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const factories = containerClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new ContainerClient(containerClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(!result.leaseDuration);
-    assert.equal(result.leaseState, "available");
-    assert.equal(result.leaseStatus, "unlocked");
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-    assert.ok(!result.blobPublicAccess);
-  });
-
-  it("can be created with a connection string", async () => {
-    const newClient = new ContainerClient(getConnectionStringFromEnvironment(), containerName);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(!result.leaseDuration);
-    assert.equal(result.leaseState, "available");
-    assert.equal(result.leaseStatus, "unlocked");
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-    assert.ok(!result.blobPublicAccess);
-  });
-
-  it("can be created with a connection string and a container name and an option bag", async () => {
-    const newClient = new ContainerClient(getConnectionStringFromEnvironment(), containerName, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(!result.leaseDuration);
-    assert.equal(result.leaseState, "available");
-    assert.equal(result.leaseStatus, "unlocked");
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-    assert.ok(!result.blobPublicAccess);
-  });
-
-  it("throws error if constructor containerName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new ContainerClient(getConnectionStringFromEnvironment(), "");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for containerName parameter",
-        error.message,
-        "Error message is different than expected."
-      );
     }
   });
 });

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -5,7 +5,7 @@ import { AppendBlobClient, newPipeline, SharedKeyCredential } from "../../src";
 import { getBSU, getConnectionStringFromEnvironment, getUniqueName } from "../utils";
 dotenv.config({ path: "../.env" });
 
-describe("AppendBlobClient", () => {
+describe("AppendBlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
   let containerClient = blobServiceClient.createContainerClient(containerName);

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+
+import * as dotenv from "dotenv";
+import { AppendBlobClient, newPipeline, SharedKeyCredential } from "../../src";
+import { getBSU, getConnectionStringFromEnvironment, getUniqueName } from "../utils";
+dotenv.config({ path: "../.env" });
+
+describe("AppendBlobClient", () => {
+  const blobServiceClient = getBSU();
+  let containerName: string = getUniqueName("container");
+  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let blobName: string = getUniqueName("blob");
+  let appendBlobClient = containerClient.createAppendBlobClient(blobName);
+
+  beforeEach(async () => {
+    containerName = getUniqueName("container");
+    containerClient = blobServiceClient.createContainerClient(containerName);
+    await containerClient.create();
+    blobName = getUniqueName("blob");
+    appendBlobClient = containerClient.createAppendBlobClient(blobName);
+  });
+
+  afterEach(async () => {
+    await containerClient.delete();
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = appendBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new AppendBlobClient(appendBlobClient.url, credential);
+
+    await newClient.create();
+    await newClient.download();
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = appendBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new AppendBlobClient(appendBlobClient.url, credential, {
+      telemetry: { value: "test/1.0" }
+    });
+
+    await newClient.create();
+    await newClient.download();
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = appendBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new AppendBlobClient(appendBlobClient.url, pipeline);
+
+    await newClient.create();
+    await newClient.download();
+  });
+
+  it("can be created with a connection string", async () => {
+    const newClient = new AppendBlobClient(
+      getConnectionStringFromEnvironment(),
+      containerName,
+      blobName
+    );
+
+    await newClient.create();
+    await newClient.download();
+  });
+
+  it("throws error if constructor containerName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new AppendBlobClient(getConnectionStringFromEnvironment(), "", "blobName");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
+  });
+
+  it("throws error if constructor blobName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new AppendBlobClient(getConnectionStringFromEnvironment(), "containerName", "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
+  });
+});

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -2,7 +2,14 @@ import * as assert from "assert";
 
 import { isNode } from "@azure/ms-rest-js";
 import * as dotenv from "dotenv";
-import { bodyToString, getBSU, getUniqueName, sleep } from "./utils";
+import { BlobClient, newPipeline, SharedKeyCredential } from "../../src";
+import {
+  bodyToString,
+  getBSU,
+  getConnectionStringFromEnvironment,
+  getUniqueName,
+  sleep
+} from "../utils";
 dotenv.config({ path: "../.env" });
 
 describe("BlobClient", () => {
@@ -223,6 +230,92 @@ describe("BlobClient", () => {
     properties = await blockBlobClient.getProperties();
     if (properties.archiveStatus) {
       assert.equal(properties.archiveStatus.toLowerCase(), "rehydrate-pending-to-hot");
+    }
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = blobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new BlobClient(blobClient.url, credential);
+
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await newClient.setMetadata(metadata);
+    const result = await newClient.getProperties();
+    assert.deepStrictEqual(result.metadata, metadata);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = blobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new BlobClient(blobClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await newClient.setMetadata(metadata);
+    const result = await newClient.getProperties();
+    assert.deepStrictEqual(result.metadata, metadata);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = blobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new BlobClient(blobClient.url, pipeline);
+
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await newClient.setMetadata(metadata);
+    const result = await newClient.getProperties();
+    assert.deepStrictEqual(result.metadata, metadata);
+  });
+
+  it("can be created with a connection string", async () => {
+    const newClient = new BlobClient(getConnectionStringFromEnvironment(), containerName, blobName);
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await newClient.setMetadata(metadata);
+    const result = await newClient.getProperties();
+    assert.deepStrictEqual(result.metadata, metadata);
+  });
+
+  it("throws error if constructor containerName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new BlobClient(getConnectionStringFromEnvironment(), "", "blobName");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
+  });
+
+  it("throws error if constructor blobName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new BlobClient(getConnectionStringFromEnvironment(), "containerName", "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
     }
   });
 });

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -12,7 +12,7 @@ import {
 } from "../utils";
 dotenv.config({ path: "../.env" });
 
-describe("BlobClient", () => {
+describe("BlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
   let containerClient = blobServiceClient.createContainerClient(containerName);

--- a/sdk/storage/storage-blob/test/node/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobserviceclient.spec.ts
@@ -1,0 +1,64 @@
+import * as assert from "assert";
+
+import * as dotenv from "dotenv";
+import { BlobServiceClient, newPipeline, SharedKeyCredential } from "../../src";
+import { getBSU, getConnectionStringFromEnvironment } from "../utils";
+dotenv.config({ path: "../.env" });
+
+describe("BlobServiceClient", () => {
+  it("can be created with a url and a credential", async () => {
+    const serviceClient = getBSU();
+    const factories = serviceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new BlobServiceClient(serviceClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const serviceClient = getBSU();
+    const factories = serviceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new BlobServiceClient(serviceClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const serviceClient = getBSU();
+    const factories = serviceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new BlobServiceClient(serviceClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created from a connection string", async () => {
+    const newClient = BlobServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+  });
+});

--- a/sdk/storage/storage-blob/test/node/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobserviceclient.spec.ts
@@ -5,7 +5,7 @@ import { BlobServiceClient, newPipeline, SharedKeyCredential } from "../../src";
 import { getBSU, getConnectionStringFromEnvironment } from "../utils";
 dotenv.config({ path: "../.env" });
 
-describe("BlobServiceClient", () => {
+describe("BlobServiceClient Node.js only", () => {
   it("can be created with a url and a credential", async () => {
     const serviceClient = getBSU();
     const factories = serviceClient.pipeline.factories;

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 
-import { bodyToString, getBSU, getUniqueName } from "../utils";
+import { bodyToString, getBSU, getUniqueName, getConnectionStringFromEnvironment } from "../utils";
+import { BlockBlobClient, newPipeline, SharedKeyCredential } from "../../src";
 
 describe("BlockBlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
@@ -49,5 +50,84 @@ describe("BlockBlobClient Node.js only", () => {
     await blockBlobClient.upload(body, Buffer.byteLength(body));
     const result = await blobClient.download(0);
     assert.deepStrictEqual(await bodyToString(result, Buffer.byteLength(body)), body);
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = blockBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new BlockBlobClient(blockBlobClient.url, credential);
+
+    const body: string = getUniqueName("randomstring");
+    await newClient.upload(body, body.length);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, body.length), body);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = blockBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new BlockBlobClient(blockBlobClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const body: string = getUniqueName("randomstring");
+    await newClient.upload(body, body.length);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, body.length), body);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = blockBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new BlockBlobClient(blockBlobClient.url, pipeline);
+
+    const body: string = getUniqueName("randomstring");
+    await newClient.upload(body, body.length);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, body.length), body);
+  });
+
+  it("can be created with a connection string", async () => {
+    const newClient = new BlockBlobClient(
+      getConnectionStringFromEnvironment(),
+      containerName,
+      blobName
+    );
+
+    const body: string = getUniqueName("randomstring");
+    await newClient.upload(body, body.length);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, body.length), body);
+  });
+
+  it("throws error if constructor containerName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new BlockBlobClient(getConnectionStringFromEnvironment(), "", "blobName");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
+  });
+
+  it("throws error if constructor blobName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new BlockBlobClient(getConnectionStringFromEnvironment(), "containerName", "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
   });
 });

--- a/sdk/storage/storage-blob/test/node/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/containerclient.spec.ts
@@ -1,7 +1,8 @@
 import * as assert from "assert";
 
-import { getBSU, getUniqueName } from "../utils";
+import { getBSU, getUniqueName, getConnectionStringFromEnvironment } from "../utils";
 import { PublicAccessType } from "../../src/generated/lib/models/index";
+import { ContainerClient, newPipeline, SharedKeyCredential } from "../../src";
 
 describe("ContainerClient", () => {
   const blobServiceClient = getBSU();
@@ -44,5 +45,114 @@ describe("ContainerClient", () => {
     const result = await containerClient.getAccessPolicy();
     assert.deepEqual(result.signedIdentifiers, containerAcl);
     assert.deepEqual(result.blobPublicAccess, access);
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = containerClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new ContainerClient(containerClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(!result.leaseDuration);
+    assert.equal(result.leaseState, "available");
+    assert.equal(result.leaseStatus, "unlocked");
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+    assert.ok(!result.blobPublicAccess);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = containerClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new ContainerClient(containerClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(!result.leaseDuration);
+    assert.equal(result.leaseState, "available");
+    assert.equal(result.leaseStatus, "unlocked");
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+    assert.ok(!result.blobPublicAccess);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = containerClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new ContainerClient(containerClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(!result.leaseDuration);
+    assert.equal(result.leaseState, "available");
+    assert.equal(result.leaseStatus, "unlocked");
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+    assert.ok(!result.blobPublicAccess);
+  });
+
+  it("can be created with a connection string", async () => {
+    const newClient = new ContainerClient(getConnectionStringFromEnvironment(), containerName);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(!result.leaseDuration);
+    assert.equal(result.leaseState, "available");
+    assert.equal(result.leaseStatus, "unlocked");
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+    assert.ok(!result.blobPublicAccess);
+  });
+
+  it("can be created with a connection string and a container name and an option bag", async () => {
+    const newClient = new ContainerClient(getConnectionStringFromEnvironment(), containerName, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(!result.leaseDuration);
+    assert.equal(result.leaseState, "available");
+    assert.equal(result.leaseStatus, "unlocked");
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+    assert.ok(!result.blobPublicAccess);
+  });
+
+  it("throws error if constructor containerName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new ContainerClient(getConnectionStringFromEnvironment(), "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName parameter",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
   });
 });

--- a/sdk/storage/storage-blob/test/node/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/containerclient.spec.ts
@@ -4,7 +4,7 @@ import { getBSU, getUniqueName, getConnectionStringFromEnvironment } from "../ut
 import { PublicAccessType } from "../../src/generated/lib/models/index";
 import { ContainerClient, newPipeline, SharedKeyCredential } from "../../src";
 
-describe("ContainerClient", () => {
+describe("ContainerClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
   let containerClient = blobServiceClient.createContainerClient(containerName);

--- a/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "../utils";
 import { newPipeline, PageBlobClient, SharedKeyCredential } from "../../src";
 
-describe("PageBlobClient", () => {
+describe("PageBlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
   let containerClient = blobServiceClient.createContainerClient(containerName);

--- a/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
@@ -1,6 +1,13 @@
 import * as assert from "assert";
 
-import { getBSU, getUniqueName, sleep } from "../utils";
+import {
+  getBSU,
+  getUniqueName,
+  sleep,
+  getConnectionStringFromEnvironment,
+  bodyToString
+} from "../utils";
+import { newPipeline, PageBlobClient, SharedKeyCredential } from "../../src";
 
 describe("PageBlobClient", () => {
   const blobServiceClient = getBSU();
@@ -34,9 +41,7 @@ describe("PageBlobClient", () => {
     let snapshotResult = await pageBlobClient.createSnapshot();
     assert.ok(snapshotResult.snapshot);
 
-    const destPageBlobClient = containerClient.createPageBlobClient(
-      getUniqueName("page")
-    );
+    const destPageBlobClient = containerClient.createPageBlobClient(getUniqueName("page"));
 
     await containerClient.setAccessPolicy("container");
 
@@ -91,5 +96,80 @@ describe("PageBlobClient", () => {
 
     const pageBlobProperties = await destPageBlobClient.getProperties();
     assert.equal(pageBlobProperties.metadata!.sourcemeta, "val");
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = pageBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new PageBlobClient(pageBlobClient.url, credential);
+
+    await newClient.create(512);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = pageBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new PageBlobClient(pageBlobClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    await newClient.create(512);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = pageBlobClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new PageBlobClient(pageBlobClient.url, pipeline);
+
+    await newClient.create(512);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
+  });
+
+  it("can be created with a connection string", async () => {
+    const newClient = new PageBlobClient(
+      getConnectionStringFromEnvironment(),
+      containerName,
+      blobName
+    );
+
+    await newClient.create(512);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
+  });
+
+  it("throws error if constructor containerName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new PageBlobClient(getConnectionStringFromEnvironment(), "", "blobName");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
+  });
+
+  it("throws error if constructor blobName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new PageBlobClient(getConnectionStringFromEnvironment(), "containerName", "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for containerName and blobName parameters",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
   });
 });

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -1,0 +1,94 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import { extractConnectionStringParts } from "../../src/utils/utils.common";
+dotenv.config({ path: "../.env" });
+
+describe("Utility Helpers Node.js only", () => {
+  it("extractConnectionStringParts throws error when passed an invalid protocol in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=a;AccountName=b;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.ok(error);
+    }
+  });
+
+  it("extractConnectionStringParts throws error when passed an invalid connection string with typo", async () => {
+    try {
+      extractConnectionStringParts(
+        // Typo in the attributes
+        "DefaultEndpointsProtocol=https;Name=b;AccountKey=c;EndpointSuffix=d"
+      );
+
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty EndpointSuffix in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=cdefg;EndpointSuffix="
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid EndpointSuffix in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty AccountKey in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid AccountKey in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty AccountName in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid AccountName in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty DefaultEndpointsProtocol in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=;AccountName=b;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+});

--- a/sdk/storage/storage-blob/test/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/pageblobclient.spec.ts
@@ -1,8 +1,6 @@
 import * as assert from "assert";
 import * as dotenv from "dotenv";
-import { newPipeline, SharedKeyCredential } from "../src";
-import { PageBlobClient } from "../src/PageBlobClient";
-import { bodyToString, getBSU, getConnectionStringFromEnvironment, getUniqueName } from "./utils";
+import { bodyToString, getBSU, getUniqueName } from "./utils";
 dotenv.config({ path: "../.env" });
 
 describe("PageBlobClient", () => {
@@ -144,80 +142,5 @@ describe("PageBlobClient", () => {
     await pageBlobClient.updateSequenceNumber("max", 100);
     propertiesResponse = await pageBlobClient.getProperties();
     assert.equal(propertiesResponse.blobSequenceNumber!, 100);
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const factories = pageBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new PageBlobClient(pageBlobClient.url, credential);
-
-    await newClient.create(512);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const factories = pageBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new PageBlobClient(pageBlobClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    await newClient.create(512);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const factories = pageBlobClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new PageBlobClient(pageBlobClient.url, pipeline);
-
-    await newClient.create(512);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
-  });
-
-  it("can be created with a connection string", async () => {
-    const newClient = new PageBlobClient(
-      getConnectionStringFromEnvironment(),
-      containerName,
-      blobName
-    );
-
-    await newClient.create(512);
-    const result = await newClient.download(0);
-    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
-  });
-
-  it("throws error if constructor containerName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new PageBlobClient(getConnectionStringFromEnvironment(), "", "blobName");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for containerName and blobName parameters",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
-  });
-
-  it("throws error if constructor blobName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new PageBlobClient(getConnectionStringFromEnvironment(), "containerName", "");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for containerName and blobName parameters",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
   });
 });

--- a/sdk/storage/storage-blob/test/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/utils.spec.ts
@@ -1,11 +1,7 @@
 import * as assert from "assert";
 import * as dotenv from "dotenv";
 import { HttpHeaders } from "../src";
-import {
-  extractConnectionStringParts,
-  sanitizeHeaders,
-  sanitizeURL
-} from "../src/utils/utils.common";
+import { sanitizeHeaders, sanitizeURL } from "../src/utils/utils.common";
 dotenv.config({ path: "../.env" });
 
 describe("Utility Helpers", () => {
@@ -41,93 +37,5 @@ describe("Utility Helpers", () => {
       sanitized.get("otherheader")!.indexOf("sasstring") !== -1,
       "Other header should not be changed."
     );
-  });
-
-  it("extractConnectionStringParts throws error when passed an invalid protocol in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=a;AccountName=b;AccountKey=c;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.ok(error);
-    }
-  });
-
-  it("extractConnectionStringParts throws error when passed an invalid connection string with typo", async () => {
-    try {
-      extractConnectionStringParts(
-        // Typo in the attributes
-        "DefaultEndpointsProtocol=https;Name=b;AccountKey=c;EndpointSuffix=d"
-      );
-
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty EndpointSuffix in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=cdefg;EndpointSuffix="
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid EndpointSuffix in the provided Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty AccountKey in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid AccountKey in the provided Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty AccountName in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=https;AccountName=;AccountKey=c;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid AccountName in the provided Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty DefaultEndpointsProtocol in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=;AccountName=b;AccountKey=c;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
   });
 });

--- a/sdk/storage/storage-blob/test/utils/index.browser.ts
+++ b/sdk/storage/storage-blob/test/utils/index.browser.ts
@@ -43,17 +43,6 @@ export function getAlternateBSU(): BlobServiceClient {
   return getGenericBSU("SECONDARY_", "-secondary");
 }
 
-export function getConnectionStringFromEnvironment(): string {
-  const connectionStringEnvVar = `STORAGE_CONNECTION_STRING`;
-  const connectionString = process.env[connectionStringEnvVar];
-
-  if (!connectionString) {
-    throw new Error(`${connectionStringEnvVar} environment variables not specified.`);
-  }
-
-  return connectionString;
-}
-
 /**
  * Read body from downloading operation methods to string.
  * Work on both Node.js and browser environment.

--- a/sdk/storage/storage-file/src/FileServiceClient.ts
+++ b/sdk/storage/storage-file/src/FileServiceClient.ts
@@ -111,6 +111,8 @@ export class FileServiceClient extends StorageClient {
   private serviceContext: Service;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of FileServiceClient from connection string.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-file/src/ShareClient.ts
+++ b/sdk/storage/storage-file/src/ShareClient.ts
@@ -286,6 +286,8 @@ export class ShareClient extends StorageClient {
   private context: Share;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of ShareClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-file/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file/src/utils/utils.common.ts
@@ -71,6 +71,8 @@ export function escapeURLPath(url: string): string {
 }
 
 /**
+ * ONLY AVAILABLE IN NODE.JS RUNTIME.
+ *
  * Extracts the parts of an Azure Storage account connection string.
  *
  * @export

--- a/sdk/storage/storage-file/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/directoryclient.spec.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
 import { getBSU, getUniqueName } from "./utils";
 import * as dotenv from "dotenv";
-import { DirectoryClient, newPipeline, SharedKeyCredential } from "../src";
 dotenv.config({ path: "../.env" });
 
 describe("DirectoryClient", () => {
@@ -203,52 +202,5 @@ describe("DirectoryClient", () => {
       assert.ok((error.statusCode as number) === 404);
     }
     await subDirClient.delete();
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const factories = dirClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new DirectoryClient(dirClient.url, credential);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const factories = dirClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new DirectoryClient(dirClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const factories = dirClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new DirectoryClient(dirClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
   });
 });

--- a/sdk/storage/storage-file/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileclient.spec.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import { isNode } from "@azure/ms-rest-js";
 import { bodyToString, getBSU, getUniqueName, sleep } from "./utils";
 import * as dotenv from "dotenv";
-import { Aborter, FileClient, newPipeline, SharedKeyCredential } from "../src";
+import { Aborter } from "../src";
 dotenv.config({ path: "../.env" });
 
 describe("FileClient", () => {
@@ -300,73 +300,5 @@ describe("FileClient", () => {
       // tslint:disable-next-line:no-empty
     } catch (err) {}
     assert.ok(eventTriggered);
-  });
-
-  it("can be created with a url and a credential", async () => {
-    await fileClient.create(content.length);
-    const metadata = {
-      a: "a",
-      b: "b"
-    };
-    await fileClient.setMetadata(metadata);
-
-    const factories = fileClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new FileClient(fileClient.url, credential);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    await fileClient.create(content.length);
-    const metadata = {
-      a: "a",
-      b: "b"
-    };
-    await fileClient.setMetadata(metadata);
-
-    const factories = fileClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new FileClient(fileClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    await fileClient.create(content.length);
-    const metadata = {
-      a: "a",
-      b: "b"
-    };
-    await fileClient.setMetadata(metadata);
-
-    const factories = fileClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new FileClient(fileClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
   });
 });

--- a/sdk/storage/storage-file/test/fileserviceclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileserviceclient.spec.ts
@@ -1,8 +1,6 @@
 import * as assert from "assert";
-import { getBSU, getUniqueName, wait, getConnectionStringFromEnvironment } from "./utils";
+import { getBSU, getUniqueName, wait } from "./utils";
 import * as dotenv from "dotenv";
-import { FileServiceClient } from "../src/FileServiceClient";
-import { newPipeline, SharedKeyCredential } from "../src";
 dotenv.config({ path: "../.env" });
 
 describe("FileServiceClient", () => {
@@ -134,90 +132,23 @@ describe("FileServiceClient", () => {
     assert.deepEqual(result.hourMetrics, serviceProperties.hourMetrics);
   });
 
-    it("createShare and deleteShare", async () => {
-        const serviceClient = getBSU();
-        const shareName = getUniqueName("share");
-        const metadata = { key: "value" };
-
-        const { shareClient } = await serviceClient.createShare(shareName, { metadata });
-        const result = await shareClient.getProperties();
-        assert.deepEqual(result.metadata, metadata);
-
-        await serviceClient.deleteShare(shareName);
-        try {
-            await shareClient.getProperties();
-            assert.fail(
-                "Expecting an error in getting properties from a deleted block blob but didn't get one."
-            );
-        } catch (error) {
-            assert.ok((error.statusCode as number) === 404);
-        }
-    });
-
-  it("can be created with a url and a credential", async () => {
+  it("createShare and deleteShare", async () => {
     const serviceClient = getBSU();
-    const factories = serviceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new FileServiceClient(serviceClient.url, credential);
+    const shareName = getUniqueName("share");
+    const metadata = { key: "value" };
 
-    const result = await newClient.getProperties();
+    const { shareClient } = await serviceClient.createShare(shareName, { metadata });
+    const result = await shareClient.getProperties();
+    assert.deepEqual(result.metadata, metadata);
 
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const serviceClient = getBSU();
-    const factories = serviceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new FileServiceClient(serviceClient.url, credential, {
-      retryOptions: { maxTries: 5 }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const serviceClient = getBSU();
-    const factories = serviceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new FileServiceClient(serviceClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created from a connection string", async () => {
-    const newClient = FileServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-  });
-
-  it("can be created from a connection string and an option bag", async () => {
-    const newClient = FileServiceClient.fromConnectionString(getConnectionStringFromEnvironment(), {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
+    await serviceClient.deleteShare(shareName);
+    try {
+      await shareClient.getProperties();
+      assert.fail(
+        "Expecting an error in getting properties from a deleted block blob but didn't get one."
+      );
+    } catch (error) {
+      assert.ok((error.statusCode as number) === 404);
+    }
   });
 });

--- a/sdk/storage/storage-file/test/node/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/directoryclient.spec.ts
@@ -1,0 +1,75 @@
+import * as assert from "assert";
+import { getBSU, getUniqueName } from "../utils";
+import * as dotenv from "dotenv";
+import { DirectoryClient, newPipeline, SharedKeyCredential } from "../../src";
+dotenv.config({ path: "../.env" });
+
+describe("DirectoryClient", () => {
+  const serviceClient = getBSU();
+  let shareName = getUniqueName("share");
+  let shareClient = serviceClient.createShareClient(shareName);
+  let dirName = getUniqueName("dir");
+  let dirClient = shareClient.createDirectoryClient(dirName);
+
+  beforeEach(async () => {
+    shareName = getUniqueName("share");
+    shareClient = serviceClient.createShareClient(shareName);
+    await shareClient.create();
+
+    dirName = getUniqueName("dir");
+    dirClient = shareClient.createDirectoryClient(dirName);
+    await dirClient.create();
+  });
+
+  afterEach(async () => {
+    await dirClient.delete();
+    await shareClient.delete();
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = dirClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new DirectoryClient(dirClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = dirClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new DirectoryClient(dirClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = dirClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new DirectoryClient(dirClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+});

--- a/sdk/storage/storage-file/test/node/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/directoryclient.spec.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv";
 import { DirectoryClient, newPipeline, SharedKeyCredential } from "../../src";
 dotenv.config({ path: "../.env" });
 
-describe("DirectoryClient", () => {
+describe("DirectoryClient Node.js only", () => {
   const serviceClient = getBSU();
   let shareName = getUniqueName("share");
   let shareClient = serviceClient.createShareClient(shareName);

--- a/sdk/storage/storage-file/test/node/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/fileclient.spec.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import { Duplex } from "stream";
 import { bodyToString, getBSU, getUniqueName } from "../utils";
 import { Buffer } from "buffer";
+import { FileClient, newPipeline, SharedKeyCredential } from "../../src";
 
 describe("FileClient Node.js only", () => {
   const serviceClient = getBSU();
@@ -11,6 +12,7 @@ describe("FileClient Node.js only", () => {
   let dirClient = shareClient.createDirectoryClient(dirName);
   let fileName = getUniqueName("file");
   let fileClient = dirClient.createFileClient(fileName);
+  const content = "Hello World";
 
   beforeEach(async () => {
     shareName = getUniqueName("share");
@@ -65,5 +67,73 @@ describe("FileClient Node.js only", () => {
     await fileClient.uploadRange(body, 0, bodyLength);
     const result = await fileClient.download(0);
     assert.deepStrictEqual(await bodyToString(result, bodyLength), body);
+  });
+
+  it("can be created with a url and a credential", async () => {
+    await fileClient.create(content.length);
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await fileClient.setMetadata(metadata);
+
+    const factories = fileClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new FileClient(fileClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    await fileClient.create(content.length);
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await fileClient.setMetadata(metadata);
+
+    const factories = fileClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new FileClient(fileClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    await fileClient.create(content.length);
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await fileClient.setMetadata(metadata);
+
+    const factories = fileClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new FileClient(fileClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
   });
 });

--- a/sdk/storage/storage-file/test/node/fileserviceclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/fileserviceclient.spec.ts
@@ -1,0 +1,74 @@
+import * as assert from "assert";
+import { getBSU, getConnectionStringFromEnvironment } from "../utils";
+import * as dotenv from "dotenv";
+import { FileServiceClient, newPipeline, SharedKeyCredential } from "../../src";
+dotenv.config({ path: "../.env" });
+
+describe("FileServiceClient", () => {
+  it("can be created with a url and a credential", async () => {
+    const serviceClient = getBSU();
+    const factories = serviceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new FileServiceClient(serviceClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const serviceClient = getBSU();
+    const factories = serviceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new FileServiceClient(serviceClient.url, credential, {
+      retryOptions: { maxTries: 5 }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const serviceClient = getBSU();
+    const factories = serviceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new FileServiceClient(serviceClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created from a connection string", async () => {
+    const newClient = FileServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+  });
+
+  it("can be created from a connection string and an option bag", async () => {
+    const newClient = FileServiceClient.fromConnectionString(getConnectionStringFromEnvironment(), {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+  });
+});

--- a/sdk/storage/storage-file/test/node/fileserviceclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/fileserviceclient.spec.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv";
 import { FileServiceClient, newPipeline, SharedKeyCredential } from "../../src";
 dotenv.config({ path: "../.env" });
 
-describe("FileServiceClient", () => {
+describe("FileServiceClient Node.js only", () => {
   it("can be created with a url and a credential", async () => {
     const serviceClient = getBSU();
     const factories = serviceClient.pipeline.factories;

--- a/sdk/storage/storage-file/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file/test/node/highlevel.node.spec.ts
@@ -7,7 +7,7 @@ import { createRandomLocalFile, getBSU, getUniqueName, readStreamToLocalFile } f
 import { RetriableReadableStreamOptions } from "../../src/utils/RetriableReadableStream";
 
 // tslint:disable:no-empty
-describe("Highlevel", () => {
+describe("Highlevel Node.js only", () => {
   const serviceClient = getBSU();
   let shareName = getUniqueName("share");
   let shareClient = serviceClient.createShareClient(shareName);

--- a/sdk/storage/storage-file/test/node/shareclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/shareclient.spec.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
-import { SignedIdentifier } from "../../src/ShareClient";
-import { getBSU, getUniqueName } from "./../utils";
+import { newPipeline, ShareClient, SharedKeyCredential, SignedIdentifier } from "../../src";
+import { getBSU, getUniqueName, getConnectionStringFromEnvironment } from "./../utils";
 
 describe("ShareClient", () => {
   const serviceClient = getBSU();
@@ -55,5 +55,92 @@ describe("ShareClient", () => {
   it("getAccessPolicy", (done) => {
     // create() with default parameters has been tested in setAccessPolicy
     done();
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = shareClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new ShareClient(shareClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = shareClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new ShareClient(shareClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = shareClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new ShareClient(shareClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a connection string and a share name", async () => {
+    const newClient = new ShareClient(getConnectionStringFromEnvironment(), shareName);
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a connection string and a share name and an option bag", async () => {
+    const newClient = new ShareClient(getConnectionStringFromEnvironment(), shareName, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("throws error if constructor shareName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new ShareClient(getConnectionStringFromEnvironment(), "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for shareName parameter",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
   });
 });

--- a/sdk/storage/storage-file/test/node/shareclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/shareclient.spec.ts
@@ -2,7 +2,7 @@ import * as assert from "assert";
 import { newPipeline, ShareClient, SharedKeyCredential, SignedIdentifier } from "../../src";
 import { getBSU, getUniqueName, getConnectionStringFromEnvironment } from "./../utils";
 
-describe("ShareClient", () => {
+describe("ShareClient Node.js only", () => {
   const serviceClient = getBSU();
   let shareName: string = getUniqueName("share");
   let shareClient = serviceClient.createShareClient(shareName);

--- a/sdk/storage/storage-file/test/node/utils.spec.ts
+++ b/sdk/storage/storage-file/test/node/utils.spec.ts
@@ -1,0 +1,94 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import { extractConnectionStringParts } from "../../src/utils/utils.common";
+dotenv.config({ path: "../.env" });
+
+describe("Utility Helpers Node.js only", () => {
+  it("extractConnectionStringParts throws error when passed an invalid protocol in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=a;AccountName=b;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.ok(error);
+    }
+  });
+
+  it("extractConnectionStringParts throws error when passed an invalid connection string with typo", async () => {
+    try {
+      extractConnectionStringParts(
+        // Typo in the attributes
+        "DefaultEndpointsProtocol=https;Name=b;AccountKey=c;EndpointSuffix=d"
+      );
+
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty EndpointSuffix in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=cdefg;EndpointSuffix="
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid EndpointSuffix in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty AccountKey in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid AccountKey in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty AccountName in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid AccountName in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty DefaultEndpointsProtocol in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=;AccountName=b;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+});

--- a/sdk/storage/storage-file/test/shareclient.spec.ts
+++ b/sdk/storage/storage-file/test/shareclient.spec.ts
@@ -1,7 +1,6 @@
 import * as assert from "assert";
 import * as dotenv from "dotenv";
-import { newPipeline, ShareClient, SharedKeyCredential } from "../src";
-import { getBSU, getConnectionStringFromEnvironment, getUniqueName } from "./utils";
+import { getBSU, getUniqueName } from "./utils";
 dotenv.config({ path: "../.env" });
 
 describe("ShareClient", () => {
@@ -130,92 +129,5 @@ describe("ShareClient", () => {
     const root = await shareClient.rootDirectoryClient;
     const result = await root.getProperties();
     assert.ok(result, "Expecting valid properties for the root directory.");
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const factories = shareClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new ShareClient(shareClient.url, credential);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const factories = shareClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new ShareClient(shareClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const factories = shareClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new ShareClient(shareClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a connection string and a share name", async () => {
-    const newClient = new ShareClient(getConnectionStringFromEnvironment(), shareName);
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a connection string and a share name and an option bag", async () => {
-    const newClient = new ShareClient(getConnectionStringFromEnvironment(), shareName, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-    const result = await newClient.getProperties();
-
-    assert.ok(result.eTag!.length > 0);
-    assert.ok(result.lastModified);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("throws error if constructor shareName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new ShareClient(getConnectionStringFromEnvironment(), "");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for shareName parameter",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
   });
 });

--- a/sdk/storage/storage-file/test/utils.spec.ts
+++ b/sdk/storage/storage-file/test/utils.spec.ts
@@ -1,11 +1,7 @@
 import * as assert from "assert";
 import * as dotenv from "dotenv";
 import { HttpHeaders } from "../src";
-import {
-  extractConnectionStringParts,
-  sanitizeHeaders,
-  sanitizeURL
-} from "../src/utils/utils.common";
+import { sanitizeHeaders, sanitizeURL } from "../src/utils/utils.common";
 dotenv.config({ path: "../.env" });
 
 describe("Utility Helpers", () => {
@@ -41,93 +37,5 @@ describe("Utility Helpers", () => {
       sanitized.get("otherheader")!.indexOf("sasstring") !== -1,
       "Other header should not be changed."
     );
-  });
-
-  it("extractConnectionStringParts throws error when passed an invalid protocol in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=a;AccountName=b;AccountKey=c;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.ok(error);
-    }
-  });
-
-  it("extractConnectionStringParts throws error when passed an invalid connection string with typo", async () => {
-    try {
-      extractConnectionStringParts(
-        // Typo in the attributes
-        "DefaultEndpointsProtocol=https;Name=b;AccountKey=c;EndpointSuffix=d"
-      );
-
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty EndpointSuffix in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=cdefg;EndpointSuffix="
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid EndpointSuffix in the provided Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty AccountKey in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid AccountKey in the provided Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty AccountName in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=https;AccountName=;AccountKey=c;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid AccountName in the provided Connection String",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
-  });
-
-  it("extractConnectionStringParts throws error with empty DefaultEndpointsProtocol in the connection string", async () => {
-    try {
-      extractConnectionStringParts(
-        "DefaultEndpointsProtocol=;AccountName=b;AccountKey=c;EndpointSuffix=d"
-      );
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
-        error.message,
-        "Connection string error message is different than expected"
-      );
-    }
   });
 });

--- a/sdk/storage/storage-file/test/utils/index.browser.ts
+++ b/sdk/storage/storage-file/test/utils/index.browser.ts
@@ -43,17 +43,6 @@ export function getAlternateBSU(): FileServiceClient {
   return getGenericBSU("SECONDARY_", "-secondary");
 }
 
-export function getConnectionStringFromEnvironment(): string {
-  const connectionStringEnvVar = `STORAGE_CONNECTION_STRING`;
-  const connectionString = process.env[connectionStringEnvVar];
-
-  if (!connectionString) {
-    throw new Error(`${connectionStringEnvVar} environment variables not specified.`);
-  }
-
-  return connectionString;
-}
-
 /**
  * Read body from downloading operation methods to string.
  * Work on both Node.js and browser environment.

--- a/sdk/storage/storage-queue/src/MessageIdClient.ts
+++ b/sdk/storage/storage-queue/src/MessageIdClient.ts
@@ -64,6 +64,8 @@ export class MessageIdClient extends StorageClient {
   private messageIdContext: MessageId;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of MessageIdClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-queue/src/MessagesClient.ts
+++ b/sdk/storage/storage-queue/src/MessagesClient.ts
@@ -165,6 +165,8 @@ export class MessagesClient extends StorageClient {
   private messagesContext: Messages;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of MessagesClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -204,6 +204,8 @@ export class QueueClient extends StorageClient {
   private queueContext: Queue;
 
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of QueueClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -115,6 +115,8 @@ export interface ServiceListQueuesSegmentOptions {
  */
 export class QueueServiceClient extends StorageClient {
   /**
+   * ONLY AVAILABLE IN NODE.JS RUNTIME.
+   *
    * Creates an instance of QueueServiceClient.
    *
    * @param {string} connectionString Connection string for an Azure storage account.
@@ -122,7 +124,10 @@ export class QueueServiceClient extends StorageClient {
    * @returns {QueueServiceClient} A new QueueServiceClient object from the given connection string.
    * @memberof QueueServiceClient
    */
-  public static fromConnectionString(connectionString: string, options?: NewPipelineOptions): QueueServiceClient {
+  public static fromConnectionString(
+    connectionString: string,
+    options?: NewPipelineOptions
+  ): QueueServiceClient {
     const extractedCreds = extractConnectionStringParts(connectionString);
     const sharedKeyCredential = new SharedKeyCredential(
       extractedCreds.accountName,

--- a/sdk/storage/storage-queue/src/utils/utils.common.ts
+++ b/sdk/storage/storage-queue/src/utils/utils.common.ts
@@ -115,6 +115,8 @@ export function getURLQueries(url: string): { [key: string]: string } {
 }
 
 /**
+ * ONLY AVAILABLE IN NODE.JS RUNTIME.
+ *
  * Extracts the parts of an Azure Storage account connection string.
  *
  * @export

--- a/sdk/storage/storage-queue/test/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/messageidclient.spec.ts
@@ -3,7 +3,6 @@ import { getQSU, sleep } from "./utils";
 import { QueueClient } from "../src/QueueClient";
 import { record } from "./utils/recorder";
 import * as dotenv from "dotenv";
-import { SharedKeyCredential, MessageIdClient, newPipeline } from "../src";
 dotenv.config({ path: "../.env" });
 
 describe("MessageIdClient", () => {
@@ -160,58 +159,5 @@ describe("MessageIdClient", () => {
       error = err;
     }
     assert.ok(error);
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const messagesClient = queueClient.createMessagesClient();
-
-    const eResult = await messagesClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-
-    const newMessage = "";
-    const messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
-    const factories = messagesClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new MessageIdClient(messageIdClient.url, credential);
-    const uResult = await newClient.update(eResult.popReceipt, newMessage);
-
-    assert.ok(uResult.version);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const messagesClient = queueClient.createMessagesClient();
-
-    const eResult = await messagesClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-
-    const newMessage = "";
-    const messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
-    const factories = messagesClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new MessageIdClient(messageIdClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-    const uResult = await newClient.update(eResult.popReceipt, newMessage);
-
-    assert.ok(uResult.version);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const messagesClient = queueClient.createMessagesClient();
-
-    const eResult = await messagesClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-
-    const newMessage = "";
-    const messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
-    const factories = messagesClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new MessageIdClient(messageIdClient.url, pipeline);
-    const uResult = await newClient.update(eResult.popReceipt, newMessage);
-
-    assert.ok(uResult.version);
   });
 });

--- a/sdk/storage/storage-queue/test/messagesclient.spec.ts
+++ b/sdk/storage/storage-queue/test/messagesclient.spec.ts
@@ -1,9 +1,8 @@
 import * as assert from "assert";
-import { getQSU, getConnectionStringFromEnvironment } from "./utils";
+import { getQSU } from "./utils";
 import { QueueClient } from "../src/QueueClient";
 import { record } from "./utils/recorder";
 import * as dotenv from "dotenv";
-import { SharedKeyCredential, MessagesClient } from "../src";
 dotenv.config({ path: "../.env" });
 
 describe("MessagesClient", () => {
@@ -341,96 +340,5 @@ describe("MessagesClient", () => {
         "The request body is too large and exceeds the maximum permissible limit."
       )
     );
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const messagesClient = queueClient.createMessagesClient();
-    const factories = messagesClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new MessagesClient(messagesClient.url, credential);
-
-    const eResult = await newClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-    assert.ok(eResult.expirationTime);
-    assert.ok(eResult.insertionTime);
-    assert.ok(eResult.messageId);
-    assert.ok(eResult.popReceipt);
-    assert.ok(eResult.requestId);
-    assert.ok(eResult.timeNextVisible);
-    assert.ok(eResult.version);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const messagesClient = queueClient.createMessagesClient();
-    const factories = messagesClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new MessagesClient(messagesClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const eResult = await newClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-    assert.ok(eResult.expirationTime);
-    assert.ok(eResult.insertionTime);
-    assert.ok(eResult.messageId);
-    assert.ok(eResult.popReceipt);
-    assert.ok(eResult.requestId);
-    assert.ok(eResult.timeNextVisible);
-    assert.ok(eResult.version);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const messagesClient = queueClient.createMessagesClient();
-    const factories = messagesClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new MessagesClient(messagesClient.url, credential);
-
-    const eResult = await newClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-    assert.ok(eResult.expirationTime);
-    assert.ok(eResult.insertionTime);
-    assert.ok(eResult.messageId);
-    assert.ok(eResult.popReceipt);
-    assert.ok(eResult.requestId);
-    assert.ok(eResult.timeNextVisible);
-    assert.ok(eResult.version);
-  });
-
-  it("can be created with a connection string and a queue name", async () => {
-    const newClient = new MessagesClient(getConnectionStringFromEnvironment(), queueName);
-
-    const eResult = await newClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-    assert.ok(eResult.expirationTime);
-    assert.ok(eResult.insertionTime);
-    assert.ok(eResult.messageId);
-    assert.ok(eResult.popReceipt);
-  });
-
-  it("can be created with a connection string and a queue name and an option bag", async () => {
-    const newClient = new MessagesClient(getConnectionStringFromEnvironment(), queueName);
-
-    const eResult = await newClient.enqueue(messageContent);
-    assert.ok(eResult.date);
-    assert.ok(eResult.expirationTime);
-    assert.ok(eResult.insertionTime);
-    assert.ok(eResult.messageId);
-    assert.ok(eResult.popReceipt);
-  });
-
-  it("throws error if constructor queueName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new MessagesClient(getConnectionStringFromEnvironment(), "");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for queueName parameter",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
   });
 });

--- a/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
@@ -1,7 +1,9 @@
 import * as assert from "assert";
-import { getQSU } from "../utils";
+import { getQSU, getConnectionStringFromEnvironment } from "../utils";
 import { record } from "../utils/recorder";
 import { QueueClient } from "../../src/QueueClient";
+import { MessagesClient } from "../../src/MessagesClient";
+import { SharedKeyCredential } from "../../src/credentials/SharedKeyCredential";
 
 describe("MessageIdClient Node", () => {
   const queueServiceClient = getQSU();
@@ -86,5 +88,96 @@ describe("MessageIdClient Node", () => {
         "The request body is too large and exceeds the maximum permissible limit."
       )
     );
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const messagesClient = queueClient.createMessagesClient();
+    const factories = messagesClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new MessagesClient(messagesClient.url, credential);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+    assert.ok(eResult.requestId);
+    assert.ok(eResult.timeNextVisible);
+    assert.ok(eResult.version);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const messagesClient = queueClient.createMessagesClient();
+    const factories = messagesClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new MessagesClient(messagesClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+    assert.ok(eResult.requestId);
+    assert.ok(eResult.timeNextVisible);
+    assert.ok(eResult.version);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const messagesClient = queueClient.createMessagesClient();
+    const factories = messagesClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new MessagesClient(messagesClient.url, credential);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+    assert.ok(eResult.requestId);
+    assert.ok(eResult.timeNextVisible);
+    assert.ok(eResult.version);
+  });
+
+  it("can be created with a connection string and a queue name", async () => {
+    const newClient = new MessagesClient(getConnectionStringFromEnvironment(), queueName);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+  });
+
+  it("can be created with a connection string and a queue name and an option bag", async () => {
+    const newClient = new MessagesClient(getConnectionStringFromEnvironment(), queueName);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+  });
+
+  it("throws error if constructor queueName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new MessagesClient(getConnectionStringFromEnvironment(), "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for queueName parameter",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
   });
 });

--- a/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
@@ -5,7 +5,7 @@ import { QueueClient } from "../../src/QueueClient";
 import { MessagesClient } from "../../src/MessagesClient";
 import { SharedKeyCredential } from "../../src/credentials/SharedKeyCredential";
 
-describe("MessageIdClient Node", () => {
+describe("MessageIdClient Node.js only", () => {
   const queueServiceClient = getQSU();
   let queueName: string;
   let queueClient: QueueClient;

--- a/sdk/storage/storage-queue/test/node/messagesclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messagesclient.spec.ts
@@ -5,7 +5,7 @@ import { QueueClient } from "../../src/QueueClient";
 import { MessagesClient } from "../../src/MessagesClient";
 import { SharedKeyCredential } from "../../src/credentials/SharedKeyCredential";
 
-describe("MessagesClient Node", () => {
+describe("MessagesClient Node.js only", () => {
   const queueServiceClient = getQSU();
   let queueName: string;
   let queueClient: QueueClient;

--- a/sdk/storage/storage-queue/test/node/messagesclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messagesclient.spec.ts
@@ -1,12 +1,15 @@
 import * as assert from "assert";
-import { getQSU } from "../utils";
+import { getQSU, getConnectionStringFromEnvironment } from "../utils";
 import { record } from "../utils/recorder";
 import { QueueClient } from "../../src/QueueClient";
+import { MessagesClient } from "../../src/MessagesClient";
+import { SharedKeyCredential } from "../../src/credentials/SharedKeyCredential";
 
-describe("MessagesURL Node", () => {
+describe("MessagesClient Node", () => {
   const queueServiceClient = getQSU();
   let queueName: string;
   let queueClient: QueueClient;
+  const messageContent = "Hello World";
 
   let recorder: any;
 
@@ -93,5 +96,96 @@ describe("MessagesURL Node", () => {
         "The request body is too large and exceeds the maximum permissible limit."
       )
     );
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const messagesClient = queueClient.createMessagesClient();
+    const factories = messagesClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new MessagesClient(messagesClient.url, credential);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+    assert.ok(eResult.requestId);
+    assert.ok(eResult.timeNextVisible);
+    assert.ok(eResult.version);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const messagesClient = queueClient.createMessagesClient();
+    const factories = messagesClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new MessagesClient(messagesClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+    assert.ok(eResult.requestId);
+    assert.ok(eResult.timeNextVisible);
+    assert.ok(eResult.version);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const messagesClient = queueClient.createMessagesClient();
+    const factories = messagesClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new MessagesClient(messagesClient.url, credential);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+    assert.ok(eResult.requestId);
+    assert.ok(eResult.timeNextVisible);
+    assert.ok(eResult.version);
+  });
+
+  it("can be created with a connection string and a queue name", async () => {
+    const newClient = new MessagesClient(getConnectionStringFromEnvironment(), queueName);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+  });
+
+  it("can be created with a connection string and a queue name and an option bag", async () => {
+    const newClient = new MessagesClient(getConnectionStringFromEnvironment(), queueName);
+
+    const eResult = await newClient.enqueue(messageContent);
+    assert.ok(eResult.date);
+    assert.ok(eResult.expirationTime);
+    assert.ok(eResult.insertionTime);
+    assert.ok(eResult.messageId);
+    assert.ok(eResult.popReceipt);
+  });
+
+  it("throws error if constructor queueName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new MessagesClient(getConnectionStringFromEnvironment(), "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for queueName parameter",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
   });
 });

--- a/sdk/storage/storage-queue/test/node/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/queueclient.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
-import { getQSU } from "../utils";
+import { getQSU, getConnectionStringFromEnvironment } from "../utils";
 import { record } from "../utils/recorder";
-import { QueueClient } from "../../src/QueueClient";
+import { newPipeline, QueueClient, SharedKeyCredential } from "../../src";
 
 describe("QueueClient Node", () => {
   const queueServiceClient = getQSU();
@@ -44,5 +44,83 @@ describe("QueueClient Node", () => {
     await queueClient.setAccessPolicy(queueAcl);
     const result = await queueClient.getAccessPolicy();
     assert.deepEqual(result.signedIdentifiers, queueAcl);
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const factories = queueClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new QueueClient(queueClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.approximateMessagesCount! >= 0);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const factories = queueClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new QueueClient(queueClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.approximateMessagesCount! >= 0);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const factories = queueClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new QueueClient(queueClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.approximateMessagesCount! >= 0);
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a connection string and a queue name", async () => {
+    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueName);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("can be created with a connection string and a queue name and an option bag", async () => {
+    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueName);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+  });
+
+  it("throws error if constructor queueName parameter is empty", async () => {
+    try {
+      // tslint:disable-next-line: no-unused-expression
+      new QueueClient(getConnectionStringFromEnvironment(), "");
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Expecting non-empty strings for queueName parameter",
+        error.message,
+        "Error message is different than expected."
+      );
+    }
   });
 });

--- a/sdk/storage/storage-queue/test/node/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/queueclient.spec.ts
@@ -3,7 +3,7 @@ import { getQSU, getConnectionStringFromEnvironment } from "../utils";
 import { record } from "../utils/recorder";
 import { newPipeline, QueueClient, SharedKeyCredential } from "../../src";
 
-describe("QueueClient Node", () => {
+describe("QueueClient Node.js only", () => {
   const queueServiceClient = getQSU();
   let queueName: string;
   let queueClient: QueueClient;

--- a/sdk/storage/storage-queue/test/node/queueserviceclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/queueserviceclient.spec.ts
@@ -1,0 +1,74 @@
+import * as assert from "assert";
+import { getQSU, getConnectionStringFromEnvironment } from "../utils";
+import { record } from "../utils/recorder";
+import { QueueServiceClient } from "../../src/QueueServiceClient";
+import { SharedKeyCredential } from "../../src/credentials/SharedKeyCredential";
+import { newPipeline } from "../../src";
+
+describe("QueueServiceClient Node", () => {
+  let recorder: any;
+
+  beforeEach(function() {
+    recorder = record(this);
+  });
+
+  afterEach(() => {
+    recorder.stop();
+  });
+
+  it("can be created with a url and a credential", async () => {
+    const queueServiceClient = getQSU();
+    const factories = queueServiceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new QueueServiceClient(queueServiceClient.url, credential);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created with a url and a credential and an option bag", async () => {
+    const queueServiceClient = getQSU();
+    const factories = queueServiceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const newClient = new QueueServiceClient(queueServiceClient.url, credential, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created with a url and a pipeline", async () => {
+    const queueServiceClient = getQSU();
+    const factories = queueServiceClient.pipeline.factories;
+    const credential = factories[factories.length - 1] as SharedKeyCredential;
+    const pipeline = newPipeline(credential);
+    const newClient = new QueueServiceClient(queueServiceClient.url, pipeline);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+    assert.ok(typeof result.version);
+    assert.ok(result.version!.length > 0);
+  });
+
+  it("can be created from a connection string", async () => {
+    const newClient = QueueServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+  });
+});

--- a/sdk/storage/storage-queue/test/node/queueserviceclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/queueserviceclient.spec.ts
@@ -5,7 +5,7 @@ import { QueueServiceClient } from "../../src/QueueServiceClient";
 import { SharedKeyCredential } from "../../src/credentials/SharedKeyCredential";
 import { newPipeline } from "../../src";
 
-describe("QueueServiceClient Node", () => {
+describe("QueueServiceClient Node.js only", () => {
   let recorder: any;
 
   beforeEach(function() {

--- a/sdk/storage/storage-queue/test/node/utils.spec.ts
+++ b/sdk/storage/storage-queue/test/node/utils.spec.ts
@@ -1,0 +1,94 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import { extractConnectionStringParts } from "../../src/utils/utils.common";
+dotenv.config({ path: "../.env" });
+
+describe("Utility Helpers Node.js only", () => {
+  it("extractConnectionStringParts throws error when passed an invalid protocol in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=a;AccountName=b;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.ok(error);
+    }
+  });
+
+  it("extractConnectionStringParts throws error when passed an invalid connection string with typo", async () => {
+    try {
+      extractConnectionStringParts(
+        // Typo in the attributes
+        "DefaultEndpointsProtocol=https;Name=b;AccountKey=c;EndpointSuffix=d"
+      );
+
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty EndpointSuffix in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=cdefg;EndpointSuffix="
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid EndpointSuffix in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty AccountKey in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=b;AccountKey=;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid AccountKey in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty AccountName in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=https;AccountName=;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid AccountName in the provided Connection String",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+
+  it("extractConnectionStringParts throws error with empty DefaultEndpointsProtocol in the connection string", async () => {
+    try {
+      extractConnectionStringParts(
+        "DefaultEndpointsProtocol=;AccountName=b;AccountKey=c;EndpointSuffix=d"
+      );
+      assert.fail("Expecting an thrown error but didn't get one.");
+    } catch (error) {
+      assert.equal(
+        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'",
+        error.message,
+        "Connection string error message is different than expected"
+      );
+    }
+  });
+});

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -1,8 +1,8 @@
 import * as assert from "assert";
-import { getQSU, getConnectionStringFromEnvironment } from "./utils";
+import { getQSU } from "./utils";
 import { record } from "./utils/recorder";
 import * as dotenv from "dotenv";
-import { SharedKeyCredential, QueueClient, newPipeline } from "../src";
+import { QueueClient } from "../src";
 dotenv.config({ path: "../.env" });
 
 describe("QueueClient", () => {
@@ -116,83 +116,5 @@ describe("QueueClient", () => {
       error = err;
     }
     assert.ok(error); // For browser, permission denied; For node, invalid permission
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const factories = queueClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new QueueClient(queueClient.url, credential);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.approximateMessagesCount! >= 0);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const factories = queueClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new QueueClient(queueClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.approximateMessagesCount! >= 0);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const factories = queueClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new QueueClient(queueClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.approximateMessagesCount! >= 0);
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a connection string and a queue name", async () => {
-    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueName);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("can be created with a connection string and a queue name and an option bag", async () => {
-    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueName);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(result.requestId);
-    assert.ok(result.version);
-    assert.ok(result.date);
-  });
-
-  it("throws error if constructor queueName parameter is empty", async () => {
-    try {
-      // tslint:disable-next-line: no-unused-expression
-      new QueueClient(getConnectionStringFromEnvironment(), "");
-      assert.fail("Expecting an thrown error but didn't get one.");
-    } catch (error) {
-      assert.equal(
-        "Expecting non-empty strings for queueName parameter",
-        error.message,
-        "Error message is different than expected."
-      );
-    }
   });
 });

--- a/sdk/storage/storage-queue/test/queueserviceclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueserviceclient.spec.ts
@@ -1,8 +1,7 @@
 import * as assert from "assert";
 import * as dotenv from "dotenv";
-import { newPipeline, SharedKeyCredential } from "../src";
 import { QueueServiceClient } from "../src/QueueServiceClient";
-import { getAlternateQSU, getConnectionStringFromEnvironment, getQSU, wait } from "./utils";
+import { getAlternateQSU, getQSU, wait } from "./utils";
 import { record } from "./utils/recorder";
 dotenv.config({ path: "../.env" });
 
@@ -218,61 +217,5 @@ describe("QueueServiceClient", () => {
         done();
       })
       .catch(done);
-  });
-
-  it("can be created with a url and a credential", async () => {
-    const queueServiceClient = getQSU();
-    const factories = queueServiceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new QueueServiceClient(queueServiceClient.url, credential);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created with a url and a credential and an option bag", async () => {
-    const queueServiceClient = getQSU();
-    const factories = queueServiceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const newClient = new QueueServiceClient(queueServiceClient.url, credential, {
-      retryOptions: {
-        maxTries: 5
-      }
-    });
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created with a url and a pipeline", async () => {
-    const queueServiceClient = getQSU();
-    const factories = queueServiceClient.pipeline.factories;
-    const credential = factories[factories.length - 1] as SharedKeyCredential;
-    const pipeline = newPipeline(credential);
-    const newClient = new QueueServiceClient(queueServiceClient.url, pipeline);
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
-    assert.ok(typeof result.version);
-    assert.ok(result.version!.length > 0);
-  });
-
-  it("can be created from a connection string", async () => {
-    const newClient = QueueServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
-
-    const result = await newClient.getProperties();
-
-    assert.ok(typeof result.requestId);
-    assert.ok(result.requestId!.length > 0);
   });
 });

--- a/sdk/storage/storage-queue/test/utils/index.browser.ts
+++ b/sdk/storage/storage-queue/test/utils/index.browser.ts
@@ -42,17 +42,6 @@ export function getAlternateQSU(): QueueServiceClient {
   return getGenericQSU("SECONDARY_", "-secondary");
 }
 
-export function getConnectionStringFromEnvironment(): string {
-  const connectionStringEnvVar = `STORAGE_CONNECTION_STRING`;
-  const connectionString = process.env[connectionStringEnvVar];
-
-  if (!connectionString) {
-    throw new Error(`${connectionStringEnvVar} environment variables not specified.`);
-  }
-
-  return connectionString;
-}
-
 /**
  * Read body from downloading operation methods to string.
  * Work on both Node.js and browser environment.


### PR DESCRIPTION
SharedKeyCredential is only available on Node.js runtime. This change moves all
constructor overload tests to node tests.