### PR TITLE
[Event Hubs] fixes cancellation of send calls

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -437,10 +437,10 @@ export class EventHubSender extends LinkEntity {
     if (!options) {
       options = {};
     }
+
+    const abortSignal: AbortSignalLike | undefined = options.abortSignal;
     const sendEventPromise = () =>
       new Promise<void>((resolve, reject) => {
-        const abortSignal: AbortSignalLike | undefined = options!.abortSignal;
-
         const rejectOnAbort = () => {
           const desc: string =
             `[${this._context.connectionId}] The send operation on the Sender "${this.name}" with ` +


### PR DESCRIPTION
Adds cancellation tests for the `send()` method. Fixes 2 issues found through testing:
1. If the `abortSignal` was in the `aborted` state before `send` was called, it was ignored.
2. If the `abortSignal` event listener was triggered, it threw an uncaught exception.