### PR TITLE
[KeyVault] Use cross-env in package.json scripts

### DIFF
--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -62,7 +62,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "env TEST_MODE=playback npm run  integration-test:node",
+    "unit-test:node": "cross-env TEST_MODE=playback npm run  integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "sideEffects": false,
@@ -81,6 +81,7 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^10.0.1",
     "chai": "^4.2.0",
+    "cross-env": "^5.2.0",
     "dotenv": "^7.0.0",
     "fs-extra": "~8.0.1",
     "mocha": "^5.2.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -62,7 +62,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "env TEST_MODE=playback npm run integration-test:node",
+    "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "sideEffects": false,
@@ -83,6 +83,7 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^10.0.1",
     "chai": "^4.2.0",
+    "cross-env": "^5.2.0",
     "dotenv": "^7.0.0",
     "fs-extra": "~8.0.1",
     "mocha": "^5.2.0",


### PR DESCRIPTION
- "env" may be unavailable on Windows