### PR TITLE
Pack license files

### DIFF
--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -51,6 +51,7 @@
     "browser/ThirdPartyNotices.txt",
     "dist/",
     "dist-esm/src/",
+    "LICENSE",
     "src/",
     "typings/src",
     "tsconfig.json"

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -51,6 +51,7 @@
     "browser/ThirdPartyNotices.txt",
     "dist/",
     "dist-esm/src/",
+    "LICENSE",
     "src/",
     "typings/src",
     "tsconfig.json"

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -48,6 +48,7 @@
     "browser/*.min.js*",
     "dist/",
     "dist-esm/src/",
+    "LICENSE",
     "src/",
     "typings/src",
     "tsconfig.json"


### PR DESCRIPTION
The guidelines don't explicitly mention that the NPM package must include the
LICENSE file. Including for consistency with other packages.

Resolves #3841.