### PR TITLE
[core-http] Use an external token cache in BearerTokenAuthenticationPolicy

### DIFF
--- a/sdk/core/core-http/lib/coreHttp.ts
+++ b/sdk/core/core-http/lib/coreHttp.ts
@@ -44,6 +44,7 @@ export { URLBuilder, URLQuery } from "./url";
 
 // Credentials
 export { TokenCredential, GetTokenOptions, AccessToken, isTokenCredential } from "@azure/core-auth";
+export { AccessTokenCache, ExpiringAccessTokenCache } from "./credentials/accessTokenCache";
 export { TokenCredentials } from "./credentials/tokenCredentials";
 export { BasicAuthenticationCredentials } from "./credentials/basicAuthenticationCredentials";
 export { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKeyCredentials";

--- a/sdk/core/core-http/lib/credentials/accessTokenCache.ts
+++ b/sdk/core/core-http/lib/credentials/accessTokenCache.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AccessToken } from "@azure/core-auth";
+
+/**
+ * Defines the default token refresh buffer duration.
+ */
+export const TokenRefreshBufferMs = 2 * 60 * 1000; // 2 Minutes
+
+/**
+ * Provides a cache for an AccessToken that was that
+ * was returned from a TokenCredential.
+ */
+export interface AccessTokenCache {
+  /**
+   * Sets the cached token.
+   *
+   * @param The {@link AccessToken} to be cached or null to
+   *        clear the cached token.
+   */
+  setCachedToken(accessToken: AccessToken | undefined): void;
+
+  /**
+   * Returns the cached {@link AccessToken} or undefined if nothing is cached.
+   */
+  getCachedToken(): AccessToken | undefined;
+}
+
+/**
+ * Provides an {@link AccessTokenCache} implementation which clears
+ * the cached {@link AccessToken}'s after the expiresOnTimestamp has
+ * passed.
+ */
+export class ExpiringAccessTokenCache implements AccessTokenCache {
+  private tokenRefreshBufferMs: number;
+  private cachedToken?: AccessToken = undefined;
+
+  /**
+   * Constructs an instance of {@link ExpiringAccessTokenCache} with
+   * an optional expiration buffer time.
+   */
+  constructor(tokenRefreshBufferMs: number = TokenRefreshBufferMs) {
+    this.tokenRefreshBufferMs = tokenRefreshBufferMs;
+  }
+
+  setCachedToken(accessToken: AccessToken | undefined): void {
+    this.cachedToken = accessToken;
+  }
+
+  getCachedToken(): AccessToken | undefined {
+    if (
+      this.cachedToken &&
+      Date.now() + this.tokenRefreshBufferMs >= this.cachedToken.expiresOnTimestamp
+    ) {
+      this.cachedToken = undefined;
+    }
+
+    return this.cachedToken;
+  }
+}

--- a/sdk/core/core-http/test/expiringAccessTokenCacheTests.ts
+++ b/sdk/core/core-http/test/expiringAccessTokenCacheTests.ts
@@ -1,0 +1,39 @@
+import { assert } from "chai";
+import { ExpiringAccessTokenCache } from "../lib/credentials/accessTokenCache";
+
+function mockToken(expirationDeltaMs: number) {
+  return {
+    token: "token",
+    expiresOnTimestamp: Date.now() + expirationDeltaMs
+  };
+}
+
+describe("ExpiringAccessTokenCache", function () {
+  it("returns a cached token within the expiration window", function() {
+    const tokenCache = new ExpiringAccessTokenCache(2000);
+    const accessToken = mockToken(5000);
+    tokenCache.setCachedToken(accessToken);
+
+    const cachedToken = tokenCache.getCachedToken();
+    assert.isDefined(cachedToken, "A cached token was not returned!");
+  });
+
+  it("returns undefined when refresh buffer is passed", function() {
+    const tokenCache = new ExpiringAccessTokenCache(5000);
+    const accessToken = mockToken(-5000);
+    tokenCache.setCachedToken(accessToken);
+
+    const cachedToken = tokenCache.getCachedToken();
+    assert.isUndefined(cachedToken, "A cached token was returned!");
+  });
+
+  it("clears the cached token when undefined is passed to setCachedToken", function() {
+    const tokenCache = new ExpiringAccessTokenCache(2000);
+    const accessToken = mockToken(5000);
+    tokenCache.setCachedToken(accessToken);
+    tokenCache.setCachedToken(undefined);
+
+    const cachedToken = tokenCache.getCachedToken();
+    assert.isUndefined(cachedToken, "A cached token was returned!");
+  });
+});

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -10,7 +10,8 @@ import { Constants } from "../../lib/util/constants";
 import { HttpOperationResponse } from "../../lib/httpOperationResponse";
 import { HttpHeaders, } from "../../lib/httpHeaders";
 import { WebResource } from "../../lib/webResource";
-import { BearerTokenAuthenticationPolicy, TokenRefreshBufferMs } from "../../lib/policies/bearerTokenAuthenticationPolicy";
+import { BearerTokenAuthenticationPolicy } from "../../lib/policies/bearerTokenAuthenticationPolicy";
+import { ExpiringAccessTokenCache, TokenRefreshBufferMs } from "../../lib/credentials/accessTokenCache";
 
 describe("BearerTokenAuthenticationPolicy", function () {
   const mockPolicy: RequestPolicy = {
@@ -77,7 +78,7 @@ describe("BearerTokenAuthenticationPolicy", function () {
       new RequestPolicyOptions(),
       credential,
       scopes,
-      {});
+      new ExpiringAccessTokenCache());
   }
 });
 

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -76,7 +76,8 @@ describe("BearerTokenAuthenticationPolicy", function () {
       mockPolicy,
       new RequestPolicyOptions(),
       credential,
-      scopes);
+      scopes,
+      {});
   }
 });
 


### PR DESCRIPTION
This change implements a simple `AccessToken` cache in the `bearerTokenAuthenticationPolicy` factory so that tokens will be cached correctly across `BearerTokenAuthenticationPolicy` instances.  This is needed because `core-http` uses a `RequestPolicyFactory` array to create a fresh list of request policies for each request sent through the pipeline.

The old caching behavior in `BearerTokenAuthenticationPolicy` assumed that there would only ever be a single instance of that class per client, meaning that the existing token cache implementation is ineffective across multiple requests.

This new behavior stores a simple object in the factory function's closure which gets used as an `AccessTokenCache` for every `BearerTokenAuthenticationPolicy` instance created by that factory, resulting in a per-client token cache.

**Questions for Reviewers**

- ~It seems that this interface needs to be exported through the public interface of `core-http` so that anyone using the `BearerTokenAuthenticationPolicy` class directly (not through the factory function) will be able to see the type.  Does that sound like something we should be doing?~
- ~Since this type of token cache will probably be needed for other authentication policies (like @jonathandturner's `ChallengeBasedAuthenticationPolicy` #4141 ), should I move the `AccessTokenCache` into the new `core-auth` once that comes online?~