### PR TITLE
Regenerate @azure/arm-compute to use @azure/core-http

### DIFF
--- a/sdk/compute/arm-compute/README.md
+++ b/sdk/compute/arm-compute/README.md
@@ -26,8 +26,8 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```typescript
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { ComputeManagementClient, ComputeManagementModels, ComputeManagementMappers } from "@azure/arm-compute";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
@@ -61,8 +61,8 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 <html lang="en">
   <head>
     <title>@azure/arm-compute sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
+    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
+    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/arm-compute/dist/arm-compute.js"></script>
     <script type="text/javascript">
@@ -94,6 +94,5 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/compute/arm-compute/README.png)

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/arm-compute",
   "author": "Microsoft Corporation",
   "description": "ComputeManagementClient Library with typescript type definitions for node.js and browser.",
-  "version": "10.0.0",
+  "version": "11.0.0-preview.1",
   "dependencies": {
     "@azure/core-arm": "^1.0.0-preview.1",
     "@azure/core-http": "^1.0.0-preview.1",

--- a/sdk/compute/arm-compute/package.json
+++ b/sdk/compute/arm-compute/package.json
@@ -4,8 +4,8 @@
   "description": "ComputeManagementClient Library with typescript type definitions for node.js and browser.",
   "version": "10.0.0",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/core-arm": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "keywords": [
@@ -26,13 +26,13 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "uglify-js": "^3.4.9"
   },
-  "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/compute/arm-compute",
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/compute/arm-compute",
   "repository": {
     "type": "git",
-    "url": "https://github.com/azure/azure-sdk-for-js.git"
+    "url": "https://github.com/Azure/azure-sdk-for-js.git"
   },
   "bugs": {
-    "url": "https://github.com/azure/azure-sdk-for-js/issues"
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "files": [
     "dist/**/*.js",

--- a/sdk/compute/arm-compute/rollup.config.js
+++ b/sdk/compute/arm-compute/rollup.config.js
@@ -8,8 +8,8 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const config = {
   input: "./esm/computeManagementClient.js",
   external: [
-    "@azure/ms-rest-js",
-    "@azure/ms-rest-azure-js"
+    "@azure/core-http",
+    "@azure/core-arm"
   ],
   output: {
     file: "./dist/arm-compute.js",
@@ -17,8 +17,8 @@ const config = {
     name: "Azure.ArmCompute",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest",
-      "@azure/ms-rest-azure-js": "msRestAzure"
+      "@azure/core-http": "coreHttp",
+      "@azure/core-arm": "coreArm"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/compute/arm-compute/src/computeManagementClient.ts
+++ b/sdk/compute/arm-compute/src/computeManagementClient.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -48,7 +48,7 @@ class ComputeManagementClient extends ComputeManagementClientContext {
    * subscription. The subscription ID forms part of the URI for every service call.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ComputeManagementClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ComputeManagementClientOptions) {
     super(credentials, subscriptionId, options);
     this.operations = new operations.Operations(this);
     this.availabilitySets = new operations.AvailabilitySets(this);

--- a/sdk/compute/arm-compute/src/computeManagementClientContext.ts
+++ b/sdk/compute/arm-compute/src/computeManagementClientContext.ts
@@ -9,14 +9,14 @@
  */
 
 import * as Models from "./models";
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-compute";
 const packageVersion = "10.0.0";
 
-export class ComputeManagementClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class ComputeManagementClientContext extends coreArm.AzureServiceClient {
+  credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;
   subscriptionId: string;
 
   /**
@@ -26,7 +26,7 @@ export class ComputeManagementClientContext extends msRestAzure.AzureServiceClie
    * subscription. The subscription ID forms part of the URI for every service call.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ComputeManagementClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ComputeManagementClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -38,7 +38,7 @@ export class ComputeManagementClientContext extends msRestAzure.AzureServiceClie
       options = {};
     }
     if(!options.userAgent) {
-      const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
+      const defaultUserAgent = coreArm.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 

--- a/sdk/compute/arm-compute/src/computeManagementClientContext.ts
+++ b/sdk/compute/arm-compute/src/computeManagementClientContext.ts
@@ -13,7 +13,7 @@ import * as coreHttp from "@azure/core-http";
 import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-compute";
-const packageVersion = "10.0.0";
+const packageVersion = "11.0.0-preview.1";
 
 export class ComputeManagementClientContext extends coreArm.AzureServiceClient {
   credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;

--- a/sdk/compute/arm-compute/src/models/index.ts
+++ b/sdk/compute/arm-compute/src/models/index.ts
@@ -6,8 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export { BaseResource, CloudError };
 
@@ -4583,7 +4583,7 @@ export interface ContainerService extends Resource {
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineExtensionImagesListVersionsOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineExtensionImagesListVersionsOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.
    */
@@ -4595,7 +4595,7 @@ export interface VirtualMachineExtensionImagesListVersionsOptionalParams extends
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineExtensionsGetOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineExtensionsGetOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The expand expression to apply on the operation.
    */
@@ -4605,7 +4605,7 @@ export interface VirtualMachineExtensionsGetOptionalParams extends msRest.Reques
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineExtensionsListOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineExtensionsListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The expand expression to apply on the operation.
    */
@@ -4615,7 +4615,7 @@ export interface VirtualMachineExtensionsListOptionalParams extends msRest.Reque
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineImagesListOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineImagesListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.
    */
@@ -4627,7 +4627,7 @@ export interface VirtualMachineImagesListOptionalParams extends msRest.RequestOp
 /**
  * Optional Parameters.
  */
-export interface VirtualMachinesGetOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachinesGetOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The expand expression to apply on the operation. Possible values include: 'instanceView'
    */
@@ -4637,7 +4637,7 @@ export interface VirtualMachinesGetOptionalParams extends msRest.RequestOptionsB
 /**
  * Optional Parameters.
  */
-export interface VirtualMachinesPowerOffOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachinesPowerOffOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The parameter to request non-graceful VM shutdown. True value for this flag indicates
    * non-graceful shutdown whereas false indicates otherwise. Default value for this flag is false
@@ -4649,7 +4649,7 @@ export interface VirtualMachinesPowerOffOptionalParams extends msRest.RequestOpt
 /**
  * Optional Parameters.
  */
-export interface VirtualMachinesReimageOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachinesReimageOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters supplied to the Reimage Virtual Machine operation.
    */
@@ -4659,7 +4659,7 @@ export interface VirtualMachinesReimageOptionalParams extends msRest.RequestOpti
 /**
  * Optional Parameters.
  */
-export interface VirtualMachinesBeginPowerOffOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachinesBeginPowerOffOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The parameter to request non-graceful VM shutdown. True value for this flag indicates
    * non-graceful shutdown whereas false indicates otherwise. Default value for this flag is false
@@ -4671,7 +4671,7 @@ export interface VirtualMachinesBeginPowerOffOptionalParams extends msRest.Reque
 /**
  * Optional Parameters.
  */
-export interface VirtualMachinesBeginReimageOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachinesBeginReimageOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters supplied to the Reimage Virtual Machine operation.
    */
@@ -4681,7 +4681,7 @@ export interface VirtualMachinesBeginReimageOptionalParams extends msRest.Reques
 /**
  * Optional Parameters.
  */
-export interface ImagesGetOptionalParams extends msRest.RequestOptionsBase {
+export interface ImagesGetOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The expand expression to apply on the operation.
    */
@@ -4691,7 +4691,7 @@ export interface ImagesGetOptionalParams extends msRest.RequestOptionsBase {
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsDeallocateOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsDeallocateOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4701,7 +4701,7 @@ export interface VirtualMachineScaleSetsDeallocateOptionalParams extends msRest.
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsPowerOffOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsPowerOffOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4717,7 +4717,7 @@ export interface VirtualMachineScaleSetsPowerOffOptionalParams extends msRest.Re
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsRestartOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsRestartOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4727,7 +4727,7 @@ export interface VirtualMachineScaleSetsRestartOptionalParams extends msRest.Req
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsStartOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsStartOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4737,7 +4737,7 @@ export interface VirtualMachineScaleSetsStartOptionalParams extends msRest.Reque
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsRedeployOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsRedeployOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4747,7 +4747,7 @@ export interface VirtualMachineScaleSetsRedeployOptionalParams extends msRest.Re
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsPerformMaintenanceOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsPerformMaintenanceOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4757,7 +4757,7 @@ export interface VirtualMachineScaleSetsPerformMaintenanceOptionalParams extends
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsReimageOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsReimageOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters for Reimaging VM ScaleSet.
    */
@@ -4767,7 +4767,7 @@ export interface VirtualMachineScaleSetsReimageOptionalParams extends msRest.Req
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsReimageAllOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsReimageAllOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4777,7 +4777,7 @@ export interface VirtualMachineScaleSetsReimageAllOptionalParams extends msRest.
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginDeallocateOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginDeallocateOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4787,7 +4787,7 @@ export interface VirtualMachineScaleSetsBeginDeallocateOptionalParams extends ms
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginPowerOffOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginPowerOffOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4803,7 +4803,7 @@ export interface VirtualMachineScaleSetsBeginPowerOffOptionalParams extends msRe
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginRestartOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginRestartOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4813,7 +4813,7 @@ export interface VirtualMachineScaleSetsBeginRestartOptionalParams extends msRes
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginStartOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginStartOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4823,7 +4823,7 @@ export interface VirtualMachineScaleSetsBeginStartOptionalParams extends msRest.
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginRedeployOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginRedeployOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4833,7 +4833,7 @@ export interface VirtualMachineScaleSetsBeginRedeployOptionalParams extends msRe
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginPerformMaintenanceOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginPerformMaintenanceOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4843,7 +4843,7 @@ export interface VirtualMachineScaleSetsBeginPerformMaintenanceOptionalParams ex
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginReimageOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginReimageOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters for Reimaging VM ScaleSet.
    */
@@ -4853,7 +4853,7 @@ export interface VirtualMachineScaleSetsBeginReimageOptionalParams extends msRes
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetsBeginReimageAllOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetsBeginReimageAllOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * A list of virtual machine instance IDs from the VM scale set.
    */
@@ -4863,7 +4863,7 @@ export interface VirtualMachineScaleSetsBeginReimageAllOptionalParams extends ms
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetExtensionsGetOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetExtensionsGetOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The expand expression to apply on the operation.
    */
@@ -4873,7 +4873,7 @@ export interface VirtualMachineScaleSetExtensionsGetOptionalParams extends msRes
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetVMsReimageOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetVMsReimageOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters for the Reimaging Virtual machine in ScaleSet.
    */
@@ -4883,7 +4883,7 @@ export interface VirtualMachineScaleSetVMsReimageOptionalParams extends msRest.R
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetVMsListOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetVMsListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply to the operation.
    */
@@ -4901,7 +4901,7 @@ export interface VirtualMachineScaleSetVMsListOptionalParams extends msRest.Requ
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetVMsPowerOffOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetVMsPowerOffOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The parameter to request non-graceful VM shutdown. True value for this flag indicates
    * non-graceful shutdown whereas false indicates otherwise. Default value for this flag is false
@@ -4913,7 +4913,7 @@ export interface VirtualMachineScaleSetVMsPowerOffOptionalParams extends msRest.
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetVMsBeginReimageOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetVMsBeginReimageOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters for the Reimaging Virtual machine in ScaleSet.
    */
@@ -4923,7 +4923,7 @@ export interface VirtualMachineScaleSetVMsBeginReimageOptionalParams extends msR
 /**
  * Optional Parameters.
  */
-export interface VirtualMachineScaleSetVMsBeginPowerOffOptionalParams extends msRest.RequestOptionsBase {
+export interface VirtualMachineScaleSetVMsBeginPowerOffOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The parameter to request non-graceful VM shutdown. True value for this flag indicates
    * non-graceful shutdown whereas false indicates otherwise. Default value for this flag is false
@@ -4935,7 +4935,7 @@ export interface VirtualMachineScaleSetVMsBeginPowerOffOptionalParams extends ms
 /**
  * Optional Parameters.
  */
-export interface GalleryImageVersionsGetOptionalParams extends msRest.RequestOptionsBase {
+export interface GalleryImageVersionsGetOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The expand expression to apply on the operation. Possible values include: 'ReplicationStatus'
    */
@@ -5608,7 +5608,7 @@ export type OperationsListResponse = ComputeOperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5628,7 +5628,7 @@ export type AvailabilitySetsCreateOrUpdateResponse = AvailabilitySet & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5648,7 +5648,7 @@ export type AvailabilitySetsUpdateResponse = AvailabilitySet & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5668,7 +5668,7 @@ export type AvailabilitySetsGetResponse = AvailabilitySet & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5688,7 +5688,7 @@ export type AvailabilitySetsListBySubscriptionResponse = AvailabilitySetListResu
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5708,7 +5708,7 @@ export type AvailabilitySetsListResponse = AvailabilitySetListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5728,7 +5728,7 @@ export type AvailabilitySetsListAvailableSizesResponse = VirtualMachineSizeListR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5748,7 +5748,7 @@ export type AvailabilitySetsListBySubscriptionNextResponse = AvailabilitySetList
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5768,7 +5768,7 @@ export type AvailabilitySetsListNextResponse = AvailabilitySetListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5788,7 +5788,7 @@ export type VirtualMachineExtensionImagesGetResponse = VirtualMachineExtensionIm
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5808,7 +5808,7 @@ export type VirtualMachineExtensionImagesListTypesResponse = Array<VirtualMachin
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5828,7 +5828,7 @@ export type VirtualMachineExtensionImagesListVersionsResponse = Array<VirtualMac
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5848,7 +5848,7 @@ export type VirtualMachineExtensionsCreateOrUpdateResponse = VirtualMachineExten
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5868,7 +5868,7 @@ export type VirtualMachineExtensionsUpdateResponse = VirtualMachineExtension & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5888,7 +5888,7 @@ export type VirtualMachineExtensionsGetResponse = VirtualMachineExtension & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5908,7 +5908,7 @@ export type VirtualMachineExtensionsListResponse = VirtualMachineExtensionsListR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5928,7 +5928,7 @@ export type VirtualMachineExtensionsBeginCreateOrUpdateResponse = VirtualMachine
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5948,7 +5948,7 @@ export type VirtualMachineExtensionsBeginUpdateResponse = VirtualMachineExtensio
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5968,7 +5968,7 @@ export type VirtualMachineImagesGetResponse = VirtualMachineImage & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -5988,7 +5988,7 @@ export type VirtualMachineImagesListResponse = Array<VirtualMachineImageResource
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6008,7 +6008,7 @@ export type VirtualMachineImagesListOffersResponse = Array<VirtualMachineImageRe
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6028,7 +6028,7 @@ export type VirtualMachineImagesListPublishersResponse = Array<VirtualMachineIma
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6048,7 +6048,7 @@ export type VirtualMachineImagesListSkusResponse = Array<VirtualMachineImageReso
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6068,7 +6068,7 @@ export type UsageListResponse = ListUsagesResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6088,7 +6088,7 @@ export type UsageListNextResponse = ListUsagesResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6108,7 +6108,7 @@ export type VirtualMachinesListByLocationResponse = VirtualMachineListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6128,7 +6128,7 @@ export type VirtualMachinesCaptureResponse = VirtualMachineCaptureResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6148,7 +6148,7 @@ export type VirtualMachinesCreateOrUpdateResponse = VirtualMachine & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6168,7 +6168,7 @@ export type VirtualMachinesUpdateResponse = VirtualMachine & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6188,7 +6188,7 @@ export type VirtualMachinesGetResponse = VirtualMachine & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6208,7 +6208,7 @@ export type VirtualMachinesInstanceViewResponse = VirtualMachineInstanceView & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6228,7 +6228,7 @@ export type VirtualMachinesListResponse = VirtualMachineListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6248,7 +6248,7 @@ export type VirtualMachinesListAllResponse = VirtualMachineListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6268,7 +6268,7 @@ export type VirtualMachinesListAvailableSizesResponse = VirtualMachineSizeListRe
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6288,7 +6288,7 @@ export type VirtualMachinesRunCommandResponse = RunCommandResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6308,7 +6308,7 @@ export type VirtualMachinesBeginCaptureResponse = VirtualMachineCaptureResult & 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6328,7 +6328,7 @@ export type VirtualMachinesBeginCreateOrUpdateResponse = VirtualMachine & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6348,7 +6348,7 @@ export type VirtualMachinesBeginUpdateResponse = VirtualMachine & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6368,7 +6368,7 @@ export type VirtualMachinesBeginRunCommandResponse = RunCommandResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6388,7 +6388,7 @@ export type VirtualMachinesListByLocationNextResponse = VirtualMachineListResult
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6408,7 +6408,7 @@ export type VirtualMachinesListNextResponse = VirtualMachineListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6428,7 +6428,7 @@ export type VirtualMachinesListAllNextResponse = VirtualMachineListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6448,7 +6448,7 @@ export type VirtualMachineSizesListResponse = VirtualMachineSizeListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6468,7 +6468,7 @@ export type ImagesCreateOrUpdateResponse = Image & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6488,7 +6488,7 @@ export type ImagesUpdateResponse = Image & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6508,7 +6508,7 @@ export type ImagesGetResponse = Image & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6528,7 +6528,7 @@ export type ImagesListByResourceGroupResponse = ImageListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6548,7 +6548,7 @@ export type ImagesListResponse = ImageListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6568,7 +6568,7 @@ export type ImagesBeginCreateOrUpdateResponse = Image & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6588,7 +6588,7 @@ export type ImagesBeginUpdateResponse = Image & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6608,7 +6608,7 @@ export type ImagesListByResourceGroupNextResponse = ImageListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6628,7 +6628,7 @@ export type ImagesListNextResponse = ImageListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6648,7 +6648,7 @@ export type VirtualMachineScaleSetsCreateOrUpdateResponse = VirtualMachineScaleS
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6668,7 +6668,7 @@ export type VirtualMachineScaleSetsUpdateResponse = VirtualMachineScaleSet & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6688,7 +6688,7 @@ export type VirtualMachineScaleSetsGetResponse = VirtualMachineScaleSet & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6708,7 +6708,7 @@ export type VirtualMachineScaleSetsGetInstanceViewResponse = VirtualMachineScale
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6728,7 +6728,7 @@ export type VirtualMachineScaleSetsListResponse = VirtualMachineScaleSetListResu
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6748,7 +6748,7 @@ export type VirtualMachineScaleSetsListAllResponse = VirtualMachineScaleSetListW
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6768,7 +6768,7 @@ export type VirtualMachineScaleSetsListSkusResponse = VirtualMachineScaleSetList
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6788,7 +6788,7 @@ export type VirtualMachineScaleSetsGetOSUpgradeHistoryResponse = VirtualMachineS
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6808,7 +6808,7 @@ export type VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomai
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6828,7 +6828,7 @@ export type VirtualMachineScaleSetsBeginCreateOrUpdateResponse = VirtualMachineS
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6848,7 +6848,7 @@ export type VirtualMachineScaleSetsBeginUpdateResponse = VirtualMachineScaleSet 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6868,7 +6868,7 @@ export type VirtualMachineScaleSetsListNextResponse = VirtualMachineScaleSetList
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6888,7 +6888,7 @@ export type VirtualMachineScaleSetsListAllNextResponse = VirtualMachineScaleSetL
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6908,7 +6908,7 @@ export type VirtualMachineScaleSetsListSkusNextResponse = VirtualMachineScaleSet
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6928,7 +6928,7 @@ export type VirtualMachineScaleSetsGetOSUpgradeHistoryNextResponse = VirtualMach
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6948,7 +6948,7 @@ export type VirtualMachineScaleSetExtensionsCreateOrUpdateResponse = VirtualMach
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6968,7 +6968,7 @@ export type VirtualMachineScaleSetExtensionsGetResponse = VirtualMachineScaleSet
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -6988,7 +6988,7 @@ export type VirtualMachineScaleSetExtensionsListResponse = VirtualMachineScaleSe
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7008,7 +7008,7 @@ export type VirtualMachineScaleSetExtensionsBeginCreateOrUpdateResponse = Virtua
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7028,7 +7028,7 @@ export type VirtualMachineScaleSetExtensionsListNextResponse = VirtualMachineSca
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7048,7 +7048,7 @@ export type VirtualMachineScaleSetRollingUpgradesGetLatestResponse = RollingUpgr
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7068,7 +7068,7 @@ export type VirtualMachineScaleSetVMsUpdateResponse = VirtualMachineScaleSetVM &
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7088,7 +7088,7 @@ export type VirtualMachineScaleSetVMsGetResponse = VirtualMachineScaleSetVM & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7108,7 +7108,7 @@ export type VirtualMachineScaleSetVMsGetInstanceViewResponse = VirtualMachineSca
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7128,7 +7128,7 @@ export type VirtualMachineScaleSetVMsListResponse = VirtualMachineScaleSetVMList
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7148,7 +7148,7 @@ export type VirtualMachineScaleSetVMsRunCommandResponse = RunCommandResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7168,7 +7168,7 @@ export type VirtualMachineScaleSetVMsBeginUpdateResponse = VirtualMachineScaleSe
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7188,7 +7188,7 @@ export type VirtualMachineScaleSetVMsBeginRunCommandResponse = RunCommandResult 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7208,7 +7208,7 @@ export type VirtualMachineScaleSetVMsListNextResponse = VirtualMachineScaleSetVM
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7228,7 +7228,7 @@ export type LogAnalyticsExportRequestRateByIntervalResponse = LogAnalyticsOperat
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7248,7 +7248,7 @@ export type LogAnalyticsExportThrottledRequestsResponse = LogAnalyticsOperationR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7268,7 +7268,7 @@ export type LogAnalyticsBeginExportRequestRateByIntervalResponse = LogAnalyticsO
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7288,7 +7288,7 @@ export type LogAnalyticsBeginExportThrottledRequestsResponse = LogAnalyticsOpera
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7308,7 +7308,7 @@ export type VirtualMachineRunCommandsListResponse = RunCommandListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7328,7 +7328,7 @@ export type VirtualMachineRunCommandsGetResponse = RunCommandDocument & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7348,7 +7348,7 @@ export type VirtualMachineRunCommandsListNextResponse = RunCommandListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7368,7 +7368,7 @@ export type ResourceSkusListResponse = ResourceSkusResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7388,7 +7388,7 @@ export type ResourceSkusListNextResponse = ResourceSkusResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7408,7 +7408,7 @@ export type DisksCreateOrUpdateResponse = Disk & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7428,7 +7428,7 @@ export type DisksUpdateResponse = Disk & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7448,7 +7448,7 @@ export type DisksGetResponse = Disk & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7468,7 +7468,7 @@ export type DisksListByResourceGroupResponse = DiskList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7488,7 +7488,7 @@ export type DisksListResponse = DiskList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7508,7 +7508,7 @@ export type DisksGrantAccessResponse = AccessUri & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7528,7 +7528,7 @@ export type DisksBeginCreateOrUpdateResponse = Disk & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7548,7 +7548,7 @@ export type DisksBeginUpdateResponse = Disk & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7568,7 +7568,7 @@ export type DisksBeginGrantAccessResponse = AccessUri & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7588,7 +7588,7 @@ export type DisksListByResourceGroupNextResponse = DiskList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7608,7 +7608,7 @@ export type DisksListNextResponse = DiskList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7628,7 +7628,7 @@ export type SnapshotsCreateOrUpdateResponse = Snapshot & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7648,7 +7648,7 @@ export type SnapshotsUpdateResponse = Snapshot & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7668,7 +7668,7 @@ export type SnapshotsGetResponse = Snapshot & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7688,7 +7688,7 @@ export type SnapshotsListByResourceGroupResponse = SnapshotList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7708,7 +7708,7 @@ export type SnapshotsListResponse = SnapshotList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7728,7 +7728,7 @@ export type SnapshotsGrantAccessResponse = AccessUri & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7748,7 +7748,7 @@ export type SnapshotsBeginCreateOrUpdateResponse = Snapshot & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7768,7 +7768,7 @@ export type SnapshotsBeginUpdateResponse = Snapshot & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7788,7 +7788,7 @@ export type SnapshotsBeginGrantAccessResponse = AccessUri & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7808,7 +7808,7 @@ export type SnapshotsListByResourceGroupNextResponse = SnapshotList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7828,7 +7828,7 @@ export type SnapshotsListNextResponse = SnapshotList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7848,7 +7848,7 @@ export type GalleriesCreateOrUpdateResponse = Gallery & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7868,7 +7868,7 @@ export type GalleriesGetResponse = Gallery & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7888,7 +7888,7 @@ export type GalleriesListByResourceGroupResponse = GalleryList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7908,7 +7908,7 @@ export type GalleriesListResponse = GalleryList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7928,7 +7928,7 @@ export type GalleriesBeginCreateOrUpdateResponse = Gallery & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7948,7 +7948,7 @@ export type GalleriesListByResourceGroupNextResponse = GalleryList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7968,7 +7968,7 @@ export type GalleriesListNextResponse = GalleryList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -7988,7 +7988,7 @@ export type GalleryImagesCreateOrUpdateResponse = GalleryImage & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8008,7 +8008,7 @@ export type GalleryImagesGetResponse = GalleryImage & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8028,7 +8028,7 @@ export type GalleryImagesListByGalleryResponse = GalleryImageList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8048,7 +8048,7 @@ export type GalleryImagesBeginCreateOrUpdateResponse = GalleryImage & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8068,7 +8068,7 @@ export type GalleryImagesListByGalleryNextResponse = GalleryImageList & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8088,7 +8088,7 @@ export type GalleryImageVersionsCreateOrUpdateResponse = GalleryImageVersion & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8108,7 +8108,7 @@ export type GalleryImageVersionsGetResponse = GalleryImageVersion & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8128,7 +8128,7 @@ export type GalleryImageVersionsListByGalleryImageResponse = GalleryImageVersion
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8148,7 +8148,7 @@ export type GalleryImageVersionsBeginCreateOrUpdateResponse = GalleryImageVersio
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8168,7 +8168,7 @@ export type GalleryImageVersionsListByGalleryImageNextResponse = GalleryImageVer
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8188,7 +8188,7 @@ export type ContainerServicesListResponse = ContainerServiceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8208,7 +8208,7 @@ export type ContainerServicesCreateOrUpdateResponse = ContainerService & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8228,7 +8228,7 @@ export type ContainerServicesGetResponse = ContainerService & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8248,7 +8248,7 @@ export type ContainerServicesListByResourceGroupResponse = ContainerServiceListR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8268,7 +8268,7 @@ export type ContainerServicesBeginCreateOrUpdateResponse = ContainerService & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8288,7 +8288,7 @@ export type ContainerServicesListNextResponse = ContainerServiceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -8308,7 +8308,7 @@ export type ContainerServicesListByResourceGroupNextResponse = ContainerServiceL
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */

--- a/sdk/compute/arm-compute/src/models/mappers.ts
+++ b/sdk/compute/arm-compute/src/models/mappers.ts
@@ -6,13 +6,13 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { CloudErrorMapper, BaseResourceMapper } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { CloudErrorMapper, BaseResourceMapper } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;
 
-export const ComputeOperationValue: msRest.CompositeMapper = {
+export const ComputeOperationValue: coreHttp.CompositeMapper = {
   serializedName: "ComputeOperationValue",
   type: {
     name: "Composite",
@@ -64,7 +64,7 @@ export const ComputeOperationValue: msRest.CompositeMapper = {
   }
 };
 
-export const InstanceViewStatus: msRest.CompositeMapper = {
+export const InstanceViewStatus: coreHttp.CompositeMapper = {
   serializedName: "InstanceViewStatus",
   type: {
     name: "Composite",
@@ -109,7 +109,7 @@ export const InstanceViewStatus: msRest.CompositeMapper = {
   }
 };
 
-export const SubResource: msRest.CompositeMapper = {
+export const SubResource: coreHttp.CompositeMapper = {
   serializedName: "SubResource",
   type: {
     name: "Composite",
@@ -125,7 +125,7 @@ export const SubResource: msRest.CompositeMapper = {
   }
 };
 
-export const Sku: msRest.CompositeMapper = {
+export const Sku: coreHttp.CompositeMapper = {
   serializedName: "Sku",
   type: {
     name: "Composite",
@@ -153,7 +153,7 @@ export const Sku: msRest.CompositeMapper = {
   }
 };
 
-export const Resource: msRest.CompositeMapper = {
+export const Resource: coreHttp.CompositeMapper = {
   serializedName: "Resource",
   type: {
     name: "Composite",
@@ -202,7 +202,7 @@ export const Resource: msRest.CompositeMapper = {
   }
 };
 
-export const AvailabilitySet: msRest.CompositeMapper = {
+export const AvailabilitySet: coreHttp.CompositeMapper = {
   serializedName: "AvailabilitySet",
   type: {
     name: "Composite",
@@ -257,7 +257,7 @@ export const AvailabilitySet: msRest.CompositeMapper = {
   }
 };
 
-export const UpdateResource: msRest.CompositeMapper = {
+export const UpdateResource: coreHttp.CompositeMapper = {
   serializedName: "UpdateResource",
   type: {
     name: "Composite",
@@ -278,7 +278,7 @@ export const UpdateResource: msRest.CompositeMapper = {
   }
 };
 
-export const AvailabilitySetUpdate: msRest.CompositeMapper = {
+export const AvailabilitySetUpdate: coreHttp.CompositeMapper = {
   serializedName: "AvailabilitySetUpdate",
   type: {
     name: "Composite",
@@ -333,7 +333,7 @@ export const AvailabilitySetUpdate: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineSize: msRest.CompositeMapper = {
+export const VirtualMachineSize: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineSize",
   type: {
     name: "Composite",
@@ -379,7 +379,7 @@ export const VirtualMachineSize: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineExtensionImage: msRest.CompositeMapper = {
+export const VirtualMachineExtensionImage: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineExtensionImage",
   type: {
     name: "Composite",
@@ -423,7 +423,7 @@ export const VirtualMachineExtensionImage: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineImageResource: msRest.CompositeMapper = {
+export const VirtualMachineImageResource: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineImageResource",
   type: {
     name: "Composite",
@@ -459,7 +459,7 @@ export const VirtualMachineImageResource: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineExtensionInstanceView: msRest.CompositeMapper = {
+export const VirtualMachineExtensionInstanceView: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineExtensionInstanceView",
   type: {
     name: "Composite",
@@ -511,7 +511,7 @@ export const VirtualMachineExtensionInstanceView: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineExtension: msRest.CompositeMapper = {
+export const VirtualMachineExtension: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineExtension",
   type: {
     name: "Composite",
@@ -578,7 +578,7 @@ export const VirtualMachineExtension: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineExtensionUpdate: msRest.CompositeMapper = {
+export const VirtualMachineExtensionUpdate: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineExtensionUpdate",
   type: {
     name: "Composite",
@@ -631,7 +631,7 @@ export const VirtualMachineExtensionUpdate: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineExtensionsListResult: msRest.CompositeMapper = {
+export const VirtualMachineExtensionsListResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineExtensionsListResult",
   type: {
     name: "Composite",
@@ -653,7 +653,7 @@ export const VirtualMachineExtensionsListResult: msRest.CompositeMapper = {
   }
 };
 
-export const PurchasePlan: msRest.CompositeMapper = {
+export const PurchasePlan: coreHttp.CompositeMapper = {
   serializedName: "PurchasePlan",
   type: {
     name: "Composite",
@@ -684,7 +684,7 @@ export const PurchasePlan: msRest.CompositeMapper = {
   }
 };
 
-export const OSDiskImage: msRest.CompositeMapper = {
+export const OSDiskImage: coreHttp.CompositeMapper = {
   serializedName: "OSDiskImage",
   type: {
     name: "Composite",
@@ -705,7 +705,7 @@ export const OSDiskImage: msRest.CompositeMapper = {
   }
 };
 
-export const DataDiskImage: msRest.CompositeMapper = {
+export const DataDiskImage: coreHttp.CompositeMapper = {
   serializedName: "DataDiskImage",
   type: {
     name: "Composite",
@@ -722,7 +722,7 @@ export const DataDiskImage: msRest.CompositeMapper = {
   }
 };
 
-export const AutomaticOSUpgradeProperties: msRest.CompositeMapper = {
+export const AutomaticOSUpgradeProperties: coreHttp.CompositeMapper = {
   serializedName: "AutomaticOSUpgradeProperties",
   type: {
     name: "Composite",
@@ -739,7 +739,7 @@ export const AutomaticOSUpgradeProperties: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineImage: msRest.CompositeMapper = {
+export const VirtualMachineImage: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineImage",
   type: {
     name: "Composite",
@@ -783,7 +783,7 @@ export const VirtualMachineImage: msRest.CompositeMapper = {
   }
 };
 
-export const UsageName: msRest.CompositeMapper = {
+export const UsageName: coreHttp.CompositeMapper = {
   serializedName: "UsageName",
   type: {
     name: "Composite",
@@ -805,7 +805,7 @@ export const UsageName: msRest.CompositeMapper = {
   }
 };
 
-export const Usage: msRest.CompositeMapper = {
+export const Usage: coreHttp.CompositeMapper = {
   serializedName: "Usage",
   type: {
     name: "Composite",
@@ -846,7 +846,7 @@ export const Usage: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineReimageParameters: msRest.CompositeMapper = {
+export const VirtualMachineReimageParameters: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineReimageParameters",
   type: {
     name: "Composite",
@@ -862,7 +862,7 @@ export const VirtualMachineReimageParameters: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineCaptureParameters: msRest.CompositeMapper = {
+export const VirtualMachineCaptureParameters: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineCaptureParameters",
   type: {
     name: "Composite",
@@ -893,7 +893,7 @@ export const VirtualMachineCaptureParameters: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineCaptureResult: msRest.CompositeMapper = {
+export const VirtualMachineCaptureResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineCaptureResult",
   type: {
     name: "Composite",
@@ -937,7 +937,7 @@ export const VirtualMachineCaptureResult: msRest.CompositeMapper = {
   }
 };
 
-export const Plan: msRest.CompositeMapper = {
+export const Plan: coreHttp.CompositeMapper = {
   serializedName: "Plan",
   type: {
     name: "Composite",
@@ -971,7 +971,7 @@ export const Plan: msRest.CompositeMapper = {
   }
 };
 
-export const HardwareProfile: msRest.CompositeMapper = {
+export const HardwareProfile: coreHttp.CompositeMapper = {
   serializedName: "HardwareProfile",
   type: {
     name: "Composite",
@@ -987,7 +987,7 @@ export const HardwareProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ImageReference: msRest.CompositeMapper = {
+export const ImageReference: coreHttp.CompositeMapper = {
   serializedName: "ImageReference",
   type: {
     name: "Composite",
@@ -1022,7 +1022,7 @@ export const ImageReference: msRest.CompositeMapper = {
   }
 };
 
-export const KeyVaultSecretReference: msRest.CompositeMapper = {
+export const KeyVaultSecretReference: coreHttp.CompositeMapper = {
   serializedName: "KeyVaultSecretReference",
   type: {
     name: "Composite",
@@ -1047,7 +1047,7 @@ export const KeyVaultSecretReference: msRest.CompositeMapper = {
   }
 };
 
-export const KeyVaultKeyReference: msRest.CompositeMapper = {
+export const KeyVaultKeyReference: coreHttp.CompositeMapper = {
   serializedName: "KeyVaultKeyReference",
   type: {
     name: "Composite",
@@ -1072,7 +1072,7 @@ export const KeyVaultKeyReference: msRest.CompositeMapper = {
   }
 };
 
-export const DiskEncryptionSettings: msRest.CompositeMapper = {
+export const DiskEncryptionSettings: coreHttp.CompositeMapper = {
   serializedName: "DiskEncryptionSettings",
   type: {
     name: "Composite",
@@ -1102,7 +1102,7 @@ export const DiskEncryptionSettings: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualHardDisk: msRest.CompositeMapper = {
+export const VirtualHardDisk: coreHttp.CompositeMapper = {
   serializedName: "VirtualHardDisk",
   type: {
     name: "Composite",
@@ -1118,7 +1118,7 @@ export const VirtualHardDisk: msRest.CompositeMapper = {
   }
 };
 
-export const DiffDiskSettings: msRest.CompositeMapper = {
+export const DiffDiskSettings: coreHttp.CompositeMapper = {
   serializedName: "DiffDiskSettings",
   type: {
     name: "Composite",
@@ -1134,7 +1134,7 @@ export const DiffDiskSettings: msRest.CompositeMapper = {
   }
 };
 
-export const ManagedDiskParameters: msRest.CompositeMapper = {
+export const ManagedDiskParameters: coreHttp.CompositeMapper = {
   serializedName: "ManagedDiskParameters",
   type: {
     name: "Composite",
@@ -1151,7 +1151,7 @@ export const ManagedDiskParameters: msRest.CompositeMapper = {
   }
 };
 
-export const OSDisk: msRest.CompositeMapper = {
+export const OSDisk: coreHttp.CompositeMapper = {
   serializedName: "OSDisk",
   type: {
     name: "Composite",
@@ -1242,7 +1242,7 @@ export const OSDisk: msRest.CompositeMapper = {
   }
 };
 
-export const DataDisk: msRest.CompositeMapper = {
+export const DataDisk: coreHttp.CompositeMapper = {
   serializedName: "DataDisk",
   type: {
     name: "Composite",
@@ -1316,7 +1316,7 @@ export const DataDisk: msRest.CompositeMapper = {
   }
 };
 
-export const StorageProfile: msRest.CompositeMapper = {
+export const StorageProfile: coreHttp.CompositeMapper = {
   serializedName: "StorageProfile",
   type: {
     name: "Composite",
@@ -1352,7 +1352,7 @@ export const StorageProfile: msRest.CompositeMapper = {
   }
 };
 
-export const AdditionalCapabilities: msRest.CompositeMapper = {
+export const AdditionalCapabilities: coreHttp.CompositeMapper = {
   serializedName: "AdditionalCapabilities",
   type: {
     name: "Composite",
@@ -1368,7 +1368,7 @@ export const AdditionalCapabilities: msRest.CompositeMapper = {
   }
 };
 
-export const AdditionalUnattendContent: msRest.CompositeMapper = {
+export const AdditionalUnattendContent: coreHttp.CompositeMapper = {
   serializedName: "AdditionalUnattendContent",
   type: {
     name: "Composite",
@@ -1412,7 +1412,7 @@ export const AdditionalUnattendContent: msRest.CompositeMapper = {
   }
 };
 
-export const WinRMListener: msRest.CompositeMapper = {
+export const WinRMListener: coreHttp.CompositeMapper = {
   serializedName: "WinRMListener",
   type: {
     name: "Composite",
@@ -1438,7 +1438,7 @@ export const WinRMListener: msRest.CompositeMapper = {
   }
 };
 
-export const WinRMConfiguration: msRest.CompositeMapper = {
+export const WinRMConfiguration: coreHttp.CompositeMapper = {
   serializedName: "WinRMConfiguration",
   type: {
     name: "Composite",
@@ -1460,7 +1460,7 @@ export const WinRMConfiguration: msRest.CompositeMapper = {
   }
 };
 
-export const WindowsConfiguration: msRest.CompositeMapper = {
+export const WindowsConfiguration: coreHttp.CompositeMapper = {
   serializedName: "WindowsConfiguration",
   type: {
     name: "Composite",
@@ -1507,7 +1507,7 @@ export const WindowsConfiguration: msRest.CompositeMapper = {
   }
 };
 
-export const SshPublicKey: msRest.CompositeMapper = {
+export const SshPublicKey: coreHttp.CompositeMapper = {
   serializedName: "SshPublicKey",
   type: {
     name: "Composite",
@@ -1529,7 +1529,7 @@ export const SshPublicKey: msRest.CompositeMapper = {
   }
 };
 
-export const SshConfiguration: msRest.CompositeMapper = {
+export const SshConfiguration: coreHttp.CompositeMapper = {
   serializedName: "SshConfiguration",
   type: {
     name: "Composite",
@@ -1551,7 +1551,7 @@ export const SshConfiguration: msRest.CompositeMapper = {
   }
 };
 
-export const LinuxConfiguration: msRest.CompositeMapper = {
+export const LinuxConfiguration: coreHttp.CompositeMapper = {
   serializedName: "LinuxConfiguration",
   type: {
     name: "Composite",
@@ -1580,7 +1580,7 @@ export const LinuxConfiguration: msRest.CompositeMapper = {
   }
 };
 
-export const VaultCertificate: msRest.CompositeMapper = {
+export const VaultCertificate: coreHttp.CompositeMapper = {
   serializedName: "VaultCertificate",
   type: {
     name: "Composite",
@@ -1602,7 +1602,7 @@ export const VaultCertificate: msRest.CompositeMapper = {
   }
 };
 
-export const VaultSecretGroup: msRest.CompositeMapper = {
+export const VaultSecretGroup: coreHttp.CompositeMapper = {
   serializedName: "VaultSecretGroup",
   type: {
     name: "Composite",
@@ -1631,7 +1631,7 @@ export const VaultSecretGroup: msRest.CompositeMapper = {
   }
 };
 
-export const OSProfile: msRest.CompositeMapper = {
+export const OSProfile: coreHttp.CompositeMapper = {
   serializedName: "OSProfile",
   type: {
     name: "Composite",
@@ -1697,7 +1697,7 @@ export const OSProfile: msRest.CompositeMapper = {
   }
 };
 
-export const NetworkInterfaceReference: msRest.CompositeMapper = {
+export const NetworkInterfaceReference: coreHttp.CompositeMapper = {
   serializedName: "NetworkInterfaceReference",
   type: {
     name: "Composite",
@@ -1714,7 +1714,7 @@ export const NetworkInterfaceReference: msRest.CompositeMapper = {
   }
 };
 
-export const NetworkProfile: msRest.CompositeMapper = {
+export const NetworkProfile: coreHttp.CompositeMapper = {
   serializedName: "NetworkProfile",
   type: {
     name: "Composite",
@@ -1736,7 +1736,7 @@ export const NetworkProfile: msRest.CompositeMapper = {
   }
 };
 
-export const BootDiagnostics: msRest.CompositeMapper = {
+export const BootDiagnostics: coreHttp.CompositeMapper = {
   serializedName: "BootDiagnostics",
   type: {
     name: "Composite",
@@ -1758,7 +1758,7 @@ export const BootDiagnostics: msRest.CompositeMapper = {
   }
 };
 
-export const DiagnosticsProfile: msRest.CompositeMapper = {
+export const DiagnosticsProfile: coreHttp.CompositeMapper = {
   serializedName: "DiagnosticsProfile",
   type: {
     name: "Composite",
@@ -1775,7 +1775,7 @@ export const DiagnosticsProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineExtensionHandlerInstanceView: msRest.CompositeMapper = {
+export const VirtualMachineExtensionHandlerInstanceView: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineExtensionHandlerInstanceView",
   type: {
     name: "Composite",
@@ -1804,7 +1804,7 @@ export const VirtualMachineExtensionHandlerInstanceView: msRest.CompositeMapper 
   }
 };
 
-export const VirtualMachineAgentInstanceView: msRest.CompositeMapper = {
+export const VirtualMachineAgentInstanceView: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineAgentInstanceView",
   type: {
     name: "Composite",
@@ -1844,7 +1844,7 @@ export const VirtualMachineAgentInstanceView: msRest.CompositeMapper = {
   }
 };
 
-export const DiskInstanceView: msRest.CompositeMapper = {
+export const DiskInstanceView: coreHttp.CompositeMapper = {
   serializedName: "DiskInstanceView",
   type: {
     name: "Composite",
@@ -1884,7 +1884,7 @@ export const DiskInstanceView: msRest.CompositeMapper = {
   }
 };
 
-export const BootDiagnosticsInstanceView: msRest.CompositeMapper = {
+export const BootDiagnosticsInstanceView: coreHttp.CompositeMapper = {
   serializedName: "BootDiagnosticsInstanceView",
   type: {
     name: "Composite",
@@ -1916,7 +1916,7 @@ export const BootDiagnosticsInstanceView: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineIdentityUserAssignedIdentitiesValue: msRest.CompositeMapper = {
+export const VirtualMachineIdentityUserAssignedIdentitiesValue: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineIdentity_userAssignedIdentitiesValue",
   type: {
     name: "Composite",
@@ -1940,7 +1940,7 @@ export const VirtualMachineIdentityUserAssignedIdentitiesValue: msRest.Composite
   }
 };
 
-export const VirtualMachineIdentity: msRest.CompositeMapper = {
+export const VirtualMachineIdentity: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineIdentity",
   type: {
     name: "Composite",
@@ -1988,7 +1988,7 @@ export const VirtualMachineIdentity: msRest.CompositeMapper = {
   }
 };
 
-export const MaintenanceRedeployStatus: msRest.CompositeMapper = {
+export const MaintenanceRedeployStatus: coreHttp.CompositeMapper = {
   serializedName: "MaintenanceRedeployStatus",
   type: {
     name: "Composite",
@@ -2046,7 +2046,7 @@ export const MaintenanceRedeployStatus: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineInstanceView: msRest.CompositeMapper = {
+export const VirtualMachineInstanceView: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineInstanceView",
   type: {
     name: "Composite",
@@ -2149,7 +2149,7 @@ export const VirtualMachineInstanceView: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachine: msRest.CompositeMapper = {
+export const VirtualMachine: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachine",
   type: {
     name: "Composite",
@@ -2275,7 +2275,7 @@ export const VirtualMachine: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineUpdate: msRest.CompositeMapper = {
+export const VirtualMachineUpdate: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineUpdate",
   type: {
     name: "Composite",
@@ -2388,7 +2388,7 @@ export const VirtualMachineUpdate: msRest.CompositeMapper = {
   }
 };
 
-export const AutomaticOSUpgradePolicy: msRest.CompositeMapper = {
+export const AutomaticOSUpgradePolicy: coreHttp.CompositeMapper = {
   serializedName: "AutomaticOSUpgradePolicy",
   type: {
     name: "Composite",
@@ -2410,7 +2410,7 @@ export const AutomaticOSUpgradePolicy: msRest.CompositeMapper = {
   }
 };
 
-export const RollingUpgradePolicy: msRest.CompositeMapper = {
+export const RollingUpgradePolicy: coreHttp.CompositeMapper = {
   serializedName: "RollingUpgradePolicy",
   type: {
     name: "Composite",
@@ -2456,7 +2456,7 @@ export const RollingUpgradePolicy: msRest.CompositeMapper = {
   }
 };
 
-export const UpgradePolicy: msRest.CompositeMapper = {
+export const UpgradePolicy: coreHttp.CompositeMapper = {
   serializedName: "UpgradePolicy",
   type: {
     name: "Composite",
@@ -2491,7 +2491,7 @@ export const UpgradePolicy: msRest.CompositeMapper = {
   }
 };
 
-export const ImageOSDisk: msRest.CompositeMapper = {
+export const ImageOSDisk: coreHttp.CompositeMapper = {
   serializedName: "ImageOSDisk",
   type: {
     name: "Composite",
@@ -2566,7 +2566,7 @@ export const ImageOSDisk: msRest.CompositeMapper = {
   }
 };
 
-export const ImageDataDisk: msRest.CompositeMapper = {
+export const ImageDataDisk: coreHttp.CompositeMapper = {
   serializedName: "ImageDataDisk",
   type: {
     name: "Composite",
@@ -2626,7 +2626,7 @@ export const ImageDataDisk: msRest.CompositeMapper = {
   }
 };
 
-export const ImageStorageProfile: msRest.CompositeMapper = {
+export const ImageStorageProfile: coreHttp.CompositeMapper = {
   serializedName: "ImageStorageProfile",
   type: {
     name: "Composite",
@@ -2661,7 +2661,7 @@ export const ImageStorageProfile: msRest.CompositeMapper = {
   }
 };
 
-export const Image: msRest.CompositeMapper = {
+export const Image: coreHttp.CompositeMapper = {
   serializedName: "Image",
   type: {
     name: "Composite",
@@ -2693,7 +2693,7 @@ export const Image: msRest.CompositeMapper = {
   }
 };
 
-export const ImageUpdate: msRest.CompositeMapper = {
+export const ImageUpdate: coreHttp.CompositeMapper = {
   serializedName: "ImageUpdate",
   type: {
     name: "Composite",
@@ -2725,7 +2725,7 @@ export const ImageUpdate: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetIdentity_userAssignedIdentitiesValue",
   type: {
     name: "Composite",
@@ -2749,7 +2749,7 @@ export const VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue: msRest.C
   }
 };
 
-export const VirtualMachineScaleSetIdentity: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetIdentity: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetIdentity",
   type: {
     name: "Composite",
@@ -2797,7 +2797,7 @@ export const VirtualMachineScaleSetIdentity: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetOSProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetOSProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetOSProfile",
   type: {
     name: "Composite",
@@ -2857,7 +2857,7 @@ export const VirtualMachineScaleSetOSProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetUpdateOSProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdateOSProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdateOSProfile",
   type: {
     name: "Composite",
@@ -2899,7 +2899,7 @@ export const VirtualMachineScaleSetUpdateOSProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetManagedDiskParameters: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetManagedDiskParameters: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetManagedDiskParameters",
   type: {
     name: "Composite",
@@ -2915,7 +2915,7 @@ export const VirtualMachineScaleSetManagedDiskParameters: msRest.CompositeMapper
   }
 };
 
-export const VirtualMachineScaleSetOSDisk: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetOSDisk: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetOSDisk",
   type: {
     name: "Composite",
@@ -3003,7 +3003,7 @@ export const VirtualMachineScaleSetOSDisk: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetUpdateOSDisk: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdateOSDisk: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdateOSDisk",
   type: {
     name: "Composite",
@@ -3061,7 +3061,7 @@ export const VirtualMachineScaleSetUpdateOSDisk: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetDataDisk: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetDataDisk: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetDataDisk",
   type: {
     name: "Composite",
@@ -3121,7 +3121,7 @@ export const VirtualMachineScaleSetDataDisk: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetStorageProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetStorageProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetStorageProfile",
   type: {
     name: "Composite",
@@ -3157,7 +3157,7 @@ export const VirtualMachineScaleSetStorageProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetUpdateStorageProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdateStorageProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdateStorageProfile",
   type: {
     name: "Composite",
@@ -3193,7 +3193,7 @@ export const VirtualMachineScaleSetUpdateStorageProfile: msRest.CompositeMapper 
   }
 };
 
-export const ApiEntityReference: msRest.CompositeMapper = {
+export const ApiEntityReference: coreHttp.CompositeMapper = {
   serializedName: "ApiEntityReference",
   type: {
     name: "Composite",
@@ -3209,7 +3209,7 @@ export const ApiEntityReference: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings",
   type: {
     name: "Composite",
@@ -3226,7 +3226,7 @@ export const VirtualMachineScaleSetPublicIPAddressConfigurationDnsSettings: msRe
   }
 };
 
-export const VirtualMachineScaleSetIpTag: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetIpTag: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetIpTag",
   type: {
     name: "Composite",
@@ -3248,7 +3248,7 @@ export const VirtualMachineScaleSetIpTag: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetPublicIPAddressConfiguration: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetPublicIPAddressConfiguration: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetPublicIPAddressConfiguration",
   type: {
     name: "Composite",
@@ -3297,7 +3297,7 @@ export const VirtualMachineScaleSetPublicIPAddressConfiguration: msRest.Composit
   }
 };
 
-export const VirtualMachineScaleSetUpdatePublicIPAddressConfiguration: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdatePublicIPAddressConfiguration: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdatePublicIPAddressConfiguration",
   type: {
     name: "Composite",
@@ -3326,7 +3326,7 @@ export const VirtualMachineScaleSetUpdatePublicIPAddressConfiguration: msRest.Co
   }
 };
 
-export const VirtualMachineScaleSetIPConfiguration: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetIPConfiguration: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetIPConfiguration",
   type: {
     name: "Composite",
@@ -3418,7 +3418,7 @@ export const VirtualMachineScaleSetIPConfiguration: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetUpdateIPConfiguration: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdateIPConfiguration: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdateIPConfiguration",
   type: {
     name: "Composite",
@@ -3509,7 +3509,7 @@ export const VirtualMachineScaleSetUpdateIPConfiguration: msRest.CompositeMapper
   }
 };
 
-export const VirtualMachineScaleSetNetworkConfigurationDnsSettings: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetNetworkConfigurationDnsSettings: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetNetworkConfigurationDnsSettings",
   type: {
     name: "Composite",
@@ -3530,7 +3530,7 @@ export const VirtualMachineScaleSetNetworkConfigurationDnsSettings: msRest.Compo
   }
 };
 
-export const VirtualMachineScaleSetNetworkConfiguration: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetNetworkConfiguration: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetNetworkConfiguration",
   type: {
     name: "Composite",
@@ -3593,7 +3593,7 @@ export const VirtualMachineScaleSetNetworkConfiguration: msRest.CompositeMapper 
   }
 };
 
-export const VirtualMachineScaleSetUpdateNetworkConfiguration: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdateNetworkConfiguration: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdateNetworkConfiguration",
   type: {
     name: "Composite",
@@ -3654,7 +3654,7 @@ export const VirtualMachineScaleSetUpdateNetworkConfiguration: msRest.CompositeM
   }
 };
 
-export const VirtualMachineScaleSetNetworkProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetNetworkProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetNetworkProfile",
   type: {
     name: "Composite",
@@ -3683,7 +3683,7 @@ export const VirtualMachineScaleSetNetworkProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetUpdateNetworkProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdateNetworkProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdateNetworkProfile",
   type: {
     name: "Composite",
@@ -3705,7 +3705,7 @@ export const VirtualMachineScaleSetUpdateNetworkProfile: msRest.CompositeMapper 
   }
 };
 
-export const SubResourceReadOnly: msRest.CompositeMapper = {
+export const SubResourceReadOnly: coreHttp.CompositeMapper = {
   serializedName: "SubResourceReadOnly",
   type: {
     name: "Composite",
@@ -3722,7 +3722,7 @@ export const SubResourceReadOnly: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetExtension: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetExtension: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetExtension",
   type: {
     name: "Composite",
@@ -3799,7 +3799,7 @@ export const VirtualMachineScaleSetExtension: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetExtensionProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetExtensionProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetExtensionProfile",
   type: {
     name: "Composite",
@@ -3821,7 +3821,7 @@ export const VirtualMachineScaleSetExtensionProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetVMProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMProfile",
   type: {
     name: "Composite",
@@ -3891,7 +3891,7 @@ export const VirtualMachineScaleSetVMProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetUpdateVMProfile: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdateVMProfile: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdateVMProfile",
   type: {
     name: "Composite",
@@ -3942,7 +3942,7 @@ export const VirtualMachineScaleSetUpdateVMProfile: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSet: msRest.CompositeMapper = {
+export const VirtualMachineScaleSet: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSet",
   type: {
     name: "Composite",
@@ -4043,7 +4043,7 @@ export const VirtualMachineScaleSet: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetVMReimageParameters: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMReimageParameters: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMReimageParameters",
   type: {
     name: "Composite",
@@ -4054,7 +4054,7 @@ export const VirtualMachineScaleSetVMReimageParameters: msRest.CompositeMapper =
   }
 };
 
-export const VirtualMachineScaleSetReimageParameters: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetReimageParameters: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetReimageParameters",
   type: {
     name: "Composite",
@@ -4076,7 +4076,7 @@ export const VirtualMachineScaleSetReimageParameters: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetUpdate: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetUpdate: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetUpdate",
   type: {
     name: "Composite",
@@ -4134,7 +4134,7 @@ export const VirtualMachineScaleSetUpdate: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetVMInstanceIDs: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMInstanceIDs: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMInstanceIDs",
   type: {
     name: "Composite",
@@ -4155,7 +4155,7 @@ export const VirtualMachineScaleSetVMInstanceIDs: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetVMInstanceRequiredIDs: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMInstanceRequiredIDs: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMInstanceRequiredIDs",
   type: {
     name: "Composite",
@@ -4177,7 +4177,7 @@ export const VirtualMachineScaleSetVMInstanceRequiredIDs: msRest.CompositeMapper
   }
 };
 
-export const VirtualMachineStatusCodeCount: msRest.CompositeMapper = {
+export const VirtualMachineStatusCodeCount: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineStatusCodeCount",
   type: {
     name: "Composite",
@@ -4201,7 +4201,7 @@ export const VirtualMachineStatusCodeCount: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetInstanceViewStatusesSummary: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetInstanceViewStatusesSummary: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetInstanceViewStatusesSummary",
   type: {
     name: "Composite",
@@ -4224,7 +4224,7 @@ export const VirtualMachineScaleSetInstanceViewStatusesSummary: msRest.Composite
   }
 };
 
-export const VirtualMachineScaleSetVMExtensionsSummary: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMExtensionsSummary: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMExtensionsSummary",
   type: {
     name: "Composite",
@@ -4254,7 +4254,7 @@ export const VirtualMachineScaleSetVMExtensionsSummary: msRest.CompositeMapper =
   }
 };
 
-export const VirtualMachineScaleSetInstanceView: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetInstanceView: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetInstanceView",
   type: {
     name: "Composite",
@@ -4297,7 +4297,7 @@ export const VirtualMachineScaleSetInstanceView: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetSkuCapacity: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetSkuCapacity: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetSkuCapacity",
   type: {
     name: "Composite",
@@ -4339,7 +4339,7 @@ export const VirtualMachineScaleSetSkuCapacity: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetSku: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetSku: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetSku",
   type: {
     name: "Composite",
@@ -4372,7 +4372,7 @@ export const VirtualMachineScaleSetSku: msRest.CompositeMapper = {
   }
 };
 
-export const ApiErrorBase: msRest.CompositeMapper = {
+export const ApiErrorBase: coreHttp.CompositeMapper = {
   serializedName: "ApiErrorBase",
   type: {
     name: "Composite",
@@ -4400,7 +4400,7 @@ export const ApiErrorBase: msRest.CompositeMapper = {
   }
 };
 
-export const InnerError: msRest.CompositeMapper = {
+export const InnerError: coreHttp.CompositeMapper = {
   serializedName: "InnerError",
   type: {
     name: "Composite",
@@ -4422,7 +4422,7 @@ export const InnerError: msRest.CompositeMapper = {
   }
 };
 
-export const ApiError: msRest.CompositeMapper = {
+export const ApiError: coreHttp.CompositeMapper = {
   serializedName: "ApiError",
   type: {
     name: "Composite",
@@ -4469,7 +4469,7 @@ export const ApiError: msRest.CompositeMapper = {
   }
 };
 
-export const RollbackStatusInfo: msRest.CompositeMapper = {
+export const RollbackStatusInfo: coreHttp.CompositeMapper = {
   serializedName: "RollbackStatusInfo",
   type: {
     name: "Composite",
@@ -4501,7 +4501,7 @@ export const RollbackStatusInfo: msRest.CompositeMapper = {
   }
 };
 
-export const UpgradeOperationHistoryStatus: msRest.CompositeMapper = {
+export const UpgradeOperationHistoryStatus: coreHttp.CompositeMapper = {
   serializedName: "UpgradeOperationHistoryStatus",
   type: {
     name: "Composite",
@@ -4538,7 +4538,7 @@ export const UpgradeOperationHistoryStatus: msRest.CompositeMapper = {
   }
 };
 
-export const RollingUpgradeProgressInfo: msRest.CompositeMapper = {
+export const RollingUpgradeProgressInfo: coreHttp.CompositeMapper = {
   serializedName: "RollingUpgradeProgressInfo",
   type: {
     name: "Composite",
@@ -4576,7 +4576,7 @@ export const RollingUpgradeProgressInfo: msRest.CompositeMapper = {
   }
 };
 
-export const UpgradeOperationHistoricalStatusInfoProperties: msRest.CompositeMapper = {
+export const UpgradeOperationHistoricalStatusInfoProperties: coreHttp.CompositeMapper = {
   serializedName: "UpgradeOperationHistoricalStatusInfoProperties",
   type: {
     name: "Composite",
@@ -4638,7 +4638,7 @@ export const UpgradeOperationHistoricalStatusInfoProperties: msRest.CompositeMap
   }
 };
 
-export const UpgradeOperationHistoricalStatusInfo: msRest.CompositeMapper = {
+export const UpgradeOperationHistoricalStatusInfo: coreHttp.CompositeMapper = {
   serializedName: "UpgradeOperationHistoricalStatusInfo",
   type: {
     name: "Composite",
@@ -4670,7 +4670,7 @@ export const UpgradeOperationHistoricalStatusInfo: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineHealthStatus: msRest.CompositeMapper = {
+export const VirtualMachineHealthStatus: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineHealthStatus",
   type: {
     name: "Composite",
@@ -4688,7 +4688,7 @@ export const VirtualMachineHealthStatus: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetVMInstanceView: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMInstanceView: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMInstanceView",
   type: {
     name: "Composite",
@@ -4787,7 +4787,7 @@ export const VirtualMachineScaleSetVMInstanceView: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetVMNetworkProfileConfiguration: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMNetworkProfileConfiguration: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMNetworkProfileConfiguration",
   type: {
     name: "Composite",
@@ -4809,7 +4809,7 @@ export const VirtualMachineScaleSetVMNetworkProfileConfiguration: msRest.Composi
   }
 };
 
-export const VirtualMachineScaleSetVMProtectionPolicy: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMProtectionPolicy: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMProtectionPolicy",
   type: {
     name: "Composite",
@@ -4831,7 +4831,7 @@ export const VirtualMachineScaleSetVMProtectionPolicy: msRest.CompositeMapper = 
   }
 };
 
-export const VirtualMachineScaleSetVM: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVM: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVM",
   type: {
     name: "Composite",
@@ -4994,7 +4994,7 @@ export const VirtualMachineScaleSetVM: msRest.CompositeMapper = {
   }
 };
 
-export const RollingUpgradeRunningStatus: msRest.CompositeMapper = {
+export const RollingUpgradeRunningStatus: coreHttp.CompositeMapper = {
   serializedName: "RollingUpgradeRunningStatus",
   type: {
     name: "Composite",
@@ -5042,7 +5042,7 @@ export const RollingUpgradeRunningStatus: msRest.CompositeMapper = {
   }
 };
 
-export const RollingUpgradeStatusInfo: msRest.CompositeMapper = {
+export const RollingUpgradeStatusInfo: coreHttp.CompositeMapper = {
   serializedName: "RollingUpgradeStatusInfo",
   type: {
     name: "Composite",
@@ -5085,7 +5085,7 @@ export const RollingUpgradeStatusInfo: msRest.CompositeMapper = {
   }
 };
 
-export const RecoveryWalkResponse: msRest.CompositeMapper = {
+export const RecoveryWalkResponse: coreHttp.CompositeMapper = {
   serializedName: "RecoveryWalkResponse",
   type: {
     name: "Composite",
@@ -5109,7 +5109,7 @@ export const RecoveryWalkResponse: msRest.CompositeMapper = {
   }
 };
 
-export const LogAnalyticsInputBase: msRest.CompositeMapper = {
+export const LogAnalyticsInputBase: coreHttp.CompositeMapper = {
   serializedName: "LogAnalyticsInputBase",
   type: {
     name: "Composite",
@@ -5158,7 +5158,7 @@ export const LogAnalyticsInputBase: msRest.CompositeMapper = {
   }
 };
 
-export const RequestRateByIntervalInput: msRest.CompositeMapper = {
+export const RequestRateByIntervalInput: coreHttp.CompositeMapper = {
   serializedName: "RequestRateByIntervalInput",
   type: {
     name: "Composite",
@@ -5182,7 +5182,7 @@ export const RequestRateByIntervalInput: msRest.CompositeMapper = {
   }
 };
 
-export const ThrottledRequestsInput: msRest.CompositeMapper = {
+export const ThrottledRequestsInput: coreHttp.CompositeMapper = {
   serializedName: "ThrottledRequestsInput",
   type: {
     name: "Composite",
@@ -5193,7 +5193,7 @@ export const ThrottledRequestsInput: msRest.CompositeMapper = {
   }
 };
 
-export const LogAnalyticsOutput: msRest.CompositeMapper = {
+export const LogAnalyticsOutput: coreHttp.CompositeMapper = {
   serializedName: "LogAnalyticsOutput",
   type: {
     name: "Composite",
@@ -5210,7 +5210,7 @@ export const LogAnalyticsOutput: msRest.CompositeMapper = {
   }
 };
 
-export const LogAnalyticsOperationResult: msRest.CompositeMapper = {
+export const LogAnalyticsOperationResult: coreHttp.CompositeMapper = {
   serializedName: "LogAnalyticsOperationResult",
   type: {
     name: "Composite",
@@ -5228,7 +5228,7 @@ export const LogAnalyticsOperationResult: msRest.CompositeMapper = {
   }
 };
 
-export const VMScaleSetConvertToSinglePlacementGroupInput: msRest.CompositeMapper = {
+export const VMScaleSetConvertToSinglePlacementGroupInput: coreHttp.CompositeMapper = {
   serializedName: "VMScaleSetConvertToSinglePlacementGroupInput",
   type: {
     name: "Composite",
@@ -5244,7 +5244,7 @@ export const VMScaleSetConvertToSinglePlacementGroupInput: msRest.CompositeMappe
   }
 };
 
-export const RunCommandInputParameter: msRest.CompositeMapper = {
+export const RunCommandInputParameter: coreHttp.CompositeMapper = {
   serializedName: "RunCommandInputParameter",
   type: {
     name: "Composite",
@@ -5268,7 +5268,7 @@ export const RunCommandInputParameter: msRest.CompositeMapper = {
   }
 };
 
-export const RunCommandInput: msRest.CompositeMapper = {
+export const RunCommandInput: coreHttp.CompositeMapper = {
   serializedName: "RunCommandInput",
   type: {
     name: "Composite",
@@ -5308,7 +5308,7 @@ export const RunCommandInput: msRest.CompositeMapper = {
   }
 };
 
-export const RunCommandParameterDefinition: msRest.CompositeMapper = {
+export const RunCommandParameterDefinition: coreHttp.CompositeMapper = {
   serializedName: "RunCommandParameterDefinition",
   type: {
     name: "Composite",
@@ -5345,7 +5345,7 @@ export const RunCommandParameterDefinition: msRest.CompositeMapper = {
   }
 };
 
-export const RunCommandDocumentBase: msRest.CompositeMapper = {
+export const RunCommandDocumentBase: coreHttp.CompositeMapper = {
   serializedName: "RunCommandDocumentBase",
   type: {
     name: "Composite",
@@ -5394,7 +5394,7 @@ export const RunCommandDocumentBase: msRest.CompositeMapper = {
   }
 };
 
-export const RunCommandDocument: msRest.CompositeMapper = {
+export const RunCommandDocument: coreHttp.CompositeMapper = {
   serializedName: "RunCommandDocument",
   type: {
     name: "Composite",
@@ -5429,7 +5429,7 @@ export const RunCommandDocument: msRest.CompositeMapper = {
   }
 };
 
-export const RunCommandResult: msRest.CompositeMapper = {
+export const RunCommandResult: coreHttp.CompositeMapper = {
   serializedName: "RunCommandResult",
   type: {
     name: "Composite",
@@ -5451,7 +5451,7 @@ export const RunCommandResult: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSkuCapacity: msRest.CompositeMapper = {
+export const ResourceSkuCapacity: coreHttp.CompositeMapper = {
   serializedName: "ResourceSkuCapacity",
   type: {
     name: "Composite",
@@ -5494,7 +5494,7 @@ export const ResourceSkuCapacity: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSkuCosts: msRest.CompositeMapper = {
+export const ResourceSkuCosts: coreHttp.CompositeMapper = {
   serializedName: "ResourceSkuCosts",
   type: {
     name: "Composite",
@@ -5525,7 +5525,7 @@ export const ResourceSkuCosts: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSkuCapabilities: msRest.CompositeMapper = {
+export const ResourceSkuCapabilities: coreHttp.CompositeMapper = {
   serializedName: "ResourceSkuCapabilities",
   type: {
     name: "Composite",
@@ -5549,7 +5549,7 @@ export const ResourceSkuCapabilities: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSkuRestrictionInfo: msRest.CompositeMapper = {
+export const ResourceSkuRestrictionInfo: coreHttp.CompositeMapper = {
   serializedName: "ResourceSkuRestrictionInfo",
   type: {
     name: "Composite",
@@ -5583,7 +5583,7 @@ export const ResourceSkuRestrictionInfo: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSkuRestrictions: msRest.CompositeMapper = {
+export const ResourceSkuRestrictions: coreHttp.CompositeMapper = {
   serializedName: "ResourceSkuRestrictions",
   type: {
     name: "Composite",
@@ -5635,7 +5635,7 @@ export const ResourceSkuRestrictions: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSkuLocationInfo: msRest.CompositeMapper = {
+export const ResourceSkuLocationInfo: coreHttp.CompositeMapper = {
   serializedName: "ResourceSkuLocationInfo",
   type: {
     name: "Composite",
@@ -5664,7 +5664,7 @@ export const ResourceSkuLocationInfo: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSku: msRest.CompositeMapper = {
+export const ResourceSku: coreHttp.CompositeMapper = {
   serializedName: "ResourceSku",
   type: {
     name: "Composite",
@@ -5800,7 +5800,7 @@ export const ResourceSku: msRest.CompositeMapper = {
   }
 };
 
-export const DiskSku: msRest.CompositeMapper = {
+export const DiskSku: coreHttp.CompositeMapper = {
   serializedName: "DiskSku",
   type: {
     name: "Composite",
@@ -5824,7 +5824,7 @@ export const DiskSku: msRest.CompositeMapper = {
   }
 };
 
-export const ImageDiskReference: msRest.CompositeMapper = {
+export const ImageDiskReference: coreHttp.CompositeMapper = {
   serializedName: "ImageDiskReference",
   type: {
     name: "Composite",
@@ -5847,7 +5847,7 @@ export const ImageDiskReference: msRest.CompositeMapper = {
   }
 };
 
-export const CreationData: msRest.CompositeMapper = {
+export const CreationData: coreHttp.CompositeMapper = {
   serializedName: "CreationData",
   type: {
     name: "Composite",
@@ -5889,7 +5889,7 @@ export const CreationData: msRest.CompositeMapper = {
   }
 };
 
-export const SourceVault: msRest.CompositeMapper = {
+export const SourceVault: coreHttp.CompositeMapper = {
   serializedName: "SourceVault",
   type: {
     name: "Composite",
@@ -5905,7 +5905,7 @@ export const SourceVault: msRest.CompositeMapper = {
   }
 };
 
-export const KeyVaultAndSecretReference: msRest.CompositeMapper = {
+export const KeyVaultAndSecretReference: coreHttp.CompositeMapper = {
   serializedName: "KeyVaultAndSecretReference",
   type: {
     name: "Composite",
@@ -5930,7 +5930,7 @@ export const KeyVaultAndSecretReference: msRest.CompositeMapper = {
   }
 };
 
-export const KeyVaultAndKeyReference: msRest.CompositeMapper = {
+export const KeyVaultAndKeyReference: coreHttp.CompositeMapper = {
   serializedName: "KeyVaultAndKeyReference",
   type: {
     name: "Composite",
@@ -5955,7 +5955,7 @@ export const KeyVaultAndKeyReference: msRest.CompositeMapper = {
   }
 };
 
-export const EncryptionSettingsElement: msRest.CompositeMapper = {
+export const EncryptionSettingsElement: coreHttp.CompositeMapper = {
   serializedName: "EncryptionSettingsElement",
   type: {
     name: "Composite",
@@ -5979,7 +5979,7 @@ export const EncryptionSettingsElement: msRest.CompositeMapper = {
   }
 };
 
-export const EncryptionSettingsCollection: msRest.CompositeMapper = {
+export const EncryptionSettingsCollection: coreHttp.CompositeMapper = {
   serializedName: "EncryptionSettingsCollection",
   type: {
     name: "Composite",
@@ -6008,7 +6008,7 @@ export const EncryptionSettingsCollection: msRest.CompositeMapper = {
   }
 };
 
-export const Disk: msRest.CompositeMapper = {
+export const Disk: coreHttp.CompositeMapper = {
   serializedName: "Disk",
   type: {
     name: "Composite",
@@ -6114,7 +6114,7 @@ export const Disk: msRest.CompositeMapper = {
   }
 };
 
-export const DiskUpdate: msRest.CompositeMapper = {
+export const DiskUpdate: coreHttp.CompositeMapper = {
   serializedName: "DiskUpdate",
   type: {
     name: "Composite",
@@ -6177,7 +6177,7 @@ export const DiskUpdate: msRest.CompositeMapper = {
   }
 };
 
-export const SnapshotSku: msRest.CompositeMapper = {
+export const SnapshotSku: coreHttp.CompositeMapper = {
   serializedName: "SnapshotSku",
   type: {
     name: "Composite",
@@ -6201,7 +6201,7 @@ export const SnapshotSku: msRest.CompositeMapper = {
   }
 };
 
-export const GrantAccessData: msRest.CompositeMapper = {
+export const GrantAccessData: coreHttp.CompositeMapper = {
   serializedName: "GrantAccessData",
   type: {
     name: "Composite",
@@ -6225,7 +6225,7 @@ export const GrantAccessData: msRest.CompositeMapper = {
   }
 };
 
-export const AccessUri: msRest.CompositeMapper = {
+export const AccessUri: coreHttp.CompositeMapper = {
   serializedName: "AccessUri",
   type: {
     name: "Composite",
@@ -6242,7 +6242,7 @@ export const AccessUri: msRest.CompositeMapper = {
   }
 };
 
-export const Snapshot: msRest.CompositeMapper = {
+export const Snapshot: coreHttp.CompositeMapper = {
   serializedName: "Snapshot",
   type: {
     name: "Composite",
@@ -6318,7 +6318,7 @@ export const Snapshot: msRest.CompositeMapper = {
   }
 };
 
-export const SnapshotUpdate: msRest.CompositeMapper = {
+export const SnapshotUpdate: coreHttp.CompositeMapper = {
   serializedName: "SnapshotUpdate",
   type: {
     name: "Composite",
@@ -6369,7 +6369,7 @@ export const SnapshotUpdate: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryIdentifier: msRest.CompositeMapper = {
+export const GalleryIdentifier: coreHttp.CompositeMapper = {
   serializedName: "GalleryIdentifier",
   type: {
     name: "Composite",
@@ -6386,7 +6386,7 @@ export const GalleryIdentifier: msRest.CompositeMapper = {
   }
 };
 
-export const Gallery: msRest.CompositeMapper = {
+export const Gallery: coreHttp.CompositeMapper = {
   serializedName: "Gallery",
   type: {
     name: "Composite",
@@ -6417,7 +6417,7 @@ export const Gallery: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryImageIdentifier: msRest.CompositeMapper = {
+export const GalleryImageIdentifier: coreHttp.CompositeMapper = {
   serializedName: "GalleryImageIdentifier",
   type: {
     name: "Composite",
@@ -6448,7 +6448,7 @@ export const GalleryImageIdentifier: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceRange: msRest.CompositeMapper = {
+export const ResourceRange: coreHttp.CompositeMapper = {
   serializedName: "ResourceRange",
   type: {
     name: "Composite",
@@ -6470,7 +6470,7 @@ export const ResourceRange: msRest.CompositeMapper = {
   }
 };
 
-export const RecommendedMachineConfiguration: msRest.CompositeMapper = {
+export const RecommendedMachineConfiguration: coreHttp.CompositeMapper = {
   serializedName: "RecommendedMachineConfiguration",
   type: {
     name: "Composite",
@@ -6494,7 +6494,7 @@ export const RecommendedMachineConfiguration: msRest.CompositeMapper = {
   }
 };
 
-export const Disallowed: msRest.CompositeMapper = {
+export const Disallowed: coreHttp.CompositeMapper = {
   serializedName: "Disallowed",
   type: {
     name: "Composite",
@@ -6515,7 +6515,7 @@ export const Disallowed: msRest.CompositeMapper = {
   }
 };
 
-export const ImagePurchasePlan: msRest.CompositeMapper = {
+export const ImagePurchasePlan: coreHttp.CompositeMapper = {
   serializedName: "ImagePurchasePlan",
   type: {
     name: "Composite",
@@ -6543,7 +6543,7 @@ export const ImagePurchasePlan: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryImage: msRest.CompositeMapper = {
+export const GalleryImage: coreHttp.CompositeMapper = {
   serializedName: "GalleryImage",
   type: {
     name: "Composite",
@@ -6642,7 +6642,7 @@ export const GalleryImage: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryArtifactPublishingProfileBase: msRest.CompositeMapper = {
+export const GalleryArtifactPublishingProfileBase: coreHttp.CompositeMapper = {
   serializedName: "GalleryArtifactPublishingProfileBase",
   type: {
     name: "Composite",
@@ -6672,7 +6672,7 @@ export const GalleryArtifactPublishingProfileBase: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryImageVersionPublishingProfile: msRest.CompositeMapper = {
+export const GalleryImageVersionPublishingProfile: coreHttp.CompositeMapper = {
   serializedName: "GalleryImageVersionPublishingProfile",
   type: {
     name: "Composite",
@@ -6714,7 +6714,7 @@ export const GalleryImageVersionPublishingProfile: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryDiskImage: msRest.CompositeMapper = {
+export const GalleryDiskImage: coreHttp.CompositeMapper = {
   serializedName: "GalleryDiskImage",
   type: {
     name: "Composite",
@@ -6743,7 +6743,7 @@ export const GalleryDiskImage: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryOSDiskImage: msRest.CompositeMapper = {
+export const GalleryOSDiskImage: coreHttp.CompositeMapper = {
   serializedName: "GalleryOSDiskImage",
   type: {
     name: "Composite",
@@ -6754,7 +6754,7 @@ export const GalleryOSDiskImage: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryDataDiskImage: msRest.CompositeMapper = {
+export const GalleryDataDiskImage: coreHttp.CompositeMapper = {
   serializedName: "GalleryDataDiskImage",
   type: {
     name: "Composite",
@@ -6772,7 +6772,7 @@ export const GalleryDataDiskImage: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryImageVersionStorageProfile: msRest.CompositeMapper = {
+export const GalleryImageVersionStorageProfile: coreHttp.CompositeMapper = {
   serializedName: "GalleryImageVersionStorageProfile",
   type: {
     name: "Composite",
@@ -6803,7 +6803,7 @@ export const GalleryImageVersionStorageProfile: msRest.CompositeMapper = {
   }
 };
 
-export const RegionalReplicationStatus: msRest.CompositeMapper = {
+export const RegionalReplicationStatus: coreHttp.CompositeMapper = {
   serializedName: "RegionalReplicationStatus",
   type: {
     name: "Composite",
@@ -6841,7 +6841,7 @@ export const RegionalReplicationStatus: msRest.CompositeMapper = {
   }
 };
 
-export const ReplicationStatus: msRest.CompositeMapper = {
+export const ReplicationStatus: coreHttp.CompositeMapper = {
   serializedName: "ReplicationStatus",
   type: {
     name: "Composite",
@@ -6871,7 +6871,7 @@ export const ReplicationStatus: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryImageVersion: msRest.CompositeMapper = {
+export const GalleryImageVersion: coreHttp.CompositeMapper = {
   serializedName: "GalleryImageVersion",
   type: {
     name: "Composite",
@@ -6913,7 +6913,7 @@ export const GalleryImageVersion: msRest.CompositeMapper = {
   }
 };
 
-export const TargetRegion: msRest.CompositeMapper = {
+export const TargetRegion: coreHttp.CompositeMapper = {
   serializedName: "TargetRegion",
   type: {
     name: "Composite",
@@ -6942,7 +6942,7 @@ export const TargetRegion: msRest.CompositeMapper = {
   }
 };
 
-export const ManagedArtifact: msRest.CompositeMapper = {
+export const ManagedArtifact: coreHttp.CompositeMapper = {
   serializedName: "ManagedArtifact",
   type: {
     name: "Composite",
@@ -6959,7 +6959,7 @@ export const ManagedArtifact: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryArtifactSource: msRest.CompositeMapper = {
+export const GalleryArtifactSource: coreHttp.CompositeMapper = {
   serializedName: "GalleryArtifactSource",
   type: {
     name: "Composite",
@@ -6977,7 +6977,7 @@ export const GalleryArtifactSource: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceCustomProfile: msRest.CompositeMapper = {
+export const ContainerServiceCustomProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceCustomProfile",
   type: {
     name: "Composite",
@@ -6994,7 +6994,7 @@ export const ContainerServiceCustomProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceServicePrincipalProfile: msRest.CompositeMapper = {
+export const ContainerServiceServicePrincipalProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceServicePrincipalProfile",
   type: {
     name: "Composite",
@@ -7018,7 +7018,7 @@ export const ContainerServiceServicePrincipalProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceOrchestratorProfile: msRest.CompositeMapper = {
+export const ContainerServiceOrchestratorProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceOrchestratorProfile",
   type: {
     name: "Composite",
@@ -7041,7 +7041,7 @@ export const ContainerServiceOrchestratorProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceMasterProfile: msRest.CompositeMapper = {
+export const ContainerServiceMasterProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceMasterProfile",
   type: {
     name: "Composite",
@@ -7072,7 +7072,7 @@ export const ContainerServiceMasterProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceAgentPoolProfile: msRest.CompositeMapper = {
+export const ContainerServiceAgentPoolProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceAgentPoolProfile",
   type: {
     name: "Composite",
@@ -7122,7 +7122,7 @@ export const ContainerServiceAgentPoolProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceWindowsProfile: msRest.CompositeMapper = {
+export const ContainerServiceWindowsProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceWindowsProfile",
   type: {
     name: "Composite",
@@ -7152,7 +7152,7 @@ export const ContainerServiceWindowsProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceSshPublicKey: msRest.CompositeMapper = {
+export const ContainerServiceSshPublicKey: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceSshPublicKey",
   type: {
     name: "Composite",
@@ -7169,7 +7169,7 @@ export const ContainerServiceSshPublicKey: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceSshConfiguration: msRest.CompositeMapper = {
+export const ContainerServiceSshConfiguration: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceSshConfiguration",
   type: {
     name: "Composite",
@@ -7192,7 +7192,7 @@ export const ContainerServiceSshConfiguration: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceLinuxProfile: msRest.CompositeMapper = {
+export const ContainerServiceLinuxProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceLinuxProfile",
   type: {
     name: "Composite",
@@ -7220,7 +7220,7 @@ export const ContainerServiceLinuxProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceVMDiagnostics: msRest.CompositeMapper = {
+export const ContainerServiceVMDiagnostics: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceVMDiagnostics",
   type: {
     name: "Composite",
@@ -7244,7 +7244,7 @@ export const ContainerServiceVMDiagnostics: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceDiagnosticsProfile: msRest.CompositeMapper = {
+export const ContainerServiceDiagnosticsProfile: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceDiagnosticsProfile",
   type: {
     name: "Composite",
@@ -7262,7 +7262,7 @@ export const ContainerServiceDiagnosticsProfile: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerService: msRest.CompositeMapper = {
+export const ContainerService: coreHttp.CompositeMapper = {
   serializedName: "ContainerService",
   type: {
     name: "Composite",
@@ -7344,7 +7344,7 @@ export const ContainerService: msRest.CompositeMapper = {
   }
 };
 
-export const ComputeOperationListResult: msRest.CompositeMapper = {
+export const ComputeOperationListResult: coreHttp.CompositeMapper = {
   serializedName: "ComputeOperationListResult",
   type: {
     name: "Composite",
@@ -7367,7 +7367,7 @@ export const ComputeOperationListResult: msRest.CompositeMapper = {
   }
 };
 
-export const AvailabilitySetListResult: msRest.CompositeMapper = {
+export const AvailabilitySetListResult: coreHttp.CompositeMapper = {
   serializedName: "AvailabilitySetListResult",
   type: {
     name: "Composite",
@@ -7396,7 +7396,7 @@ export const AvailabilitySetListResult: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineSizeListResult: msRest.CompositeMapper = {
+export const VirtualMachineSizeListResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineSizeListResult",
   type: {
     name: "Composite",
@@ -7418,7 +7418,7 @@ export const VirtualMachineSizeListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ListUsagesResult: msRest.CompositeMapper = {
+export const ListUsagesResult: coreHttp.CompositeMapper = {
   serializedName: "ListUsagesResult",
   type: {
     name: "Composite",
@@ -7447,7 +7447,7 @@ export const ListUsagesResult: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineListResult: msRest.CompositeMapper = {
+export const VirtualMachineListResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineListResult",
   type: {
     name: "Composite",
@@ -7476,7 +7476,7 @@ export const VirtualMachineListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ImageListResult: msRest.CompositeMapper = {
+export const ImageListResult: coreHttp.CompositeMapper = {
   serializedName: "ImageListResult",
   type: {
     name: "Composite",
@@ -7505,7 +7505,7 @@ export const ImageListResult: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetListResult: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetListResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetListResult",
   type: {
     name: "Composite",
@@ -7534,7 +7534,7 @@ export const VirtualMachineScaleSetListResult: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetListWithLinkResult: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetListWithLinkResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetListWithLinkResult",
   type: {
     name: "Composite",
@@ -7563,7 +7563,7 @@ export const VirtualMachineScaleSetListWithLinkResult: msRest.CompositeMapper = 
   }
 };
 
-export const VirtualMachineScaleSetListSkusResult: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetListSkusResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetListSkusResult",
   type: {
     name: "Composite",
@@ -7592,7 +7592,7 @@ export const VirtualMachineScaleSetListSkusResult: msRest.CompositeMapper = {
   }
 };
 
-export const VirtualMachineScaleSetListOSUpgradeHistory: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetListOSUpgradeHistory: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetListOSUpgradeHistory",
   type: {
     name: "Composite",
@@ -7621,7 +7621,7 @@ export const VirtualMachineScaleSetListOSUpgradeHistory: msRest.CompositeMapper 
   }
 };
 
-export const VirtualMachineScaleSetExtensionListResult: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetExtensionListResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetExtensionListResult",
   type: {
     name: "Composite",
@@ -7650,7 +7650,7 @@ export const VirtualMachineScaleSetExtensionListResult: msRest.CompositeMapper =
   }
 };
 
-export const VirtualMachineScaleSetVMListResult: msRest.CompositeMapper = {
+export const VirtualMachineScaleSetVMListResult: coreHttp.CompositeMapper = {
   serializedName: "VirtualMachineScaleSetVMListResult",
   type: {
     name: "Composite",
@@ -7679,7 +7679,7 @@ export const VirtualMachineScaleSetVMListResult: msRest.CompositeMapper = {
   }
 };
 
-export const RunCommandListResult: msRest.CompositeMapper = {
+export const RunCommandListResult: coreHttp.CompositeMapper = {
   serializedName: "RunCommandListResult",
   type: {
     name: "Composite",
@@ -7708,7 +7708,7 @@ export const RunCommandListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceSkusResult: msRest.CompositeMapper = {
+export const ResourceSkusResult: coreHttp.CompositeMapper = {
   serializedName: "ResourceSkusResult",
   type: {
     name: "Composite",
@@ -7737,7 +7737,7 @@ export const ResourceSkusResult: msRest.CompositeMapper = {
   }
 };
 
-export const DiskList: msRest.CompositeMapper = {
+export const DiskList: coreHttp.CompositeMapper = {
   serializedName: "DiskList",
   type: {
     name: "Composite",
@@ -7766,7 +7766,7 @@ export const DiskList: msRest.CompositeMapper = {
   }
 };
 
-export const SnapshotList: msRest.CompositeMapper = {
+export const SnapshotList: coreHttp.CompositeMapper = {
   serializedName: "SnapshotList",
   type: {
     name: "Composite",
@@ -7795,7 +7795,7 @@ export const SnapshotList: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryList: msRest.CompositeMapper = {
+export const GalleryList: coreHttp.CompositeMapper = {
   serializedName: "GalleryList",
   type: {
     name: "Composite",
@@ -7824,7 +7824,7 @@ export const GalleryList: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryImageList: msRest.CompositeMapper = {
+export const GalleryImageList: coreHttp.CompositeMapper = {
   serializedName: "GalleryImageList",
   type: {
     name: "Composite",
@@ -7853,7 +7853,7 @@ export const GalleryImageList: msRest.CompositeMapper = {
   }
 };
 
-export const GalleryImageVersionList: msRest.CompositeMapper = {
+export const GalleryImageVersionList: coreHttp.CompositeMapper = {
   serializedName: "GalleryImageVersionList",
   type: {
     name: "Composite",
@@ -7882,7 +7882,7 @@ export const GalleryImageVersionList: msRest.CompositeMapper = {
   }
 };
 
-export const ContainerServiceListResult: msRest.CompositeMapper = {
+export const ContainerServiceListResult: coreHttp.CompositeMapper = {
   serializedName: "ContainerServiceListResult",
   type: {
     name: "Composite",

--- a/sdk/compute/arm-compute/src/models/parameters.ts
+++ b/sdk/compute/arm-compute/src/models/parameters.ts
@@ -8,9 +8,9 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 
-export const acceptLanguage: msRest.OperationParameter = {
+export const acceptLanguage: coreHttp.OperationParameter = {
   parameterPath: "acceptLanguage",
   mapper: {
     serializedName: "accept-language",
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion0: msRest.OperationQueryParameter = {
+export const apiVersion0: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -32,7 +32,7 @@ export const apiVersion0: msRest.OperationQueryParameter = {
     }
   }
 };
-export const apiVersion1: msRest.OperationQueryParameter = {
+export const apiVersion1: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -44,7 +44,7 @@ export const apiVersion1: msRest.OperationQueryParameter = {
     }
   }
 };
-export const apiVersion2: msRest.OperationQueryParameter = {
+export const apiVersion2: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -56,7 +56,7 @@ export const apiVersion2: msRest.OperationQueryParameter = {
     }
   }
 };
-export const apiVersion3: msRest.OperationQueryParameter = {
+export const apiVersion3: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -68,7 +68,7 @@ export const apiVersion3: msRest.OperationQueryParameter = {
     }
   }
 };
-export const availabilitySetName: msRest.OperationURLParameter = {
+export const availabilitySetName: coreHttp.OperationURLParameter = {
   parameterPath: "availabilitySetName",
   mapper: {
     required: true,
@@ -78,7 +78,7 @@ export const availabilitySetName: msRest.OperationURLParameter = {
     }
   }
 };
-export const commandId: msRest.OperationURLParameter = {
+export const commandId: coreHttp.OperationURLParameter = {
   parameterPath: "commandId",
   mapper: {
     required: true,
@@ -88,7 +88,7 @@ export const commandId: msRest.OperationURLParameter = {
     }
   }
 };
-export const containerServiceName: msRest.OperationURLParameter = {
+export const containerServiceName: coreHttp.OperationURLParameter = {
   parameterPath: "containerServiceName",
   mapper: {
     required: true,
@@ -98,7 +98,7 @@ export const containerServiceName: msRest.OperationURLParameter = {
     }
   }
 };
-export const diskName: msRest.OperationURLParameter = {
+export const diskName: coreHttp.OperationURLParameter = {
   parameterPath: "diskName",
   mapper: {
     required: true,
@@ -108,7 +108,7 @@ export const diskName: msRest.OperationURLParameter = {
     }
   }
 };
-export const expand0: msRest.OperationQueryParameter = {
+export const expand0: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "expand"
@@ -120,7 +120,7 @@ export const expand0: msRest.OperationQueryParameter = {
     }
   }
 };
-export const expand1: msRest.OperationQueryParameter = {
+export const expand1: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "expand"
@@ -135,7 +135,7 @@ export const expand1: msRest.OperationQueryParameter = {
     }
   }
 };
-export const filter: msRest.OperationQueryParameter = {
+export const filter: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "filter"
@@ -147,7 +147,7 @@ export const filter: msRest.OperationQueryParameter = {
     }
   }
 };
-export const galleryImageName: msRest.OperationURLParameter = {
+export const galleryImageName: coreHttp.OperationURLParameter = {
   parameterPath: "galleryImageName",
   mapper: {
     required: true,
@@ -157,7 +157,7 @@ export const galleryImageName: msRest.OperationURLParameter = {
     }
   }
 };
-export const galleryImageVersionName: msRest.OperationURLParameter = {
+export const galleryImageVersionName: coreHttp.OperationURLParameter = {
   parameterPath: "galleryImageVersionName",
   mapper: {
     required: true,
@@ -167,7 +167,7 @@ export const galleryImageVersionName: msRest.OperationURLParameter = {
     }
   }
 };
-export const galleryName: msRest.OperationURLParameter = {
+export const galleryName: coreHttp.OperationURLParameter = {
   parameterPath: "galleryName",
   mapper: {
     required: true,
@@ -177,7 +177,7 @@ export const galleryName: msRest.OperationURLParameter = {
     }
   }
 };
-export const imageName: msRest.OperationURLParameter = {
+export const imageName: coreHttp.OperationURLParameter = {
   parameterPath: "imageName",
   mapper: {
     required: true,
@@ -187,7 +187,7 @@ export const imageName: msRest.OperationURLParameter = {
     }
   }
 };
-export const instanceId: msRest.OperationURLParameter = {
+export const instanceId: coreHttp.OperationURLParameter = {
   parameterPath: "instanceId",
   mapper: {
     required: true,
@@ -197,7 +197,7 @@ export const instanceId: msRest.OperationURLParameter = {
     }
   }
 };
-export const location0: msRest.OperationURLParameter = {
+export const location0: coreHttp.OperationURLParameter = {
   parameterPath: "location",
   mapper: {
     required: true,
@@ -207,7 +207,7 @@ export const location0: msRest.OperationURLParameter = {
     }
   }
 };
-export const location1: msRest.OperationURLParameter = {
+export const location1: coreHttp.OperationURLParameter = {
   parameterPath: "location",
   mapper: {
     required: true,
@@ -220,7 +220,7 @@ export const location1: msRest.OperationURLParameter = {
     }
   }
 };
-export const nextPageLink: msRest.OperationURLParameter = {
+export const nextPageLink: coreHttp.OperationURLParameter = {
   parameterPath: "nextPageLink",
   mapper: {
     required: true,
@@ -231,7 +231,7 @@ export const nextPageLink: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const offer: msRest.OperationURLParameter = {
+export const offer: coreHttp.OperationURLParameter = {
   parameterPath: "offer",
   mapper: {
     required: true,
@@ -241,7 +241,7 @@ export const offer: msRest.OperationURLParameter = {
     }
   }
 };
-export const orderby: msRest.OperationQueryParameter = {
+export const orderby: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "orderby"
@@ -253,7 +253,7 @@ export const orderby: msRest.OperationQueryParameter = {
     }
   }
 };
-export const platformUpdateDomain: msRest.OperationQueryParameter = {
+export const platformUpdateDomain: coreHttp.OperationQueryParameter = {
   parameterPath: "platformUpdateDomain",
   mapper: {
     required: true,
@@ -263,7 +263,7 @@ export const platformUpdateDomain: msRest.OperationQueryParameter = {
     }
   }
 };
-export const publisherName: msRest.OperationURLParameter = {
+export const publisherName: coreHttp.OperationURLParameter = {
   parameterPath: "publisherName",
   mapper: {
     required: true,
@@ -273,7 +273,7 @@ export const publisherName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceGroupName: msRest.OperationURLParameter = {
+export const resourceGroupName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
     required: true,
@@ -283,7 +283,7 @@ export const resourceGroupName: msRest.OperationURLParameter = {
     }
   }
 };
-export const select: msRest.OperationQueryParameter = {
+export const select: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "select"
@@ -295,7 +295,7 @@ export const select: msRest.OperationQueryParameter = {
     }
   }
 };
-export const skipShutdown: msRest.OperationQueryParameter = {
+export const skipShutdown: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "skipShutdown"
@@ -308,7 +308,7 @@ export const skipShutdown: msRest.OperationQueryParameter = {
     }
   }
 };
-export const skus: msRest.OperationURLParameter = {
+export const skus: coreHttp.OperationURLParameter = {
   parameterPath: "skus",
   mapper: {
     required: true,
@@ -318,7 +318,7 @@ export const skus: msRest.OperationURLParameter = {
     }
   }
 };
-export const snapshotName: msRest.OperationURLParameter = {
+export const snapshotName: coreHttp.OperationURLParameter = {
   parameterPath: "snapshotName",
   mapper: {
     required: true,
@@ -328,7 +328,7 @@ export const snapshotName: msRest.OperationURLParameter = {
     }
   }
 };
-export const subscriptionId: msRest.OperationURLParameter = {
+export const subscriptionId: coreHttp.OperationURLParameter = {
   parameterPath: "subscriptionId",
   mapper: {
     required: true,
@@ -338,7 +338,7 @@ export const subscriptionId: msRest.OperationURLParameter = {
     }
   }
 };
-export const top: msRest.OperationQueryParameter = {
+export const top: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "top"
@@ -350,7 +350,7 @@ export const top: msRest.OperationQueryParameter = {
     }
   }
 };
-export const type: msRest.OperationURLParameter = {
+export const type: coreHttp.OperationURLParameter = {
   parameterPath: "type",
   mapper: {
     required: true,
@@ -360,7 +360,7 @@ export const type: msRest.OperationURLParameter = {
     }
   }
 };
-export const version: msRest.OperationURLParameter = {
+export const version: coreHttp.OperationURLParameter = {
   parameterPath: "version",
   mapper: {
     required: true,
@@ -370,7 +370,7 @@ export const version: msRest.OperationURLParameter = {
     }
   }
 };
-export const virtualMachineScaleSetName: msRest.OperationURLParameter = {
+export const virtualMachineScaleSetName: coreHttp.OperationURLParameter = {
   parameterPath: "virtualMachineScaleSetName",
   mapper: {
     required: true,
@@ -380,7 +380,7 @@ export const virtualMachineScaleSetName: msRest.OperationURLParameter = {
     }
   }
 };
-export const vmExtensionName: msRest.OperationURLParameter = {
+export const vmExtensionName: coreHttp.OperationURLParameter = {
   parameterPath: "vmExtensionName",
   mapper: {
     required: true,
@@ -390,7 +390,7 @@ export const vmExtensionName: msRest.OperationURLParameter = {
     }
   }
 };
-export const vmName: msRest.OperationURLParameter = {
+export const vmName: coreHttp.OperationURLParameter = {
   parameterPath: "vmName",
   mapper: {
     required: true,
@@ -400,7 +400,7 @@ export const vmName: msRest.OperationURLParameter = {
     }
   }
 };
-export const vmScaleSetName: msRest.OperationURLParameter = {
+export const vmScaleSetName: coreHttp.OperationURLParameter = {
   parameterPath: "vmScaleSetName",
   mapper: {
     required: true,
@@ -410,7 +410,7 @@ export const vmScaleSetName: msRest.OperationURLParameter = {
     }
   }
 };
-export const vmssExtensionName: msRest.OperationURLParameter = {
+export const vmssExtensionName: coreHttp.OperationURLParameter = {
   parameterPath: "vmssExtensionName",
   mapper: {
     required: true,

--- a/sdk/compute/arm-compute/src/operations/availabilitySets.ts
+++ b/sdk/compute/arm-compute/src/operations/availabilitySets.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/availabilitySetsMappers";
 import * as Parameters from "../models/parameters";
@@ -34,14 +34,14 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsCreateOrUpdateResponse>;
+  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsCreateOrUpdateResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param parameters Parameters supplied to the Create Availability Set operation.
    * @param callback The callback
    */
-  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, callback: msRest.ServiceCallback<Models.AvailabilitySet>): void;
+  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, callback: coreHttp.ServiceCallback<Models.AvailabilitySet>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
@@ -49,8 +49,8 @@ export class AvailabilitySets {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AvailabilitySet>): void;
-  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AvailabilitySet>, callback?: msRest.ServiceCallback<Models.AvailabilitySet>): Promise<Models.AvailabilitySetsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.AvailabilitySet>): void;
+  createOrUpdate(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySet, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.AvailabilitySet>, callback?: coreHttp.ServiceCallback<Models.AvailabilitySet>): Promise<Models.AvailabilitySetsCreateOrUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -70,14 +70,14 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsUpdateResponse>
    */
-  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsUpdateResponse>;
+  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsUpdateResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param parameters Parameters supplied to the Update Availability Set operation.
    * @param callback The callback
    */
-  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, callback: msRest.ServiceCallback<Models.AvailabilitySet>): void;
+  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, callback: coreHttp.ServiceCallback<Models.AvailabilitySet>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
@@ -85,8 +85,8 @@ export class AvailabilitySets {
    * @param options The optional parameters
    * @param callback The callback
    */
-  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AvailabilitySet>): void;
-  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AvailabilitySet>, callback?: msRest.ServiceCallback<Models.AvailabilitySet>): Promise<Models.AvailabilitySetsUpdateResponse> {
+  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.AvailabilitySet>): void;
+  update(resourceGroupName: string, availabilitySetName: string, parameters: Models.AvailabilitySetUpdate, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.AvailabilitySet>, callback?: coreHttp.ServiceCallback<Models.AvailabilitySet>): Promise<Models.AvailabilitySetsUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -103,23 +103,23 @@ export class AvailabilitySets {
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, availabilitySetName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteMethod(resourceGroupName: string, availabilitySetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param callback The callback
    */
-  deleteMethod(resourceGroupName: string, availabilitySetName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteMethod(resourceGroupName: string, availabilitySetName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(resourceGroupName: string, availabilitySetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteMethod(resourceGroupName: string, availabilitySetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, availabilitySetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteMethod(resourceGroupName: string, availabilitySetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -137,21 +137,21 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsGetResponse>
    */
-  get(resourceGroupName: string, availabilitySetName: string, options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsGetResponse>;
+  get(resourceGroupName: string, availabilitySetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param callback The callback
    */
-  get(resourceGroupName: string, availabilitySetName: string, callback: msRest.ServiceCallback<Models.AvailabilitySet>): void;
+  get(resourceGroupName: string, availabilitySetName: string, callback: coreHttp.ServiceCallback<Models.AvailabilitySet>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, availabilitySetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AvailabilitySet>): void;
-  get(resourceGroupName: string, availabilitySetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AvailabilitySet>, callback?: msRest.ServiceCallback<Models.AvailabilitySet>): Promise<Models.AvailabilitySetsGetResponse> {
+  get(resourceGroupName: string, availabilitySetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.AvailabilitySet>): void;
+  get(resourceGroupName: string, availabilitySetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.AvailabilitySet>, callback?: coreHttp.ServiceCallback<Models.AvailabilitySet>): Promise<Models.AvailabilitySetsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -167,17 +167,17 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsListBySubscriptionResponse>
    */
-  listBySubscription(options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsListBySubscriptionResponse>;
+  listBySubscription(options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsListBySubscriptionResponse>;
   /**
    * @param callback The callback
    */
-  listBySubscription(callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  listBySubscription(callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBySubscription(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
-  listBySubscription(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AvailabilitySetListResult>, callback?: msRest.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListBySubscriptionResponse> {
+  listBySubscription(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  listBySubscription(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.AvailabilitySetListResult>, callback?: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListBySubscriptionResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -192,19 +192,19 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsListResponse>
    */
-  list(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsListResponse>;
+  list(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsListResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  list(resourceGroupName: string, callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  list(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
-  list(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AvailabilitySetListResult>, callback?: msRest.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListResponse> {
+  list(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  list(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.AvailabilitySetListResult>, callback?: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -222,21 +222,21 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsListAvailableSizesResponse>
    */
-  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsListAvailableSizesResponse>;
+  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsListAvailableSizesResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param callback The callback
    */
-  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, callback: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
+  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param availabilitySetName The name of the availability set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
-  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineSizeListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): Promise<Models.AvailabilitySetsListAvailableSizesResponse> {
+  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
+  listAvailableSizes(resourceGroupName: string, availabilitySetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): Promise<Models.AvailabilitySetsListAvailableSizesResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -253,19 +253,19 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsListBySubscriptionNextResponse>
    */
-  listBySubscriptionNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsListBySubscriptionNextResponse>;
+  listBySubscriptionNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsListBySubscriptionNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listBySubscriptionNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  listBySubscriptionNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBySubscriptionNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
-  listBySubscriptionNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AvailabilitySetListResult>, callback?: msRest.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListBySubscriptionNextResponse> {
+  listBySubscriptionNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  listBySubscriptionNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.AvailabilitySetListResult>, callback?: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListBySubscriptionNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -281,19 +281,19 @@ export class AvailabilitySets {
    * @param [options] The optional parameters
    * @returns Promise<Models.AvailabilitySetsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.AvailabilitySetsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AvailabilitySetsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.AvailabilitySetListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.AvailabilitySetListResult>, callback?: msRest.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.AvailabilitySetListResult>, callback?: coreHttp.ServiceCallback<Models.AvailabilitySetListResult>): Promise<Models.AvailabilitySetsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -305,8 +305,8 @@ export class AvailabilitySets {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const createOrUpdateOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}",
   urlParameters: [
@@ -338,7 +338,7 @@ const createOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const updateOperationSpec: msRest.OperationSpec = {
+const updateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}",
   urlParameters: [
@@ -370,7 +370,7 @@ const updateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteMethodOperationSpec: msRest.OperationSpec = {
+const deleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}",
   urlParameters: [
@@ -394,7 +394,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}",
   urlParameters: [
@@ -419,7 +419,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBySubscriptionOperationSpec: msRest.OperationSpec = {
+const listBySubscriptionOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/availabilitySets",
   urlParameters: [
@@ -442,7 +442,7 @@ const listBySubscriptionOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets",
   urlParameters: [
@@ -466,7 +466,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAvailableSizesOperationSpec: msRest.OperationSpec = {
+const listAvailableSizesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}/vmSizes",
   urlParameters: [
@@ -491,7 +491,7 @@ const listAvailableSizesOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBySubscriptionNextOperationSpec: msRest.OperationSpec = {
+const listBySubscriptionNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -512,7 +512,7 @@ const listBySubscriptionNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/containerServices.ts
+++ b/sdk/compute/arm-compute/src/operations/containerServices.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/containerServicesMappers";
 import * as Parameters from "../models/parameters";
@@ -35,17 +35,17 @@ export class ContainerServices {
    * @param [options] The optional parameters
    * @returns Promise<Models.ContainerServicesListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.ContainerServicesListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.ContainerServicesListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ContainerServiceListResult>, callback?: msRest.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ContainerServiceListResult>, callback?: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -65,7 +65,7 @@ export class ContainerServices {
    * @param [options] The optional parameters
    * @returns Promise<Models.ContainerServicesCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, containerServiceName: string, parameters: Models.ContainerService, options?: msRest.RequestOptionsBase): Promise<Models.ContainerServicesCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, containerServiceName: string, parameters: Models.ContainerService, options?: coreHttp.RequestOptionsBase): Promise<Models.ContainerServicesCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,containerServiceName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ContainerServicesCreateOrUpdateResponse>;
   }
@@ -81,14 +81,14 @@ export class ContainerServices {
    * @param [options] The optional parameters
    * @returns Promise<Models.ContainerServicesGetResponse>
    */
-  get(resourceGroupName: string, containerServiceName: string, options?: msRest.RequestOptionsBase): Promise<Models.ContainerServicesGetResponse>;
+  get(resourceGroupName: string, containerServiceName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ContainerServicesGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param containerServiceName The name of the container service in the specified subscription and
    * resource group.
    * @param callback The callback
    */
-  get(resourceGroupName: string, containerServiceName: string, callback: msRest.ServiceCallback<Models.ContainerService>): void;
+  get(resourceGroupName: string, containerServiceName: string, callback: coreHttp.ServiceCallback<Models.ContainerService>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param containerServiceName The name of the container service in the specified subscription and
@@ -96,8 +96,8 @@ export class ContainerServices {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, containerServiceName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ContainerService>): void;
-  get(resourceGroupName: string, containerServiceName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ContainerService>, callback?: msRest.ServiceCallback<Models.ContainerService>): Promise<Models.ContainerServicesGetResponse> {
+  get(resourceGroupName: string, containerServiceName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ContainerService>): void;
+  get(resourceGroupName: string, containerServiceName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ContainerService>, callback?: coreHttp.ServiceCallback<Models.ContainerService>): Promise<Models.ContainerServicesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -118,9 +118,9 @@ export class ContainerServices {
    * @param containerServiceName The name of the container service in the specified subscription and
    * resource group.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, containerServiceName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, containerServiceName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,containerServiceName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -134,19 +134,19 @@ export class ContainerServices {
    * @param [options] The optional parameters
    * @returns Promise<Models.ContainerServicesListByResourceGroupResponse>
    */
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.ContainerServicesListByResourceGroupResponse>;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ContainerServicesListByResourceGroupResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ContainerServiceListResult>, callback?: msRest.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ContainerServiceListResult>, callback?: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -165,9 +165,9 @@ export class ContainerServices {
    * resource group.
    * @param parameters Parameters supplied to the Create or Update a Container Service operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, containerServiceName: string, parameters: Models.ContainerService, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, containerServiceName: string, parameters: Models.ContainerService, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -189,9 +189,9 @@ export class ContainerServices {
    * @param containerServiceName The name of the container service in the specified subscription and
    * resource group.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, containerServiceName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, containerServiceName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -211,19 +211,19 @@ export class ContainerServices {
    * @param [options] The optional parameters
    * @returns Promise<Models.ContainerServicesListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ContainerServicesListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ContainerServicesListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ContainerServiceListResult>, callback?: msRest.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ContainerServiceListResult>, callback?: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -242,19 +242,19 @@ export class ContainerServices {
    * @param [options] The optional parameters
    * @returns Promise<Models.ContainerServicesListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ContainerServicesListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ContainerServicesListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ContainerServiceListResult>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ContainerServiceListResult>, callback?: msRest.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ContainerServiceListResult>, callback?: coreHttp.ServiceCallback<Models.ContainerServiceListResult>): Promise<Models.ContainerServicesListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -266,8 +266,8 @@ export class ContainerServices {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.ContainerService/containerServices",
   urlParameters: [
@@ -290,7 +290,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}",
   urlParameters: [
@@ -315,7 +315,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices",
   urlParameters: [
@@ -339,7 +339,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}",
   urlParameters: [
@@ -377,7 +377,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/containerServices/{containerServiceName}",
   urlParameters: [
@@ -401,7 +401,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -422,7 +422,7 @@ const listNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/disks.ts
+++ b/sdk/compute/arm-compute/src/operations/disks.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/disksMappers";
 import * as Parameters from "../models/parameters";
@@ -37,7 +37,7 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, diskName: string, disk: Models.Disk, options?: msRest.RequestOptionsBase): Promise<Models.DisksCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, diskName: string, disk: Models.Disk, options?: coreHttp.RequestOptionsBase): Promise<Models.DisksCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,diskName,disk,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.DisksCreateOrUpdateResponse>;
   }
@@ -52,7 +52,7 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksUpdateResponse>
    */
-  update(resourceGroupName: string, diskName: string, disk: Models.DiskUpdate, options?: msRest.RequestOptionsBase): Promise<Models.DisksUpdateResponse> {
+  update(resourceGroupName: string, diskName: string, disk: Models.DiskUpdate, options?: coreHttp.RequestOptionsBase): Promise<Models.DisksUpdateResponse> {
     return this.beginUpdate(resourceGroupName,diskName,disk,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.DisksUpdateResponse>;
   }
@@ -66,7 +66,7 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksGetResponse>
    */
-  get(resourceGroupName: string, diskName: string, options?: msRest.RequestOptionsBase): Promise<Models.DisksGetResponse>;
+  get(resourceGroupName: string, diskName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DisksGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param diskName The name of the managed disk that is being created. The name can't be changed
@@ -74,7 +74,7 @@ export class Disks {
    * maximum name length is 80 characters.
    * @param callback The callback
    */
-  get(resourceGroupName: string, diskName: string, callback: msRest.ServiceCallback<Models.Disk>): void;
+  get(resourceGroupName: string, diskName: string, callback: coreHttp.ServiceCallback<Models.Disk>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param diskName The name of the managed disk that is being created. The name can't be changed
@@ -83,8 +83,8 @@ export class Disks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, diskName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Disk>): void;
-  get(resourceGroupName: string, diskName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Disk>, callback?: msRest.ServiceCallback<Models.Disk>): Promise<Models.DisksGetResponse> {
+  get(resourceGroupName: string, diskName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Disk>): void;
+  get(resourceGroupName: string, diskName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Disk>, callback?: coreHttp.ServiceCallback<Models.Disk>): Promise<Models.DisksGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -102,9 +102,9 @@ export class Disks {
    * after the disk is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * maximum name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, diskName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, diskName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,diskName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -115,19 +115,19 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksListByResourceGroupResponse>
    */
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.DisksListByResourceGroupResponse>;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DisksListByResourceGroupResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.DiskList>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.DiskList>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DiskList>): void;
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DiskList>, callback?: msRest.ServiceCallback<Models.DiskList>): Promise<Models.DisksListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DiskList>): void;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DiskList>, callback?: coreHttp.ServiceCallback<Models.DiskList>): Promise<Models.DisksListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -142,17 +142,17 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.DisksListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.DisksListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.DiskList>): void;
+  list(callback: coreHttp.ServiceCallback<Models.DiskList>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DiskList>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DiskList>, callback?: msRest.ServiceCallback<Models.DiskList>): Promise<Models.DisksListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DiskList>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DiskList>, callback?: coreHttp.ServiceCallback<Models.DiskList>): Promise<Models.DisksListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -171,7 +171,7 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksGrantAccessResponse>
    */
-  grantAccess(resourceGroupName: string, diskName: string, grantAccessData: Models.GrantAccessData, options?: msRest.RequestOptionsBase): Promise<Models.DisksGrantAccessResponse> {
+  grantAccess(resourceGroupName: string, diskName: string, grantAccessData: Models.GrantAccessData, options?: coreHttp.RequestOptionsBase): Promise<Models.DisksGrantAccessResponse> {
     return this.beginGrantAccess(resourceGroupName,diskName,grantAccessData,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.DisksGrantAccessResponse>;
   }
@@ -183,9 +183,9 @@ export class Disks {
    * after the disk is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * maximum name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  revokeAccess(resourceGroupName: string, diskName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  revokeAccess(resourceGroupName: string, diskName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginRevokeAccess(resourceGroupName,diskName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -198,9 +198,9 @@ export class Disks {
    * maximum name length is 80 characters.
    * @param disk Disk object supplied in the body of the Put disk operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, diskName: string, disk: Models.Disk, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, diskName: string, disk: Models.Disk, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -220,9 +220,9 @@ export class Disks {
    * maximum name length is 80 characters.
    * @param disk Disk object supplied in the body of the Patch disk operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, diskName: string, disk: Models.DiskUpdate, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, diskName: string, disk: Models.DiskUpdate, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -241,9 +241,9 @@ export class Disks {
    * after the disk is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * maximum name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, diskName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, diskName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -262,9 +262,9 @@ export class Disks {
    * maximum name length is 80 characters.
    * @param grantAccessData Access data object supplied in the body of the get disk access operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginGrantAccess(resourceGroupName: string, diskName: string, grantAccessData: Models.GrantAccessData, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginGrantAccess(resourceGroupName: string, diskName: string, grantAccessData: Models.GrantAccessData, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -283,9 +283,9 @@ export class Disks {
    * after the disk is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * maximum name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRevokeAccess(resourceGroupName: string, diskName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRevokeAccess(resourceGroupName: string, diskName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -302,19 +302,19 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DisksListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DisksListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DiskList>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DiskList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DiskList>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DiskList>, callback?: msRest.ServiceCallback<Models.DiskList>): Promise<Models.DisksListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DiskList>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DiskList>, callback?: coreHttp.ServiceCallback<Models.DiskList>): Promise<Models.DisksListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -330,19 +330,19 @@ export class Disks {
    * @param [options] The optional parameters
    * @returns Promise<Models.DisksListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DisksListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DisksListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DiskList>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DiskList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DiskList>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DiskList>, callback?: msRest.ServiceCallback<Models.DiskList>): Promise<Models.DisksListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DiskList>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DiskList>, callback?: coreHttp.ServiceCallback<Models.DiskList>): Promise<Models.DisksListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -354,8 +354,8 @@ export class Disks {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}",
   urlParameters: [
@@ -380,7 +380,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks",
   urlParameters: [
@@ -404,7 +404,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/disks",
   urlParameters: [
@@ -427,7 +427,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}",
   urlParameters: [
@@ -462,7 +462,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}",
   urlParameters: [
@@ -497,7 +497,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}",
   urlParameters: [
@@ -522,7 +522,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginGrantAccessOperationSpec: msRest.OperationSpec = {
+const beginGrantAccessOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}/beginGetAccess",
   urlParameters: [
@@ -555,7 +555,7 @@ const beginGrantAccessOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRevokeAccessOperationSpec: msRest.OperationSpec = {
+const beginRevokeAccessOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/disks/{diskName}/endGetAccess",
   urlParameters: [
@@ -579,7 +579,7 @@ const beginRevokeAccessOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -600,7 +600,7 @@ const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/galleries.ts
+++ b/sdk/compute/arm-compute/src/operations/galleries.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/galleriesMappers";
 import * as Parameters from "../models/parameters";
@@ -36,7 +36,7 @@ export class Galleries {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleriesCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, galleryName: string, gallery: Models.Gallery, options?: msRest.RequestOptionsBase): Promise<Models.GalleriesCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, galleryName: string, gallery: Models.Gallery, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleriesCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,galleryName,gallery,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.GalleriesCreateOrUpdateResponse>;
   }
@@ -48,21 +48,21 @@ export class Galleries {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleriesGetResponse>
    */
-  get(resourceGroupName: string, galleryName: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleriesGetResponse>;
+  get(resourceGroupName: string, galleryName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleriesGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery.
    * @param callback The callback
    */
-  get(resourceGroupName: string, galleryName: string, callback: msRest.ServiceCallback<Models.Gallery>): void;
+  get(resourceGroupName: string, galleryName: string, callback: coreHttp.ServiceCallback<Models.Gallery>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, galleryName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Gallery>): void;
-  get(resourceGroupName: string, galleryName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Gallery>, callback?: msRest.ServiceCallback<Models.Gallery>): Promise<Models.GalleriesGetResponse> {
+  get(resourceGroupName: string, galleryName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Gallery>): void;
+  get(resourceGroupName: string, galleryName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Gallery>, callback?: coreHttp.ServiceCallback<Models.Gallery>): Promise<Models.GalleriesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -78,9 +78,9 @@ export class Galleries {
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery to be deleted.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, galleryName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, galleryName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,galleryName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -91,19 +91,19 @@ export class Galleries {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleriesListByResourceGroupResponse>
    */
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleriesListByResourceGroupResponse>;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleriesListByResourceGroupResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.GalleryList>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryList>): void;
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryList>, callback?: msRest.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryList>, callback?: coreHttp.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -118,17 +118,17 @@ export class Galleries {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleriesListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.GalleriesListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.GalleriesListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.GalleryList>): void;
+  list(callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryList>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryList>, callback?: msRest.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryList>, callback?: coreHttp.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -144,9 +144,9 @@ export class Galleries {
    * and numbers with dots and periods allowed in the middle. The maximum length is 80 characters.
    * @param gallery Parameters supplied to the create or update Shared Image Gallery operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, galleryName: string, gallery: Models.Gallery, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, galleryName: string, gallery: Models.Gallery, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -163,9 +163,9 @@ export class Galleries {
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery to be deleted.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, galleryName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, galleryName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -182,19 +182,19 @@ export class Galleries {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleriesListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleriesListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleriesListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.GalleryList>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryList>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryList>, callback?: msRest.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryList>, callback?: coreHttp.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -210,19 +210,19 @@ export class Galleries {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleriesListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleriesListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleriesListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.GalleryList>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryList>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryList>, callback?: msRest.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryList>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryList>, callback?: coreHttp.ServiceCallback<Models.GalleryList>): Promise<Models.GalleriesListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -234,8 +234,8 @@ export class Galleries {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}",
   urlParameters: [
@@ -260,7 +260,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries",
   urlParameters: [
@@ -284,7 +284,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/galleries",
   urlParameters: [
@@ -307,7 +307,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}",
   urlParameters: [
@@ -345,7 +345,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}",
   urlParameters: [
@@ -370,7 +370,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -391,7 +391,7 @@ const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/galleryImageVersions.ts
+++ b/sdk/compute/arm-compute/src/operations/galleryImageVersions.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/galleryImageVersionsMappers";
 import * as Parameters from "../models/parameters";
@@ -41,7 +41,7 @@ export class GalleryImageVersions {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleryImageVersionsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, galleryImageVersion: Models.GalleryImageVersion, options?: msRest.RequestOptionsBase): Promise<Models.GalleryImageVersionsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, galleryImageVersion: Models.GalleryImageVersion, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleryImageVersionsCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,galleryName,galleryImageName,galleryImageVersionName,galleryImageVersion,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.GalleryImageVersionsCreateOrUpdateResponse>;
   }
@@ -65,7 +65,7 @@ export class GalleryImageVersions {
    * @param galleryImageVersionName The name of the gallery Image Version to be retrieved.
    * @param callback The callback
    */
-  get(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, callback: msRest.ServiceCallback<Models.GalleryImageVersion>): void;
+  get(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, callback: coreHttp.ServiceCallback<Models.GalleryImageVersion>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery in which the Image Definition resides.
@@ -75,8 +75,8 @@ export class GalleryImageVersions {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options: Models.GalleryImageVersionsGetOptionalParams, callback: msRest.ServiceCallback<Models.GalleryImageVersion>): void;
-  get(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options?: Models.GalleryImageVersionsGetOptionalParams | msRest.ServiceCallback<Models.GalleryImageVersion>, callback?: msRest.ServiceCallback<Models.GalleryImageVersion>): Promise<Models.GalleryImageVersionsGetResponse> {
+  get(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options: Models.GalleryImageVersionsGetOptionalParams, callback: coreHttp.ServiceCallback<Models.GalleryImageVersion>): void;
+  get(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options?: Models.GalleryImageVersionsGetOptionalParams | coreHttp.ServiceCallback<Models.GalleryImageVersion>, callback?: coreHttp.ServiceCallback<Models.GalleryImageVersion>): Promise<Models.GalleryImageVersionsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -97,9 +97,9 @@ export class GalleryImageVersions {
    * resides.
    * @param galleryImageVersionName The name of the gallery Image Version to be deleted.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,galleryName,galleryImageName,galleryImageVersionName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -113,7 +113,7 @@ export class GalleryImageVersions {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleryImageVersionsListByGalleryImageResponse>
    */
-  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleryImageVersionsListByGalleryImageResponse>;
+  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleryImageVersionsListByGalleryImageResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery in which the Image Definition resides.
@@ -121,7 +121,7 @@ export class GalleryImageVersions {
    * Image Versions are to be listed.
    * @param callback The callback
    */
-  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, callback: msRest.ServiceCallback<Models.GalleryImageVersionList>): void;
+  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, callback: coreHttp.ServiceCallback<Models.GalleryImageVersionList>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery in which the Image Definition resides.
@@ -130,8 +130,8 @@ export class GalleryImageVersions {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryImageVersionList>): void;
-  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryImageVersionList>, callback?: msRest.ServiceCallback<Models.GalleryImageVersionList>): Promise<Models.GalleryImageVersionsListByGalleryImageResponse> {
+  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryImageVersionList>): void;
+  listByGalleryImage(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryImageVersionList>, callback?: coreHttp.ServiceCallback<Models.GalleryImageVersionList>): Promise<Models.GalleryImageVersionsListByGalleryImageResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -155,9 +155,9 @@ export class GalleryImageVersions {
    * @param galleryImageVersion Parameters supplied to the create or update gallery Image Version
    * operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, galleryImageVersion: Models.GalleryImageVersion, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, galleryImageVersion: Models.GalleryImageVersion, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -179,9 +179,9 @@ export class GalleryImageVersions {
    * resides.
    * @param galleryImageVersionName The name of the gallery Image Version to be deleted.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImageVersionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -200,19 +200,19 @@ export class GalleryImageVersions {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleryImageVersionsListByGalleryImageNextResponse>
    */
-  listByGalleryImageNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleryImageVersionsListByGalleryImageNextResponse>;
+  listByGalleryImageNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleryImageVersionsListByGalleryImageNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByGalleryImageNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.GalleryImageVersionList>): void;
+  listByGalleryImageNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.GalleryImageVersionList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByGalleryImageNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryImageVersionList>): void;
-  listByGalleryImageNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryImageVersionList>, callback?: msRest.ServiceCallback<Models.GalleryImageVersionList>): Promise<Models.GalleryImageVersionsListByGalleryImageNextResponse> {
+  listByGalleryImageNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryImageVersionList>): void;
+  listByGalleryImageNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryImageVersionList>, callback?: coreHttp.ServiceCallback<Models.GalleryImageVersionList>): Promise<Models.GalleryImageVersionsListByGalleryImageNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -224,8 +224,8 @@ export class GalleryImageVersions {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}",
   urlParameters: [
@@ -253,7 +253,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByGalleryImageOperationSpec: msRest.OperationSpec = {
+const listByGalleryImageOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions",
   urlParameters: [
@@ -279,7 +279,7 @@ const listByGalleryImageOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}",
   urlParameters: [
@@ -319,7 +319,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}/versions/{galleryImageVersionName}",
   urlParameters: [
@@ -346,7 +346,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByGalleryImageNextOperationSpec: msRest.OperationSpec = {
+const listByGalleryImageNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/galleryImages.ts
+++ b/sdk/compute/arm-compute/src/operations/galleryImages.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/galleryImagesMappers";
 import * as Parameters from "../models/parameters";
@@ -39,7 +39,7 @@ export class GalleryImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleryImagesCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImage: Models.GalleryImage, options?: msRest.RequestOptionsBase): Promise<Models.GalleryImagesCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImage: Models.GalleryImage, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleryImagesCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,galleryName,galleryImageName,galleryImage,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.GalleryImagesCreateOrUpdateResponse>;
   }
@@ -53,7 +53,7 @@ export class GalleryImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleryImagesGetResponse>
    */
-  get(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleryImagesGetResponse>;
+  get(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleryImagesGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery from which the Image Definitions are to
@@ -61,7 +61,7 @@ export class GalleryImages {
    * @param galleryImageName The name of the gallery Image Definition to be retrieved.
    * @param callback The callback
    */
-  get(resourceGroupName: string, galleryName: string, galleryImageName: string, callback: msRest.ServiceCallback<Models.GalleryImage>): void;
+  get(resourceGroupName: string, galleryName: string, galleryImageName: string, callback: coreHttp.ServiceCallback<Models.GalleryImage>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery from which the Image Definitions are to
@@ -70,8 +70,8 @@ export class GalleryImages {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, galleryName: string, galleryImageName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryImage>): void;
-  get(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryImage>, callback?: msRest.ServiceCallback<Models.GalleryImage>): Promise<Models.GalleryImagesGetResponse> {
+  get(resourceGroupName: string, galleryName: string, galleryImageName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryImage>): void;
+  get(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryImage>, callback?: coreHttp.ServiceCallback<Models.GalleryImage>): Promise<Models.GalleryImagesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -90,9 +90,9 @@ export class GalleryImages {
    * deleted.
    * @param galleryImageName The name of the gallery Image Definition to be deleted.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,galleryName,galleryImageName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -105,14 +105,14 @@ export class GalleryImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleryImagesListByGalleryResponse>
    */
-  listByGallery(resourceGroupName: string, galleryName: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleryImagesListByGalleryResponse>;
+  listByGallery(resourceGroupName: string, galleryName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleryImagesListByGalleryResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery from which Image Definitions are to be
    * listed.
    * @param callback The callback
    */
-  listByGallery(resourceGroupName: string, galleryName: string, callback: msRest.ServiceCallback<Models.GalleryImageList>): void;
+  listByGallery(resourceGroupName: string, galleryName: string, callback: coreHttp.ServiceCallback<Models.GalleryImageList>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param galleryName The name of the Shared Image Gallery from which Image Definitions are to be
@@ -120,8 +120,8 @@ export class GalleryImages {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByGallery(resourceGroupName: string, galleryName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryImageList>): void;
-  listByGallery(resourceGroupName: string, galleryName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryImageList>, callback?: msRest.ServiceCallback<Models.GalleryImageList>): Promise<Models.GalleryImagesListByGalleryResponse> {
+  listByGallery(resourceGroupName: string, galleryName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryImageList>): void;
+  listByGallery(resourceGroupName: string, galleryName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryImageList>, callback?: coreHttp.ServiceCallback<Models.GalleryImageList>): Promise<Models.GalleryImagesListByGalleryResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -142,9 +142,9 @@ export class GalleryImages {
    * middle. The maximum length is 80 characters.
    * @param galleryImage Parameters supplied to the create or update gallery image operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImage: Models.GalleryImage, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, galleryName: string, galleryImageName: string, galleryImage: Models.GalleryImage, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -164,9 +164,9 @@ export class GalleryImages {
    * deleted.
    * @param galleryImageName The name of the gallery Image Definition to be deleted.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, galleryName: string, galleryImageName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -184,19 +184,19 @@ export class GalleryImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.GalleryImagesListByGalleryNextResponse>
    */
-  listByGalleryNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.GalleryImagesListByGalleryNextResponse>;
+  listByGalleryNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GalleryImagesListByGalleryNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByGalleryNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.GalleryImageList>): void;
+  listByGalleryNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.GalleryImageList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByGalleryNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GalleryImageList>): void;
-  listByGalleryNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GalleryImageList>, callback?: msRest.ServiceCallback<Models.GalleryImageList>): Promise<Models.GalleryImagesListByGalleryNextResponse> {
+  listByGalleryNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GalleryImageList>): void;
+  listByGalleryNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GalleryImageList>, callback?: coreHttp.ServiceCallback<Models.GalleryImageList>): Promise<Models.GalleryImagesListByGalleryNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -208,8 +208,8 @@ export class GalleryImages {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}",
   urlParameters: [
@@ -235,7 +235,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByGalleryOperationSpec: msRest.OperationSpec = {
+const listByGalleryOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images",
   urlParameters: [
@@ -260,7 +260,7 @@ const listByGalleryOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}",
   urlParameters: [
@@ -299,7 +299,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/galleries/{galleryName}/images/{galleryImageName}",
   urlParameters: [
@@ -325,7 +325,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByGalleryNextOperationSpec: msRest.OperationSpec = {
+const listByGalleryNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/images.ts
+++ b/sdk/compute/arm-compute/src/operations/images.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/imagesMappers";
 import * as Parameters from "../models/parameters";
@@ -35,7 +35,7 @@ export class Images {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImagesCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, imageName: string, parameters: Models.Image, options?: msRest.RequestOptionsBase): Promise<Models.ImagesCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, imageName: string, parameters: Models.Image, options?: coreHttp.RequestOptionsBase): Promise<Models.ImagesCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,imageName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ImagesCreateOrUpdateResponse>;
   }
@@ -48,7 +48,7 @@ export class Images {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImagesUpdateResponse>
    */
-  update(resourceGroupName: string, imageName: string, parameters: Models.ImageUpdate, options?: msRest.RequestOptionsBase): Promise<Models.ImagesUpdateResponse> {
+  update(resourceGroupName: string, imageName: string, parameters: Models.ImageUpdate, options?: coreHttp.RequestOptionsBase): Promise<Models.ImagesUpdateResponse> {
     return this.beginUpdate(resourceGroupName,imageName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ImagesUpdateResponse>;
   }
@@ -58,9 +58,9 @@ export class Images {
    * @param resourceGroupName The name of the resource group.
    * @param imageName The name of the image.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, imageName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, imageName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,imageName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -78,15 +78,15 @@ export class Images {
    * @param imageName The name of the image.
    * @param callback The callback
    */
-  get(resourceGroupName: string, imageName: string, callback: msRest.ServiceCallback<Models.Image>): void;
+  get(resourceGroupName: string, imageName: string, callback: coreHttp.ServiceCallback<Models.Image>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param imageName The name of the image.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, imageName: string, options: Models.ImagesGetOptionalParams, callback: msRest.ServiceCallback<Models.Image>): void;
-  get(resourceGroupName: string, imageName: string, options?: Models.ImagesGetOptionalParams | msRest.ServiceCallback<Models.Image>, callback?: msRest.ServiceCallback<Models.Image>): Promise<Models.ImagesGetResponse> {
+  get(resourceGroupName: string, imageName: string, options: Models.ImagesGetOptionalParams, callback: coreHttp.ServiceCallback<Models.Image>): void;
+  get(resourceGroupName: string, imageName: string, options?: Models.ImagesGetOptionalParams | coreHttp.ServiceCallback<Models.Image>, callback?: coreHttp.ServiceCallback<Models.Image>): Promise<Models.ImagesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -103,19 +103,19 @@ export class Images {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImagesListByResourceGroupResponse>
    */
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.ImagesListByResourceGroupResponse>;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ImagesListByResourceGroupResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ImageListResult>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageListResult>): void;
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageListResult>, callback?: msRest.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ImageListResult>, callback?: coreHttp.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -131,17 +131,17 @@ export class Images {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImagesListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.ImagesListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.ImagesListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.ImageListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageListResult>, callback?: msRest.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ImageListResult>, callback?: coreHttp.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -156,9 +156,9 @@ export class Images {
    * @param imageName The name of the image.
    * @param parameters Parameters supplied to the Create Image operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, imageName: string, parameters: Models.Image, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, imageName: string, parameters: Models.Image, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -176,9 +176,9 @@ export class Images {
    * @param imageName The name of the image.
    * @param parameters Parameters supplied to the Update Image operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, imageName: string, parameters: Models.ImageUpdate, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, imageName: string, parameters: Models.ImageUpdate, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -195,9 +195,9 @@ export class Images {
    * @param resourceGroupName The name of the resource group.
    * @param imageName The name of the image.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, imageName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, imageName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -214,19 +214,19 @@ export class Images {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImagesListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ImagesListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ImagesListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ImageListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageListResult>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageListResult>, callback?: msRest.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ImageListResult>, callback?: coreHttp.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -243,19 +243,19 @@ export class Images {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImagesListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ImagesListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ImagesListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ImageListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageListResult>, callback?: msRest.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ImageListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ImageListResult>, callback?: coreHttp.ServiceCallback<Models.ImageListResult>): Promise<Models.ImagesListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -267,8 +267,8 @@ export class Images {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}",
   urlParameters: [
@@ -294,7 +294,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images",
   urlParameters: [
@@ -318,7 +318,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/images",
   urlParameters: [
@@ -341,7 +341,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}",
   urlParameters: [
@@ -376,7 +376,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}",
   urlParameters: [
@@ -411,7 +411,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/images/{imageName}",
   urlParameters: [
@@ -436,7 +436,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -457,7 +457,7 @@ const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/logAnalytics.ts
+++ b/sdk/compute/arm-compute/src/operations/logAnalytics.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/logAnalyticsMappers";
 import * as Parameters from "../models/parameters";
@@ -35,7 +35,7 @@ export class LogAnalytics {
    * @param [options] The optional parameters
    * @returns Promise<Models.LogAnalyticsExportRequestRateByIntervalResponse>
    */
-  exportRequestRateByInterval(parameters: Models.RequestRateByIntervalInput, location: string, options?: msRest.RequestOptionsBase): Promise<Models.LogAnalyticsExportRequestRateByIntervalResponse> {
+  exportRequestRateByInterval(parameters: Models.RequestRateByIntervalInput, location: string, options?: coreHttp.RequestOptionsBase): Promise<Models.LogAnalyticsExportRequestRateByIntervalResponse> {
     return this.beginExportRequestRateByInterval(parameters,location,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.LogAnalyticsExportRequestRateByIntervalResponse>;
   }
@@ -48,7 +48,7 @@ export class LogAnalytics {
    * @param [options] The optional parameters
    * @returns Promise<Models.LogAnalyticsExportThrottledRequestsResponse>
    */
-  exportThrottledRequests(parameters: Models.ThrottledRequestsInput, location: string, options?: msRest.RequestOptionsBase): Promise<Models.LogAnalyticsExportThrottledRequestsResponse> {
+  exportThrottledRequests(parameters: Models.ThrottledRequestsInput, location: string, options?: coreHttp.RequestOptionsBase): Promise<Models.LogAnalyticsExportThrottledRequestsResponse> {
     return this.beginExportThrottledRequests(parameters,location,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.LogAnalyticsExportThrottledRequestsResponse>;
   }
@@ -59,9 +59,9 @@ export class LogAnalytics {
    * @param parameters Parameters supplied to the LogAnalytics getRequestRateByInterval Api.
    * @param location The location upon which virtual-machine-sizes is queried.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginExportRequestRateByInterval(parameters: Models.RequestRateByIntervalInput, location: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginExportRequestRateByInterval(parameters: Models.RequestRateByIntervalInput, location: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         parameters,
@@ -78,9 +78,9 @@ export class LogAnalytics {
    * @param parameters Parameters supplied to the LogAnalytics getThrottledRequests Api.
    * @param location The location upon which virtual-machine-sizes is queried.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginExportThrottledRequests(parameters: Models.ThrottledRequestsInput, location: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginExportThrottledRequests(parameters: Models.ThrottledRequestsInput, location: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         parameters,
@@ -93,8 +93,8 @@ export class LogAnalytics {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const beginExportRequestRateByIntervalOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const beginExportRequestRateByIntervalOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/logAnalytics/apiAccess/getRequestRateByInterval",
   urlParameters: [
@@ -126,7 +126,7 @@ const beginExportRequestRateByIntervalOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginExportThrottledRequestsOperationSpec: msRest.OperationSpec = {
+const beginExportThrottledRequestsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/logAnalytics/apiAccess/getThrottledRequests",
   urlParameters: [

--- a/sdk/compute/arm-compute/src/operations/operations.ts
+++ b/sdk/compute/arm-compute/src/operations/operations.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/operationsMappers";
 import * as Parameters from "../models/parameters";
@@ -31,17 +31,17 @@ export class Operations {
    * @param [options] The optional parameters
    * @returns Promise<Models.OperationsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.OperationsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.OperationsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.ComputeOperationListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.ComputeOperationListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ComputeOperationListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ComputeOperationListResult>, callback?: msRest.ServiceCallback<Models.ComputeOperationListResult>): Promise<Models.OperationsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ComputeOperationListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ComputeOperationListResult>, callback?: coreHttp.ServiceCallback<Models.ComputeOperationListResult>): Promise<Models.OperationsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -52,8 +52,8 @@ export class Operations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Compute/operations",
   queryParameters: [

--- a/sdk/compute/arm-compute/src/operations/resourceSkus.ts
+++ b/sdk/compute/arm-compute/src/operations/resourceSkus.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/resourceSkusMappers";
 import * as Parameters from "../models/parameters";
@@ -31,17 +31,17 @@ export class ResourceSkus {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceSkusListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.ResourceSkusListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceSkusListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.ResourceSkusResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.ResourceSkusResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceSkusResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceSkusResult>, callback?: msRest.ServiceCallback<Models.ResourceSkusResult>): Promise<Models.ResourceSkusListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceSkusResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceSkusResult>, callback?: coreHttp.ServiceCallback<Models.ResourceSkusResult>): Promise<Models.ResourceSkusListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -56,19 +56,19 @@ export class ResourceSkus {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceSkusListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourceSkusListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceSkusListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ResourceSkusResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ResourceSkusResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceSkusResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceSkusResult>, callback?: msRest.ServiceCallback<Models.ResourceSkusResult>): Promise<Models.ResourceSkusListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceSkusResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceSkusResult>, callback?: coreHttp.ServiceCallback<Models.ResourceSkusResult>): Promise<Models.ResourceSkusListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -80,8 +80,8 @@ export class ResourceSkus {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/skus",
   urlParameters: [
@@ -104,7 +104,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/snapshots.ts
+++ b/sdk/compute/arm-compute/src/operations/snapshots.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/snapshotsMappers";
 import * as Parameters from "../models/parameters";
@@ -37,7 +37,7 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, snapshotName: string, snapshot: Models.Snapshot, options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, snapshotName: string, snapshot: Models.Snapshot, options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,snapshotName,snapshot,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.SnapshotsCreateOrUpdateResponse>;
   }
@@ -52,7 +52,7 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsUpdateResponse>
    */
-  update(resourceGroupName: string, snapshotName: string, snapshot: Models.SnapshotUpdate, options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsUpdateResponse> {
+  update(resourceGroupName: string, snapshotName: string, snapshot: Models.SnapshotUpdate, options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsUpdateResponse> {
     return this.beginUpdate(resourceGroupName,snapshotName,snapshot,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.SnapshotsUpdateResponse>;
   }
@@ -66,7 +66,7 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsGetResponse>
    */
-  get(resourceGroupName: string, snapshotName: string, options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsGetResponse>;
+  get(resourceGroupName: string, snapshotName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param snapshotName The name of the snapshot that is being created. The name can't be changed
@@ -74,7 +74,7 @@ export class Snapshots {
    * max name length is 80 characters.
    * @param callback The callback
    */
-  get(resourceGroupName: string, snapshotName: string, callback: msRest.ServiceCallback<Models.Snapshot>): void;
+  get(resourceGroupName: string, snapshotName: string, callback: coreHttp.ServiceCallback<Models.Snapshot>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param snapshotName The name of the snapshot that is being created. The name can't be changed
@@ -83,8 +83,8 @@ export class Snapshots {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, snapshotName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Snapshot>): void;
-  get(resourceGroupName: string, snapshotName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Snapshot>, callback?: msRest.ServiceCallback<Models.Snapshot>): Promise<Models.SnapshotsGetResponse> {
+  get(resourceGroupName: string, snapshotName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Snapshot>): void;
+  get(resourceGroupName: string, snapshotName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Snapshot>, callback?: coreHttp.ServiceCallback<Models.Snapshot>): Promise<Models.SnapshotsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -102,9 +102,9 @@ export class Snapshots {
    * after the snapshot is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * max name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, snapshotName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, snapshotName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,snapshotName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -115,19 +115,19 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsListByResourceGroupResponse>
    */
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsListByResourceGroupResponse>;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsListByResourceGroupResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.SnapshotList>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.SnapshotList>): void;
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.SnapshotList>, callback?: msRest.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SnapshotList>, callback?: coreHttp.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -142,17 +142,17 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.SnapshotList>): void;
+  list(callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.SnapshotList>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.SnapshotList>, callback?: msRest.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SnapshotList>, callback?: coreHttp.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -172,7 +172,7 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsGrantAccessResponse>
    */
-  grantAccess(resourceGroupName: string, snapshotName: string, grantAccessData: Models.GrantAccessData, options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsGrantAccessResponse> {
+  grantAccess(resourceGroupName: string, snapshotName: string, grantAccessData: Models.GrantAccessData, options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsGrantAccessResponse> {
     return this.beginGrantAccess(resourceGroupName,snapshotName,grantAccessData,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.SnapshotsGrantAccessResponse>;
   }
@@ -184,9 +184,9 @@ export class Snapshots {
    * after the snapshot is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * max name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  revokeAccess(resourceGroupName: string, snapshotName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  revokeAccess(resourceGroupName: string, snapshotName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginRevokeAccess(resourceGroupName,snapshotName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -199,9 +199,9 @@ export class Snapshots {
    * max name length is 80 characters.
    * @param snapshot Snapshot object supplied in the body of the Put disk operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, snapshotName: string, snapshot: Models.Snapshot, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, snapshotName: string, snapshot: Models.Snapshot, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -221,9 +221,9 @@ export class Snapshots {
    * max name length is 80 characters.
    * @param snapshot Snapshot object supplied in the body of the Patch snapshot operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, snapshotName: string, snapshot: Models.SnapshotUpdate, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, snapshotName: string, snapshot: Models.SnapshotUpdate, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -242,9 +242,9 @@ export class Snapshots {
    * after the snapshot is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * max name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, snapshotName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, snapshotName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -264,9 +264,9 @@ export class Snapshots {
    * @param grantAccessData Access data object supplied in the body of the get snapshot access
    * operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginGrantAccess(resourceGroupName: string, snapshotName: string, grantAccessData: Models.GrantAccessData, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginGrantAccess(resourceGroupName: string, snapshotName: string, grantAccessData: Models.GrantAccessData, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -285,9 +285,9 @@ export class Snapshots {
    * after the snapshot is created. Supported characters for the name are a-z, A-Z, 0-9 and _. The
    * max name length is 80 characters.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRevokeAccess(resourceGroupName: string, snapshotName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRevokeAccess(resourceGroupName: string, snapshotName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -304,19 +304,19 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.SnapshotList>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.SnapshotList>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.SnapshotList>, callback?: msRest.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SnapshotList>, callback?: coreHttp.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -332,19 +332,19 @@ export class Snapshots {
    * @param [options] The optional parameters
    * @returns Promise<Models.SnapshotsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.SnapshotsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.SnapshotsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.SnapshotList>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.SnapshotList>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.SnapshotList>, callback?: msRest.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.SnapshotList>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SnapshotList>, callback?: coreHttp.ServiceCallback<Models.SnapshotList>): Promise<Models.SnapshotsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -356,8 +356,8 @@ export class Snapshots {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}",
   urlParameters: [
@@ -382,7 +382,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots",
   urlParameters: [
@@ -406,7 +406,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/snapshots",
   urlParameters: [
@@ -429,7 +429,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}",
   urlParameters: [
@@ -464,7 +464,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}",
   urlParameters: [
@@ -499,7 +499,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}",
   urlParameters: [
@@ -524,7 +524,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginGrantAccessOperationSpec: msRest.OperationSpec = {
+const beginGrantAccessOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}/beginGetAccess",
   urlParameters: [
@@ -557,7 +557,7 @@ const beginGrantAccessOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRevokeAccessOperationSpec: msRest.OperationSpec = {
+const beginRevokeAccessOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/snapshots/{snapshotName}/endGetAccess",
   urlParameters: [
@@ -581,7 +581,7 @@ const beginRevokeAccessOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -602,7 +602,7 @@ const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/usageOperations.ts
+++ b/sdk/compute/arm-compute/src/operations/usageOperations.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/usageOperationsMappers";
 import * as Parameters from "../models/parameters";
@@ -33,19 +33,19 @@ export class UsageOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.UsageListResponse>
    */
-  list(location: string, options?: msRest.RequestOptionsBase): Promise<Models.UsageListResponse>;
+  list(location: string, options?: coreHttp.RequestOptionsBase): Promise<Models.UsageListResponse>;
   /**
    * @param location The location for which resource usage is queried.
    * @param callback The callback
    */
-  list(location: string, callback: msRest.ServiceCallback<Models.ListUsagesResult>): void;
+  list(location: string, callback: coreHttp.ServiceCallback<Models.ListUsagesResult>): void;
   /**
    * @param location The location for which resource usage is queried.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(location: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ListUsagesResult>): void;
-  list(location: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ListUsagesResult>, callback?: msRest.ServiceCallback<Models.ListUsagesResult>): Promise<Models.UsageListResponse> {
+  list(location: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ListUsagesResult>): void;
+  list(location: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ListUsagesResult>, callback?: coreHttp.ServiceCallback<Models.ListUsagesResult>): Promise<Models.UsageListResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -62,19 +62,19 @@ export class UsageOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.UsageListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.UsageListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.UsageListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ListUsagesResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ListUsagesResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ListUsagesResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ListUsagesResult>, callback?: msRest.ServiceCallback<Models.ListUsagesResult>): Promise<Models.UsageListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ListUsagesResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ListUsagesResult>, callback?: coreHttp.ServiceCallback<Models.ListUsagesResult>): Promise<Models.UsageListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -86,8 +86,8 @@ export class UsageOperations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/usages",
   urlParameters: [
@@ -111,7 +111,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/virtualMachineExtensionImages.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineExtensionImages.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineExtensionImagesMappers";
 import * as Parameters from "../models/parameters";
@@ -35,7 +35,7 @@ export class VirtualMachineExtensionImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineExtensionImagesGetResponse>
    */
-  get(location: string, publisherName: string, type: string, version: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineExtensionImagesGetResponse>;
+  get(location: string, publisherName: string, type: string, version: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineExtensionImagesGetResponse>;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName
@@ -43,7 +43,7 @@ export class VirtualMachineExtensionImages {
    * @param version
    * @param callback The callback
    */
-  get(location: string, publisherName: string, type: string, version: string, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionImage>): void;
+  get(location: string, publisherName: string, type: string, version: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName
@@ -52,8 +52,8 @@ export class VirtualMachineExtensionImages {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(location: string, publisherName: string, type: string, version: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionImage>): void;
-  get(location: string, publisherName: string, type: string, version: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineExtensionImage>, callback?: msRest.ServiceCallback<Models.VirtualMachineExtensionImage>): Promise<Models.VirtualMachineExtensionImagesGetResponse> {
+  get(location: string, publisherName: string, type: string, version: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage>): void;
+  get(location: string, publisherName: string, type: string, version: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage>): Promise<Models.VirtualMachineExtensionImagesGetResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -73,21 +73,21 @@ export class VirtualMachineExtensionImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineExtensionImagesListTypesResponse>
    */
-  listTypes(location: string, publisherName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineExtensionImagesListTypesResponse>;
+  listTypes(location: string, publisherName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineExtensionImagesListTypesResponse>;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName
    * @param callback The callback
    */
-  listTypes(location: string, publisherName: string, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
+  listTypes(location: string, publisherName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName
    * @param options The optional parameters
    * @param callback The callback
    */
-  listTypes(location: string, publisherName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
-  listTypes(location: string, publisherName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>, callback?: msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>): Promise<Models.VirtualMachineExtensionImagesListTypesResponse> {
+  listTypes(location: string, publisherName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
+  listTypes(location: string, publisherName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>): Promise<Models.VirtualMachineExtensionImagesListTypesResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -113,7 +113,7 @@ export class VirtualMachineExtensionImages {
    * @param type
    * @param callback The callback
    */
-  listVersions(location: string, publisherName: string, type: string, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
+  listVersions(location: string, publisherName: string, type: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName
@@ -121,8 +121,8 @@ export class VirtualMachineExtensionImages {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listVersions(location: string, publisherName: string, type: string, options: Models.VirtualMachineExtensionImagesListVersionsOptionalParams, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
-  listVersions(location: string, publisherName: string, type: string, options?: Models.VirtualMachineExtensionImagesListVersionsOptionalParams | msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>, callback?: msRest.ServiceCallback<Models.VirtualMachineExtensionImage[]>): Promise<Models.VirtualMachineExtensionImagesListVersionsResponse> {
+  listVersions(location: string, publisherName: string, type: string, options: Models.VirtualMachineExtensionImagesListVersionsOptionalParams, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>): void;
+  listVersions(location: string, publisherName: string, type: string, options?: Models.VirtualMachineExtensionImagesListVersionsOptionalParams | coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineExtensionImage[]>): Promise<Models.VirtualMachineExtensionImagesListVersionsResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -136,8 +136,8 @@ export class VirtualMachineExtensionImages {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions/{version}",
   urlParameters: [
@@ -164,7 +164,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listTypesOperationSpec: msRest.OperationSpec = {
+const listTypesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types",
   urlParameters: [
@@ -200,7 +200,7 @@ const listTypesOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listVersionsOperationSpec: msRest.OperationSpec = {
+const listVersionsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmextension/types/{type}/versions",
   urlParameters: [

--- a/sdk/compute/arm-compute/src/operations/virtualMachineExtensions.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineExtensions.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineExtensionsMappers";
 import * as Parameters from "../models/parameters";
@@ -37,7 +37,7 @@ export class VirtualMachineExtensions {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineExtensionsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtension, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineExtensionsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtension, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineExtensionsCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,vmName,vmExtensionName,extensionParameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachineExtensionsCreateOrUpdateResponse>;
   }
@@ -52,7 +52,7 @@ export class VirtualMachineExtensions {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineExtensionsUpdateResponse>
    */
-  update(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtensionUpdate, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineExtensionsUpdateResponse> {
+  update(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtensionUpdate, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineExtensionsUpdateResponse> {
     return this.beginUpdate(resourceGroupName,vmName,vmExtensionName,extensionParameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachineExtensionsUpdateResponse>;
   }
@@ -63,9 +63,9 @@ export class VirtualMachineExtensions {
    * @param vmName The name of the virtual machine where the extension should be deleted.
    * @param vmExtensionName The name of the virtual machine extension.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, vmName: string, vmExtensionName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, vmName: string, vmExtensionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,vmName,vmExtensionName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -85,7 +85,7 @@ export class VirtualMachineExtensions {
    * @param vmExtensionName The name of the virtual machine extension.
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmName: string, vmExtensionName: string, callback: msRest.ServiceCallback<Models.VirtualMachineExtension>): void;
+  get(resourceGroupName: string, vmName: string, vmExtensionName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtension>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine containing the extension.
@@ -93,8 +93,8 @@ export class VirtualMachineExtensions {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmName: string, vmExtensionName: string, options: Models.VirtualMachineExtensionsGetOptionalParams, callback: msRest.ServiceCallback<Models.VirtualMachineExtension>): void;
-  get(resourceGroupName: string, vmName: string, vmExtensionName: string, options?: Models.VirtualMachineExtensionsGetOptionalParams | msRest.ServiceCallback<Models.VirtualMachineExtension>, callback?: msRest.ServiceCallback<Models.VirtualMachineExtension>): Promise<Models.VirtualMachineExtensionsGetResponse> {
+  get(resourceGroupName: string, vmName: string, vmExtensionName: string, options: Models.VirtualMachineExtensionsGetOptionalParams, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtension>): void;
+  get(resourceGroupName: string, vmName: string, vmExtensionName: string, options?: Models.VirtualMachineExtensionsGetOptionalParams | coreHttp.ServiceCallback<Models.VirtualMachineExtension>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineExtension>): Promise<Models.VirtualMachineExtensionsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -119,15 +119,15 @@ export class VirtualMachineExtensions {
    * @param vmName The name of the virtual machine containing the extension.
    * @param callback The callback
    */
-  list(resourceGroupName: string, vmName: string, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionsListResult>): void;
+  list(resourceGroupName: string, vmName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionsListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine containing the extension.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceGroupName: string, vmName: string, options: Models.VirtualMachineExtensionsListOptionalParams, callback: msRest.ServiceCallback<Models.VirtualMachineExtensionsListResult>): void;
-  list(resourceGroupName: string, vmName: string, options?: Models.VirtualMachineExtensionsListOptionalParams | msRest.ServiceCallback<Models.VirtualMachineExtensionsListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineExtensionsListResult>): Promise<Models.VirtualMachineExtensionsListResponse> {
+  list(resourceGroupName: string, vmName: string, options: Models.VirtualMachineExtensionsListOptionalParams, callback: coreHttp.ServiceCallback<Models.VirtualMachineExtensionsListResult>): void;
+  list(resourceGroupName: string, vmName: string, options?: Models.VirtualMachineExtensionsListOptionalParams | coreHttp.ServiceCallback<Models.VirtualMachineExtensionsListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineExtensionsListResult>): Promise<Models.VirtualMachineExtensionsListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -146,9 +146,9 @@ export class VirtualMachineExtensions {
    * @param extensionParameters Parameters supplied to the Create Virtual Machine Extension
    * operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtension, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtension, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -169,9 +169,9 @@ export class VirtualMachineExtensions {
    * @param extensionParameters Parameters supplied to the Update Virtual Machine Extension
    * operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtensionUpdate, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, vmName: string, vmExtensionName: string, extensionParameters: Models.VirtualMachineExtensionUpdate, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -190,9 +190,9 @@ export class VirtualMachineExtensions {
    * @param vmName The name of the virtual machine where the extension should be deleted.
    * @param vmExtensionName The name of the virtual machine extension.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, vmName: string, vmExtensionName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, vmName: string, vmExtensionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -206,8 +206,8 @@ export class VirtualMachineExtensions {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}",
   urlParameters: [
@@ -234,7 +234,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions",
   urlParameters: [
@@ -260,7 +260,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}",
   urlParameters: [
@@ -296,7 +296,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}",
   urlParameters: [
@@ -329,7 +329,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/extensions/{vmExtensionName}",
   urlParameters: [

--- a/sdk/compute/arm-compute/src/operations/virtualMachineImages.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineImages.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineImagesMappers";
 import * as Parameters from "../models/parameters";
@@ -36,7 +36,7 @@ export class VirtualMachineImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineImagesGetResponse>
    */
-  get(location: string, publisherName: string, offer: string, skus: string, version: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineImagesGetResponse>;
+  get(location: string, publisherName: string, offer: string, skus: string, version: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineImagesGetResponse>;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName A valid image publisher.
@@ -45,7 +45,7 @@ export class VirtualMachineImages {
    * @param version A valid image SKU version.
    * @param callback The callback
    */
-  get(location: string, publisherName: string, offer: string, skus: string, version: string, callback: msRest.ServiceCallback<Models.VirtualMachineImage>): void;
+  get(location: string, publisherName: string, offer: string, skus: string, version: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineImage>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName A valid image publisher.
@@ -55,8 +55,8 @@ export class VirtualMachineImages {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(location: string, publisherName: string, offer: string, skus: string, version: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineImage>): void;
-  get(location: string, publisherName: string, offer: string, skus: string, version: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineImage>, callback?: msRest.ServiceCallback<Models.VirtualMachineImage>): Promise<Models.VirtualMachineImagesGetResponse> {
+  get(location: string, publisherName: string, offer: string, skus: string, version: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineImage>): void;
+  get(location: string, publisherName: string, offer: string, skus: string, version: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineImage>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineImage>): Promise<Models.VirtualMachineImagesGetResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -88,7 +88,7 @@ export class VirtualMachineImages {
    * @param skus A valid image SKU.
    * @param callback The callback
    */
-  list(location: string, publisherName: string, offer: string, skus: string, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  list(location: string, publisherName: string, offer: string, skus: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName A valid image publisher.
@@ -97,8 +97,8 @@ export class VirtualMachineImages {
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(location: string, publisherName: string, offer: string, skus: string, options: Models.VirtualMachineImagesListOptionalParams, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
-  list(location: string, publisherName: string, offer: string, skus: string, options?: Models.VirtualMachineImagesListOptionalParams | msRest.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListResponse> {
+  list(location: string, publisherName: string, offer: string, skus: string, options: Models.VirtualMachineImagesListOptionalParams, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  list(location: string, publisherName: string, offer: string, skus: string, options?: Models.VirtualMachineImagesListOptionalParams | coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -118,21 +118,21 @@ export class VirtualMachineImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineImagesListOffersResponse>
    */
-  listOffers(location: string, publisherName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineImagesListOffersResponse>;
+  listOffers(location: string, publisherName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineImagesListOffersResponse>;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName A valid image publisher.
    * @param callback The callback
    */
-  listOffers(location: string, publisherName: string, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  listOffers(location: string, publisherName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName A valid image publisher.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listOffers(location: string, publisherName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
-  listOffers(location: string, publisherName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListOffersResponse> {
+  listOffers(location: string, publisherName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  listOffers(location: string, publisherName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListOffersResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -149,19 +149,19 @@ export class VirtualMachineImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineImagesListPublishersResponse>
    */
-  listPublishers(location: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineImagesListPublishersResponse>;
+  listPublishers(location: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineImagesListPublishersResponse>;
   /**
    * @param location The name of a supported Azure region.
    * @param callback The callback
    */
-  listPublishers(location: string, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  listPublishers(location: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listPublishers(location: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
-  listPublishers(location: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListPublishersResponse> {
+  listPublishers(location: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  listPublishers(location: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListPublishersResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -179,14 +179,14 @@ export class VirtualMachineImages {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineImagesListSkusResponse>
    */
-  listSkus(location: string, publisherName: string, offer: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineImagesListSkusResponse>;
+  listSkus(location: string, publisherName: string, offer: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineImagesListSkusResponse>;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName A valid image publisher.
    * @param offer A valid image publisher offer.
    * @param callback The callback
    */
-  listSkus(location: string, publisherName: string, offer: string, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  listSkus(location: string, publisherName: string, offer: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
   /**
    * @param location The name of a supported Azure region.
    * @param publisherName A valid image publisher.
@@ -194,8 +194,8 @@ export class VirtualMachineImages {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listSkus(location: string, publisherName: string, offer: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
-  listSkus(location: string, publisherName: string, offer: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: msRest.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListSkusResponse> {
+  listSkus(location: string, publisherName: string, offer: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): void;
+  listSkus(location: string, publisherName: string, offer: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineImageResource[]>): Promise<Models.VirtualMachineImagesListSkusResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -209,8 +209,8 @@ export class VirtualMachineImages {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers/{offer}/skus/{skus}/versions/{version}",
   urlParameters: [
@@ -238,7 +238,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers/{offer}/skus/{skus}/versions",
   urlParameters: [
@@ -279,7 +279,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOffersOperationSpec: msRest.OperationSpec = {
+const listOffersOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers",
   urlParameters: [
@@ -315,7 +315,7 @@ const listOffersOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listPublishersOperationSpec: msRest.OperationSpec = {
+const listPublishersOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers",
   urlParameters: [
@@ -350,7 +350,7 @@ const listPublishersOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listSkusOperationSpec: msRest.OperationSpec = {
+const listSkusOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/publishers/{publisherName}/artifacttypes/vmimage/offers/{offer}/skus",
   urlParameters: [

--- a/sdk/compute/arm-compute/src/operations/virtualMachineRunCommands.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineRunCommands.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineRunCommandsMappers";
 import * as Parameters from "../models/parameters";
@@ -32,19 +32,19 @@ export class VirtualMachineRunCommands {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineRunCommandsListResponse>
    */
-  list(location: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineRunCommandsListResponse>;
+  list(location: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineRunCommandsListResponse>;
   /**
    * @param location The location upon which run commands is queried.
    * @param callback The callback
    */
-  list(location: string, callback: msRest.ServiceCallback<Models.RunCommandListResult>): void;
+  list(location: string, callback: coreHttp.ServiceCallback<Models.RunCommandListResult>): void;
   /**
    * @param location The location upon which run commands is queried.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(location: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.RunCommandListResult>): void;
-  list(location: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.RunCommandListResult>, callback?: msRest.ServiceCallback<Models.RunCommandListResult>): Promise<Models.VirtualMachineRunCommandsListResponse> {
+  list(location: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.RunCommandListResult>): void;
+  list(location: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.RunCommandListResult>, callback?: coreHttp.ServiceCallback<Models.RunCommandListResult>): Promise<Models.VirtualMachineRunCommandsListResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -61,21 +61,21 @@ export class VirtualMachineRunCommands {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineRunCommandsGetResponse>
    */
-  get(location: string, commandId: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineRunCommandsGetResponse>;
+  get(location: string, commandId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineRunCommandsGetResponse>;
   /**
    * @param location The location upon which run commands is queried.
    * @param commandId The command id.
    * @param callback The callback
    */
-  get(location: string, commandId: string, callback: msRest.ServiceCallback<Models.RunCommandDocument>): void;
+  get(location: string, commandId: string, callback: coreHttp.ServiceCallback<Models.RunCommandDocument>): void;
   /**
    * @param location The location upon which run commands is queried.
    * @param commandId The command id.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(location: string, commandId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.RunCommandDocument>): void;
-  get(location: string, commandId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.RunCommandDocument>, callback?: msRest.ServiceCallback<Models.RunCommandDocument>): Promise<Models.VirtualMachineRunCommandsGetResponse> {
+  get(location: string, commandId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.RunCommandDocument>): void;
+  get(location: string, commandId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.RunCommandDocument>, callback?: coreHttp.ServiceCallback<Models.RunCommandDocument>): Promise<Models.VirtualMachineRunCommandsGetResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -92,19 +92,19 @@ export class VirtualMachineRunCommands {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineRunCommandsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineRunCommandsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineRunCommandsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.RunCommandListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.RunCommandListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.RunCommandListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.RunCommandListResult>, callback?: msRest.ServiceCallback<Models.RunCommandListResult>): Promise<Models.VirtualMachineRunCommandsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.RunCommandListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.RunCommandListResult>, callback?: coreHttp.ServiceCallback<Models.RunCommandListResult>): Promise<Models.VirtualMachineRunCommandsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -116,8 +116,8 @@ export class VirtualMachineRunCommands {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/runCommands",
   urlParameters: [
@@ -141,7 +141,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/runCommands/{commandId}",
   urlParameters: [
@@ -166,7 +166,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetExtensions.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetExtensions.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineScaleSetExtensionsMappers";
 import * as Parameters from "../models/parameters";
@@ -37,7 +37,7 @@ export class VirtualMachineScaleSetExtensions {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetExtensionsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, extensionParameters: Models.VirtualMachineScaleSetExtension, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetExtensionsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, extensionParameters: Models.VirtualMachineScaleSetExtension, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetExtensionsCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,vmScaleSetName,vmssExtensionName,extensionParameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachineScaleSetExtensionsCreateOrUpdateResponse>;
   }
@@ -48,9 +48,9 @@ export class VirtualMachineScaleSetExtensions {
    * @param vmScaleSetName The name of the VM scale set where the extension should be deleted.
    * @param vmssExtensionName The name of the VM scale set extension.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,vmScaleSetName,vmssExtensionName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -70,7 +70,7 @@ export class VirtualMachineScaleSetExtensions {
    * @param vmssExtensionName The name of the VM scale set extension.
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtension>): void;
+  get(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtension>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set containing the extension.
@@ -78,8 +78,8 @@ export class VirtualMachineScaleSetExtensions {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options: Models.VirtualMachineScaleSetExtensionsGetOptionalParams, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtension>): void;
-  get(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options?: Models.VirtualMachineScaleSetExtensionsGetOptionalParams | msRest.ServiceCallback<Models.VirtualMachineScaleSetExtension>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtension>): Promise<Models.VirtualMachineScaleSetExtensionsGetResponse> {
+  get(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options: Models.VirtualMachineScaleSetExtensionsGetOptionalParams, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtension>): void;
+  get(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options?: Models.VirtualMachineScaleSetExtensionsGetOptionalParams | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtension>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtension>): Promise<Models.VirtualMachineScaleSetExtensionsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -98,21 +98,21 @@ export class VirtualMachineScaleSetExtensions {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetExtensionsListResponse>
    */
-  list(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetExtensionsListResponse>;
+  list(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetExtensionsListResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set containing the extension.
    * @param callback The callback
    */
-  list(resourceGroupName: string, vmScaleSetName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
+  list(resourceGroupName: string, vmScaleSetName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set containing the extension.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceGroupName: string, vmScaleSetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
-  list(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): Promise<Models.VirtualMachineScaleSetExtensionsListResponse> {
+  list(resourceGroupName: string, vmScaleSetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
+  list(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): Promise<Models.VirtualMachineScaleSetExtensionsListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -131,9 +131,9 @@ export class VirtualMachineScaleSetExtensions {
    * @param vmssExtensionName The name of the VM scale set extension.
    * @param extensionParameters Parameters supplied to the Create VM scale set Extension operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, extensionParameters: Models.VirtualMachineScaleSetExtension, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, extensionParameters: Models.VirtualMachineScaleSetExtension, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -152,9 +152,9 @@ export class VirtualMachineScaleSetExtensions {
    * @param vmScaleSetName The name of the VM scale set where the extension should be deleted.
    * @param vmssExtensionName The name of the VM scale set extension.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, vmScaleSetName: string, vmssExtensionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -172,19 +172,19 @@ export class VirtualMachineScaleSetExtensions {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetExtensionsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetExtensionsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetExtensionsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): Promise<Models.VirtualMachineScaleSetExtensionsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetExtensionListResult>): Promise<Models.VirtualMachineScaleSetExtensionsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -196,8 +196,8 @@ export class VirtualMachineScaleSetExtensions {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}",
   urlParameters: [
@@ -224,7 +224,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions",
   urlParameters: [
@@ -249,7 +249,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}",
   urlParameters: [
@@ -285,7 +285,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensions/{vmssExtensionName}",
   urlParameters: [
@@ -311,7 +311,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetOperations.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetOperations.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineScaleSetOperationsMappers";
 import * as Parameters from "../models/parameters";
@@ -32,16 +32,16 @@ export class VirtualMachineScaleSetOperations {
    * @param vmScaleSetName The name of the virtual machine scale set to create or update.
    * @param parameters The input object for ConvertToSinglePlacementGroup API.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the virtual machine scale set to create or update.
    * @param parameters The input object for ConvertToSinglePlacementGroup API.
    * @param callback The callback
    */
-  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, callback: msRest.ServiceCallback<void>): void;
+  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the virtual machine scale set to create or update.
@@ -49,8 +49,8 @@ export class VirtualMachineScaleSetOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  convertToSinglePlacementGroup(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VMScaleSetConvertToSinglePlacementGroupInput, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -64,8 +64,8 @@ export class VirtualMachineScaleSetOperations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const convertToSinglePlacementGroupOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const convertToSinglePlacementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/convertToSinglePlacementGroup",
   urlParameters: [

--- a/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetRollingUpgrades.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetRollingUpgrades.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineScaleSetRollingUpgradesMappers";
 import * as Parameters from "../models/parameters";
@@ -32,9 +32,9 @@ export class VirtualMachineScaleSetRollingUpgrades {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  cancel(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  cancel(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginCancel(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -46,9 +46,9 @@ export class VirtualMachineScaleSetRollingUpgrades {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  startOSUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  startOSUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginStartOSUpgrade(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -60,9 +60,9 @@ export class VirtualMachineScaleSetRollingUpgrades {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  startExtensionUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  startExtensionUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginStartExtensionUpgrade(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -74,21 +74,21 @@ export class VirtualMachineScaleSetRollingUpgrades {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetRollingUpgradesGetLatestResponse>
    */
-  getLatest(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetRollingUpgradesGetLatestResponse>;
+  getLatest(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetRollingUpgradesGetLatestResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param callback The callback
    */
-  getLatest(resourceGroupName: string, vmScaleSetName: string, callback: msRest.ServiceCallback<Models.RollingUpgradeStatusInfo>): void;
+  getLatest(resourceGroupName: string, vmScaleSetName: string, callback: coreHttp.ServiceCallback<Models.RollingUpgradeStatusInfo>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getLatest(resourceGroupName: string, vmScaleSetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.RollingUpgradeStatusInfo>): void;
-  getLatest(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.RollingUpgradeStatusInfo>, callback?: msRest.ServiceCallback<Models.RollingUpgradeStatusInfo>): Promise<Models.VirtualMachineScaleSetRollingUpgradesGetLatestResponse> {
+  getLatest(resourceGroupName: string, vmScaleSetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.RollingUpgradeStatusInfo>): void;
+  getLatest(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.RollingUpgradeStatusInfo>, callback?: coreHttp.ServiceCallback<Models.RollingUpgradeStatusInfo>): Promise<Models.VirtualMachineScaleSetRollingUpgradesGetLatestResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -104,9 +104,9 @@ export class VirtualMachineScaleSetRollingUpgrades {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCancel(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCancel(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -124,9 +124,9 @@ export class VirtualMachineScaleSetRollingUpgrades {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginStartOSUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginStartOSUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -144,9 +144,9 @@ export class VirtualMachineScaleSetRollingUpgrades {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginStartExtensionUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginStartExtensionUpgrade(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -159,8 +159,8 @@ export class VirtualMachineScaleSetRollingUpgrades {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getLatestOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getLatestOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/rollingUpgrades/latest",
   urlParameters: [
@@ -185,7 +185,7 @@ const getLatestOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCancelOperationSpec: msRest.OperationSpec = {
+const beginCancelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/rollingUpgrades/cancel",
   urlParameters: [
@@ -209,7 +209,7 @@ const beginCancelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginStartOSUpgradeOperationSpec: msRest.OperationSpec = {
+const beginStartOSUpgradeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/osRollingUpgrade",
   urlParameters: [
@@ -233,7 +233,7 @@ const beginStartOSUpgradeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginStartExtensionUpgradeOperationSpec: msRest.OperationSpec = {
+const beginStartExtensionUpgradeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/extensionRollingUpgrade",
   urlParameters: [

--- a/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetVMs.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineScaleSetVMs.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineScaleSetVMsMappers";
 import * as Parameters from "../models/parameters";
@@ -33,9 +33,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  reimage(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsReimageOptionalParams): Promise<msRest.RestResponse> {
+  reimage(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsReimageOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginReimage(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -47,9 +47,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  reimageAll(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  reimageAll(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginReimageAll(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -62,9 +62,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deallocate(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deallocate(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeallocate(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -79,7 +79,7 @@ export class VirtualMachineScaleSetVMs {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetVMsUpdateResponse>
    */
-  update(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.VirtualMachineScaleSetVM, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsUpdateResponse> {
+  update(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.VirtualMachineScaleSetVM, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsUpdateResponse> {
     return this.beginUpdate(resourceGroupName,vmScaleSetName,instanceId,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachineScaleSetVMsUpdateResponse>;
   }
@@ -90,9 +90,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -105,14 +105,14 @@ export class VirtualMachineScaleSetVMs {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetVMsGetResponse>
    */
-  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsGetResponse>;
+  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVM>): void;
+  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVM>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
@@ -120,8 +120,8 @@ export class VirtualMachineScaleSetVMs {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVM>): void;
-  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetVM>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetVM>): Promise<Models.VirtualMachineScaleSetVMsGetResponse> {
+  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVM>): void;
+  get(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVM>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVM>): Promise<Models.VirtualMachineScaleSetVMsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -141,14 +141,14 @@ export class VirtualMachineScaleSetVMs {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetVMsGetInstanceViewResponse>
    */
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsGetInstanceViewResponse>;
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsGetInstanceViewResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param callback The callback
    */
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>): void;
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
@@ -156,8 +156,8 @@ export class VirtualMachineScaleSetVMs {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>): void;
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>): Promise<Models.VirtualMachineScaleSetVMsGetInstanceViewResponse> {
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>): void;
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMInstanceView>): Promise<Models.VirtualMachineScaleSetVMsGetInstanceViewResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -182,15 +182,15 @@ export class VirtualMachineScaleSetVMs {
    * @param virtualMachineScaleSetName The name of the VM scale set.
    * @param callback The callback
    */
-  list(resourceGroupName: string, virtualMachineScaleSetName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
+  list(resourceGroupName: string, virtualMachineScaleSetName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param virtualMachineScaleSetName The name of the VM scale set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceGroupName: string, virtualMachineScaleSetName: string, options: Models.VirtualMachineScaleSetVMsListOptionalParams, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
-  list(resourceGroupName: string, virtualMachineScaleSetName: string, options?: Models.VirtualMachineScaleSetVMsListOptionalParams | msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): Promise<Models.VirtualMachineScaleSetVMsListResponse> {
+  list(resourceGroupName: string, virtualMachineScaleSetName: string, options: Models.VirtualMachineScaleSetVMsListOptionalParams, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
+  list(resourceGroupName: string, virtualMachineScaleSetName: string, options?: Models.VirtualMachineScaleSetVMsListOptionalParams | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): Promise<Models.VirtualMachineScaleSetVMsListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -209,9 +209,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  powerOff(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsPowerOffOptionalParams): Promise<msRest.RestResponse> {
+  powerOff(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsPowerOffOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginPowerOff(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -222,9 +222,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  restart(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  restart(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginRestart(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -235,9 +235,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  start(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  start(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginStart(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -248,9 +248,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  redeploy(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  redeploy(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginRedeploy(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -261,9 +261,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  performMaintenance(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  performMaintenance(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginPerformMaintenance(resourceGroupName,vmScaleSetName,instanceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -277,7 +277,7 @@ export class VirtualMachineScaleSetVMs {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetVMsRunCommandResponse>
    */
-  runCommand(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.RunCommandInput, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsRunCommandResponse> {
+  runCommand(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.RunCommandInput, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsRunCommandResponse> {
     return this.beginRunCommand(resourceGroupName,vmScaleSetName,instanceId,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachineScaleSetVMsRunCommandResponse>;
   }
@@ -288,9 +288,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginReimage(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsBeginReimageOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginReimage(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsBeginReimageOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -309,9 +309,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginReimageAll(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginReimageAll(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -331,9 +331,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeallocate(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeallocate(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -353,9 +353,9 @@ export class VirtualMachineScaleSetVMs {
    * @param instanceId The instance ID of the virtual machine.
    * @param parameters Parameters supplied to the Update Virtual Machine Scale Sets VM operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.VirtualMachineScaleSetVM, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.VirtualMachineScaleSetVM, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -374,9 +374,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -396,9 +396,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginPowerOff(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsBeginPowerOffOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginPowerOff(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: Models.VirtualMachineScaleSetVMsBeginPowerOffOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -416,9 +416,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRestart(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRestart(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -436,9 +436,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginStart(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginStart(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -456,9 +456,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRedeploy(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRedeploy(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -476,9 +476,9 @@ export class VirtualMachineScaleSetVMs {
    * @param vmScaleSetName The name of the VM scale set.
    * @param instanceId The instance ID of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginPerformMaintenance(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginPerformMaintenance(resourceGroupName: string, vmScaleSetName: string, instanceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -497,9 +497,9 @@ export class VirtualMachineScaleSetVMs {
    * @param instanceId The instance ID of the virtual machine.
    * @param parameters Parameters supplied to the Run command operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRunCommand(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.RunCommandInput, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRunCommand(resourceGroupName: string, vmScaleSetName: string, instanceId: string, parameters: Models.RunCommandInput, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -518,19 +518,19 @@ export class VirtualMachineScaleSetVMs {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetVMsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetVMsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): Promise<Models.VirtualMachineScaleSetVMsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetVMListResult>): Promise<Models.VirtualMachineScaleSetVMsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -542,8 +542,8 @@ export class VirtualMachineScaleSetVMs {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}",
   urlParameters: [
@@ -569,7 +569,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getInstanceViewOperationSpec: msRest.OperationSpec = {
+const getInstanceViewOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/instanceView",
   urlParameters: [
@@ -595,7 +595,7 @@ const getInstanceViewOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{virtualMachineScaleSetName}/virtualMachines",
   urlParameters: [
@@ -623,7 +623,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginReimageOperationSpec: msRest.OperationSpec = {
+const beginReimageOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/reimage",
   urlParameters: [
@@ -655,7 +655,7 @@ const beginReimageOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginReimageAllOperationSpec: msRest.OperationSpec = {
+const beginReimageAllOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/reimageall",
   urlParameters: [
@@ -680,7 +680,7 @@ const beginReimageAllOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeallocateOperationSpec: msRest.OperationSpec = {
+const beginDeallocateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/deallocate",
   urlParameters: [
@@ -705,7 +705,7 @@ const beginDeallocateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}",
   urlParameters: [
@@ -741,7 +741,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}",
   urlParameters: [
@@ -767,7 +767,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginPowerOffOperationSpec: msRest.OperationSpec = {
+const beginPowerOffOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/poweroff",
   urlParameters: [
@@ -793,7 +793,7 @@ const beginPowerOffOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRestartOperationSpec: msRest.OperationSpec = {
+const beginRestartOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/restart",
   urlParameters: [
@@ -818,7 +818,7 @@ const beginRestartOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginStartOperationSpec: msRest.OperationSpec = {
+const beginStartOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/start",
   urlParameters: [
@@ -843,7 +843,7 @@ const beginStartOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRedeployOperationSpec: msRest.OperationSpec = {
+const beginRedeployOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/redeploy",
   urlParameters: [
@@ -868,7 +868,7 @@ const beginRedeployOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginPerformMaintenanceOperationSpec: msRest.OperationSpec = {
+const beginPerformMaintenanceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/performMaintenance",
   urlParameters: [
@@ -893,7 +893,7 @@ const beginPerformMaintenanceOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRunCommandOperationSpec: msRest.OperationSpec = {
+const beginRunCommandOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/virtualmachines/{instanceId}/runCommand",
   urlParameters: [
@@ -927,7 +927,7 @@ const beginRunCommandOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/virtualMachineScaleSets.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineScaleSets.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineScaleSetsMappers";
 import * as Parameters from "../models/parameters";
@@ -35,7 +35,7 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSet, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSet, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,vmScaleSetName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachineScaleSetsCreateOrUpdateResponse>;
   }
@@ -48,7 +48,7 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsUpdateResponse>
    */
-  update(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSetUpdate, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsUpdateResponse> {
+  update(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSetUpdate, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsUpdateResponse> {
     return this.beginUpdate(resourceGroupName,vmScaleSetName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachineScaleSetsUpdateResponse>;
   }
@@ -58,9 +58,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -72,21 +72,21 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsGetResponse>
    */
-  get(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetResponse>;
+  get(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmScaleSetName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSet>): void;
+  get(resourceGroupName: string, vmScaleSetName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSet>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmScaleSetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSet>): void;
-  get(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSet>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSet>): Promise<Models.VirtualMachineScaleSetsGetResponse> {
+  get(resourceGroupName: string, vmScaleSetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSet>): void;
+  get(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSet>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSet>): Promise<Models.VirtualMachineScaleSetsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -104,9 +104,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deallocate(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsDeallocateOptionalParams): Promise<msRest.RestResponse> {
+  deallocate(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsDeallocateOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginDeallocate(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -117,9 +117,9 @@ export class VirtualMachineScaleSets {
    * @param vmScaleSetName The name of the VM scale set.
    * @param vmInstanceIDs A list of virtual machine instance IDs from the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteInstances(resourceGroupName,vmScaleSetName,vmInstanceIDs,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -131,21 +131,21 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsGetInstanceViewResponse>
    */
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetInstanceViewResponse>;
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetInstanceViewResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param callback The callback
    */
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>): void;
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>): void;
-  getInstanceView(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>): Promise<Models.VirtualMachineScaleSetsGetInstanceViewResponse> {
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>): void;
+  getInstanceView(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetInstanceView>): Promise<Models.VirtualMachineScaleSetsGetInstanceViewResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -162,19 +162,19 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsListResponse>
    */
-  list(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListResponse>;
+  list(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  list(resourceGroupName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
+  list(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
-  list(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>): Promise<Models.VirtualMachineScaleSetsListResponse> {
+  list(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
+  list(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>): Promise<Models.VirtualMachineScaleSetsListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -191,17 +191,17 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsListAllResponse>
    */
-  listAll(options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListAllResponse>;
+  listAll(options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListAllResponse>;
   /**
    * @param callback The callback
    */
-  listAll(callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
+  listAll(callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAll(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
-  listAll(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): Promise<Models.VirtualMachineScaleSetsListAllResponse> {
+  listAll(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
+  listAll(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): Promise<Models.VirtualMachineScaleSetsListAllResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -218,21 +218,21 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsListSkusResponse>
    */
-  listSkus(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListSkusResponse>;
+  listSkus(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListSkusResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param callback The callback
    */
-  listSkus(resourceGroupName: string, vmScaleSetName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
+  listSkus(resourceGroupName: string, vmScaleSetName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listSkus(resourceGroupName: string, vmScaleSetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
-  listSkus(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): Promise<Models.VirtualMachineScaleSetsListSkusResponse> {
+  listSkus(resourceGroupName: string, vmScaleSetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
+  listSkus(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): Promise<Models.VirtualMachineScaleSetsListSkusResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -250,21 +250,21 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryResponse>
    */
-  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryResponse>;
+  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param callback The callback
    */
-  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
+  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
-  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryResponse> {
+  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
+  getOSUpgradeHistory(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -282,9 +282,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  powerOff(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsPowerOffOptionalParams): Promise<msRest.RestResponse> {
+  powerOff(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsPowerOffOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginPowerOff(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -294,9 +294,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  restart(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsRestartOptionalParams): Promise<msRest.RestResponse> {
+  restart(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsRestartOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginRestart(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -306,9 +306,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  start(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsStartOptionalParams): Promise<msRest.RestResponse> {
+  start(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsStartOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginStart(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -318,9 +318,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  redeploy(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsRedeployOptionalParams): Promise<msRest.RestResponse> {
+  redeploy(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsRedeployOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginRedeploy(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -333,9 +333,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  performMaintenance(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsPerformMaintenanceOptionalParams): Promise<msRest.RestResponse> {
+  performMaintenance(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsPerformMaintenanceOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginPerformMaintenance(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -346,9 +346,9 @@ export class VirtualMachineScaleSets {
    * @param vmScaleSetName The name of the VM scale set.
    * @param vmInstanceIDs A list of virtual machine instance IDs from the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  updateInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  updateInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginUpdateInstances(resourceGroupName,vmScaleSetName,vmInstanceIDs,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -360,9 +360,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  reimage(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsReimageOptionalParams): Promise<msRest.RestResponse> {
+  reimage(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsReimageOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginReimage(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -373,9 +373,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  reimageAll(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsReimageAllOptionalParams): Promise<msRest.RestResponse> {
+  reimageAll(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsReimageAllOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginReimageAll(resourceGroupName,vmScaleSetName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -391,7 +391,7 @@ export class VirtualMachineScaleSets {
    * @returns
    * Promise<Models.VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse>
    */
-  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse>;
+  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
@@ -399,7 +399,7 @@ export class VirtualMachineScaleSets {
    * requested
    * @param callback The callback
    */
-  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, callback: msRest.ServiceCallback<Models.RecoveryWalkResponse>): void;
+  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, callback: coreHttp.ServiceCallback<Models.RecoveryWalkResponse>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
@@ -408,8 +408,8 @@ export class VirtualMachineScaleSets {
    * @param options The optional parameters
    * @param callback The callback
    */
-  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.RecoveryWalkResponse>): void;
-  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.RecoveryWalkResponse>, callback?: msRest.ServiceCallback<Models.RecoveryWalkResponse>): Promise<Models.VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse> {
+  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.RecoveryWalkResponse>): void;
+  forceRecoveryServiceFabricPlatformUpdateDomainWalk(resourceGroupName: string, vmScaleSetName: string, platformUpdateDomain: number, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.RecoveryWalkResponse>, callback?: coreHttp.ServiceCallback<Models.RecoveryWalkResponse>): Promise<Models.VirtualMachineScaleSetsForceRecoveryServiceFabricPlatformUpdateDomainWalkResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -427,9 +427,9 @@ export class VirtualMachineScaleSets {
    * @param vmScaleSetName The name of the VM scale set to create or update.
    * @param parameters The scale set object.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSet, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSet, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -447,9 +447,9 @@ export class VirtualMachineScaleSets {
    * @param vmScaleSetName The name of the VM scale set to create or update.
    * @param parameters The scale set object.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSetUpdate, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, vmScaleSetName: string, parameters: Models.VirtualMachineScaleSetUpdate, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -466,9 +466,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, vmScaleSetName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, vmScaleSetName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -486,9 +486,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeallocate(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginDeallocateOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginDeallocate(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginDeallocateOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -505,9 +505,9 @@ export class VirtualMachineScaleSets {
    * @param vmScaleSetName The name of the VM scale set.
    * @param vmInstanceIDs A list of virtual machine instance IDs from the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -526,9 +526,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginPowerOff(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginPowerOffOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginPowerOff(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginPowerOffOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -544,9 +544,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRestart(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginRestartOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginRestart(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginRestartOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -562,9 +562,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginStart(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginStartOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginStart(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginStartOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -580,9 +580,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRedeploy(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginRedeployOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginRedeploy(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginRedeployOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -601,9 +601,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginPerformMaintenance(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginPerformMaintenanceOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginPerformMaintenance(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginPerformMaintenanceOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -620,9 +620,9 @@ export class VirtualMachineScaleSets {
    * @param vmScaleSetName The name of the VM scale set.
    * @param vmInstanceIDs A list of virtual machine instance IDs from the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdateInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdateInstances(resourceGroupName: string, vmScaleSetName: string, vmInstanceIDs: Models.VirtualMachineScaleSetVMInstanceRequiredIDs, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -641,9 +641,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginReimage(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginReimageOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginReimage(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginReimageOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -660,9 +660,9 @@ export class VirtualMachineScaleSets {
    * @param resourceGroupName The name of the resource group.
    * @param vmScaleSetName The name of the VM scale set.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginReimageAll(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginReimageAllOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginReimageAll(resourceGroupName: string, vmScaleSetName: string, options?: Models.VirtualMachineScaleSetsBeginReimageAllOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -679,19 +679,19 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListResult>): Promise<Models.VirtualMachineScaleSetsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListResult>): Promise<Models.VirtualMachineScaleSetsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -709,19 +709,19 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsListAllNextResponse>
    */
-  listAllNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListAllNextResponse>;
+  listAllNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListAllNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAllNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
+  listAllNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAllNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
-  listAllNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): Promise<Models.VirtualMachineScaleSetsListAllNextResponse> {
+  listAllNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): void;
+  listAllNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListWithLinkResult>): Promise<Models.VirtualMachineScaleSetsListAllNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -738,19 +738,19 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsListSkusNextResponse>
    */
-  listSkusNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListSkusNextResponse>;
+  listSkusNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsListSkusNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listSkusNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
+  listSkusNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listSkusNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
-  listSkusNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): Promise<Models.VirtualMachineScaleSetsListSkusNextResponse> {
+  listSkusNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): void;
+  listSkusNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListSkusResult>): Promise<Models.VirtualMachineScaleSetsListSkusNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -766,19 +766,19 @@ export class VirtualMachineScaleSets {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryNextResponse>
    */
-  getOSUpgradeHistoryNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryNextResponse>;
+  getOSUpgradeHistoryNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  getOSUpgradeHistoryNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
+  getOSUpgradeHistoryNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getOSUpgradeHistoryNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
-  getOSUpgradeHistoryNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>, callback?: msRest.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryNextResponse> {
+  getOSUpgradeHistoryNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): void;
+  getOSUpgradeHistoryNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineScaleSetListOSUpgradeHistory>): Promise<Models.VirtualMachineScaleSetsGetOSUpgradeHistoryNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -790,8 +790,8 @@ export class VirtualMachineScaleSets {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}",
   urlParameters: [
@@ -816,7 +816,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getInstanceViewOperationSpec: msRest.OperationSpec = {
+const getInstanceViewOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/instanceView",
   urlParameters: [
@@ -841,7 +841,7 @@ const getInstanceViewOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets",
   urlParameters: [
@@ -865,7 +865,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAllOperationSpec: msRest.OperationSpec = {
+const listAllOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachineScaleSets",
   urlParameters: [
@@ -888,7 +888,7 @@ const listAllOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listSkusOperationSpec: msRest.OperationSpec = {
+const listSkusOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/skus",
   urlParameters: [
@@ -913,7 +913,7 @@ const listSkusOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOSUpgradeHistoryOperationSpec: msRest.OperationSpec = {
+const getOSUpgradeHistoryOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/osUpgradeHistory",
   urlParameters: [
@@ -938,7 +938,7 @@ const getOSUpgradeHistoryOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const forceRecoveryServiceFabricPlatformUpdateDomainWalkOperationSpec: msRest.OperationSpec = {
+const forceRecoveryServiceFabricPlatformUpdateDomainWalkOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/forceRecoveryServiceFabricPlatformUpdateDomainWalk",
   urlParameters: [
@@ -964,7 +964,7 @@ const forceRecoveryServiceFabricPlatformUpdateDomainWalkOperationSpec: msRest.Op
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}",
   urlParameters: [
@@ -999,7 +999,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}",
   urlParameters: [
@@ -1031,7 +1031,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}",
   urlParameters: [
@@ -1056,7 +1056,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeallocateOperationSpec: msRest.OperationSpec = {
+const beginDeallocateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/deallocate",
   urlParameters: [
@@ -1087,7 +1087,7 @@ const beginDeallocateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteInstancesOperationSpec: msRest.OperationSpec = {
+const beginDeleteInstancesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/delete",
   urlParameters: [
@@ -1118,7 +1118,7 @@ const beginDeleteInstancesOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginPowerOffOperationSpec: msRest.OperationSpec = {
+const beginPowerOffOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/poweroff",
   urlParameters: [
@@ -1150,7 +1150,7 @@ const beginPowerOffOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRestartOperationSpec: msRest.OperationSpec = {
+const beginRestartOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/restart",
   urlParameters: [
@@ -1181,7 +1181,7 @@ const beginRestartOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginStartOperationSpec: msRest.OperationSpec = {
+const beginStartOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/start",
   urlParameters: [
@@ -1212,7 +1212,7 @@ const beginStartOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRedeployOperationSpec: msRest.OperationSpec = {
+const beginRedeployOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/redeploy",
   urlParameters: [
@@ -1243,7 +1243,7 @@ const beginRedeployOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginPerformMaintenanceOperationSpec: msRest.OperationSpec = {
+const beginPerformMaintenanceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/performMaintenance",
   urlParameters: [
@@ -1274,7 +1274,7 @@ const beginPerformMaintenanceOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateInstancesOperationSpec: msRest.OperationSpec = {
+const beginUpdateInstancesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/manualupgrade",
   urlParameters: [
@@ -1305,7 +1305,7 @@ const beginUpdateInstancesOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginReimageOperationSpec: msRest.OperationSpec = {
+const beginReimageOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/reimage",
   urlParameters: [
@@ -1336,7 +1336,7 @@ const beginReimageOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginReimageAllOperationSpec: msRest.OperationSpec = {
+const beginReimageAllOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmScaleSetName}/reimageall",
   urlParameters: [
@@ -1367,7 +1367,7 @@ const beginReimageAllOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1388,7 +1388,7 @@ const listNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAllNextOperationSpec: msRest.OperationSpec = {
+const listAllNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1409,7 +1409,7 @@ const listAllNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listSkusNextOperationSpec: msRest.OperationSpec = {
+const listSkusNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1430,7 +1430,7 @@ const listSkusNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOSUpgradeHistoryNextOperationSpec: msRest.OperationSpec = {
+const getOSUpgradeHistoryNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/compute/arm-compute/src/operations/virtualMachineSizes.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachineSizes.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachineSizesMappers";
 import * as Parameters from "../models/parameters";
@@ -33,19 +33,19 @@ export class VirtualMachineSizes {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachineSizesListResponse>
    */
-  list(location: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachineSizesListResponse>;
+  list(location: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachineSizesListResponse>;
   /**
    * @param location The location upon which virtual-machine-sizes is queried.
    * @param callback The callback
    */
-  list(location: string, callback: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
+  list(location: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
   /**
    * @param location The location upon which virtual-machine-sizes is queried.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(location: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
-  list(location: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineSizeListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): Promise<Models.VirtualMachineSizesListResponse> {
+  list(location: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
+  list(location: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): Promise<Models.VirtualMachineSizesListResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -57,8 +57,8 @@ export class VirtualMachineSizes {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/vmSizes",
   urlParameters: [

--- a/sdk/compute/arm-compute/src/operations/virtualMachines.ts
+++ b/sdk/compute/arm-compute/src/operations/virtualMachines.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/virtualMachinesMappers";
 import * as Parameters from "../models/parameters";
@@ -33,19 +33,19 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesListByLocationResponse>
    */
-  listByLocation(location: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesListByLocationResponse>;
+  listByLocation(location: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesListByLocationResponse>;
   /**
    * @param location The location for which virtual machines under the subscription are queried.
    * @param callback The callback
    */
-  listByLocation(location: string, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listByLocation(location: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
   /**
    * @param location The location for which virtual machines under the subscription are queried.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByLocation(location: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
-  listByLocation(location: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListByLocationResponse> {
+  listByLocation(location: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listByLocation(location: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListByLocationResponse> {
     return this.client.sendOperationRequest(
       {
         location,
@@ -64,7 +64,7 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesCaptureResponse>
    */
-  capture(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineCaptureParameters, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesCaptureResponse> {
+  capture(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineCaptureParameters, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesCaptureResponse> {
     return this.beginCapture(resourceGroupName,vmName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachinesCaptureResponse>;
   }
@@ -77,7 +77,7 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachine, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachine, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,vmName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachinesCreateOrUpdateResponse>;
   }
@@ -90,7 +90,7 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesUpdateResponse>
    */
-  update(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineUpdate, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesUpdateResponse> {
+  update(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineUpdate, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesUpdateResponse> {
     return this.beginUpdate(resourceGroupName,vmName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachinesUpdateResponse>;
   }
@@ -100,9 +100,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -120,15 +120,15 @@ export class VirtualMachines {
    * @param vmName The name of the virtual machine.
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmName: string, callback: msRest.ServiceCallback<Models.VirtualMachine>): void;
+  get(resourceGroupName: string, vmName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachine>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, vmName: string, options: Models.VirtualMachinesGetOptionalParams, callback: msRest.ServiceCallback<Models.VirtualMachine>): void;
-  get(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesGetOptionalParams | msRest.ServiceCallback<Models.VirtualMachine>, callback?: msRest.ServiceCallback<Models.VirtualMachine>): Promise<Models.VirtualMachinesGetResponse> {
+  get(resourceGroupName: string, vmName: string, options: Models.VirtualMachinesGetOptionalParams, callback: coreHttp.ServiceCallback<Models.VirtualMachine>): void;
+  get(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesGetOptionalParams | coreHttp.ServiceCallback<Models.VirtualMachine>, callback?: coreHttp.ServiceCallback<Models.VirtualMachine>): Promise<Models.VirtualMachinesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -146,21 +146,21 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesInstanceViewResponse>
    */
-  instanceView(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesInstanceViewResponse>;
+  instanceView(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesInstanceViewResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param callback The callback
    */
-  instanceView(resourceGroupName: string, vmName: string, callback: msRest.ServiceCallback<Models.VirtualMachineInstanceView>): void;
+  instanceView(resourceGroupName: string, vmName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineInstanceView>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param options The optional parameters
    * @param callback The callback
    */
-  instanceView(resourceGroupName: string, vmName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineInstanceView>): void;
-  instanceView(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineInstanceView>, callback?: msRest.ServiceCallback<Models.VirtualMachineInstanceView>): Promise<Models.VirtualMachinesInstanceViewResponse> {
+  instanceView(resourceGroupName: string, vmName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineInstanceView>): void;
+  instanceView(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineInstanceView>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineInstanceView>): Promise<Models.VirtualMachinesInstanceViewResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -177,9 +177,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  convertToManagedDisks(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  convertToManagedDisks(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginConvertToManagedDisks(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -190,9 +190,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deallocate(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deallocate(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeallocate(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -202,23 +202,23 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  generalize(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  generalize(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param callback The callback
    */
-  generalize(resourceGroupName: string, vmName: string, callback: msRest.ServiceCallback<void>): void;
+  generalize(resourceGroupName: string, vmName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param options The optional parameters
    * @param callback The callback
    */
-  generalize(resourceGroupName: string, vmName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  generalize(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  generalize(resourceGroupName: string, vmName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  generalize(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -236,19 +236,19 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesListResponse>
    */
-  list(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesListResponse>;
+  list(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesListResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param callback The callback
    */
-  list(resourceGroupName: string, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
+  list(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
-  list(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListResponse> {
+  list(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
+  list(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -264,17 +264,17 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesListAllResponse>
    */
-  listAll(options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesListAllResponse>;
+  listAll(options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesListAllResponse>;
   /**
    * @param callback The callback
    */
-  listAll(callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listAll(callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAll(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
-  listAll(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListAllResponse> {
+  listAll(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listAll(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListAllResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -290,21 +290,21 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesListAvailableSizesResponse>
    */
-  listAvailableSizes(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesListAvailableSizesResponse>;
+  listAvailableSizes(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesListAvailableSizesResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param callback The callback
    */
-  listAvailableSizes(resourceGroupName: string, vmName: string, callback: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
+  listAvailableSizes(resourceGroupName: string, vmName: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAvailableSizes(resourceGroupName: string, vmName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
-  listAvailableSizes(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineSizeListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineSizeListResult>): Promise<Models.VirtualMachinesListAvailableSizesResponse> {
+  listAvailableSizes(resourceGroupName: string, vmName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): void;
+  listAvailableSizes(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineSizeListResult>): Promise<Models.VirtualMachinesListAvailableSizesResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -321,9 +321,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  powerOff(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesPowerOffOptionalParams): Promise<msRest.RestResponse> {
+  powerOff(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesPowerOffOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginPowerOff(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -333,9 +333,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  restart(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  restart(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginRestart(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -345,9 +345,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  start(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  start(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginStart(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -357,9 +357,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  redeploy(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  redeploy(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginRedeploy(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -369,9 +369,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  reimage(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesReimageOptionalParams): Promise<msRest.RestResponse> {
+  reimage(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesReimageOptionalParams): Promise<coreHttp.RestResponse> {
     return this.beginReimage(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -381,9 +381,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  performMaintenance(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  performMaintenance(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginPerformMaintenance(resourceGroupName,vmName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -396,7 +396,7 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesRunCommandResponse>
    */
-  runCommand(resourceGroupName: string, vmName: string, parameters: Models.RunCommandInput, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesRunCommandResponse> {
+  runCommand(resourceGroupName: string, vmName: string, parameters: Models.RunCommandInput, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesRunCommandResponse> {
     return this.beginRunCommand(resourceGroupName,vmName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.VirtualMachinesRunCommandResponse>;
   }
@@ -408,9 +408,9 @@ export class VirtualMachines {
    * @param vmName The name of the virtual machine.
    * @param parameters Parameters supplied to the Capture Virtual Machine operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCapture(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineCaptureParameters, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCapture(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineCaptureParameters, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -428,9 +428,9 @@ export class VirtualMachines {
    * @param vmName The name of the virtual machine.
    * @param parameters Parameters supplied to the Create Virtual Machine operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachine, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachine, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -448,9 +448,9 @@ export class VirtualMachines {
    * @param vmName The name of the virtual machine.
    * @param parameters Parameters supplied to the Update Virtual Machine operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineUpdate, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, vmName: string, parameters: Models.VirtualMachineUpdate, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -467,9 +467,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -486,9 +486,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginConvertToManagedDisks(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginConvertToManagedDisks(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -505,9 +505,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeallocate(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeallocate(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -524,9 +524,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginPowerOff(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesBeginPowerOffOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginPowerOff(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesBeginPowerOffOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -542,9 +542,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRestart(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRestart(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -560,9 +560,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginStart(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginStart(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -578,9 +578,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRedeploy(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRedeploy(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -596,9 +596,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginReimage(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesBeginReimageOptionalParams): Promise<msRestAzure.LROPoller> {
+  beginReimage(resourceGroupName: string, vmName: string, options?: Models.VirtualMachinesBeginReimageOptionalParams): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -614,9 +614,9 @@ export class VirtualMachines {
    * @param resourceGroupName The name of the resource group.
    * @param vmName The name of the virtual machine.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginPerformMaintenance(resourceGroupName: string, vmName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginPerformMaintenance(resourceGroupName: string, vmName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -633,9 +633,9 @@ export class VirtualMachines {
    * @param vmName The name of the virtual machine.
    * @param parameters Parameters supplied to the Run command operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginRunCommand(resourceGroupName: string, vmName: string, parameters: Models.RunCommandInput, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginRunCommand(resourceGroupName: string, vmName: string, parameters: Models.RunCommandInput, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -653,19 +653,19 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesListByLocationNextResponse>
    */
-  listByLocationNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesListByLocationNextResponse>;
+  listByLocationNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesListByLocationNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByLocationNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listByLocationNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByLocationNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
-  listByLocationNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListByLocationNextResponse> {
+  listByLocationNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listByLocationNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListByLocationNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -682,19 +682,19 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -711,19 +711,19 @@ export class VirtualMachines {
    * @param [options] The optional parameters
    * @returns Promise<Models.VirtualMachinesListAllNextResponse>
    */
-  listAllNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.VirtualMachinesListAllNextResponse>;
+  listAllNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.VirtualMachinesListAllNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAllNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listAllNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAllNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.VirtualMachineListResult>): void;
-  listAllNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.VirtualMachineListResult>, callback?: msRest.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListAllNextResponse> {
+  listAllNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): void;
+  listAllNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.VirtualMachineListResult>, callback?: coreHttp.ServiceCallback<Models.VirtualMachineListResult>): Promise<Models.VirtualMachinesListAllNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -735,8 +735,8 @@ export class VirtualMachines {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listByLocationOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listByLocationOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/locations/{location}/virtualMachines",
   urlParameters: [
@@ -760,7 +760,7 @@ const listByLocationOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}",
   urlParameters: [
@@ -786,7 +786,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const instanceViewOperationSpec: msRest.OperationSpec = {
+const instanceViewOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/instanceView",
   urlParameters: [
@@ -811,7 +811,7 @@ const instanceViewOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const generalizeOperationSpec: msRest.OperationSpec = {
+const generalizeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/generalize",
   urlParameters: [
@@ -834,7 +834,7 @@ const generalizeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines",
   urlParameters: [
@@ -858,7 +858,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAllOperationSpec: msRest.OperationSpec = {
+const listAllOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Compute/virtualMachines",
   urlParameters: [
@@ -881,7 +881,7 @@ const listAllOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAvailableSizesOperationSpec: msRest.OperationSpec = {
+const listAvailableSizesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/vmSizes",
   urlParameters: [
@@ -906,7 +906,7 @@ const listAvailableSizesOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCaptureOperationSpec: msRest.OperationSpec = {
+const beginCaptureOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/capture",
   urlParameters: [
@@ -939,7 +939,7 @@ const beginCaptureOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}",
   urlParameters: [
@@ -974,7 +974,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}",
   urlParameters: [
@@ -1009,7 +1009,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}",
   urlParameters: [
@@ -1034,7 +1034,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginConvertToManagedDisksOperationSpec: msRest.OperationSpec = {
+const beginConvertToManagedDisksOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/convertToManagedDisks",
   urlParameters: [
@@ -1058,7 +1058,7 @@ const beginConvertToManagedDisksOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeallocateOperationSpec: msRest.OperationSpec = {
+const beginDeallocateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/deallocate",
   urlParameters: [
@@ -1082,7 +1082,7 @@ const beginDeallocateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginPowerOffOperationSpec: msRest.OperationSpec = {
+const beginPowerOffOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/powerOff",
   urlParameters: [
@@ -1107,7 +1107,7 @@ const beginPowerOffOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRestartOperationSpec: msRest.OperationSpec = {
+const beginRestartOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/restart",
   urlParameters: [
@@ -1131,7 +1131,7 @@ const beginRestartOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginStartOperationSpec: msRest.OperationSpec = {
+const beginStartOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/start",
   urlParameters: [
@@ -1155,7 +1155,7 @@ const beginStartOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRedeployOperationSpec: msRest.OperationSpec = {
+const beginRedeployOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/redeploy",
   urlParameters: [
@@ -1179,7 +1179,7 @@ const beginRedeployOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginReimageOperationSpec: msRest.OperationSpec = {
+const beginReimageOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/reimage",
   urlParameters: [
@@ -1210,7 +1210,7 @@ const beginReimageOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginPerformMaintenanceOperationSpec: msRest.OperationSpec = {
+const beginPerformMaintenanceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/performMaintenance",
   urlParameters: [
@@ -1234,7 +1234,7 @@ const beginPerformMaintenanceOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginRunCommandOperationSpec: msRest.OperationSpec = {
+const beginRunCommandOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachines/{vmName}/runCommand",
   urlParameters: [
@@ -1267,7 +1267,7 @@ const beginRunCommandOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByLocationNextOperationSpec: msRest.OperationSpec = {
+const listByLocationNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1288,7 +1288,7 @@ const listByLocationNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1309,7 +1309,7 @@ const listNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAllNextOperationSpec: msRest.OperationSpec = {
+const listAllNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",


### PR DESCRIPTION
This change is the first part of the work for #4226 where we're attempting to regenerate a subset of the management plane libraries with a version of `autorest.typescript` that's been updated to use `@azure/core-http` and `@azure/core-arm`.

**NOTE:** This PR won't be merged until an update has been shipped for `autorest.typescript` with the changes used to regenerate this library.  A PR is out for these changes here: https://github.com/Azure/autorest.typescript/pull/451