### PR TITLE
[Storage] Add fs.createWriteStream() shim for browser rollup

### DIFF
--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -101,6 +101,7 @@ export function browserConfig(test = false, production = false) {
         fs: `
           export function statSync() { }
           export function createReadStream() { }
+          export function createWriteStream() { }
         `,
         os: `
           export const type = 1;

--- a/sdk/storage/storage-file/rollup.base.config.js
+++ b/sdk/storage/storage-file/rollup.base.config.js
@@ -101,6 +101,7 @@ export function browserConfig(test = false, production = false) {
         fs: `
           export function statSync() { }
           export function createReadStream() { }
+          export function createWriteStream() { }
         `,
         os: `
           export const type = 1;


### PR DESCRIPTION
This removes one rollup warning.