### PR TITLE
Rename createXxxClient to getXxxClient

### DIFF
--- a/sdk/storage/README.md
+++ b/sdk/storage/README.md
@@ -197,7 +197,7 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
 
   const createContainerResponse = await containerClient.create();
   console.log(
@@ -208,8 +208,8 @@ async function main() {
   // Create a blob
   const content = "hello";
   const blobName = "newblob" + new Date().getTime();
-  const blobClient = containerClient.createBlobClient(blobName);
-  const blockBlobClient = blobClient.createBlockBlobClient();
+  const blobClient = containerClient.getBlobClient(blobName);
+  const blockBlobClient = blobClient.getBlockBlobClient();
   const uploadBlobResponse = await blockBlobClient.upload(
     content,
     content.length

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -172,7 +172,7 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
 
   const createContainerResponse = await containerClient.create();
   console.log(
@@ -183,8 +183,8 @@ async function main() {
   // Create a blob
   const content = "hello";
   const blobName = "newblob" + new Date().getTime();
-  const blobClient = containerClient.createBlobClient(blobName);
-  const blockBlobClient = blobClient.createBlockBlobClient();
+  const blobClient = containerClient.getBlobClient(blobName);
+  const blockBlobClient = blobClient.getBlockBlobClient();
   const uploadBlobResponse = await blockBlobClient.upload(
     content,
     content.length

--- a/sdk/storage/storage-blob/samples/javascript/advanced.js
+++ b/sdk/storage/storage-blob/samples/javascript/advanced.js
@@ -55,13 +55,13 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
   await containerClient.create();
 
   // Create a blob
   const blobName = "newblob" + new Date().getTime();
-  const blobClient = containerClient.createBlobClient(blobName);
-  const blockBlobClient = blobClient.createBlockBlobClient();
+  const blobClient = containerClient.getBlobClient(blobName);
+  const blockBlobClient = blobClient.getBlockBlobClient();
 
   // Parallel uploading with BlockBlobClient.uploadFile() in Node.js runtime
   // BlockBlobClient.uploadFile() is only available in Node.js

--- a/sdk/storage/storage-blob/samples/javascript/azureAdAuth.js
+++ b/sdk/storage/storage-blob/samples/javascript/azureAdAuth.js
@@ -29,7 +29,7 @@ async function main() {
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
   const createContainerResponse = await blobServiceClient
-    .createContainerClient(containerName)
+    .getContainerClient(containerName)
     .create();
   console.log(`Created container ${containerName} successfully`, createContainerResponse.requestId);
 }

--- a/sdk/storage/storage-blob/samples/javascript/basic.js
+++ b/sdk/storage/storage-blob/samples/javascript/basic.js
@@ -45,7 +45,7 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
 
   const createContainerResponse = await containerClient.create();
   console.log(`Create container ${containerName} successfully`, createContainerResponse.requestId);
@@ -53,8 +53,8 @@ async function main() {
   // Create a blob
   const content = "hello";
   const blobName = "newblob" + new Date().getTime();
-  const blobClient = containerClient.createBlobClient(blobName);
-  const blockBlobClient = blobClient.createBlockBlobClient();
+  const blobClient = containerClient.getBlobClient(blobName);
+  const blockBlobClient = blobClient.getBlockBlobClient();
   const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
   console.log(`Upload block blob ${blobName} successfully`, uploadBlobResponse.requestId);
 

--- a/sdk/storage/storage-blob/samples/javascript/iterator.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterator.js
@@ -40,7 +40,7 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
 
   const createContainerResponse = await containerClient.create();
   console.log(`Created container ${containerName} successfully`, createContainerResponse.requestId);
@@ -49,8 +49,8 @@ async function main() {
     // Create a blob
     const content = "hello";
     const blobName = "newblob" + new Date().getTime();
-    const blobClient = containerClient.createBlobClient(blobName);
-    const blockBlobClient = blobClient.createBlockBlobClient();
+    const blobClient = containerClient.getBlobClient(blobName);
+    const blockBlobClient = blobClient.getBlockBlobClient();
     const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
     console.log(`Uploaded block blob ${blobName} successfully`, uploadBlobResponse.requestId);
   }

--- a/sdk/storage/storage-blob/samples/typescript/advanced.ts
+++ b/sdk/storage/storage-blob/samples/typescript/advanced.ts
@@ -30,13 +30,13 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
   await containerClient.create();
 
   // Create a blob
   const blobName = "newblob" + new Date().getTime();
-  const blobClient = containerClient.createBlobClient(blobName);
-  const blockBlobClient = blobClient.createBlockBlobClient();
+  const blobClient = containerClient.getBlobClient(blobName);
+  const blockBlobClient = blobClient.getBlockBlobClient();
 
   // Parallel uploading with BlockBlobClient.uploadFile() in Node.js runtime
   // BlockBlobClient.uploadFile() is only available in Node.js

--- a/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
@@ -29,7 +29,7 @@ async function main() {
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
   const createContainerResponse = await blobServiceClient
-    .createContainerClient(containerName)
+    .getContainerClient(containerName)
     .create();
   console.log(`Created container ${containerName} successfully`, createContainerResponse.requestId);
 }

--- a/sdk/storage/storage-blob/samples/typescript/basic.ts
+++ b/sdk/storage/storage-blob/samples/typescript/basic.ts
@@ -49,7 +49,7 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
 
   const createContainerResponse = await containerClient.create();
   console.log(`Create container ${containerName} successfully`, createContainerResponse.requestId);
@@ -57,8 +57,8 @@ async function main() {
   // Create a blob
   const content = "hello";
   const blobName = "newblob" + new Date().getTime();
-  const blobClient = containerClient.createBlobClient(blobName);
-  const blockBlobClient = blobClient.createBlockBlobClient();
+  const blobClient = containerClient.getBlobClient(blobName);
+  const blockBlobClient = blobClient.getBlockBlobClient();
   const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
   console.log(`Upload block blob ${blobName} successfully`, uploadBlobResponse.requestId);
 

--- a/sdk/storage/storage-blob/samples/typescript/iterators-blobs.ts
+++ b/sdk/storage/storage-blob/samples/typescript/iterators-blobs.ts
@@ -23,7 +23,7 @@ async function main() {
 
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
-  const containerClient = blobServiceClient.createContainerClient(containerName);
+  const containerClient = blobServiceClient.getContainerClient(containerName);
 
   const createContainerResponse = await containerClient.create();
   console.log(`Created container ${containerName} successfully`, createContainerResponse.requestId);
@@ -32,8 +32,8 @@ async function main() {
     // Create a blob
     const content = "hello";
     const blobName = "newblob" + new Date().getTime();
-    const blobClient = containerClient.createBlobClient(blobName);
-    const blockBlobClient = blobClient.createBlockBlobClient();
+    const blobClient = containerClient.getBlobClient(blobName);
+    const blockBlobClient = blobClient.getBlockBlobClient();
     const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
     console.log(`Uploaded block blob ${blobName} successfully`, uploadBlobResponse.requestId);
   }

--- a/sdk/storage/storage-blob/samples/typescript/proxyAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/proxyAuth.ts
@@ -23,7 +23,7 @@ async function main() {
   // Create a container
   const containerName = `newcontainer${new Date().getTime()}`;
   const createContainerResponse = await blobServiceClient
-    .createContainerClient(containerName)
+    .getContainerClient(containerName)
     .create();
   console.log(`Created container ${containerName} successfully`, createContainerResponse.requestId);
 }

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -679,7 +679,7 @@ export class BlobClient extends StorageClient {
    * @returns {AppendBlobClient}
    * @memberof BlobClient
    */
-  public createAppendBlobClient(): AppendBlobClient {
+  public getAppendBlobClient(): AppendBlobClient {
     return new AppendBlobClient(this.url, this.pipeline);
   }
 
@@ -689,7 +689,7 @@ export class BlobClient extends StorageClient {
    * @returns {BlockBlobClient}
    * @memberof BlobClient
    */
-  public createBlockBlobClient(): BlockBlobClient {
+  public getBlockBlobClient(): BlockBlobClient {
     return new BlockBlobClient(this.url, this.pipeline);
   }
 
@@ -699,7 +699,7 @@ export class BlobClient extends StorageClient {
    * @returns {PageBlobClient}
    * @memberof BlobClient
    */
-  public createPageBlobClient(): PageBlobClient {
+  public getPageBlobClient(): PageBlobClient {
     return new PageBlobClient(this.url, this.pipeline);
   }
 

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -249,7 +249,7 @@ export class BlobServiceClient extends StorageClient {
    * @returns {ContainerClient} A new ContainerClient object for the given container name.
    * @memberof BlobServiceClient
    */
-  public createContainerClient(containerName: string): ContainerClient {
+  public getContainerClient(containerName: string): ContainerClient {
     return new ContainerClient(
       appendToURLPath(this.url, encodeURIComponent(containerName)),
       this.pipeline
@@ -271,7 +271,7 @@ export class BlobServiceClient extends StorageClient {
     containerClient: ContainerClient;
     containerCreateResponse: Models.ContainerCreateResponse;
   }> {
-    const containerClient = this.createContainerClient(containerName);
+    const containerClient = this.getContainerClient(containerName);
     const containerCreateResponse = await containerClient.create(options);
     return {
       containerClient,
@@ -291,7 +291,7 @@ export class BlobServiceClient extends StorageClient {
     containerName: string,
     options?: ContainerDeleteMethodOptions
   ): Promise<Models.ContainerDeleteResponse> {
-    const containerClient = this.createContainerClient(containerName);
+    const containerClient = this.getContainerClient(containerName);
     return await containerClient.delete(options);
   }
 

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -574,7 +574,7 @@ export class ContainerClient extends StorageClient {
    * @returns {BlobClient} A new BlobClient object for the given blob name.
    * @memberof BlobClient
    */
-  public createBlobClient(blobName: string): BlobClient {
+  public getBlobClient(blobName: string): BlobClient {
     return new BlobClient(appendToURLPath(this.url, encodeURIComponent(blobName)), this.pipeline);
   }
 
@@ -585,7 +585,7 @@ export class ContainerClient extends StorageClient {
    * @returns {AppendBlobClient}
    * @memberof ContainerClient
    */
-  public createAppendBlobClient(blobName: string): AppendBlobClient {
+  public getAppendBlobClient(blobName: string): AppendBlobClient {
     return new AppendBlobClient(
       appendToURLPath(this.url, encodeURIComponent(blobName)),
       this.pipeline
@@ -599,7 +599,7 @@ export class ContainerClient extends StorageClient {
    * @returns {BlockBlobClient}
    * @memberof ContainerClient
    */
-  public createBlockBlobClient(blobName: string): BlockBlobClient {
+  public getBlockBlobClient(blobName: string): BlockBlobClient {
     return new BlockBlobClient(
       appendToURLPath(this.url, encodeURIComponent(blobName)),
       this.pipeline
@@ -613,7 +613,7 @@ export class ContainerClient extends StorageClient {
    * @returns {PageBlobClient}
    * @memberof ContainerClient
    */
-  public createPageBlobClient(blobName: string): PageBlobClient {
+  public getPageBlobClient(blobName: string): PageBlobClient {
     return new PageBlobClient(
       appendToURLPath(this.url, encodeURIComponent(blobName)),
       this.pipeline
@@ -877,7 +877,7 @@ export class ContainerClient extends StorageClient {
     contentLength: number,
     options?: BlockBlobUploadOptions
   ): Promise<{ blockBlobClient: BlockBlobClient; response: Models.BlockBlobUploadResponse }> {
-    const blockBlobClient = this.createBlockBlobClient(blobName);
+    const blockBlobClient = this.getBlockBlobClient(blobName);
     const response = await blockBlobClient.upload(body, contentLength, options);
     return {
       blockBlobClient,
@@ -901,7 +901,7 @@ export class ContainerClient extends StorageClient {
     blobName: string,
     options?: BlobDeleteOptions
   ): Promise<Models.BlobDeleteResponse> {
-    const blobClient = this.createBlobClient(blobName);
+    const blobClient = this.getBlobClient(blobName);
     return await blobClient.delete(options);
   }
 

--- a/sdk/storage/storage-blob/src/utils/utils.common.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.common.ts
@@ -48,7 +48,7 @@ import { HeaderConstants, URLConstants } from "./constants";
  *
  * Another special character is "?", use "%2F" to represent a blob name with "?" in a URL string.
  *
- * ### Strategy for containerName, blobName or other specific XXXName parameters in methods such as `containerClient.createBlobClient(blobName)`
+ * ### Strategy for containerName, blobName or other specific XXXName parameters in methods such as `containerClient.getBlobClient(blobName)`
  *
  * We will apply strategy one, and call encodeURIComponent for these parameters like blobName. Because what customers passes in is a plain name instead of a URL.
  *

--- a/sdk/storage/storage-blob/test/aborter.spec.ts
+++ b/sdk/storage/storage-blob/test/aborter.spec.ts
@@ -18,7 +18,7 @@ describe("Aborter", () => {
   beforeEach(async function() {
     recorder = record(this);
     containerName = recorder.getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
   });
 
   afterEach(() => {

--- a/sdk/storage/storage-blob/test/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/appendblobclient.spec.ts
@@ -18,10 +18,10 @@ describe("AppendBlobClient", () => {
   beforeEach(async function() {
     recorder = record(this);
     containerName = recorder.getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = recorder.getUniqueName("blob");
-    appendBlobClient = containerClient.createAppendBlobClient(blobName);
+    appendBlobClient = containerClient.getAppendBlobClient(blobName);
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -8,19 +8,19 @@ dotenv.config({ path: "../.env" });
 describe("BlobClient", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
   let blobName: string = getUniqueName("blob");
-  let blobClient = containerClient.createBlobClient(blobName);
-  let blockBlobClient = blobClient.createBlockBlobClient();
+  let blobClient = containerClient.getBlobClient(blobName);
+  let blockBlobClient = blobClient.getBlockBlobClient();
   const content = "Hello World";
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    blockBlobClient = blobClient.createBlockBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
     await blockBlobClient.upload(content, content.length);
   });
 
@@ -196,7 +196,7 @@ describe("BlobClient", () => {
   });
 
   it("startCopyFromClient", async () => {
-    const newBlobClient = containerClient.createBlobClient(getUniqueName("copiedblob"));
+    const newBlobClient = containerClient.getBlobClient(getUniqueName("copiedblob"));
     const result = await newBlobClient.startCopyFromURL(blobClient.url);
     assert.ok(result.copyId);
 
@@ -208,7 +208,7 @@ describe("BlobClient", () => {
   });
 
   it("abortCopyFromClient should failed for a completed copy operation", async () => {
-    const newBlobClient = containerClient.createBlobClient(getUniqueName("copiedblob"));
+    const newBlobClient = containerClient.getBlobClient(getUniqueName("copiedblob"));
     const result = await newBlobClient.startCopyFromURL(blobClient.url);
     assert.ok(result.copyId);
     sleep(1 * 1000);

--- a/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
@@ -34,8 +34,8 @@ describe("BlobServiceClient", () => {
     const containerNamePrefix = getUniqueName("container");
     const containerName1 = `${containerNamePrefix}x1`;
     const containerName2 = `${containerNamePrefix}x2`;
-    const containerClient1 = blobServiceClient.createContainerClient(containerName1);
-    const containerClient2 = blobServiceClient.createContainerClient(containerName2);
+    const containerClient1 = blobServiceClient.getContainerClient(containerName1);
+    const containerClient2 = blobServiceClient.getContainerClient(containerName2);
     await containerClient1.create({ metadata: { key: "val" } });
     await containerClient2.create({ metadata: { key: "val" } });
 
@@ -89,7 +89,7 @@ describe("BlobServiceClient", () => {
 
     for (let i = 0; i < 4; i++) {
       const containerName = `${containerNamePrefix}x${i}`;
-      const containerClient = blobServiceClient.createContainerClient(containerName);
+      const containerClient = blobServiceClient.getContainerClient(containerName);
       await containerClient.create({ metadata: { key: "val" } });
       containerClients.push(containerClient);
     }
@@ -119,8 +119,8 @@ describe("BlobServiceClient", () => {
     const containerNamePrefix = getUniqueName("container");
     const containerName1 = `${containerNamePrefix}x1`;
     const containerName2 = `${containerNamePrefix}x2`;
-    const containerClient1 = blobServiceClient.createContainerClient(containerName1);
-    const containerClient2 = blobServiceClient.createContainerClient(containerName2);
+    const containerClient1 = blobServiceClient.getContainerClient(containerName1);
+    const containerClient2 = blobServiceClient.getContainerClient(containerName2);
     await containerClient1.create({ metadata: { key: "val" } });
     await containerClient2.create({ metadata: { key: "val" } });
 
@@ -161,7 +161,7 @@ describe("BlobServiceClient", () => {
 
     for (let i = 0; i < 4; i++) {
       const containerName = `${containerNamePrefix}x${i}`;
-      const containerClient = blobServiceClient.createContainerClient(containerName);
+      const containerClient = blobServiceClient.getContainerClient(containerName);
       await containerClient.create({ metadata: { key: "val" } });
       containerClients.push(containerClient);
     }
@@ -197,7 +197,7 @@ describe("BlobServiceClient", () => {
 
     for (let i = 0; i < 4; i++) {
       const containerName = `${containerNamePrefix}x${i}`;
-      const containerClient = blobServiceClient.createContainerClient(containerName);
+      const containerClient = blobServiceClient.getContainerClient(containerName);
       await containerClient.create({ metadata: { key: "val" } });
       containerClients.push(containerClient);
     }

--- a/sdk/storage/storage-blob/test/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blockblobclient.spec.ts
@@ -19,11 +19,11 @@ describe("BlockBlobClient", () => {
   beforeEach(async function() {
     recorder = record(this);
     containerName = recorder.getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = recorder.getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    blockBlobClient = blobClient.createBlockBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
   });
 
   afterEach(async () => {
@@ -88,7 +88,7 @@ describe("BlockBlobClient", () => {
       // tslint:disable-next-line:no-empty
     } catch (err) {}
 
-    const newBlockBlobClient = containerClient.createBlockBlobClient(
+    const newBlockBlobClient = containerClient.getBlockBlobClient(
       recorder.getUniqueName("newblockblob")
     );
     await newBlockBlobClient.stageBlockFromURL(base64encode("1"), blockBlobClient.url);
@@ -110,7 +110,7 @@ describe("BlockBlobClient", () => {
       // tslint:disable-next-line:no-empty
     } catch (err) {}
 
-    const newBlockBlobClient = containerClient.createBlockBlobClient(
+    const newBlockBlobClient = containerClient.getBlockBlobClient(
       recorder.getUniqueName("newblockblob")
     );
     await newBlockBlobClient.stageBlockFromURL(base64encode("1"), blockBlobClient.url, 0, 4);

--- a/sdk/storage/storage-blob/test/browser/highlevel.browser.spec.ts
+++ b/sdk/storage/storage-blob/test/browser/highlevel.browser.spec.ts
@@ -31,11 +31,11 @@ describe("Highlevel", () => {
   beforeEach(async function() {
     recorder = record(this);
     containerName = recorder.getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = recorder.getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    blockBlobClient = blobClient.createBlockBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -6,11 +6,11 @@ dotenv.config({ path: "../.env" });
 describe("ContainerClient", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
   });
 
@@ -49,7 +49,7 @@ describe("ContainerClient", () => {
   });
 
   it("create with all parameters configured", async () => {
-    const cClient = blobServiceClient.createContainerClient(getUniqueName(containerName));
+    const cClient = blobServiceClient.getContainerClient(getUniqueName(containerName));
     const metadata = { key: "value" };
     const access = "container";
     await cClient.create({ metadata, access });
@@ -66,8 +66,8 @@ describe("ContainerClient", () => {
   it("listBlobsFlat with default parameters", async () => {
     const blobClients = [];
     for (let i = 0; i < 3; i++) {
-      const blobClient = containerClient.createBlobClient(getUniqueName(`blockblob/${i}`));
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blobClient = containerClient.getBlobClient(getUniqueName(`blockblob/${i}`));
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0);
       blobClients.push(blobClient);
     }
@@ -95,8 +95,8 @@ describe("ContainerClient", () => {
       keyb: "c"
     };
     for (let i = 0; i < 2; i++) {
-      const blobClient = containerClient.createBlobClient(getUniqueName(`${prefix}/${i}`));
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blobClient = containerClient.getBlobClient(getUniqueName(`${prefix}/${i}`));
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0, {
         metadata
       });
@@ -144,8 +144,8 @@ describe("ContainerClient", () => {
       keyb: "c"
     };
     for (let i = 0; i < 4; i++) {
-      const blobClient = containerClient.createBlobClient(getUniqueName(`${prefix}/${i}`));
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blobClient = containerClient.getBlobClient(getUniqueName(`${prefix}/${i}`));
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0, {
         metadata
       });
@@ -175,8 +175,8 @@ describe("ContainerClient", () => {
       keyb: "c"
     };
     for (let i = 0; i < 2; i++) {
-      const blobClient = containerClient.createBlobClient(getUniqueName(`${prefix}/${i}`));
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blobClient = containerClient.getBlobClient(getUniqueName(`${prefix}/${i}`));
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0, {
         metadata
       });
@@ -209,8 +209,8 @@ describe("ContainerClient", () => {
       keyb: "c"
     };
     for (let i = 0; i < 4; i++) {
-      const blobClient = containerClient.createBlobClient(getUniqueName(`${prefix}/${i}`));
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blobClient = containerClient.getBlobClient(getUniqueName(`${prefix}/${i}`));
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0, {
         metadata
       });
@@ -244,8 +244,8 @@ describe("ContainerClient", () => {
       keyb: "c"
     };
     for (let i = 0; i < 4; i++) {
-      const blobClient = containerClient.createBlobClient(getUniqueName(`${prefix}/${i}`));
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blobClient = containerClient.getBlobClient(getUniqueName(`${prefix}/${i}`));
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0, {
         metadata
       });
@@ -290,8 +290,8 @@ describe("ContainerClient", () => {
   it("listBlobHierarchySegment with default parameters", async () => {
     const blobClients = [];
     for (let i = 0; i < 3; i++) {
-      const blobClient = containerClient.createBlobClient(getUniqueName(`blockblob${i}/${i}`));
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blobClient = containerClient.getBlobClient(getUniqueName(`blockblob${i}/${i}`));
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0);
       blobClients.push(blobClient);
     }
@@ -323,10 +323,10 @@ describe("ContainerClient", () => {
     };
     const delimiter = "/";
     for (let i = 0; i < 2; i++) {
-      const blobClient = containerClient.createBlobClient(
+      const blobClient = containerClient.getBlobClient(
         getUniqueName(`${prefix}${i}${delimiter}${i}`)
       );
-      const blockBlobClient = blobClient.createBlockBlobClient();
+      const blockBlobClient = blobClient.getBlockBlobClient();
       await blockBlobClient.upload("", 0, {
         metadata
       });

--- a/sdk/storage/storage-blob/test/leaseclient.spec.ts
+++ b/sdk/storage/storage-blob/test/leaseclient.spec.ts
@@ -7,11 +7,11 @@ dotenv.config({ path: "../.env" });
 describe("LeaseClient from Container", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
   });
 
@@ -135,19 +135,19 @@ describe("LeaseClient from Container", () => {
 describe("LeaseClient from Blob", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
   let blobName: string = getUniqueName("blob");
-  let blobClient = containerClient.createBlobClient(blobName);
-  let blockBlobClient = blobClient.createBlockBlobClient();
+  let blobClient = containerClient.getBlobClient(blobName);
+  let blockBlobClient = blobClient.getBlockBlobClient();
   const content = "Hello World";
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    blockBlobClient = blobClient.createBlockBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
     await blockBlobClient.upload(content, content.length);
   });
 

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -10,16 +10,16 @@ dotenv.config({ path: "../.env" });
 describe("AppendBlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
   let blobName: string = getUniqueName("blob");
-  let appendBlobClient = containerClient.createAppendBlobClient(blobName);
+  let appendBlobClient = containerClient.getAppendBlobClient(blobName);
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = getUniqueName("blob");
-    appendBlobClient = containerClient.createAppendBlobClient(blobName);
+    appendBlobClient = containerClient.getAppendBlobClient(blobName);
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -17,19 +17,19 @@ dotenv.config({ path: "../.env" });
 describe("BlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
   let blobName: string = getUniqueName("blob");
-  let blobClient = containerClient.createBlobClient(blobName);
-  let blockBlobClient = blobClient.createBlockBlobClient();
+  let blobClient = containerClient.getBlobClient(blobName);
+  let blockBlobClient = blobClient.getBlockBlobClient();
   const content = "Hello World";
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    blockBlobClient = blobClient.createBlockBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
     await blockBlobClient.upload(content, content.length);
   });
 
@@ -205,7 +205,7 @@ describe("BlobClient Node.js only", () => {
   });
 
   it("startCopyFromClient", async () => {
-    const newBlobClient = containerClient.createBlobClient(getUniqueName("copiedblob"));
+    const newBlobClient = containerClient.getBlobClient(getUniqueName("copiedblob"));
     const result = await newBlobClient.startCopyFromURL(blobClient.url);
     assert.ok(result.copyId);
 
@@ -217,7 +217,7 @@ describe("BlobClient Node.js only", () => {
   });
 
   it("abortCopyFromClient should failed for a completed copy operation", async () => {
-    const newBlobClient = containerClient.createBlobClient(getUniqueName("copiedblob"));
+    const newBlobClient = containerClient.getBlobClient(getUniqueName("copiedblob"));
     const result = await newBlobClient.startCopyFromURL(blobClient.url);
     assert.ok(result.copyId);
     sleep(1 * 1000);

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -8,18 +8,18 @@ import { assertClientUsesTokenCredential } from '../utils/assert';
 describe("BlockBlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
   let blobName: string = getUniqueName("blob");
-  let blobClient = containerClient.createBlobClient(blobName);
-  let blockBlobClient = blobClient.createBlockBlobClient();
+  let blobClient = containerClient.getBlobClient(blobName);
+  let blockBlobClient = blobClient.getBlockBlobClient();
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    blockBlobClient = blobClient.createBlockBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-blob/test/node/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/containerclient.spec.ts
@@ -9,11 +9,11 @@ import { assertClientUsesTokenCredential } from '../utils/assert';
 describe("ContainerClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
   });
 

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -29,11 +29,11 @@ describe("Highlevel", () => {
   beforeEach(async function() {
     recorder = record(this);
     containerName = recorder.getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = recorder.getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    blockBlobClient = blobClient.createBlockBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
@@ -14,18 +14,18 @@ import { assertClientUsesTokenCredential } from '../utils/assert';
 describe("PageBlobClient Node.js only", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
   let blobName: string = getUniqueName("blob");
-  let blobClient = containerClient.createBlobClient(blobName);
-  let pageBlobClient = blobClient.createPageBlobClient();
+  let blobClient = containerClient.getBlobClient(blobName);
+  let pageBlobClient = blobClient.getPageBlobClient();
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    pageBlobClient = blobClient.createPageBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    pageBlobClient = blobClient.getPageBlobClient();
   });
 
   afterEach(async () => {
@@ -43,7 +43,7 @@ describe("PageBlobClient Node.js only", () => {
     let snapshotResult = await pageBlobClient.createSnapshot();
     assert.ok(snapshotResult.snapshot);
 
-    const destPageBlobClient = containerClient.createPageBlobClient(getUniqueName("page"));
+    const destPageBlobClient = containerClient.getPageBlobClient(getUniqueName("page"));
 
     await containerClient.setAccessPolicy("container");
 

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -183,7 +183,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const containerName = recorder.getUniqueName("container");
-    const containerClient = blobServiceClient.createContainerClient(containerName);
+    const containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
 
     const containerSAS = generateBlobSASQueryParameters(
@@ -224,10 +224,10 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const containerName = recorder.getUniqueName("container");
-    const containerClient = blobServiceClient.createContainerClient(containerName);
+    const containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     const blobName = recorder.getUniqueName("blob");
-    const blobClient = containerClient.createPageBlobClient(blobName);
+    const blobClient = containerClient.getPageBlobClient(blobName);
     await blobClient.create(1024, {
       blobHTTPHeaders: {
         blobContentType: "content-type-original"
@@ -278,13 +278,13 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const containerName = recorder.getUniqueName("container-with-dash");
-    const containerClient = blobServiceClient.createContainerClient(containerName);
+    const containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
 
     const blobName = recorder.getUniqueName(
       "////Upper/blob/empty /another 汉字 ру́сский язы́к ру́сский язы́к عربي/عربى にっぽんご/にほんご . special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'"
     );
-    const blobClient = containerClient.createPageBlobClient(blobName);
+    const blobClient = containerClient.getPageBlobClient(blobName);
     await blobClient.create(1024, {
       blobHTTPHeaders: {
         blobContentType: "content-type-original"
@@ -336,11 +336,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const containerName = recorder.getUniqueName("container");
-    const containerClient = blobServiceClient.createContainerClient(containerName);
+    const containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
 
     const blobName = recorder.getUniqueName("blob");
-    const blobClient = containerClient.createPageBlobClient(blobName);
+    const blobClient = containerClient.getPageBlobClient(blobName);
     await blobClient.create(1024);
 
     const id = "unique-id";

--- a/sdk/storage/storage-blob/test/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/pageblobclient.spec.ts
@@ -6,18 +6,18 @@ dotenv.config({ path: "../.env" });
 describe("PageBlobClient", () => {
   const blobServiceClient = getBSU();
   let containerName: string = getUniqueName("container");
-  let containerClient = blobServiceClient.createContainerClient(containerName);
+  let containerClient = blobServiceClient.getContainerClient(containerName);
   let blobName: string = getUniqueName("blob");
-  let blobClient = containerClient.createBlobClient(blobName);
-  let pageBlobClient = blobClient.createPageBlobClient();
+  let blobClient = containerClient.getBlobClient(blobName);
+  let pageBlobClient = blobClient.getPageBlobClient();
 
   beforeEach(async () => {
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     blobName = getUniqueName("blob");
-    blobClient = containerClient.createBlobClient(blobName);
-    pageBlobClient = blobClient.createPageBlobClient();
+    blobClient = containerClient.getBlobClient(blobName);
+    pageBlobClient = blobClient.getPageBlobClient();
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-blob/test/retrypolicy.spec.ts
+++ b/sdk/storage/storage-blob/test/retrypolicy.spec.ts
@@ -19,7 +19,7 @@ describe("RetryPolicy", () => {
   beforeEach(async function() {
     recorder = record(this);
     containerName = getUniqueName("container");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
   });
 

--- a/sdk/storage/storage-blob/test/specialnaming.spec.ts
+++ b/sdk/storage/storage-blob/test/specialnaming.spec.ts
@@ -17,7 +17,7 @@ describe("Special Naming Tests", () => {
   before(async function() {
     recorder = record(this);
     containerName = recorder.getUniqueName("1container-with-dash");
-    containerClient = blobServiceClient.createContainerClient(containerName);
+    containerClient = blobServiceClient.getContainerClient(containerName);
     await containerClient.create();
     recorder.stop();
   });
@@ -38,7 +38,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special container and blob names with spaces", async () => {
     const blobName: string = recorder.getUniqueName("blob empty");
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     const response = (await containerClient
@@ -71,7 +71,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special container and blob names with /", async () => {
     const blobName: string = recorder.getUniqueName("////blob/empty /another");
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -106,7 +106,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special container and blob names uppercase", async () => {
     const blobName: string = recorder.getUniqueName("////Upper/blob/empty /another");
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -141,7 +141,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special blob names Chinese characters", async () => {
     const blobName: string = recorder.getUniqueName("////Upper/blob/empty /another 汉字");
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -178,7 +178,7 @@ describe("Special Naming Tests", () => {
     const blobName: string = recorder.getUniqueName(
       "汉字. special ~!@#$%^&*()_+`1234567890-={}|[]\\:\";'<>?,/'"
     );
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -221,7 +221,7 @@ describe("Special Naming Tests", () => {
   it("Should work with special blob name Russian URI encoded", async () => {
     const blobName: string = recorder.getUniqueName("ру́сский язы́к");
     const blobNameEncoded: string = encodeURIComponent(blobName);
-    const blockBlobClient = containerClient.createBlockBlobClient(blobNameEncoded);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobNameEncoded);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -237,7 +237,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special blob name Russian", async () => {
     const blobName: string = recorder.getUniqueName("ру́сский язы́к");
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -273,7 +273,7 @@ describe("Special Naming Tests", () => {
   it("Should work with special blob name Arabic URI encoded", async () => {
     const blobName: string = recorder.getUniqueName("عربي/عربى");
     const blobNameEncoded: string = encodeURIComponent(blobName);
-    const blockBlobClient = containerClient.createBlockBlobClient(blobNameEncoded);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobNameEncoded);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -289,7 +289,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special blob name Arabic", async () => {
     const blobName: string = recorder.getUniqueName("عربي/عربى");
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -325,7 +325,7 @@ describe("Special Naming Tests", () => {
   it("Should work with special blob name Japanese URI encoded", async () => {
     const blobName: string = recorder.getUniqueName("にっぽんご/にほんご");
     const blobNameEncoded: string = encodeURIComponent(blobName);
-    const blockBlobClient = containerClient.createBlockBlobClient(blobNameEncoded);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobNameEncoded);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();
@@ -341,7 +341,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special blob name Japanese", async () => {
     const blobName: string = recorder.getUniqueName("にっぽんご/にほんご");
-    const blockBlobClient = containerClient.createBlockBlobClient(blobName);
+    const blockBlobClient = containerClient.getBlockBlobClient(blobName);
 
     await blockBlobClient.upload("A", 1);
     await blockBlobClient.getProperties();

--- a/sdk/storage/storage-file/README.md
+++ b/sdk/storage/storage-file/README.md
@@ -167,20 +167,20 @@ async function main() {
 
   // Create a share
   const shareName = `newshare${new Date().getTime()}`;
-  const shareClient = serviceClient.createShareClient(shareName);
+  const shareClient = serviceClient.getShareClient(shareName);
   await shareClient.create();
   console.log(`Create share ${shareName} successfully`);
 
   // Create a directory
   const directoryName = `newdirectory${new Date().getTime()}`;
-  const directoryClient = shareClient.createDirectoryClient(directoryName);
+  const directoryClient = shareClient.getDirectoryClient(directoryName);
   await directoryClient.create();
   console.log(`Create directory ${directoryName} successfully`);
 
   // Create a file
   const content = "Hello World!";
   const fileName = "newfile" + new Date().getTime();
-  const fileClient = directoryClient.createFileClient(fileName);
+  const fileClient = directoryClient.getFileClient(fileName);
   await fileClient.create(content.length);
   console.log(`Create file ${fileName} successfully`);
 

--- a/sdk/storage/storage-file/samples/javascript/advanced.js
+++ b/sdk/storage/storage-file/samples/javascript/advanced.js
@@ -55,19 +55,19 @@ async function main() {
 
   // Create a share
   const shareName = `newshare${new Date().getTime()}`;
-  const shareClient = servieClient.createShareClient(shareName);
+  const shareClient = servieClient.getShareClient(shareName);
   await shareClient.create();
   console.log(`Create share ${shareName} successfully`);
 
   // Create a directory
   const directoryName = `newdirectory${new Date().getTime()}`;
-  const directoryClient = shareClient.createDirectoryClient(directoryName);
+  const directoryClient = shareClient.getDirectoryClient(directoryName);
   await directoryClient.create();
   console.log(`Create directory ${directoryName} successfully`);
 
   // Upload local file to Azure file parallelly
   const fileName = "newfile" + new Date().getTime();
-  const fileClient = directoryClient.createFileClient(fileName);
+  const fileClient = directoryClient.getFileClient(fileName);
   const fileSize = fs.statSync(localFilePath).size;
 
   // Parallel uploading with FileClient.uploadFile() in Node.js runtime

--- a/sdk/storage/storage-file/samples/javascript/basic.js
+++ b/sdk/storage/storage-file/samples/javascript/basic.js
@@ -39,20 +39,20 @@ async function main() {
 
   // Create a share
   const shareName = `newshare${new Date().getTime()}`;
-  const shareClient = serviceClient.createShareClient(shareName);
+  const shareClient = serviceClient.getShareClient(shareName);
   await shareClient.create();
   console.log(`Create share ${shareName} successfully`);
 
   // Create a directory
   const directoryName = `newdirectory${new Date().getTime()}`;
-  const directoryClient = shareClient.createDirectoryClient(directoryName);
+  const directoryClient = shareClient.getDirectoryClient(directoryName);
   await directoryClient.create();
   console.log(`Create directory ${directoryName} successfully`);
 
   // Create a file
   const content = "Hello World!";
   const fileName = "newfile" + new Date().getTime();
-  const fileClient = directoryClient.createFileClient(fileName);
+  const fileClient = directoryClient.getFileClient(fileName);
   await fileClient.create(content.length);
   console.log(`Create file ${fileName} successfully`);
 

--- a/sdk/storage/storage-file/samples/typescript/advanced.ts
+++ b/sdk/storage/storage-file/samples/typescript/advanced.ts
@@ -30,19 +30,19 @@ async function main() {
 
   // Create a share
   const shareName = `newshare${new Date().getTime()}`;
-  const shareClient = serviceClient.createShareClient(shareName);
+  const shareClient = serviceClient.getShareClient(shareName);
   await shareClient.create();
   console.log(`Create share ${shareName} successfully`);
 
   // Create a directory
   const directoryName = `newdirectory${new Date().getTime()}`;
-  const directoryClient = shareClient.createDirectoryClient(directoryName);
+  const directoryClient = shareClient.getDirectoryClient(directoryName);
   await directoryClient.create();
   console.log(`Create directory ${directoryName} successfully`);
 
   // Upload local file to Azure file parallelly
   const fileName = "newfile" + new Date().getTime();
-  const fileClient = directoryClient.createFileClient(fileName);
+  const fileClient = directoryClient.getFileClient(fileName);
   const fileSize = fs.statSync(localFilePath).size;
 
   // Parallel uploading with FileClient.uploadFile() in Node.js runtime

--- a/sdk/storage/storage-file/samples/typescript/basic.ts
+++ b/sdk/storage/storage-file/samples/typescript/basic.ts
@@ -33,20 +33,20 @@ async function main() {
 
   // Create a share
   const shareName = `newshare${new Date().getTime()}`;
-  const shareClient = serviceClient.createShareClient(shareName);
+  const shareClient = serviceClient.getShareClient(shareName);
   await shareClient.create();
   console.log(`Create share ${shareName} successfully`);
 
   // Create a directory
   const directoryName = `newdirectory${new Date().getTime()}`;
-  const directoryClient = shareClient.createDirectoryClient(directoryName);
+  const directoryClient = shareClient.getDirectoryClient(directoryName);
   await directoryClient.create();
   console.log(`Create directory ${directoryName} successfully`);
 
   // Create a file
   const content = "Hello World!";
   const fileName = "newfile" + new Date().getTime();
-  const fileClient = directoryClient.createFileClient(fileName);
+  const fileClient = directoryClient.getFileClient(fileName);
   await fileClient.create(content.length);
   console.log(`Create file ${fileName} successfully`);
 

--- a/sdk/storage/storage-file/samples/typescript/iterators-files-and-directories.ts
+++ b/sdk/storage/storage-file/samples/typescript/iterators-files-and-directories.ts
@@ -23,13 +23,13 @@ async function main() {
 
   // Create a share
   const shareName = `newshare${new Date().getTime()}`;
-  const shareClient = serviceClient.createShareClient(shareName);
+  const shareClient = serviceClient.getShareClient(shareName);
   await shareClient.create();
   console.log(`Create share ${shareName} successfully`);
 
   // Create a directory
   const directoryName = `newdirectory${new Date().getTime()}`;
-  const directoryClient = shareClient.createDirectoryClient(directoryName);
+  const directoryClient = shareClient.getDirectoryClient(directoryName);
   await directoryClient.create();
   console.log(`Create directory ${directoryName} successfully`);
 
@@ -38,11 +38,11 @@ async function main() {
 
   // Creates 3 files and 3 directories in the above directory
   for (let i = 0; i < 3; i++) {
-    const directoryClient2 = directoryClient.createDirectoryClient(directoryName + "-sub-" + i);
+    const directoryClient2 = directoryClient.getDirectoryClient(directoryName + "-sub-" + i);
     await directoryClient2.create();
     console.log(`Create sub directory ${directoryName + "-sub-" + i} successfully`);
 
-    const fileClient = directoryClient.createFileClient(fileName + "-sub-" + i);
+    const fileClient = directoryClient.getFileClient(fileName + "-sub-" + i);
     await fileClient.create(content.length);
     console.log(`Create file ${fileName + "-sub-" + i} successfully`);
   }

--- a/sdk/storage/storage-file/src/DirectoryClient.ts
+++ b/sdk/storage/storage-file/src/DirectoryClient.ts
@@ -246,7 +246,7 @@ export class DirectoryClient extends StorageClient {
    * @returns {DirectoryClient} The DirectoryClient object for the given subdirectory name.
    * @memberof DirectoryClient
    */
-  public createDirectoryClient(subDirectoryName: string): DirectoryClient {
+  public getDirectoryClient(subDirectoryName: string): DirectoryClient {
     return new DirectoryClient(
       appendToURLPath(this.url, encodeURIComponent(subDirectoryName)),
       this.pipeline
@@ -269,7 +269,7 @@ export class DirectoryClient extends StorageClient {
     directoryClient: DirectoryClient;
     directoryCreateResponse: Models.DirectoryCreateResponse;
   }> {
-    const directoryClient = this.createDirectoryClient(directoryName);
+    const directoryClient = this.getDirectoryClient(directoryName);
     const directoryCreateResponse = await directoryClient.create(options);
     return {
       directoryClient,
@@ -291,7 +291,7 @@ export class DirectoryClient extends StorageClient {
     directoryName: string,
     options?: DirectoryDeleteOptions
   ): Promise<Models.DirectoryDeleteResponse> {
-    const directoryClient = this.createDirectoryClient(directoryName);
+    const directoryClient = this.getDirectoryClient(directoryName);
     return await directoryClient.delete(options);
   }
 
@@ -310,7 +310,7 @@ export class DirectoryClient extends StorageClient {
     size: number,
     options?: FileCreateOptions
   ): Promise<{ fileClient: FileClient; fileCreateResponse: Models.FileCreateResponse }> {
-    const fileClient = this.createFileClient(fileName);
+    const fileClient = this.getFileClient(fileName);
     const fileCreateResponse = await fileClient.create(size, options);
     return {
       fileClient,
@@ -341,7 +341,7 @@ export class DirectoryClient extends StorageClient {
     fileName: string,
     options?: FileDeleteOptions
   ): Promise<Models.FileDeleteResponse> {
-    const fileClient = this.createFileClient(fileName);
+    const fileClient = this.getFileClient(fileName);
     return await fileClient.delete(options);
   }
 
@@ -352,7 +352,7 @@ export class DirectoryClient extends StorageClient {
    * @returns {FileClient} A new FileClient object for the given file name.
    * @memberof FileClient
    */
-  public createFileClient(fileName: string): FileClient {
+  public getFileClient(fileName: string): FileClient {
     return new FileClient(appendToURLPath(this.url, encodeURIComponent(fileName)), this.pipeline);
   }
 

--- a/sdk/storage/storage-file/src/FileServiceClient.ts
+++ b/sdk/storage/storage-file/src/FileServiceClient.ts
@@ -216,7 +216,7 @@ export class FileServiceClient extends StorageClient {
    * @returns {ShareClient} The ShareClient object for the given share name.
    * @memberof FileServiceClient
    */
-  public createShareClient(shareName: string): ShareClient {
+  public getShareClient(shareName: string): ShareClient {
     return new ShareClient(appendToURLPath(this.url, shareName), this.pipeline);
   }
 
@@ -232,7 +232,7 @@ export class FileServiceClient extends StorageClient {
     shareName: string,
     options?: ShareCreateOptions
   ): Promise<{ shareCreateResponse: Models.ShareCreateResponse; shareClient: ShareClient }> {
-    const shareClient = this.createShareClient(shareName);
+    const shareClient = this.getShareClient(shareName);
     const shareCreateResponse = await shareClient.create(options);
     return {
       shareCreateResponse,
@@ -252,7 +252,7 @@ export class FileServiceClient extends StorageClient {
     shareName: string,
     options?: ShareDeleteMethodOptions
   ): Promise<Models.ShareDeleteResponse> {
-    const shareClient = this.createShareClient(shareName);
+    const shareClient = this.getShareClient(shareName);
     return await shareClient.delete(options);
   }
 

--- a/sdk/storage/storage-file/src/ShareClient.ts
+++ b/sdk/storage/storage-file/src/ShareClient.ts
@@ -399,7 +399,7 @@ export class ShareClient extends StorageClient {
    * @returns {DirectoryClient} The DirectoryClient object for the given directory name.
    * @memberof ShareClient
    */
-  public createDirectoryClient(directoryName: string): DirectoryClient {
+  public getDirectoryClient(directoryName: string): DirectoryClient {
     return new DirectoryClient(
       appendToURLPath(this.url, encodeURIComponent(directoryName)),
       this.pipeline
@@ -415,7 +415,7 @@ export class ShareClient extends StorageClient {
    * @memberof ShareClient
    */
   public get rootDirectoryClient(): DirectoryClient {
-    return this.createDirectoryClient("");
+    return this.getDirectoryClient("");
   }
 
   /**
@@ -434,7 +434,7 @@ export class ShareClient extends StorageClient {
     directoryClient: DirectoryClient;
     directoryCreateResponse: Models.DirectoryCreateResponse;
   }> {
-    const directoryClient = this.createDirectoryClient(directoryName);
+    const directoryClient = this.getDirectoryClient(directoryName);
     const directoryCreateResponse = await directoryClient.create(options);
     return {
       directoryClient,
@@ -456,7 +456,7 @@ export class ShareClient extends StorageClient {
     directoryName: string,
     options?: DirectoryDeleteOptions
   ): Promise<Models.DirectoryDeleteResponse> {
-    const directoryClient = this.createDirectoryClient(directoryName);
+    const directoryClient = this.getDirectoryClient(directoryName);
     return await directoryClient.delete(options);
   }
 
@@ -477,7 +477,7 @@ export class ShareClient extends StorageClient {
     options?: FileCreateOptions
   ): Promise<{ fileClient: FileClient; fileCreateResponse: Models.FileCreateResponse }> {
     const directoryClient = this.rootDirectoryClient;
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
     const fileCreateResponse = await fileClient.create(size, options);
     return {
       fileClient,
@@ -510,7 +510,7 @@ export class ShareClient extends StorageClient {
     options?: FileDeleteOptions
   ): Promise<Models.FileDeleteResponse> {
     const directoryClient = this.rootDirectoryClient;
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
     return await fileClient.delete(options);
   }
 

--- a/sdk/storage/storage-file/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file/src/utils/utils.common.ts
@@ -48,7 +48,7 @@ import { HeaderConstants, URLConstants } from "./constants";
  *
  * Another special character is "?", use "%2F" to represent a blob name with "?" in a URL string.
  *
- * ### Strategy for containerName, blobName or other specific XXXName parameters in methods such as `ContainerClient.createBlobClient(blobName)`
+ * ### Strategy for containerName, blobName or other specific XXXName parameters in methods such as `ContainerClient.getBlobClient(blobName)`
  *
  * We will apply strategy one, and call encodeURIComponent for these parameters like blobName. Because what customers passes in is a plain name instead of a URL.
  *

--- a/sdk/storage/storage-file/test/aborter.spec.ts
+++ b/sdk/storage/storage-file/test/aborter.spec.ts
@@ -18,7 +18,7 @@ describe("Aborter", () => {
   beforeEach(async function() {
     recorder = record(this);
     shareName = getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
   });
 
   afterEach(() => {

--- a/sdk/storage/storage-file/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/directoryclient.spec.ts
@@ -6,17 +6,17 @@ dotenv.config({ path: "../.env" });
 describe("DirectoryClient", () => {
   const serviceClient = getBSU();
   let shareName = getUniqueName("share");
-  let shareClient = serviceClient.createShareClient(shareName);
+  let shareClient = serviceClient.getShareClient(shareName);
   let dirName = getUniqueName("dir");
-  let dirClient = shareClient.createDirectoryClient(dirName);
+  let dirClient = shareClient.getDirectoryClient(dirName);
 
   beforeEach(async () => {
     shareName = getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
 
     dirName = getUniqueName("dir");
-    dirClient = shareClient.createDirectoryClient(dirName);
+    dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
   });
 
@@ -56,7 +56,7 @@ describe("DirectoryClient", () => {
   });
 
   it("create with all parameters configured", async () => {
-    const cClient = serviceClient.createShareClient(getUniqueName(shareName));
+    const cClient = serviceClient.getShareClient(getUniqueName(shareName));
     const metadata = { key: "value" };
     await cClient.create({ metadata });
     const result = await cClient.getProperties();
@@ -70,18 +70,18 @@ describe("DirectoryClient", () => {
 
   it("listFilesAndDirectories under root directory", async () => {
     const subDirClients = [];
-    const rootDirClient = shareClient.createDirectoryClient("");
+    const rootDirClient = shareClient.getDirectoryClient("");
 
     const prefix = getUniqueName(`pre${new Date().getTime().toString()}`);
     for (let i = 0; i < 3; i++) {
-      const subDirClient = rootDirClient.createDirectoryClient(getUniqueName(`${prefix}dir${i}`));
+      const subDirClient = rootDirClient.getDirectoryClient(getUniqueName(`${prefix}dir${i}`));
       await subDirClient.create();
       subDirClients.push(subDirClient);
     }
 
     const subFileClients = [];
     for (let i = 0; i < 3; i++) {
-      const subFileClient = rootDirClient.createFileClient(getUniqueName(`${prefix}file${i}`));
+      const subFileClient = rootDirClient.getFileClient(getUniqueName(`${prefix}file${i}`));
       await subFileClient.create(1024);
       subFileClients.push(subFileClient);
     }
@@ -117,18 +117,18 @@ describe("DirectoryClient", () => {
 
   it("listFilesAndDirectories with all parameters confirgured", async () => {
     const subDirClients = [];
-    const rootDirClient = shareClient.createDirectoryClient("");
+    const rootDirClient = shareClient.getDirectoryClient("");
 
     const prefix = getUniqueName(`pre${new Date().getTime().toString()}`);
     for (let i = 0; i < 3; i++) {
-      const subDirClient = rootDirClient.createDirectoryClient(getUniqueName(`${prefix}dir${i}`));
+      const subDirClient = rootDirClient.getDirectoryClient(getUniqueName(`${prefix}dir${i}`));
       await subDirClient.create();
       subDirClients.push(subDirClient);
     }
 
     const subFileClients = [];
     for (let i = 0; i < 3; i++) {
-      const subFileClient = rootDirClient.createFileClient(getUniqueName(`${prefix}file${i}`));
+      const subFileClient = rootDirClient.getFileClient(getUniqueName(`${prefix}file${i}`));
       await subFileClient.create(1024);
       subFileClients.push(subFileClient);
     }
@@ -169,18 +169,18 @@ describe("DirectoryClient", () => {
 
   it("Verify PagedAsyncIterableIterator for listFilesAndDirectories", async () => {
     const subDirClients = [];
-    const rootDirClient = shareClient.createDirectoryClient("");
+    const rootDirClient = shareClient.getDirectoryClient("");
 
     const prefix = getUniqueName(`pre${new Date().getTime().toString()}`);
     for (let i = 0; i < 3; i++) {
-      const subDirClient = rootDirClient.createDirectoryClient(getUniqueName(`${prefix}dir${i}`));
+      const subDirClient = rootDirClient.getDirectoryClient(getUniqueName(`${prefix}dir${i}`));
       await subDirClient.create();
       subDirClients.push(subDirClient);
     }
 
     const subFileClients = [];
     for (let i = 0; i < 3; i++) {
-      const subFileClient = rootDirClient.createFileClient(getUniqueName(`${prefix}file${i}`));
+      const subFileClient = rootDirClient.getFileClient(getUniqueName(`${prefix}file${i}`));
       await subFileClient.create(1024);
       subFileClients.push(subFileClient);
     }
@@ -202,18 +202,18 @@ describe("DirectoryClient", () => {
 
   it("Verify PagedAsyncIterableIterator(generator .next() syntax) for listFilesAndDirectories", async () => {
     const subDirClients = [];
-    const rootDirClient = shareClient.createDirectoryClient("");
+    const rootDirClient = shareClient.getDirectoryClient("");
 
     const prefix = getUniqueName(`pre${new Date().getTime().toString()}`);
     for (let i = 0; i < 3; i++) {
-      const subDirClient = rootDirClient.createDirectoryClient(getUniqueName(`${prefix}dir${i}`));
+      const subDirClient = rootDirClient.getDirectoryClient(getUniqueName(`${prefix}dir${i}`));
       await subDirClient.create();
       subDirClients.push(subDirClient);
     }
 
     const subFileClients = [];
     for (let i = 0; i < 3; i++) {
-      const subFileClient = rootDirClient.createFileClient(getUniqueName(`${prefix}file${i}`));
+      const subFileClient = rootDirClient.getFileClient(getUniqueName(`${prefix}file${i}`));
       await subFileClient.create(1024);
       subFileClients.push(subFileClient);
     }
@@ -241,18 +241,18 @@ describe("DirectoryClient", () => {
 
   it("Verify PagedAsyncIterableIterator for listFilesAndDirectories", async () => {
     const subDirClients = [];
-    const rootDirClient = shareClient.createDirectoryClient("");
+    const rootDirClient = shareClient.getDirectoryClient("");
 
     const prefix = getUniqueName(`pre${new Date().getTime().toString()}`);
     for (let i = 0; i < 3; i++) {
-      const subDirClient = rootDirClient.createDirectoryClient(getUniqueName(`${prefix}dir${i}`));
+      const subDirClient = rootDirClient.getDirectoryClient(getUniqueName(`${prefix}dir${i}`));
       await subDirClient.create();
       subDirClients.push(subDirClient);
     }
 
     const subFileClients = [];
     for (let i = 0; i < 3; i++) {
-      const subFileClient = rootDirClient.createFileClient(getUniqueName(`${prefix}file${i}`));
+      const subFileClient = rootDirClient.getFileClient(getUniqueName(`${prefix}file${i}`));
       await subFileClient.create(1024);
       subFileClients.push(subFileClient);
     }
@@ -281,18 +281,18 @@ describe("DirectoryClient", () => {
 
   it("Verify PagedAsyncIterableIterator(byPage() - continuationToken) for listFilesAndDirectories", async () => {
     const subDirClients = [];
-    const rootDirClient = shareClient.createDirectoryClient("");
+    const rootDirClient = shareClient.getDirectoryClient("");
 
     const prefix = getUniqueName(`pre${new Date().getTime().toString()}`);
     for (let i = 0; i < 3; i++) {
-      const subDirClient = rootDirClient.createDirectoryClient(getUniqueName(`${prefix}dir${i}`));
+      const subDirClient = rootDirClient.getDirectoryClient(getUniqueName(`${prefix}dir${i}`));
       await subDirClient.create();
       subDirClients.push(subDirClient);
     }
 
     const subFileClients = [];
     for (let i = 0; i < 3; i++) {
-      const subFileClient = rootDirClient.createFileClient(getUniqueName(`${prefix}file${i}`));
+      const subFileClient = rootDirClient.getFileClient(getUniqueName(`${prefix}file${i}`));
       await subFileClient.create(1024);
       subFileClients.push(subFileClient);
     }

--- a/sdk/storage/storage-file/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileclient.spec.ts
@@ -21,15 +21,15 @@ describe("FileClient", () => {
   beforeEach(async function () {
     recorder = record(this);
     shareName = recorder.getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
 
     dirName = recorder.getUniqueName("dir");
-    dirClient = shareClient.createDirectoryClient(dirName);
+    dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
 
     fileName = recorder.getUniqueName("file");
-    fileClient = dirClient.createFileClient(fileName);
+    fileClient = dirClient.getFileClient(fileName);
   });
 
   afterEach(async () => {
@@ -145,7 +145,7 @@ describe("FileClient", () => {
 
   it("startCopyFromURL", async () => {
     await fileClient.create(1024);
-    const newFileClient = dirClient.createFileClient(recorder.getUniqueName("copiedfile"));
+    const newFileClient = dirClient.getFileClient(recorder.getUniqueName("copiedfile"));
     const result = await newFileClient.startCopyFromURL(fileClient.url);
     assert.ok(result.copyId);
 
@@ -158,7 +158,7 @@ describe("FileClient", () => {
 
   it("abortCopyFromURL should failed for a completed copy operation", async () => {
     await fileClient.create(content.length);
-    const newFileClient = dirClient.createFileClient(recorder.getUniqueName("copiedfile"));
+    const newFileClient = dirClient.getFileClient(recorder.getUniqueName("copiedfile"));
     const result = await newFileClient.startCopyFromURL(fileClient.url);
     assert.ok(result.copyId);
     sleep(1 * 1000);

--- a/sdk/storage/storage-file/test/fileserviceclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileserviceclient.spec.ts
@@ -46,8 +46,8 @@ describe("FileServiceClient", () => {
     const shareNamePrefix = recorder.getUniqueName("share");
     const shareName1 = `${shareNamePrefix}x1`;
     const shareName2 = `${shareNamePrefix}x2`;
-    const shareClient1 = serviceClient.createShareClient(shareName1);
-    const shareClient2 = serviceClient.createShareClient(shareName2);
+    const shareClient1 = serviceClient.getShareClient(shareName1);
+    const shareClient2 = serviceClient.getShareClient(shareName2);
     await shareClient1.create({ metadata: { key: "val" } });
     await shareClient2.create({ metadata: { key: "val" } });
 
@@ -90,8 +90,8 @@ describe("FileServiceClient", () => {
     const shareNamePrefix = recorder.getUniqueName("share");
     const shareName1 = `${shareNamePrefix}x1`;
     const shareName2 = `${shareNamePrefix}x2`;
-    const shareClient1 = serviceClient.createShareClient(shareName1);
-    const shareClient2 = serviceClient.createShareClient(shareName2);
+    const shareClient1 = serviceClient.getShareClient(shareName1);
+    const shareClient2 = serviceClient.getShareClient(shareName2);
     await shareClient1.create({ metadata: { key: "val" } });
     await shareClient2.create({ metadata: { key: "val" } });
 
@@ -115,8 +115,8 @@ describe("FileServiceClient", () => {
     const shareNamePrefix = recorder.getUniqueName("share");
     const shareName1 = `${shareNamePrefix}x1`;
     const shareName2 = `${shareNamePrefix}x2`;
-    const shareClient1 = serviceClient.createShareClient(shareName1);
-    const shareClient2 = serviceClient.createShareClient(shareName2);
+    const shareClient1 = serviceClient.getShareClient(shareName1);
+    const shareClient2 = serviceClient.getShareClient(shareName2);
     await shareClient1.create({ metadata: { key: "val" } });
     await shareClient2.create({ metadata: { key: "val" } });
 
@@ -146,7 +146,7 @@ describe("FileServiceClient", () => {
     const shareNamePrefix = recorder.getUniqueName("share");
 
     for (let i = 0; i < 4; i++) {
-      const shareClient = serviceClient.createShareClient(`${shareNamePrefix}x${i}`);
+      const shareClient = serviceClient.getShareClient(`${shareNamePrefix}x${i}`);
       await shareClient.create({ metadata: { key: "val" } });
       shareClients.push(shareClient);
     }
@@ -176,7 +176,7 @@ describe("FileServiceClient", () => {
     const shareNamePrefix = recorder.getUniqueName("share");
 
     for (let i = 0; i < 4; i++) {
-      const shareClient = serviceClient.createShareClient(`${shareNamePrefix}x${i}`);
+      const shareClient = serviceClient.getShareClient(`${shareNamePrefix}x${i}`);
       await shareClient.create({ metadata: { key: "val" } });
       shareClients.push(shareClient);
     }

--- a/sdk/storage/storage-file/test/node/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/directoryclient.spec.ts
@@ -7,17 +7,17 @@ dotenv.config({ path: "../.env" });
 describe("DirectoryClient Node.js only", () => {
   const serviceClient = getBSU();
   let shareName = getUniqueName("share");
-  let shareClient = serviceClient.createShareClient(shareName);
+  let shareClient = serviceClient.getShareClient(shareName);
   let dirName = getUniqueName("dir");
-  let dirClient = shareClient.createDirectoryClient(dirName);
+  let dirClient = shareClient.getDirectoryClient(dirName);
 
   beforeEach(async () => {
     shareName = getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
 
     dirName = getUniqueName("dir");
-    dirClient = shareClient.createDirectoryClient(dirName);
+    dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
   });
 

--- a/sdk/storage/storage-file/test/node/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/fileclient.spec.ts
@@ -7,24 +7,24 @@ import { FileClient, newPipeline, SharedKeyCredential } from "../../src";
 describe("FileClient Node.js only", () => {
   const serviceClient = getBSU();
   let shareName = getUniqueName("share");
-  let shareClient = serviceClient.createShareClient(shareName);
+  let shareClient = serviceClient.getShareClient(shareName);
   let dirName = getUniqueName("dir");
-  let dirClient = shareClient.createDirectoryClient(dirName);
+  let dirClient = shareClient.getDirectoryClient(dirName);
   let fileName = getUniqueName("file");
-  let fileClient = dirClient.createFileClient(fileName);
+  let fileClient = dirClient.getFileClient(fileName);
   const content = "Hello World";
 
   beforeEach(async () => {
     shareName = getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
 
     dirName = getUniqueName("dir");
-    dirClient = shareClient.createDirectoryClient(dirName);
+    dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
 
     fileName = getUniqueName("file");
-    fileClient = dirClient.createFileClient(fileName);
+    fileClient = dirClient.getFileClient(fileName);
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-file/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file/test/node/highlevel.node.spec.ts
@@ -31,13 +31,13 @@ describe("Highlevel Node.js only", () => {
   beforeEach(async function() {
     recorder = record(this);
     shareName = recorder.getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
     dirName = recorder.getUniqueName("dir");
-    dirClient = shareClient.createDirectoryClient(dirName);
+    dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
     fileName = recorder.getUniqueName("file");
-    fileClient = dirClient.createFileClient(fileName);
+    fileClient = dirClient.getFileClient(fileName);
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-file/test/node/sas.spec.ts
+++ b/sdk/storage/storage-file/test/node/sas.spec.ts
@@ -180,7 +180,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const shareName = recorder.getUniqueName("share");
-    const shareClient = serviceClient.createShareClient(shareName);
+    const shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
 
     const shareSAS = generateFileSASQueryParameters(
@@ -199,7 +199,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sasURL = `${shareClient.url}?${shareSAS}`;
     const shareClientwithSAS = new ShareClient(sasURL);
 
-    const dirURLwithSAS = shareClientwithSAS.createDirectoryClient("");
+    const dirURLwithSAS = shareClientwithSAS.getDirectoryClient("");
     (await dirURLwithSAS
       .listFilesAndDirectories()
       .byPage()
@@ -220,15 +220,15 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const shareName = recorder.getUniqueName("share");
-    const shareClient = serviceClient.createShareClient(shareName);
+    const shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
 
     const dirName = recorder.getUniqueName("dir");
-    const dirClient = shareClient.createDirectoryClient(dirName);
+    const dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
 
     const fileName = recorder.getUniqueName("file");
-    const fileClient = dirClient.createFileClient(fileName);
+    const fileClient = dirClient.getFileClient(fileName);
     await fileClient.create(1024, {
       fileHTTPHeaders: {
         fileContentType: "content-type-original"
@@ -279,15 +279,15 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const shareName = recorder.getUniqueName("share");
-    const shareClient = serviceClient.createShareClient(shareName);
+    const shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
 
     const dirName = recorder.getUniqueName("dir");
-    const dirClient = shareClient.createDirectoryClient(dirName);
+    const dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
 
     const fileName = recorder.getUniqueName("file");
-    const fileClient = dirClient.createFileClient(fileName);
+    const fileClient = dirClient.getFileClient(fileName);
     await fileClient.create(1024, {
       fileHTTPHeaders: {
         fileContentType: "content-type-original"
@@ -317,7 +317,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sasURL = `${shareClient.url}?${shareSAS}`;
     const shareClientwithSAS = new ShareClient(sasURL, newPipeline(new AnonymousCredential()));
 
-    const dirClientwithSAS = shareClientwithSAS.createDirectoryClient("");
+    const dirClientwithSAS = shareClientwithSAS.getDirectoryClient("");
     (await dirClientwithSAS
       .listFilesAndDirectories()
       .byPage()

--- a/sdk/storage/storage-file/test/node/shareclient.spec.ts
+++ b/sdk/storage/storage-file/test/node/shareclient.spec.ts
@@ -5,11 +5,11 @@ import { getBSU, getUniqueName, getConnectionStringFromEnvironment } from "./../
 describe("ShareClient Node.js only", () => {
   const serviceClient = getBSU();
   let shareName: string = getUniqueName("share");
-  let shareClient = serviceClient.createShareClient(shareName);
+  let shareClient = serviceClient.getShareClient(shareName);
 
   beforeEach(async () => {
     shareName = getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
   });
 

--- a/sdk/storage/storage-file/test/node/sharedkeycredentialpolicy.spec.ts
+++ b/sdk/storage/storage-file/test/node/sharedkeycredentialpolicy.spec.ts
@@ -12,7 +12,7 @@ describe("SharedKeyCredentialPolicy Node.js only", () => {
   before(async function() {
     recorder = record(this);
     shareName = recorder.getUniqueName("1share-with-dash");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
     recorder.stop();
   });
@@ -33,21 +33,21 @@ describe("SharedKeyCredentialPolicy Node.js only", () => {
 
   it("SharedKeyCredentialPolicy should work with special share and file names with spaces", async () => {
     const dirName = recorder.getUniqueName("dir empty");
-    const dirClient = shareClient.createDirectoryClient(dirName);
+    const dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
 
     const fileName: string = recorder.getUniqueName("file empty");
-    const fileClient = dirClient.createFileClient(fileName);
+    const fileClient = dirClient.getFileClient(fileName);
     await fileClient.create(0);
   });
 
   it("SharedKeyCredentialPolicy should work with special share and file names uppercase", async () => {
     const dirName = recorder.getUniqueName("Dir empty");
-    const dirClient = shareClient.createDirectoryClient(dirName);
+    const dirClient = shareClient.getDirectoryClient(dirName);
     await dirClient.create();
 
     const fileName: string = recorder.getUniqueName("Upper_another");
-    const fileClient = dirClient.createFileClient(fileName);
+    const fileClient = dirClient.getFileClient(fileName);
     await fileClient.create(0);
   });
 });

--- a/sdk/storage/storage-file/test/retrypolicy.spec.ts
+++ b/sdk/storage/storage-file/test/retrypolicy.spec.ts
@@ -17,7 +17,7 @@ describe("RetryPolicy", () => {
   beforeEach(async function() {
     recorder = record(this);
     shareName = recorder.getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
   });
 

--- a/sdk/storage/storage-file/test/shareclient.spec.ts
+++ b/sdk/storage/storage-file/test/shareclient.spec.ts
@@ -6,11 +6,11 @@ dotenv.config({ path: "../.env" });
 describe("ShareClient", () => {
   const serviceClient = getBSU();
   let shareName: string = getUniqueName("share");
-  let shareClient = serviceClient.createShareClient(shareName);
+  let shareClient = serviceClient.getShareClient(shareName);
 
   beforeEach(async () => {
     shareName = getUniqueName("share");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
     await shareClient.create();
   });
 
@@ -45,7 +45,7 @@ describe("ShareClient", () => {
   });
 
   it("create with all parameters configured", async () => {
-    const shareClient2 = serviceClient.createShareClient(getUniqueName(shareName));
+    const shareClient2 = serviceClient.getShareClient(getUniqueName(shareName));
     const metadata = { key: "value" };
     await shareClient2.create({ metadata });
     const result = await shareClient2.getProperties();

--- a/sdk/storage/storage-file/test/specialnaming.spec.ts
+++ b/sdk/storage/storage-file/test/specialnaming.spec.ts
@@ -21,10 +21,10 @@ describe("Special Naming Tests", () => {
     recorder = record(this);
 
     shareName = recorder.getUniqueName("1share-with-dash");
-    shareClient = serviceClient.createShareClient(shareName);
+    shareClient = serviceClient.getShareClient(shareName);
 
     directoryName = recorder.getUniqueName("dir");
-    directoryClient = shareClient.createDirectoryClient(directoryName);
+    directoryClient = shareClient.getDirectoryClient(directoryName);
 
     await shareClient.create();
     await directoryClient.create();
@@ -48,7 +48,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special container and file names with spaces", async () => {
     const fileName: string = recorder.getUniqueName("file empty");
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
 
     await fileClient.create(10);
 
@@ -79,7 +79,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special container and file names uppercase", async () => {
     const fileName: string = recorder.getUniqueName("Upper file empty another");
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -112,7 +112,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special file names Chinese characters", async () => {
     const fileName: string = recorder.getUniqueName("Upper file empty another 汉字");
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -147,7 +147,7 @@ describe("Special Naming Tests", () => {
     const fileName: string = recorder.getUniqueName(
       "汉字. special ~!@#$%^&()_+`1234567890-={}[];','"
     );
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -193,8 +193,8 @@ describe("Special Naming Tests", () => {
     const directoryName: string = recorder.getUniqueName(
       "汉字. special ~!@#$%^&()_+`1234567890-={}[];','"
     );
-    const specialDirectoryClient = shareClient.createDirectoryClient(directoryName);
-    const rootDirectoryClient = shareClient.createDirectoryClient("");
+    const specialDirectoryClient = shareClient.getDirectoryClient(directoryName);
+    const rootDirectoryClient = shareClient.getDirectoryClient("");
 
     await specialDirectoryClient.create();
     await specialDirectoryClient.getProperties();
@@ -225,7 +225,7 @@ describe("Special Naming Tests", () => {
     await specialDirectoryClient.create();
     await specialDirectoryClient.getProperties();
 
-    const rootDirectoryClient = shareClient.createDirectoryClient("");
+    const rootDirectoryClient = shareClient.getDirectoryClient("");
 
     const response = (await rootDirectoryClient
       .listFilesAndDirectories({
@@ -241,7 +241,7 @@ describe("Special Naming Tests", () => {
   it("Should work with special file name Russian URI encoded", async () => {
     const fileName: string = recorder.getUniqueName("ру́сский язы́к");
     const blobNameEncoded: string = encodeURIComponent(fileName);
-    const fileClient = directoryClient.createFileClient(blobNameEncoded);
+    const fileClient = directoryClient.getFileClient(blobNameEncoded);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -258,7 +258,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special file name Russian", async () => {
     const fileName: string = recorder.getUniqueName("ру́сский язы́к");
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -296,7 +296,7 @@ describe("Special Naming Tests", () => {
   it("Should work with special file name Arabic URI encoded", async () => {
     const fileName: string = recorder.getUniqueName("عربي/عربى");
     const blobNameEncoded: string = encodeURIComponent(fileName);
-    const fileClient = directoryClient.createFileClient(blobNameEncoded);
+    const fileClient = directoryClient.getFileClient(blobNameEncoded);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -313,7 +313,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special file name Arabic", async () => {
     const fileName: string = recorder.getUniqueName("عربيعربى");
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -351,7 +351,7 @@ describe("Special Naming Tests", () => {
   it("Should work with special file name Japanese URI encoded", async () => {
     const fileName: string = recorder.getUniqueName("にっぽんごにほんご");
     const blobNameEncoded: string = encodeURIComponent(fileName);
-    const fileClient = directoryClient.createFileClient(blobNameEncoded);
+    const fileClient = directoryClient.getFileClient(blobNameEncoded);
 
     await fileClient.create(10);
     await fileClient.getProperties();
@@ -368,7 +368,7 @@ describe("Special Naming Tests", () => {
 
   it("Should work with special file name Japanese", async () => {
     const fileName: string = recorder.getUniqueName("にっぽんごにほんご");
-    const fileClient = directoryClient.createFileClient(fileName);
+    const fileClient = directoryClient.getFileClient(fileName);
 
     await fileClient.create(10);
     await fileClient.getProperties();

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -168,7 +168,7 @@ async function main() {
 
   // Create a new queue
   const queueName = `newqueue${new Date().getTime()}`;
-  const queueClient = queueServiceClient.createQueueClient(queueName);
+  const queueClient = queueServiceClient.getQueueClient(queueName);
   const createQueueResponse = await queueClient.create();
   console.log(
     `Create queue ${queueName} successfully, service assigned request Id: ${
@@ -177,7 +177,7 @@ async function main() {
   );
 
   // Enqueue a message into the queue using the enqueue method.
-  const messagesClient = queueClient.createMessagesClient();
+  const messagesClient = queueClient.getMessagesClient();
   const enqueueQueueResponse = await messagesClient.enqueue(
     "Hello World!"
   );
@@ -207,7 +207,7 @@ async function main() {
         dequeueMessageItem.messageText
       }`
     );
-    const messageIdClient = messagesClient.createMessageIdClient(
+    const messageIdClient = messagesClient.getMessageIdClient(
       dequeueMessageItem.messageId
     );
     const deleteMessageResponse = await messageIdClient.delete(

--- a/sdk/storage/storage-queue/samples/javascript/basic.js
+++ b/sdk/storage/storage-queue/samples/javascript/basic.js
@@ -80,7 +80,7 @@ async function main() {
 
   // Create a new queue
   const queueName = `newqueue${new Date().getTime()}`;
-  const queueClient = queueServiceClient.createQueueClient(queueName);
+  const queueClient = queueServiceClient.getQueueClient(queueName);
   const createQueueResponse = await queueClient.create();
   console.log(
     `Create queue ${queueName} successfully, service assigned request Id: ${createQueueResponse.requestId}`
@@ -88,14 +88,14 @@ async function main() {
 
   // Create a new queue
   const queueName = `newqueue${new Date().getTime()}`;
-  const queueClient = queueServiceClient.createQueueClient(queueName);
+  const queueClient = queueServiceClient.getQueueClient(queueName);
   const createQueueResponse = await queueClient.create();
   console.log(
     `Create queue ${queueName} successfully, service assigned request Id: ${createQueueResponse.requestId}`
   );
 
   // Enqueue a message into the queue using the enqueue method.
-  const messagesClient = queueClient.createMessagesClient();
+  const messagesClient = queueClient.getMessagesClient();
   const enqueueQueueResponse = await messagesClient.enqueue("Hello World!");
   console.log(
     `Enqueue message successfully, service assigned message Id: ${enqueueQueueResponse.messageId}, service assigned request Id: ${enqueueQueueResponse.requestId}`
@@ -113,7 +113,7 @@ async function main() {
   if (dequeueResponse.dequeuedMessageItems.length == 1) {
     const dequeueMessageItem = dequeueResponse.dequeuedMessageItems[0];
     console.log(`Processing & deleting message with content: ${dequeueMessageItem.messageText}`);
-    const messageIdClient = messagesClient.createMessageIdClient(dequeueMessageItem.messageId);
+    const messageIdClient = messagesClient.getMessageIdClient(dequeueMessageItem.messageId);
     const deleteMessageResponse = await messageIdClient.delete(dequeueMessageItem.popReceipt);
     console.log(
       `Delete message succesfully, service assigned request Id: ${deleteMessageResponse.requestId}`

--- a/sdk/storage/storage-queue/samples/typescript/basic.ts
+++ b/sdk/storage/storage-queue/samples/typescript/basic.ts
@@ -54,14 +54,14 @@ async function main() {
 
   // Create a new queue
   const queueName = `newqueue${new Date().getTime()}`;
-  const queueClient = queueServiceClient.createQueueClient(queueName);
+  const queueClient = queueServiceClient.getQueueClient(queueName);
   const createQueueResponse = await queueClient.create();
   console.log(
     `Create queue ${queueName} successfully, service assigned request Id: ${createQueueResponse.requestId}`
   );
 
   // Enqueue a message into the queue using the enqueue method.
-  const messagesClient = queueClient.createMessagesClient();
+  const messagesClient = queueClient.getMessagesClient();
   const enqueueQueueResponse = await messagesClient.enqueue("Hello World!");
   console.log(
     `Enqueue message successfully, service assigned message Id: ${enqueueQueueResponse.messageId}, service assigned request Id: ${enqueueQueueResponse.requestId}`
@@ -79,7 +79,7 @@ async function main() {
   if (dequeueResponse.dequeuedMessageItems.length == 1) {
     const dequeueMessageItem = dequeueResponse.dequeuedMessageItems[0];
     console.log(`Processing & deleting message with content: ${dequeueMessageItem.messageText}`);
-    const messageIdClient = messagesClient.createMessageIdClient(dequeueMessageItem.messageId);
+    const messageIdClient = messagesClient.getMessageIdClient(dequeueMessageItem.messageId);
     const deleteMessageResponse = await messageIdClient.delete(dequeueMessageItem.popReceipt);
     console.log(
       `Delete message succesfully, service assigned request Id: ${deleteMessageResponse.requestId}`

--- a/sdk/storage/storage-queue/src/MessagesClient.ts
+++ b/sdk/storage/storage-queue/src/MessagesClient.ts
@@ -267,7 +267,7 @@ export class MessagesClient extends StorageClient {
    * @param {string} messageId Id of a message.
    * @returns {MessageIdClient} a MessageIdClient instance for the given messageId.
    */
-  public createMessageIdClient(messageId: string): MessageIdClient {
+  public getMessageIdClient(messageId: string): MessageIdClient {
     return new MessageIdClient(appendToURLPath(this.url, messageId), this.pipeline);
   }
 

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -307,7 +307,7 @@ export class QueueClient extends StorageClient {
    * Creates a MessagesClient object.
    * @param queueName
    */
-  public createMessagesClient(): MessagesClient {
+  public getMessagesClient(): MessagesClient {
     return new MessagesClient(appendToURLPath(this.url, "messages"), this.pipeline);
   }
 

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -230,7 +230,7 @@ export class QueueServiceClient extends StorageClient {
    * Creates a QueueClient object.
    * @param queueName
    */
-  public createQueueClient(queueName: string): QueueClient {
+  public getQueueClient(queueName: string): QueueClient {
     return new QueueClient(appendToURLPath(this.url, queueName), this.pipeline);
   }
 

--- a/sdk/storage/storage-queue/test/aborter.spec.ts
+++ b/sdk/storage/storage-queue/test/aborter.spec.ts
@@ -18,7 +18,7 @@ describe("Aborter", () => {
   beforeEach(async function() {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
   });
 
   afterEach(async () => {

--- a/sdk/storage/storage-queue/test/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/messageidclient.spec.ts
@@ -16,7 +16,7 @@ describe("MessageIdClient", () => {
   beforeEach(async function () {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
   });
 
@@ -26,7 +26,7 @@ describe("MessageIdClient", () => {
   });
 
   it("update and delete empty message with default parameters", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
     assert.ok(eResult.date);
     assert.ok(eResult.expirationTime);
@@ -38,7 +38,7 @@ describe("MessageIdClient", () => {
     assert.ok(eResult.version);
 
     let newMessage = "";
-    let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
+    let messageIdClient = messagesClient.getMessageIdClient(eResult.messageId);
     let uResult = await messageIdClient.update(eResult.popReceipt, newMessage);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
@@ -60,7 +60,7 @@ describe("MessageIdClient", () => {
   });
 
   it("update and delete message with all parameters", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
     assert.ok(eResult.date);
     assert.ok(eResult.expirationTime);
@@ -72,7 +72,7 @@ describe("MessageIdClient", () => {
     assert.ok(eResult.version);
 
     let newMessage = "New Message";
-    let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
+    let messageIdClient = messagesClient.getMessageIdClient(eResult.messageId);
     let uResult = await messageIdClient.update(eResult.popReceipt, newMessage, 10);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
@@ -91,7 +91,7 @@ describe("MessageIdClient", () => {
   });
 
   it("update message with 64KB characters size which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
     assert.ok(eResult.date);
     assert.ok(eResult.expirationTime);
@@ -103,7 +103,7 @@ describe("MessageIdClient", () => {
     assert.ok(eResult.version);
 
     let newMessage = new Array(64 * 1024 + 1).join("a");
-    let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
+    let messageIdClient = messagesClient.getMessageIdClient(eResult.messageId);
     let uResult = await messageIdClient.update(eResult.popReceipt, newMessage);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
@@ -117,7 +117,7 @@ describe("MessageIdClient", () => {
   });
 
   it("update message negative with 65537B (64KB+1B) characters size which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
     assert.ok(eResult.date);
     assert.ok(eResult.expirationTime);
@@ -130,7 +130,7 @@ describe("MessageIdClient", () => {
 
     let newMessage = new Array(64 * 1024 + 2).join("a");
 
-    let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
+    let messageIdClient = messagesClient.getMessageIdClient(eResult.messageId);
 
     let error;
     try {
@@ -147,10 +147,10 @@ describe("MessageIdClient", () => {
   });
 
   it("delete message negative", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
 
-    let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
+    let messageIdClient = messagesClient.getMessageIdClient(eResult.messageId);
 
     let error;
     try {

--- a/sdk/storage/storage-queue/test/messagesclient.spec.ts
+++ b/sdk/storage/storage-queue/test/messagesclient.spec.ts
@@ -16,7 +16,7 @@ describe("MessagesClient", () => {
   beforeEach(async function () {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
   });
 
@@ -26,7 +26,7 @@ describe("MessagesClient", () => {
   });
 
   it("enqueue, peek, dequeue and clear message with default parameters", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
     assert.ok(eResult.date);
     assert.ok(eResult.expirationTime);
@@ -68,7 +68,7 @@ describe("MessagesClient", () => {
   });
 
   it("enqueue, peek, dequeue and clear message with all parameters", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
 
     let eResult = await messagesClient.enqueue(messageContent, {
       messageTimeToLive: 40,
@@ -138,7 +138,7 @@ describe("MessagesClient", () => {
   });
 
   it("enqueue, peek, dequeue empty message, and peek, dequeue with numberOfMessages > count(messages)", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
 
     let eResult = await messagesClient.enqueue("", {
       messageTimeToLive: 40,
@@ -182,7 +182,7 @@ describe("MessagesClient", () => {
   });
 
   it("enqueue, peek, dequeue special characters", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
 
     let specialMessage =
       "!@#$%^&*()_+`-=[]|};'\":,./?><`~漢字㒈保ᨍ揫^p[뷁)׷񬓔7񈺝l鮍򧽶ͺ簣ڞ츊䈗㝯綞߫⯹?ÎᦡC왶żsmt㖩닡򈸱𕩣ОլFZ򃀮9tC榅ٻ컦驿Ϳ[𱿛봻烌󱰷򙥱Ռ򽒏򘤰δŊϜ췮㐦9ͽƙp퐂ʩ由巩KFÓ֮򨾭⨿󊻅aBm󶴂旨Ϣ񓙠򻐪񇧱򆋸ջ֨ipn򒷐ꝷՆ򆊙斡賆𒚑m˞𻆕󛿓򐞺Ӯ򡗺򴜍<񐸩԰Bu)򁉂񖨞á<џɏ嗂�⨣1PJ㬵┡ḸI򰱂ˮaࢸ۳i灛ȯɨb𹺪򕕱뿶uٔ䎴񷯆Φ륽󬃨س_NƵ¦\u00E9";
@@ -229,7 +229,7 @@ describe("MessagesClient", () => {
   });
 
   it("enqueue, peek, dequeue with 64KB characters size which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let messageContent = new Array(64 * 1024 + 1).join("a");
 
     let eResult = await messagesClient.enqueue(messageContent, {
@@ -274,7 +274,7 @@ describe("MessagesClient", () => {
   });
 
   it("enqueue, peek and dequeue negative", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent, {
       messageTimeToLive: 40
     });
@@ -325,7 +325,7 @@ describe("MessagesClient", () => {
   });
 
   it("enqueue negative with 65537B(64KB+1B) characters size which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let messageContent = new Array(64 * 1024 + 2).join("a");
 
     let error;

--- a/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
@@ -19,7 +19,7 @@ describe("MessageIdClient Node.js only", () => {
   beforeEach(async function () {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
   });
 
@@ -29,7 +29,7 @@ describe("MessageIdClient Node.js only", () => {
   });
 
   it("update message with 64KB characters including special char which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
     assert.ok(eResult.date);
     assert.ok(eResult.expirationTime);
@@ -46,7 +46,7 @@ describe("MessageIdClient Node.js only", () => {
     buffer.fill("a");
     buffer.write(specialChars, 0);
     let newMessage = buffer.toString();
-    let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
+    let messageIdClient = messagesClient.getMessageIdClient(eResult.messageId);
     let uResult = await messageIdClient.update(eResult.popReceipt, newMessage);
     assert.ok(uResult.version);
     assert.ok(uResult.timeNextVisible);
@@ -60,7 +60,7 @@ describe("MessageIdClient Node.js only", () => {
   });
 
   it("update message negative with 65537B (64KB+1B) characters including special char which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let eResult = await messagesClient.enqueue(messageContent);
     assert.ok(eResult.date);
     assert.ok(eResult.expirationTime);
@@ -77,7 +77,7 @@ describe("MessageIdClient Node.js only", () => {
     buffer.fill("a");
     buffer.write(specialChars, 0);
     let newMessage = buffer.toString();
-    let messageIdClient = messagesClient.createMessageIdClient(eResult.messageId);
+    let messageIdClient = messagesClient.getMessageIdClient(eResult.messageId);
 
     let error;
     try {
@@ -94,7 +94,7 @@ describe("MessageIdClient Node.js only", () => {
   });
 
   it("can be created with a url and a credential", async () => {
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
     const factories = (messagesClient as any).pipeline.factories;
     const credential = factories[factories.length - 1] as SharedKeyCredential;
     const newClient = new MessagesClient(messagesClient.url, credential);
@@ -111,7 +111,7 @@ describe("MessageIdClient Node.js only", () => {
   });
 
   it("can be created with a url and a credential and an option bag", async () => {
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
     const factories = (messagesClient as any).pipeline.factories;
     const credential = factories[factories.length - 1] as SharedKeyCredential;
     const newClient = new MessagesClient(messagesClient.url, credential, {
@@ -132,7 +132,7 @@ describe("MessageIdClient Node.js only", () => {
   });
 
   it("can be created with a url and a pipeline", async () => {
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
     const factories = (messagesClient as any).pipeline.factories;
     const credential = factories[factories.length - 1] as SharedKeyCredential;
     const newClient = new MessagesClient(messagesClient.url, credential);

--- a/sdk/storage/storage-queue/test/node/messagesclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messagesclient.spec.ts
@@ -18,7 +18,7 @@ describe("MessagesClient Node.js only", () => {
   beforeEach(async function () {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
   });
 
@@ -28,7 +28,7 @@ describe("MessagesClient Node.js only", () => {
   });
 
   it("enqueue, peek, dequeue with 64KB characters including special char which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let specialChars =
       "!@#$%^&*()_+`-=[]|};'\":,./?><`~漢字㒈保ᨍ揫^p[뷁)׷񬓔7񈺝l鮍򧽶ͺ簣ڞ츊䈗㝯綞߫⯹?ÎᦡC왶żsmt㖩닡򈸱𕩣ОլFZ򃀮9tC榅ٻ컦驿Ϳ[𱿛봻烌󱰷򙥱Ռ򽒏򘤰δŊϜ췮㐦9ͽƙp퐂ʩ由巩KFÓ֮򨾭⨿󊻅aBm󶴂旨Ϣ񓙠򻐪񇧱򆋸ջ֨ipn򒷐ꝷՆ򆊙斡賆𒚑m˞𻆕󛿓򐞺Ӯ򡗺򴜍<񐸩԰Bu)򁉂񖨞á<џɏ嗂�⨣1PJ㬵┡ḸI򰱂ˮaࢸ۳i灛ȯɨb𹺪򕕱뿶uٔ䎴񷯆Φ륽󬃨س_NƵ¦";
     let buffer = Buffer.alloc(64 * 1024); //64KB
@@ -78,7 +78,7 @@ describe("MessagesClient Node.js only", () => {
   });
 
   it("enqueue negative with 65537B(64KB+1B) characters including special char which is computed after encoding", async () => {
-    let messagesClient = queueClient.createMessagesClient();
+    let messagesClient = queueClient.getMessagesClient();
     let specialChars =
       "!@#$%^&*()_+`-=[]|};'\":,./?><`~漢字㒈保ᨍ揫^p[뷁)׷񬓔7񈺝l鮍򧽶ͺ簣ڞ츊䈗㝯綞߫⯹?ÎᦡC왶żsmt㖩닡򈸱𕩣ОլFZ򃀮9tC榅ٻ컦驿Ϳ[𱿛봻烌󱰷򙥱Ռ򽒏򘤰δŊϜ췮㐦9ͽƙp퐂ʩ由巩KFÓ֮򨾭⨿󊻅aBm󶴂旨Ϣ񓙠򻐪񇧱򆋸ջ֨ipn򒷐ꝷՆ򆊙斡賆𒚑m˞𻆕󛿓򐞺Ӯ򡗺򴜍<񐸩԰Bu)򁉂񖨞á<џɏ嗂�⨣1PJ㬵┡ḸI򰱂ˮaࢸ۳i灛ȯɨb𹺪򕕱뿶uٔ䎴񷯆Φ륽󬃨س_NƵ¦";
     let buffer = Buffer.alloc(64 * 1024 + 1);
@@ -101,7 +101,7 @@ describe("MessagesClient Node.js only", () => {
   });
 
   it("can be created with a url and a credential", async () => {
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
     const factories = (messagesClient as any).pipeline.factories;
     const credential = factories[factories.length - 1] as SharedKeyCredential;
     const newClient = new MessagesClient(messagesClient.url, credential);
@@ -118,7 +118,7 @@ describe("MessagesClient Node.js only", () => {
   });
 
   it("can be created with a url and a credential and an option bag", async () => {
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
     const factories = (messagesClient as any).pipeline.factories;
     const credential = factories[factories.length - 1] as SharedKeyCredential;
     const newClient = new MessagesClient(messagesClient.url, credential, {
@@ -139,7 +139,7 @@ describe("MessagesClient Node.js only", () => {
   });
 
   it("can be created with a url and a pipeline", async () => {
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
     const factories = (messagesClient as any).pipeline.factories;
     const credential = factories[factories.length - 1] as SharedKeyCredential;
     const newClient = new MessagesClient(messagesClient.url, credential);

--- a/sdk/storage/storage-queue/test/node/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/queueclient.spec.ts
@@ -15,7 +15,7 @@ describe("QueueClient Node.js only", () => {
   beforeEach(async function () {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
   });
 

--- a/sdk/storage/storage-queue/test/node/sas.spec.ts
+++ b/sdk/storage/storage-queue/test/node/sas.spec.ts
@@ -183,7 +183,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const queueName = recorder.getUniqueName("queue");
-    const queueClient = queueServiceClient.createQueueClient(queueName);
+    const queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
 
     const queueSAS = generateQueueSASQueryParameters(
@@ -218,7 +218,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const queueName = recorder.getUniqueName("queue");
-    const queueClient = queueServiceClient.createQueueClient(queueName);
+    const queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
 
     const queueSAS = generateQueueSASQueryParameters(
@@ -236,7 +236,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const messageContent = "Hello World!";
 
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
     const sasURLForMessages = `${messagesClient.url}?${queueSAS}`;
     const messagesClientWithSAS = new MessagesClient(
       sasURLForMessages,
@@ -247,7 +247,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     let pResult = await messagesClient.peek();
     assert.deepStrictEqual(pResult.peekedMessageItems.length, 1);
 
-    const messageIdClient = messagesClient.createMessageIdClient(enqueueResult.messageId);
+    const messageIdClient = messagesClient.getMessageIdClient(enqueueResult.messageId);
     const sasURLForMessageId = `${messageIdClient.url}?${queueSAS}`;
     const messageIdClientWithSAS = new MessageIdClient(sasURLForMessageId);
 
@@ -271,7 +271,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const sharedKeyCredential = factories[factories.length - 1];
 
     const queueName = recorder.getUniqueName("queue");
-    const queueClient = queueServiceClient.createQueueClient(queueName);
+    const queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
 
     const id = "unique-id";
@@ -294,7 +294,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
       sharedKeyCredential as SharedKeyCredential
     );
 
-    const messagesClient = queueClient.createMessagesClient();
+    const messagesClient = queueClient.getMessagesClient();
 
     const sasURL = `${messagesClient.url}?${queueSAS}`;
     const messagesClientwithSAS = new MessagesClient(sasURL);
@@ -312,7 +312,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     await sleep(2 * 1000);
 
-    const messageIdClient = messagesClient.createMessageIdClient(
+    const messageIdClient = messagesClient.getMessageIdClient(
       dResult.dequeuedMessageItems[0].messageId
     );
 

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -15,7 +15,7 @@ describe("QueueClient", () => {
   beforeEach(async function () {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
   });
 
@@ -46,7 +46,7 @@ describe("QueueClient", () => {
 
   it("getProperties negative", async () => {
     const queueName2 = recorder.getUniqueName("queue", "queue2");
-    const queueClient2 = queueServiceClient.createQueueClient(queueName2);
+    const queueClient2 = queueServiceClient.getQueueClient(queueName2);
     let error;
     try {
       await queueClient2.getProperties();
@@ -67,7 +67,7 @@ describe("QueueClient", () => {
   });
 
   it("create with all parameters", async () => {
-    const qURL = queueServiceClient.createQueueClient(recorder.getUniqueName(queueName));
+    const qURL = queueServiceClient.getQueueClient(recorder.getUniqueName(queueName));
     const metadata = { key: "value" };
     await qURL.create({ metadata });
     const result = await qURL.getProperties();
@@ -76,7 +76,7 @@ describe("QueueClient", () => {
 
   // create with invalid queue name
   it("create negative", async () => {
-    const qURL = queueServiceClient.createQueueClient("");
+    const qURL = queueServiceClient.getQueueClient("");
     let error;
     try {
       await qURL.create();

--- a/sdk/storage/storage-queue/test/queueserviceclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueserviceclient.spec.ts
@@ -42,8 +42,8 @@ describe("QueueServiceClient", () => {
     const queueNamePrefix = recorder.getUniqueName("queue");
     const queueName1 = `${queueNamePrefix}x1`;
     const queueName2 = `${queueNamePrefix}x2`;
-    const queueClient1 = queueServiceClient.createQueueClient(queueName1);
-    const queueClient2 = queueServiceClient.createQueueClient(queueName2);
+    const queueClient1 = queueServiceClient.getQueueClient(queueName1);
+    const queueClient2 = queueServiceClient.getQueueClient(queueName2);
     await queueClient1.create({ metadata: { key: "val" } });
     await queueClient2.create({ metadata: { key: "val" } });
 
@@ -84,8 +84,8 @@ describe("QueueServiceClient", () => {
     const queueName1 = `${queueNamePrefix}x1`;
     const queueName2 = `${queueNamePrefix}x2`;
 
-    const queueClient1 = queueServiceClient.createQueueClient(queueName1);
-    const queueClient2 = queueServiceClient.createQueueClient(queueName2);
+    const queueClient1 = queueServiceClient.getQueueClient(queueName1);
+    const queueClient2 = queueServiceClient.getQueueClient(queueName2);
     await queueClient1.create({ metadata: { key: "val" } });
     await queueClient2.create({ metadata: { key: "val" } });
 
@@ -108,8 +108,8 @@ describe("QueueServiceClient", () => {
     const queueName1 = `${queueNamePrefix}x1`;
     const queueName2 = `${queueNamePrefix}x2`;
 
-    const queueClient1 = queueServiceClient.createQueueClient(queueName1);
-    const queueClient2 = queueServiceClient.createQueueClient(queueName2);
+    const queueClient1 = queueServiceClient.getQueueClient(queueName1);
+    const queueClient2 = queueServiceClient.getQueueClient(queueName2);
     await queueClient1.create({ metadata: { key: "val" } });
     await queueClient2.create({ metadata: { key: "val" } });
 
@@ -135,7 +135,7 @@ describe("QueueServiceClient", () => {
     const queueNamePrefix = recorder.getUniqueName("queue");
 
     for (let i = 0; i < 4; i++) {
-      const queueClient = queueServiceClient.createQueueClient(`${queueNamePrefix}x${i}`);
+      const queueClient = queueServiceClient.getQueueClient(`${queueNamePrefix}x${i}`);
       await queueClient.create({ metadata: { key: "val" } });
       queueClients.push(queueClient);
     }
@@ -163,7 +163,7 @@ describe("QueueServiceClient", () => {
     const queueNamePrefix = recorder.getUniqueName("queue");
 
     for (let i = 0; i < 4; i++) {
-      const queueClient = queueServiceClient.createQueueClient(`${queueNamePrefix}x${i}`);
+      const queueClient = queueServiceClient.getQueueClient(`${queueNamePrefix}x${i}`);
       await queueClient.create({ metadata: { key: "val" } });
       queueClients.push(queueClient);
     }

--- a/sdk/storage/storage-queue/test/retrypolicy.spec.ts
+++ b/sdk/storage/storage-queue/test/retrypolicy.spec.ts
@@ -18,7 +18,7 @@ describe("RetryPolicy", () => {
   beforeEach(async function() {
     recorder = record(this);
     queueName = recorder.getUniqueName("queue");
-    queueClient = queueServiceClient.createQueueClient(queueName);
+    queueClient = queueServiceClient.getQueueClient(queueName);
     await queueClient.create();
   });
 


### PR DESCRIPTION
- to avoid confusion with other `create<Resource>()` methods
- to be consistent with other languages.