### PR TITLE
[Identity] Add "crypto" and "fs" rollup externals

### DIFF
--- a/sdk/identity/identity/rollup.base.config.js
+++ b/sdk/identity/identity/rollup.base.config.js
@@ -12,7 +12,7 @@ const input = "dist-esm/src/index.js";
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["events"];
+  const externalNodeBuiltins = ["crypto", "events", "fs"];
   const baseConfig = {
     input: input,
     external: depNames.concat(externalNodeBuiltins),


### PR DESCRIPTION
Addresses the following rollup warnings:

```
dist-esm/src/index.js → dist/index.js...
(!) Unresolved dependencies
https://rollupjs.org/guide/en#warning-treating-module-as-external-dependency
crypto (imported by dist-esm\src\credentials\clientCertificateCredential.js)
fs (imported by dist-esm\src\credentials\clientCertificateCredential.js)
created dist/index.js in 155ms
```