### PR TITLE
[Storage] Fixing rollup error

### DIFF
--- a/sdk/storage/storage-blob/.nycrc
+++ b/sdk/storage/storage-blob/.nycrc
@@ -5,6 +5,7 @@
     "exclude": [
       "**/*.d.ts",
       "src/BlobDownloadResponse.browser.ts",
+      "src/credentials/SharedKeyCredential.browser.ts",
       "src/highlevel.browser.ts",
       "src/highlevel.common.ts",
       "src/models.ts",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -8,6 +8,7 @@
   "browser": {
     "./dist/index.js": "./browser/azure-storage-blob.min.js",
     "./dist-esm/src/index.js": "./dist-esm/src/index.browser.js",
+    "./dist-esm/src/credentials/SharedKeyCredential.js": "./dist-esm/src/credentials/SharedKeyCredential.browser.js",
     "./dist-esm/test/utils/index.js": "./dist-esm/test/utils/index.browser.js",
     "./dist-esm/src/BlobDownloadResponse.js": "./dist-esm/src/BlobDownloadResponse.browser.js",
     "os": false,

--- a/sdk/storage/storage-blob/src/AppendBlobClient.ts
+++ b/sdk/storage/storage-blob/src/AppendBlobClient.ts
@@ -5,7 +5,8 @@ import {
   HttpRequestBody,
   TransferProgressEvent,
   TokenCredential,
-  isTokenCredential
+  isTokenCredential,
+  isNode
 } from "@azure/core-http";
 
 import * as Models from "./generated/lib/models";
@@ -203,16 +204,20 @@ export class AppendBlobClient extends BlobClient {
       blobNameOrOptions &&
       typeof blobNameOrOptions === "string"
     ) {
-      const containerName = credentialOrPipelineOrContainerName;
-      const blobName = blobNameOrOptions;
+      if (isNode) {
+        const containerName = credentialOrPipelineOrContainerName;
+        const blobName = blobNameOrOptions;
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
-      pipeline = newPipeline(sharedKeyCredential, options);
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for containerName and blobName parameters");
     }

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -637,16 +637,20 @@ export class BlobClient extends StorageClient {
       blobNameOrOptions &&
       typeof blobNameOrOptions === "string"
     ) {
-      const containerName = credentialOrPipelineOrContainerName;
-      const blobName = blobNameOrOptions;
+      if (isNode) {
+        const containerName = credentialOrPipelineOrContainerName;
+        const blobName = blobNameOrOptions;
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
-      pipeline = newPipeline(sharedKeyCredential, options);
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for containerName and blobName parameters");
     }

--- a/sdk/storage/storage-blob/src/BlockBlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlockBlobClient.ts
@@ -9,7 +9,8 @@ import {
   HttpResponse,
   TransferProgressEvent,
   TokenCredential,
-  isTokenCredential
+  isTokenCredential,
+  isNode
 } from "@azure/core-http";
 
 import * as Models from "./generated/lib/models";
@@ -479,16 +480,20 @@ export class BlockBlobClient extends BlobClient {
       blobNameOrOptions &&
       typeof blobNameOrOptions === "string"
     ) {
-      const containerName = credentialOrPipelineOrContainerName;
-      const blobName = blobNameOrOptions;
+      if (isNode) {
+        const containerName = credentialOrPipelineOrContainerName;
+        const blobName = blobNameOrOptions;
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
-      pipeline = newPipeline(sharedKeyCredential, options);
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for containerName and blobName parameters");
     }
@@ -779,7 +784,7 @@ export class BlockBlobClient extends BlobClient {
     if (numBlocks > BLOCK_BLOB_MAX_BLOCKS) {
       throw new RangeError(
         `The buffer's size is too big or the BlockSize is too small;` +
-        `the number of blocks must be <= ${BLOCK_BLOB_MAX_BLOCKS}`
+          `the number of blocks must be <= ${BLOCK_BLOB_MAX_BLOCKS}`
       );
     }
 
@@ -981,7 +986,7 @@ export class BlockBlobClient extends BlobClient {
     if (numBlocks > BLOCK_BLOB_MAX_BLOCKS) {
       throw new RangeError(
         `The buffer's size is too big or the BlockSize is too small;` +
-        `the number of blocks must be <= ${BLOCK_BLOB_MAX_BLOCKS}`
+          `the number of blocks must be <= ${BLOCK_BLOB_MAX_BLOCKS}`
       );
     }
 

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -5,7 +5,8 @@ import {
   HttpRequestBody,
   HttpResponse,
   TokenCredential,
-  isTokenCredential
+  isTokenCredential,
+  isNode
 } from "@azure/core-http";
 import * as Models from "./generated/lib/models";
 import { Aborter } from "./Aborter";
@@ -204,24 +205,24 @@ export interface SignedIdentifier {
 export declare type ContainerGetAccessPolicyResponse = {
   signedIdentifiers: SignedIdentifier[];
 } & Models.ContainerGetAccessPolicyHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: HttpResponse & {
     /**
-     * The parsed HTTP response headers.
+     * The underlying HTTP response.
      */
-    parsedHeaders: Models.ContainerGetAccessPolicyHeaders;
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Models.SignedIdentifier[];
+    _response: HttpResponse & {
+      /**
+       * The parsed HTTP response headers.
+       */
+      parsedHeaders: Models.ContainerGetAccessPolicyHeaders;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Models.SignedIdentifier[];
+    };
   };
-};
 
 /**
  * Options to configure Container - Set Access Policy operation.
@@ -529,15 +530,19 @@ export class ContainerClient extends StorageClient {
       credentialOrPipelineOrContainerName &&
       typeof credentialOrPipelineOrContainerName === "string"
     ) {
-      const containerName = credentialOrPipelineOrContainerName;
+      if (isNode) {
+        const containerName = credentialOrPipelineOrContainerName;
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + containerName + "/";
-      pipeline = newPipeline(sharedKeyCredential, options);
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + containerName + "/";
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for containerName parameter");
     }

--- a/sdk/storage/storage-blob/src/PageBlobClient.ts
+++ b/sdk/storage/storage-blob/src/PageBlobClient.ts
@@ -5,7 +5,8 @@ import {
   HttpRequestBody,
   TransferProgressEvent,
   TokenCredential,
-  isTokenCredential
+  isTokenCredential,
+  isNode
 } from "@azure/core-http";
 
 import * as Models from "./generated/lib/models";
@@ -359,16 +360,20 @@ export class PageBlobClient extends BlobClient {
       blobNameOrOptions &&
       typeof blobNameOrOptions === "string"
     ) {
-      const containerName = credentialOrPipelineOrContainerName;
-      const blobName = blobNameOrOptions;
+      if (isNode) {
+        const containerName = credentialOrPipelineOrContainerName;
+        const blobName = blobNameOrOptions;
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
-      pipeline = newPipeline(sharedKeyCredential, options);
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for containerName and blobName parameters");
     }

--- a/sdk/storage/storage-blob/src/credentials/SharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-blob/src/credentials/SharedKeyCredential.browser.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export class SharedKeyCredential {}

--- a/sdk/storage/storage-blob/src/credentials/SharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-blob/src/credentials/SharedKeyCredential.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export class SharedKeyCredential {}
+export const SharedKeyCredential = undefined;

--- a/sdk/storage/storage-file/.nycrc
+++ b/sdk/storage/storage-file/.nycrc
@@ -5,6 +5,7 @@
     "exclude": [
       "**/*.d.ts",
       "src/FileDownloadResponse.browser.ts",
+      "src/credentials/SharedKeyCredential.browser.ts",
       "src/highlevel.browser.ts",
       "src/highlevel.common.ts",
       "src/policies/BrowserPolicy.ts",

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -8,6 +8,7 @@
   "browser": {
     "./dist/index.js": "./browser/azure-storage-file.min.js",
     "./dist-esm/src/index.js": "./dist-esm/src/index.browser.js",
+    "./dist-esm/src/credentials/SharedKeyCredential.js": "./dist-esm/src/credentials/SharedKeyCredential.browser.js",
     "./dist-esm/test/utils/index.js": "./dist-esm/test/utils/index.browser.js",
     "./dist-esm/src/FileDownloadResponse.js": "./dist-esm/src/FileDownloadResponse.browser.js",
     "os": false,

--- a/sdk/storage/storage-file/src/FileServiceClient.ts
+++ b/sdk/storage/storage-file/src/FileServiceClient.ts
@@ -12,6 +12,7 @@ import { Credential } from "./credentials/Credential";
 import { SharedKeyCredential } from "./credentials/SharedKeyCredential";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
+import { isNode } from "@azure/core-http";
 
 /**
  * Options to configure List Shares Segment operation.
@@ -158,13 +159,17 @@ export class FileServiceClient extends StorageClient {
     connectionString: string,
     options?: NewPipelineOptions
   ): FileServiceClient {
-    const extractedCreds = extractConnectionStringParts(connectionString);
-    const sharedKeyCredential = new SharedKeyCredential(
-      extractedCreds.accountName,
-      extractedCreds.accountKey
-    );
-    const pipeline = newPipeline(sharedKeyCredential, options);
-    return new FileServiceClient(extractedCreds.url, pipeline);
+    if (isNode) {
+      const extractedCreds = extractConnectionStringParts(connectionString);
+      const sharedKeyCredential = new SharedKeyCredential(
+        extractedCreds.accountName,
+        extractedCreds.accountKey
+      );
+      const pipeline = newPipeline(sharedKeyCredential, options);
+      return new FileServiceClient(extractedCreds.url, pipeline);
+    } else {
+      throw new Error("Connection string is only supported in Node.js environment");
+    }
   }
 
   /**
@@ -428,7 +433,7 @@ export class FileServiceClient extends StorageClient {
         });
       }
     };
-}
+  }
 
   /**
    * Gets the properties of a storage account's File service, including properties for Storage

--- a/sdk/storage/storage-file/src/ShareClient.ts
+++ b/sdk/storage/storage-file/src/ShareClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { HttpResponse } from "@azure/core-http";
+import { HttpResponse, isNode } from "@azure/core-http";
 
 import { Aborter } from "./Aborter";
 import * as Models from "./generated/lib/models";
@@ -225,24 +225,24 @@ export interface SignedIdentifier {
 export declare type ShareGetAccessPolicyResponse = {
   signedIdentifiers: SignedIdentifier[];
 } & Models.ShareGetAccessPolicyHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: HttpResponse & {
     /**
-     * The parsed HTTP response headers.
+     * The underlying HTTP response.
      */
-    parsedHeaders: Models.ShareGetAccessPolicyHeaders;
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Models.SignedIdentifier[];
+    _response: HttpResponse & {
+      /**
+       * The parsed HTTP response headers.
+       */
+      parsedHeaders: Models.ShareGetAccessPolicyHeaders;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Models.SignedIdentifier[];
+    };
   };
-};
 
 /**
  * Options to configure Share - Create Snapshot operation.
@@ -341,14 +341,18 @@ export class ShareClient extends StorageClient {
       credentialOrPipelineOrShareName &&
       typeof credentialOrPipelineOrShareName === "string"
     ) {
-      const shareName = credentialOrPipelineOrShareName;
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + shareName;
-      pipeline = newPipeline(sharedKeyCredential, options);
+      if (isNode) {
+        const shareName = credentialOrPipelineOrShareName;
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + shareName;
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for shareName parameter");
     }

--- a/sdk/storage/storage-file/src/credentials/SharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-file/src/credentials/SharedKeyCredential.browser.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export class SharedKeyCredential {}

--- a/sdk/storage/storage-file/src/credentials/SharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-file/src/credentials/SharedKeyCredential.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export class SharedKeyCredential {}
+export const SharedKeyCredential = undefined;

--- a/sdk/storage/storage-queue/.nycrc
+++ b/sdk/storage/storage-queue/.nycrc
@@ -4,6 +4,7 @@
     ],
     "exclude": [
       "**/*.d.ts",
+      "src/credentials/SharedKeyCredential.browser.ts",
       "src/models.ts",
       "src/generated/lib/storageClient.ts"
     ],

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -8,6 +8,7 @@
   "browser": {
     "./dist/index.js": "./browser/azure-storage-queue.min.js",
     "./dist-esm/src/index.js": "./dist-esm/src/index.browser.js",
+    "./dist-esm/src/credentials/SharedKeyCredential.js": "./dist-esm/src/credentials/SharedKeyCredential.browser.js",
     "./dist-esm/test/utils/index.js": "./dist-esm/test/utils/index.browser.js",
     "os": false,
     "process": false

--- a/sdk/storage/storage-queue/src/MessageIdClient.ts
+++ b/sdk/storage/storage-queue/src/MessageIdClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TokenCredential, isTokenCredential } from "@azure/core-http";
+import { TokenCredential, isTokenCredential, isNode } from "@azure/core-http";
 import * as Models from "./generated/lib/models";
 import { Aborter } from "./Aborter";
 import { MessageId } from "./generated/lib/operations";
@@ -94,11 +94,7 @@ export class MessageIdClient extends StorageClient {
    * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof MessageIdClient
    */
-  constructor(
-    url: string,
-    credential?: Credential | TokenCredential,
-    options?: NewPipelineOptions
-  );
+  constructor(url: string, credential?: Credential | TokenCredential, options?: NewPipelineOptions);
   /**
    * Creates an instance of MessageIdClient.
    *
@@ -139,16 +135,20 @@ export class MessageIdClient extends StorageClient {
       messageIdOrOptions &&
       typeof messageIdOrOptions === "string"
     ) {
-      const queueName = credentialOrPipelineOrQueueName;
-      const messageId = messageIdOrOptions;
+      if (isNode) {
+        const queueName = credentialOrPipelineOrQueueName;
+        const messageId = messageIdOrOptions;
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + queueName + "/" + messageId;
-      pipeline = newPipeline(sharedKeyCredential, options);
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + queueName + "/" + messageId;
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for queueName and messageId parameters");
     }

--- a/sdk/storage/storage-queue/src/MessagesClient.ts
+++ b/sdk/storage/storage-queue/src/MessagesClient.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-  HttpResponse,
-  TokenCredential,
-  isTokenCredential
-} from "@azure/core-http";
+import { HttpResponse, TokenCredential, isTokenCredential, isNode } from "@azure/core-http";
 import * as Models from "./generated/lib/models";
 import { Aborter } from "./Aborter";
 import { Messages } from "./generated/lib/operations";
@@ -42,7 +38,7 @@ export interface MessagesClearOptions {
  * @interface MessagesEnqueueOptions
  * @extends {Models.MessagesEnqueueOptionalParams}
  */
-export interface MessagesEnqueueOptions extends Models.MessagesEnqueueOptionalParams { }
+export interface MessagesEnqueueOptions extends Models.MessagesEnqueueOptionalParams {}
 
 /**
  * Options to configure Messages - Dequeue operation
@@ -51,7 +47,7 @@ export interface MessagesEnqueueOptions extends Models.MessagesEnqueueOptionalPa
  * @interface MessagesDequeueOptions
  * @extends {Models.MessagesDequeueOptionalParams}
  */
-export interface MessagesDequeueOptions extends Models.MessagesDequeueOptionalParams { }
+export interface MessagesDequeueOptions extends Models.MessagesDequeueOptionalParams {}
 
 /**
  * Options to configure Messages - Peek operation
@@ -60,7 +56,7 @@ export interface MessagesDequeueOptions extends Models.MessagesDequeueOptionalPa
  * @interface MessagesPeekOptions
  * @extends {Models.MessagesPeekOptionalParams}
  */
-export interface MessagesPeekOptions extends Models.MessagesPeekOptionalParams { }
+export interface MessagesPeekOptions extends Models.MessagesPeekOptionalParams {}
 
 export declare type MessagesEnqueueResponse = {
   /**
@@ -89,68 +85,68 @@ export declare type MessagesEnqueueResponse = {
    */
   timeNextVisible: Date;
 } & Models.MessagesEnqueueHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: HttpResponse & {
     /**
-     * The parsed HTTP response headers.
+     * The underlying HTTP response.
      */
-    parsedHeaders: Models.MessagesEnqueueHeaders;
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Models.EnqueuedMessage[];
+    _response: HttpResponse & {
+      /**
+       * The parsed HTTP response headers.
+       */
+      parsedHeaders: Models.MessagesEnqueueHeaders;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Models.EnqueuedMessage[];
+    };
   };
-};
 
 export declare type MessagesDequeueResponse = {
   dequeuedMessageItems: Models.DequeuedMessageItem[];
 } & Models.MessagesDequeueHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: HttpResponse & {
     /**
-     * The parsed HTTP response headers.
+     * The underlying HTTP response.
      */
-    parsedHeaders: Models.MessagesDequeueHeaders;
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Models.DequeuedMessageItem[];
+    _response: HttpResponse & {
+      /**
+       * The parsed HTTP response headers.
+       */
+      parsedHeaders: Models.MessagesDequeueHeaders;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Models.DequeuedMessageItem[];
+    };
   };
-};
 
 export declare type MessagesPeekResponse = {
   peekedMessageItems: Models.PeekedMessageItem[];
 } & Models.MessagesPeekHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: HttpResponse & {
     /**
-     * The parsed HTTP response headers.
+     * The underlying HTTP response.
      */
-    parsedHeaders: Models.MessagesPeekHeaders;
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Models.PeekedMessageItem[];
+    _response: HttpResponse & {
+      /**
+       * The parsed HTTP response headers.
+       */
+      parsedHeaders: Models.MessagesPeekHeaders;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Models.PeekedMessageItem[];
+    };
   };
-};
 
 /**
  * A MessagesClient represents a URL to an Azure Storage Queue's messages allowing you to manipulate its messages.
@@ -192,11 +188,7 @@ export class MessagesClient extends StorageClient {
    * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof MessagesClient
    */
-  constructor(
-    url: string,
-    credential?: Credential | TokenCredential,
-    options?: NewPipelineOptions
-  );
+  constructor(url: string, credential?: Credential | TokenCredential, options?: NewPipelineOptions);
   /**
    * Creates an instance of MessagesClient.
    *
@@ -232,14 +224,18 @@ export class MessagesClient extends StorageClient {
       credentialOrPipelineOrQueueName &&
       typeof credentialOrPipelineOrQueueName === "string"
     ) {
-      const queueName = credentialOrPipelineOrQueueName;
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + queueName + "/messages";
-      pipeline = newPipeline(sharedKeyCredential, options);
+      if (isNode) {
+        const queueName = credentialOrPipelineOrQueueName;
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + queueName + "/messages";
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for queueName parameter");
     }

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-  HttpResponse,
-  TokenCredential,
-  isTokenCredential
-} from "@azure/core-http";
+import { HttpResponse, TokenCredential, isTokenCredential, isNode } from "@azure/core-http";
 import * as Models from "./generated/lib/models";
 import { Aborter } from "./Aborter";
 import { Queue } from "./generated/lib/operations";
@@ -172,24 +168,24 @@ export interface SignedIdentifier {
 export declare type QueueGetAccessPolicyResponse = {
   signedIdentifiers: SignedIdentifier[];
 } & Models.QueueGetAccessPolicyHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: HttpResponse & {
     /**
-     * The parsed HTTP response headers.
+     * The underlying HTTP response.
      */
-    parsedHeaders: Models.QueueGetAccessPolicyHeaders;
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Models.SignedIdentifier[];
+    _response: HttpResponse & {
+      /**
+       * The parsed HTTP response headers.
+       */
+      parsedHeaders: Models.QueueGetAccessPolicyHeaders;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Models.SignedIdentifier[];
+    };
   };
-};
 
 /**
  * A QueueClient represents a URL to the Azure Storage queue.
@@ -231,11 +227,7 @@ export class QueueClient extends StorageClient {
    * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueClient
    */
-  constructor(
-    url: string,
-    credential?: Credential | TokenCredential,
-    options?: NewPipelineOptions
-  );
+  constructor(url: string, credential?: Credential | TokenCredential, options?: NewPipelineOptions);
   /**
    * Creates an instance of QueueClient.
    *
@@ -271,15 +263,19 @@ export class QueueClient extends StorageClient {
       credentialOrPipelineOrQueueName &&
       typeof credentialOrPipelineOrQueueName === "string"
     ) {
-      const queueName = credentialOrPipelineOrQueueName;
+      if (isNode) {
+        const queueName = credentialOrPipelineOrQueueName;
 
-      const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const sharedKeyCredential = new SharedKeyCredential(
-        extractedCreds.accountName,
-        extractedCreds.accountKey
-      );
-      urlOrConnectionString = extractedCreds.url + "/" + queueName;
-      pipeline = newPipeline(sharedKeyCredential, options);
+        const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
+        const sharedKeyCredential = new SharedKeyCredential(
+          extractedCreds.accountName,
+          extractedCreds.accountKey
+        );
+        urlOrConnectionString = extractedCreds.url + "/" + queueName;
+        pipeline = newPipeline(sharedKeyCredential, options);
+      } else {
+        throw new Error("Connection string is only supported in Node.js environment");
+      }
     } else {
       throw new Error("Expecting non-empty strings for queueName parameter");
     }

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TokenCredential, isTokenCredential } from "@azure/core-http";
+import { TokenCredential, isTokenCredential, isNode } from "@azure/core-http";
 import * as Models from "./generated/lib/models";
 import { Aborter } from "./Aborter";
 import { ListQueuesIncludeType } from "./generated/lib/models/index";
@@ -158,14 +158,18 @@ export class QueueServiceClient extends StorageClient {
     connectionString: string,
     options?: NewPipelineOptions
   ): QueueServiceClient {
-    const extractedCreds = extractConnectionStringParts(connectionString);
-    const sharedKeyCredential = new SharedKeyCredential(
-      extractedCreds.accountName,
-      extractedCreds.accountKey
-    );
+    if (isNode) {
+      const extractedCreds = extractConnectionStringParts(connectionString);
+      const sharedKeyCredential = new SharedKeyCredential(
+        extractedCreds.accountName,
+        extractedCreds.accountKey
+      );
 
-    const pipeline = newPipeline(sharedKeyCredential, options);
-    return new QueueServiceClient(extractedCreds.url, pipeline);
+      const pipeline = newPipeline(sharedKeyCredential, options);
+      return new QueueServiceClient(extractedCreds.url, pipeline);
+    } else {
+      throw new Error("Connection string is only supported in Node.js environment");
+    }
   }
 
   /**
@@ -189,11 +193,7 @@ export class QueueServiceClient extends StorageClient {
    * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueServiceClient
    */
-  constructor(
-    url: string,
-    credential?: Credential | TokenCredential,
-    options?: NewPipelineOptions
-  );
+  constructor(url: string, credential?: Credential | TokenCredential, options?: NewPipelineOptions);
   /**
    * Creates an instance of QueueServiceClient.
    *

--- a/sdk/storage/storage-queue/src/credentials/SharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-queue/src/credentials/SharedKeyCredential.browser.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export class SharedKeyCredential {}

--- a/sdk/storage/storage-queue/src/credentials/SharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-queue/src/credentials/SharedKeyCredential.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export class SharedKeyCredential {}
+export const SharedKeyCredential = undefined;


### PR DESCRIPTION
After adding the connection string support we now uses SharedKeyCredential which
is only available in Node.js. This caused rollup errors with the upgrade to
rollup v5.

Fixing it by adding a stub for browser and adding `if (isNode)` check for the
code.