### PR TITLE
[Identity] Rename some classes for cross-language consistency

### DIFF
--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -3,7 +3,7 @@
 
 import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
 
-export class AggregateCredential implements TokenCredential {
+export class ChainedTokenCredential implements TokenCredential {
   private _sources: TokenCredential[] = [];
 
   constructor(...sources: TokenCredential[]) {

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { IdentityClientOptions } from "../client/identityClient";
-import { AggregateCredential } from "./aggregateCredential";
+import { ChainedTokenCredential } from "./chainedTokenCredential";
 import { EnvironmentCredential } from "./environmentCredential";
 import { ManagedIdentityCredential } from "./managedIdentityCredential";
 
-export class SystemCredential extends AggregateCredential {
+export class DefaultAzureCredential extends ChainedTokenCredential {
   constructor(identityClientOptions?: IdentityClientOptions) {
     super(
       new EnvironmentCredential(identityClientOptions),

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -4,7 +4,7 @@
 import { TokenCredential } from "@azure/core-http";
 import { SystemCredential } from "./credentials/systemCredential";
 
-export { AggregateCredential } from "./credentials/aggregateCredential";
+export { ChainedTokenCredential } from "./credentials/chainedTokenCredential";
 export { IdentityClientOptions } from "./client/identityClient";
 export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { TokenCredential } from "@azure/core-http";
-import { SystemCredential } from "./credentials/systemCredential";
+import { DefaultAzureCredential } from "./credentials/defaultAzureCredential";
 
 export { ChainedTokenCredential } from "./credentials/chainedTokenCredential";
 export { IdentityClientOptions } from "./client/identityClient";
@@ -10,10 +10,10 @@ export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { ManagedIdentityCredential } from "./credentials/managedIdentityCredential";
-export { SystemCredential } from "./credentials/systemCredential";
+export { DefaultAzureCredential } from "./credentials/defaultAzureCredential";
 
 export { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 
 export function getDefaultAzureCredential(): TokenCredential {
-  return new SystemCredential();
+  return new DefaultAzureCredential();
 }


### PR DESCRIPTION
This change renames the following two classes in `@azure/identity`:

- `AggregateCredential` -> `ChainedTokenCredential`
- `SystemCredential` -> `DefaultAzureCredential`

The Azure.Identity v-team decided to rename these to be clearer and consistent across language implementations.