### PR TITLE
Update pnpm-lock

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4,7 +4,7 @@ dependencies:
   '@azure/event-hubs': 1.0.8
   '@azure/logger-js': 1.1.0
   '@azure/ms-rest-azure-js': 1.3.8
-  '@azure/ms-rest-js': 1.8.12
+  '@azure/ms-rest-js': 1.8.13
   '@azure/ms-rest-nodeauth': 0.9.3
   '@microsoft/api-extractor': 7.2.1
   '@rush-temp/abort-controller': 'file:projects/abort-controller.tgz'
@@ -51,9 +51,9 @@ dependencies:
   '@types/sinon': 5.0.7
   '@types/tough-cookie': 2.3.5
   '@types/tunnel': 0.0.0
-  '@types/underscore': 1.8.19
+  '@types/underscore': 1.9.0
   '@types/uuid': 3.4.4
-  '@types/webpack': 4.4.32
+  '@types/webpack': 4.4.33
   '@types/webpack-dev-middleware': 2.0.2
   '@types/ws': 6.0.1
   '@types/xml2js': 0.4.4
@@ -87,7 +87,7 @@ dependencies:
   events: 3.0.0
   execa: 1.0.0
   express: 4.17.1
-  form-data: 2.3.3
+  form-data: 2.4.0
   fs-extra: 8.0.1
   glob: 7.1.4
   gulp: 4.0.2
@@ -249,7 +249,7 @@ packages:
   /@azure/arm-servicebus/0.1.0:
     dependencies:
       '@azure/ms-rest-azure-js': 1.3.8
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       tslib: 1.10.0
     dev: false
     resolution:
@@ -280,16 +280,16 @@ packages:
       integrity: sha512-l7z0DPCi2Hp88w12JhDTtx5d0Y3+vhfE7JKJb9O7sEz71Cwp053N8piTtTnnk/tUor9oZHgEKi/p3tQQmLPjvA==
   /@azure/ms-rest-azure-js/1.3.8:
     dependencies:
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       tslib: 1.10.0
     dev: false
     resolution:
       integrity: sha512-AHLfDTCyIH6wBK6+CpImI6sc9mLZ17ZgUrTx3Rhwv+3Mb3Z73BxormkarfR6Stb6scrBYitxJ27FXyndXlGAYg==
-  /@azure/ms-rest-js/1.8.12:
+  /@azure/ms-rest-js/1.8.13:
     dependencies:
       '@types/tunnel': 0.0.0
       axios: 0.19.0
-      form-data: 2.3.3
+      form-data: 2.4.0
       tough-cookie: 2.5.0
       tslib: 1.10.0
       tunnel: 0.0.6
@@ -297,11 +297,11 @@ packages:
       xml2js: 0.4.19
     dev: false
     resolution:
-      integrity: sha512-1jHF1jHDXHKgdql+3uEh7798WXap3J9CefltYvH6iRypua4tu1C6mN1LFkaSUY/+OtOvkzTZkL83cxAfQPP8QA==
+      integrity: sha512-jAa6Y2XrvwbEqkaEXDHK+ReNo0WnCPS+LgQ1dRAJUUNxK4CghF5u+SXsVtPENritilVE7FVteqsLOtlhTk+haA==
   /@azure/ms-rest-nodeauth/0.9.3:
     dependencies:
       '@azure/ms-rest-azure-env': 1.1.2
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       adal-node: 0.1.28
     dev: false
     resolution:
@@ -445,18 +445,18 @@ packages:
   /@sinonjs/formatio/3.2.1:
     dependencies:
       '@sinonjs/commons': 1.4.0
-      '@sinonjs/samsam': 3.3.1
+      '@sinonjs/samsam': 3.3.2
     dev: false
     resolution:
       integrity: sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
-  /@sinonjs/samsam/3.3.1:
+  /@sinonjs/samsam/3.3.2:
     dependencies:
       '@sinonjs/commons': 1.4.0
       array-from: 2.1.1
       lodash: 4.17.11
     dev: false
     resolution:
-      integrity: sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==
+      integrity: sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==
   /@sinonjs/text-encoding/0.7.1:
     dev: false
     resolution:
@@ -707,10 +707,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
-  /@types/underscore/1.8.19:
+  /@types/underscore/1.9.0:
     dev: false
     resolution:
-      integrity: sha512-9r6zM91/lTnSYTEJbxf7FwgeVXzRZDegaGPXF+Bp0MSMYTTI2UvQPkoti/YE9ZWThU+0DMya6l9XePvOPBLKow==
+      integrity: sha512-1koEJ2AhXaR0HVP3VlN0pCb51n87g5QL9rUiGaY+Nte9gBd2FYf/zNvS5ZtHg7o6owYNS6QA/4ZJ/mIiz2q1hA==
   /@types/uuid/3.4.4:
     dependencies:
       '@types/node': 8.10.49
@@ -722,11 +722,11 @@ packages:
       '@types/connect': 3.4.32
       '@types/loglevel': 1.5.4
       '@types/memory-fs': 0.3.2
-      '@types/webpack': 4.4.32
+      '@types/webpack': 4.4.33
     dev: false
     resolution:
       integrity: sha512-uZ1avIbAcnspcDKKm0WfgIdvBYRqUapPmwb0MYGzzB74q2F3T4Xi+qPSoS0Oq5iQvIMVxOm7KMqHQJii4VDCsw==
-  /@types/webpack/4.4.32:
+  /@types/webpack/4.4.33:
     dependencies:
       '@types/anymatch': 1.3.1
       '@types/node': 8.10.49
@@ -735,7 +735,7 @@ packages:
       source-map: 0.6.1
     dev: false
     resolution:
-      integrity: sha512-mNARoaSJTzbiHxtZbf9NULFilu2frqD+g9Iyl9V2jPYJWXi+AC3Hz8lQWPZ5LLtgUm7iF4SDDMB/1bPrbRQgFw==
+      integrity: sha512-MU5Lokm30QHF9Wn0+yq/hnToPlEBRQVa72mgn1/W8OpJu63aRDKy0aEdMI+pCk8F6zwQJfSFaVzx1JN1MLXx8A==
   /@types/ws/6.0.1:
     dependencies:
       '@types/events': 3.0.0
@@ -2269,8 +2269,8 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30000974
-      electron-to-chromium: 1.3.159
+      caniuse-lite: 1.0.30000975
+      electron-to-chromium: 1.3.165
     dev: false
     hasBin: true
     resolution:
@@ -2353,7 +2353,7 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
-  /cacache/11.3.2:
+  /cacache/11.3.3:
     dependencies:
       bluebird: 3.5.5
       chownr: 1.1.1
@@ -2371,7 +2371,7 @@ packages:
       y18n: 4.0.0
     dev: false
     resolution:
-      integrity: sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==
+      integrity: sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==
   /cache-base/1.0.1:
     dependencies:
       collection-visit: 1.0.0
@@ -2458,10 +2458,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /caniuse-lite/1.0.30000974:
+  /caniuse-lite/1.0.30000975:
     dev: false
     resolution:
-      integrity: sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
+      integrity: sha512-ZsXA9YWQX6ATu5MNg+Vx/cMQ+hM6vBBSqDeJs8ruk9z0ky4yIHML15MoxcFt088ST2uyjgqyUGRJButkptWf0w==
   /caseless/0.12.0:
     dev: false
     resolution:
@@ -2915,6 +2915,7 @@ packages:
       integrity: sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==
   /core-js/2.6.9:
     dev: false
+    requiresBuild: true
     resolution:
       integrity: sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
   /core-util-is/1.0.2:
@@ -3367,10 +3368,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.159:
+  /electron-to-chromium/1.3.165:
     dev: false
     resolution:
-      integrity: sha512-bhiEr8/A97GUBcUzNb9MFNhzQOjakbKmEKBEAa6UMY45zG2e8PM63LOgAPXEJE9bQiaQH6nOdYiYf8X821tZjQ==
+      integrity: sha512-iIS8axR524EAnvUtWUNnREnYjQrS0zUvutIKYgTVuN3MzcjrV31EuJYKw7DGOtFO9DQw+JiXeaVDPQWMskG1wQ==
   /elliptic/6.4.1:
     dependencies:
       bn.js: 4.11.8
@@ -3689,7 +3690,7 @@ packages:
       semver: 5.7.0
       strip-ansi: 4.0.0
       strip-json-comments: 2.0.1
-      table: 5.4.0
+      table: 5.4.1
       text-table: 0.2.0
     dev: false
     engines:
@@ -4208,6 +4209,16 @@ packages:
       node: '>= 0.12'
     resolution:
       integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  /form-data/2.4.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.24
+    dev: false
+    engines:
+      node: '>= 0.12'
+    resolution:
+      integrity: sha512-4FinE8RfqYnNim20xDwZZE0V2kOs/AuElIjFUbPuegQSaoZM+vUT5FnwSl10KPugH4voTg1bEQlcbCG9ka75TA==
   /forwarded/0.1.2:
     dev: false
     engines:
@@ -6593,6 +6604,7 @@ packages:
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
+    deprecated: 'Critical bug fixed in v2.0.1, please upgrade to the latest version.'
     dev: false
     engines:
       node: '>=0.10.0'
@@ -8541,6 +8553,7 @@ packages:
       is-extendable: 0.1.1
       is-plain-object: 2.0.4
       to-object-path: 0.3.0
+    deprecated: 'Critical bug fixed in v3.0.1, please upgrade to the latest version.'
     dev: false
     engines:
       node: '>=0.10.0'
@@ -8552,6 +8565,7 @@ packages:
       is-extendable: 0.1.1
       is-plain-object: 2.0.4
       split-string: 3.1.0
+    deprecated: 'Critical bug fixed in v3.0.1, please upgrade to the latest version.'
     dev: false
     engines:
       node: '>=0.10.0'
@@ -8638,7 +8652,7 @@ packages:
     dependencies:
       '@sinonjs/commons': 1.4.0
       '@sinonjs/formatio': 3.2.1
-      '@sinonjs/samsam': 3.3.1
+      '@sinonjs/samsam': 3.3.2
       diff: 3.5.0
       lolex: 4.1.0
       nise: 1.5.0
@@ -9138,7 +9152,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=
-  /table/5.4.0:
+  /table/5.4.1:
     dependencies:
       ajv: 6.10.0
       lodash: 4.17.11
@@ -9148,7 +9162,7 @@ packages:
     engines:
       node: '>=6.0.0'
     resolution:
-      integrity: sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==
+      integrity: sha512-E6CK1/pZe2N75rGZQotFOdmzWQ1AILtgYbMAbAjvms0S1l5IDB47zG3nCnFGB/w+7nB3vKofbLXCH7HPBo864w==
   /tapable/1.1.3:
     dev: false
     engines:
@@ -9176,7 +9190,7 @@ packages:
       integrity: sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=
   /terser-webpack-plugin/1.3.0:
     dependencies:
-      cacache: 11.3.2
+      cacache: 11.3.3
       find-cache-dir: 2.1.0
       is-wsl: 1.1.0
       loader-utils: 1.2.3
@@ -9475,10 +9489,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
-  /tslib/1.9.3:
-    dev: false
-    resolution:
-      integrity: sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
   /tslint-config-prettier/1.18.0:
     dev: false
     engines:
@@ -9510,29 +9520,6 @@ packages:
       typescript: ^2.2.0 || ^3.0.0
     resolution:
       integrity: sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==
-  /tslint/5.16.0_typescript@3.4.5:
-    dependencies:
-      '@babel/code-frame': 7.0.0
-      builtin-modules: 1.1.1
-      chalk: 2.4.2
-      commander: 2.20.0
-      diff: 3.5.0
-      glob: 7.1.4
-      js-yaml: 3.13.1
-      minimatch: 3.0.4
-      mkdirp: 0.5.1
-      resolve: 1.11.0
-      semver: 5.7.0
-      tslib: 1.9.3
-      tsutils: 2.29.0_typescript@3.4.5
-    dev: false
-    engines:
-      node: '>=4.8.0'
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
-    resolution:
-      integrity: sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==
   /tslint/5.17.0:
     dependencies:
       '@babel/code-frame': 7.0.0
@@ -9583,15 +9570,6 @@ packages:
   /tsutils/2.29.0:
     dependencies:
       tslib: 1.10.0
-    dev: false
-    peerDependencies:
-      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
-    resolution:
-      integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  /tsutils/2.29.0_typescript@3.4.5:
-    dependencies:
-      tslib: 1.9.3
-      typescript: 3.4.5
     dev: false
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
@@ -10498,7 +10476,6 @@ packages:
       integrity: sha1-T6akXQDbwV8xikr6HZr8Aljhdsw=
   'file:projects/abort-controller.tgz':
     dependencies:
-      '@azure/ms-rest-js': 1.8.12
       '@microsoft/api-extractor': 7.2.1
       '@types/mocha': 5.2.7
       '@types/node': 8.10.49
@@ -10605,7 +10582,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-7OByRlQjTk5hFwjj4qXLiAvEVNwJhwbUO97jTcEC1N2Bl2TT3puk7ep0gPCHGxnpa5DGsV4B+AW0q69H/thwjw==
+      integrity: sha512-f8B3dXjSZfHnofgu6xYSg8pEblPbSHB0MUM2ZhhOQXd6oDmaYxY7qm0Hb3abDIvzZ/if/9983vERMSDfCTIdig==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -10623,7 +10600,7 @@ packages:
       '@types/tough-cookie': 2.3.5
       '@types/tunnel': 0.0.0
       '@types/uuid': 3.4.4
-      '@types/webpack': 4.4.32
+      '@types/webpack': 4.4.33
       '@types/webpack-dev-middleware': 2.0.2
       '@types/xml2js': 0.4.4
       abortcontroller-polyfill: 1.3.0
@@ -10631,7 +10608,7 @@ packages:
       axios-mock-adapter: 1.16.0_axios@0.19.0
       chai: 4.2.0
       express: 4.17.1
-      form-data: 2.3.3
+      form-data: 2.4.0
       glob: 7.1.4
       karma: 4.1.0
       karma-chai: 0.1.0_chai@4.2.0+karma@4.1.0
@@ -10711,7 +10688,7 @@ packages:
       '@types/semaphore': 1.1.0
       '@types/sinon': 5.0.7
       '@types/tunnel': 0.0.0
-      '@types/underscore': 1.8.19
+      '@types/underscore': 1.9.0
       binary-search-bounds: 2.0.3
       create-hmac: 1.1.7
       execa: 1.0.0
@@ -10913,9 +10890,7 @@ packages:
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
     dependencies:
-      '@azure/ms-rest-azure-js': 1.3.8
-      '@azure/ms-rest-js': 1.8.12
-      '@azure/ms-rest-nodeauth': 0.9.3
+      '@microsoft/api-extractor': 7.2.1
       '@types/chai': 4.1.7
       chai: 4.2.0
       prettier: 1.18.2
@@ -10926,23 +10901,28 @@ packages:
       tslib: 1.10.0
       typescript: 3.5.2
       uglify-js: 3.6.0
+      url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-Vm5I+1u3FxVrKqYbUCh1kRAlSqTQjWJpHVLvG9+s4GldJ/PwDUO+Z1qKzLFkjSfVpI4qEGIFytm61gXnhtK4aA==
+      integrity: sha512-CbBoSMACt2Iv4WzEAIwVR0BD2KWRN6N/uYlmFQWsQGZ2tUJf5yJIBbWKCkjWlqjbo8WHkN0i+HGv77kFIiFC5g==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
     dependencies:
-      '@azure/ms-rest-azure-js': 1.3.8
-      '@azure/ms-rest-js': 1.8.12
-      '@azure/ms-rest-nodeauth': 0.9.3
       '@microsoft/api-extractor': 7.2.1
       '@types/chai': 4.1.7
+      '@types/dotenv': 6.1.1
+      '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
+      '@types/nock': 10.0.3
       chai: 4.2.0
+      dotenv: 7.0.0
+      fs-extra: 8.0.1
       mocha: 5.2.0
+      nock: 10.0.6
       prettier: 1.18.2
+      query-string: 6.7.0
       rimraf: 2.6.3
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
@@ -10951,21 +10931,28 @@ packages:
       tslib: 1.10.0
       typescript: 3.5.2
       uglify-js: 3.6.0
+      url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-FJGpJcyErvKa0HwAIGLRJqwM72F7dLzZax9gmeVa1q2KreuWz6FcuYquYztqw9R1Ei+fs2xPCBGuqyzVN1SjYA==
+      integrity: sha512-K6c3KsPD2e9c2hXDDiXlE6RDQmwgjDfS9Xw9T6eZqcn5/1iQhzcv7KuqAX3xCRHExkHs1M8z2Ok60yv6TPNW5Q==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
     dependencies:
       '@azure/ms-rest-azure-js': 1.3.8
-      '@azure/ms-rest-js': 1.8.12
-      '@azure/ms-rest-nodeauth': 0.9.3
+      '@azure/ms-rest-js': 1.8.13
+      '@microsoft/api-extractor': 7.2.1
       '@types/chai': 4.1.7
+      '@types/dotenv': 6.1.1
+      '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
+      '@types/nock': 10.0.3
       chai: 4.2.0
+      dotenv: 7.0.0
+      fs-extra: 8.0.1
       mocha: 5.2.0
+      nock: 10.0.6
       prettier: 1.18.2
       rimraf: 2.6.3
       rollup: 1.13.1
@@ -10975,10 +10962,11 @@ packages:
       tslib: 1.10.0
       typescript: 3.5.2
       uglify-js: 3.6.0
+      url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-77kt1Ub5AYhrWBAGkhBeosJnRdEIpstTowJyOdLzNA8e0XFYSF0qwWGaRCzOnIlUKxiH+NNJqzjAg8/Jvhjztw==
+      integrity: sha512-H4UES51GjlOFEUkUn2EBlDqZl0Rrri6FyLAuj2xSXCoaymc/XYHx5KI/aoLn1uBdGxtKd2dbkRb7GIDvd+3pMQ==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -11051,7 +11039,6 @@ packages:
       rollup-plugin-terser: 4.0.4_rollup@1.13.1
       ts-node: 7.0.1
       tslib: 1.10.0
-      tslint: 5.16.0_typescript@3.4.5
       typescript: 3.5.2
       ws: 6.2.1
     dev: false
@@ -11062,10 +11049,13 @@ packages:
     version: 0.0.0
   'file:projects/storage-blob.tgz':
     dependencies:
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       '@microsoft/api-extractor': 7.2.1
       '@types/dotenv': 6.1.1
+      '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
+      '@types/nise': 1.4.0
+      '@types/nock': 10.0.3
       '@types/node': 8.10.49
       '@typescript-eslint/eslint-plugin': 1.9.0_eslint@5.16.0+typescript@3.5.2
       '@typescript-eslint/parser': 1.10.2_eslint@5.16.0+typescript@3.5.2
@@ -11080,6 +11070,7 @@ packages:
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.1.1
       events: 3.0.0
+      fs-extra: 8.0.1
       gulp: 4.0.2
       gulp-zip: 4.2.0
       inherits: 2.0.3
@@ -11090,6 +11081,8 @@ packages:
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.1.0
       karma-ie-launcher: 1.0.0_karma@4.1.0
+      karma-json-preprocessor: 0.3.3_karma@4.1.0
+      karma-json-to-file-reporter: 1.0.1
       karma-junit-reporter: 1.2.0_karma@4.1.0
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.1.0
@@ -11097,9 +11090,12 @@ packages:
       mocha: 5.2.0
       mocha-junit-reporter: 1.23.0_mocha@5.2.0
       mocha-multi: 1.1.0_mocha@5.2.0
+      nise: 1.5.0
+      nock: 10.0.6
       nyc: 14.1.1
       prettier: 1.18.2
       puppeteer: 1.17.0
+      query-string: 6.7.0
       rimraf: 2.6.3
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
@@ -11118,13 +11114,13 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-74jrCV32FOjHWyvWm8sM7avyWwc2mL6Z9ia/aYNJfRX7nQdCDi3LT0LPjb/ucyg86MFAuvxEvLTLhgFaISziBA==
+      integrity: sha512-WJdFCSQL+1tIPJnfmMLYBeFwavPo2h0FFLippjNnrUfa8Fto2EUNjdhHEdZCcvv06rhrqIpZdeHS/oU+JEx2Zw==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-datalake.tgz':
     dependencies:
       '@azure/ms-rest-azure-js': 1.3.8
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       '@typescript-eslint/eslint-plugin': 1.9.0_eslint@5.16.0+typescript@3.5.2
       '@typescript-eslint/parser': 1.10.2_eslint@5.16.0+typescript@3.5.2
       eslint: 5.16.0
@@ -11148,10 +11144,13 @@ packages:
     version: 0.0.0
   'file:projects/storage-file.tgz':
     dependencies:
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       '@microsoft/api-extractor': 7.2.1
       '@types/dotenv': 6.1.1
+      '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
+      '@types/nise': 1.4.0
+      '@types/nock': 10.0.3
       '@types/node': 8.10.49
       '@typescript-eslint/eslint-plugin': 1.9.0_eslint@5.16.0+typescript@3.5.2
       '@typescript-eslint/parser': 1.10.2_eslint@5.16.0+typescript@3.5.2
@@ -11166,6 +11165,7 @@ packages:
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.1.1
       events: 3.0.0
+      fs-extra: 8.0.1
       gulp: 4.0.2
       gulp-zip: 4.2.0
       inherits: 2.0.3
@@ -11176,6 +11176,8 @@ packages:
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.1.0
       karma-ie-launcher: 1.0.0_karma@4.1.0
+      karma-json-preprocessor: 0.3.3_karma@4.1.0
+      karma-json-to-file-reporter: 1.0.1
       karma-junit-reporter: 1.2.0_karma@4.1.0
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.1.0
@@ -11183,9 +11185,12 @@ packages:
       mocha: 5.2.0
       mocha-junit-reporter: 1.23.0_mocha@5.2.0
       mocha-multi: 1.1.0_mocha@5.2.0
+      nise: 1.5.0
+      nock: 10.0.6
       nyc: 14.1.1
       prettier: 1.18.2
       puppeteer: 1.17.0
+      query-string: 6.7.0
       rimraf: 2.6.3
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
@@ -11204,12 +11209,12 @@ packages:
     dev: false
     name: '@rush-temp/storage-file'
     resolution:
-      integrity: sha512-c9iKC3raf9srYiAHW9rwhNdBt6z7jJvRzg1ESMsDtDFUanvwwwUybmLRbCaY4ByIdUMkneJAJBM5OAcVWEJLgQ==
+      integrity: sha512-INgQrtnGxnwj3+CZgCMZys3Hi44dK5xFD9N9ccwRh6LgqNyA1ySNOB/7W9lFXSVsWijaEh7wVOk1Y7hArxa0uQ==
       tarball: 'file:projects/storage-file.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
     dependencies:
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       '@microsoft/api-extractor': 7.2.1
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 7.0.0
@@ -11278,7 +11283,7 @@ packages:
     version: 0.0.0
   'file:projects/template.tgz':
     dependencies:
-      '@azure/ms-rest-js': 1.8.12
+      '@azure/ms-rest-js': 1.8.13
       '@microsoft/api-extractor': 7.2.1
       '@types/mocha': 5.2.7
       '@types/node': 8.10.49
@@ -11342,7 +11347,6 @@ packages:
       integrity: sha512-c3cFI0Our99carkgcyOFLmX5QRh5fIqyVv9S75VRX7woNtBGXPvWRE8VOxEN9o8N8FjSEQzc6PPEO6YRz7ok8Q==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
   '@azure/amqp-common': ^1.0.0-preview.5
   '@azure/arm-servicebus': ^0.1.0


### PR DESCRIPTION
This PR updates `pnpm-lock.yaml` to the latest matching versions of all packages.  Eventually this should be run automatically on a regular schedule (say nightly), but I want to update it now to minimize the diff when upgrading a package (like `rollup-plugin-node-resolve`).

This PR was generated with the following commands:

```
del common\config\rush\pnpm-lock.yaml
rush update
```