### PR TITLE
Adds sdk-type to package.json to support CI/PR validation.

### DIFF
--- a/sdk/core/core-asynciterator-polyfill/package.json
+++ b/sdk/core/core-asynciterator-polyfill/package.json
@@ -5,6 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-js"
   },
+  "sdk-type": "client",
   "version": "1.0.0-preview.1",
   "description": "Polyfill for IE/Node 8 for Symbol.asyncIterator",
   "tags": [


### PR DESCRIPTION
To support automated targetting of packages for CI/PR validation pipelines we add an ```sdk-type``` attribute to the ```package.json``` file.