### PR TITLE
updated test matrix to include more node versions for eventhubs tests

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -57,14 +57,13 @@ jobs:
       - script: echo $(EVENTHUB_NAME)
       - script: echo $(NodeVersion)
       - script: echo $(EVENTHUB_CONNECTION_STRING)
+      - script: |
       - template: ../steps/tests-common.yml
         parameters:
           NodeVersion: $(NodeVersion)
           PackageName: ${{ parameters.PackageName }}
           TestType: $(TestType)
           EnvVars: ${{ parameters.EnvVars }}
-            ${{ insert }}: ${{ parameters.EnvVars }}
-            - EVENTHUB_NAME: $(EVENTHUB_NAME)
           OSName: $(OSName)
           TestResultsFiles: $(TestResultsFiles)
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -54,7 +54,6 @@ jobs:
     timeoutInMinutes: 240
 
     steps:
-      - script: |
       - template: ../steps/tests-common.yml
         parameters:
           NodeVersion: $(NodeVersion)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -63,5 +63,8 @@ jobs:
           PackageName: ${{ parameters.PackageName }}
           TestType: $(TestType)
           EnvVars: ${{ parameters.EnvVars }}
+            ${{ insert }}: ${{ parameters.EnvVars }}
+            - EVENTHUB_NAME: $(EVENTHUB_NAME)
           OSName: $(OSName)
           TestResultsFiles: $(TestResultsFiles)
+

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -63,7 +63,7 @@ jobs:
           PackageName: ${{ parameters.PackageName }}
           TestType: $(TestType)
           EnvVars: ${{ parameters.EnvVars }}
-            ${{ insert }}: ${{ parameters.EnvVars }}
+            #${{ insert }}: ${{ parameters.EnvVars }}
             - EVENTHUB_NAME: $(EVENTHUB_NAME)
           OSName: $(OSName)
           TestResultsFiles: $(TestResultsFiles)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -56,6 +56,7 @@ jobs:
     steps:
       - script: echo $(EVENTHUB_NAME)
       - script: echo $(NodeVersion)
+      - script: echo $(EVENTHUB_CONNECTION_STRING)
       - template: ../steps/tests-common.yml
         parameters:
           NodeVersion: $(NodeVersion)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -62,4 +62,3 @@ jobs:
           EnvVars: ${{ parameters.EnvVars }}
           OSName: $(OSName)
           TestResultsFiles: $(TestResultsFiles)
-

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -54,6 +54,8 @@ jobs:
     timeoutInMinutes: 240
 
     steps:
+      - script: echo $(EVENTHUB_NAME)
+      - script: echo $(NodeVersion)
       - template: ../steps/tests-common.yml
         parameters:
           NodeVersion: $(NodeVersion)

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -54,9 +54,6 @@ jobs:
     timeoutInMinutes: 240
 
     steps:
-      - script: echo $(EVENTHUB_NAME)
-      - script: echo $(NodeVersion)
-      - script: echo $(EVENTHUB_CONNECTION_STRING)
       - script: |
       - template: ../steps/tests-common.yml
         parameters:

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -63,7 +63,7 @@ jobs:
           PackageName: ${{ parameters.PackageName }}
           TestType: $(TestType)
           EnvVars: ${{ parameters.EnvVars }}
-            #${{ insert }}: ${{ parameters.EnvVars }}
+            ${{ insert }}: ${{ parameters.EnvVars }}
             - EVENTHUB_NAME: $(EVENTHUB_NAME)
           OSName: $(OSName)
           TestResultsFiles: $(TestResultsFiles)

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -59,6 +59,3 @@ jobs:
         IOTHUB_CONNECTION_STRING: $(js-event-hubs-test-iothub-connection-string)
         EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         ENDPOINT: $(js-event-hubs-test-endpoint)
-
-      # Event Hubs tests now support concurrent execution
-      MaxParallel: 0

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -6,22 +6,57 @@ jobs:
       PackageName: "@azure/event-hubs"
       # Remove Browser tests from matrix since they are currently a no-op
       Matrix:
+        Linux_Node8X:
+          OSVmImage: "ubuntu-16.04"
+          TestType: "node"
+          NodeVersion: "8.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
+        Windows_Node8X:
+          OSVmImage: "vs2017-win2016"
+          TestType: "node"
+          NodeVersion: "8.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
+        Mac_Node8X:
+          OSVmImage: "macOS-10.13"
+          TestType: "node"
+          NodeVersion: "8.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
         Linux_Node10X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
+          NodeVersion: "10.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-lin10)
         Windows_Node10X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
+          NodeVersion: "10.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-win10)
         Mac_Node10X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
+          NodeVersion: "10.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-mac10)
+        Linux_Node12X:
+          OSVmImage: "ubuntu-16.04"
+          TestType: "node"
+          NodeVersion: "12.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-lin12)
+        Windows_Node12X:
+          OSVmImage: "vs2017-win2016"
+          TestType: "node"
+          NodeVersion: "12.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-win12)
+        Mac_Node12X:
+          OSVmImage: "macOS-10.13"
+          TestType: "node"
+          NodeVersion: "12.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         ENDPOINT: $(js-event-hubs-test-endpoint)
         EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-        EVENTHUB_NAME: $(js-event-hubs-test-name)
         IOTHUB_CONNECTION_STRING: $(js-event-hubs-test-iothub-connection-string)
 
       # Event Hubs tests do not support concurrent execution

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -11,69 +11,54 @@ jobs:
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin10)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node10X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win10)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node10X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac10)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node12X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin12)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node12X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win12)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node12X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node8X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node8X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node8X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
+
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)        
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         IOTHUB_CONNECTION_STRING: $(js-event-hubs-test-iothub-connection-string)
+        EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+        ENDPOINT: $(js-event-hubs-test-endpoint)
 
       # Event Hubs tests do not support concurrent execution
       MaxParallel: 1

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -11,52 +11,60 @@ jobs:
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Windows_Node8X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Mac_Node8X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Linux_Node10X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin10)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Windows_Node10X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win10)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Mac_Node10X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac10)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Linux_Node12X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin12)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Windows_Node12X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win12)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         Mac_Node12X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         ENDPOINT: $(js-event-hubs-test-endpoint)
-        EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         IOTHUB_CONNECTION_STRING: $(js-event-hubs-test-iothub-connection-string)
 
       # Event Hubs tests do not support concurrent execution

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -10,47 +10,47 @@ jobs:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "10.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-lin10)
+          EVENTHUB_NAME: "hub_linux_node10"
         Windows_Node10X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "10.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-win10)
+          EVENTHUB_NAME: "hub_windows_node10"
         Mac_Node10X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "10.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-mac10)
+          EVENTHUB_NAME: "hub_mac_node10"
         Linux_Node12X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "12.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-lin12)
+          EVENTHUB_NAME: "hub_linux_node12"
         Windows_Node12X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "12.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-win12)
+          EVENTHUB_NAME: "hub_windows_node12"
         Mac_Node12X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "12.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
+          EVENTHUB_NAME: "hub_mac_node12"
         Linux_Node8X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "8.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
+          EVENTHUB_NAME: "hub_linux_node8"
         Windows_Node8X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "8.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
+          EVENTHUB_NAME: "hub_windows_node8"
         Mac_Node8X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "8.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
+          EVENTHUB_NAME: "hub_mac_node8"
 
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -6,27 +6,6 @@ jobs:
       PackageName: "@azure/event-hubs"
       # Remove Browser tests from matrix since they are currently a no-op
       Matrix:
-        Linux_Node8X:
-          OSVmImage: "ubuntu-16.04"
-          TestType: "node"
-          NodeVersion: "8.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
-        Windows_Node8X:
-          OSVmImage: "vs2017-win2016"
-          TestType: "node"
-          NodeVersion: "8.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
-        Mac_Node8X:
-          OSVmImage: "macOS-10.13"
-          TestType: "node"
-          NodeVersion: "8.x"
-          EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
-          ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node10X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
@@ -67,6 +46,27 @@ jobs:
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
+        Linux_Node8X:
+          OSVmImage: "ubuntu-16.04"
+          TestType: "node"
+          NodeVersion: "8.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
+        Windows_Node8X:
+          OSVmImage: "vs2017-win2016"
+          TestType: "node"
+          NodeVersion: "8.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
+        Mac_Node8X:
+          OSVmImage: "macOS-10.13"
+          TestType: "node"
+          NodeVersion: "8.x"
+          EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
       EnvVars:

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -11,63 +11,63 @@ jobs:
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin10)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node10X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win10)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node10X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac10)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node12X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin12)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node12X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win12)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node12X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node8X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node8X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node8X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
-          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          EVENTHUB_CONNECTION_STRING: $(some-testing)
           ENDPOINT: $(js-event-hubs-test-endpoint)
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -12,59 +12,67 @@ jobs:
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node8X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node8X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node10X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin10)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node10X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win10)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node10X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac10)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node12X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin12)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node12X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win12)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node12X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
           EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+          ENDPOINT: $(js-event-hubs-test-endpoint)
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        ENDPOINT: $(js-event-hubs-test-endpoint)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)        
         IOTHUB_CONNECTION_STRING: $(js-event-hubs-test-iothub-connection-string)
 
       # Event Hubs tests do not support concurrent execution

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -60,5 +60,5 @@ jobs:
         EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
         ENDPOINT: $(js-event-hubs-test-endpoint)
 
-      # Event Hubs tests do not support concurrent execution
+      # Event Hubs tests now support concurrent execution
       MaxParallel: 0

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -61,4 +61,4 @@ jobs:
         ENDPOINT: $(js-event-hubs-test-endpoint)
 
       # Event Hubs tests do not support concurrent execution
-      MaxParallel: 1
+      MaxParallel: 0

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -11,63 +11,63 @@ jobs:
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin10)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node10X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win10)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node10X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "10.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac10)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node12X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin12)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node12X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win12)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node12X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "12.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac12)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Linux_Node8X:
           OSVmImage: "ubuntu-16.04"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-lin8)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Windows_Node8X:
           OSVmImage: "vs2017-win2016"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-win8)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
         Mac_Node8X:
           OSVmImage: "macOS-10.13"
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: $(js-event-hubs-test-name-mac8)
-          EVENTHUB_CONNECTION_STRING: $(some-testing)
+          EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
           ENDPOINT: $(js-event-hubs-test-endpoint)
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)


### PR DESCRIPTION
- Added node versions - 8, 10 and 12 for eventhub tests
- Added separate env variable for eventhub-name for each item in the matrix

@Azure/azure-sdk-eng 