### PR TITLE
[Event Hubs] fixes case where getEventIterator could return undefined events

### DIFF
--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -33,7 +33,7 @@ export interface EventIteratorOptions {
  * The Receiver class is an abstraction over the underlying AMQP receiver link.
  * @class Receiver
  */
-export class EventHubConsumer  {
+export class EventHubConsumer {
   /**
    * @property Describes the amqp connection context for the QueueClient.
    */
@@ -154,6 +154,9 @@ export class EventHubConsumer  {
     const maxWaitTimeInSeconds = 60;
     while (true) {
       const currentBatch = await this.receiveBatch(maxMessageCount, maxWaitTimeInSeconds, options.abortSignal);
+      if (!currentBatch || !currentBatch.length) {
+        continue;
+      }
       yield currentBatch[0];
     }
   }

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -602,6 +602,35 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
       data.length.should.equal(messageCount, `Failed to receive ${messageCount} expected messages`);
     });
 
+    it("should not return undefined if no messages are found", async function(): Promise<void> {
+      const partitionId = partitionIds[0];
+
+      receiver = client.createConsumer(
+        EventHubClient.defaultConsumerGroup,
+        partitionId,
+        EventPosition.fromEnqueuedTime(Date.now())
+      );
+      const eventIterator = receiver.getEventIterator({
+        // behind the scenes, eventIterator will wait up to 60 seconds before returning.
+        // set timeout to 70 seconds to give the iterator a chance to yield a value.
+        abortSignal: AbortController.timeout(70000)
+      });
+
+      const data: ReceivedEventData[] = [];
+      try {
+        for await (const event of eventIterator) {
+          data.push(event);
+          break;
+        }
+        // no events should have been received, so fail quickly if one was
+        throw new Error(`Test failure`);
+      } catch (err) {
+        data.length.should.equal(0);
+        err.name.should.equal("AbortError");
+        err.message.should.equal("The receive operation has been cancelled by the user.");
+      }
+    });
+
     it("should support being cancelled", async function(): Promise<void> {
       const partitionId = partitionIds[0];
       const time = Date.now();


### PR DESCRIPTION
Fixes #3942 

Updates `getEventIterator` to check the length of the array returned from `receiveBatch` before yielding an event.