### PR TITLE
[Event Hubs] JSDoc updates

### DIFF
--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -31,8 +31,9 @@ export { delay }
 // @public
 export interface EventData {
     body: any;
-    // Warning: (ae-forgotten-export) The symbol "Properties" needs to be exported by the entry point index.d.ts
-    properties?: Properties;
+    properties?: {
+        [key: string]: any;
+    };
 }
 
 // @public
@@ -151,7 +152,9 @@ export interface ReceivedEventData {
     enqueuedTimeUtc: Date;
     offset: string;
     partitionKey: string | null;
-    properties?: Properties;
+    properties?: {
+        [key: string]: any;
+    };
     sequenceNumber: number;
 }
 

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -31,9 +31,8 @@ export { delay }
 // @public
 export interface EventData {
     body: any;
-    properties?: {
-        [key: string]: any;
-    };
+    // Warning: (ae-forgotten-export) The symbol "Properties" needs to be exported by the entry point index.d.ts
+    properties?: Properties;
 }
 
 // @public
@@ -152,9 +151,7 @@ export interface ReceivedEventData {
     enqueuedTimeUtc: Date;
     offset: string;
     partitionKey: string | null;
-    properties?: {
-        [key: string]: any;
-    };
+    properties?: Properties;
     sequenceNumber: number;
 }
 

--- a/sdk/eventhub/event-hubs/src/batchingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/batchingReceiver.ts
@@ -28,7 +28,7 @@ import { EventPosition } from "./eventPosition";
  */
 export class BatchingReceiver extends EventHubReceiver {
   /**
-   * @property {boolean} isReceivingMessages Indicates whether the link is actively receiving
+   * @property isReceivingMessages Indicates whether the link is actively receiving
    * messages. Default: false.
    */
   isReceivingMessages: boolean = false;
@@ -36,11 +36,11 @@ export class BatchingReceiver extends EventHubReceiver {
    * Instantiate a new receiver from the AMQP `Receiver`. Used by `EventHubClient`.
    * @ignore
    * @constructor
-   * @param {ConnectionContext} context                        The connection context.
-   * @param {string} consumerGroup The consumer group from which the receiver should receive events from.
-   * @param {string} partitionId                               Partition ID from which to receive.
-   * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
-   * @param {EventHubConsumerOptions} [options]                         Options for how you'd like to connect.
+   * @param context                        The connection context.
+   * @param consumerGroup The consumer group from which the receiver should receive events from.
+   * @param partitionId                               Partition ID from which to receive.
+   * @param eventPosition The event position in the partition at which to start receiving messages.
+   * @param [options]                         Options for how you'd like to connect.
    */
   constructor(
     context: ConnectionContext,
@@ -57,12 +57,12 @@ export class BatchingReceiver extends EventHubReceiver {
    * a given max wait time in seconds, whichever happens first. This method can be used directly
    * after creating the receiver object.
    * @ignore
-   * @param {number} maxMessageCount The maximum message count. Must be a value greater than 0.
-   * @param {number} [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver
+   * @param maxMessageCount The maximum message count. Must be a value greater than 0.
+   * @param [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver
    * should wait to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
-   * @param {RetryOptions} [retryOptions] Retry options for the receive operation
-   * @param {AbortSignalLike} abortSignal Signal to cancel current operation.
-   * @returns {Promise<ReceivedEventData[]>} A promise that resolves with an array of ReceivedEventData objects.
+   * @param [retryOptions] Retry options for the receive operation
+   * @param abortSignal Signal to cancel current operation.
+   * @returns A promise that resolves with an array of ReceivedEventData objects.
    */
   receive(
     maxMessageCount: number,
@@ -373,11 +373,11 @@ export class BatchingReceiver extends EventHubReceiver {
    * Creates a batching receiver.
    * @static
    * @ignore
-   * @param {ConnectionContext} context    The connection context.
-   * @param {string} consumerGroup  The consumer group from which the receiver should receive events from.
-   * @param {string} partitionId  The partitionId to receive events from.
-   * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
-   * @param {EventHubConsumerOptions} [options]     Receive options.
+   * @param context    The connection context.
+   * @param consumerGroup  The consumer group from which the receiver should receive events from.
+   * @param partitionId  The partitionId to receive events from.
+   * @param eventPosition The event position in the partition at which to start receiving messages.
+   * @param [options]     Receive options.
    */
   static create(
     context: ConnectionContext,

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -53,6 +53,7 @@ export interface ConnectionContext extends ConnectionContextBase {
 
 /**
  * @internal
+ * @ignore
  */
 export interface ConnectionContextOptions extends EventHubClientOptions {
   managementSessionAddress?: string;
@@ -61,6 +62,7 @@ export interface ConnectionContextOptions extends EventHubClientOptions {
 
 /**
  * @internal
+ * @ignore
  */
 export namespace ConnectionContext {
   /**

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -27,25 +27,25 @@ import { Dictionary, OnAmqpEvent, EventContext, ConnectionEvents } from "rhea-pr
  */
 export interface ConnectionContext extends ConnectionContextBase {
   /**
-   * @property {EventHubConnectionConfig} config The EventHub connection config that is created after
+   * @property config The EventHub connection config that is created after
    * parsing the connection string.
    */
   readonly config: EventHubConnectionConfig;
   /**
-   * @property {boolean} wasConnectionCloseCalled Indicates whether the close() method was
+   * @property wasConnectionCloseCalled Indicates whether the close() method was
    * called on theconnection object.
    */
   wasConnectionCloseCalled: boolean;
   /**
-   * @property {Dictionary<EventHubReceiver>} receivers A dictionary of the EventHub Receivers associated with this client.
+   * @property receivers A dictionary of the EventHub Receivers associated with this client.
    */
   receivers: Dictionary<EventHubReceiver>;
   /**
-   * @property {Dictionary<EventHubSender>} senders A dictionary of the EventHub Senders associated with this client.
+   * @property senders A dictionary of the EventHub Senders associated with this client.
    */
   senders: Dictionary<EventHubSender>;
   /**
-   * @property {ManagementClient} managementSession A reference to the management session ($management endpoint) on
+   * @property managementSession A reference to the management session ($management endpoint) on
    * the underlying amqp connection for the EventHub Client.
    */
   managementSession?: ManagementClient;
@@ -64,7 +64,7 @@ export interface ConnectionContextOptions extends EventHubClientOptions {
  */
 export namespace ConnectionContext {
   /**
-   * @property {string} userAgent The user agent string for the EventHubs client.
+   * @property userAgent The user agent string for the EventHubs client.
    * See guideline at https://github.com/Azure/azure-sdk/blob/master/docs/design/Telemetry.mdk
    */
   const userAgent: string = `azsdk-js-azureeventhubs/${packageJsonInfo.version} (NODE-VERSION ${

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -7,6 +7,7 @@ import { Constants } from "@azure/core-amqp";
 /**
  * Describes the delivery annotations.
  * @interface EventHubDeliveryAnnotations
+ * @ignore
  */
 export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
   /**
@@ -34,6 +35,7 @@ export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
 /**
  * Map containing message attributes that will be held in the message header.
  * @interface EventHubMessageAnnotations
+ * @ignore
  */
 export interface EventHubMessageAnnotations extends MessageAnnotations {
   /**
@@ -182,11 +184,9 @@ export interface EventData {
   /**
    * @property [properties] The application specific properties.
    */
-  properties?: Properties;
-}
-
-export interface Properties {
-  [key: string]: any;
+  properties?: {
+    [key: string]: any;
+  };
 }
 
 /**
@@ -200,7 +200,9 @@ export interface ReceivedEventData {
   /**
    * @property [properties] The application specific properties.
    */
-  properties?: Properties;
+  properties?: {
+    [key: string]: any;
+  };
   /**
    * @property [enqueuedTimeUtc] The enqueued time of the event.
    */

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -173,16 +173,16 @@ export function toAmqpMessage(data: EventData, partitionKey?: string): Message {
 }
 
 /**
- * Describes the structure of an event to be sent to Event Hub
+ * Describes the structure of an event to be sent to Event Hub.
  * @interface
  */
 export interface EventData {
   /**
-   * @property body - The message body that needs to be sent or is received.
+   * @property The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property [properties] The application specific properties.
+   * @property The application specific properties.
    */
   properties?: {
     [key: string]: any;
@@ -198,26 +198,26 @@ export interface ReceivedEventData {
    */
   body: any;
   /**
-   * @property [properties] The application specific properties.
+   * @property The application specific properties.
    */
   properties?: {
     [key: string]: any;
   };
   /**
-   * @property [enqueuedTimeUtc] The enqueued time of the event.
+   * @property The enqueued time of the event.
    */
   enqueuedTimeUtc: Date;
   /**
-   * @property [partitionKey] If specified EventHub will hash this to a partitionId.
+   * @property When specified Event Hub will hash this to a partitionId.
    * It guarantees that messages end up in a specific partition on the event hub.
    */
   partitionKey: string | null;
   /**
-   * @property [offset] The offset of the event.
+   * @property The offset of the event.
    */
   offset: string;
   /**
-   * @property [sequenceNumber] The sequence number of the event.
+   * @property The sequence number of the event.
    */
   sequenceNumber: number;
 }

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -1,12 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-  Message,
-  Dictionary,
-  MessageAnnotations,
-  DeliveryAnnotations
-} from "rhea-promise";
+import { Message, Dictionary, MessageAnnotations, DeliveryAnnotations } from "rhea-promise";
 import { Constants } from "@azure/core-amqp";
 
 /**
@@ -15,23 +10,23 @@ import { Constants } from "@azure/core-amqp";
  */
 export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
   /**
-   * @property {string} [last_enqueued_offset] The offset of the last event.
+   * @property [last_enqueued_offset] The offset of the last event.
    */
   last_enqueued_offset?: string;
   /**
-   * @property {number} [last_enqueued_sequence_number] The sequence number of the last event.
+   * @property [last_enqueued_sequence_number] The sequence number of the last event.
    */
   last_enqueued_sequence_number?: number;
   /**
-   * @property {number} [last_enqueued_time_utc] The enqueued time of the last event.
+   * @property [last_enqueued_time_utc] The enqueued time of the last event.
    */
   last_enqueued_time_utc?: number;
   /**
-   * @property {number} [runtime_info_retrieval_time_utc] The retrieval time of the last event.
+   * @property [runtime_info_retrieval_time_utc] The retrieval time of the last event.
    */
   runtime_info_retrieval_time_utc?: number;
   /**
-   * @property {string} Any unknown delivery annotations.
+   * @property Any unknown delivery annotations.
    */
   [x: string]: any;
 }
@@ -42,78 +37,80 @@ export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
  */
 export interface EventHubMessageAnnotations extends MessageAnnotations {
   /**
-   * @property {string | null} [x-opt-partition-key] Annotation for the partition key set for the event.
+   * @property [x-opt-partition-key] Annotation for the partition key set for the event.
    */
   "x-opt-partition-key"?: string | null;
   /**
-   * @property {number} [x-opt-sequence-number] Annontation for the sequence number of the event.
+   * @property [x-opt-sequence-number] Annontation for the sequence number of the event.
    */
   "x-opt-sequence-number"?: number;
   /**
-   * @property {number} [x-opt-enqueued-time] Annotation for the enqueued time of the event.
+   * @property [x-opt-enqueued-time] Annotation for the enqueued time of the event.
    */
   "x-opt-enqueued-time"?: number;
   /**
-   * @property {string} [x-opt-offset] Annotation for the offset of the event.
+   * @property [x-opt-offset] Annotation for the offset of the event.
    */
   "x-opt-offset"?: string;
   /**
-   * @property {any} Any other annotation that can be added to the message.
+   * @property Any other annotation that can be added to the message.
    */
   [x: string]: any;
 }
 
 /**
  * Describes the structure of an event to be sent or received from the EventHub.
- * @interface EventData
+ * @interface
+ * @ignore
  */
 export interface EventDataInternal {
   /**
-   * @property {any} body - The message body that needs to be sent or is received.
+   * @property body - The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property {Date} [enqueuedTimeUtc] The enqueued time of the event.
+   * @property [enqueuedTimeUtc] The enqueued time of the event.
    */
   enqueuedTimeUtc?: Date;
   /**
-   * @property {string | null} [partitionKey] If specified EventHub will hash this to a partitionId.
+   * @property [partitionKey] If specified EventHub will hash this to a partitionId.
    * It guarantees that messages end up in a specific partition on the event hub.
    */
   partitionKey?: string | null;
   /**
-   * @property {string} [offset] The offset of the event.
+   * @property [offset] The offset of the event.
    */
   offset?: string;
   /**
-   * @property {number} [sequenceNumber] The sequence number of the event.
+   * @property [sequenceNumber] The sequence number of the event.
    */
   sequenceNumber?: number;
   /**
-   * @property {Dictionary<any>} [properties] The application specific properties.
+   * @property [properties] The application specific properties.
    */
   properties?: Dictionary<any>;
   /**
-   * @property {number} [lastSequenceNumber] The last sequence number of the event within the partition stream of the Event Hub.
+   * @property [lastSequenceNumber] The last sequence number of the event within the partition stream of the Event Hub.
    */
   lastSequenceNumber?: number;
   /**
-   * @property {string} [lastEnqueuedOffset] The offset of the last enqueued event.
+   * @property [lastEnqueuedOffset] The offset of the last enqueued event.
    */
   lastEnqueuedOffset?: string;
   /**
-   * @property {Date} [lastEnqueuedTime] The enqueued UTC time of the last event.
+   * @property [lastEnqueuedTime] The enqueued UTC time of the last event.
    */
   lastEnqueuedTime?: Date;
   /**
-   * @property {Date} [retrievalTime] The time when the runtime info was retrieved
+   * @property [retrievalTime] The time when the runtime info was retrieved
    */
   retrievalTime?: Date;
 }
 
 /**
  * Converts the AMQP message to an EventData.
- * @param {AmqpMessage} msg The AMQP message that needs to be converted to EventData.
+ * @param msg The AMQP message that needs to be converted to EventData.
+ * @ignore
  */
 export function fromAmqpMessage(msg: Message): EventDataInternal {
   const data: EventDataInternal = {
@@ -150,6 +147,7 @@ export function fromAmqpMessage(msg: Message): EventDataInternal {
  * Converts an EventData object to an AMQP message.
  * @param data The EventData object that needs to be converted to an AMQP message.
  * @param partitionKey An optional key to determine the partition that this event should land in.
+ * @ignore
  */
 export function toAmqpMessage(data: EventData, partitionKey?: string): Message {
   const msg: Message = {
@@ -174,16 +172,21 @@ export function toAmqpMessage(data: EventData, partitionKey?: string): Message {
 
 /**
  * Describes the structure of an event to be sent to Event Hub
+ * @interface
  */
 export interface EventData {
   /**
-   * @property {any} body - The message body that needs to be sent or is received.
+   * @property body - The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property {Dictionary<any>} [applicationProperties] The application specific properties.
+   * @property [properties] The application specific properties.
    */
-  properties?: { [key: string]: any };
+  properties?: Properties;
+}
+
+export interface Properties {
+  [key: string]: any;
 }
 
 /**
@@ -191,28 +194,28 @@ export interface EventData {
  */
 export interface ReceivedEventData {
   /**
-   * @property {any} body - The message body that needs to be sent or is received.
+   * @property The message body that needs to be sent or is received.
    */
   body: any;
   /**
-   * @property {Dictionary<any>} [applicationProperties] The application specific properties.
+   * @property [properties] The application specific properties.
    */
-  properties?: { [key: string]: any };
+  properties?: Properties;
   /**
-   * @property {Date} [enqueuedTimeUtc] The enqueued time of the event.
+   * @property [enqueuedTimeUtc] The enqueued time of the event.
    */
   enqueuedTimeUtc: Date;
   /**
-   * @property {string | null} [partitionKey] If specified EventHub will hash this to a partitionId.
+   * @property [partitionKey] If specified EventHub will hash this to a partitionId.
    * It guarantees that messages end up in a specific partition on the event hub.
    */
   partitionKey: string | null;
   /**
-   * @property {string} [offset] The offset of the event.
+   * @property [offset] The offset of the event.
    */
   offset: string;
   /**
-   * @property {number} [sequenceNumber] The sequence number of the event.
+   * @property [sequenceNumber] The sequence number of the event.
    */
   sequenceNumber: number;
 }

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -246,6 +246,7 @@ export class EventHubClient {
    * Closes the AMQP connection to the Event Hub for this client,
    * returning a promise that will be resolved when disconnection is completed.
    * @returns Promise<void>
+   * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
   async close(): Promise<void> {
     try {
@@ -296,6 +297,7 @@ export class EventHubClient {
    * @param options Options to create the Receiver where you can specify the position from
    * which to start receiving events, the consumer group to receive events from, retry options
    * and more.
+   * @throws {TypeError} Thrown if a required parameter is missing.
    */
   createConsumer(
     consumerGroup: string,
@@ -313,6 +315,7 @@ export class EventHubClient {
   /**
    * Provides the eventhub runtime information.
    * @returns A promise that resolves with HubInformation.
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getProperties(abortSignal?: AbortSignalLike): Promise<EventHubProperties> {
     try {
@@ -329,6 +332,7 @@ export class EventHubClient {
   /**
    * Provides an array of partitionIds.
    * @returns A promise that resolves with an Array of strings.
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getPartitionIds(abortSignal?: AbortSignalLike): Promise<Array<string>> {
     try {
@@ -344,6 +348,7 @@ export class EventHubClient {
    * Provides information about the specified partition.
    * @param partitionId Partition ID for which partition information is required.
    * @returns A promise that resoloves with EventHubPartitionRuntimeInformation.
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getPartitionProperties(partitionId: string, abortSignal?: AbortSignalLike): Promise<PartitionProperties> {
     throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
@@ -364,6 +369,7 @@ export class EventHubClient {
    * @param iothubConnectionString - Connection string of the form 'HostName=iot-host-name;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key'
    * @param [options] Options that can be provided during client creation.
    * @returns - Promise<EventHubClient>.
+   * @throws {Error} Thrown if the iothubConnectionString is not provided as a string.
    */
   static async createFromIotHubConnectionString(
     iothubConnectionString: string,

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -245,7 +245,7 @@ export class EventHubClient {
   /**
    * Closes the AMQP connection to the Event Hub for this client,
    * returning a promise that will be resolved when disconnection is completed.
-   * @returns {Promise<void>} Promise<void>
+   * @returns Promise<void>
    */
   async close(): Promise<void> {
     try {
@@ -280,7 +280,7 @@ export class EventHubClient {
    * @param options Options to create a Sender where you can specify the id of the partition
    * to which events need to be sent to and retry options.
    *
-   * @return {Promise<void>} Promise<void>
+   * @returns Promise<void>
    */
   createProducer(options?: EventHubProducerOptions): EventHubProducer {
     return new EventHubProducer(this._context, options);
@@ -312,7 +312,7 @@ export class EventHubClient {
 
   /**
    * Provides the eventhub runtime information.
-   * @returns {Promise<EventHubProperties>} A promise that resolves with HubInformation.
+   * @returns A promise that resolves with HubInformation.
    */
   async getProperties(abortSignal?: AbortSignalLike): Promise<EventHubProperties> {
     try {
@@ -328,7 +328,7 @@ export class EventHubClient {
 
   /**
    * Provides an array of partitionIds.
-   * @returns {Promise<Array<string>>} A promise that resolves with an Array of strings.
+   * @returns A promise that resolves with an Array of strings.
    */
   async getPartitionIds(abortSignal?: AbortSignalLike): Promise<Array<string>> {
     try {
@@ -342,8 +342,8 @@ export class EventHubClient {
 
   /**
    * Provides information about the specified partition.
-   * @param {string} partitionId Partition ID for which partition information is required.
-   * @returns {Promise<PartitionProperties>} A promise that resoloves with EventHubPartitionRuntimeInformation.
+   * @param partitionId Partition ID for which partition information is required.
+   * @returns A promise that resoloves with EventHubPartitionRuntimeInformation.
    */
   async getPartitionProperties(partitionId: string, abortSignal?: AbortSignalLike): Promise<PartitionProperties> {
     throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
@@ -361,9 +361,9 @@ export class EventHubClient {
 
   /**
    * Creates an EventHub Client from connection string.
-   * @param {string} iothubConnectionString - Connection string of the form 'HostName=iot-host-name;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key'
-   * @param {EventHubClientOptions} [options] Options that can be provided during client creation.
-   * @returns {Promise<EventHubClient>} - Promise<EventHubClient>.
+   * @param iothubConnectionString - Connection string of the form 'HostName=iot-host-name;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key'
+   * @param [options] Options that can be provided during client creation.
+   * @returns - Promise<EventHubClient>.
    */
   static async createFromIotHubConnectionString(
     iothubConnectionString: string,

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -24,15 +24,15 @@ import { EventHubConsumer } from "./receiver";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
 
 /**
- * Retry policy options for operations on the EventHubClient
+ * Retry policy options for operations on the EventHubClient.
  */
 export interface RetryOptions {
   /**
-   * Total number of times to attempt an operation
+   * Total number of times to attempt an operation.
    */
   retryCount?: number;
   /**
-   * Number of milliseconds to wait between retries
+   * Number of milliseconds to wait between retries.
    */
   retryInterval?: number;
   // /**
@@ -48,7 +48,7 @@ export interface RetryOptions {
 }
 
 /**
- * Options to passed when creating a sender using the EventHubClient
+ * Options to passed when creating a producer using the EventHubClient.
  */
 export interface EventHubProducerOptions {
   /**
@@ -59,54 +59,54 @@ export interface EventHubProducerOptions {
   partitionId?: string;
   /**
    * @property
-   * Retry options for the send operation on the sender. If no value is provided here, the
+   * Retry options for the send operation on the producer. If no value is provided here, the
    * retry options set when creating the `EventHubClient` is used.
    */
   retryOptions?: RetryOptions;
 }
 
 /**
- * Options that can be passed when sending a batch of events using the EventHubsClient
+ * Options that can be passed when sending a batch of events using the EventHubsClient.
  */
 export interface SendOptions {
   /**
    * @property
-   * If specified EventHub will hash this string to map to a partitionId.
+   * If specified, Event Hubs will hash this string to map to a partitionId.
    * It guarantees that messages with the same partitionKey end up in the same partition.
-   * This will be ignored if the sender was created using a `paritionId`.
+   * This will be ignored if the producer was created using a `paritionId`.
    */
   partitionKey?: string | null;
   /**
    * @property
-   * Cancel current operation
+   * Can cancel the current operation.
    */
   abortSignal?: AbortSignalLike;
 }
 
 /**
- * Options that can be passed to the receive operations on the EventHubsClient
+ * Options that can be passed to the receive operations on the EventHubsClient.
  * @interface EventHubConsumerOptions
  */
 export interface EventHubConsumerOptions {
   /**
    * @property
-   * The priority value that this receiver is currently using for partition ownership.
-   * If another receiver is currently active for the same partition with no or lesser
-   * priority, then it will get disconnected.
-   * If another receiver is currently active with a higher priority, then this receiver
+   * The level that this consumer is currently using for partition ownership.
+   * If another consumer is currently active for the same partition with no or lower
+   * level, then it will get disconnected.
+   * If another consumer is currently active with a higher level, then this consumer
    * will fail to connect.
    */
   ownerLevel?: number;
   /**
    * @property
-   * Retry options for the receive operation on the receiver. If no value is provided here, the
+   * Retry options for the receive operation on the consumer. If no value is provided here, the
    * retry options set when creating the `EventHubClient` is used.
    */
   retryOptions?: RetryOptions;
 }
 
 /**
- * Describes the options that can be provided while creating the EventHub Client.
+ * Describes the options that can be provided while creating the EventHubClient.
  * @interface ClientOptions
  */
 export interface EventHubClientOptions {
@@ -148,8 +148,8 @@ export interface EventHubClientOptions {
   webSocketConstructorOptions?: any;
   /**
    * @property
-   * Retry options for all the operations on the client/sender/receiver.
-   * This can be overridden by the retry options set on the sender and receiver.
+   * Retry options for all the operations on the client/producer/consumer.
+   * This can be overridden by the retry options set on the producer and consumer.
    */
   retryOptions?: RetryOptions;
 }
@@ -172,7 +172,7 @@ export class EventHubClient {
   /**
    * @property
    * @readonly
-   * The name of the Event Hub instance for which this client is created
+   * The name of the Event Hub instance for which this client is created.
    */
   get eventHubName(): string {
     return this._context.config.entityPath;
@@ -180,13 +180,13 @@ export class EventHubClient {
 
   /**
    * @constructor
-   * @param connectionString - Connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;EntityPath=my-event-hub-name'
+   * @param connectionString - Connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;EntityPath=my-event-hub-name'.
    * @param options - The options that can be provided during client creation.
    */
   constructor(connectionString: string, options?: EventHubClientOptions);
   /**
    * @constructor
-   * @param connectionString - Connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;'
+   * @param connectionString - Connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;'.
    * @param eventHubPath - EventHub path of the form 'my-event-hub-name'
    * @param options - The options that can be provided during client creation.
    */
@@ -195,7 +195,7 @@ export class EventHubClient {
    * @constructor
    * @param host - Fully qualified domain name for Event Hubs. Most likely,
    * <yournamespace>.servicebus.windows.net
-   * @param eventHubPath - EventHub path of the form 'my-event-hub-name'
+   * @param eventHubPath - EventHub path of the form 'my-event-hub-name'.
    * @param credential - SharedKeyCredential object or your credential that implements the TokenCredential interface.
    * @param options - The options that can be provided during client creation.
    */
@@ -275,11 +275,11 @@ export class EventHubClient {
   }
 
   /**
-   * Creates a Sender that can be used to send events to the Event Hub for which this client
+   * Creates an EventHubProducer that can be used to send events to the Event Hub for which this client
    * was created.
    *
-   * @param options Options to create a Sender where you can specify the id of the partition
-   * to which events need to be sent to and retry options.
+   * @param options Options to create a EventHubProducer where you can specify the id of the partition
+   * to which events need to be sent to, and retry options.
    *
    * @returns Promise<void>
    */
@@ -288,13 +288,13 @@ export class EventHubClient {
   }
 
   /**
-   * Creates a Receiver that can be used to receive events from the Event Hub for which this
+   * Creates an EventHubConsumer that can be used to receive events from the Event Hub for which this
    * client was created.
    *
-   * @param consumerGroup The consumer group from which the receiver should receive events from.
-   * @param partitionId The id of the partition from which to receive events
+   * @param consumerGroup The consumer group from which the consumer should receive events.
+   * @param partitionId The id of the partition from which to receive events.
    * @param eventPosition The event position in the partition at which to start receiving messages.
-   * @param options Options to create the Receiver where you can specify the position from
+   * @param options Options to create the EventHubConsumer where you can specify the position from
    * which to start receiving events, the consumer group to receive events from, retry options
    * and more.
    * @throws {TypeError} Thrown if a required parameter is missing.
@@ -313,8 +313,8 @@ export class EventHubClient {
   }
 
   /**
-   * Provides the eventhub runtime information.
-   * @returns A promise that resolves with HubInformation.
+   * Provides the Event Hub runtime information.
+   * @returns A promise that resolves with EventHubProperties.
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getProperties(abortSignal?: AbortSignalLike): Promise<EventHubProperties> {
@@ -347,7 +347,7 @@ export class EventHubClient {
   /**
    * Provides information about the specified partition.
    * @param partitionId Partition ID for which partition information is required.
-   * @returns A promise that resoloves with EventHubPartitionRuntimeInformation.
+   * @returns A promise that resoloves with PartitionProperties.
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getPartitionProperties(partitionId: string, abortSignal?: AbortSignalLike): Promise<PartitionProperties> {
@@ -365,8 +365,8 @@ export class EventHubClient {
   }
 
   /**
-   * Creates an EventHub Client from connection string.
-   * @param iothubConnectionString - Connection string of the form 'HostName=iot-host-name;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key'
+   * Creates an EventHubClient from connection string.
+   * @param iothubConnectionString - Connection string of the form 'HostName=iot-host-name;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key'.
    * @param [options] Options that can be provided during client creation.
    * @returns - Promise<EventHubClient>.
    * @throws {Error} Thrown if the iothubConnectionString is not provided as a string.

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -36,19 +36,19 @@ interface CreateReceiverOptions {
  */
 export interface ReceiverRuntimeInfo {
   /**
-   * @property {number} lastSequenceNumber The logical sequence number of the event.
+   * @property lastSequenceNumber The logical sequence number of the event.
    */
   lastEnqueuedSequenceNumber?: number;
   /**
-   * @property {Date} lastEnqueuedTimeUtc The enqueued time of the last event.
+   * @property lastEnqueuedTimeUtc The enqueued time of the last event.
    */
   lastEnqueuedTimeUtc?: Date;
   /**
-   * @property {string} lastEnqueuedOffset The offset of the last enqueued event.
+   * @property lastEnqueuedOffset The offset of the last enqueued event.
    */
   lastEnqueuedOffset?: string;
   /**
-   * @property {Date} retrievalTime The enqueued time of the last event.
+   * @property retrievalTime The enqueued time of the last event.
    */
   retrievalTime?: Date;
 }
@@ -70,103 +70,103 @@ export type OnError = (error: MessagingError | Error) => void;
  */
 export class EventHubReceiver extends LinkEntity {
   /**
-   * @property {string} consumerGroup The EventHub consumer group from which the receiver will
+   * @property consumerGroup The EventHub consumer group from which the receiver will
    * receive messages. (Default: "default").
    */
   consumerGroup: string;
   /**
-   * @property {ReceiverRuntimeInfo} runtimeInfo The receiver runtime info.
+   * @property runtimeInfo The receiver runtime info.
    */
   runtimeInfo: ReceiverRuntimeInfo;
   /**
-   * @property {number} [ownerLevel] The Receiver ownerLevel.
+   * @property [ownerLevel] The Receiver ownerLevel.
    */
   ownerLevel?: number;
   /**
-   * @property {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
+   * @property eventPosition The event position in the partition at which to start receiving messages.
    */
   eventPosition: EventPosition;
   /**
-   * @property {EventHubConsumerOptions} [options] Optional properties that can be set while creating
+   * @property [options] Optional properties that can be set while creating
    * the EventHubConsumer.
    */
   options: EventHubConsumerOptions;
   /**
-   * @property {number} [prefetchCount] The number of messages that the receiver can fetch/receive
+   * @property [prefetchCount] The number of messages that the receiver can fetch/receive
    * initially. Defaults to 1000.
    */
   prefetchCount?: number = Constants.defaultPrefetchCount;
   /**
-   * @property {boolean} receiverRuntimeMetricEnabled Indicates whether receiver runtime metric
+   * @property receiverRuntimeMetricEnabled Indicates whether receiver runtime metric
    * is enabled. Default: false.
    */
   receiverRuntimeMetricEnabled: boolean = false;
   /**
-   * @property {Receiver} [_receiver] The AMQP receiver link.
+   * @property [_receiver] The AMQP receiver link.
    * @protected
    */
   protected _receiver?: Receiver;
   /**
-   * @property {OnMessage} _onMessage The message handler provided by the user that will be wrapped
+   * @property _onMessage The message handler provided by the user that will be wrapped
    * inside _onAmqpMessage.
    * @protected
    */
   protected _onMessage?: OnMessage;
   /**
-   * @property {OnError} _onError The error handler provided by the user that will be wrapped
+   * @property _onError The error handler provided by the user that will be wrapped
    * inside _onAmqpError.
    * @protected
    */
   protected _onError?: OnError;
   /**
-   * @property {() => void} onAbort The aborter handler that will be invoked when user will call Aborter.abort()
+   * @property onAbort The aborter handler that will be invoked when user will call Aborter.abort()
    * to cancel the receive request.
    * @protected
    */
   protected _onAbort: () => void;
   /**
-   * @property {OnAmqpEvent} _onAmqpError The message handler that will be set as the handler on the
+   * @property _onAmqpError The message handler that will be set as the handler on the
    * underlying rhea receiver for the "message" event.
    * @protected
    */
   protected _onAmqpMessage: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onAmqpError The message handler that will be set as the handler on the
+   * @property _onAmqpError The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_error" event.
    * @protected
    */
   protected _onAmqpError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onAmqpClose The message handler that will be set as the handler on the
+   * @property _onAmqpClose The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_close" event.
    * @protected
    */
   protected _onAmqpClose: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
+   * @property _onSessionError The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_error" event.
    * @protected
    */
   protected _onSessionError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onSessionClose The message handler that will be set as the handler on
+   * @property _onSessionClose The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_close" event.
    * @protected
    */
   protected _onSessionClose: OnAmqpEvent;
   /**
-   * @property {number} _checkpoint Describes sequenceNumber of the last message received.
+   * @property _checkpoint Describes sequenceNumber of the last message received.
    * This is used as the sequenceNumber to receive messages from incase of recovery.
    */
   protected _checkpoint: number;
   /**
-   * @property {Aborter | undefined} _aborter Describes Aborter instance that will be set by the user
+   * @property _aborter Describes Aborter instance that will be set by the user
    * to cancel the request.
    */
   protected _abortSignal: AbortSignalLike | undefined;
 
   /**
-   * @property {number} Returns sequenceNumber of the last event received.
+   * @property Returns sequenceNumber of the last event received.
    * @readonly
    */
   get checkpoint(): number {
@@ -177,11 +177,11 @@ export class EventHubReceiver extends LinkEntity {
    * Instantiate a new receiver from the AMQP `Receiver`. Used by `EventHubClient`.
    * @ignore
    * @constructor
-   * @param {EventHubClient} client                            The EventHub client.
-   * @param {string} consumerGroup  The consumer group from which the receiver should receive events from.
-   * @param {string} partitionId                               Partition ID from which to receive.
-   * @param {EventPosition} eventPosition The position in the stream from where to start receiving events.
-   * @param {EventHubConsumerOptions} [options]                         Receiver options.
+   * @param client                            The EventHub client.
+   * @param consumerGroup  The consumer group from which the receiver should receive events from.
+   * @param partitionId                               Partition ID from which to receive.
+   * @param eventPosition The position in the stream from where to start receiving events.
+   * @param [options]                         Receiver options.
    */
   constructor(
     context: ConnectionContext,
@@ -393,8 +393,8 @@ export class EventHubReceiver extends LinkEntity {
   /**
    * Will reconnect the receiver link if necessary.
    * @ignore
-   * @param {AmqpError | Error} [receiverError] The receiver error if any.
-   * @returns {Promise<void>} Promise<void>.
+   * @param [receiverError] The receiver error if any.
+   * @returns Promise<void>.
    */
   async onDetached(receiverError?: AmqpError | Error): Promise<void> {
     try {
@@ -496,7 +496,7 @@ export class EventHubReceiver extends LinkEntity {
   /**
    * Closes the underlying AMQP receiver.
    * @ignore
-   * @returns {Promise<void>}
+   * @returns
    */
   async close(): Promise<void> {
     if (this._receiver) {
@@ -512,7 +512,7 @@ export class EventHubReceiver extends LinkEntity {
   /**
    * Determines whether the AMQP receiver link is open. If open then returns true else returns false.
    * @ignore
-   * @return {boolean} boolean
+   * @returns boolean
    */
   isOpen(): boolean {
     const result: boolean = this._receiver! && this._receiver!.isOpen();
@@ -535,7 +535,7 @@ export class EventHubReceiver extends LinkEntity {
   /**
    * Creates a new AMQP receiver under a new AMQP session.
    * @ignore
-   * @returns {Promise<void>}
+   * @returns
    */
   protected async _init(options?: RheaReceiverOptions): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -42,37 +42,37 @@ interface CreateSenderOptions {
  */
 export class EventHubSender extends LinkEntity {
   /**
-   * @property {string} senderLock The unqiue lock name per connection that is used to acquire the
+   * @property senderLock The unqiue lock name per connection that is used to acquire the
    * lock for establishing a sender link by an entity on that connection.
    * @readonly
    */
   readonly senderLock: string = `sender-${uuid()}`;
   /**
-   * @property {OnAmqpEvent} _onAmqpError The handler function to handle errors that happen on the
+   * @property _onAmqpError The handler function to handle errors that happen on the
    * underlying sender.
    * @readonly
    */
   private readonly _onAmqpError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onAmqpClose The handler function to handle "sender_close" event
+   * @property _onAmqpClose The handler function to handle "sender_close" event
    * that happens on the underlying sender.
    * @readonly
    */
   private readonly _onAmqpClose: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
+   * @property _onSessionError The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_error" event.
    * @private
    */
   private _onSessionError: OnAmqpEvent;
   /**
-   * @property {OnAmqpEvent} _onSessionClose The message handler that will be set as the handler on
+   * @property _onSessionClose The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_close" event.
    * @private
    */
   private _onSessionClose: OnAmqpEvent;
   /**
-   * @property {Sender} [_sender] The AMQP sender link.
+   * @property [_sender] The AMQP sender link.
    * @private
    */
   private _sender?: Sender;
@@ -81,8 +81,8 @@ export class EventHubSender extends LinkEntity {
    * Creates a new EventHubSender instance.
    * @ignore
    * @constructor
-   * @param {ConnectionContext} context The connection context.
-   * @param {string|number} [partitionId] The EventHub partition id to which the sender
+   * @param context The connection context.
+   * @param [partitionId] The EventHub partition id to which the sender
    * wants to send the event data.
    */
   constructor(context: ConnectionContext, partitionId?: string, name?: string) {
@@ -208,8 +208,8 @@ export class EventHubSender extends LinkEntity {
   /**
    * Will reconnect the sender link if necessary.
    * @ignore
-   * @param {AmqpError | Error} [senderError] The sender error if any.
-   * @returns {Promise<void>} Promise<void>.
+   * @param [senderError] The sender error if any.
+   * @returns Promise<void>.
    */
   async onDetached(senderError?: AmqpError | Error): Promise<void> {
     try {
@@ -297,7 +297,7 @@ export class EventHubSender extends LinkEntity {
   /**
    * Deletes the sender fromt the context. Clears the token renewal timer. Closes the sender link.
    * @ignore
-   * @return {Promise<void>} Promise<void>
+   * @returns Promise<void>
    */
   async close(): Promise<void> {
     if (this._sender) {
@@ -315,7 +315,7 @@ export class EventHubSender extends LinkEntity {
   /**
    * Determines whether the AMQP sender link is open. If open then returns true else returns false.
    * @ignore
-   * @return {boolean} boolean
+   * @returns boolean
    */
   isOpen(): boolean {
     const result: boolean = this._sender! && this._sender!.isOpen();
@@ -426,7 +426,7 @@ export class EventHubSender extends LinkEntity {
    * for the message to be accepted or rejected and accordingly resolve or reject the promise.
    * @ignore
    * @param message The message to be sent to EventHub.
-   * @return {Promise<void>} Promise<void>
+   * @returns Promise<void>
    */
   private _trySendBatch(
     message: AmqpMessage | Buffer,
@@ -606,7 +606,7 @@ export class EventHubSender extends LinkEntity {
   /**
    * Initializes the sender session on the connection.
    * @ignore
-   * @returns {Promise<void>}
+   * @returns
    */
   private async _init(options?: RheaSenderOptions): Promise<void> {
     try {
@@ -671,8 +671,8 @@ export class EventHubSender extends LinkEntity {
    * not present in the context or returns the one present in the context.
    * @ignore
    * @static
-   * @param {(string)} [partitionId] Partition ID to which it will send event data.
-   * @returns {Promise<EventHubSender>}
+   * @param [partitionId] Partition ID to which it will send event data.
+   * @returns
    */
   static create(context: ConnectionContext, partitionId?: string): EventHubSender {
     const ehSender: EventHubSender = new EventHubSender(context, partitionId);

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -10,23 +10,23 @@ import { translate, Constants, ErrorNameConditionMapper } from "@azure/core-amqp
  */
 export interface EventPositionOptions {
   /**
-   * @property [offset] The offset of the event at the position. It can be undefined
+   * @property The offset of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an enqueued time.
    */
   offset?: string;
   /**
-   * @property isInclusive Indicates if the current event at the specified offset is
+   * @property Indicates if the current event at the specified offset is
    * included or not. It is only applicable if offset is set. Default value: false.
    */
   isInclusive?: boolean;
   /**
-   * @property [enqueuedTime] The enqueued time of the event at the position. It can be undefined
+   * @property The enqueued time of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an offset.
    */
   enqueuedTime?: Date | number;
 
   /**
-   * @property [sequenceNumber] The sequence number of the event at the position. It can be undefined
+   * @property The sequence number of the event at the position. It can be undefined
    * if the position is just created from an enqueued time or an offset.
    */
   sequenceNumber?: number;
@@ -39,38 +39,36 @@ export interface EventPositionOptions {
  */
 export class EventPosition {
   /**
-   * @property startOfStream The offset from which events would be received: `"-1"`.
-   *
+   * @property The offset from which events would be received: `"-1"`.
    * @static
    * @readonly
    */
   private static readonly startOfStream: string = "-1";
 
   /**
-   * @property endOfStream The offset from which events would be received: `"@latest"`.
-   *
+   * @property The offset from which events would be received: `"@latest"`.
    * @static
    * @readonly
    */
   private static readonly endOfStream: string = "@latest";
   /**
-   * @property [offset] The offset of the event at the position. It can be undefined
+   * @property The offset of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an enqueued time.
    */
   offset?: string;
   /**
-   * @property isInclusive Indicates if the current event at the specified offset is
+   * @property Indicates if the current event at the specified offset is
    * included or not. It is only applicable if offset is set. Default value: false.
    */
   isInclusive: boolean = false;
   /**
-   * @property [enqueuedTime] The enqueued time of the event at the position. It can be undefined
+   * @property The enqueued time of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an offset.
    */
   enqueuedTime?: Date | number;
 
   /**
-   * @property [sequenceNumber] The sequence number of the event at the position. It can be undefined
+   * @property The sequence number of the event at the position. It can be undefined
    * if the position is just created from an enqueued time or an offset.
    */
   sequenceNumber?: number;

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -10,23 +10,23 @@ import { translate, Constants, ErrorNameConditionMapper } from "@azure/core-amqp
  */
 export interface EventPositionOptions {
   /**
-   * @property {string} [offset] The offset of the event at the position. It can be undefined
+   * @property [offset] The offset of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an enqueued time.
    */
   offset?: string;
   /**
-   * @property {boolean} isInclusive Indicates if the current event at the specified offset is
+   * @property isInclusive Indicates if the current event at the specified offset is
    * included or not. It is only applicable if offset is set. Default value: false.
    */
   isInclusive?: boolean;
   /**
-   * @property {Date|number} [enqueuedTime] The enqueued time of the event at the position. It can be undefined
+   * @property [enqueuedTime] The enqueued time of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an offset.
    */
   enqueuedTime?: Date | number;
 
   /**
-   * @property {number} [sequenceNumber] The sequence number of the event at the position. It can be undefined
+   * @property [sequenceNumber] The sequence number of the event at the position. It can be undefined
    * if the position is just created from an enqueued time or an offset.
    */
   sequenceNumber?: number;
@@ -39,7 +39,7 @@ export interface EventPositionOptions {
  */
 export class EventPosition {
   /**
-   * @property {string} startOfStream The offset from which events would be received: `"-1"`.
+   * @property startOfStream The offset from which events would be received: `"-1"`.
    *
    * @static
    * @readonly
@@ -47,30 +47,30 @@ export class EventPosition {
   private static readonly startOfStream: string = "-1";
 
   /**
-   * @property {string} endOfStream The offset from which events would be received: `"@latest"`.
+   * @property endOfStream The offset from which events would be received: `"@latest"`.
    *
    * @static
    * @readonly
    */
   private static readonly endOfStream: string = "@latest";
   /**
-   * @property {string} [offset] The offset of the event at the position. It can be undefined
+   * @property [offset] The offset of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an enqueued time.
    */
   offset?: string;
   /**
-   * @property {boolean} isInclusive Indicates if the current event at the specified offset is
+   * @property isInclusive Indicates if the current event at the specified offset is
    * included or not. It is only applicable if offset is set. Default value: false.
    */
   isInclusive: boolean = false;
   /**
-   * @property {Date|number} [enqueuedTime] The enqueued time of the event at the position. It can be undefined
+   * @property [enqueuedTime] The enqueued time of the event at the position. It can be undefined
    * if the position is just created from a sequence number or an offset.
    */
   enqueuedTime?: Date | number;
 
   /**
-   * @property {number} [sequenceNumber] The sequence number of the event at the position. It can be undefined
+   * @property [sequenceNumber] The sequence number of the event at the position. It can be undefined
    * if the position is just created from an enqueued time or an offset.
    */
   sequenceNumber?: number;
@@ -91,12 +91,12 @@ export class EventPosition {
 
   /**
    * Creates a position at the given offset.
-   * @param {string} offset The offset of the data relative to the Event Hub partition stream.
+   * @param offset The offset of the data relative to the Event Hub partition stream.
    * The offset is a marker or identifier for an event within the Event Hubs stream.
    * The identifier is unique within a partition of the Event Hubs stream.
-   * @param {boolean} isInclusive If true, the specified event is included;
+   * @param isInclusive If true, the specified event is included;
    * otherwise the next event is returned. Default: false.
-   * @return {EventPosition} EventPosition
+   * @returns EventPosition
    */
   static fromOffset(offset: string, isInclusive?: boolean): EventPosition {
     if (offset == undefined) {
@@ -107,10 +107,10 @@ export class EventPosition {
 
   /**
    * Creates a position at the given sequence number.
-   * @param {number} sequenceNumber The logical sequence number of the event within the partition stream of the Event Hub.
-   * @param {boolean} isInclusive If true, the specified event is included;
+   * @param sequenceNumber The logical sequence number of the event within the partition stream of the Event Hub.
+   * @param isInclusive If true, the specified event is included;
    * otherwise the next event is returned. Default false.
-   * @return {EventPosition} EventPosition
+   * @returns EventPosition
    */
   static fromSequenceNumber(sequenceNumber: number, isInclusive?: boolean): EventPosition {
     if (sequenceNumber == undefined) {
@@ -124,8 +124,8 @@ export class EventPosition {
 
   /**
    * Creates a position at the given enqueued time.
-   * @param {Date | number} enqueuedTime The enqueue time. This value represents the actual time of enqueuing the message.
-   * @return {EventPosition} EventPosition
+   * @param enqueuedTime The enqueue time. This value represents the actual time of enqueuing the message.
+   * @returns EventPosition
    */
   static fromEnqueuedTime(enqueuedTime: Date | number): EventPosition {
     if (enqueuedTime == undefined) {
@@ -137,7 +137,7 @@ export class EventPosition {
   /**
    * Returns the position for the start of a stream. Provide this position in receiver creation to
    * start receiving from the first available event in the partition.
-   * @return {EventPosition} EventPosition
+   * @returns EventPosition
    */
 
   static earliest(): EventPosition {
@@ -147,7 +147,7 @@ export class EventPosition {
   /**
    * Returns the position for the end of a stream. Provide this position in receiver creation to
    * start receiving from the next available event in the partition after the receiver is created.
-   * @return {EventPosition} EventPosition
+   * @returns EventPosition
    */
 
   static latest(): EventPosition {

--- a/sdk/eventhub/event-hubs/src/iothub/iothubClient.ts
+++ b/sdk/eventhub/event-hubs/src/iothub/iothubClient.ts
@@ -28,7 +28,7 @@ export interface EHConfig extends ParsedRedirectError {
  */
 export class IotHubClient {
   /**
-   * @property {string} connectionString the IotHub connection string.
+   * @property connectionString the IotHub connection string.
    */
   connectionString: string;
 
@@ -39,19 +39,16 @@ export class IotHubClient {
    * Constructs the EventHub connection string by catching the redirect error and parsing the error
    * information.
    * @ignore
-   * @param {ConnectionContextOptions} [options] optional parameters to be provided while creating
+   * @param [options] optional parameters to be provided while creating
    * the connection context.
-   * @return {Promise<string>} Promise<string>
+   * @returns Promise<string>
    */
   async getEventHubConnectionString(options?: ConnectionContextOptions): Promise<string> {
     const iothubconfig = IotHubConnectionConfig.create(this.connectionString);
     const config = IotHubConnectionConfig.convertToEventHubConnectionConfig(iothubconfig);
     let result: string = "";
     if (!options) options = {};
-    const tokenProvider = new IotSharedKeyCredential(
-      config.sharedAccessKeyName,
-      config.sharedAccessKey
-    );
+    const tokenProvider = new IotSharedKeyCredential(config.sharedAccessKeyName, config.sharedAccessKey);
     options.managementSessionAddress = `/messages/events/$management`;
     const context = ConnectionContext.create(config, tokenProvider, options);
     try {
@@ -78,7 +75,7 @@ export class IotHubClient {
    * Closes the AMQP connection to the Event Hub for this client,
    * returning a promise that will be resolved when disconnection is completed.
    * @ignore
-   * @returns {Promise<any>}
+   * @returns
    */
   async close(context: ConnectionContext): Promise<any> {
     try {

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -6,6 +6,10 @@ import { defaultLock, SharedKeyCredential, AccessToken, Constants, TokenType } f
 import { ConnectionContext } from "./connectionContext";
 import { Sender, Receiver } from "rhea-promise";
 import * as log from "./log";
+
+/**
+ * @ignore
+ */
 export interface LinkEntityOptions {
   /**
    * @property [name] The unique name for the entity. If not provided then a guid will be

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -8,20 +8,20 @@ import { Sender, Receiver } from "rhea-promise";
 import * as log from "./log";
 export interface LinkEntityOptions {
   /**
-   * @property {string} [name] The unique name for the entity. If not provided then a guid will be
+   * @property [name] The unique name for the entity. If not provided then a guid will be
    * assigned.
    */
   name?: string;
   /**
-   * @property {string} [partitionId] The partitionId associated with the link entity.
+   * @property [partitionId] The partitionId associated with the link entity.
    */
   partitionId?: string;
   /**
-   * @property {string} address The link entity address in one of the following forms:
+   * @property address The link entity address in one of the following forms:
    */
   address?: string;
   /**
-   * @property {string} audience The link entity token audience in one of the following forms:
+   * @property audience The link entity token audience in one of the following forms:
    */
   audience?: string;
 }
@@ -33,11 +33,11 @@ export interface LinkEntityOptions {
  */
 export class LinkEntity {
   /**
-   * @property {string} [name] The unique name for the entity (mostly a guid).
+   * @property [name] The unique name for the entity (mostly a guid).
    */
   name: string;
   /**
-   * @property {string} address The link entity address in one of the following forms:
+   * @property address The link entity address in one of the following forms:
    *
    * **Sender**
    * - `"<hubName>"`
@@ -51,7 +51,7 @@ export class LinkEntity {
    */
   address: string;
   /**
-   * @property {string} audience The link entity token audience in one of the following forms:
+   * @property audience The link entity token audience in one of the following forms:
    *
    * **Sender**
    * - `"sb://<yournamespace>.servicebus.windows.net/<hubName>"`
@@ -65,28 +65,28 @@ export class LinkEntity {
    */
   audience: string;
   /**
-   * @property {string} [partitionId] The partitionId associated with the link entity.
+   * @property [partitionId] The partitionId associated with the link entity.
    */
   partitionId?: string;
   /**
-   * @property {boolean} isConnecting Indicates whether the link is in the process of connecting
+   * @property isConnecting Indicates whether the link is in the process of connecting
    * (establishing) itself. Default value: `false`.
    */
   isConnecting: boolean = false;
   /**
-   * @property {ConnectionContext} _context Provides relevant information about the amqp connection,
+   * @property _context Provides relevant information about the amqp connection,
    * cbs and $management sessions, token provider, sender and receivers.
    * @protected
    */
   protected _context: ConnectionContext;
   /**
-   * @property {NodeJS.Timer} _tokenRenewalTimer The token renewal timer that keeps track of when
+   * @property _tokenRenewalTimer The token renewal timer that keeps track of when
    * the Link Entity is due for token renewal.
    * @protected
    */
   protected _tokenRenewalTimer?: NodeJS.Timer;
   /**
-   * @property {number} _tokenTimeout Indicates token timeout
+   * @property _tokenTimeout Indicates token timeout
    * @protected
    */
   protected _tokenTimeout?: number;
@@ -94,8 +94,8 @@ export class LinkEntity {
    * Creates a new LinkEntity instance.
    * @ignore
    * @constructor
-   * @param {ConnectionContext} context The connection context.
-   * @param {LinkEntityOptions} [options] Options that can be provided while creating the LinkEntity.
+   * @param context The connection context.
+   * @param [options] Options that can be provided while creating the LinkEntity.
    */
   constructor(context: ConnectionContext, options?: LinkEntityOptions) {
     if (!options) options = {};
@@ -110,8 +110,8 @@ export class LinkEntity {
    * Negotiates cbs claim for the LinkEntity.
    * @ignore
    * @protected
-   * @param {boolean} [setTokenRenewal] Set the token renewal timer. Default false.
-   * @return {Promise<void>} Promise<void>
+   * @param [setTokenRenewal] Set the token renewal timer. Default false.
+   * @returns Promise<void>
    */
   protected async _negotiateClaim(setTokenRenewal?: boolean): Promise<void> {
     // Acquire the lock and establish a cbs session if it does not exist on the connection.
@@ -180,7 +180,7 @@ export class LinkEntity {
    * Ensures that the token is renewed within the predefined renewal margin.
    * @ignore
    * @protected
-   * @returns {void}
+   * @returns
    */
   protected async _ensureTokenRenewal(): Promise<void> {
     if (!this._tokenTimeout) {
@@ -215,7 +215,7 @@ export class LinkEntity {
    * Closes the Sender|Receiver link and it's underlying session and also removes it from the
    * internal map.
    * @ignore
-   * @param {Sender | Receiver} [link] The Sender or Receiver link that needs to be closed and
+   * @param [link] The Sender or Receiver link that needs to be closed and
    * removed.
    */
   protected async _closeLink(link?: Sender | Receiver): Promise<void> {
@@ -247,7 +247,7 @@ export class LinkEntity {
 
   /**
    * Provides the current type of the LinkEntity.
-   * @return {string} The entity type.
+   * @returns The entity type.
    */
   private get _type(): string {
     let result = "LinkEntity";

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -10,51 +10,51 @@ import * as log from "./log";
 import { RetryOptions } from "./eventHubClient";
 import { AbortSignalLike } from "@azure/abort-controller";
 /**
- * Describes the runtime information of an EventHub.
+ * Describes the runtime information of an Event Hub.
  * @interface HubRuntimeInformation
  */
 export interface EventHubProperties {
   /**
-   * @property path - The name of the event hub.
+   * @property The name of the event hub.
    */
   path: string;
   /**
-   * @property createdAt - The date and time the hub was created in UTC.
+   * @property The date and time the hub was created in UTC.
    */
   createdAt: Date;
   /**
-   * @property partitionIds - The slice of string partition identifiers.
+   * @property The slice of string partition identifiers.
    */
   partitionIds: string[];
 }
 
 /**
  * Describes the runtime information of an EventHub Partition.
- * @interface PartitionInformation
+ * @interface PartitionProperties
  */
 export interface PartitionProperties {
   /**
-   * @property hubPath - The name of the eventhub.
+   * @property The name of the Event Hub.
    */
   eventHubPath: string;
   /**
-   * @property partitionId - Identifier of the partition within the eventhub.
+   * @property Identifier of the partition within the Event Hub.
    */
   partitionId: string;
   /**
-   * @property beginningSequenceNumber - The starting sequence number of the partition's message log.
+   * @property The starting sequence number of the partition's message log.
    */
   beginningSequenceNumber: number;
   /**
-   * @property lastSequenceNumber - The last sequence number of the partition's message log.
+   * @property The last sequence number of the partition's message log.
    */
   lastEnqueuedSequenceNumber: number;
   /**
-   * @property lastEnqueuedOffset - The offset of the last enqueued message in the partition's message log.
+   * @property The offset of the last enqueued message in the partition's message log.
    */
   lastEnqueuedOffset: string;
   /**
-   * @property lastEnqueuedTimeUtc - The time of the last enqueued message in the partition's message log in UTC.
+   * @property The time of the last enqueued message in the partition's message log in UTC.
    */
   lastEnqueuedTimeUtc: Date;
 }

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -15,15 +15,15 @@ import { AbortSignalLike } from "@azure/abort-controller";
  */
 export interface EventHubProperties {
   /**
-   * @property {string} path - The name of the event hub.
+   * @property path - The name of the event hub.
    */
   path: string;
   /**
-   * @property {Date} createdAt - The date and time the hub was created in UTC.
+   * @property createdAt - The date and time the hub was created in UTC.
    */
   createdAt: Date;
   /**
-   * @property {string[]} partitionIds - The slice of string partition identifiers.
+   * @property partitionIds - The slice of string partition identifiers.
    */
   partitionIds: string[];
 }
@@ -34,27 +34,27 @@ export interface EventHubProperties {
  */
 export interface PartitionProperties {
   /**
-   * @property {string} hubPath - The name of the eventhub.
+   * @property hubPath - The name of the eventhub.
    */
   eventHubPath: string;
   /**
-   * @property {string} partitionId - Identifier of the partition within the eventhub.
+   * @property partitionId - Identifier of the partition within the eventhub.
    */
   partitionId: string;
   /**
-   * @property {number} beginningSequenceNumber - The starting sequence number of the partition's message log.
+   * @property beginningSequenceNumber - The starting sequence number of the partition's message log.
    */
   beginningSequenceNumber: number;
   /**
-   * @property {number} lastSequenceNumber - The last sequence number of the partition's message log.
+   * @property lastSequenceNumber - The last sequence number of the partition's message log.
    */
   lastEnqueuedSequenceNumber: number;
   /**
-   * @property {string} lastEnqueuedOffset - The offset of the last enqueued message in the partition's message log.
+   * @property lastEnqueuedOffset - The offset of the last enqueued message in the partition's message log.
    */
   lastEnqueuedOffset: string;
   /**
-   * @property {Date} lastEnqueuedTimeUtc - The time of the last enqueued message in the partition's message log in UTC.
+   * @property lastEnqueuedTimeUtc - The time of the last enqueued message in the partition's message log in UTC.
    */
   lastEnqueuedTimeUtc: Date;
 }
@@ -76,12 +76,12 @@ export interface ManagementClientOptions {
 export class ManagementClient extends LinkEntity {
   readonly managementLock: string = `${Constants.managementRequestKey}-${uuid()}`;
   /**
-   * @property {string} entityPath - The name/path of the entity (hub name) for which the management
+   * @property entityPath - The name/path of the entity (hub name) for which the management
    * request needs to be made.
    */
   entityPath: string;
   /**
-   * @property {string} replyTo The reply to Guid for the management client.
+   * @property replyTo The reply to Guid for the management client.
    */
   replyTo: string = uuid();
   /**
@@ -94,8 +94,8 @@ export class ManagementClient extends LinkEntity {
    * Instantiates the management client.
    * @constructor
    * @ignore
-   * @param {BaseConnectionContext} context The connection context.
-   * @param {string} [address] The address for the management endpoint. For IotHub it will be
+   * @param context The connection context.
+   * @param [address] The address for the management endpoint. For IotHub it will be
    * `/messages/events/$management`.
    */
   constructor(context: ConnectionContext, options?: ManagementClientOptions) {
@@ -110,8 +110,8 @@ export class ManagementClient extends LinkEntity {
   /**
    * Provides the eventhub runtime information.
    * @ignore
-   * @param {Connection} connection - The established amqp connection
-   * @returns {Promise<EventHubProperties>}
+   * @param connection - The established amqp connection
+   * @returns
    */
   async getHubRuntimeInformation(options?: {
     retryOptions?: RetryOptions;
@@ -147,8 +147,8 @@ export class ManagementClient extends LinkEntity {
   /**
    * Provides an array of partitionIds.
    * @ignore
-   * @param {Connection} connection - The established amqp connection
-   * @returns {Promise<Array<string>>}
+   * @param connection - The established amqp connection
+   * @returns
    */
   async getPartitionIds(): Promise<Array<string>> {
     const runtimeInfo = await this.getHubRuntimeInformation();
@@ -158,8 +158,8 @@ export class ManagementClient extends LinkEntity {
   /**
    * Provides information about the specified partition.
    * @ignore
-   * @param {Connection} connection - The established amqp connection
-   * @param {string} partitionId Partition ID for which partition information is required.
+   * @param connection - The established amqp connection
+   * @param partitionId Partition ID for which partition information is required.
    */
   async getPartitionProperties(
     partitionId: string,
@@ -200,7 +200,7 @@ export class ManagementClient extends LinkEntity {
    * Closes the AMQP management session to the Event Hub for this client,
    * returning a promise that will be resolved when disconnection is completed.
    * @ignore
-   * @return {Promise<void>}
+   * @returns
    */
   async close(): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -61,6 +61,7 @@ export interface PartitionProperties {
 
 /**
  * @internal
+ * @ignore
  */
 export interface ManagementClientOptions {
   address?: string;

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -47,7 +47,7 @@ export class EventHubConsumer {
    */
   private _eventPosition: EventPosition;
   /**
-   * @property {boolean} [_isClosed] Denotes if close() was called on this receiver
+   * @property [_isClosed] Denotes if close() was called on this receiver
    */
   private _isClosed: boolean = false;
 
@@ -75,7 +75,7 @@ export class EventHubConsumer {
   }
 
   /**
-   * @property {string} [consumerGroup] The consumer group from which the handler is receiving
+   * @property [consumerGroup] The consumer group from which the handler is receiving
    * events from.
    * @readonly
    */
@@ -84,7 +84,7 @@ export class EventHubConsumer {
   }
 
   /**
-   * @property {number} [ownerLevel] The ownerLevel value of the underlying receiver, if present.
+   * @property [ownerLevel] The ownerLevel value of the underlying receiver, if present.
    * @readonly
    */
   get ownerLevel(): number | undefined {
@@ -126,12 +126,12 @@ export class EventHubConsumer {
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
    * the provided onMessage handler and error will be passed to the provided onError handler.
    *
-   * @param {OnMessage} onMessage The message handler to receive event data objects.
-   * @param {OnError} onError The error handler to receive an error that occurs
+   * @param onMessage The message handler to receive event data objects.
+   * @param onError The error handler to receive an error that occurs
    * while receiving messages.
-   * @param {AbortSignalLike} abortSignal Signal to cancel current operation.
+   * @param abortSignal Signal to cancel current operation.
    *
-   * @returns {ReceiveHandler} ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
+   * @returns ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
    */
   receive(onMessage: OnMessage, onError: OnError, abortSignal?: AbortSignalLike): ReceiveHandler {
     this._throwIfReceiverOrConnectionClosed();
@@ -180,12 +180,12 @@ export class EventHubConsumer {
    * Receives a batch of EventData objects from an EventHub partition for a given count and a given max wait time in seconds, whichever
    * happens first. This method can be used directly after creating the receiver object and **MUST NOT** be used along with the `start()` method.
    *
-   * @param {number} maxMessageCount The maximum message count. Must be a value greater than 0.
-   * @param {number} [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver should wait
+   * @param maxMessageCount The maximum message count. Must be a value greater than 0.
+   * @param [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver should wait
    * to receiver the said amount of messages. If not provided, it defaults to 60 seconds.
-   * @param {AbortSignalLike} abortSignal Signal to cancel current operation.
+   * @param abortSignal Signal to cancel current operation.
    *
-   * @returns {Promise<ReceivedEventData[]>} Promise<ReceivedEventData[]>.
+   * @returns Promise<ReceivedEventData[]>.
    */
   async receiveBatch(
     maxMessageCount: number,
@@ -252,7 +252,7 @@ export class EventHubConsumer {
    * Use the `createConsumer` function on the EventHubClient to instantiate
    * a new Receiver
    *
-   * @returns {Promise<void>}
+   * @returns
    */
   async close(): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -22,16 +22,16 @@ export interface EventIteratorOptions {
    */
   // prefetchCount?: number;
   /**
-   * Cancellation token to cancel the operation
+   * Signal to cancel the operation.
    */
   abortSignal?: AbortSignalLike;
 }
 
 /**
- * The Receiver class can be used to receive messages in a batch or by registering handlers.
- * Use the `createConsumer` function on the QueueClient or SubscriptionClient to instantiate a Receiver.
- * The Receiver class is an abstraction over the underlying AMQP receiver link.
- * @class Receiver
+ * The EventHubConsumer class can be used to receive messages in a batch or by registering handlers.
+ * Use the `createConsumer` function on the EventHubClient to instantiate an EventHubConsumer.
+ * The EventHubConsumer class is an abstraction over the underlying AMQP receiver link.
+ * @class EventHubConsumer
  */
 export class EventHubConsumer {
   /**
@@ -47,7 +47,7 @@ export class EventHubConsumer {
    */
   private _eventPosition: EventPosition;
   /**
-   * @property [_isClosed] Denotes if close() was called on this receiver
+   * @property Denotes if close() was called on this receiver
    */
   private _isClosed: boolean = false;
 
@@ -57,7 +57,7 @@ export class EventHubConsumer {
   private _batchingReceiver: BatchingReceiver | undefined;
 
   /**
-   * @property Returns `true` if the receiver is closed. This can happen either because the receiver
+   * @property Returns `true` if the consumer is closed. This can happen either because the consumer
    * itself has been closed or the client that created it has been closed.
    * @readonly
    */
@@ -66,8 +66,7 @@ export class EventHubConsumer {
   }
 
   /**
-   * @property Returns `true` if the receiver is closed. This can happen either because the receiver
-   * itself has been closed or the client that created it has been closed.
+   * @property Returns the Partition ID to receive events from.
    * @readonly
    */
   public get partitionId(): string {
@@ -75,7 +74,7 @@ export class EventHubConsumer {
   }
 
   /**
-   * @property [consumerGroup] The consumer group from which the handler is receiving
+   * @property The consumer group from which the handler is receiving
    * events from.
    * @readonly
    */
@@ -84,7 +83,7 @@ export class EventHubConsumer {
   }
 
   /**
-   * @property [ownerLevel] The ownerLevel value of the underlying receiver, if present.
+   * @property The ownerLevel value of the underlying consumer, if present.
    * @readonly
    */
   get ownerLevel(): number | undefined {
@@ -92,7 +91,7 @@ export class EventHubConsumer {
   }
 
   /**
-   * Indicates whether the receiver is currently receiving messages or not.
+   * Indicates whether the consumer is currently receiving messages or not.
    * When this returns true, new `receive()` or `receiveBatch()` calls cannot be made.
    */
   get isReceivingMessages(): boolean {
@@ -123,7 +122,7 @@ export class EventHubConsumer {
     this._receiverOptions = options || {};
   }
   /**
-   * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
+   * Starts the consumer by establishing an AMQP session and an AMQP receiver link on the session. Messages will be passed to
    * the provided onMessage handler and error will be passed to the provided onError handler.
    *
    * @param onMessage The message handler to receive event data objects.
@@ -135,7 +134,7 @@ export class EventHubConsumer {
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    * @throws {TypeError} Thrown if a required parameter is missing.
    * @throws {Error} Thrown if the underlying connection or receiver has been closed.
-   * Create a new consumer using the EventHubClient createConsumer method.
+   * Create a new EventHubConsumer using the EventHubClient createConsumer method.
    * @throws {Error} Thrown if the receiver is already receiving messages.
    */
   receive(onMessage: OnMessage, onError: OnError, abortSignal?: AbortSignalLike): ReceiveHandler {
@@ -163,7 +162,8 @@ export class EventHubConsumer {
   }
 
   /**
-   * Gets an async iterator over events from the receiver.
+   * Gets an async iterator over events from the consumer.
+   * @param [options] Options to pass to the event iterator.
    */
   async *getEventIterator(options?: EventIteratorOptions): AsyncIterableIterator<ReceivedEventData> {
     if (!options) {
@@ -194,7 +194,7 @@ export class EventHubConsumer {
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    * @throws {MessagingError} Thrown if an error is encountered while receiving a message.
    * @throws {Error} Thrown if the underlying connection or receiver has been closed.
-   * Create a new consumer using the EventHubClient createConsumer method.
+   * Create a new EventHubConsumer using the EventHubClient createConsumer method.
    * @throws {Error} Thrown if the receiver is already receiving messages.
    */
   async receiveBatch(
@@ -260,7 +260,7 @@ export class EventHubConsumer {
    * Closes the underlying AMQP receiver link.
    * Once closed, the consumer cannot be used for any further operations.
    * Use the `createConsumer` function on the EventHubClient to instantiate
-   * a new Receiver
+   * a new EventHubConsumer
    *
    * @returns
    * @throws {Error} Thrown if the underlying connection encounters an error while closing.

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -132,6 +132,11 @@ export class EventHubConsumer {
    * @param abortSignal Signal to cancel current operation.
    *
    * @returns ReceiveHandler - An object that provides a mechanism to stop receiving more messages.
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
+   * @throws {TypeError} Thrown if a required parameter is missing.
+   * @throws {Error} Thrown if the underlying connection or receiver has been closed.
+   * Create a new consumer using the EventHubClient createConsumer method.
+   * @throws {Error} Thrown if the receiver is already receiving messages.
    */
   receive(onMessage: OnMessage, onError: OnError, abortSignal?: AbortSignalLike): ReceiveHandler {
     this._throwIfReceiverOrConnectionClosed();
@@ -178,7 +183,7 @@ export class EventHubConsumer {
 
   /**
    * Receives a batch of EventData objects from an EventHub partition for a given count and a given max wait time in seconds, whichever
-   * happens first. This method can be used directly after creating the receiver object and **MUST NOT** be used along with the `start()` method.
+   * happens first. This method can be used directly after creating the consumer object and **MUST NOT** be used along with the `start()` method.
    *
    * @param maxMessageCount The maximum message count. Must be a value greater than 0.
    * @param [maxWaitTimeInSeconds] The maximum wait time in seconds for which the Receiver should wait
@@ -186,6 +191,11 @@ export class EventHubConsumer {
    * @param abortSignal Signal to cancel current operation.
    *
    * @returns Promise<ReceivedEventData[]>.
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
+   * @throws {MessagingError} Thrown if an error is encountered while receiving a message.
+   * @throws {Error} Thrown if the underlying connection or receiver has been closed.
+   * Create a new consumer using the EventHubClient createConsumer method.
+   * @throws {Error} Thrown if the receiver is already receiving messages.
    */
   async receiveBatch(
     maxMessageCount: number,
@@ -248,11 +258,12 @@ export class EventHubConsumer {
 
   /**
    * Closes the underlying AMQP receiver link.
-   * Once closed, the receiver cannot be used for any further operations.
+   * Once closed, the consumer cannot be used for any further operations.
    * Use the `createConsumer` function on the EventHubClient to instantiate
    * a new Receiver
    *
    * @returns
+   * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
   async close(): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -10,9 +10,9 @@ import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "
 
 /**
  * The EventHubProducer class can be used to send messages.
- * Use the `createProducer` function on the EventHubClient to instantiate a Sender.
- * The Sender class is an abstraction over the underlying AMQP sender link.
- * @class Sender
+ * Use the `createProducer` function on the EventHubClient to instantiate an EventHubProducer.
+ * The EventHubProducer class is an abstraction over the underlying AMQP sender link.
+ * @class EventHubProducer
  */
 export class EventHubProducer {
   /**
@@ -29,7 +29,7 @@ export class EventHubProducer {
   private _eventHubSender: EventHubSender | undefined;
 
   /**
-   * @property Returns `true` if either the sender or the client that created it has been closed
+   * @property Returns `true` if either the producer or the client that created it has been closed.
    * @readonly
    */
   public get isClosed(): boolean {
@@ -73,11 +73,11 @@ export class EventHubProducer {
 
   /**
    * Closes the underlying AMQP sender link.
-   * Once closed, the sender cannot be used for any further operations.
-   * Use the `createProducer` function on the EventHubClient to instantiate a new Sender
+   * Once closed, the producer cannot be used for any further operations.
+   * Use the `createProducer` function on the EventHubClient to instantiate a new EventHubProducer.
    *
    * @returns
-   * * @throws {Error} Thrown if the underlying connection encounters an error while closing.
+   * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
   async close(): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -9,7 +9,7 @@ import * as log from "./log";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
 
 /**
- * The Sender class can be used to send messages.
+ * The EventHubProducer class can be used to send messages.
  * Use the `createProducer` function on the EventHubClient to instantiate a Sender.
  * The Sender class is an abstraction over the underlying AMQP sender link.
  * @class Sender
@@ -56,6 +56,11 @@ export class EventHubProducer {
    * request via retry options, log level and cancellation token.
    *
    * @returns Promise<void>
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
+   * @throws {MessagingError} Thrown if an error is encountered while sending a message.
+   * @throws {TypeError} Thrown if a required parameter is missing.
+   * @throws {Error} Thrown if the underlying connection or sender has been closed.
+   * Create a new producer using the EventHubClient createProducer method.
    */
   async send(eventData: EventData | EventData[], options?: SendOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
@@ -72,6 +77,7 @@ export class EventHubProducer {
    * Use the `createProducer` function on the EventHubClient to instantiate a new Sender
    *
    * @returns
+   * * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
   async close(): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -55,7 +55,7 @@ export class EventHubProducer {
    * @param options Options where you can specifiy the partition to send the message to along with controlling the send
    * request via retry options, log level and cancellation token.
    *
-   * @return {Promise<void>} Promise<void>
+   * @returns Promise<void>
    */
   async send(eventData: EventData | EventData[], options?: SendOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
@@ -71,7 +71,7 @@ export class EventHubProducer {
    * Once closed, the sender cannot be used for any further operations.
    * Use the `createProducer` function on the EventHubClient to instantiate a new Sender
    *
-   * @returns {Promise<void>}
+   * @returns
    */
   async close(): Promise<void> {
     try {

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -11,8 +11,8 @@ import { AbortSignalLike } from "@azure/abort-controller";
 import { EventPosition } from "./eventPosition";
 
 /**
- * Describes the receive handler object that is returned from the receive() method with handlers is
- * called. The ReceiveHandler is used to stop receiving more messages.
+ * Describes the receive handler object that is returned from the receive() method with handlers.
+ * The ReceiveHandler is used to stop receiving more messages.
  * @class ReceiveHandler
  */
 export class ReceiveHandler {
@@ -33,8 +33,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property [partitionId] The partitionId from which the handler is receiving
-   * events from.
+   * @property The partitionId from which the handler is receiving events.
    * @readonly
    */
   get partitionId(): string | undefined {
@@ -42,8 +41,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property [consumerGroup] The consumer group from which the handler is receiving
-   * events from.
+   * @property The consumer group from which the handler is receiving events.
    * @readonly
    */
   get consumerGroup(): string | undefined {
@@ -51,7 +49,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property isReceiverOpen Indicates whether the receiver is connected/open.
+   * @property Indicates whether the receiver is connected/open.
    * `true` - is open; `false` otherwise.
    * @readonly
    */
@@ -62,6 +60,7 @@ export class ReceiveHandler {
   /**
    * Stops the underlying EventHubReceiver from receiving more messages.
    * @returns Promise<void>
+   * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
   async stop(): Promise<void> {
     if (this._receiver) {

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -17,7 +17,7 @@ import { EventPosition } from "./eventPosition";
  */
 export class ReceiveHandler {
   /**
-   * @property {EventHubReceiver} _receiver  The underlying EventHubReceiver.
+   * @property _receiver  The underlying EventHubReceiver.
    * @private
    */
   private _receiver: EventHubReceiver;
@@ -26,14 +26,14 @@ export class ReceiveHandler {
    * Creates an instance of the ReceiveHandler.
    * @constructor
    * @internal
-   * @param {EventHubReceiver} receiver The underlying EventHubReceiver.
+   * @param receiver The underlying EventHubReceiver.
    */
   constructor(receiver: EventHubReceiver) {
     this._receiver = receiver;
   }
 
   /**
-   * @property {string} [partitionId] The partitionId from which the handler is receiving
+   * @property [partitionId] The partitionId from which the handler is receiving
    * events from.
    * @readonly
    */
@@ -42,7 +42,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property {string} [consumerGroup] The consumer group from which the handler is receiving
+   * @property [consumerGroup] The consumer group from which the handler is receiving
    * events from.
    * @readonly
    */
@@ -51,7 +51,7 @@ export class ReceiveHandler {
   }
 
   /**
-   * @property {boolean} isReceiverOpen Indicates whether the receiver is connected/open.
+   * @property isReceiverOpen Indicates whether the receiver is connected/open.
    * `true` - is open; `false` otherwise.
    * @readonly
    */
@@ -61,7 +61,7 @@ export class ReceiveHandler {
 
   /**
    * Stops the underlying EventHubReceiver from receiving more messages.
-   * @return {Promise<void>} Promise<void>
+   * @returns Promise<void>
    */
   async stop(): Promise<void> {
     if (this._receiver) {
@@ -92,11 +92,11 @@ export class StreamingReceiver extends EventHubReceiver {
    * Instantiate a new receiver from the AMQP `Receiver`. Used by `EventHubClient`.
    * @ignore
    * @constructor
-   * @param {EventHubClient} client          The EventHub client.
-   * @param {string} consumerGroup The consumer group from which the receiver should receive events from.
-   * @param {string} partitionId             Partition ID from which to receive.
-   * @param {EventPosition} eventPosition    The event position in the partition at
-   * @param {EventHubConsumerOptions} [options]       Options for how you'd like to connect.
+   * @param client          The EventHub client.
+   * @param consumerGroup The consumer group from which the receiver should receive events from.
+   * @param partitionId             Partition ID from which to receive.
+   * @param eventPosition    The event position in the partition at
+   * @param [options]       Options for how you'd like to connect.
    */
   constructor(
     context: ConnectionContext,
@@ -112,9 +112,9 @@ export class StreamingReceiver extends EventHubReceiver {
   /**
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session.
    * @ignore
-   * @param {OnMessage} onMessage The message handler to receive event data objects.
-   * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
-   * @param {AbortSignalLike} abortSignal Signal to cancel current operation.
+   * @param onMessage The message handler to receive event data objects.
+   * @param onError The error handler to receive an error that occurs while receivin messages.
+   * @param abortSignal Signal to cancel current operation.
    */
   receive(onMessage: OnMessage, onError: OnError, abortSignal?: AbortSignalLike): ReceiveHandler {
     this._onMessage = onMessage;
@@ -166,11 +166,11 @@ export class StreamingReceiver extends EventHubReceiver {
    * Creates a streaming receiver.
    * @static
    * @ignore
-   * @param {ConnectionContext} context    The connection context.
-   * @param {string} consumerGroup The consumer group from which the receiver should receive events from.
-   * @param {string} partitionId  The partitionId to receive events from.
-   * @param {EventPosition} eventPosition The event position in the partition at which to start receiving messages.
-   * @param {EventHubConsumerOptions} [options]     Receive options.
+   * @param context    The connection context.
+   * @param consumerGroup The consumer group from which the receiver should receive events from.
+   * @param partitionId  The partitionId to receive events from.
+   * @param eventPosition The event position in the partition at which to start receiving messages.
+   * @param [options]     Receive options.
    */
   static create(
     context: ConnectionContext,


### PR DESCRIPTION
This PR will address #2657 

I'm testing changes using `typedoc` and `type2docfx`.

## Tasks

- [x] internal classes, interfaces and enums should have the @Internal tag so that they are not documented
- [x] docs on all other members need to be reviewed and updated appropriately
- [x] user facing apis that throw errors should document the errors that are thrown. If the error can be avoided programmatically, then we should document how to do so.
- [x] Parameter descriptions of the format @param {type} name get printed as is in our docs.microsoft.com, so skip the type in the {}