### PR TITLE
[JS] [KeyVault] TypeDoc documentation cleanup

### DIFF
--- a/sdk/keyvault/keyvault-keys/typedoc.json
+++ b/sdk/keyvault/keyvault-keys/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "mode": "file",
+  "out": "../../../docGen/keyvault-keys ./src",
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "exclude": [
+    "node_modules/**/*",
+    "src/core/*"
+  ],
+  "ignoreCompilerErrors": true
+}

--- a/sdk/keyvault/keyvault-secrets/typedoc.json
+++ b/sdk/keyvault/keyvault-secrets/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "mode": "file",
+  "out": "../../../docGen/keyvault-secrets ./src",
+  "excludeNotExported": true,
+  "excludePrivate": true,
+  "exclude": [
+    "node_modules/**/*",
+    "src/core/*"
+  ],
+  "ignoreCompilerErrors": true
+}


### PR DESCRIPTION
Our current documentation has about 251 globals. This PR makes it so we
end up with 8 globals only.

Most of the links won't work, but the one with 251 globals has a similar
issue since most of the methods use types from external resources, like
`@core-http`.

The current generated docs, with 251 global entries for each of the
keyvault packages, requires the user to go several layers deep to
understand a single parameter from a function that is of immediate use
once initializing either the KeysClient or the SecretsClient. Having
said that, our goal is to simplify the current generated docs so that we
can make it better incrementally, starting with samples, more control
over the generated core files and other tweaks.

Fixes #4139