### PR TITLE
[JS] [KeyVault] No query-string in keyvault-keys

### DIFF
--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -96,7 +96,6 @@
     "mocha": "^5.2.0",
     "nock": "^10.0.6",
     "prettier": "^1.16.4",
-    "query-string": "^6.5.0",
     "rimraf": "^2.6.2",
     "rollup": "~1.13.1",
     "rollup-plugin-commonjs": "^10.0.0",


### PR DESCRIPTION
Removed query-string since we're not using it.
keyvault-secrets is not using it either!
Related to #3990