### PR TITLE
[Event Hubs] Add tests for client creation and client close() 

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -21,7 +21,7 @@ import { IotHubClient } from "./iothub/iothubClient";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { EventHubProducer } from "./sender";
 import { EventHubConsumer } from "./receiver";
-import { throwTypeErrorIfParameterMissing } from "./util/error";
+import { throwTypeErrorIfParameterMissing, throwErrorIfConnectionClosed } from "./util/error";
 
 /**
  * Retry policy options for operations on the EventHubClient.
@@ -284,6 +284,7 @@ export class EventHubClient {
    * @returns Promise<void>
    */
   createProducer(options?: EventHubProducerOptions): EventHubProducer {
+    throwErrorIfConnectionClosed(this._context);
     return new EventHubProducer(this._context, options);
   }
 
@@ -305,6 +306,7 @@ export class EventHubClient {
     eventPosition: EventPosition,
     options?: EventHubConsumerOptions
   ): EventHubConsumer {
+    throwErrorIfConnectionClosed(this._context);
     throwTypeErrorIfParameterMissing(this._context.connectionId, "consumerGroup", consumerGroup);
     throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
     throwTypeErrorIfParameterMissing(this._context.connectionId, "eventPosition", eventPosition);
@@ -318,6 +320,7 @@ export class EventHubClient {
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getProperties(abortSignal?: AbortSignalLike): Promise<EventHubProperties> {
+    throwErrorIfConnectionClosed(this._context);
     try {
       return await this._context.managementSession!.getHubRuntimeInformation({
         retryOptions: this._clientOptions.retryOptions,
@@ -335,6 +338,7 @@ export class EventHubClient {
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getPartitionIds(abortSignal?: AbortSignalLike): Promise<Array<string>> {
+    throwErrorIfConnectionClosed(this._context);
     try {
       const runtimeInfo = await this.getProperties(abortSignal);
       return runtimeInfo.partitionIds;
@@ -351,6 +355,7 @@ export class EventHubClient {
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getPartitionProperties(partitionId: string, abortSignal?: AbortSignalLike): Promise<PartitionProperties> {
+    throwErrorIfConnectionClosed(this._context);
     throwTypeErrorIfParameterMissing(this._context.connectionId, "partitionId", partitionId);
     partitionId = String(partitionId);
     try {

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -281,6 +281,7 @@ export class EventHubClient {
    * @param options Options to create a EventHubProducer where you can specify the id of the partition
    * to which events need to be sent to, and retry options.
    *
+   * @throws {Error} Thrown if the underlying connection has been closed, create a new EventHubClient.
    * @returns Promise<void>
    */
   createProducer(options?: EventHubProducerOptions): EventHubProducer {
@@ -298,6 +299,7 @@ export class EventHubClient {
    * @param options Options to create the EventHubConsumer where you can specify the position from
    * which to start receiving events, the consumer group to receive events from, retry options
    * and more.
+   * @throws {Error} Thrown if the underlying connection has been closed, create a new EventHubClient.
    * @throws {TypeError} Thrown if a required parameter is missing.
    */
   createConsumer(
@@ -317,6 +319,7 @@ export class EventHubClient {
   /**
    * Provides the Event Hub runtime information.
    * @returns A promise that resolves with EventHubProperties.
+   * @throws {Error} Thrown if the underlying connection has been closed, create a new EventHubClient.
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getProperties(abortSignal?: AbortSignalLike): Promise<EventHubProperties> {
@@ -335,6 +338,7 @@ export class EventHubClient {
   /**
    * Provides an array of partitionIds.
    * @returns A promise that resolves with an Array of strings.
+   * @throws {Error} Thrown if the underlying connection has been closed, create a new EventHubClient.
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getPartitionIds(abortSignal?: AbortSignalLike): Promise<Array<string>> {
@@ -352,6 +356,7 @@ export class EventHubClient {
    * Provides information about the specified partition.
    * @param partitionId Partition ID for which partition information is required.
    * @returns A promise that resoloves with PartitionProperties.
+   * @throws {Error} Thrown if the underlying connection has been closed, create a new EventHubClient.
    * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    */
   async getPartitionProperties(partitionId: string, abortSignal?: AbortSignalLike): Promise<PartitionProperties> {

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -62,7 +62,7 @@ export class EventHubConsumer {
    * @readonly
    */
   public get isClosed(): boolean {
-    return this._isClosed;
+    return this._isClosed || this._context.wasConnectionCloseCalled;
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -33,7 +33,7 @@ export class EventHubProducer {
    * @readonly
    */
   public get isClosed(): boolean {
-    return this._isClosed;
+    return this._isClosed || this._context.wasConnectionCloseCalled;
   }
 
   /**

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -10,304 +10,374 @@ import chaiString from "chai-string";
 chai.use(chaiString);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:client-spec");
-import { EventHubClient, EventPosition } from "../src";
+import { EventHubClient, EventPosition, TokenCredential, EventHubProducer, EventHubConsumer } from "../src";
 import { packageJsonInfo } from "../src/util/constants";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
-import { AbortController } from "@azure/abort-controller";
 // import { EnvironmentCredential } from "@azure/identity";
 const env = getEnvVars();
 
-describe("EventHubClient #RunnableInBrowser", function(): void {
-  describe(".fromConnectionString", function(): void {
-    it("throws when it cannot find the Event Hub path", function(): void {
-      const connectionString = "Endpoint=sb://abc";
-      const test = function(): EventHubClient {
-        return new EventHubClient(connectionString);
-      };
-      test.should.throw(
-        Error,
-        `Either provide "path" or the "connectionString": "${connectionString}", ` +
+describe("Create EventHubClient #RunnableInBrowser", function(): void {
+  it("throws when it cannot find the Event Hub path", function(): void {
+    const connectionString = "Endpoint=sb://abc";
+    const test = function(): EventHubClient {
+      return new EventHubClient(connectionString);
+    };
+    test.should.throw(
+      Error,
+      `Either provide "path" or the "connectionString": "${connectionString}", ` +
         `must contain EntityPath="<path-to-the-entity>".`
-      );
-    });
-
-    it("creates an EventHubClient from a connection string", function(): void {
-      const client = new EventHubClient("Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=d");
-      client.should.be.an.instanceof(EventHubClient);
-    });
-
-    it("creates an EventHubClient from a connection string and an Event Hub path", function(): void {
-      const client = new EventHubClient("Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c", "path");
-      client.should.be.an.instanceof(EventHubClient);
-    });
+    );
   });
+
+  it("creates an EventHubClient from a connection string", function(): void {
+    const client = new EventHubClient(
+      "Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=my-event-hub-path"
+    );
+    client.should.be.an.instanceof(EventHubClient);
+    should.equal(client.eventHubName, "my-event-hub-path");
+  });
+
+  it("creates an EventHubClient from a connection string and an Event Hub path", function(): void {
+    const client = new EventHubClient("Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c", "my-event-hub-path");
+    client.should.be.an.instanceof(EventHubClient);
+    should.equal(client.eventHubName, "my-event-hub-path");
+  });
+
+  it("creates an EventHubClient from a custom TokenCredential", function(): void {
+    const dummyCredential: TokenCredential = {
+      getToken: async () => {
+        return {
+          token: "boo",
+          expiresOnTimestamp: 12324
+        };
+      }
+    };
+    const client = new EventHubClient("abc", "my-event-hub-path", dummyCredential);
+    client.should.be.an.instanceof(EventHubClient);
+    should.equal(client.eventHubName, "my-event-hub-path");
+  });
+
+  // it("creates an EventHubClient from an Azure.Identity credential", async function(): Promise<void> {
+  //   should.exist(
+  //     env[EnvVarKeys.AZURE_CLIENT_ID],
+  //     "define AZURE_CLIENT_ID in your environment before running integration tests."
+  //   );
+  //   should.exist(
+  //     env[EnvVarKeys.AZURE_TENANT_ID],
+  //     "define AZURE_TENANT_ID in your environment before running integration tests."
+  //   );
+  //   should.exist(
+  //     env[EnvVarKeys.AZURE_CLIENT_SECRET],
+  //     "define AZURE_CLIENT_SECRET in your environment before running integration tests."
+  //   );
+  //   should.exist(env[EnvVarKeys.ENDPOINT], "define ENDPOINT in your environment before running integration tests.");
+
+  //   const credential = new EnvironmentCredential();
+  //   const client = new EventHubClient(env.ENDPOINT, env.EVENTHUB_NAME, credential);
+
+  //   // Extra check involving actual call to the service to ensure this works
+  //   const hubInfo = await client.getProperties();
+  //   should.equal(hubInfo.path, client.eventHubName);
+  //   await client.close();
+  // });
 });
 
-function arrayOfIncreasingNumbersFromZero(length: any): Array<string> {
-  // tslint:disable-next-line: no-null-keyword
-  return Array.apply(null, new Array(length)).map((x: any, i: any) => {
-    return `${i}`;
-  });
-}
-
-before("validate environment", function(): void {
-  should.exist(
-    env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
-    "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
-  );
-  should.exist(
-    env[EnvVarKeys.EVENTHUB_NAME],
-    "define EVENTHUB_NAME in your environment before running integration tests."
-  );
-});
-
-const service = {
-  connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
-  path: env[EnvVarKeys.EVENTHUB_NAME]
-};
-
-describe("EventHubClient on #RunnableInBrowser", function(): void {
+describe("ServiceCommunicationError for non existent namespace", function(): void {
   let client: EventHubClient;
 
-  afterEach("close the connection", async function(): Promise<void> {
-    if (client) {
-      debug(">>>>>>>> afterEach: closing the client.");
-      await client.close();
+  beforeEach(() => {
+    client = new EventHubClient("Endpoint=sb://a;SharedAccessKeyName=b;SharedAccessKey=c;EntityPath=d");
+  });
+
+  afterEach(() => {
+    return client.close();
+  });
+
+  it("should throw ServiceCommunicationError while getting hub runtime info", async function(): Promise<void> {
+    try {
+      await client.getProperties();
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "ServiceCommunicationError");
     }
   });
 
-  describe("user-agent", function(): void {
-    it("should correctly populate the default user agent", function(done: Mocha.Done): void {
-      client = new EventHubClient(service.connectionString, service.path);
-      const packageVersion = packageJsonInfo.version;
-      const properties = client["_context"].connection.options.properties;
-      properties!["user-agent"].should.startWith(`azsdk-js-azureeventhubs/${packageVersion}`);
-      should.equal(properties!.product, "MSJSClient");
-      should.equal(properties!.version, packageVersion);
-      should.equal(properties!.framework, `Node/${process.version}`);
-      should.equal(properties!.platform, `(${os.arch()}-${os.type()}-${os.release()})`);
-      done();
-    });
-
-    it("should correctly populate the custom user agent", function(done: Mocha.Done): void {
-      const customua = "/js-event-processor-host=0.2.0";
-      client = new EventHubClient(service.connectionString, service.path, {
-        userAgent: customua
-      });
-      const packageVersion = packageJsonInfo.version;
-      const properties = client["_context"].connection.options.properties;
-      properties!["user-agent"].should.startWith(`azsdk-js-azureeventhubs/${packageVersion}`);
-      properties!["user-agent"].should.endWith(customua);
-      should.equal(properties!.product, "MSJSClient");
-      should.equal(properties!.version, packageVersion);
-      should.equal(properties!.framework, `Node/${process.version}`);
-      should.equal(properties!.platform, `(${os.arch()}-${os.type()}-${os.release()})`);
-      done();
-    });
+  it("should throw ServiceCommunicationError while getting partition runtime info", async function(): Promise<void> {
+    try {
+      await client.getPartitionProperties("0");
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "ServiceCommunicationError");
+    }
   });
 
-  describe("#close", function(): void {
-    it("is a no-op when the connection is already closed", function(): Chai.PromisedAssertion {
-      client = new EventHubClient(service.connectionString, service.path);
-      return client.close().should.be.fulfilled;
-    });
+  it("should throw ServiceCommunicationError while creating a sender", async function(): Promise<void> {
+    try {
+      const sender = client.createProducer({ partitionId: "0" });
+      await sender.send([{ body: "Hello World" }]);
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "ServiceCommunicationError");
+    }
   });
 
-  describe("getPartitionIds", function(): void {
-    it("returns an array of partition IDs", async function(): Promise<void> {
-      client = new EventHubClient(service.connectionString, service.path);
-      const ids = await client.getPartitionIds();
-      ids.should.have.members(arrayOfIncreasingNumbersFromZero(ids.length));
-    });
+  it("should throw ServiceCommunicationError while creating a receiver", async function(): Promise<void> {
+    try {
+      const receiver = client.createConsumer(EventHubClient.defaultConsumerGroup, "0", EventPosition.earliest());
+      await receiver.receiveBatch(10, 5);
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "ServiceCommunicationError");
+    }
+  });
+});
 
-    it("respects cancellationTokens", async function(): Promise<void> {
-      client = new EventHubClient(service.connectionString, service.path);
-      try {
-        const controller = new AbortController();
-        setTimeout(() => controller.abort(), 1);
-        await client.getPartitionIds(controller.signal);
-        throw new Error(`Test failure`);
-      } catch (err) {
-        err.message.should.match(/The [\w]+ operation has been cancelled by the user.$/gi);
-      }
-    });
+describe("MessagingEntityNotFoundError for non existent eventhub", function(): void {
+  let client: EventHubClient;
+
+  beforeEach(() => {
+    should.exist(
+      env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
+      "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
+    );
+    client = new EventHubClient(env[EnvVarKeys.EVENTHUB_CONNECTION_STRING], "bad" + Math.random());
   });
 
-  describe("non existent eventhub", function(): void {
-    it("should throw MessagingEntityNotFoundError while getting hub runtime info", async function(): Promise<void> {
-      try {
-        client = new EventHubClient(service.connectionString, "bad" + Math.random());
-        await client.getProperties();
-      } catch (err) {
-        debug(err);
-        should.equal(err.name, "MessagingEntityNotFoundError");
-      }
-    });
-
-    it("should throw MessagingEntityNotFoundError while getting partition runtime info", async function(): Promise<
-      void
-    > {
-      try {
-        client = new EventHubClient(service.connectionString, "bad" + Math.random());
-        await client.getPartitionProperties("0");
-      } catch (err) {
-        debug(err);
-        should.equal(err.name, "MessagingEntityNotFoundError");
-      }
-    });
-
-    it("should throw MessagingEntityNotFoundError while creating a sender", async function(): Promise<void> {
-      try {
-        client = new EventHubClient(service.connectionString, "bad" + Math.random());
-        const sender = client.createProducer({ partitionId: "0" });
-        await sender.send([{ body: "Hello World" }]);
-      } catch (err) {
-        debug(err);
-        should.equal(err.name, "MessagingEntityNotFoundError");
-      }
-    });
-
-    it("should throw MessagingEntityNotFoundError while creating a receiver", async function(): Promise<void> {
-      try {
-        client = new EventHubClient(service.connectionString, "bad" + Math.random());
-        const receiver = client.createConsumer(EventHubClient.defaultConsumerGroup, "0", EventPosition.earliest());
-        await receiver.receiveBatch(10, 5);
-      } catch (err) {
-        debug(err);
-        should.equal(err.name, "MessagingEntityNotFoundError");
-      }
-    });
+  afterEach(() => {
+    return client.close();
   });
 
-  describe("createConsumer", function(): void {
-    it("should throw an error if EventPosition is missing", function() {
-      try {
-        client = new EventHubClient(service.connectionString, service.path);
-        client.createConsumer(EventHubClient.defaultConsumerGroup, "0", undefined as any);
-        throw new Error("Test failure");
-      } catch (err) {
-        err.name.should.equal("TypeError");
-        err.message.should.equal(`Missing parameter "eventPosition"`);
-      }
-    });
-
-    it("should throw an error if consumerGroup is missing", function() {
-      try {
-        client = new EventHubClient(service.connectionString, service.path);
-        client.createConsumer(undefined as any, "0", EventPosition.earliest());
-        throw new Error("Test failure");
-      } catch (err) {
-        err.name.should.equal("TypeError");
-        err.message.should.equal(`Missing parameter "consumerGroup"`);
-      }
-    });
+  it("should throw MessagingEntityNotFoundError while getting hub runtime info", async function(): Promise<void> {
+    try {
+      await client.getProperties();
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "MessagingEntityNotFoundError");
+    }
   });
 
-  describe("non existent consumer group", function(): void {
-    it("should throw MessagingEntityNotFoundError while creating a receiver", function(done: Mocha.Done): void {
-      try {
-        client = new EventHubClient(service.connectionString, service.path);
-        debug(">>>>>>>> client created.");
-        const onMessage = (data: any) => {
-          debug(">>>>> data: ", data);
-        };
-        const onError = (error: any) => {
-          debug(">>>>>>>> error occurred", error);
-          // sleep for 3 seconds so that receiver link and the session can be closed properly then
-          // in aftereach the connection can be closed. closing the connection while the receiver
-          // link and it's session are being closed (and the session being removed from rhea's
-          // internal map) can create havoc.
-          setTimeout(() => {
-            done(should.equal(error.name, "MessagingEntityNotFoundError"));
-          }, 3000);
-        };
-        const receiver = client.createConsumer("some-random-name", "0", EventPosition.earliest());
-        receiver.receive(onMessage, onError);
-        debug(">>>>>>>> attached the error handler on the receiver...");
-      } catch (err) {
-        debug(">>> Some error", err);
-        throw new Error("This code path must not have hit.. " + JSON.stringify(err));
-      }
-    });
+  it("should throw MessagingEntityNotFoundError while getting partition runtime info", async function(): Promise<void> {
+    try {
+      await client.getPartitionProperties("0");
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "MessagingEntityNotFoundError");
+    }
   });
 
-  describe("on invalid partition ids like", function(): void {
-    const invalidIds = ["XYZ", "-1", "1000", "-", " "];
-    invalidIds.forEach(function(id: string): void {
-      it(`"${id}" should throw an error`, async function(): Promise<void> {
-        try {
-          client = new EventHubClient(service.connectionString, service.path);
-          await client.getPartitionProperties(id);
-        } catch (err) {
-          debug(`>>>> Received error - `, err);
-          should.exist(err);
-          err.message.should.match(
-            /.*The specified partition is invalid for an EventHub partition sender or receiver.*/gi
-          );
-        }
-      });
-    });
-
-    // tslint:disable-next-line: no-null-keyword
-    const invalidIds2 = ["", null];
-    invalidIds2.forEach(function(id: string | null): void {
-      it(`"${id}" should throw an error`, async function(): Promise<void> {
-        try {
-          client = new EventHubClient(service.connectionString, service.path);
-          await client.getPartitionProperties(id as any);
-        } catch (err) {
-          debug(`>>>> Received error - `, err);
-          should.exist(err);
-        }
-      });
-    });
+  it("should throw MessagingEntityNotFoundError while creating a sender", async function(): Promise<void> {
+    try {
+      const sender = client.createProducer({ partitionId: "0" });
+      await sender.send([{ body: "Hello World" }]);
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "MessagingEntityNotFoundError");
+    }
   });
-}).timeout(60000);
 
-// describe("Test AadTokenCredentials", function(): void {
-//   let errorWasThrown: boolean = false;
-//   before("validate environment", function(): void {
-//     should.exist(
-//       env[EnvVarKeys.AZURE_CLIENT_ID],
-//       "define AZURE_CLIENT_ID in your environment before running integration tests."
-//     );
-//     should.exist(
-//       env[EnvVarKeys.AZURE_TENANT_ID],
-//       "define AZURE_TENANT_ID in your environment before running integration tests."
-//     );
-//     should.exist(
-//       env[EnvVarKeys.AZURE_CLIENT_SECRET],
-//       "define AZURE_CLIENT_SECRET in your environment before running integration tests."
-//     );
-//     should.exist(env[EnvVarKeys.ENDPOINT], "define ENDPOINT in your environment before running integration tests.");
-//   });
+  it("should throw MessagingEntityNotFoundError while creating a receiver", async function(): Promise<void> {
+    try {
+      const receiver = client.createConsumer(EventHubClient.defaultConsumerGroup, "0", EventPosition.earliest());
+      await receiver.receiveBatch(10, 5);
+    } catch (err) {
+      debug(err);
+      should.equal(err.name, "MessagingEntityNotFoundError");
+    }
+  });
+});
 
-//   async function testAadTokenCredentials(client: EventHubClient): Promise<void> {
-//     const sender = client.createProducer();
-//     const partitionIds = await client.getPartitionIds();
-//     const receiver = await client.createConsumer(partitionIds[0]);
-//     await sender.send({ body: "Hello world" });
-//     const msgs = await receiver.receiveBatch(1);
+describe("User Agent on EventHubClient on #RunnableInBrowser", function(): void {
+  let client: EventHubClient;
 
-//     should.equal(msgs.length, 1, "Unexpected number of messages");
-//   }
+  beforeEach(() => {
+    should.exist(
+      env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
+      "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
+    );
+    should.exist(
+      env[EnvVarKeys.EVENTHUB_NAME],
+      "define EVENTHUB_NAME in your environment before running integration tests."
+    );
+  });
 
-//   it("throws error for invalid tokenCredentials", async function(): Promise<void> {
-//     const client = new EventHubClient(env.ENDPOINT, env.EVENTHUB_NAME);
-//     await testAadTokenCredentials(client).catch((err: any) => {
-//       errorWasThrown = true;
-//       should.equal(
-//         err.message,
-//         "Please provide a token credentials interface or a valid object of SharedKeyCredential."
-//       );
-//     });
-//     should.equal(errorWasThrown, true, "Error thrown flag must be true");
-//   });
+  afterEach(() => {
+    return client.close();
+  });
 
-//   it("sends a message to the Event Hub entity", async function(): Promise<void> {
-//     const credential = new EnvironmentCredential();
-//     const client = new EventHubClient(env.ENDPOINT, env.EVENTHUB_NAME, credential);
-//     await testAadTokenCredentials(client);
-//     await client.close();
-//   });
-// });
+  it("should correctly populate the default user agent", function(done: Mocha.Done): void {
+    client = new EventHubClient(env[EnvVarKeys.EVENTHUB_CONNECTION_STRING], env[EnvVarKeys.EVENTHUB_NAME]);
+    const packageVersion = packageJsonInfo.version;
+    const properties = client["_context"].connection.options.properties;
+    properties!["user-agent"].should.startWith(`azsdk-js-azureeventhubs/${packageVersion}`);
+    should.equal(properties!.product, "MSJSClient");
+    should.equal(properties!.version, packageVersion);
+    should.equal(properties!.framework, `Node/${process.version}`);
+    should.equal(properties!.platform, `(${os.arch()}-${os.type()}-${os.release()})`);
+    done();
+  });
+
+  it("should correctly populate the custom user agent", function(done: Mocha.Done): void {
+    const customua = "/js-event-processor-host=0.2.0";
+
+    client = new EventHubClient(env[EnvVarKeys.EVENTHUB_CONNECTION_STRING], env[EnvVarKeys.EVENTHUB_NAME], {
+      userAgent: customua
+    });
+    const packageVersion = packageJsonInfo.version;
+    const properties = client["_context"].connection.options.properties;
+    properties!["user-agent"].should.startWith(`azsdk-js-azureeventhubs/${packageVersion}`);
+    properties!["user-agent"].should.endWith(customua);
+    should.equal(properties!.product, "MSJSClient");
+    should.equal(properties!.version, packageVersion);
+    should.equal(properties!.framework, `Node/${process.version}`);
+    should.equal(properties!.platform, `(${os.arch()}-${os.type()}-${os.release()})`);
+    done();
+  });
+});
+
+describe("Errors after close()", function(): void {
+  let client: EventHubClient;
+  let sender: EventHubProducer;
+  let receiver: EventHubConsumer;
+
+  afterEach(() => {
+    return client.close();
+  });
+
+  async function beforeEachTest(entityToClose: string): Promise<void> {
+    should.exist(
+      env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
+      "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
+    );
+    should.exist(
+      env[EnvVarKeys.EVENTHUB_NAME],
+      "define EVENTHUB_NAME in your environment before running integration tests."
+    );
+    client = new EventHubClient(env[EnvVarKeys.EVENTHUB_CONNECTION_STRING], env[EnvVarKeys.EVENTHUB_NAME]);
+
+    const timeNow = Date.now();
+
+    // Ensure sender link is opened
+    sender = client.createProducer({ partitionId: "0" });
+    await sender.send({ body: "dummy send to ensure AMQP connection is opened" });
+
+    // Ensure receiver link is opened
+    receiver = client.createConsumer(EventHubClient.defaultConsumerGroup, "0", EventPosition.fromEnqueuedTime(timeNow));
+    const msgs = await receiver.receiveBatch(1, 10);
+    should.equal(msgs.length, 1);
+
+    // close(), so that we can then test the resulting error.
+    switch (entityToClose) {
+      case "client":
+        await client.close();
+        break;
+      case "sender":
+        await sender.close();
+        break;
+      case "receiver":
+        await receiver.close();
+        break;
+      default:
+        break;
+    }
+  }
+
+  /**
+   * Tests that each feature of the sender throws expected error
+   */
+  async function testSender(expectedErrorMsg: string): Promise<void> {
+    should.equal(sender.isClosed, true, "Sender is not marked as closed.");
+
+    const testMessage = { body: "test" };
+    let errorSend: string = "";
+    await sender.send(testMessage).catch(err => {
+      errorSend = err.message;
+    });
+    should.equal(errorSend, expectedErrorMsg, "Expected error not thrown for send()");
+  }
+
+  /**
+   * Tests that each feature of the receiver throws expected error
+   */
+  async function testReceiver(expectedErrorMsg: string): Promise<void> {
+    should.equal(receiver.isClosed, true, "Receiver is not marked as closed.");
+
+    let errorReceiveBatch: string = "";
+    await receiver.receiveBatch(1, 1).catch(err => {
+      errorReceiveBatch = err.message;
+    });
+    should.equal(errorReceiveBatch, expectedErrorMsg, "Expected error not thrown for receiveMessages()");
+
+    let errorReceiveStream: string = "";
+    try {
+      receiver.receive(() => Promise.resolve(), e => console.log(e));
+    } catch (err) {
+      errorReceiveStream = err.message;
+    }
+    should.equal(errorReceiveStream, expectedErrorMsg, "Expected error not thrown for registerMessageHandler()");
+  }
+
+  it("errors after close() on client", async function(): Promise<void> {
+    await beforeEachTest("client");
+    const expectedErrorMsg = "The underlying AMQP connection is closed.";
+
+    await testSender(expectedErrorMsg);
+    await testReceiver(expectedErrorMsg);
+
+    let errorNewSender: string = "";
+    try {
+      client.createProducer();
+    } catch (err) {
+      errorNewSender = err.message;
+    }
+    should.equal(errorNewSender, expectedErrorMsg, "Expected error not thrown for createSender()");
+
+    let errorNewReceiver: string = "";
+    try {
+      receiver = client.createConsumer(EventHubClient.defaultConsumerGroup, "0", EventPosition.earliest());
+    } catch (err) {
+      errorNewReceiver = err.message;
+    }
+    should.equal(errorNewReceiver, expectedErrorMsg, "Expected error not thrown for createReceiver()");
+
+    let errorGetPartitionIds: string = "";
+    try {
+      await client.getPartitionIds();
+    } catch (err) {
+      errorGetPartitionIds = err.message;
+    }
+    should.equal(errorGetPartitionIds, expectedErrorMsg, "Expected error not thrown for getPartitionIds()");
+
+    let errorGetPartitionProperties: string = "";
+    try {
+      await client.getPartitionProperties("0");
+    } catch (err) {
+      errorGetPartitionProperties = err.message;
+    }
+    should.equal(errorGetPartitionProperties, expectedErrorMsg, "Expected error not thrown for getPartitionProperties()");
+
+    let errorGetProperties: string = "";
+    try {
+      await client.getProperties();
+    } catch (err) {
+      errorGetProperties = err.message;
+    }
+    should.equal(errorGetProperties, expectedErrorMsg, "Expected error not thrown for getProperties()");
+
+  });
+
+  it("errors after close() on sender", async function(): Promise<void> {
+    const senderErrorMsg =
+      `The sender for "${client.eventHubName}" has been closed and can no longer be used. ` +
+      `Please create a new sender using the "createProducer" function on the EventHubClient.`;
+    await beforeEachTest("sender");
+    await testSender(senderErrorMsg);
+  });
+
+  it("errors after close() on receiver", async function(): Promise<void> {
+    const receiverErrorMsg =
+      `The receiver for "${client.eventHubName}" has been closed and can no longer be used. ` +
+      `Please create a new receiver using the "createConsumer" function on the EventHubClient.`;
+    await beforeEachTest("receiver");
+    await testReceiver(receiverErrorMsg);
+  });
+});

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -39,85 +39,116 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
     });
   }
 
-  it("gets the hub runtime information", async function(): Promise<void> {
-    client = new EventHubClient(service.connectionString, service.path, {
-      userAgent: "/js-event-processor-host=0.2.0"
+  describe("getPartitionIds", function(): void {
+    it("returns an array of partition IDs", async function(): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path);
+      const ids = await client.getPartitionIds();
+      ids.should.have.members(arrayOfIncreasingNumbersFromZero(ids.length));
     });
-    const hubRuntimeInfo = await client.getProperties();
-    debug(hubRuntimeInfo);
-    hubRuntimeInfo.path.should.equal(service.path);
 
-    hubRuntimeInfo.partitionIds.should.have.members(
-      arrayOfIncreasingNumbersFromZero(hubRuntimeInfo.partitionIds.length)
-    );
-    hubRuntimeInfo.createdAt.should.be.instanceof(Date);
-  });
-
-  it("can cancel a request for hub runtime information", async function(): Promise<void> {
-    client = new EventHubClient(service.connectionString, service.path, {
-      userAgent: "/js-event-processor-host=0.2.0"
+    it("respects cancellationTokens", async function(): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path);
+      try {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(), 1);
+        await client.getPartitionIds(controller.signal);
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.message.should.match(/The [\w]+ operation has been cancelled by the user.$/gi);
+      }
     });
-    try {
-      const controller = new AbortController();
-      setTimeout(() => controller.abort(), 1);
-      await client.getProperties(controller.signal);
-      throw new Error(`Test failure`);
-    } catch (err) {
-      err.message.should.match(/The [\w]+ operation has been cancelled by the user.$/gi);
-    }
   });
 
-  it("gets the partition runtime information with partitionId as a string", async function(): Promise<void> {
-    client = new EventHubClient(service.connectionString, service.path);
-    const partitionRuntimeInfo = await client.getPartitionProperties("0");
-    debug(partitionRuntimeInfo);
-    partitionRuntimeInfo.partitionId.should.equal("0");
-    partitionRuntimeInfo.eventHubPath.should.equal(service.path);
-    partitionRuntimeInfo.lastEnqueuedTimeUtc.should.be.instanceof(Date);
-    should.exist(partitionRuntimeInfo.lastEnqueuedSequenceNumber);
-    should.exist(partitionRuntimeInfo.lastEnqueuedOffset);
+  describe("hub runtime information", function(): void {
+    it("gets the hub runtime information", async function(): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path, {
+        userAgent: "/js-event-processor-host=0.2.0"
+      });
+      const hubRuntimeInfo = await client.getProperties();
+      debug(hubRuntimeInfo);
+      hubRuntimeInfo.path.should.equal(service.path);
+
+      hubRuntimeInfo.partitionIds.should.have.members(
+        arrayOfIncreasingNumbersFromZero(hubRuntimeInfo.partitionIds.length)
+      );
+      hubRuntimeInfo.createdAt.should.be.instanceof(Date);
+    });
+
+    it("can cancel a request for hub runtime information", async function(): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path, {
+        userAgent: "/js-event-processor-host=0.2.0"
+      });
+      try {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(), 1);
+        await client.getProperties(controller.signal);
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.message.should.match(/The [\w]+ operation has been cancelled by the user.$/gi);
+      }
+    });
   });
 
-  it("gets the partition runtime information with partitionId as a number", async function(): Promise<void> {
-    client = new EventHubClient(service.connectionString, service.path);
-    const partitionRuntimeInfo = await client.getPartitionProperties(0 as any);
-    debug(partitionRuntimeInfo);
-    partitionRuntimeInfo.partitionId.should.equal("0");
-    partitionRuntimeInfo.eventHubPath.should.equal(service.path);
-    partitionRuntimeInfo.lastEnqueuedTimeUtc.should.be.instanceof(Date);
-    should.exist(partitionRuntimeInfo.lastEnqueuedSequenceNumber);
-    should.exist(partitionRuntimeInfo.lastEnqueuedOffset);
-  });
+  describe("partition runtime information", function(): void {
+    it("should throw an error if partitionId is missing", async function(): Promise<void> {
+      try {
+        client = new EventHubClient(service.connectionString, service.path);
+        await client.getPartitionProperties(undefined as any);
+        throw new Error("Test failure");
+      } catch (err) {
+        err.name.should.equal("TypeError");
+        err.message.should.equal(`Missing parameter "partitionId"`);
+      }
+    });
 
-  it("can cancel a request for getPartitionInformation", async function(): Promise<void> {
-    client = new EventHubClient(service.connectionString, service.path);
-    try {
-      const controller = new AbortController();
-      setTimeout(() => controller.abort(), 1);
-      await client.getPartitionProperties("0", controller.signal);
-      throw new Error(`Test failure`);
-    } catch (err) {
-      err.message.should.match(/The [\w]+ operation has been cancelled by the user.$/gi);
-    }
-  });
+    it("gets the partition runtime information with partitionId as a string", async function(): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path);
+      const partitionRuntimeInfo = await client.getPartitionProperties("0");
+      debug(partitionRuntimeInfo);
+      partitionRuntimeInfo.partitionId.should.equal("0");
+      partitionRuntimeInfo.eventHubPath.should.equal(service.path);
+      partitionRuntimeInfo.lastEnqueuedTimeUtc.should.be.instanceof(Date);
+      should.exist(partitionRuntimeInfo.lastEnqueuedSequenceNumber);
+      should.exist(partitionRuntimeInfo.lastEnqueuedOffset);
+    });
 
-  it("should fail the partition runtime information when partitionId is empty string", async function(): Promise<void> {
-    client = new EventHubClient(service.connectionString, service.path);
-    try {
-      await client.getPartitionProperties("");
-    } catch (err) {
-      err.message.should.match(/.*The specified partition is invalid for an EventHub partition sender or receiver.*/gi);
-    }
-  });
+    it("gets the partition runtime information with partitionId as a number", async function(): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path);
+      const partitionRuntimeInfo = await client.getPartitionProperties(0 as any);
+      debug(partitionRuntimeInfo);
+      partitionRuntimeInfo.partitionId.should.equal("0");
+      partitionRuntimeInfo.eventHubPath.should.equal(service.path);
+      partitionRuntimeInfo.lastEnqueuedTimeUtc.should.be.instanceof(Date);
+      should.exist(partitionRuntimeInfo.lastEnqueuedSequenceNumber);
+      should.exist(partitionRuntimeInfo.lastEnqueuedOffset);
+    });
 
-  it("should fail the partition runtime information when partitionId is a negative number", async function(): Promise<
-    void
-  > {
-    client = new EventHubClient(service.connectionString, service.path);
-    try {
-      await client.getPartitionProperties(-1 as any);
-    } catch (err) {
-      err.message.should.match(/.*The specified partition is invalid for an EventHub partition sender or receiver.*/gi);
-    }
+    const invalidIds = ["XYZ", -1, 1000, "-", " ", ""];
+    invalidIds.forEach(function(id: any): void {
+      it(`should fail the partition runtime information when partitionId is "${id}"`, async function(): Promise<void> {
+        try {
+          client = new EventHubClient(service.connectionString, service.path);
+          await client.getPartitionProperties(id as any);
+        } catch (err) {
+          debug(`>>>> Received error - `, err);
+          should.exist(err);
+          err.message.should.match(
+            /.*The specified partition is invalid for an EventHub partition sender or receiver.*/gi
+          );
+        }
+      });
+    });
+
+    it("can cancel a request for getPartitionInformation", async function(): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path);
+      try {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(), 1);
+        await client.getPartitionProperties("0", controller.signal);
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.message.should.match(/The [\w]+ operation has been cancelled by the user.$/gi);
+      }
+    });
   });
 }).timeout(60000);


### PR DESCRIPTION
This PR fixes #3710 by

- Adding tests to cover client creation
- Adding tests to cover errors when client/sender/receiver is closed()
- Moved tests out of client.spec.ts into respective files
     - errors when creating consumer
     - getPartitionIds related tests
     - errors for invalid partitionId
- Refactor for simplicity and ease of maintainence