### PR TITLE
Update typedoc to block the prebuilt definitions

### DIFF
--- a/sdk/keyvault/keyvault-keys/typedoc.json
+++ b/sdk/keyvault/keyvault-keys/typedoc.json
@@ -1,11 +1,11 @@
 {
   "mode": "file",
-  "out": "../../../docGen/keyvault-keys ./src",
+  "out": "../../../docGen/keyvault-keys",
   "excludeNotExported": true,
   "excludePrivate": true,
   "exclude": [
     "node_modules/**/*",
-    "src/core/*"
+    "src/core/**/*"
   ],
   "ignoreCompilerErrors": true
 }

--- a/sdk/keyvault/keyvault-secrets/typedoc.json
+++ b/sdk/keyvault/keyvault-secrets/typedoc.json
@@ -1,11 +1,11 @@
 {
   "mode": "file",
-  "out": "../../../docGen/keyvault-secrets ./src",
+  "out": "../../../docGen/keyvault-secrets",
   "excludeNotExported": true,
   "excludePrivate": true,
   "exclude": [
     "node_modules/**/*",
-    "src/core/*"
+    "src/core/**/*"
   ],
   "ignoreCompilerErrors": true
 }


### PR DESCRIPTION
This changes the glob to exclude the prebuilt definitions from the typedocs.