### PR TITLE
[KeyVault] KeyVault already supports abortSignal, so I added a test

### DIFF
--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -75,6 +75,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@azure/abort-controller": "1.0.0-preview.1",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@azure/abort-controller": "1.0.0-preview.1",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",


### PR DESCRIPTION
Since KeyVault already supports abortSignal:

- Should we add tests for some of the API calls with abortSignal?
    - In case we should test abortSignal, what API calls should we test? (or should we test all of
      them?)
    - In case we should test abortSignal, remember that this PR is missing the recording files,
      so I would need to generate them before we merge this.
- Should we do the same for keyvault-certificates?

Fixes #4183