### PR TITLE
[core-http] Add dependency on "process"

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -113,6 +113,7 @@
     "@types/tunnel": "^0.0.0",
     "axios": "^0.19.0",
     "form-data": "^2.3.2",
+    "process": "^0.11.10",
     "tough-cookie": "^2.4.3",
     "tslib": "^1.9.3",
     "tunnel": "0.0.6",


### PR DESCRIPTION
- Required if a consumer of this library uses "rollup-plugin-inject" to shim the process module (as is currently done in "core-amqp")