### PR TITLE
Add samples to API docs

### DIFF
--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -151,6 +151,17 @@ export class KeysClient {
 
   /**
    * Creates an instance of KeysClient.
+   *
+   * Example usage:
+   * ```ts
+   * import { KeysClient } from "@azure/keyvault-keys";
+   * import { EnvironmentCredential } from "@azure/identity";
+   *
+   * let url = `https://<MY KEYVAULT HERE>.vault.azure.net`;
+   * let credentials = new EnvironmentCredential();
+   *
+   * let client = new KeysClient(url, credentials);
+   * ```
    * @param {string} url the base url to the key vault.
    * @param {ServiceClientCredentials | TokenCredential} The credential to use for API requests.
    * @param {(Pipeline | NewPipelineOptions)} [pipelineOrOptions={}] Optional. A Pipeline, or options to create a default Pipeline instance.
@@ -197,6 +208,13 @@ export class KeysClient {
    * The create key operation can be used to create any key type in Azure Key Vault. If the named key
    * already exists, Azure Key Vault creates a new version of the key. It requires the keys/create
    * permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * // Create an elliptic-curve key:
+   * let result = await client.createKey("MyKey", "EC");
+   * ```
    * @summary Creates a new key, stores it, then returns key parameters and attributes to the client.
    * @param name The name of the key.
    * @param keyType The type of the key.
@@ -242,6 +260,12 @@ export class KeysClient {
    * The create key operation can be used to create any key type in Azure Key Vault. If the named key
    * already exists, Azure Key Vault creates a new version of the key. It requires the keys/create
    * permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * let result = await client.createEcKey("MyKey", { curve: "P-256" });
+   * ```
    * @summary Creates a new key, stores it, then returns key parameters and attributes to the client.
    * @param name The name of the key.
    * @param keyType The type of the key.
@@ -283,6 +307,12 @@ export class KeysClient {
    * The create key operation can be used to create any key type in Azure Key Vault. If the named key
    * already exists, Azure Key Vault creates a new version of the key. It requires the keys/create
    * permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * let result = await client.createRsaKey("MyKey", { keySize: 2048 });
+   * ```
    * @summary Creates a new key, stores it, then returns key parameters and attributes to the client.
    * @param name The name of the key.
    * @param keyType The type of the key.
@@ -324,6 +354,13 @@ export class KeysClient {
    * The import key operation may be used to import any key type into an Azure Key Vault. If the
    * named key already exists, Azure Key Vault creates a new version of the key. This operation
    * requires the keys/import permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * // Key contents in myKeyContents
+   * let result = await client.importKey("MyKey", myKeyContents);
+   * ```
    * @summary Imports an externally created key, stores it, and returns key parameters and attributes
    * to the client.
    * @param name Name for the imported key.
@@ -363,6 +400,12 @@ export class KeysClient {
   /**
    * The DELETE operation applies to any key stored in Azure Key Vault. DELETE cannot be applied
    * to an individual version of a key. This operation requires the keys/delete permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * let result = await client.deleteKey("MyKey");
+   * ```
    * @summary Deletes a key from a specified key vault.
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param name The name of the key.
@@ -382,6 +425,14 @@ export class KeysClient {
    * The UPDATE operation changes specified attributes of an existing stored key. Attributes that
    * are not specified in the request are left unchanged. The value of a key itself cannot be
    * changed. This operation requires the keys/set permission.
+   *
+   * Example usage:
+   * ```ts
+   * let keyName = "MyKey";
+   * let client = new KeysClient(url, credentials);
+   * let key = await client.getKey(keyName);
+   * let result = await client.updateKey(keyName, key.version, { enabled: false });
+   * ```
    * @summary Updates the attributes associated with a specified key in a given key vault.
    * @param name The name of the key.
    * @param keyVersion The version of the key.
@@ -425,6 +476,12 @@ export class KeysClient {
   /**
    * The GET operation is applicable to any key stored in Azure Key Vault. This operation requires
    * the keys/get permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * let key = await client.getKey("MyKey");
+   * ```
    * @summary Get a specified key from a given key vault.
    * @param name The name of the key.
    * @param [options] The optional parameters
@@ -443,6 +500,12 @@ export class KeysClient {
   /**
    * The Get Deleted Key operation returns the specified deleted key along with its attributes.
    * This operation requires the keys/get permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * let key = await client.getDeletedKey("MyDeletedKey");
+   * ```
    * @summary Gets the specified deleted key.
    * @param name The name of the key.
    * @param [options] The optional parameters
@@ -461,6 +524,14 @@ export class KeysClient {
    * The purge deleted key operation removes the key permanently, without the possibility of
    * recovery. This operation can only be enabled on a soft-delete enabled vault. This operation
    * requires the keys/purge permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * await client.deleteKey("MyKey");
+   * // ...
+   * await client.purgeDeletedKey("MyKey");
+   * ```
    * @summary Permanently deletes the specified key.
    * @param name The name of the key.
    * @param [options] The optional parameters
@@ -477,6 +548,14 @@ export class KeysClient {
   /**
    * Recovers the deleted key in the specified vault. This operation can only be performed on a
    * soft-delete enabled vault. This operation requires the keys/recover permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * await client.deleteKey("MyKey");
+   * // ...
+   * await client.recoverDeletedKey("MyKey");
+   * ```
    * @summary Recovers the deleted key to the latest version.
    * @param name The name of the deleted key.
    * @param [options] The optional parameters
@@ -494,6 +573,12 @@ export class KeysClient {
   /**
    * Requests that a backup of the specified key be downloaded to the client. All versions of the
    * key will be downloaded. This operation requires the keys/backup permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * let backupContents = await client.backupKey("MyKey");
+   * ```
    * @summary Backs up the specified key.
    * @param name The name of the key.
    * @param [options] The optional parameters
@@ -511,6 +596,14 @@ export class KeysClient {
   /**
    * Restores a backed up key, and all its versions, to a vault. This operation requires the
    * keys/restore permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * let backupContents = await client.backupKey("MyKey");
+   * // ...
+   * let key = await client.restoreKey(backupContents);
+   * ```
    * @summary Restores a backed up key to a vault.
    * @param backup The backup blob associated with a key bundle.
    * @param [options] The optional parameters
@@ -569,6 +662,15 @@ export class KeysClient {
   /**
    * Iterates all versions of the given key in the vault. The full key identifier, attributes, and tags are provided
    * in the response. This operation requires the keys/list permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * for await (const keyAttr of client.listKeyVersions("MyKey")) {
+   *   const key = await client.getKey(keyAttr.name);
+   *   console.log("key version: ", key);
+   * }
+   * ```
    * @param name Name of the key to fetch versions for
    * @param [options] The optional parameters
    * @returns PagedAsyncIterableIterator<KeyAttributes, KeyAttributes[]>
@@ -625,6 +727,15 @@ export class KeysClient {
   /**
    * Iterates the latest version of all keys in the vault.  The full key identifier and attributes are provided
    * in the response. No values are returned for the keys. This operations requires the keys/list permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * for await (const keyAttr of client.listKeys()) {
+   *   const key = await client.getKey(keyAttr.name);
+   *   console.log("key: ", key);
+   * }
+   * ```
    * @summary List all keys in the vault
    * @param [options] The optional parameters
    * @returns PagedAsyncIterableIterator<KeyAttributes, KeyAttributes[]>
@@ -685,6 +796,15 @@ export class KeysClient {
   /**
    * Iterates the deleted keys in the vault.  The full key identifier and attributes are provided
    * in the response. No values are returned for the keys. This operations requires the keys/list permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new KeysClient(url, credentials);
+   * for await (const keyAttr of client.listDeletedKeys()) {
+   *   const deletedKey = await client.getKey(keyAttr.name);
+   *   console.log("deleted key: ", deletedKey);
+   * }
+   * ```
    * @summary List all keys in the vault
    * @param [options] The optional parameters
    * @returns PagedAsyncIterableIterator<KeyAttributes, KeyAttributes[]>

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -72,7 +72,6 @@ export { ProxyOptions, RetryOptions, TelemetryOptions };
 export class SecretsClient {
   /**
    * A static method used to create a new Pipeline object with the provided Credential.
-   *
    * @static
    * @param {ServiceClientCredentials | TokenCredential} The credential to use for API requests.
    * @param {NewPipelineOptions} [pipelineOptions] Optional. Options.
@@ -134,6 +133,17 @@ export class SecretsClient {
 
   /**
    * Creates an instance of SecretsClient.
+   *
+   * Example usage:
+   * ```ts
+   * import { SecretsClient } from "@azure/keyvault-secrets";
+   * import { EnvironmentCredential } from "@azure/identity";
+   *
+   * let url = `https://<MY KEYVAULT HERE>.vault.azure.net`;
+   * let credentials = new EnvironmentCredential();
+   *
+   * let client = new SecretsClient(url, credentials);
+   * ```
    * @param {string} url the base url to the key vault.
    * @param {ServiceClientCredentials | TokenCredential} The credential to use for API requests.
    * @param {(Pipeline | NewPipelineOptions)} [pipelineOrOptions={}] Optional. A Pipeline, or options to create a default Pipeline instance.
@@ -180,6 +190,12 @@ export class SecretsClient {
    * The SET operation adds a secret to the Azure Key Vault. If the named secret already exists,
    * Azure Key Vault creates a new version of that secret. This operation requires the secrets/set
    * permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * await client.setSecret("MySecretName", "ABC123");
+   * ```
    * @summary Adds a secret in a specified key vault.
    * @param secretName The name of the secret.
    * @param value The value of the secret.
@@ -223,6 +239,12 @@ export class SecretsClient {
   /**
    * The DELETE operation applies to any secret stored in Azure Key Vault. DELETE cannot be applied
    * to an individual version of a secret. This operation requires the secrets/delete permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * await client.deleteSecret("MySecretName");
+   * ```
    * @summary Deletes a secret from a specified key vault.
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
@@ -241,6 +263,14 @@ export class SecretsClient {
    * The UPDATE operation changes specified attributes of an existing stored secret. Attributes that
    * are not specified in the request are left unchanged. The value of a secret itself cannot be
    * changed. This operation requires the secrets/set permission.
+   *
+   * Example usage:
+   * ```ts
+   * let secretName = "MySecretName";
+   * let client = new SecretsClient(url, credentials);
+   * let secret = await client.getSecret(secretName);
+   * await client.updateSecret(secretName, secret.version, { enabled: false });
+   * ```
    * @summary Updates the attributes associated with a specified secret in a given key vault.
    * @param secretName The name of the secret.
    * @param secretVersion The version of the secret.
@@ -289,6 +319,12 @@ export class SecretsClient {
   /**
    * The GET operation is applicable to any secret stored in Azure Key Vault. This operation requires
    * the secrets/get permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * let secret = await client.getSecret("MySecretName");
+   * ```
    * @summary Get a specified secret from a given key vault.
    * @param secretName The name of the secret.
    * @param [options] The optional parameters
@@ -307,6 +343,12 @@ export class SecretsClient {
   /**
    * The Get Deleted Secret operation returns the specified deleted secret along with its attributes.
    * This operation requires the secrets/get permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * await client.getDeletedSecret("MyDeletedSecret");
+   * ```
    * @summary Gets the specified deleted secret.
    * @param secretName The name of the secret.
    * @param [options] The optional parameters
@@ -324,6 +366,13 @@ export class SecretsClient {
    * The purge deleted secret operation removes the secret permanently, without the possibility of
    * recovery. This operation can only be enabled on a soft-delete enabled vault. This operation
    * requires the secrets/purge permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * await client.deleteSecret("MySecretName");
+   * await client.purgeDeletedSecret("MySecretName");
+   * ```
    * @summary Permanently deletes the specified secret.
    * @param secretName The name of the secret.
    * @param [options] The optional parameters
@@ -336,6 +385,13 @@ export class SecretsClient {
   /**
    * Recovers the deleted secret in the specified vault. This operation can only be performed on a
    * soft-delete enabled vault. This operation requires the secrets/recover permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * await client.deleteSecret("MySecretName");
+   * await client.recoverDeletedSecret("MySecretName");
+   * ```
    * @summary Recovers the deleted secret to the latest version.
    * @param secretName The name of the deleted secret.
    * @param [options] The optional parameters
@@ -352,6 +408,12 @@ export class SecretsClient {
   /**
    * Requests that a backup of the specified secret be downloaded to the client. All versions of the
    * secret will be downloaded. This operation requires the secrets/backup permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * let backupResult = await client.backupSecret("MySecretName");
+   * ```
    * @summary Backs up the specified secret.
    * @param secretName The name of the secret.
    * @param [options] The optional parameters
@@ -369,6 +431,14 @@ export class SecretsClient {
   /**
    * Restores a backed up secret, and all its versions, to a vault. This operation requires the
    * secrets/restore permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * let mySecretBundle = await client.backupSecret("MySecretName");
+   * // ...
+   * await client.restoreSecret(mySecretBundle);
+   * ```
    * @summary Restores a backed up secret to a vault.
    * @param secretBundleBackup The backup blob associated with a secret bundle.
    * @param [options] The optional parameters
@@ -430,6 +500,15 @@ export class SecretsClient {
   /**
    * Iterates all versions of the given secret in the vault. The full secret identifier and attributes are provided
    * in the response. No values are returned for the secrets. This operations requires the secrets/list permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * for await (const secretAttr of client.listSecretVersions("MySecretName")) {
+   *   const secret = await client.getSecret(secretAttr.name);
+   *   console.log("secret version: ", secret);
+   * }
+   * ```
    * @param secretName Name of the secret to fetch versions for
    * @param [options] The optional parameters
    * @returns PagedAsyncIterableIterator<SecretAttributes, SecretAttributes[]>
@@ -489,6 +568,15 @@ export class SecretsClient {
   /**
    * Iterates the latest version of all secrets in the vault.  The full secret identifier and attributes are provided
    * in the response. No values are returned for the secrets. This operations requires the secrets/list permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * for await (const secretAttr of client.listSecrets()) {
+   *   const secret = await client.getSecret(secretAttr.name);
+   *   console.log("secret: ", secret);
+   * }
+   * ```
    * @summary List all secrets in the vault
    * @param [options] The optional parameters
    * @returns PagedAsyncIterableIterator<SecretAttributes, SecretAttributes[]>
@@ -549,6 +637,15 @@ export class SecretsClient {
   /**
    * Iterates the deleted secrets in the vault.  The full secret identifier and attributes are provided
    * in the response. No values are returned for the secrets. This operations requires the secrets/list permission.
+   *
+   * Example usage:
+   * ```ts
+   * let client = new SecretsClient(url, credentials);
+   * for await (const secretAttr of client.listDeletedSecrets()) {
+   *   const deletedSecret = await client.getSecret(secretAttr.name);
+   *   console.log("deleted secret: ", deletedSecret);
+   * }
+   * ```
    * @summary List all secrets in the vault
    * @param [options] The optional parameters
    * @returns PagedAsyncIterableIterator<SecretAttributes, SecretAttributes[]>


### PR DESCRIPTION
This adds small samples to the methods on the clients in the API docs. This should make it easier for people who are trying to understand how a method works to get going without having to search for a full example.
