### PR TITLE
Update dev dependency "resolve" to latest

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -12,13 +12,11 @@
    * SemVer range specifier.  See the Rush documentation for details about this feature.
    */
   "preferredVersions": {
-
     /**
      * When someone asks for "^1.0.0" make sure they get "1.2.3" when working in this repo,
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
-    "resolve": "1.11.0"
   },
 
   /**
@@ -31,8 +29,7 @@
    * USUAL VERSION (WHICH IS INFERRED BY LOOKING AT ALL PROJECTS IN THE REPO).
    * This design avoids unnecessary churn in this file.
    */
-   "allowedAlternativeVersions": {
-
+  "allowedAlternativeVersions": {
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -54,7 +54,7 @@ dependencies:
   '@types/underscore': 1.9.1
   '@types/uuid': 3.4.4
   '@types/webpack': 4.4.34
-  '@types/webpack-dev-middleware': 2.0.2
+  '@types/webpack-dev-middleware': 2.0.3
   '@types/ws': 6.0.1
   '@types/xml2js': 0.4.4
   '@types/yargs': 11.1.2
@@ -138,7 +138,6 @@ dependencies:
   qs: 6.7.0
   query-string: 6.8.1
   requirejs: 2.3.6
-  resolve: 1.11.0
   rhea: 1.0.7
   rhea-promise: 0.1.15
   rimraf: 2.6.3
@@ -602,10 +601,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mkJejrAacgignkBce2+qD9S4VncjEfAT0Dion0fRcqpav3Sd2KiLTHODZOXRP3S8b0ZY5sXr9meDB3P8MSH8Cg==
-  /@types/loglevel/1.5.4:
-    dev: false
-    resolution:
-      integrity: sha512-8dx4ckP0vndJeN+iKZwdGiapLqFjVQ3JLOt92uqK0C63acs5NcPLbUOpfXCJkKVRjZLBQjw8NIGNBSsnatFnFQ==
   /@types/long/4.0.0:
     dev: false
     resolution:
@@ -717,15 +712,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==
-  /@types/webpack-dev-middleware/2.0.2:
+  /@types/webpack-dev-middleware/2.0.3:
     dependencies:
       '@types/connect': 3.4.32
-      '@types/loglevel': 1.5.4
       '@types/memory-fs': 0.3.2
       '@types/webpack': 4.4.34
+      loglevel: 1.6.3
     dev: false
     resolution:
-      integrity: sha512-uZ1avIbAcnspcDKKm0WfgIdvBYRqUapPmwb0MYGzzB74q2F3T4Xi+qPSoS0Oq5iQvIMVxOm7KMqHQJii4VDCsw==
+      integrity: sha512-DzNJJ6ah/6t1n8sfAgQyEbZ/OMmFcF9j9P3aesnm7G6/iBFR/qiGin8K89J0RmaWIBzhTMdDg3I5PmKmSv7N9w==
   /@types/webpack/4.4.34:
     dependencies:
       '@types/anymatch': 1.3.1
@@ -2100,7 +2095,7 @@ packages:
       component-emitter: 1.3.0
       define-property: 1.0.0
       isobject: 3.0.1
-      mixin-deep: 1.3.1
+      mixin-deep: 1.3.2
       pascalcase: 0.1.1
     dev: false
     engines:
@@ -2379,9 +2374,9 @@ packages:
       get-value: 2.0.6
       has-value: 1.0.0
       isobject: 3.0.1
-      set-value: 2.0.0
+      set-value: 2.0.1
       to-object-path: 0.3.0
-      union-value: 1.0.0
+      union-value: 1.0.1
       unset-value: 1.0.0
     dev: false
     engines:
@@ -4925,6 +4920,18 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  /http-errors/1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+    dev: false
+    engines:
+      node: '>= 0.6'
+    resolution:
+      integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
   /http-proxy/1.17.0:
     dependencies:
       eventemitter3: 3.1.2
@@ -6055,7 +6062,7 @@ packages:
       is-plain-object: 2.0.4
       object.map: 1.0.1
       rechoir: 0.6.2
-      resolve: 1.11.0
+      resolve: 1.11.1
     dev: false
     engines:
       node: '>= 0.8'
@@ -6329,7 +6336,7 @@ packages:
     dependencies:
       findup-sync: 2.0.0
       micromatch: 3.1.10
-      resolve: 1.11.0
+      resolve: 1.11.1
       stack-trace: 0.0.10
     dev: false
     engines:
@@ -6622,16 +6629,15 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==
-  /mixin-deep/1.3.1:
+  /mixin-deep/1.3.2:
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
-    deprecated: 'Critical bug fixed in v2.0.1, please upgrade to the latest version.'
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==
+      integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
   /mkdirp/0.5.1:
     dependencies:
       minimist: 0.0.8
@@ -6948,7 +6954,7 @@ packages:
   /normalize-package-data/2.5.0:
     dependencies:
       hosted-git-info: 2.7.1
-      resolve: 1.11.0
+      resolve: 1.11.1
       semver: 5.7.0
       validate-npm-package-license: 3.0.4
     dev: false
@@ -7920,7 +7926,7 @@ packages:
       integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
   /rechoir/0.6.2:
     dependencies:
-      resolve: 1.11.0
+      resolve: 1.11.1
     dev: false
     engines:
       node: '>= 0.10'
@@ -8184,12 +8190,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
-  /resolve/1.11.0:
-    dependencies:
-      path-parse: 1.0.6
-    dev: false
-    resolution:
-      integrity: sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
   /resolve/1.11.1:
     dependencies:
       path-parse: 1.0.6
@@ -8265,7 +8265,7 @@ packages:
       estree-walker: 0.6.1
       is-reference: 1.1.2
       magic-string: 0.25.2
-      resolve: 1.11.0
+      resolve: 1.11.1
       rollup-pluginutils: 2.8.1
     dev: false
     peerDependencies:
@@ -8277,7 +8277,7 @@ packages:
       estree-walker: 0.6.1
       is-reference: 1.1.2
       magic-string: 0.25.2
-      resolve: 1.11.0
+      resolve: 1.11.1
       rollup: 1.13.1
       rollup-pluginutils: 2.8.1
     dev: false
@@ -8561,7 +8561,7 @@ packages:
       escape-html: 1.0.3
       etag: 1.8.1
       fresh: 0.5.2
-      http-errors: 1.7.2
+      http-errors: 1.7.3
       mime: 1.6.0
       ms: 2.1.1
       on-finished: 2.3.0
@@ -8591,30 +8591,17 @@ packages:
     dev: false
     resolution:
       integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-  /set-value/0.4.3:
-    dependencies:
-      extend-shallow: 2.0.1
-      is-extendable: 0.1.1
-      is-plain-object: 2.0.4
-      to-object-path: 0.3.0
-    deprecated: 'Critical bug fixed in v3.0.1, please upgrade to the latest version.'
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha1-fbCPnT0i3H945Trzw79GZuzfzPE=
-  /set-value/2.0.0:
+  /set-value/2.0.1:
     dependencies:
       extend-shallow: 2.0.1
       is-extendable: 0.1.1
       is-plain-object: 2.0.4
       split-string: 3.1.0
-    deprecated: 'Critical bug fixed in v3.0.1, please upgrade to the latest version.'
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+      integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   /setimmediate/1.0.5:
     dev: false
     resolution:
@@ -9575,7 +9562,7 @@ packages:
       js-yaml: 3.13.1
       minimatch: 3.0.4
       mkdirp: 0.5.1
-      resolve: 1.11.0
+      resolve: 1.11.1
       semver: 5.7.0
       tslib: 1.10.0
       tsutils: 2.29.0
@@ -9598,7 +9585,7 @@ packages:
       js-yaml: 3.13.1
       minimatch: 3.0.4
       mkdirp: 0.5.1
-      resolve: 1.11.0
+      resolve: 1.11.1
       semver: 5.7.0
       tslib: 1.10.0
       tsutils: 2.29.0_typescript@3.5.2
@@ -9826,17 +9813,17 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==
-  /union-value/1.0.0:
+  /union-value/1.0.1:
     dependencies:
       arr-union: 3.1.0
       get-value: 2.0.6
       is-extendable: 0.1.1
-      set-value: 0.4.3
+      set-value: 2.0.1
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=
+      integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
   /unique-filename/1.1.1:
     dependencies:
       unique-slug: 2.0.2
@@ -10598,7 +10585,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-S4PkwShh9kZ3+6XRwSb5Ynh7EShodUeGh6Q5mIK4gyCAnN1VZgkheNbz2/7jNxVT31il5r6HIh9dy6llVKbAog==
+      integrity: sha512-1u2xINxLM36rIfPfmQF5QqgM+8d6A9kUdzRCS8VDFxeUUZex4UXeIrc1LL252dzLq+onveygfQqOK7dqHDxrLA==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -10617,7 +10604,7 @@ packages:
       '@types/tunnel': 0.0.0
       '@types/uuid': 3.4.4
       '@types/webpack': 4.4.34
-      '@types/webpack-dev-middleware': 2.0.2
+      '@types/webpack-dev-middleware': 2.0.3
       '@types/xml2js': 0.4.4
       abortcontroller-polyfill: 1.3.0
       axios: 0.19.0
@@ -10641,6 +10628,7 @@ packages:
       npm-run-all: 4.1.5
       nyc: 14.1.1
       opn-cli: 4.1.0
+      process: 0.11.10
       puppeteer: 1.18.0
       rimraf: 2.6.3
       rollup: 1.13.1
@@ -10674,7 +10662,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-WAIn25SPFI6eOx6jGZKvzlNXpbjMJ0Aa0G8u7lTgBJO79PC0dvVnio2zWffytQwDKQapF1NkDcZXCS7MeT0SAA==
+      integrity: sha512-jKUV5PQCbPdIm2WIY/KQKz9RxK2FCpW+SSUqnJ3Qky1lvI/eIBx5gumoKtqxQpPk5tinRdXQ/v5uamf5edfOCA==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -10794,6 +10782,7 @@ packages:
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
       rollup-plugin-uglify: 6.0.2_rollup@1.13.1
+      ts-mocha: 6.0.0_mocha@5.2.0
       ts-node: 7.0.1
       tslib: 1.10.0
       tslint: 5.18.0_typescript@3.5.2
@@ -10803,7 +10792,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-IseawXRVfBFQYeppyjjc1eOWxXWE99c7B+ONu67TvRgO9Wt+aXMn6EqGR5RVspeu1psp7HPG0404aDGYJQocTw==
+      integrity: sha512-Alp0kNBSfYO7xjDdy0S38g9Ran1bSOHtlbcQNbesfvD803YL4qCBvWFwDDo08qABplqOj5OLwskq6d5Faj5tVQ==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -10899,13 +10888,14 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-tmJkM8v1YqnVyndqD9vVHQEGeUT0PKuUN4oGDZ+A8r7brpJRByrEXsDIsDsbMczrxW8AgAg6lSZ45sUj/J8vCg==
+      integrity: sha512-CmC6hyAqaRzDogWyTTK+nyeytUE4ThbgQiR4TYN0vyihtF9b0W6JXwSM+O4zIKwoFkhGztaK6iINCe4jmPmTJg==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
     dependencies:
       '@microsoft/api-extractor': 7.2.1
       '@types/chai': 4.1.7
+      '@types/node': 8.10.49
       chai: 4.2.0
       prettier: 1.18.2
       rimraf: 2.6.3
@@ -10919,7 +10909,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-jf2qNSU+UsIdb1on92zDd6GBMr3xA+Ablll0hFdTZTC5rdsYjeerJwol7TMaTVTXbsuQI0fJDNhbxWUCfGOtKg==
+      integrity: sha512-rtHAu32lG7NDuVgoWi2L7yGhj2R+wmcvaOue9lZOFtk5XwUrt5m0AGGBwCjJttO7LTwcFlaQv99y3rPvgGO5HA==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
@@ -10930,6 +10920,7 @@ packages:
       '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
       '@types/nock': 10.0.3
+      '@types/node': 8.10.49
       '@typescript-eslint/eslint-plugin': 1.9.0_eslint@5.16.0+typescript@3.5.2
       '@typescript-eslint/parser': 1.11.0_eslint@5.16.0+typescript@3.5.2
       chai: 4.2.0
@@ -10945,7 +10936,6 @@ packages:
       mocha: 5.2.0
       nock: 10.0.6
       prettier: 1.18.2
-      query-string: 6.8.1
       rimraf: 2.6.3
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
@@ -10958,7 +10948,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-goKFmM55Ab72/LrjBYNDsmIsK6NgqRfvttoTGbIoZA6K5Y6TNUKcZz8JUTFwALeUQzWOnvnyBHJHUnxCpm3O8A==
+      integrity: sha512-ew3OR+3xkP9hIHi9zXfFJ8FZo9PGWO+REJ1TcRljBgZw18+l3qMd27qhJrsO/8xJPr4G2lgs0k4Q4TGauskAtg==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10971,6 +10961,7 @@ packages:
       '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
       '@types/nock': 10.0.3
+      '@types/node': 8.10.49
       '@typescript-eslint/eslint-plugin': 1.9.0_eslint@5.16.0+typescript@3.5.2
       '@typescript-eslint/parser': 1.11.0_eslint@5.16.0+typescript@3.5.2
       chai: 4.2.0
@@ -10998,7 +10989,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-SAkyTL9OCnyF9rMSe9HxK6BJA6Z1tkcJJSbqWCDG8CE0K1qsAFT3Py4KMoyH7Zhxan76CdwZ2Pmn200iwhLvrw==
+      integrity: sha512-7lxQwmnE7+8MH0uJUtUEMNaATGdEZo9DRsqstP0YlVHHEfCo1axiQSRBREMJVKAWY7jpHE9v3suRa2GqO0u1Xg==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -11519,7 +11510,6 @@ specifiers:
   qs: 6.7.0
   query-string: ^6.5.0
   requirejs: ^2.3.5
-  resolve: 1.11.0
   rhea: ^1.0.4
   rhea-promise: ^0.1.15
   rimraf: ^2.6.2

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -83,7 +83,7 @@ dependencies:
   eslint-detailed-reporter: 0.8.0
   eslint-plugin-no-null: 1.0.2
   eslint-plugin-no-only-tests: 2.3.1
-  eslint-plugin-promise: 4.1.1
+  eslint-plugin-promise: 4.2.1
   events: 3.0.0
   execa: 1.0.0
   express: 4.17.1
@@ -148,7 +148,7 @@ dependencies:
   rollup-plugin-json: 3.1.0
   rollup-plugin-multi-entry: 2.1.0
   rollup-plugin-node-globals: 1.4.0
-  rollup-plugin-node-resolve: 5.0.4
+  rollup-plugin-node-resolve: 5.1.0
   rollup-plugin-replace: 2.2.0
   rollup-plugin-resolve: 0.0.1-predev.1
   rollup-plugin-shim: 1.0.0
@@ -2264,8 +2264,8 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30000976
-      electron-to-chromium: 1.3.172
+      caniuse-lite: 1.0.30000977
+      electron-to-chromium: 1.3.173
     dev: false
     hasBin: true
     resolution:
@@ -2453,10 +2453,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /caniuse-lite/1.0.30000976:
+  /caniuse-lite/1.0.30000977:
     dev: false
     resolution:
-      integrity: sha512-tleNB1IwPRqZiod6nUNum63xQCMN96BUO2JTeiwuRM7p9d616EHsMBjBWJMudX39qCaPuWY8KEWzMZq7A9XQMQ==
+      integrity: sha512-RTXL32vdfAc2g9aoDL6vnBzbOO/3sM+T+YX4m7W9iFZnl3qIz7WYoZZpcZpALud8xq4+N56rnruX/NQy9HQu6A==
   /caseless/0.12.0:
     dev: false
     resolution:
@@ -3363,10 +3363,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.172:
+  /electron-to-chromium/1.3.173:
     dev: false
     resolution:
-      integrity: sha512-bHgFvYeHBiQNNuY/WvoX37zLosPgMbR8nKU1r4mylHptLvuMMny/KG/L28DTIlcoOCJjMAhEimy3DHDgDayPbg==
+      integrity: sha512-weH16m8as+4Fy4XJxrn/nFXsIqB7zkxERhvj/5YX2HE4HB8MCu98Wsef4E3mu0krIT27ic0bGsr+TvqYrUn6Qg==
   /elliptic/6.4.1:
     dependencies:
       bn.js: 4.11.8
@@ -3622,12 +3622,12 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-LzCzeQrlkNjEwUWEoGhfjz+Kgqe0080W6qC8I8eFwSMXIsr1zShuIQnRuSZc4Oi7k1vdUaNGDc+/GFvg6IHSHA==
-  /eslint-plugin-promise/4.1.1:
+  /eslint-plugin-promise/4.2.1:
     dev: false
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-faAHw7uzlNPy7b45J1guyjazw28M+7gJokKUjC5JSFoYfUEyy6Gw/i7YQvmv2Yk00sUjWcmzXQLpU1Ki/C2IZQ==
+      integrity: sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
   /eslint-scope/4.0.3:
     dependencies:
       esrecurse: 4.2.1
@@ -4134,7 +4134,7 @@ packages:
       integrity: sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
   /flat-cache/2.0.1:
     dependencies:
-      flatted: 2.0.0
+      flatted: 2.0.1
       rimraf: 2.6.3
       write: 1.0.3
     dev: false
@@ -4142,10 +4142,10 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
-  /flatted/2.0.0:
+  /flatted/2.0.1:
     dev: false
     resolution:
-      integrity: sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
+      integrity: sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
   /flush-write-stream/1.1.1:
     dependencies:
       inherits: 2.0.4
@@ -5941,7 +5941,7 @@ packages:
       core-js: 2.6.9
       di: 0.0.1
       dom-serialize: 2.2.1
-      flatted: 2.0.0
+      flatted: 2.0.1
       glob: 7.1.4
       graceful-fs: 4.1.15
       http-proxy: 1.17.0
@@ -6194,7 +6194,7 @@ packages:
     dependencies:
       date-format: 2.0.0
       debug: 4.1.1
-      flatted: 2.0.0
+      flatted: 2.0.1
       rfdc: 1.1.4
       streamroller: 1.0.5
     dev: false
@@ -8316,7 +8316,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==
-  /rollup-plugin-node-resolve/5.0.4:
+  /rollup-plugin-node-resolve/5.1.0:
     dependencies:
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
@@ -8327,8 +8327,8 @@ packages:
     peerDependencies:
       rollup: '>=1.11.0'
     resolution:
-      integrity: sha512-L/fGn+uZOCk/e3uNa3MITUCA3tXndcsaH0Bc7rq7v389vEXMXAYnmF0giEUWbhYxE7PyMGglByVrR8AeIP9klw==
-  /rollup-plugin-node-resolve/5.0.4_rollup@1.13.1:
+      integrity: sha512-2hwwHNj0s8UEtUNT+lJq8rFWEznP7yJm3GCHBicadF6hiNX1aRARRZIjz2doeTlTGg/hOvJr4C/8+3k9Y/J5Hg==
+  /rollup-plugin-node-resolve/5.1.0_rollup@1.13.1:
     dependencies:
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
@@ -8340,7 +8340,7 @@ packages:
     peerDependencies:
       rollup: '>=1.11.0'
     resolution:
-      integrity: sha512-L/fGn+uZOCk/e3uNa3MITUCA3tXndcsaH0Bc7rq7v389vEXMXAYnmF0giEUWbhYxE7PyMGglByVrR8AeIP9klw==
+      integrity: sha512-2hwwHNj0s8UEtUNT+lJq8rFWEznP7yJm3GCHBicadF6hiNX1aRARRZIjz2doeTlTGg/hOvJr4C/8+3k9Y/J5Hg==
   /rollup-plugin-replace/2.2.0:
     dependencies:
       magic-string: 0.25.2
@@ -10505,7 +10505,7 @@ packages:
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
       rollup-plugin-uglify: 6.0.2_rollup@1.13.1
@@ -10545,7 +10545,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       events: 3.0.0
       is-buffer: 2.0.3
       jssha: 2.3.1
@@ -10568,7 +10568,7 @@ packages:
       rollup-plugin-json: 3.1.0
       rollup-plugin-multi-entry: 2.1.0
       rollup-plugin-node-globals: 1.4.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
@@ -10636,7 +10636,7 @@ packages:
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-json: 3.1.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-resolve: 0.0.1-predev.1
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
       rollup-plugin-visualizer: 1.1.1_rollup@1.13.1
@@ -10675,7 +10675,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       prettier: 1.18.2
       typescript: 3.5.2
     dev: false
@@ -10749,7 +10749,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       https-proxy-agent: 2.2.1
       is-buffer: 2.0.3
       jssha: 2.3.1
@@ -10777,7 +10777,7 @@ packages:
       rollup-plugin-inject: 2.2.0
       rollup-plugin-json: 3.1.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
@@ -10823,7 +10823,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       mocha: 5.2.0
       mocha-junit-reporter: 1.23.0_mocha@5.2.0
       mocha-multi: 1.1.0_mocha@5.2.0
@@ -10836,7 +10836,7 @@ packages:
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-json: 3.1.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
       rollup-plugin-uglify: 6.0.2_rollup@1.13.1
@@ -10876,7 +10876,7 @@ packages:
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-json: 3.1.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
       rollup-plugin-uglify: 6.0.2_rollup@1.13.1
@@ -10901,7 +10901,7 @@ packages:
       rimraf: 2.6.3
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       tslib: 1.10.0
       typescript: 3.5.2
       uglify-js: 3.6.0
@@ -10931,7 +10931,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       fs-extra: 8.0.1
       mocha: 5.2.0
       nock: 10.0.6
@@ -10939,7 +10939,7 @@ packages:
       rimraf: 2.6.3
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       ts-mocha: 6.0.0_mocha@5.2.0
       tslib: 1.10.0
       typescript: 3.5.2
@@ -10972,7 +10972,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       fs-extra: 8.0.1
       mocha: 5.2.0
       nock: 10.0.6
@@ -10980,7 +10980,7 @@ packages:
       rimraf: 2.6.3
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       ts-mocha: 6.0.0_mocha@5.2.0
       tslib: 1.10.0
       typescript: 3.5.2
@@ -11023,7 +11023,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       https-proxy-agent: 2.2.1
       is-buffer: 2.0.3
       karma: 4.1.0
@@ -11055,7 +11055,7 @@ packages:
       rollup-plugin-inject: 2.2.0
       rollup-plugin-json: 3.1.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
@@ -11091,7 +11091,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       events: 3.0.0
       fs-extra: 8.0.1
       gulp: 4.0.2
@@ -11123,7 +11123,7 @@ packages:
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
@@ -11151,9 +11151,9 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       rollup: 1.13.1
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       ts-node: 7.0.1
       tslib: 1.10.0
       typescript: 3.5.2
@@ -11186,7 +11186,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       events: 3.0.0
       fs-extra: 8.0.1
       gulp: 4.0.2
@@ -11218,7 +11218,7 @@ packages:
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
@@ -11256,7 +11256,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       fs-extra: 8.0.1
       gulp: 4.0.2
       gulp-zip: 4.2.0
@@ -11287,7 +11287,7 @@ packages:
       rollup: 1.13.1
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
@@ -11319,7 +11319,7 @@ packages:
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
       eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.1.1
+      eslint-plugin-promise: 4.2.1
       events: 3.0.0
       inherits: 2.0.4
       mocha: 5.2.0
@@ -11331,7 +11331,7 @@ packages:
       rollup-plugin-commonjs: 10.0.0_rollup@1.13.1
       rollup-plugin-json: 3.1.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.0.4_rollup@1.13.1
+      rollup-plugin-node-resolve: 5.1.0_rollup@1.13.1
       rollup-plugin-replace: 2.2.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.13.1
       rollup-plugin-uglify: 6.0.2_rollup@1.13.1
@@ -11370,6 +11370,7 @@ packages:
       integrity: sha512-c3cFI0Our99carkgcyOFLmX5QRh5fIqyVv9S75VRX7woNtBGXPvWRE8VOxEN9o8N8FjSEQzc6PPEO6YRz7ok8Q==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure/amqp-common': ^1.0.0-preview.5
   '@azure/arm-servicebus': ^0.1.0

--- a/sdk/core/abort-controller/rollup.base.config.js
+++ b/sdk/core/abort-controller/rollup.base.config.js
@@ -95,8 +95,8 @@ export function browserConfig(test = false) {
       }),
       cjs({
         namedExports: {
-          events: ["EventEmitter"],
-          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
+          "events/": ["EventEmitter"],
+          "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
         }
       })
     ]

--- a/sdk/core/abort-controller/rollup.base.config.js
+++ b/sdk/core/abort-controller/rollup.base.config.js
@@ -94,6 +94,9 @@ export function browserConfig(test = false) {
         preferBuiltins: false
       }),
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
           "events/": ["EventEmitter"],
           "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]

--- a/sdk/core/core-amqp/rollup.base.config.js
+++ b/sdk/core/core-amqp/rollup.base.config.js
@@ -132,7 +132,7 @@ export function browserConfig(test = false) {
       cjs({
         namedExports: {
           chai: ["should"],
-          assert: ["equal", "deepEqual", "notEqual"]
+          "assert/": ["equal", "deepEqual", "notEqual"]
         }
       }),
 

--- a/sdk/core/core-amqp/rollup.base.config.js
+++ b/sdk/core/core-amqp/rollup.base.config.js
@@ -130,6 +130,9 @@ export function browserConfig(test = false) {
       }),
 
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
           chai: ["should"],
           "assert/": ["equal", "deepEqual", "notEqual"]

--- a/sdk/eventhub/event-hubs/rollup.base.config.js
+++ b/sdk/eventhub/event-hubs/rollup.base.config.js
@@ -131,7 +131,7 @@ export function browserConfig(test = false) {
 
       cjs({
         namedExports: {
-          events: ["EventEmitter"]
+          "events/": ["EventEmitter"]
         }
       }),
 

--- a/sdk/eventhub/event-hubs/rollup.base.config.js
+++ b/sdk/eventhub/event-hubs/rollup.base.config.js
@@ -130,6 +130,9 @@ export function browserConfig(test = false) {
       }),
 
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
           "events/": ["EventEmitter"]
         }

--- a/sdk/eventhub/event-processor-host/rollup.base.config.js
+++ b/sdk/eventhub/event-processor-host/rollup.base.config.js
@@ -106,7 +106,7 @@ export function browserConfig(test = false) {
         preferBuiltins: false
       }),
       cjs({
-        namedExports: { events: ["EventEmitter"] }
+        namedExports: { "events/": ["EventEmitter"] }
       }),
       json()
     ]

--- a/sdk/eventhub/event-processor-host/rollup.base.config.js
+++ b/sdk/eventhub/event-processor-host/rollup.base.config.js
@@ -106,6 +106,9 @@ export function browserConfig(test = false) {
         preferBuiltins: false
       }),
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: { "events/": ["EventEmitter"] }
       }),
       json()

--- a/sdk/identity/identity/rollup.base.config.js
+++ b/sdk/identity/identity/rollup.base.config.js
@@ -83,6 +83,9 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: { "events/": ["EventEmitter"] }
       }),
       viz({ filename: "browser/browser-stats.html", sourcemap: false })

--- a/sdk/identity/identity/rollup.base.config.js
+++ b/sdk/identity/identity/rollup.base.config.js
@@ -83,7 +83,7 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
-        namedExports: { events: ["EventEmitter"] }
+        namedExports: { "events/": ["EventEmitter"] }
       }),
       viz({ filename: "browser/browser-stats.html", sourcemap: false })
     ]

--- a/sdk/servicebus/service-bus/rollup.base.config.js
+++ b/sdk/servicebus/service-bus/rollup.base.config.js
@@ -143,7 +143,7 @@ export function browserConfig({ test = false, production = false } = {}) {
         dedupe: ["buffer"]
       }),
       cjs({
-        namedExports: { events: ["EventEmitter"], long: ["ZERO"] }
+        namedExports: { "events/": ["EventEmitter"], long: ["ZERO"] }
       }),
 
       // rhea and rhea-promise use the Buffer global which requires

--- a/sdk/servicebus/service-bus/rollup.base.config.js
+++ b/sdk/servicebus/service-bus/rollup.base.config.js
@@ -143,6 +143,9 @@ export function browserConfig({ test = false, production = false } = {}) {
         dedupe: ["buffer"]
       }),
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: { "events/": ["EventEmitter"], long: ["ZERO"] }
       }),
 

--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -109,8 +109,8 @@ export function browserConfig(test = false, production = false) {
       }),
       cjs({
         namedExports: {
-          events: ["EventEmitter"],
-          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
+          "events/": ["EventEmitter"],
+          "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
         }
       })
     ]

--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -108,6 +108,9 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
           "events/": ["EventEmitter"],
           "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]

--- a/sdk/storage/storage-file/rollup.base.config.js
+++ b/sdk/storage/storage-file/rollup.base.config.js
@@ -109,8 +109,8 @@ export function browserConfig(test = false, production = false) {
       }),
       cjs({
         namedExports: {
-          events: ["EventEmitter"],
-          assert: [
+          "events/": ["EventEmitter"],
+          "assert/": [
             "ok",
             "deepEqual",
             "equal",

--- a/sdk/storage/storage-file/rollup.base.config.js
+++ b/sdk/storage/storage-file/rollup.base.config.js
@@ -108,6 +108,9 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
           "events/": ["EventEmitter"],
           "assert/": [

--- a/sdk/storage/storage-queue/rollup.base.config.js
+++ b/sdk/storage/storage-queue/rollup.base.config.js
@@ -108,6 +108,9 @@ export function browserConfig(test = false, production = false) {
       }),
       cjs({
         namedExports: {
+          // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+          // modules with built-in names must have a trailing slash.
+          // https://github.com/rollup/rollup-plugin-commonjs/issues/394
           "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual"]
         }
       })

--- a/sdk/storage/storage-queue/rollup.base.config.js
+++ b/sdk/storage/storage-queue/rollup.base.config.js
@@ -108,7 +108,7 @@ export function browserConfig(test = false, production = false) {
       }),
       cjs({
         namedExports: {
-          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual"]
+          "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual"]
         }
       })
     ]

--- a/sdk/template/template/rollup.base.config.js
+++ b/sdk/template/template/rollup.base.config.js
@@ -83,6 +83,9 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
+        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
+        // modules with built-in names must have a trailing slash.
+        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: { "events/": ["EventEmitter"] }
       }),
       viz({ filename: "browser/browser-stats.html", sourcemap: false })

--- a/sdk/template/template/rollup.base.config.js
+++ b/sdk/template/template/rollup.base.config.js
@@ -83,7 +83,7 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
-        namedExports: { events: ["EventEmitter"] }
+        namedExports: { "events/": ["EventEmitter"] }
       }),
       viz({ filename: "browser/browser-stats.html", sourcemap: false })
     ]


### PR DESCRIPTION
- Repo has been updated to "rollup-plugin-node-resolve@5.0.2", which is compatible with "resolve@1.11.1"
- Added trailing slash to named exports of modules with built-in names
  - Required when using  "rollup-plugin-commonjs@10.0.0" with "resolve@1.11.1"
  - https://github.com/rollup/rollup-plugin-commonjs/issues/394
- Fixes #3589