### PR TITLE
[Event Hubs] adds tests/fixes bugs with receive cancellation

### DIFF
--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -93,7 +93,7 @@ export class BatchingReceiver extends EventHubReceiver {
           return rejectOnAbort();
         }
 
-        const removeListeners = () => {
+        const cleanUpBeforeReturn = () => {
           if (this._abortSignal) {
             this._abortSignal.removeEventListener("abort", this._onAbort);
           }
@@ -112,7 +112,7 @@ export class BatchingReceiver extends EventHubReceiver {
 
         // Final action to be performed after maxMessageCount is reached or the maxWaitTime is over.
         const finalAction = (timeOver: boolean) => {
-          removeListeners();
+          cleanUpBeforeReturn();
           resolve(eventDatas);
         };
 
@@ -164,7 +164,7 @@ export class BatchingReceiver extends EventHubReceiver {
         };
 
         const onAbort = async () => {
-          removeListeners();
+          cleanUpBeforeReturn();
           await this.close();
           rejectOnAbort();
         };
@@ -337,14 +337,14 @@ export class BatchingReceiver extends EventHubReceiver {
             await this._init(rcvrOptions);
             if (abortSignal && abortSignal.aborted) {
               // exit early if operation was cancelled while initializing connection
-              removeListeners();
+              cleanUpBeforeReturn();
               await this.close();
               return rejectOnAbort();
             }
             addCreditAndSetTimer();
           } catch (err) {
             // remove listeners if a connection could not be established
-            removeListeners();
+            cleanUpBeforeReturn();
             return reject(err);
           }
         } else {

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -158,7 +158,7 @@ export class BatchingReceiver extends EventHubReceiver {
           }
         };
 
-        const onAbort = () => {
+        const onAbort = async () => {
           this.isReceivingMessages = false;
           if (this._receiver) {
             this._receiver.removeListener(ReceiverEvents.receiverError, onReceiveError);
@@ -174,6 +174,7 @@ export class BatchingReceiver extends EventHubReceiver {
             `[${this._context.connectionId}] The receive operation on the Receiver "${this.name}" with ` +
             `address "${this.address}" has been cancelled by the user.`;
           log.error(desc);
+          await this.close();
           reject(new AbortError("The receive operation has been cancelled by the user."));
         };
 
@@ -344,6 +345,7 @@ export class BatchingReceiver extends EventHubReceiver {
           try {
             await this._init(rcvrOptions);
             if (abortSignal && abortSignal.aborted) {
+              await this.close();
               // exit early if operation was cancelled while initializing connection
               return rejectOnAbort();
             }

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -170,12 +170,8 @@ export class BatchingReceiver extends EventHubReceiver {
           if (this._abortSignal) {
             this._abortSignal.removeEventListener("abort", this._onAbort);
           }
-          const desc: string =
-            `[${this._context.connectionId}] The receive operation on the Receiver "${this.name}" with ` +
-            `address "${this.address}" has been cancelled by the user.`;
-          log.error(desc);
           await this.close();
-          reject(new AbortError("The receive operation has been cancelled by the user."));
+          rejectOnAbort();
         };
 
         // Action to be taken when an error is received.

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -18,7 +18,7 @@ import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
 import { EventPosition } from "./eventPosition";
 import { getEventPositionFilter } from "./util/utils";
-import { AbortSignalLike } from "@azure/abort-controller";
+import { AbortSignalLike, AbortError } from "@azure/abort-controller";
 
 interface CreateReceiverOptions {
   onMessage: OnAmqpEvent;
@@ -243,7 +243,7 @@ export class EventHubReceiver extends LinkEntity {
         `address "${this.address}" has been cancelled by the user.`;
       log.error(desc);
       await this.close();
-      this._onError!(new Error(desc));
+      this._onError!(new AbortError("The receive operation has been cancelled by the user."));
     };
 
     this._onAmqpError = (context: EventContext) => {

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -451,7 +451,7 @@ export class EventHubSender extends LinkEntity {
 
         if (abortSignal && abortSignal.aborted) {
           // operation has been cancelled, so exit quickly
-          rejectOnAbort();
+          return rejectOnAbort();
         }
 
         let waitTimer: any;

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -3,5 +3,5 @@
 
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "2.1.0"
+  version: "3.0.0-preview.1"
 };


### PR DESCRIPTION
Fixes #3597 
Adds tests and fixes some bugs found when using the event hubs receiver in streaming/batching modes, or as an event iterator.

I wasn't sure if the user should be allowed to call `receiveBatch` again if a previous call on the same receiver was cancelled. I added a commit that adds support for this by calling `close()` on the receiver when the user cancels the operation. Otherwise the user gets an error indicating that the receiver is already receiving messages if they call `receiveBatch` again.

I'll rebase after this gets reviewed in case anyone wants to run the tests locally.