### PR TITLE
[core-http] Add "proxyPolicy" to "browser" config

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -43,6 +43,7 @@
   ],
   "browser": {
     "./es/lib/policies/msRestUserAgentPolicy.js": "./es/lib/policies/msRestUserAgentPolicy.browser.js",
+    "./es/lib/policies/proxyPolicy.js": "./es/lib/policies/proxyPolicy.browser.js",
     "./es/lib/util/base64.js": "./es/lib/util/base64.browser.js",
     "./es/lib/util/xml.js": "./es/lib/util/xml.browser.js",
     "./es/lib/defaultHttpClient.js": "./es/lib/defaultHttpClient.browser.js"


### PR DESCRIPTION
- Required for consumers to generate a correct browser bundle