### PR TITLE
[Identity] Enable managed identity auth for App Service and Cloud Shell

### DIFF
--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -18,8 +18,8 @@ const SelfSignedJwtLifetimeMins = 10;
 const DefaultAuthorityHost = "https://login.microsoftonline.com";
 const DefaultScopeSuffix = "/.default";
 export const ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
-export const MsiVmApiVersion = "2018-02-01";
-export const MsiAppServiceApiVersion = "2017-09-01";
+export const ImdsApiVersion = "2018-02-01";
+export const AppServiceMsiApiVersion = "2017-09-01";
 
 export class IdentityClient extends ServiceClient {
   constructor(options?: IdentityClientOptions) {
@@ -83,10 +83,10 @@ export class IdentityClient extends ServiceClient {
     return date;
   }
 
-  private createAzureVmMsiAuthRequest(resource: string, clientId?: string): RequestPrepareOptions {
+  private createImdsAuthRequest(resource: string, clientId?: string): RequestPrepareOptions {
     const queryParameters: any = {
       resource,
-      "api-version": MsiVmApiVersion
+      "api-version": ImdsApiVersion
     };
 
     if (clientId) {
@@ -107,7 +107,7 @@ export class IdentityClient extends ServiceClient {
   private createAppServiceMsiAuthRequest(resource: string, clientId?: string): RequestPrepareOptions {
     const queryParameters: any = {
       resource,
-      "api-version": MsiAppServiceApiVersion,
+      "api-version": AppServiceMsiApiVersion,
     };
 
     if (clientId) {
@@ -201,7 +201,7 @@ export class IdentityClient extends ServiceClient {
       }
     } else {
       // Running in an Azure VM
-      authRequestOptions = this.createAzureVmMsiAuthRequest(resource, clientId);
+      authRequestOptions = this.createImdsAuthRequest(resource, clientId);
     }
 
     const webResource = this.createWebResource({

--- a/sdk/identity/identity/test/client/identityClient.spec.ts
+++ b/sdk/identity/identity/test/client/identityClient.spec.ts
@@ -19,8 +19,10 @@ function isExpectedError(expectedErrorName: string): (error: any) => boolean {
 describe("IdentityClient", function () {
   it("throws an exception when an authentication request fails", async () => {
     const mockHttp = new MockAuthHttpClient({
-      status: 400,
-      bodyAsText: `{ "error": "test_error", "error_description": "This is a test error" }`
+      authResponse: {
+        status: 400,
+        bodyAsText: `{ "error": "test_error", "error_description": "This is a test error" }`
+      }
     });
     const client = new IdentityClient(mockHttp.identityClientOptions);
 
@@ -34,7 +36,13 @@ describe("IdentityClient", function () {
   });
 
   it("returns a usable error when the authentication response doesn't contain a body", async () => {
-    const mockHttp = new MockAuthHttpClient({ status: 500, bodyAsText: '' });
+    const mockHttp = new MockAuthHttpClient({
+      authResponse: {
+        status: 500,
+        bodyAsText: ''
+      }
+    });
+
     const client = new IdentityClient(mockHttp.identityClientOptions);
     await assertRejects(
       client.authenticateClientSecret("tenant", "client", "secret", "https://test/.default"),

--- a/sdk/identity/identity/test/credentials/authTestUtils.ts
+++ b/sdk/identity/identity/test/credentials/authTestUtils.ts
@@ -3,7 +3,7 @@
 
 import assert from "assert";
 import { IdentityClientOptions } from "../../src";
-import { HttpHeaders, HttpOperationResponse, WebResource, HttpClient } from "@azure/core-http";
+import { HttpHeaders, HttpOperationResponse, WebResource, HttpClient, delay, RestError } from "@azure/core-http";
 
 export interface MockAuthResponse {
   status: number;
@@ -12,20 +12,29 @@ export interface MockAuthResponse {
   bodyAsText?: string;
 }
 
+export interface MockAuthHttpClientOptions {
+  authResponse?: MockAuthResponse,
+  mockTimeout?: boolean
+}
+
 export class MockAuthHttpClient implements HttpClient {
   private requestPromise: Promise<WebResource>;
   private requestResolve: (request: WebResource) => void;
+
   private authResponse: MockAuthResponse;
+  private mockTimeout: boolean;
 
   public identityClientOptions: IdentityClientOptions;
+  public sendRequestCount: number = 0;
 
-  constructor(authResponse?: MockAuthResponse) {
+  constructor(options?: MockAuthHttpClientOptions) {
+    options = options || {};
     this.requestResolve = () => { };
     this.requestPromise = new Promise((resolve) => {
       this.requestResolve = resolve;
     });
 
-    this.authResponse = authResponse || {
+    this.authResponse = options.authResponse || {
       status: 200,
       headers: new HttpHeaders(),
       parsedBody: {
@@ -34,6 +43,11 @@ export class MockAuthHttpClient implements HttpClient {
       }
     };
 
+    this.mockTimeout =
+      options.mockTimeout !== undefined
+        ? options.mockTimeout
+        : false;
+
     this.identityClientOptions = {
       authorityHost: "https://authority",
       httpClient: this,
@@ -41,13 +55,19 @@ export class MockAuthHttpClient implements HttpClient {
     };
   }
 
-  sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse> {
+  async sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse> {
+    this.sendRequestCount++;
     this.requestResolve(httpRequest);
-    return Promise.resolve({
+
+    if (this.mockTimeout) {
+      await delay(httpRequest.timeout);
+      throw new RestError("Request timed out", RestError.REQUEST_SEND_ERROR);
+    }
+    return {
       request: httpRequest,
       headers: this.authResponse.headers || new HttpHeaders(),
       ...this.authResponse
-    });
+    };
   }
 
   getAuthRequest(): Promise<WebResource> {

--- a/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
@@ -1,23 +1,42 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import qs from "qs";
 import assert from "assert";
 import { ManagedIdentityCredential } from "../../src";
-import { MockAuthHttpClient } from "./authTestUtils";
-import { WebResource } from "@azure/core-http";
+import { ImdsEndpoint, MsiVmApiVersion, MsiAppServiceApiVersion } from "../../src/client/identityClient";
+import { MockAuthHttpClient, MockAuthResponse } from "./authTestUtils";
+import { WebResource, AccessToken } from "@azure/core-http";
+
+interface AuthRequestDetails {
+  request: WebResource,
+  token: AccessToken | null
+};
 
 describe("ManagedIdentityCredential", function () {
+  afterEach(() => {
+    delete process.env.MSI_ENDPOINT
+    delete process.env.MSI_SECRET
+  });
+
   it("sends an authorization request with a modified resource name", async () => {
-    const authRequest = await getMsiTokenAuthRequest(["https://service/.default"], "client");
+    const authDetails = await getMsiTokenAuthRequest(["https://service/.default"], "client");
+    const authRequest = authDetails.request;
+
     assert.ok(authRequest.query, "No query string parameters on request");
     if (authRequest.query) {
+      assert.equal(authRequest.method, "GET");
       assert.equal(authRequest.query["client_id"], "client");
       assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
+      assert.ok(authRequest.url.startsWith(ImdsEndpoint), "URL does not start with expected host and path");
+      assert.ok(authRequest.url.indexOf(`api-version=${MsiVmApiVersion}`) > -1, "URL does not have expected version");
     }
   });
 
   it("sends an authorization request with an unmodified resource name", async () => {
-    const authRequest = await getMsiTokenAuthRequest("someResource");
+    const authDetails = await getMsiTokenAuthRequest("someResource");
+    const authRequest = authDetails.request;
+
     assert.ok(authRequest.query, "No query string parameters on request");
     if (authRequest.query) {
       assert.equal(authRequest.query["client_id"], undefined);
@@ -25,17 +44,69 @@ describe("ManagedIdentityCredential", function () {
     }
   });
 
+  it("sends an authorization request correctly in an App Service environment", async () => {
+    // Trigger App Service behavior by setting environment variables
+    process.env.MSI_ENDPOINT = "https://endpoint";
+    process.env.MSI_SECRET = "secret";
+
+    const authDetails = await getMsiTokenAuthRequest(["https://service/.default"], "client", {
+      status: 200,
+      parsedBody: {
+        token: "token",
+        expires_on: "06/20/2019 02:57:58 +00:00"
+      }
+    });
+    const authRequest = authDetails.request;
+
+    assert.ok(authRequest.query, "No query string parameters on request");
+    if (authRequest.query) {
+      assert.equal(authRequest.method, "GET");
+      assert.equal(authRequest.query["client_id"], "client");
+      assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
+      assert.ok(authRequest.url.startsWith(process.env.MSI_ENDPOINT), "URL does not start with expected host and path");
+      assert.equal(authRequest.headers.get("secret"), process.env.MSI_SECRET);
+      assert.ok(authRequest.url.indexOf(`api-version=${MsiAppServiceApiVersion}`) > -1, "URL does not have expected version");
+      if (authDetails.token) {
+        assert.equal(authDetails.token.expiresOnTimestamp, 1560999478000);
+      } else {
+        assert.fail("No token was returned!");
+      }
+    }
+  });
+
+  it("sends an authorization request correctly in an Cloud Shell environment", async () => {
+    // Trigger Cloud Shell behavior by setting environment variables
+    process.env.MSI_ENDPOINT = "https://endpoint";
+
+    const authDetails = await getMsiTokenAuthRequest(["https://service/.default"], "client");
+    const authRequest = authDetails.request;
+
+    assert.ok(authRequest.body !== undefined, "No body on request");
+    if (authRequest.body) {
+      const bodyParams = qs.parse(authRequest.body);
+      assert.equal(authRequest.method, "POST");
+      assert.equal(bodyParams.client_id, "client");
+      assert.equal(decodeURIComponent(bodyParams.resource), "https://service");
+      assert.ok(authRequest.url.startsWith(process.env.MSI_ENDPOINT), "URL does not start with expected host and path");
+      assert.equal(authRequest.headers.get("secret"), undefined);
+    }
+  });
+
   async function getMsiTokenAuthRequest(
     scopes: string | string[],
-    clientId?: string
-  ): Promise<WebResource> {
-    const mockHttpClient = new MockAuthHttpClient();
+    clientId?: string,
+    mockAuthResponse?: MockAuthResponse
+  ): Promise<AuthRequestDetails> {
+    const mockHttpClient = new MockAuthHttpClient(mockAuthResponse);
     const credential = new ManagedIdentityCredential(
       clientId,
       mockHttpClient.identityClientOptions
     );
 
-    await credential.getToken(scopes);
-    return mockHttpClient.getAuthRequest();
+    const token = await credential.getToken(scopes);
+    return {
+      request: await mockHttpClient.getAuthRequest(),
+      token
+    };
   }
 });

--- a/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/credentials/managedIdentityCredential.spec.ts
@@ -4,7 +4,7 @@
 import qs from "qs";
 import assert from "assert";
 import { ManagedIdentityCredential } from "../../src";
-import { ImdsEndpoint, MsiVmApiVersion, MsiAppServiceApiVersion } from "../../src/client/identityClient";
+import { ImdsEndpoint, ImdsApiVersion, AppServiceMsiApiVersion } from "../../src/client/identityClient";
 import { MockAuthHttpClient, MockAuthResponse } from "./authTestUtils";
 import { WebResource, AccessToken } from "@azure/core-http";
 
@@ -29,7 +29,7 @@ describe("ManagedIdentityCredential", function () {
       assert.equal(authRequest.query["client_id"], "client");
       assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
       assert.ok(authRequest.url.startsWith(ImdsEndpoint), "URL does not start with expected host and path");
-      assert.ok(authRequest.url.indexOf(`api-version=${MsiVmApiVersion}`) > -1, "URL does not have expected version");
+      assert.ok(authRequest.url.indexOf(`api-version=${ImdsApiVersion}`) > -1, "URL does not have expected version");
     }
   });
 
@@ -65,7 +65,7 @@ describe("ManagedIdentityCredential", function () {
       assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
       assert.ok(authRequest.url.startsWith(process.env.MSI_ENDPOINT), "URL does not start with expected host and path");
       assert.equal(authRequest.headers.get("secret"), process.env.MSI_SECRET);
-      assert.ok(authRequest.url.indexOf(`api-version=${MsiAppServiceApiVersion}`) > -1, "URL does not have expected version");
+      assert.ok(authRequest.url.indexOf(`api-version=${AppServiceMsiApiVersion}`) > -1, "URL does not have expected version");
       if (authDetails.token) {
         assert.equal(authDetails.token.expiresOnTimestamp, 1560999478000);
       } else {


### PR DESCRIPTION
This change enables managed service identity authentication when `ManagedIdentityCredential` is used in App Service apps and inside of Cloud Shell.  It's based on this document that @chlowell put together: https://gist.github.com/chlowell/dce9afbfc4abda00f173a98cf84e0b04

**Tasks**

- [x] Test these changes on an Azure VM
- [x] Test these changes on an App Service app configured with MSI auth
- [x] Test these changes in Cloud Shell