### PR TITLE
Switch Rollup minifier plugin to rollup-plugin-terser

### DIFF
--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -107,7 +107,7 @@
     "rollup-plugin-node-resolve": "^5.0.2",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "typescript": "^3.2.2"
   }
 }

--- a/sdk/core/abort-controller/rollup.base.config.js
+++ b/sdk/core/abort-controller/rollup.base.config.js
@@ -5,7 +5,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 
 const pkg = require("./package.json");
@@ -57,7 +57,7 @@ export function nodeConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -118,7 +118,7 @@ export function browserConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -116,7 +116,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "sinon": "^7.1.0",
     "ts-node": "^7.0.1",
     "typescript": "^3.2.2",

--- a/sdk/core/core-amqp/rollup.base.config.js
+++ b/sdk/core/core-amqp/rollup.base.config.js
@@ -7,7 +7,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import inject from "rollup-plugin-inject";
 import shim from "rollup-plugin-shim";
@@ -78,7 +78,7 @@ export function nodeConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -162,7 +162,7 @@ export function browserConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -88,7 +88,7 @@
     "rollup-plugin-node-resolve": "^5.0.2",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "typescript": "^3.2.2",
     "util": "^0.11.1"

--- a/sdk/core/core-auth/rollup.base.config.js
+++ b/sdk/core/core-auth/rollup.base.config.js
@@ -2,7 +2,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import viz from "rollup-plugin-visualizer";
 
@@ -43,8 +43,13 @@ export function nodeConfig(test = false) {
 
     // mark assert as external
     baseConfig.external.push("assert");
+
+    // Disable tree-shaking of test code.  In rollup-plugin-node-resolve@5.0.0, rollup started respecting
+    // the "sideEffects" field in package.json.  Since our package.json sets "sideEffects=false", this also
+    // applies to test code, which causes all tests to be removed by tree-shaking.
+    baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -86,9 +91,14 @@ export function browserConfig(test = false, production = false) {
     baseConfig.input = "dist-esm/test/**/*.spec.js";
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
     baseConfig.output.file = "test-browser/index.js";
+
+    // Disable tree-shaking of test code.  In rollup-plugin-node-resolve@5.0.0, rollup started respecting
+    // the "sideEffects" field in package.json.  Since our package.json sets "sideEffects=false", this also
+    // applies to test code, which causes all tests to be removed by tree-shaking.
+    baseConfig.treeshake = false;
   } else if (production) {
     baseConfig.output.file = "browser/core-auth.min.js";
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -129,7 +129,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "ts-mocha": "^6.0.0",
     "ts-node": "^7.0.1",
     "typescript": "^3.2.2",

--- a/sdk/eventhub/event-hubs/rollup.base.config.js
+++ b/sdk/eventhub/event-hubs/rollup.base.config.js
@@ -6,7 +6,7 @@ import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import json from "rollup-plugin-json";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
 import inject from "rollup-plugin-inject";
@@ -79,7 +79,7 @@ export function nodeConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -170,7 +170,7 @@ export function browserConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -133,7 +133,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^7.0.1",

--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -5,7 +5,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
 // import visualizer from "rollup-plugin-visualizer";
@@ -66,7 +66,7 @@ export function nodeConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -135,7 +135,7 @@ export function browserConfig(test = false, production = false) {
   } else if (production) {
     baseConfig.output.file = "browser/azure-storage-blob.min.js";
     baseConfig.plugins.push(
-      uglify({
+      terser({
         output: {
           preamble: banner
         }

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -133,7 +133,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^7.0.1",

--- a/sdk/storage/storage-file/rollup.base.config.js
+++ b/sdk/storage/storage-file/rollup.base.config.js
@@ -5,7 +5,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
 // import visualizer from "rollup-plugin-visualizer";
@@ -66,7 +66,7 @@ export function nodeConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -144,7 +144,7 @@ export function browserConfig(test = false, production = false) {
   } else if (production) {
     baseConfig.output.file = "browser/azure-storage-file.min.js";
     baseConfig.plugins.push(
-      uglify({
+      terser({
         output: {
           preamble: banner
         }

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -131,7 +131,7 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-shim": "^1.0.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^7.0.1",

--- a/sdk/storage/storage-queue/rollup.base.config.js
+++ b/sdk/storage/storage-queue/rollup.base.config.js
@@ -5,7 +5,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import shim from "rollup-plugin-shim";
 // import visualizer from "rollup-plugin-visualizer";
@@ -66,7 +66,7 @@ export function nodeConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -133,7 +133,7 @@ export function browserConfig(test = false, production = false) {
   } else if (production) {
     baseConfig.output.file = "browser/azure-storage-queue.min.js";
     baseConfig.plugins.push(
-      uglify({
+      terser({
         output: {
           preamble: banner
         }

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -90,7 +90,7 @@
     "rollup-plugin-node-resolve": "^5.0.2",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "typescript": "^3.2.2",
     "util": "^0.11.1"

--- a/sdk/template/template/rollup.base.config.js
+++ b/sdk/template/template/rollup.base.config.js
@@ -2,7 +2,7 @@ import nodeResolve from "rollup-plugin-node-resolve";
 import multiEntry from "rollup-plugin-multi-entry";
 import cjs from "rollup-plugin-commonjs";
 import replace from "rollup-plugin-replace";
-import { uglify } from "rollup-plugin-uglify";
+import { terser } from "rollup-plugin-terser";
 import sourcemaps from "rollup-plugin-sourcemaps";
 import viz from "rollup-plugin-visualizer";
 
@@ -49,7 +49,7 @@ export function nodeConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;
@@ -103,7 +103,7 @@ export function browserConfig(test = false, production = false) {
     baseConfig.treeshake = false;
   } else if (production) {
     baseConfig.output.file = "browser/azure-template.min.js";
-    baseConfig.plugins.push(uglify());
+    baseConfig.plugins.push(terser());
   }
 
   return baseConfig;


### PR DESCRIPTION
In PR #4165, @bterlson recommended that I use `rollup-plugin-terser` instead of `rollup-plugin-uglify` to mitigate an issue where an ES6 class definition caused the minifier to throw an error about an unexpected token.  @HarshaNalluru [asked](https://github.com/Azure/azure-sdk-for-js/pull/4165#discussion_r300778206) whether we should be using this everywhere, so this PR is an attempt to get us moved over to `rollup-plugin-terser` anywhere that `rollup-plugin-uglify` is being used.  The `keyvault` libraries and `core-http` both use `uglifyjs` directly (they probably shouldn't) so I didn't update those at this time (but I can if folks feel strongly about it).

I've made changes for each library in individual commits so it's easy to drop any that we don't feel should be moved over!