### PR TITLE
[Event Hubs] improve producer tests

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -73,7 +73,7 @@ export interface SendOptions {
    * @property
    * If specified, Event Hubs will hash this string to map to a partitionId.
    * It guarantees that messages with the same partitionKey end up in the same partition.
-   * This will be ignored if the producer was created using a `paritionId`.
+   * Specifying this will throw an error if the producer was created using a `paritionId`.
    */
   partitionKey?: string | null;
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -85,7 +85,7 @@ export class EventHubSender extends LinkEntity {
    * @param [partitionId] The EventHub partition id to which the sender
    * wants to send the event data.
    */
-  constructor(context: ConnectionContext, partitionId?: string, name?: string) {
+  constructor(context: ConnectionContext, partitionId?: string) {
     super(context, {
       name: context.config.getSenderAddress(partitionId),
       partitionId: partitionId
@@ -343,9 +343,13 @@ export class EventHubSender extends LinkEntity {
       // throw an error if partition key and partition id are both defined
       if (options && typeof options.partitionKey === "string" && typeof options.partitionId === "string") {
         const error = new Error(
-          `PartitionId "${options.partitionId}" and PartitionKey "${options.partitionKey}" are both defined.`
+          "Partition key is not supported when using producers that were created using a partition id."
         );
-        log.error("PartitionId and PartitionKey were both defined while trying to send the message %O", error);
+        log.error(
+          "[%s] Partition key is not supported when using producers that were created using a partition id. %O",
+          this._context.connectionId,
+          error
+        );
         throw error;
       }
       if (!this.isOpen()) {

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -340,6 +340,14 @@ export class EventHubSender extends LinkEntity {
    */
   async send(events: EventData[], options?: SendOptions & EventHubProducerOptions): Promise<void> {
     try {
+      // throw an error if partition key and partition id are both defined
+      if (options && typeof options.partitionKey === "string" && typeof options.partitionId === "string") {
+        const error = new Error(
+          `PartitionId "${options.partitionId}" and PartitionKey "${options.partitionKey}" are both defined.`
+        );
+        log.error("PartitionId and PartitionKey were both defined while trying to send the message %O", error);
+        throw error;
+      }
       if (!this.isOpen()) {
         log.sender(
           "Acquiring lock %s for initializing the session, sender and " + "possibly the connection.",

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -60,6 +60,7 @@ export class EventHubProducer {
    * @throws {MessagingError} Thrown if an error is encountered while sending a message.
    * @throws {TypeError} Thrown if a required parameter is missing.
    * @throws {Error} Thrown if the underlying connection or sender has been closed.
+   * @throws {Error} Thrown if a partitionKey is provided when the producer was created with a partitionId.
    * Create a new producer using the EventHubClient createProducer method.
    */
   async send(eventData: EventData | EventData[], options?: SendOptions): Promise<void> {

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -179,7 +179,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       }
 
       const sender = client.createProducer({ partitionId });
-      await sender.send(d, { partitionKey: "pk1234656" });
+      await sender.send(d);
       debug("Successfully sent 5 messages batched together.");
 
       const receiver = client.createConsumer(
@@ -231,7 +231,7 @@ describe("Misc tests #RunnableInBrowser", function(): void {
       }
 
       const sender = client.createProducer({ partitionId });
-      await sender.send(d, { partitionKey: "pk1234656" });
+      await sender.send(d);
       debug("Successfully sent 5 messages batched together.");
 
       const receiver = client.createConsumer(

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -91,7 +91,9 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
         await client.createProducer({ partitionId: "0" }).send(data, { partitionKey: "1" });
         throw new Error("Test Failure");
       } catch (err) {
-        err.message.should.equal(`PartitionId "0" and PartitionKey "1" are both defined.`);
+        err.message.should.equal(
+          "Partition key is not supported when using producers that were created using a partition id."
+        );
       }
     });
   });
@@ -166,6 +168,22 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
       } catch (err) {
         err.name.should.equal("AbortError");
         err.message.should.equal("The send operation has been cancelled by the user.");
+      }
+    });
+
+    it("should throw when partitionId and partitionKey are provided", async function(): Promise<void> {
+      try {
+        const data: EventData[] = [
+          {
+            body: "Sender paritition id and partition key"
+          }
+        ];
+        await client.createProducer({ partitionId: "0" }).send(data, { partitionKey: "1" });
+        throw new Error("Test Failure");
+      } catch (err) {
+        err.message.should.equal(
+          "Partition key is not supported when using producers that were created using a partition id."
+        );
       }
     });
   });

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -7,7 +7,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:sender-spec");
-import { EventHubClient, EventData } from "../src";
+import { EventHubClient, EventData, EventHubProducer } from "../src";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
 const env = getEnvVars();
@@ -43,6 +43,56 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
     it("with partition key should be sent successfully.", async function(): Promise<void> {
       const data: EventData = { body: "Hello World 1" };
       await client.createProducer().send(data, { partitionKey: "1" });
+    });
+
+    it("with partition key as a number should be sent successfully.", async function(): Promise<void> {
+      const data: EventData = { body: "Hello World 1" };
+      await client.createProducer().send(data, { partitionKey: 1 as any });
+    });
+
+    it("should be sent successfully to a specific partition.", async function(): Promise<void> {
+      const data: EventData = { body: "Hello World 1" };
+      await client.createProducer({ partitionId: "0" }).send(data);
+    });
+
+    it("should support being cancelled", async function(): Promise<void> {
+      try {
+        const data: EventData = { body: "Sender single message Cancellation Test - timeout 0" };
+        const sender = client.createProducer();
+        // call send() once to create a connection
+        await sender.send(data);
+        // abortSignal event listeners will be triggered after synchronous paths are executed
+        const abortSignal = AbortController.timeout(0);
+        await sender.send(data, { abortSignal });
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.name.should.equal("AbortError");
+        err.message.should.equal("The send operation has been cancelled by the user.");
+      }
+    });
+
+    it("should support being cancelled from an already aborted AbortSignal", async function(): Promise<void> {
+      const abortController = new AbortController();
+      abortController.abort();
+
+      try {
+        const data: EventData = { body: "Sender single message Cancellation Test - immediate" };
+        await client.createProducer().send(data, { abortSignal: abortController.signal });
+        throw new Error(`Test failure`);
+      } catch (err) {
+        err.name.should.equal("AbortError");
+        err.message.should.equal("The send operation has been cancelled by the user.");
+      }
+    });
+
+    it("should throw when partitionId and partitionKey are provided", async function(): Promise<void> {
+      try {
+        const data: EventData = { body: "Sender paritition id and partition key" };
+        await client.createProducer({ partitionId: "0" }).send(data, { partitionKey: "1" });
+        throw new Error("Test Failure");
+      } catch (err) {
+        err.message.should.equal(`PartitionId "0" and PartitionKey "1" are both defined.`);
+      }
     });
   });
 
@@ -120,6 +170,31 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
     });
   });
 
+  describe("multiple producers", function(): void {
+    it("should be isolated on same partitionId", async function(): Promise<void> {
+      const producers: EventHubProducer[] = [];
+
+      // create multiple producers with the same partition id
+      for (let i = 0; i < 5; i++) {
+        producers.push(client.createProducer({ partitionId: "0" }));
+      }
+
+      // ensure all producers can send a message
+      for (const producer of producers) {
+        await producer.send({ body: "foo" });
+      }
+
+      do {
+        // close one of the producers and send messages with remaining senders
+        // also closes all of the senders by the end of the test!
+        await producers.pop()!.close();
+        for (const producer of producers) {
+          await producer.send({ body: "bar" });
+        }
+      } while (producers.length);
+    });
+  });
+
   describe("Multiple messages", function(): void {
     it("should be sent successfully in parallel", async function(): Promise<void> {
       const promises = [];
@@ -187,19 +262,6 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
         err.message.should.match(
           /.*The received message \(delivery-id:(\d+), size:3000\d\d bytes\) exceeds the limit \(262144 bytes\) currently allowed on the link\..*/gi
         );
-      }
-    });
-
-    it("Error thrown when the 'partitionKey' is not of type 'string'", async function(): Promise<void> {
-      const data: EventData = {
-        body: "Hello World"
-      };
-      try {
-        await client.createProducer({ partitionId: "0" }).send([data], { partitionKey: 1 as any });
-      } catch (err) {
-        debug(err);
-        should.exist(err);
-        err.message.should.match(/.*'partitionKey' must be of type 'string'.*/gi);
       }
     });
 


### PR DESCRIPTION
Addresses #3986 
I did have to update the `send` method to throw an error if `partitionId` and `partitionKey` were both provided. Previously, `partitionKey` was ignored if `partitionId` was provided (and the docs stated so as well).