### PR TITLE
[Event Hubs] makes eventPosition, consumer group mandatory

### DIFF
--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -18,6 +18,7 @@ import { EventHubReceiver } from "./eventHubReceiver";
 import { ConnectionContext } from "./connectionContext";
 import { AbortSignalLike, AbortError } from "@azure/abort-controller";
 import * as log from "./log";
+import { EventPosition } from './eventPosition';
 
 /**
  * Describes the batching receiver where the user can receive a specified number of messages for a predefined time.
@@ -37,10 +38,11 @@ export class BatchingReceiver extends EventHubReceiver {
    * @constructor
    * @param {ConnectionContext} context                        The connection context.
    * @param {string} partitionId                               Partition ID from which to receive.
+   * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    * @param {EventReceiverOptions} [options]                         Options for how you'd like to connect.
    */
-  constructor(context: ConnectionContext, partitionId: string | number, options?: EventReceiverOptions) {
-    super(context, partitionId, options);
+  constructor(context: ConnectionContext, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
+    super(context, partitionId, eventPosition, options);
   }
 
   /**
@@ -366,14 +368,16 @@ export class BatchingReceiver extends EventHubReceiver {
    * @ignore
    * @param {ConnectionContext} context    The connection context.
    * @param {string | number} partitionId  The partitionId to receive events from.
+   * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    * @param {EventReceiverOptions} [options]     Receive options.
    */
   static create(
     context: ConnectionContext,
     partitionId: string | number,
+    eventPosition: EventPosition,
     options?: EventReceiverOptions
   ): BatchingReceiver {
-    const bReceiver = new BatchingReceiver(context, partitionId, options);
+    const bReceiver = new BatchingReceiver(context, partitionId, eventPosition, options);
     context.receivers[bReceiver.name] = bReceiver;
     return bReceiver;
   }

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -37,12 +37,13 @@ export class BatchingReceiver extends EventHubReceiver {
    * @ignore
    * @constructor
    * @param {ConnectionContext} context                        The connection context.
+   * @param {string} consumerGroup The consumer group from which the receiver should receive events from.
    * @param {string} partitionId                               Partition ID from which to receive.
    * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    * @param {EventReceiverOptions} [options]                         Options for how you'd like to connect.
    */
-  constructor(context: ConnectionContext, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
-    super(context, partitionId, eventPosition, options);
+  constructor(context: ConnectionContext, consumerGroup: string, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
+    super(context, consumerGroup, partitionId, eventPosition, options);
   }
 
   /**
@@ -367,17 +368,19 @@ export class BatchingReceiver extends EventHubReceiver {
    * @static
    * @ignore
    * @param {ConnectionContext} context    The connection context.
+   * @param {string} consumerGroup  The consumer group from which the receiver should receive events from.
    * @param {string | number} partitionId  The partitionId to receive events from.
    * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    * @param {EventReceiverOptions} [options]     Receive options.
    */
   static create(
     context: ConnectionContext,
+    consumerGroup: string,
     partitionId: string | number,
     eventPosition: EventPosition,
     options?: EventReceiverOptions
   ): BatchingReceiver {
-    const bReceiver = new BatchingReceiver(context, partitionId, eventPosition, options);
+    const bReceiver = new BatchingReceiver(context, consumerGroup, partitionId, eventPosition, options);
     context.receivers[bReceiver.name] = bReceiver;
     return bReceiver;
   }

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -18,7 +18,7 @@ import { EventHubReceiver } from "./eventHubReceiver";
 import { ConnectionContext } from "./connectionContext";
 import { AbortSignalLike, AbortError } from "@azure/abort-controller";
 import * as log from "./log";
-import { EventPosition } from './eventPosition';
+import { EventPosition } from "./eventPosition";
 
 /**
  * Describes the batching receiver where the user can receive a specified number of messages for a predefined time.
@@ -42,7 +42,13 @@ export class BatchingReceiver extends EventHubReceiver {
    * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    * @param {EventReceiverOptions} [options]                         Options for how you'd like to connect.
    */
-  constructor(context: ConnectionContext, consumerGroup: string, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
+  constructor(
+    context: ConnectionContext,
+    consumerGroup: string,
+    partitionId: string | number,
+    eventPosition: EventPosition,
+    options?: EventReceiverOptions
+  ) {
     super(context, consumerGroup, partitionId, eventPosition, options);
   }
 

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -10,7 +10,8 @@ import {
   SharedKeyCredential,
   ConnectionConfig,
   parseConnectionString,
-  EventHubConnectionStringModel
+  EventHubConnectionStringModel,
+  Constants
 } from "@azure/core-amqp";
 
 import { ConnectionContext } from "./connectionContext";
@@ -404,4 +405,10 @@ export class EventHubClient {
     const connectionString = await new IotHubClient(iothubConnectionString).getEventHubConnectionString();
     return new EventHubClient(connectionString, options);
   }
+
+  /**
+   * @property
+   * The name of the default consumer group for any Event Hub instance
+   */
+  static defaultConsumerGroup: string = Constants.defaultConsumerGroup;
 }

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -96,7 +96,7 @@ export interface EventReceiverOptions {
    * If another receiver is currently active with a higher priority, then this receiver
    * will fail to connect.
    */
-  exclusiveReceiverPriority?: number;
+  ownerLevel?: number;
   /**
    * @property
    * Retry options for the receive operation on the receiver. If no value is provided here, the

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -90,12 +90,6 @@ export interface SendOptions {
 export interface EventReceiverOptions {
   /**
    * @property
-   * The consumer group from which the receiver should receive events from.
-   * If not provided, then default consumer group by the name "$default" is used.
-   */
-  consumerGroup?: string;
-  /**
-   * @property
    * The priority value that this receiver is currently using for partition ownership.
    * If another receiver is currently active for the same partition with no or lesser
    * priority, then it will get disconnected.
@@ -300,17 +294,24 @@ export class EventHubClient {
    * Creates a Receiver that can be used to receive events from the Event Hub for which this
    * client was created.
    *
+   * @param consumerGroup The consumer group from which the receiver should receive events from.
    * @param partitionId The id of the partition from which to receive events
    * @param eventPosition The event position in the partition at which to start receiving messages.
    * @param options Options to create the Receiver where you can specify the position from
    * which to start receiving events, the consumer group to receive events from, retry options
    * and more.
    */
-  createReceiver(partitionId: string, eventPosition: EventPosition, options?: EventReceiverOptions): EventReceiver {
+  createReceiver(
+    consumerGroup: string,
+    partitionId: string,
+    eventPosition: EventPosition,
+    options?: EventReceiverOptions
+  ): EventReceiver {
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "consumerGroup", consumerGroup);
     throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
     throwTypeErrorIfParameterMissing(this._context.connectionId, "eventPosition", eventPosition);
     partitionId = String(partitionId);
-    return new EventReceiver(this._context, partitionId, eventPosition, options);
+    return new EventReceiver(this._context, consumerGroup, partitionId, eventPosition, options);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -90,11 +90,6 @@ export interface SendOptions {
 export interface EventReceiverOptions {
   /**
    * @property
-   * The event position in the partition at which to start receiving messages.
-   */
-  beginReceivingAt?: EventPosition;
-  /**
-   * @property
    * The consumer group from which the receiver should receive events from.
    * If not provided, then default consumer group by the name "$default" is used.
    */
@@ -306,14 +301,16 @@ export class EventHubClient {
    * client was created.
    *
    * @param partitionId The id of the partition from which to receive events
+   * @param eventPosition The event position in the partition at which to start receiving messages.
    * @param options Options to create the Receiver where you can specify the position from
    * which to start receiving events, the consumer group to receive events from, retry options
    * and more.
    */
-  createReceiver(partitionId: string, options?: EventReceiverOptions): EventReceiver {
+  createReceiver(partitionId: string, eventPosition: EventPosition, options?: EventReceiverOptions): EventReceiver {
     throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
+    throwTypeErrorIfParameterMissing(this._context.connectionId, "eventPosition", eventPosition);
     partitionId = String(partitionId);
-    return new EventReceiver(this._context, partitionId, options);
+    return new EventReceiver(this._context, partitionId, eventPosition, options);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -197,16 +197,17 @@ export class EventHubReceiver extends LinkEntity {
    * @ignore
    * @constructor
    * @param {EventHubClient} client                            The EventHub client.
+   * @param {string} consumerGroup  The consumer group from which the receiver should receive events from.
    * @param {string} partitionId                               Partition ID from which to receive.
    * @param {EventReceiverOptions} [options]                         Receiver options.
    */
-  constructor(context: ConnectionContext, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
+  constructor(context: ConnectionContext, consumerGroup: string, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
     super(context, {
       partitionId: partitionId,
-      name: context.config.getReceiverAddress(partitionId, options && options.consumerGroup)
+      name: context.config.getReceiverAddress(partitionId, consumerGroup)
     });
     if (!options) options = {};
-    this.consumerGroup = options.consumerGroup ? options.consumerGroup : Constants.defaultConsumerGroup;
+    this.consumerGroup = consumerGroup;
     this.address = context.config.getReceiverAddress(partitionId, this.consumerGroup);
     this.audience = context.config.getReceiverAudience(partitionId, this.consumerGroup);
     this.epoch = options.exclusiveReceiverPriority;

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -199,6 +199,7 @@ export class EventHubReceiver extends LinkEntity {
    * @param {EventHubClient} client                            The EventHub client.
    * @param {string} consumerGroup  The consumer group from which the receiver should receive events from.
    * @param {string} partitionId                               Partition ID from which to receive.
+   * @param {EventPosition} eventPosition The position in the stream from where to start receiving events.
    * @param {EventReceiverOptions} [options]                         Receiver options.
    */
   constructor(

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -98,9 +98,9 @@ export class EventHubReceiver extends LinkEntity {
    */
   runtimeInfo: ReceiverRuntimeInfo;
   /**
-   * @property {number} [epoch] The Receiver epoch.
+   * @property {number} [ownerLevel] The Receiver ownerLevel.
    */
-  epoch?: number;
+  ownerLevel?: number;
   /**
    * @property {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    */
@@ -201,7 +201,13 @@ export class EventHubReceiver extends LinkEntity {
    * @param {string} partitionId                               Partition ID from which to receive.
    * @param {EventReceiverOptions} [options]                         Receiver options.
    */
-  constructor(context: ConnectionContext, consumerGroup: string, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
+  constructor(
+    context: ConnectionContext,
+    consumerGroup: string,
+    partitionId: string | number,
+    eventPosition: EventPosition,
+    options?: EventReceiverOptions
+  ) {
     super(context, {
       partitionId: partitionId,
       name: context.config.getReceiverAddress(partitionId, consumerGroup)
@@ -210,7 +216,7 @@ export class EventHubReceiver extends LinkEntity {
     this.consumerGroup = consumerGroup;
     this.address = context.config.getReceiverAddress(partitionId, this.consumerGroup);
     this.audience = context.config.getReceiverAudience(partitionId, this.consumerGroup);
-    this.epoch = options.exclusiveReceiverPriority;
+    this.ownerLevel = options.ownerLevel;
     this.eventPosition = eventPosition;
     this.options = options;
     this.receiverRuntimeMetricEnabled = false;
@@ -639,9 +645,9 @@ export class EventHubReceiver extends LinkEntity {
       onSessionError: options.onSessionError || this._onSessionError,
       onSessionClose: options.onSessionClose || this._onSessionClose
     };
-    if (this.epoch !== undefined && this.epoch !== null) {
+    if (this.ownerLevel !== undefined && this.ownerLevel !== null) {
       if (!rcvrOptions.properties) rcvrOptions.properties = {};
-      rcvrOptions.properties[Constants.attachEpoch] = types.wrap_long(this.epoch);
+      rcvrOptions.properties[Constants.attachEpoch] = types.wrap_long(this.ownerLevel);
     }
     if (this.receiverRuntimeMetricEnabled) {
       rcvrOptions.desired_capabilities = Constants.enableReceiverRuntimeMetricName;

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -102,6 +102,10 @@ export class EventHubReceiver extends LinkEntity {
    */
   epoch?: number;
   /**
+   * @property {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
+   */
+  eventPosition: EventPosition;
+  /**
    * @property {ReceiveOptions} [options] Optional properties that can be set while creating
    * the EventHubReceiver.
    */
@@ -196,7 +200,7 @@ export class EventHubReceiver extends LinkEntity {
    * @param {string} partitionId                               Partition ID from which to receive.
    * @param {EventReceiverOptions} [options]                         Receiver options.
    */
-  constructor(context: ConnectionContext, partitionId: string | number, options?: EventReceiverOptions) {
+  constructor(context: ConnectionContext, partitionId: string | number, eventPosition: EventPosition, options?: EventReceiverOptions) {
     super(context, {
       partitionId: partitionId,
       name: context.config.getReceiverAddress(partitionId, options && options.consumerGroup)
@@ -206,6 +210,7 @@ export class EventHubReceiver extends LinkEntity {
     this.address = context.config.getReceiverAddress(partitionId, this.consumerGroup);
     this.audience = context.config.getReceiverAudience(partitionId, this.consumerGroup);
     this.epoch = options.exclusiveReceiverPriority;
+    this.eventPosition = eventPosition;
     this.options = options;
     this.receiverRuntimeMetricEnabled = false;
     this.runtimeInfo = {};
@@ -640,7 +645,7 @@ export class EventHubReceiver extends LinkEntity {
     if (this.receiverRuntimeMetricEnabled) {
       rcvrOptions.desired_capabilities = Constants.enableReceiverRuntimeMetricName;
     }
-    const eventPosition = options.eventPosition || this.options.beginReceivingAt;
+    const eventPosition = options.eventPosition || this.eventPosition;
     if (eventPosition) {
       // Set filter on the receiver if event position is specified.
       const filterClause = getEventPositionFilter(eventPosition);

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -133,7 +133,7 @@ export class EventPosition {
    * @return {EventPosition} EventPosition
    */
 
-  static fromFirstAvailableEvent(): EventPosition {
+  static earliest(): EventPosition {
     return EventPosition.fromOffset(EventPosition.startOfStream);
   }
 
@@ -143,7 +143,7 @@ export class EventPosition {
    * @return {EventPosition} EventPosition
    */
 
-  static fromNewEventsOnly(): EventPosition {
+  static latest(): EventPosition {
     return EventPosition.fromOffset(EventPosition.endOfStream);
   }
 }

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -28,3 +28,5 @@ export {
   SharedKeyCredential,
   delay
 } from "@azure/core-amqp";
+import { Constants } from "@azure/core-amqp";
+export const defaultConsumerGroup = Constants.defaultConsumerGroup;

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -28,5 +28,3 @@ export {
   SharedKeyCredential,
   delay
 } from "@azure/core-amqp";
-import { Constants } from "@azure/core-amqp";
-export const defaultConsumerGroup = Constants.defaultConsumerGroup;

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -39,6 +39,10 @@ export class EventReceiver {
    */
   private _context: ConnectionContext;
   /**
+   * @property The consumer group from which the receiver should receive events from.
+   */
+  private _consumerGroup: string;
+  /**
    * @property The event position in the partition at which to start receiving messages.
    */
   private _eventPosition: EventPosition;
@@ -75,8 +79,8 @@ export class EventReceiver {
    * events from.
    * @readonly
    */
-  get consumerGroup(): string | undefined {
-    return this._receiverOptions && this._receiverOptions.consumerGroup;
+  get consumerGroup(): string {
+    return this._consumerGroup;
   }
 
   /**
@@ -92,11 +96,13 @@ export class EventReceiver {
    */
   constructor(
     context: ConnectionContext,
+    consumerGroup: string,
     partitionId: string,
     eventPosition: EventPosition,
     options?: EventReceiverOptions
   ) {
     this._context = context;
+    this._consumerGroup = consumerGroup;
     this._partitionId = partitionId;
     this._eventPosition = eventPosition;
     this._receiverOptions = options || {};
@@ -127,6 +133,7 @@ export class EventReceiver {
     }
     this._streamingReceiver = StreamingReceiver.create(
       this._context,
+      this.consumerGroup,
       this.partitionId,
       this._eventPosition,
       this._receiverOptions
@@ -224,6 +231,7 @@ export class EventReceiver {
     if (!this._batchingReceiver) {
       this._batchingReceiver = BatchingReceiver.create(
         this._context,
+        this.consumerGroup,
         this.partitionId,
         this._eventPosition,
         this._receiverOptions
@@ -232,6 +240,7 @@ export class EventReceiver {
       await this._batchingReceiver.close();
       this._batchingReceiver = BatchingReceiver.create(
         this._context,
+        this.consumerGroup,
         this.partitionId,
         this._eventPosition,
         this._receiverOptions

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -84,11 +84,11 @@ export class EventReceiver {
   }
 
   /**
-   * @property {number} [epoch] The epoch value of the underlying receiver, if present.
+   * @property {number} [ownerLevel] The ownerLevel value of the underlying receiver, if present.
    * @readonly
    */
-  get exclusiveReceiverPriority(): number | undefined {
-    return this._receiverOptions && this._receiverOptions.exclusiveReceiverPriority;
+  get ownerLevel(): number | undefined {
+    return this._receiverOptions && this._receiverOptions.ownerLevel;
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -95,17 +95,19 @@ export class StreamingReceiver extends EventHubReceiver {
    * @ignore
    * @constructor
    * @param {EventHubClient} client          The EventHub client.
+   * @param {string} consumerGroup The consumer group from which the receiver should receive events from.
    * @param {string} partitionId             Partition ID from which to receive.
    * @param {EventPosition} eventPosition    The event position in the partition at
    * @param {EventReceiverOptions} [options]       Options for how you'd like to connect.
    */
   constructor(
     context: ConnectionContext,
+    consumerGroup: string,
     partitionId: string | number,
     eventPosition: EventPosition,
     options?: EventReceiverOptions
   ) {
-    super(context, partitionId, eventPosition, options);
+    super(context, consumerGroup, partitionId, eventPosition, options);
     this.receiveHandler = new ReceiveHandler(this);
   }
 
@@ -167,17 +169,19 @@ export class StreamingReceiver extends EventHubReceiver {
    * @static
    * @ignore
    * @param {ConnectionContext} context    The connection context.
+   * @param {string} consumerGroup The consumer group from which the receiver should receive events from.
    * @param {string | number} partitionId  The partitionId to receive events from.
    * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    * @param {EventReceiverOptions} [options]     Receive options.
    */
   static create(
     context: ConnectionContext,
+    consumerGroup: string,
     partitionId: string | number,
     eventPosition: EventPosition,
     options?: EventReceiverOptions
   ): StreamingReceiver {
-    const sReceiver = new StreamingReceiver(context, partitionId, eventPosition, options);
+    const sReceiver = new StreamingReceiver(context, consumerGroup, partitionId, eventPosition, options);
     context.receivers[sReceiver.name] = sReceiver;
     return sReceiver;
   }

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -8,6 +8,7 @@ import { EventHubReceiver, OnMessage, OnError } from "./eventHubReceiver";
 import { ConnectionContext } from "./connectionContext";
 import * as log from "./log";
 import { AbortSignalLike } from "@azure/abort-controller";
+import { EventPosition } from "./eventPosition";
 
 /**
  * Describes the receive handler object that is returned from the receive() method with handlers is
@@ -95,10 +96,16 @@ export class StreamingReceiver extends EventHubReceiver {
    * @constructor
    * @param {EventHubClient} client          The EventHub client.
    * @param {string} partitionId             Partition ID from which to receive.
+   * @param {EventPosition} eventPosition    The event position in the partition at
    * @param {EventReceiverOptions} [options]       Options for how you'd like to connect.
    */
-  constructor(context: ConnectionContext, partitionId: string | number, options?: EventReceiverOptions) {
-    super(context, partitionId, options);
+  constructor(
+    context: ConnectionContext,
+    partitionId: string | number,
+    eventPosition: EventPosition,
+    options?: EventReceiverOptions
+  ) {
+    super(context, partitionId, eventPosition, options);
     this.receiveHandler = new ReceiveHandler(this);
   }
 
@@ -161,14 +168,16 @@ export class StreamingReceiver extends EventHubReceiver {
    * @ignore
    * @param {ConnectionContext} context    The connection context.
    * @param {string | number} partitionId  The partitionId to receive events from.
+   * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
    * @param {EventReceiverOptions} [options]     Receive options.
    */
   static create(
     context: ConnectionContext,
     partitionId: string | number,
+    eventPosition: EventPosition,
     options?: EventReceiverOptions
   ): StreamingReceiver {
-    const sReceiver = new StreamingReceiver(context, partitionId, options);
+    const sReceiver = new StreamingReceiver(context, partitionId, eventPosition, options);
     context.receivers[sReceiver.name] = sReceiver;
     return sReceiver;
   }

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -10,7 +10,7 @@ import chaiString from "chai-string";
 chai.use(chaiString);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:client-spec");
-import { EventHubClient, EventPosition } from "../src";
+import { EventHubClient, EventPosition, defaultConsumerGroup } from "../src";
 import { packageJsonInfo } from "../src/util/constants";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
@@ -174,7 +174,7 @@ describe("EventHubClient on #RunnableInBrowser", function(): void {
     it("should throw MessagingEntityNotFoundError while creating a receiver", async function(): Promise<void> {
       try {
         client = EventHubClient.createFromConnectionString(service.connectionString!, "bad" + Math.random());
-        const receiver = client.createReceiver("0", EventPosition.earliest());
+        const receiver = client.createReceiver(defaultConsumerGroup, "0", EventPosition.earliest());
         await receiver.receiveBatch(10, 5);
       } catch (err) {
         debug(err);
@@ -187,11 +187,22 @@ describe("EventHubClient on #RunnableInBrowser", function(): void {
     it("should throw an error if EventPosition is missing", function() {
       try {
         client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
-        client.createReceiver("0", undefined as any);
+        client.createReceiver(defaultConsumerGroup, "0", undefined as any);
         throw new Error("Test failure");
       } catch (err) {
         err.name.should.equal("TypeError");
         err.message.should.equal(`Missing parameter "eventPosition"`);
+      }
+    });
+
+    it("should throw an error if consumerGroup is missing", function() {
+      try {
+        client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+        client.createReceiver(undefined as any, "0", EventPosition.earliest());
+        throw new Error("Test failure");
+      } catch (err) {
+        err.name.should.equal("TypeError");
+        err.message.should.equal(`Missing parameter "consumerGroup"`);
       }
     });
   });
@@ -214,7 +225,7 @@ describe("EventHubClient on #RunnableInBrowser", function(): void {
             done(should.equal(error.name, "MessagingEntityNotFoundError"));
           }, 3000);
         };
-        const receiver = client.createReceiver("0", EventPosition.earliest(), { consumerGroup: "some-random-name" });
+        const receiver = client.createReceiver("some-random-name", "0", EventPosition.earliest());
         receiver.receive(onMessage, onError);
         debug(">>>>>>>> attached the error handler on the receiver...");
       } catch (err) {
@@ -304,4 +315,3 @@ describe("EventHubClient on #RunnableInBrowser", function(): void {
 //     await client.close();
 //   });
 // });
-

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -10,7 +10,7 @@ import chaiString from "chai-string";
 chai.use(chaiString);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:client-spec");
-import { EventHubClient, EventPosition, defaultConsumerGroup } from "../src";
+import { EventHubClient, EventPosition } from "../src";
 import { packageJsonInfo } from "../src/util/constants";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
@@ -174,7 +174,7 @@ describe("EventHubClient on #RunnableInBrowser", function(): void {
     it("should throw MessagingEntityNotFoundError while creating a receiver", async function(): Promise<void> {
       try {
         client = EventHubClient.createFromConnectionString(service.connectionString!, "bad" + Math.random());
-        const receiver = client.createReceiver(defaultConsumerGroup, "0", EventPosition.earliest());
+        const receiver = client.createReceiver(EventHubClient.defaultConsumerGroup, "0", EventPosition.earliest());
         await receiver.receiveBatch(10, 5);
       } catch (err) {
         debug(err);
@@ -187,7 +187,7 @@ describe("EventHubClient on #RunnableInBrowser", function(): void {
     it("should throw an error if EventPosition is missing", function() {
       try {
         client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
-        client.createReceiver(defaultConsumerGroup, "0", undefined as any);
+        client.createReceiver(EventHubClient.defaultConsumerGroup, "0", undefined as any);
         throw new Error("Test failure");
       } catch (err) {
         err.name.should.equal("TypeError");

--- a/sdk/eventhub/event-hubs/test/eventPosition.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventPosition.spec.ts
@@ -62,14 +62,14 @@ describe("EventPosition #RunnableInBrowser", function(): void {
 
     it("should create from an offset from start", function(done: Mocha.Done): void {
       const result = "amqp.annotation.x-opt-offset > '-1'";
-      const pos = EventPosition.fromFirstAvailableEvent();
+      const pos = EventPosition.earliest();
       result.should.equal(getEventPositionFilter(pos));
       done();
     });
 
     it("should create from an offset from end", function(done: Mocha.Done): void {
       const result = "amqp.annotation.x-opt-offset > '@latest'";
-      const pos = EventPosition.fromNewEventsOnly();
+      const pos = EventPosition.latest();
       result.should.equal(getEventPositionFilter(pos));
       done();
     });

--- a/sdk/eventhub/event-hubs/test/iothub.spec.ts
+++ b/sdk/eventhub/event-hubs/test/iothub.spec.ts
@@ -7,7 +7,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:iothub-spec");
-import { EventHubClient, EventPosition, defaultConsumerGroup } from "../src";
+import { EventHubClient, EventPosition } from "../src";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 const env = getEnvVars();
 
@@ -42,7 +42,7 @@ describe("EventHub Client with iothub connection string ", function(): void {
 
   it("should be able to receive messages from the event hub", async function(): Promise<void> {
     client = await EventHubClient.createFromIotHubConnectionString(service.connectionString!);
-    const receiver = client.createReceiver(defaultConsumerGroup, "0", EventPosition.earliest());
+    const receiver = client.createReceiver(EventHubClient.defaultConsumerGroup, "0", EventPosition.earliest());
     const datas = await receiver.receiveBatch(15, 10);
     debug(">>>> Received events from partition %s, %O", "0", datas);
   });

--- a/sdk/eventhub/event-hubs/test/iothub.spec.ts
+++ b/sdk/eventhub/event-hubs/test/iothub.spec.ts
@@ -7,7 +7,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:iothub-spec");
-import { EventHubClient, EventPosition } from "../src";
+import { EventHubClient, EventPosition, defaultConsumerGroup } from "../src";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 const env = getEnvVars();
 
@@ -42,7 +42,7 @@ describe("EventHub Client with iothub connection string ", function(): void {
 
   it("should be able to receive messages from the event hub", async function(): Promise<void> {
     client = await EventHubClient.createFromIotHubConnectionString(service.connectionString!);
-    const receiver = client.createReceiver("0", EventPosition.earliest());
+    const receiver = client.createReceiver(defaultConsumerGroup, "0", EventPosition.earliest());
     const datas = await receiver.receiveBatch(15, 10);
     debug(">>>> Received events from partition %s, %O", "0", datas);
   });

--- a/sdk/eventhub/event-hubs/test/iothub.spec.ts
+++ b/sdk/eventhub/event-hubs/test/iothub.spec.ts
@@ -7,7 +7,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:iothub-spec");
-import { EventHubClient } from "../src";
+import { EventHubClient, EventPosition } from "../src";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 const env = getEnvVars();
 
@@ -42,7 +42,7 @@ describe("EventHub Client with iothub connection string ", function(): void {
 
   it("should be able to receive messages from the event hub", async function(): Promise<void> {
     client = await EventHubClient.createFromIotHubConnectionString(service.connectionString!);
-    const receiver = client.createReceiver("0");
+    const receiver = client.createReceiver("0", EventPosition.earliest());
     const datas = await receiver.receiveBatch(15, 10);
     debug(">>>> Received events from partition %s, %O", "0", datas);
   });

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -47,9 +47,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
     debug(`Partition ${partitionId} has last message with offset ${offset}.`);
     debug("Sending one message with %d bytes.", bodysize);
-    breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
-      beginReceivingAt: EventPosition.fromOffset(offset)
-    });
+    breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
     let data = await breceiver.receive(5, 10);
     should.equal(data.length, 0, "Unexpected to receive message before client sends it");
     const sender = client.createSender({ partitionId });
@@ -83,9 +81,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
     debug(`Partition ${partitionId} has last message with offset ${offset}.`);
     debug("Sending one message %O", obj);
-    breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
-      beginReceivingAt: EventPosition.fromOffset(offset)
-    });
+    breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
     const sender = client.createSender({ partitionId });
     await sender.send([obj]);
     debug("Successfully sent the large message.");
@@ -115,9 +111,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
     debug(`Partition ${partitionId} has last message with offset ${offset}.`);
     debug("Sending one message %O", obj);
-    breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
-      beginReceivingAt: EventPosition.fromOffset(offset)
-    });
+    breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
     const sender = client.createSender({ partitionId });
     await sender.send([obj]);
     debug("Successfully sent the large message.");
@@ -138,9 +132,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
     debug(`Partition ${partitionId} has last message with offset ${offset}.`);
     debug("Sending one message %O", obj);
-    breceiver = BatchingReceiver.create((client as any)._context, partitionId, {
-      beginReceivingAt: EventPosition.fromOffset(offset)
-    });
+    breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
     const sender = client.createSender({ partitionId });
     await sender.send([obj]);
     debug("Successfully sent the large message.");
@@ -159,6 +151,9 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       const partitionId = hubInfo.partitionIds[0];
       const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
       debug(`Partition ${partitionId} has last message with offset ${offset}.`);
+      breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
+      let data = await breceiver.receive(5, 10);
+      should.equal(data.length, 0, "Unexpected to receive message before client sends it");
       const messageCount = 5;
       const d: EventData[] = [];
       for (let i = 0; i < messageCount; i++) {
@@ -170,10 +165,8 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       await sender.send(d, { partitionKey: "pk1234656" });
       debug("Successfully sent 5 messages batched together.");
 
-      const receiver = client.createReceiver(partitionId, {
-        beginReceivingAt: EventPosition.fromOffset(offset)
-      });
-      const data = await receiver.receiveBatch(5, 30);
+      const receiver = client.createReceiver(partitionId, EventPosition.fromOffset(offset));
+      data = await receiver.receiveBatch(5, 30);
 
       debug("received message: ", data);
       should.exist(data);
@@ -192,6 +185,9 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       const partitionId = hubInfo.partitionIds[0];
       const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
       debug(`Partition ${partitionId} has last message with offset ${offset}.`);
+      breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
+      let data = await breceiver.receive(5, 10);
+      should.equal(data.length, 0, "Unexpected to receive message before client sends it");
       const messageCount = 5;
       const d: EventData[] = [];
       for (let i = 0; i < messageCount; i++) {
@@ -220,10 +216,8 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       await sender.send(d, { partitionKey: "pk1234656" });
       debug("Successfully sent 5 messages batched together.");
 
-      const receiver = client.createReceiver(partitionId, {
-        beginReceivingAt: EventPosition.fromOffset(offset)
-      });
-      const data = await receiver.receiveBatch(5, 30);
+      const receiver = client.createReceiver(partitionId, EventPosition.fromOffset(offset));
+      data = await receiver.receiveBatch(5, 30);
 
       debug("received message: ", data);
       should.exist(data);
@@ -261,9 +255,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     const partitionMap: any = {};
     let totalReceived = 0;
     for (const id of partitionIds) {
-      const receiver = client.createReceiver(id, {
-        beginReceivingAt: EventPosition.fromOffset(partitionOffsets[id])
-      });
+      const receiver = client.createReceiver(id, EventPosition.fromOffset(partitionOffsets[id]));
       const data = await receiver.receiveBatch(50, 10);
       debug(`Received ${data.length} messages from partition ${id}.`);
       for (const d of data) {

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -9,7 +9,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:misc-spec");
-import { EventPosition, EventHubClient, EventData, EventHubProperties, defaultConsumerGroup } from "../src";
+import { EventPosition, EventHubClient, EventData, EventHubProperties } from "../src";
 import { BatchingReceiver } from "../src/batchingReceiver";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 const env = getEnvVars();
@@ -49,7 +49,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     debug("Sending one message with %d bytes.", bodysize);
     breceiver = BatchingReceiver.create(
       (client as any)._context,
-      defaultConsumerGroup,
+      EventHubClient.defaultConsumerGroup,
       partitionId,
       EventPosition.fromOffset(offset)
     );
@@ -88,7 +88,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     debug("Sending one message %O", obj);
     breceiver = BatchingReceiver.create(
       (client as any)._context,
-      defaultConsumerGroup,
+      EventHubClient.defaultConsumerGroup,
       partitionId,
       EventPosition.fromOffset(offset)
     );
@@ -123,7 +123,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     debug("Sending one message %O", obj);
     breceiver = BatchingReceiver.create(
       (client as any)._context,
-      defaultConsumerGroup,
+      EventHubClient.defaultConsumerGroup,
       partitionId,
       EventPosition.fromOffset(offset)
     );
@@ -149,7 +149,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     debug("Sending one message %O", obj);
     breceiver = BatchingReceiver.create(
       (client as any)._context,
-      defaultConsumerGroup,
+      EventHubClient.defaultConsumerGroup,
       partitionId,
       EventPosition.fromOffset(offset)
     );
@@ -182,7 +182,11 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       await sender.send(d, { partitionKey: "pk1234656" });
       debug("Successfully sent 5 messages batched together.");
 
-      const receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromOffset(offset));
+      const receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromOffset(offset)
+      );
       const data = await receiver.receiveBatch(5, 30);
       await receiver.close();
       debug("received message: ", data);
@@ -230,7 +234,11 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       await sender.send(d, { partitionKey: "pk1234656" });
       debug("Successfully sent 5 messages batched together.");
 
-      const receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromOffset(offset));
+      const receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromOffset(offset)
+      );
       const data = await receiver.receiveBatch(5, 30);
       await receiver.close();
       debug("received message: ", data);
@@ -269,7 +277,11 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     const partitionMap: any = {};
     let totalReceived = 0;
     for (const id of partitionIds) {
-      const receiver = client.createReceiver(defaultConsumerGroup, id, EventPosition.fromOffset(partitionOffsets[id]));
+      const receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        id,
+        EventPosition.fromOffset(partitionOffsets[id])
+      );
       const data = await receiver.receiveBatch(50, 10);
       await receiver.close();
       debug(`Received ${data.length} messages from partition ${id}.`);

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -151,9 +151,6 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       const partitionId = hubInfo.partitionIds[0];
       const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
       debug(`Partition ${partitionId} has last message with offset ${offset}.`);
-      breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
-      let data = await breceiver.receive(5, 10);
-      should.equal(data.length, 0, "Unexpected to receive message before client sends it");
       const messageCount = 5;
       const d: EventData[] = [];
       for (let i = 0; i < messageCount; i++) {
@@ -185,7 +182,6 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       const partitionId = hubInfo.partitionIds[0];
       const offset = (await client.getPartitionInformation(partitionId)).lastEnqueuedOffset;
       debug(`Partition ${partitionId} has last message with offset ${offset}.`);
-      breceiver = BatchingReceiver.create((client as any)._context, partitionId, EventPosition.fromOffset(offset));
       let data = await breceiver.receive(5, 10);
       should.equal(data.length, 0, "Unexpected to receive message before client sends it");
       const messageCount = 5;

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -8,15 +8,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:receiver-spec");
-import {
-  EventPosition,
-  EventHubClient,
-  EventData,
-  MessagingError,
-  ReceivedEventData,
-  EventReceiver,
-  defaultConsumerGroup
-} from "../src";
+import { EventPosition, EventHubClient, EventData, MessagingError, ReceivedEventData, EventReceiver } from "../src";
 import { BatchingReceiver } from "../src/batchingReceiver";
 import { ReceiveHandler } from "../src/streamingReceiver";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
@@ -64,7 +56,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
 
   describe("with partitionId 0 as number", function(): void {
     it("should work for receiveBatch", async function(): Promise<void> {
-      receiver = client.createReceiver(defaultConsumerGroup, partitionIds[0], EventPosition.fromSequenceNumber(0));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionIds[0],
+        EventPosition.fromSequenceNumber(0)
+      );
       const result = await receiver.receiveBatch(10, 20);
       should.equal(true, Array.isArray(result));
     });
@@ -89,9 +85,14 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
             });
         }
       };
-      receiver = client.createReceiver(defaultConsumerGroup, partitionIds[0], EventPosition.fromOffset("0"), {
-        ownerLevel: 1
-      });
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionIds[0],
+        EventPosition.fromOffset("0"),
+        {
+          ownerLevel: 1
+        }
+      );
       rcvHandler = receiver.receive(onMsg, onError);
     });
   });
@@ -150,7 +151,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       await client.createSender({ partitionId: partitionId }).send([ed]);
       debug("Sent the new message after creating the receiver. We should only receive this message.");
       receiver = client.createReceiver(
-        defaultConsumerGroup,
+        EventHubClient.defaultConsumerGroup,
         partitionId,
         EventPosition.fromOffset(pInfo.lastEnqueuedOffset)
       );
@@ -186,7 +187,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       debug(`Creating new receiver with last enqueued offset: "${pInfo.lastEnqueuedOffset}".`);
       breceiver = BatchingReceiver.create(
         (client as any)._context,
-        defaultConsumerGroup,
+        EventHubClient.defaultConsumerGroup,
         partitionId,
         EventPosition.fromOffset(pInfo.lastEnqueuedOffset, true)
       );
@@ -219,7 +220,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       debug("Sent the new message after creating the receiver. We should only receive this message.");
 
       receiver = client.createReceiver(
-        defaultConsumerGroup,
+        EventHubClient.defaultConsumerGroup,
         partitionId,
         EventPosition.fromEnqueuedTime(pInfo.lastEnqueuedTimeUtc)
       );
@@ -247,7 +248,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       debug(`Creating new receiver with last enqueued sequence number: "${pInfo.lastEnqueuedSequenceNumber}".`);
       breceiver = BatchingReceiver.create(
         (client as any)._context,
-        defaultConsumerGroup,
+        EventHubClient.defaultConsumerGroup,
         partitionId,
         EventPosition.fromSequenceNumber(pInfo.lastEnqueuedSequenceNumber)
       );
@@ -286,7 +287,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       debug(`Creating new receiver with last sequence number: "${pInfo.lastEnqueuedSequenceNumber}".`);
       breceiver = BatchingReceiver.create(
         (client as any)._context,
-        defaultConsumerGroup,
+        EventHubClient.defaultConsumerGroup,
         partitionId,
         EventPosition.fromSequenceNumber(pInfo.lastEnqueuedSequenceNumber, true)
       );
@@ -313,7 +314,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       } finally {
         await sender.close();
       }
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       const received: ReceivedEventData[] = await new Promise((resolve, reject) => {
         let shouldStop = false;
@@ -345,7 +350,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         await new Promise((resolve, reject) => {
@@ -387,7 +396,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         await new Promise((resolve, reject) => {
@@ -424,7 +437,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
   describe("in batch mode #RunnableInBrowser", function(): void {
     it("should receive messages correctly", async function(): Promise<void> {
       const partitionId = partitionIds[0];
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.earliest());
+      receiver = client.createReceiver(EventHubClient.defaultConsumerGroup, partitionId, EventPosition.earliest());
       const data = await receiver.receiveBatch(5, 10);
       debug("received messages: ", data);
       data.length.should.equal(5, "Failed to receive five expected messages");
@@ -441,7 +454,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         // abortSignal event listeners will be triggered after synchronous paths are executed
@@ -465,7 +482,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         // abortSignal event listeners will be triggered after synchronous paths are executed
@@ -490,7 +511,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         // call receiveBatch once to establish a connection
@@ -516,7 +541,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         // abortSignal event listeners will be triggered after synchronous paths are executed
@@ -553,7 +582,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
       const eventIterator = receiver.getEventIterator();
 
       let messagesReceivedCount = 0;
@@ -580,7 +613,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         // abortSignal event listeners will be triggered after synchronous paths are executed
@@ -607,7 +644,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         await sender.close();
       }
 
-      receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+      receiver = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(time)
+      );
 
       try {
         // abortSignal event listeners will be triggered after synchronous paths are executed
@@ -649,7 +690,11 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         }
 
         const data: ReceivedEventData[] = [];
-        receiver = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.fromEnqueuedTime(time));
+        receiver = client.createReceiver(
+          EventHubClient.defaultConsumerGroup,
+          partitionId,
+          EventPosition.fromEnqueuedTime(time)
+        );
 
         // start with iterator
         for await (const event of receiver.getEventIterator()) {
@@ -746,9 +791,14 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       const onMsg = (data: ReceivedEventData) => {
         debug(">>>> ownerLevel Receiver 1", data);
       };
-      const receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-        ownerLevel: 2
-      });
+      const receiver1 = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.latest(),
+        {
+          ownerLevel: 2
+        }
+      );
       ownerLevelRcvr1 = receiver1.receive(onMsg, onError);
       debug("Created ownerLevel receiver 1 %s", ownerLevelRcvr1);
       setTimeout(() => {
@@ -773,9 +823,14 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         const onMsg2 = (data: ReceivedEventData) => {
           debug(">>>> ownerLevel Receiver 2", data);
         };
-        const receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-          ownerLevel: 1
-        });
+        const receiver2 = client.createReceiver(
+          EventHubClient.defaultConsumerGroup,
+          partitionId,
+          EventPosition.latest(),
+          {
+            ownerLevel: 1
+          }
+        );
         ownerLevelRcvr2 = receiver2.receive(onMsg2, onError2);
         debug("Created ownerLevel receiver 2 %s", ownerLevelRcvr2);
       }, 3000);
@@ -807,9 +862,14 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       const onMsg = (data: ReceivedEventData) => {
         debug(">>>> ownerLevel Receiver 1", data);
       };
-      const receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-        ownerLevel: 1
-      });
+      const receiver1 = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.latest(),
+        {
+          ownerLevel: 1
+        }
+      );
       ownerLevelRcvr1 = receiver1.receive(onMsg, onError);
       debug("Created ownerLevel receiver 1 %s", ownerLevelRcvr1);
       setTimeout(() => {
@@ -820,7 +880,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         const onMsg2 = (data: ReceivedEventData) => {
           debug(">>>> ownerLevel Receiver 2", data);
         };
-        receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
+        receiver2 = client.createReceiver(EventHubClient.defaultConsumerGroup, partitionId, EventPosition.latest(), {
           ownerLevel: 2
         });
         ownerLevelRcvr2 = receiver2.receive(onMsg2, onError2);
@@ -839,9 +899,14 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       const onmsg1 = (data: ReceivedEventData) => {
         debug(">>>> ownerLevel Receiver ", data);
       };
-      const receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-        ownerLevel: 1
-      });
+      const receiver1 = client.createReceiver(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.latest(),
+        {
+          ownerLevel: 1
+        }
+      );
       ownerLevelRcvr = receiver1.receive(onmsg1, onerr1);
       debug("Created ownerLevel receiver %s", ownerLevelRcvr);
       const onerr2 = (error: MessagingError | Error) => {
@@ -865,7 +930,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       const onmsg2 = (data: ReceivedEventData) => {
         debug(">>>> non ownerLevel Receiver", data);
       };
-      const receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest());
+      const receiver2 = client.createReceiver(EventHubClient.defaultConsumerGroup, partitionId, EventPosition.latest());
       nonownerLevelRcvr = receiver2.receive(onmsg2, onerr2);
       debug("Created non ownerLevel receiver %s", nonownerLevelRcvr);
     });
@@ -897,7 +962,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       const onmsg3 = (data: ReceivedEventData) => {
         debug(">>>> non ownerLevel Receiver", data);
       };
-      receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest());
+      receiver1 = client.createReceiver(EventHubClient.defaultConsumerGroup, partitionId, EventPosition.latest());
       nonownerLevelRcvr = receiver1.receive(onmsg3, onerr3);
       debug("Created non ownerLevel receiver %s", nonownerLevelRcvr);
       setTimeout(() => {
@@ -910,7 +975,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         const onmsg4 = (data: ReceivedEventData) => {
           debug(">>>> ownerLevel Receiver ", data);
         };
-        receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
+        receiver2 = client.createReceiver(EventHubClient.defaultConsumerGroup, partitionId, EventPosition.latest(), {
           ownerLevel: 1
         });
         ownerLevelRcvr = receiver2.receive(onmsg4, onerr4);
@@ -926,7 +991,9 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         it(`"${id}" should throw an error`, async function(): Promise<void> {
           try {
             debug("Created receiver and will be receiving messages from partition id ...", id);
-            const d = await client.createReceiver(defaultConsumerGroup, id, EventPosition.latest()).receiveBatch(10, 3);
+            const d = await client
+              .createReceiver(EventHubClient.defaultConsumerGroup, id, EventPosition.latest())
+              .receiveBatch(10, 3);
             debug("received messages ", d.length);
           } catch (err) {
             debug("Receiver received an error", err);
@@ -942,7 +1009,9 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         try {
           const id = " ";
           debug("Created receiver and will be receiving messages from partition id ...", id);
-          const d = await client.createReceiver(defaultConsumerGroup, id, EventPosition.latest()).receiveBatch(10, 3);
+          const d = await client
+            .createReceiver(EventHubClient.defaultConsumerGroup, id, EventPosition.latest())
+            .receiveBatch(10, 3);
           debug("received messages ", d.length);
         } catch (err) {
           debug("Receiver received an error", err);
@@ -955,7 +1024,9 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       invalidIds2.forEach(function(id: string): void {
         it(`"${id}" should throw an error`, async function(): Promise<void> {
           try {
-            await client.createReceiver(defaultConsumerGroup, id, EventPosition.latest()).receiveBatch(10, 3);
+            await client
+              .createReceiver(EventHubClient.defaultConsumerGroup, id, EventPosition.latest())
+              .receiveBatch(10, 3);
           } catch (err) {
             debug(`>>>> Received error - `, err);
             should.exist(err);
@@ -990,7 +1061,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
           debug(err);
         };
         const rcvHndlr = client
-          .createReceiver(defaultConsumerGroup, partitionId, eventPosition)
+          .createReceiver(EventHubClient.defaultConsumerGroup, partitionId, eventPosition)
           .receive(onMsg, onError);
         rcvHndlrs.push(rcvHndlr);
       }
@@ -1019,7 +1090,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
             });
         };
         const failedRcvHandler = client
-          .createReceiver(defaultConsumerGroup, partitionId, eventPosition)
+          .createReceiver(EventHubClient.defaultConsumerGroup, partitionId, eventPosition)
           .receive(onmsg2, onerr2);
         rcvHndlrs.push(failedRcvHandler);
       }, 5000);

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -133,11 +133,6 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       const partitionId = partitionIds[0];
       const pInfo = await client.getPartitionInformation(partitionId);
       debug(`Creating new receiver with last enqueued offset: "${pInfo.lastEnqueuedOffset}".`);
-      breceiver = BatchingReceiver.create(
-        (client as any)._context,
-        parseInt(partitionId),
-        EventPosition.fromOffset(pInfo.lastEnqueuedOffset)
-      );
       debug("Establishing the receiver link...");
       // send a new message. We should only receive this new message.
       const uid = uuid();
@@ -200,11 +195,6 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       const partitionId = partitionIds[0];
       const pInfo = await client.getPartitionInformation(partitionId);
       debug(`Creating new receiver with last enqueued time: "${pInfo.lastEnqueuedTimeUtc}".`);
-      breceiver = BatchingReceiver.create(
-        (client as any)._context,
-        partitionId,
-        EventPosition.fromEnqueuedTime(pInfo.lastEnqueuedTimeUtc)
-      );
       debug("Establishing the receiver link...");
 
       // send a new message. We should only receive this new message.
@@ -225,7 +215,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       data[0].properties!.stamp.should.equal(uid);
     });
 
-    it("'after the particular sequence number' should receive messages correctly #RunnableInBrowser", async function(): Promise<
+    it("'after the particular sequence number' should receive messages correctly", async function(): Promise<
       void
     > {
       const partitionId = partitionIds[0];

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -90,7 +90,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
         }
       };
       receiver = client.createReceiver(defaultConsumerGroup, partitionIds[0], EventPosition.fromOffset("0"), {
-        exclusiveReceiverPriority: 1
+        ownerLevel: 1
       });
       rcvHandler = receiver.receive(onMsg, onError);
     });
@@ -734,35 +734,35 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
   //   });
   // });
 
-  describe("with epoch", function(): void {
-    it("should behave correctly when a receiver with lower epoch value is connected after a receiver with higher epoch value to a partition in a consumer group", function(done: Mocha.Done): void {
+  describe("with ownerLevel", function(): void {
+    it("should behave correctly when a receiver with lower ownerLevel value is connected after a receiver with higher ownerLevel value to a partition in a consumer group", function(done: Mocha.Done): void {
       const partitionId = partitionIds[0];
-      let epochRcvr1: ReceiveHandler;
-      let epochRcvr2: ReceiveHandler;
+      let ownerLevelRcvr1: ReceiveHandler;
+      let ownerLevelRcvr2: ReceiveHandler;
       const onError = (error: MessagingError | Error) => {
-        debug(">>>> epoch Receiver 1", error);
-        throw new Error("An Error should not have happened for epoch receiver with epoch value 2.");
+        debug(">>>> ownerLevel Receiver 1", error);
+        throw new Error("An Error should not have happened for ownerLevel receiver with ownerLevel value 2.");
       };
       const onMsg = (data: ReceivedEventData) => {
-        debug(">>>> epoch Receiver 1", data);
+        debug(">>>> ownerLevel Receiver 1", data);
       };
       const receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-        exclusiveReceiverPriority: 2
+        ownerLevel: 2
       });
-      epochRcvr1 = receiver1.receive(onMsg, onError);
-      debug("Created epoch receiver 1 %s", epochRcvr1);
+      ownerLevelRcvr1 = receiver1.receive(onMsg, onError);
+      debug("Created ownerLevel receiver 1 %s", ownerLevelRcvr1);
       setTimeout(() => {
         const onError2 = (error: MessagingError | Error) => {
-          debug(">>>> epoch Receiver 2", error);
+          debug(">>>> ownerLevel Receiver 2", error);
           should.exist(error);
           should.equal(error.name, "ReceiverDisconnectedError");
-          epochRcvr2
+          ownerLevelRcvr2
             .stop()
             .then(() => receiver2.close())
-            .then(() => epochRcvr1.stop())
+            .then(() => ownerLevelRcvr1.stop())
             .then(() => receiver1.close())
             .then(() => {
-              debug("Successfully closed the epoch receivers 1 and 2.");
+              debug("Successfully closed the ownerLevel receivers 1 and 2.");
               done();
             })
             .catch(err => {
@@ -771,32 +771,32 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
             });
         };
         const onMsg2 = (data: ReceivedEventData) => {
-          debug(">>>> epoch Receiver 2", data);
+          debug(">>>> ownerLevel Receiver 2", data);
         };
         const receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-          exclusiveReceiverPriority: 1
+          ownerLevel: 1
         });
-        epochRcvr2 = receiver2.receive(onMsg2, onError2);
-        debug("Created epoch receiver 2 %s", epochRcvr2);
+        ownerLevelRcvr2 = receiver2.receive(onMsg2, onError2);
+        debug("Created ownerLevel receiver 2 %s", ownerLevelRcvr2);
       }, 3000);
     });
 
-    it("should behave correctly when a receiver with higher epoch value is connected after a receiver with lower epoch value to a partition in a consumer group", function(done: Mocha.Done): void {
+    it("should behave correctly when a receiver with higher ownerLevel value is connected after a receiver with lower ownerLevel value to a partition in a consumer group", function(done: Mocha.Done): void {
       const partitionId = partitionIds[0];
-      let epochRcvr1: ReceiveHandler;
-      let epochRcvr2: ReceiveHandler;
+      let ownerLevelRcvr1: ReceiveHandler;
+      let ownerLevelRcvr2: ReceiveHandler;
       let receiver2: EventReceiver;
       const onError = (error: MessagingError | Error) => {
-        debug(">>>> epoch Receiver 1", error);
+        debug(">>>> ownerLevel Receiver 1", error);
         should.exist(error);
         should.equal(error.name, "ReceiverDisconnectedError");
-        epochRcvr1
+        ownerLevelRcvr1
           .stop()
           .then(() => receiver1.close())
-          .then(() => epochRcvr2.stop())
+          .then(() => ownerLevelRcvr2.stop())
           .then(() => receiver2.close())
           .then(() => {
-            debug("Successfully closed the epoch receivers 1 and 2.");
+            debug("Successfully closed the ownerLevel receivers 1 and 2.");
             done();
           })
           .catch(err => {
@@ -805,56 +805,56 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
           });
       };
       const onMsg = (data: ReceivedEventData) => {
-        debug(">>>> epoch Receiver 1", data);
+        debug(">>>> ownerLevel Receiver 1", data);
       };
       const receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-        exclusiveReceiverPriority: 1
+        ownerLevel: 1
       });
-      epochRcvr1 = receiver1.receive(onMsg, onError);
-      debug("Created epoch receiver 1 %s", epochRcvr1);
+      ownerLevelRcvr1 = receiver1.receive(onMsg, onError);
+      debug("Created ownerLevel receiver 1 %s", ownerLevelRcvr1);
       setTimeout(() => {
         const onError2 = (error: MessagingError | Error) => {
-          debug(">>>> epoch Receiver 2", error);
-          throw new Error("An Error should not have happened for epoch receiver with epoch value 2.");
+          debug(">>>> ownerLevel Receiver 2", error);
+          throw new Error("An Error should not have happened for ownerLevel receiver with ownerLevel value 2.");
         };
         const onMsg2 = (data: ReceivedEventData) => {
-          debug(">>>> epoch Receiver 2", data);
+          debug(">>>> ownerLevel Receiver 2", data);
         };
-        const receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-          exclusiveReceiverPriority: 2
+        receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
+          ownerLevel: 2
         });
-        epochRcvr2 = receiver2.receive(onMsg2, onError2);
-        debug("Created epoch receiver 2 %s", epochRcvr2);
+        ownerLevelRcvr2 = receiver2.receive(onMsg2, onError2);
+        debug("Created ownerLevel receiver 2 %s", ownerLevelRcvr2);
       }, 3000);
     });
 
-    it("should behave correctly when a non epoch receiver is created after an epoch receiver", function(done: Mocha.Done): void {
+    it("should behave correctly when a non ownerLevel receiver is created after an ownerLevel receiver", function(done: Mocha.Done): void {
       const partitionId = partitionIds[0];
-      let epochRcvr: ReceiveHandler;
-      let nonEpochRcvr: ReceiveHandler;
+      let ownerLevelRcvr: ReceiveHandler;
+      let nonownerLevelRcvr: ReceiveHandler;
       const onerr1 = (error: MessagingError | Error) => {
-        debug(">>>> epoch Receiver ", error);
-        throw new Error("An Error should not have happened for epoch receiver with epoch value 1.");
+        debug(">>>> ownerLevel Receiver ", error);
+        throw new Error("An Error should not have happened for ownerLevel receiver with ownerLevel value 1.");
       };
       const onmsg1 = (data: ReceivedEventData) => {
-        debug(">>>> epoch Receiver ", data);
+        debug(">>>> ownerLevel Receiver ", data);
       };
       const receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-        exclusiveReceiverPriority: 1
+        ownerLevel: 1
       });
-      epochRcvr = receiver1.receive(onmsg1, onerr1);
-      debug("Created epoch receiver %s", epochRcvr);
+      ownerLevelRcvr = receiver1.receive(onmsg1, onerr1);
+      debug("Created ownerLevel receiver %s", ownerLevelRcvr);
       const onerr2 = (error: MessagingError | Error) => {
-        debug(">>>> non epoch Receiver", error);
+        debug(">>>> non ownerLevel Receiver", error);
         should.exist(error);
         should.equal(error.name, "ReceiverDisconnectedError");
-        nonEpochRcvr
+        nonownerLevelRcvr
           .stop()
           .then(() => receiver2.close())
-          .then(() => epochRcvr.stop())
+          .then(() => ownerLevelRcvr.stop())
           .then(() => receiver1.close())
           .then(() => {
-            debug("Successfully closed the nonEpoch and epoch receivers");
+            debug("Successfully closed the nonownerLevel and ownerLevel receivers");
             done();
           })
           .catch(err => {
@@ -863,30 +863,30 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
           });
       };
       const onmsg2 = (data: ReceivedEventData) => {
-        debug(">>>> non epoch Receiver", data);
+        debug(">>>> non ownerLevel Receiver", data);
       };
       const receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest());
-      nonEpochRcvr = receiver2.receive(onmsg2, onerr2);
-      debug("Created non epoch receiver %s", nonEpochRcvr);
+      nonownerLevelRcvr = receiver2.receive(onmsg2, onerr2);
+      debug("Created non ownerLevel receiver %s", nonownerLevelRcvr);
     });
 
-    it("should behave correctly when an epoch receiver is created after a non epoch receiver", function(done: Mocha.Done): void {
+    it("should behave correctly when an ownerLevel receiver is created after a non ownerLevel receiver", function(done: Mocha.Done): void {
       const partitionId = partitionIds[0];
-      let epochRcvr: ReceiveHandler;
-      let nonEpochRcvr: ReceiveHandler;
+      let ownerLevelRcvr: ReceiveHandler;
+      let nonownerLevelRcvr: ReceiveHandler;
       let receiver1: EventReceiver;
       let receiver2: EventReceiver;
       const onerr3 = (error: MessagingError | Error) => {
-        debug(">>>> non epoch Receiver", error);
+        debug(">>>> non ownerLevel Receiver", error);
         should.exist(error);
         should.equal(error.name, "ReceiverDisconnectedError");
-        nonEpochRcvr
+        nonownerLevelRcvr
           .stop()
           .then(() => receiver1.close())
-          .then(() => epochRcvr.stop())
+          .then(() => ownerLevelRcvr.stop())
           .then(() => receiver2.close())
           .then(() => {
-            debug("Successfully closed the nonEpoch and epoch receivers");
+            debug("Successfully closed the nonownerLevel and ownerLevel receivers");
             done();
           })
           .catch(err => {
@@ -895,24 +895,26 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
           });
       };
       const onmsg3 = (data: ReceivedEventData) => {
-        debug(">>>> non epoch Receiver", data);
+        debug(">>>> non ownerLevel Receiver", data);
       };
       receiver1 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest());
-      nonEpochRcvr = receiver1.receive(onmsg3, onerr3);
-      debug("Created non epoch receiver %s", nonEpochRcvr);
+      nonownerLevelRcvr = receiver1.receive(onmsg3, onerr3);
+      debug("Created non ownerLevel receiver %s", nonownerLevelRcvr);
       setTimeout(() => {
         const onerr4 = (error: MessagingError | Error) => {
-          debug(">>>> epoch Receiver ", error);
-          throw new Error("OnErr4 >> An Error should not have happened for epoch receiver with epoch value 1.");
+          debug(">>>> ownerLevel Receiver ", error);
+          throw new Error(
+            "OnErr4 >> An Error should not have happened for ownerLevel receiver with ownerLevel value 1."
+          );
         };
         const onmsg4 = (data: ReceivedEventData) => {
-          debug(">>>> epoch Receiver ", data);
+          debug(">>>> ownerLevel Receiver ", data);
         };
         receiver2 = client.createReceiver(defaultConsumerGroup, partitionId, EventPosition.latest(), {
-          exclusiveReceiverPriority: 1
+          ownerLevel: 1
         });
-        epochRcvr = receiver2.receive(onmsg4, onerr4);
-        debug("Created epoch receiver %s", epochRcvr);
+        ownerLevelRcvr = receiver2.receive(onmsg4, onerr4);
+        debug("Created ownerLevel receiver %s", ownerLevelRcvr);
       }, 3000);
     });
   });


### PR DESCRIPTION
This change makes `EventPosition` mandatory when creating a receiver.

Also renamed:
- `EventPosition.fromFirstAvailableEvent()` -> `EventPosition.earliest()`
- `EventPosition.fromNewEventsOnly()` -> `EventPosition.latest()`