### PR TITLE
[JS] [KeyVault] User agent fixed

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.0.0-preview.2 (2019-07-03)
+- Fix broken links for API references and samples.
+- Update custom user agent string to include the right package name and version.
+ 
 ## 4.0.0-preview.1 (2019-06-28)
 For release notes and more information please visit
 https://aka.ms/azure-sdk-preview1-js

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -191,7 +191,7 @@ export class KeysClient {
         userAgentInfo.push(telemetry.value);
       }
     }
-    const libInfo = `Azure-KeyVault-Keys/${SDK_VERSION}`;
+    const libInfo = `azsdk-js-keyvault-keys/${SDK_VERSION}`;
     if (userAgentInfo.indexOf(libInfo) === -1) {
       userAgentInfo.push(libInfo);
     }

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.0.0-preview.2 (2019-07-03)
+- Fix broken links for API references and samples.
+- Update custom user agent string to include the right package name and version.
+
 ## 4.0.0-preview.1 (2019-06-28)
 For release notes and more information please visit
 https://aka.ms/azure-sdk-preview1-js

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -173,7 +173,7 @@ export class SecretsClient {
         userAgentInfo.push(telemetry.value);
       }
     }
-    const libInfo = `Azure-KeyVault-Secrets/${SDK_VERSION}`;
+    const libInfo = `azsdk-js-keyvault-secrets/${SDK_VERSION}`;
     if (userAgentInfo.indexOf(libInfo) === -1) {
       userAgentInfo.push(libInfo);
     }


### PR DESCRIPTION
Fixes #4150

The user agents should now look as follows:

```
azsdk-js-keyvault-secrets/4.0.0-preview.1 (Node 10.16.0; Ubuntu; Linux x86_64; rv:34.0)
azsdk-js-keyvault-keys/4.0.0-preview.1 (Node 10.16.0; Ubuntu; Linux x86_64; rv:34.0)
```

Read the issue #4150 for more details.