### PR TITLE
Update `npm install` commands in README.md to use package version

### DIFF
--- a/sdk/core/abort-controller/README.md
+++ b/sdk/core/abort-controller/README.md
@@ -12,7 +12,7 @@ parameter to cancel an operation.
 - Installing this library
 
 ```
-npm install @azure/abort-controller
+npm install @azure/abort-controller@1.0.0-preview.1
 ```
 
 ## Key Concepts

--- a/sdk/core/core-amqp/README.md
+++ b/sdk/core/core-amqp/README.md
@@ -24,7 +24,7 @@ Some of the common functionalities include:
 - Installing this library
 
 ```bash
-npm install @azure/core-amqp
+npm install @azure/core-amqp@1.0.0-preview.1
 ```
 
 - [`rhea-promise`](https://github.com/amqp/rhea-promise) is a peer dependency. You need to explicitly install this library as a dependency

--- a/sdk/identity/identity/README.md
+++ b/sdk/identity/identity/README.md
@@ -18,7 +18,7 @@ to authenticate API requests. It supports token authentication using an Azure Ac
 
 Install Azure Identity with `npm`:
 ```sh
-npm install --save @azure/identity
+npm install --save @azure/identity@1.0.0-preview.1
 ```
 
 ## Key concepts


### PR DESCRIPTION
This change updates README.md files for `identity`, `abort-controller`, and `core-amqp` to use the package's version number in `npm install` commands.  This is necessary since these packages will not be tagged as `latest` when published to npm.