### PR TITLE
Improve README for polyfill and core-paging library

### DIFF
--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -25,6 +25,15 @@ To use this polyfill, just include an import of this library in your code
 import "@azure/core-asynciterator-polyfill";
 ```
 
+## Next steps
+
+Try out this package in your application if you are working on platforms that do not have support for
+[Symbol.asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) and provide feedback!
+
+## Troubleshooting
+
+Log an issue at https://github.com/Azure/azure-sdk-for-js/issues
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -7,11 +7,15 @@ for platforms that do not have support for it by default.
 
 ### Installation
 
-Use npm to install this package as follow
+If using this as part of another project in the [azure-sdk-fo-js](https://github.com/Azure/azure-sdk-for-js) repo,
+then simply run `rush install` after cloning the repo.
+
+Otherwise, use npm to install this package in your application as follows
 
 ```
 npm install @azure/abort-controller
 ```
+
 
 ## Examples
 

--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -16,6 +16,11 @@ Otherwise, use npm to install this package in your application as follows
 npm install @azure/core-asynciterator-polyfill
 ```
 
+## Key Concepts
+
+[Symbol.asyncIterator](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) is not supported 
+in all platforms and therefore you might need a polyfill in order to get it working on such platforms. Importing the polyfill from
+this library lets you use the iterator in your applications.
 
 ## Examples
 

--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -13,7 +13,7 @@ then simply run `rush install` after cloning the repo.
 Otherwise, use npm to install this package in your application as follows
 
 ```
-npm install @azure/abort-controller
+npm install @azure/core-asynciterator-polyfill
 ```
 
 

--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -7,7 +7,7 @@ for platforms that do not have support for it by default.
 
 ### Installation
 
-If using this as part of another project in the [azure-sdk-fo-js](https://github.com/Azure/azure-sdk-for-js) repo,
+If using this as part of another project in the [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js) repo,
 then simply run `rush install` after cloning the repo.
 
 Otherwise, use npm to install this package in your application as follows

--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -1,19 +1,17 @@
 # Azure Async Iterator Polyfill client library for JS
 
-This library acts to polyfill for Symbol.asyncIterator
+This library provides a polyfill for [Symbol.asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)
+for platforms that do not have support for it by default.
 
 ## Getting started
 
-### Requirements
-- node.js version > 6.x
-- npm install -g typescript
-
 ### Installation
-- After cloning the repo, execute `rush install`
 
-## Key concepts
+Use npm to install this package as follow
 
-This is a polyfill for Symbol.asyncIterator for platforms that do not have support for it by default.
+```
+npm install @azure/abort-controller
+```
 
 ## Examples
 
@@ -23,21 +21,7 @@ To use this polyfill, just include an import of this library in your code
 import "@azure/core-asynciterator-polyfill";
 ```
 
-## Next steps
-
-### node.js
-- Set the subscriptionId and token
-- Run `node samples/node-sample.js`
-
-### In the browser
-- Set the subscriptionId and token and then run
-- Open index.html file in the browser. It should show the response from GET request on the storage account. From Chrome type Ctrl + Shift + I and you can see the logs in console.
-
-## Troubleshooting
-
-To be added later.
-
-# Contributing
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -8,7 +8,7 @@ for platforms that do not have support for it by default.
 ### Installation
 
 If using this as part of another project in the [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js) repo,
-then simply run `rush install` after cloning the repo.
+then run `rush install` after cloning the repo.
 
 Otherwise, use npm to install this package in your application as follows
 
@@ -16,7 +16,7 @@ Otherwise, use npm to install this package in your application as follows
 npm install @azure/core-asynciterator-polyfill
 ```
 
-## Key Concepts
+## Key concepts
 
 [Symbol.asyncIterator](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) is not supported 
 in all platforms and therefore you might need a polyfill in order to get it working on such platforms. Importing the polyfill from

--- a/sdk/core/core-asynciterator-polyfill/README.md
+++ b/sdk/core/core-asynciterator-polyfill/README.md
@@ -1,6 +1,6 @@
 # Azure Async Iterator Polyfill client library for JS
 
-This library provides a polyfill for [Symbol.asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)
+This library provides a polyfill for [Symbol.asyncIterator](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)
 for platforms that do not have support for it by default.
 
 ## Getting started
@@ -28,7 +28,7 @@ import "@azure/core-asynciterator-polyfill";
 ## Next steps
 
 Try out this package in your application if you are working on platforms that do not have support for
-[Symbol.asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) and provide feedback!
+[Symbol.asyncIterator](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) and provide feedback!
 
 ## Troubleshooting
 

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -6,7 +6,7 @@ This library provides core types for paging async iterable iterators.
 
 ### Installation
 
-If using this as part of another project in the [azure-sdk-fo-js](https://github.com/Azure/azure-sdk-for-js) repo,
+If using this as part of another project in the [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js) repo,
 then simply run `rush install` after cloning the repo.
 
 Otherwise, use npm to install this package in your application as follows

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -7,7 +7,7 @@ This library provides core types for paging async iterable iterators.
 ### Installation
 
 If using this as part of another project in the [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js) repo,
-then simply run `rush install` after cloning the repo.
+then run `rush install` after cloning the repo.
 
 Otherwise, use npm to install this package in your application as follows
 

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -1,17 +1,19 @@
 # Azure Core Paging client library for JS
 
-[![Build Status](https://dev.azure.com/azure-public/adx/_apis/build/status/public.Azure.ms-rest-js)](https://dev.azure.com/azure-public/adx/_build/latest?definitionId=6)
-
-Core types for paging async iterable iterators
+This library provides core types for paging async iterable iterators.
 
 ## Getting started
 
-### Requirements
-- node.js version > 6.x
-- npm install -g typescript
-
 ### Installation
-- After cloning the repo, execute `rush install`
+
+If using this as part of another project in the [azure-sdk-fo-js](https://github.com/Azure/azure-sdk-for-js) repo,
+then simply run `rush install` after cloning the repo.
+
+Otherwise, use npm to install this package in your application as follows
+
+```javascript
+npm install @azure/core-paging
+```
 
 ## Key concepts
 
@@ -46,20 +48,6 @@ And using the types:
     }
   }
 ```
-
-## Next steps
-
-### node.js
-- Set the subscriptionId and token
-- Run `node samples/node-sample.js`
-
-### In the browser
-- Set the subscriptionId and token and then run
-- Open index.html file in the browser. It should show the response from GET request on the storage account. From Chrome type Ctrl + Shift + I and you can see the logs in console.
-
-## Troubleshooting
-
-To be added later.
 
 # Contributing
 

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -49,6 +49,14 @@ And using the types:
   }
 ```
 
+## Next steps
+
+Try out this package in your application when dealing with async iterable iterators and provide feedback!
+
+## Troubleshooting
+
+Log an issue at https://github.com/Azure/azure-sdk-for-js/issues
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/sdk/core/core-paging/README.md
+++ b/sdk/core/core-paging/README.md
@@ -49,7 +49,7 @@ And using the types:
   }
 ```
 
-# Contributing
+## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us


### PR DESCRIPTION
Polyfill:

- Merging key concepts to initial description as there isnt a lot of key concepts :) The merged version makes  the intent of the package clear up front

Polyfill and core-paging
- Update installation steps
- Update "Next Steps" . What is present doesnt make sense as there are no "samples" or "index.html" files
- Fixed header levels