### PR TITLE
[core-amqp] removes ms-rest-nodeauth dependency

### DIFF
--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -53,7 +53,6 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.1",
     "@azure/core-http": "^1.0.0-preview.1",
-    "@azure/ms-rest-nodeauth": "^0.9.2",
     "@types/async-lock": "^1.1.0",
     "@types/is-buffer": "^2.0.0",
     "async-lock": "^1.1.3",


### PR DESCRIPTION
The core-amqp package doesn't use ms-rest-nodeauth, so removing it as a dependency.