### PR TITLE
Migrate over fixes from @azure/ms-rest-js for storage libs

### DIFF
--- a/sdk/core/core-http/lib/axiosHttpClient.ts
+++ b/sdk/core/core-http/lib/axiosHttpClient.ts
@@ -143,6 +143,15 @@ export class AxiosHttpClient implements HttpClient {
           config.httpAgent = agent.agent;
         }
       }
+      // This hack is still required with 0.19.0 version of axios since axios tries to merge the
+      // Content-Type header from it's config["<method name>"] where the method name is lower-case,
+      // into the request header. It could be possible that the Content-Type header is not present
+      // in the original request and this would create problems while creating the signature for
+      // storage data plane sdks.
+      axios.interceptors.request.use((config: AxiosRequestConfig) => ({
+        ...config,
+        method: (config.method as Method) && (config.method as Method).toUpperCase() as Method
+      }));
 
       res = await axios.request(config);
     } catch (err) {

--- a/sdk/core/core-http/test/mockHttp.ts
+++ b/sdk/core/core-http/test/mockHttp.ts
@@ -4,7 +4,7 @@
 import xhrMock, { proxy } from "xhr-mock";
 import MockAdapter from "axios-mock-adapter";
 import { isNode, HttpMethods } from "../lib/coreHttp";
-import { AxiosRequestConfig, AxiosInstance } from "axios";
+import { AxiosRequestConfig, AxiosInstance, Method } from "axios";
 
 export type UrlFilter = string | RegExp;
 
@@ -41,6 +41,10 @@ class NodeHttpMock implements HttpMockFacade {
       throw new Error("Axios instance cannot be undefined");
     }
     this._mockAdapter = new MockAdapter(axiosInstance);
+    axiosInstance.interceptors.request.use((config: AxiosRequestConfig) => ({
+      ...config,
+      method: (config.method as Method) && (config.method as Method).toLowerCase() as Method
+    }));
   }
 
   setup(): void {


### PR DESCRIPTION
These changes come from the following two commits:

Azure/ms-rest-js@bbeb122
Azure/ms-rest-js@d7ed995

These changes are needed to fix issues in `storage-blob` and `storage-queue`.  These fixes were commited to `feature/storage` in PR #3853 but weren't moved over to `master`.