### PR TITLE
[Event Hubs] Add constructor overload that takes connection string and event hubs path

### DIFF
--- a/sdk/core/core-amqp/src/index.ts
+++ b/sdk/core/core-amqp/src/index.ts
@@ -7,7 +7,7 @@ export { RequestResponseLink, SendRequestOptions } from "./requestResponseLink";
 export { retry, RetryConfig, RetryOperationType } from "./retry";
 export { DataTransformer, DefaultDataTransformer } from "./dataTransformer";
 export { TokenType } from "./auth/token";
-export { AccessToken, TokenCredential } from "@azure/core-http";
+export { AccessToken, TokenCredential, isTokenCredential } from "@azure/core-http";
 export { SharedKeyCredential } from "./auth/sas";
 export { IotSharedKeyCredential } from "./auth/iotSas";
 

--- a/sdk/core/core-http/lib/credentials/tokenCredential.ts
+++ b/sdk/core/core-http/lib/credentials/tokenCredential.ts
@@ -49,8 +49,5 @@ export interface AccessToken {
  * @param credential The assumed TokenCredential to be tested.
  */
 export function isTokenCredential(credential: any): credential is TokenCredential {
-  if (!credential) {
-    return false;
-  }
-  return "getToken" in credential;
+  return credential && typeof credential.getToken === "function";
 }

--- a/sdk/core/core-http/lib/credentials/tokenCredential.ts
+++ b/sdk/core/core-http/lib/credentials/tokenCredential.ts
@@ -14,10 +14,7 @@ export interface TokenCredential {
    * @param options The options used to configure any requests this
    *                TokenCredential implementation might make.
    */
-  getToken(
-    scopes: string | string[],
-    options?: GetTokenOptions
-  ): Promise<AccessToken | null>;
+  getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
 }
 
 /**
@@ -52,5 +49,8 @@ export interface AccessToken {
  * @param credential The assumed TokenCredential to be tested.
  */
 export function isTokenCredential(credential: any): credential is TokenCredential {
+  if (!credential) {
+    return false;
+  }
   return "getToken" in credential;
 }

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.1",
     "@azure/core-amqp": "^1.0.0-preview.1",
-    "@azure/core-http": "^1.2.6",
     "async-lock": "^1.1.3",
     "debug": "^3.1.0",
     "is-buffer": "^2.0.3",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.1",
     "@azure/core-amqp": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.2.6",
     "async-lock": "^1.1.3",
     "debug": "^3.1.0",
     "is-buffer": "^2.0.3",

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -39,10 +39,10 @@ export interface EventData {
 // @public
 export class EventHubClient {
     constructor(connectionString: string, options?: EventHubClientOptions);
-    constructor(host: string, eventHubPath: string, credential: SharedKeyCredential | TokenCredential, options?: EventHubClientOptions);
+    constructor(connectionString: string, eventHubPath: string, options?: EventHubClientOptions);
+    constructor(host: string, eventHubPath: string, credential: TokenCredential, options?: EventHubClientOptions);
     close(): Promise<void>;
     createConsumer(consumerGroup: string, partitionId: string, eventPosition: EventPosition, options?: EventHubConsumerOptions): EventHubConsumer;
-    static createFromConnectionString(connectionString: string, entityPath?: string, options?: EventHubClientOptions): EventHubClient;
     static createFromIotHubConnectionString(iothubConnectionString: string, options?: EventHubClientOptions): Promise<EventHubClient>;
     createProducer(options?: EventHubProducerOptions): EventHubProducer;
     static defaultConsumerGroup: string;

--- a/sdk/eventhub/event-hubs/samples/getHubRuntimeInfo.ts
+++ b/sdk/eventhub/event-hubs/samples/getHubRuntimeInfo.ts
@@ -10,10 +10,10 @@ import { EventHubClient } from "@azure/event-hubs";
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = "";
-const eventHubsName = "";
+const eventHubName = "";
 
 async function main(): Promise<void> {
-  const client = new EventHubClient(connectionString, eventHubsName);
+  const client = new EventHubClient(connectionString, eventHubName);
 
   const info = await client.getProperties();
   console.log("RuntimeInfo: ", info);

--- a/sdk/eventhub/event-hubs/samples/getHubRuntimeInfo.ts
+++ b/sdk/eventhub/event-hubs/samples/getHubRuntimeInfo.ts
@@ -13,9 +13,9 @@ const connectionString = "";
 const eventHubsName = "";
 
 async function main(): Promise<void> {
-  const client = EventHubClient.createFromConnectionString(connectionString, eventHubsName);
+  const client = new EventHubClient(connectionString, eventHubsName);
 
-  const info = await client.getHubRuntimeInformation();
+  const info = await client.getProperties();
   console.log("RuntimeInfo: ", info);
 
   const pInfo = await client.getPartitionInformation(info.partitionIds[0]);

--- a/sdk/eventhub/event-hubs/samples/iotGetHubRuntimeInfo.ts
+++ b/sdk/eventhub/event-hubs/samples/iotGetHubRuntimeInfo.ts
@@ -13,7 +13,7 @@ const connectionString = "";
 async function main(): Promise<void> {
   const client = await EventHubClient.createFromIotHubConnectionString(connectionString);
 
-  const info = await client.getHubRuntimeInformation();
+  const info = await client.getProperties();
   console.log("RuntimeInfo: ", info);
 
   const pInfo = await client.getPartitionInformation(info.partitionIds[0]);

--- a/sdk/eventhub/event-hubs/samples/receiveEventsStreaming.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsStreaming.ts
@@ -27,11 +27,11 @@ async function main(): Promise<void> {
   };
 
   try {
-    const consumerHandler = consumer.receive(onMessageHandler, onErrorHandler);
+    const rcvHandler = consumer.receive(onMessageHandler, onErrorHandler);
 
     // Waiting long enough before closing the consumer to receive event
     await delay(5000);
-    await consumerHandler.stop();
+    await rcvHandler.stop();
   } finally {
     await client.close();
   }

--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -28,9 +28,9 @@ const listOfScientists = [
 ];
 
 async function main(): Promise<void> {
-  const client = EventHubClient.createFromConnectionString(connectionString, eventHubName);
+  const client = new EventHubClient(connectionString, eventHubName);
   const partitionIds = await client.getPartitionIds();
-  const sender = client.createSender({ partitionId: partitionIds[0] });
+  const producer = client.createProducer({ partitionId: partitionIds[0] });
   const events: EventData[] = [];
   try {
     // NOTE: For receiving events from Azure Stream Analytics, please send Events to an EventHub
@@ -46,7 +46,7 @@ async function main(): Promise<void> {
     }
     console.log("Sending batch events...");
 
-    await sender.send(events);
+    await producer.send(events);
   } finally {
     await client.close();
   }

--- a/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
@@ -22,13 +22,13 @@ import { EnvironmentCredential } from "@azure/identity";
 
 // Define Event Hubs Endpoint and related entity name here here
 const evenHubsEndpoint = ""; // <your-eventhubs-namespace>.servicebus.windows.net
-const eventHubsName = "";
+const eventHubName = "";
 
 // Define AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET of your AAD application in your environment
 
 async function main(): Promise<void> {
   const credential = new EnvironmentCredential();
-  const client = new EventHubClient(evenHubsEndpoint, eventHubsName, credential);
+  const client = new EventHubClient(evenHubsEndpoint, eventHubName, credential);
   /*
    Refer to other samples, and place your code here
    to send/receive events

--- a/sdk/eventhub/event-hubs/samples/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/websockets.ts
@@ -28,7 +28,7 @@ urlParts.auth = "username:password"; // Skip this if proxy server does not need 
 const proxyAgent = new httpsProxyAgent(urlParts);
 
 async function main(): Promise<void> {
-  const client = EventHubClient.createFromConnectionString(connectionString, eventHubsName, {
+  const client = new EventHubClient(connectionString, eventHubsName, {
     webSocket: WebSocket,
     webSocketConstructorOptions: { agent: proxyAgent }
   });

--- a/sdk/eventhub/event-hubs/samples/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/websockets.ts
@@ -18,7 +18,7 @@ const httpsProxyAgent = require("https-proxy-agent");
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = "";
-const eventHubsName = "";
+const eventHubName = "";
 
 // Create an instance of the `HttpsProxyAgent` class with the proxy server information like
 // proxy url, username and password
@@ -28,7 +28,7 @@ urlParts.auth = "username:password"; // Skip this if proxy server does not need 
 const proxyAgent = new httpsProxyAgent(urlParts);
 
 async function main(): Promise<void> {
-  const client = new EventHubClient(connectionString, eventHubsName, {
+  const client = new EventHubClient(connectionString, eventHubName, {
     webSocket: WebSocket,
     webSocketConstructorOptions: { agent: proxyAgent }
   });

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -23,6 +23,7 @@ import { AbortSignalLike } from "@azure/abort-controller";
 import { EventHubProducer } from "./sender";
 import { EventHubConsumer } from "./receiver";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
+import { isTokenCredential } from "@azure/core-http";
 
 /**
  * Retry policy options for operations on the EventHubClient
@@ -187,31 +188,44 @@ export class EventHubClient {
   constructor(connectionString: string, options?: EventHubClientOptions);
   /**
    * @constructor
+   * @param connectionString - Connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;'
+   * @param eventHubPath - EventHub path of the form 'my-event-hub-name'
+   * @param options - The options that can be provided during client creation.
+   */
+  constructor(connectionString: string, eventHubPath: string, options?: EventHubClientOptions);
+  /**
+   * @constructor
    * @param host - Fully qualified domain name for Event Hubs. Most likely,
    * <yournamespace>.servicebus.windows.net
    * @param eventHubPath - EventHub path of the form 'my-event-hub-name'
    * @param credential - SharedKeyCredential object or your credential that implements the TokenCredential interface.
    * @param options - The options that can be provided during client creation.
    */
-  constructor(
-    host: string,
-    eventHubPath: string,
-    credential: SharedKeyCredential | TokenCredential,
-    options?: EventHubClientOptions
-  );
+  constructor(host: string, eventHubPath: string, credential: TokenCredential, options?: EventHubClientOptions);
   constructor(
     hostOrConnectionString: string,
     eventHubPathOrOptions?: string | EventHubClientOptions,
-    credential?: SharedKeyCredential | TokenCredential,
+    credentialOrOptions?: TokenCredential | EventHubClientOptions,
     options?: EventHubClientOptions
   ) {
     let connectionString;
-    let cred: TokenCredential | SharedKeyCredential;
+    let credential: TokenCredential | SharedKeyCredential;
     hostOrConnectionString = String(hostOrConnectionString);
 
-    if (typeof eventHubPathOrOptions !== "string") {
+    if (!isTokenCredential(credentialOrOptions)) {
       connectionString = hostOrConnectionString;
-      options = eventHubPathOrOptions;
+      if (typeof eventHubPathOrOptions !== "string") {
+        options = eventHubPathOrOptions;
+      } else {
+        const eventHubPath = String(eventHubPathOrOptions);
+        if (!eventHubPath) {
+          throw new Error(`Please provide a event hub path.`);
+        }
+        if (connectionString.indexOf(";EntityPath=") === -1) {
+          connectionString = `${connectionString};EntityPath=${eventHubPath}`;
+        }
+        options = credentialOrOptions;
+      }
       const parsedCS = parseConnectionString<EventHubConnectionStringModel>(connectionString);
       if (!parsedCS.EntityPath) {
         throw new Error(
@@ -219,32 +233,21 @@ export class EventHubClient {
             '"Endpoint=sb://fully-qualified-host-name/;SharedAccessKeyName=shared-access-policy-name;SharedAccessKey=shared-access-key;EntityPath=event-hub-name"'
         );
       }
-      cred = new SharedKeyCredential(parsedCS.SharedAccessKeyName, parsedCS.SharedAccessKey);
+      credential = new SharedKeyCredential(parsedCS.SharedAccessKeyName, parsedCS.SharedAccessKey);
     } else {
-      const eventHubPath = eventHubPathOrOptions;
-      let sharedAccessKeyName = "defaultKeyName";
-      let sharedAccessKey = "defaultKeyValue";
+      const eventHubPath = String(eventHubPathOrOptions);
+      let host = hostOrConnectionString;
+      credential = credentialOrOptions;
 
-      if (!credential) {
-        throw new Error("Please provide either a token credential interface or a valid SharedKeyCredential object.");
-      }
-
-      cred = credential;
-      if (cred instanceof SharedKeyCredential) {
-        sharedAccessKeyName = cred.keyName;
-        sharedAccessKey = cred.key;
-      }
-
-      let host = String(hostOrConnectionString);
       if (!host.endsWith("/")) host += "/";
-      connectionString = `Endpoint=sb://${host};SharedAccessKeyName=${sharedAccessKeyName};SharedAccessKey=${sharedAccessKey};EntityPath=${eventHubPath}`;
+      connectionString = `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;SharedAccessKey=defaultKeyValue;EntityPath=${eventHubPath}`;
     }
 
     const config = EventHubConnectionConfig.create(connectionString);
     ConnectionConfig.validate(config);
 
     this._clientOptions = options || {};
-    this._context = ConnectionContext.create(config, cred, this._clientOptions);
+    this._context = ConnectionContext.create(config, credential, this._clientOptions);
   }
 
   /**
@@ -362,31 +365,6 @@ export class EventHubClient {
       log.error("An error occurred while getting the partition information: %O", err);
       throw err;
     }
-  }
-
-  /**
-   * Creates an EventHubClient from connection string. If the connection string doesnt have
-   * the EntityPath set in it, then use the entityPath parameter to pass the event hub name
-   * @param {string} connectionString - Connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key'
-   * @param {string} [entityPath] - EventHub path of the form 'my-event-hub-name'
-   * @param {EventHubClientOptions} [options] Options that can be provided during client creation.
-   * @returns {EventHubClient} - An instance of the eventhub client.
-   */
-
-  static createFromConnectionString(
-    connectionString: string,
-    entityPath?: string,
-    options?: EventHubClientOptions
-  ): EventHubClient {
-    const config = ConnectionConfig.create(connectionString, entityPath);
-    if (!config.entityPath) {
-      throw new Error(
-        `Either provide "path" or the "connectionString": "${connectionString}", ` +
-          `must contain EntityPath="<path-to-the-entity>".`
-      );
-    }
-    const sharedTokenCredential = new SharedKeyCredential(config.sharedAccessKeyName, config.sharedAccessKey);
-    return new EventHubClient(config.host, config.entityPath, sharedTokenCredential, options);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -20,14 +20,14 @@ const env = getEnvVars();
 describe("EventHubClient #RunnableInBrowser", function(): void {
   describe(".fromConnectionString", function(): void {
     it("throws when it cannot find the Event Hub path", function(): void {
-      const endpoint = "Endpoint=sb://abc";
+      const connectionString = "Endpoint=sb://abc";
       const test = function(): EventHubClient {
-        return new EventHubClient(endpoint);
+        return new EventHubClient(connectionString);
       };
       test.should.throw(
         Error,
-        'EntityPath is missing in the connection string. The value for the "connectionString" parameter must be of the form ' +
-          '"Endpoint=sb://fully-qualified-host-name/;SharedAccessKeyName=shared-access-policy-name;SharedAccessKey=shared-access-key;EntityPath=event-hub-name"'
+        `Either provide "path" or the "connectionString": "${connectionString}", ` +
+        `must contain EntityPath="<path-to-the-entity>".`
       );
     });
 

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -40,7 +40,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
   }
 
   it("gets the hub runtime information", async function(): Promise<void> {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path, {
+    client = new EventHubClient(service.connectionString, service.path, {
       userAgent: "/js-event-processor-host=0.2.0"
     });
     const hubRuntimeInfo = await client.getProperties();
@@ -54,7 +54,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
   });
 
   it("can cancel a request for hub runtime information", async function(): Promise<void> {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path, {
+    client = new EventHubClient(service.connectionString, service.path, {
       userAgent: "/js-event-processor-host=0.2.0"
     });
     try {
@@ -68,7 +68,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
   });
 
   it("gets the partition runtime information with partitionId as a string", async function(): Promise<void> {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+    client = new EventHubClient(service.connectionString, service.path);
     const partitionRuntimeInfo = await client.getPartitionInformation("0");
     debug(partitionRuntimeInfo);
     partitionRuntimeInfo.id.should.equal("0");
@@ -79,7 +79,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
   });
 
   it("gets the partition runtime information with partitionId as a number", async function(): Promise<void> {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+    client = new EventHubClient(service.connectionString, service.path);
     const partitionRuntimeInfo = await client.getPartitionInformation(0 as any);
     debug(partitionRuntimeInfo);
     partitionRuntimeInfo.id.should.equal("0");
@@ -90,7 +90,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
   });
 
   it("can cancel a request for getPartitionInformation", async function(): Promise<void> {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+    client = new EventHubClient(service.connectionString, service.path);
     try {
       const controller = new AbortController();
       setTimeout(() => controller.abort(), 1);
@@ -102,7 +102,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
   });
 
   it("should fail the partition runtime information when partitionId is empty string", async function(): Promise<void> {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+    client = new EventHubClient(service.connectionString, service.path);
     try {
       await client.getPartitionInformation("");
     } catch (err) {
@@ -113,7 +113,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
   it("should fail the partition runtime information when partitionId is a negative number", async function(): Promise<
     void
   > {
-    client = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+    client = new EventHubClient(service.connectionString, service.path);
     try {
       await client.getPartitionInformation(-1 as any);
     } catch (err) {

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -19,7 +19,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
     connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
     path: env[EnvVarKeys.EVENTHUB_NAME]
   };
-  const client: EventHubClient = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+  const client: EventHubClient = new EventHubClient(service.connectionString, service.path);
   let breceiver: BatchingReceiver;
   let hubInfo: EventHubProperties;
   before("validate environment", async function(): Promise<void> {

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -20,7 +20,7 @@ describe("EventHub Receiver #RunnableInBrowser", function(): void {
     connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
     path: env[EnvVarKeys.EVENTHUB_NAME]
   };
-  const client: EventHubClient = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+  const client: EventHubClient = new EventHubClient(service.connectionString, service.path);
   let breceiver: BatchingReceiver;
   let receiver: EventHubConsumer | undefined;
   let partitionIds: string[];

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -17,7 +17,7 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
     connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
     path: env[EnvVarKeys.EVENTHUB_NAME]
   };
-  const client: EventHubClient = EventHubClient.createFromConnectionString(service.connectionString!, service.path);
+  const client: EventHubClient = new EventHubClient(service.connectionString, service.path);
   before("validate environment", function(): void {
     should.exist(
       env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],


### PR DESCRIPTION
* Add a constructor overload that follows below signature

```typescript
constructor(connectionString: string, eventHubPath: string, options?: EventHubClientOptions)
```
*  remove the static helper that we have for connectionstring + event hub path
* Remove  SharedKeyCredential from the constructor  
* Update all the samples
* update tests
