### PR TITLE
[Event Hubs] Pass cancellation token in close()

### DIFF
--- a/sdk/core/core-amqp/src/cbs.ts
+++ b/sdk/core/core-amqp/src/cbs.ts
@@ -18,7 +18,7 @@ import * as log from "./log";
 import { translate } from "./errors";
 import { defaultLock } from "./util/utils";
 import { RequestResponseLink } from "./requestResponseLink";
-import { AbortSignalLike, AbortError } from "@azure/abort-controller";
+import { AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * Describes the CBS Response.
@@ -223,46 +223,19 @@ export class CbsClient {
    * @return {Promise<void>}
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
       if (this._isCbsSenderReceiverLinkOpen()) {
-        const rejectOnAbort = () => {
-          const desc: string =
-            `[${this.connection.id}] The close request on the cbs session` +
-            `has been cancelled by the user.`;
-          log.error(desc);
-          const error = new AbortError(`The close operation has been cancelled by the user.`);
-          reject(error);
-        };
-
-        const onAbort = () => {
-          abortSignal!.removeEventListener("abort", onAbort);
-          rejectOnAbort();
-        };
-
-        if (abortSignal) {
-          // the aborter may have been triggered between request attempts
-          // so check if it was triggered and reject if needed.
-          if (abortSignal.aborted) {
-            return rejectOnAbort();
-          }
-          abortSignal.addEventListener("abort", onAbort);
-        }
         try {
           const cbsLink = this._cbsSenderReceiverLink;
           this._cbsSenderReceiverLink = undefined;
-          await cbsLink!.close();
-          log.cbs("[%s] Successfully closed the cbs session.", this.connection.id);
-          return resolve();
+          await cbsLink!.close(abortSignal);
+          log.cbs("[%s] Successfully closed the cbs session.", this.connection.id)
         } catch (err) {
           const msg = `An error occurred while closing the cbs link: ${err.stack ||
             JSON.stringify(err)}.`;
           log.error("[%s] %s", this.connection.id, msg);
-          return reject(new Error(msg));
+          throw new Error(msg);
         }
-      } else {
-        return resolve();
       }
-    });
   }
 
   /**

--- a/sdk/core/core-amqp/src/cbs.ts
+++ b/sdk/core/core-amqp/src/cbs.ts
@@ -223,19 +223,19 @@ export class CbsClient {
    * @return {Promise<void>}
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
+    try {
       if (this._isCbsSenderReceiverLinkOpen()) {
-        try {
-          const cbsLink = this._cbsSenderReceiverLink;
-          this._cbsSenderReceiverLink = undefined;
-          await cbsLink!.close(abortSignal);
-          log.cbs("[%s] Successfully closed the cbs session.", this.connection.id)
-        } catch (err) {
-          const msg = `An error occurred while closing the cbs link: ${err.stack ||
-            JSON.stringify(err)}.`;
-          log.error("[%s] %s", this.connection.id, msg);
-          throw new Error(msg);
-        }
+        const cbsLink = this._cbsSenderReceiverLink;
+        this._cbsSenderReceiverLink = undefined;
+        await cbsLink!.close(abortSignal);
+        log.cbs("[%s] Successfully closed the cbs session.", this.connection.id);
       }
+    } catch (err) {
+      const msg = `An error occurred while closing the cbs link: ${err.stack ||
+        JSON.stringify(err)}.`;
+      log.error("[%s] %s", this.connection.id, msg);
+      throw new Error(msg);
+    }
   }
 
   /**

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -41,7 +41,7 @@ export class EventHubClient {
     constructor(connectionString: string, options?: EventHubClientOptions);
     constructor(connectionString: string, eventHubPath: string, options?: EventHubClientOptions);
     constructor(host: string, eventHubPath: string, credential: TokenCredential, options?: EventHubClientOptions);
-    close(): Promise<void>;
+    close(abortSignal?: AbortSignalLike): Promise<void>;
     createConsumer(consumerGroup: string, partitionId: string, eventPosition: EventPosition, options?: EventHubConsumerOptions): EventHubConsumer;
     static createFromIotHubConnectionString(iothubConnectionString: string, options?: EventHubClientOptions): Promise<EventHubClient>;
     createProducer(options?: EventHubProducerOptions): EventHubProducer;
@@ -67,7 +67,7 @@ export class EventHubConsumer {
     // 
     // @internal
     constructor(context: ConnectionContext, consumerGroup: string, partitionId: string, eventPosition: EventPosition, options?: EventHubConsumerOptions);
-    close(): Promise<void>;
+    close(abortSignal?: AbortSignalLike): Promise<void>;
     readonly consumerGroup: string;
     getEventIterator(options?: EventIteratorOptions): AsyncIterableIterator<ReceivedEventData>;
     readonly isClosed: boolean;
@@ -88,7 +88,7 @@ export interface EventHubConsumerOptions {
 export class EventHubProducer {
     // @internal
     constructor(context: ConnectionContext, options?: EventHubProducerOptions);
-    close(): Promise<void>;
+    close(abortSignal?: AbortSignalLike): Promise<void>;
     readonly isClosed: boolean;
     send(eventData: EventData | EventData[], options?: SendOptions): Promise<void>;
     }
@@ -167,7 +167,7 @@ export class ReceiveHandler {
     readonly consumerGroup: string | undefined;
     readonly isReceiverOpen: boolean;
     readonly partitionId: string | undefined;
-    stop(): Promise<void>;
+    stop(abortSignal?: AbortSignalLike): Promise<void>;
 }
 
 // @public

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -255,24 +255,27 @@ export class EventHubClient {
   /**
    * Closes the AMQP connection to the Event Hub instance,
    * returning a promise that will be resolved when disconnection is completed.
+   * @param abortSignal An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    * @returns Promise<void>
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
-  async close(): Promise<void> {
+  async close(abortSignal?: AbortSignalLike): Promise<void> {
     try {
       if (this._context.connection.isOpen()) {
         // Close all the senders.
         for (const senderName of Object.keys(this._context.senders)) {
-          await this._context.senders[senderName].close();
+          await this._context.senders[senderName].close(abortSignal);
         }
         // Close all the receivers.
         for (const receiverName of Object.keys(this._context.receivers)) {
-          await this._context.receivers[receiverName].close();
+          await this._context.receivers[receiverName].close(abortSignal);
         }
         // Close the cbs session;
-        await this._context.cbsSession.close();
+        await this._context.cbsSession.close(abortSignal);
         // Close the management session
-        await this._context.managementSession!.close();
+        await this._context.managementSession!.close(abortSignal);
         await this._context.connection.close();
         this._context.wasConnectionCloseCalled = true;
         log.client("Closed the amqp connection '%s' on the client.", this._context.connectionId);

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -504,43 +504,14 @@ export class EventHubReceiver extends LinkEntity {
    * @returns
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-      if (this._receiver) {
-        const rejectOnAbort = () => {
-          const desc: string =
-            `[${this._context.connectionId}] The close request on the receiver` +
-            `to "${this.address}" has been cancelled by the user.`;
-          log.error(desc);
-          const error = new AbortError(`The close operation has been cancelled by the user.`);
-          reject(error);
-        };
-
-        const onAbort = () => {
-          abortSignal!.removeEventListener("abort", onAbort);
-          rejectOnAbort();
-        };
-
-        if (abortSignal) {
-          // the aborter may have been triggered between request attempts
-          // so check if it was triggered and reject if needed.
-          if (abortSignal.aborted) {
-            return rejectOnAbort();
-          }
-          abortSignal.addEventListener("abort", onAbort);
-        }
-        log.sender(
-          "[%s] Closing the Receiver for the entity '%s'.",
-          this._context.connectionId,
-          this._context.config.entityPath
-        );
-        const receiverLink = this._receiver;
-        this._deleteFromCache();
-        await this._closeLink(receiverLink);
-        return resolve();
-      } else {
-        return resolve();
-      }
-    });
+    log.receiver(
+      "[%s] Closing the Receiver for the entity '%s'.",
+      this._context.connectionId,
+      this._context.config.entityPath
+    );
+    const receiverLink = this._receiver;
+    this._deleteFromCache();
+    await this._closeLink(receiverLink, abortSignal);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -504,14 +504,14 @@ export class EventHubReceiver extends LinkEntity {
    * @returns
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
-    log.receiver(
-      "[%s] Closing the Receiver for the entity '%s'.",
-      this._context.connectionId,
-      this._context.config.entityPath
-    );
-    const receiverLink = this._receiver;
-    this._deleteFromCache();
-    await this._closeLink(receiverLink, abortSignal);
+    if (this._receiver) {
+      if (this._abortSignal) {
+        this._abortSignal.removeEventListener("abort", this._onAbort);
+      }
+      const receiverLink = this._receiver;
+      this._deleteFromCache();
+      await this._closeLink(receiverLink, abortSignal);
+    }
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -508,6 +508,11 @@ export class EventHubReceiver extends LinkEntity {
       if (this._abortSignal) {
         this._abortSignal.removeEventListener("abort", this._onAbort);
       }
+      log.receiver(
+        "[%s] Closing the Receiver for the entity '%s'.",
+        this._context.connectionId,
+        this._context.config.entityPath
+      );
       const receiverLink = this._receiver;
       this._deleteFromCache();
       await this._closeLink(receiverLink, abortSignal);

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -503,15 +503,44 @@ export class EventHubReceiver extends LinkEntity {
    * @ignore
    * @returns
    */
-  async close(): Promise<void> {
-    if (this._receiver) {
-      if (this._abortSignal) {
-        this._abortSignal.removeEventListener("abort", this._onAbort);
+  async close(abortSignal?: AbortSignalLike): Promise<void> {
+    return new Promise<void>(async (resolve, reject) => {
+      if (this._receiver) {
+        const rejectOnAbort = () => {
+          const desc: string =
+            `[${this._context.connectionId}] The close request on the receiver` +
+            `to "${this.address}" has been cancelled by the user.`;
+          log.error(desc);
+          const error = new AbortError(`The close operation has been cancelled by the user.`);
+          reject(error);
+        };
+
+        const onAbort = () => {
+          abortSignal!.removeEventListener("abort", onAbort);
+          rejectOnAbort();
+        };
+
+        if (abortSignal) {
+          // the aborter may have been triggered between request attempts
+          // so check if it was triggered and reject if needed.
+          if (abortSignal.aborted) {
+            return rejectOnAbort();
+          }
+          abortSignal.addEventListener("abort", onAbort);
+        }
+        log.sender(
+          "[%s] Closing the Receiver for the entity '%s'.",
+          this._context.connectionId,
+          this._context.config.entityPath
+        );
+        const receiverLink = this._receiver;
+        this._deleteFromCache();
+        await this._closeLink(receiverLink);
+        return resolve();
+      } else {
+        return resolve();
       }
-      const receiverLink = this._receiver;
-      this._deleteFromCache();
-      await this._closeLink(receiverLink);
-    }
+    });
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -304,14 +304,16 @@ export class EventHubSender extends LinkEntity {
    * @returns Promise<void>
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
-    log.sender(
-      "[%s] Closing the Sender for the entity '%s'.",
-      this._context.connectionId,
-      this._context.config.entityPath
-    );
-    const senderLink = this._sender;
-    this._deleteFromCache();
-    await this._closeLink(senderLink, abortSignal);
+    if (this._sender) {
+      log.sender(
+        "[%s] Closing the Sender for the entity '%s'.",
+        this._context.connectionId,
+        this._context.config.entityPath
+      );
+      const senderLink = this._sender;
+      this._deleteFromCache();
+      await this._closeLink(senderLink, abortSignal);
+    }
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -304,41 +304,14 @@ export class EventHubSender extends LinkEntity {
    * @returns Promise<void>
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-        if (this._sender) {
-          const rejectOnAbort = () => {
-            const desc: string =
-              `[${this._context.connectionId}] The close operation on the Sender "${this.name}" with ` +
-              `address "${this.address}" has been cancelled by the user.`;
-            log.error(desc);
-            reject(new AbortError("The close operation has been cancelled by the user."));
-          };
-
-          const onAbort = () => {
-            abortSignal!.removeEventListener("abort", onAbort);
-            rejectOnAbort();
-          };
-
-          if (abortSignal) {
-            if (abortSignal.aborted) {
-              // operation has been cancelled, so exit quickly
-              return rejectOnAbort();
-            }
-            abortSignal.addEventListener("abort", onAbort);
-          }
-          log.sender(
-            "[%s] Closing the Sender for the entity '%s'.",
-            this._context.connectionId,
-            this._context.config.entityPath
-          );
-          const senderLink = this._sender;
-          this._deleteFromCache();
-          await this._closeLink(senderLink);
-          return resolve();
-        } else {
-          return resolve();
-        }
-    });
+    log.sender(
+      "[%s] Closing the Sender for the entity '%s'.",
+      this._context.connectionId,
+      this._context.config.entityPath
+    );
+    const senderLink = this._sender;
+    this._deleteFromCache();
+    await this._closeLink(senderLink, abortSignal);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -8,7 +8,7 @@ import { ConnectionContext } from "./connectionContext";
 import { LinkEntity } from "./linkEntity";
 import * as log from "./log";
 import { RetryOptions } from "./eventHubClient";
-import { AbortSignalLike, AbortError } from "@azure/abort-controller";
+import { AbortSignalLike } from "@azure/abort-controller";
 /**
  * Describes the runtime information of an Event Hub.
  * @interface HubRuntimeInformation
@@ -205,44 +205,19 @@ export class ManagementClient extends LinkEntity {
    * @returns
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
-    return new Promise<void>(async (resolve, reject) => {
-      if (this._isMgmtRequestResponseLinkOpen()) {
-        const rejectOnAbort = () => {
-          const desc: string = `[${this._context.connectionId}] The close on the management session request has been cancelled by the user.`;
-          log.error(desc);
-          const error = new AbortError(`The close operation has been cancelled by the user.`);
-          reject(error);
-        };
-
-        const onAbort = () => {
-          abortSignal!.removeEventListener("abort", onAbort);
-          rejectOnAbort();
-        };
-
-        if (abortSignal) {
-          // the aborter may have been triggered between request attempts
-          // so check if it was triggered and reject if needed.
-          if (abortSignal.aborted) {
-            return rejectOnAbort();
-          }
-          abortSignal.addEventListener("abort", onAbort);
-        }
-        try {
-          const mgmtLink = this._mgmtReqResLink;
-          this._mgmtReqResLink = undefined;
-          clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
-          await mgmtLink!.close();
-          log.mgmt("Successfully closed the management session.");
-          return resolve();
-        } catch (err) {
-          const msg = `An error occurred while closing the management session: ${err}`;
-          log.error(msg);
-          throw new Error(msg);
-        }
-      } else {
-        return resolve();
+    if (this._isMgmtRequestResponseLinkOpen()) {
+      try {
+        const mgmtLink = this._mgmtReqResLink;
+        this._mgmtReqResLink = undefined;
+        clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
+        await mgmtLink!.close(abortSignal);
+        log.mgmt("Successfully closed the management session.");
+      } catch (err) {
+        const msg = `An error occurred while closing the management session: ${err}`;
+        log.error(msg);
+        throw new Error(msg);
       }
-    });
+    }
   }
 
   private async _init(): Promise<void> {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -205,18 +205,18 @@ export class ManagementClient extends LinkEntity {
    * @returns
    */
   async close(abortSignal?: AbortSignalLike): Promise<void> {
-    if (this._isMgmtRequestResponseLinkOpen()) {
-      try {
+    try {
+      if (this._isMgmtRequestResponseLinkOpen()) {
         const mgmtLink = this._mgmtReqResLink;
         this._mgmtReqResLink = undefined;
         clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
         await mgmtLink!.close(abortSignal);
         log.mgmt("Successfully closed the management session.");
-      } catch (err) {
-        const msg = `An error occurred while closing the management session: ${err}`;
-        log.error(msg);
-        throw new Error(msg);
       }
+    } catch (err) {
+      const msg = `An error occurred while closing the management session: ${err}`;
+      log.error(msg);
+      throw new Error(msg);
     }
   }
 

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -284,22 +284,24 @@ export class EventHubConsumer {
    * Once closed, the consumer cannot be used for any further operations.
    * Use the `createConsumer` function on the EventHubClient to instantiate
    * a new EventHubConsumer.
-   *
+   * @param abortSignal An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    * @returns
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
-  async close(): Promise<void> {
+  async close(abortSignal?: AbortSignalLike): Promise<void> {
     try {
       if (this._context.connection && this._context.connection.isOpen()) {
         // Close the streaming receiver.
         if (this._streamingReceiver) {
-          await this._streamingReceiver.close();
+          await this._streamingReceiver.close(abortSignal);
           this._streamingReceiver = undefined;
         }
 
         // Close the batching receiver.
         if (this._batchingReceiver) {
-          await this._batchingReceiver.close();
+          await this._batchingReceiver.close(abortSignal);
           this._batchingReceiver = undefined;
         }
       }

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -7,6 +7,7 @@ import { EventHubProducerOptions, SendOptions } from "./eventHubClient";
 import { ConnectionContext } from "./connectionContext";
 import * as log from "./log";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
+import { AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * A producer responsible for sending `EventData` to a specific Event Hub.
@@ -84,14 +85,16 @@ export class EventHubProducer {
    * Closes the underlying AMQP sender link.
    * Once closed, the producer cannot be used for any further operations.
    * Use the `createProducer` function on the EventHubClient to instantiate a new EventHubProducer.
-   *
+   * @param abortSignal An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    * @returns
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
-  async close(): Promise<void> {
+  async close(abortSignal?: AbortSignalLike): Promise<void> {
     try {
       if (this._context.connection && this._context.connection.isOpen() && this._eventHubSender) {
-        await this._eventHubSender.close();
+        await this._eventHubSender.close(abortSignal);
         this._eventHubSender = undefined;
       }
       this._isClosed = true;

--- a/sdk/eventhub/event-hubs/src/streamingReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/streamingReceiver.ts
@@ -59,13 +59,16 @@ export class ReceiveHandler {
 
   /**
    * Stops the underlying EventHubReceiver from receiving more messages.
+   * @param abortSignal An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
+   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    * @returns Promise<void>
+   * @throws {AbortError} Thrown if the operation is cancelled via the abortSignal.
    * @throws {Error} Thrown if the underlying connection encounters an error while closing.
    */
-  async stop(): Promise<void> {
+  async stop(abortSignal?: AbortSignalLike): Promise<void> {
     if (this._receiver) {
       try {
-        await this._receiver.close();
+        await this._receiver.close(abortSignal);
       } catch (err) {
         log.error(
           "An error occurred while stopping the receiver '%s' with address '%s': %O",


### PR DESCRIPTION
Every async operation like close(), stop() method on streaming receiver takes a cancellation token such that if the user ever wants to cancel all ongoing operations, they should be able to do that.

close() operation on sender, receiver, cbsSession. management session return a promise only because we wait for rhea to fire a close event which is done when the remote i.e the service indicates that the link is closed.