### PR TITLE
[Event Hubs] adds asyncIterator symbol pollyfill

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -20,7 +20,7 @@ Install the Azure Event Hubs client library using npm
 
 **Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a
 [Event Hubs Namespace](https://docs.microsoft.com/en-us/azure/event-hubs/) to use this package.
-If you are using this package in a Node.js application, then use Node.js 6.x or higher.
+If you are using this package in a Node.js application, then use Node.js 8.x or higher.
 
 ### Configure Typescript
 

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -24,7 +24,7 @@
     "./dist/index.js": "./browser/index.js"
   },
   "engine": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "files": [
     "dist/",
@@ -64,6 +64,7 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.1",
     "@azure/core-amqp": "^1.0.0-preview.1",
+    "@azure/core-asynciterator-polyfill": "^1.0.0-preview.1",
     "async-lock": "^1.1.3",
     "debug": "^3.1.0",
     "is-buffer": "^2.0.3",

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -12,6 +12,7 @@ import { BatchingReceiver } from "./batchingReceiver";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { throwErrorIfConnectionClosed } from "./util/error";
 import { EventPosition } from "./eventPosition";
+import "@azure/core-asynciterator-polyfill";
 
 /**
  * Options to pass when creating an iterator to iterate over events


### PR DESCRIPTION
When testing, I discovered that the `getEventIterator` method won't work in node.js 8.x.

This change adds the asyncIterator symbol pollyfill to support node.js 8.x.

Also updates the readme/package.json to indicate that node.js 8 is the lowest version this package supports.