### PR TITLE
update CODEOWNERS links to point to sync documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 # See for instructions on this file https://help.github.com/articles/about-codeowners/
+
+# Instructions for subscribing to scheduled build failure notifications:
+# https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners-notifications.md

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-# See for instructions on this file https://help.github.com/articles/about-codeowners/
-
 # Instructions for CODEOWNERS file format and automatic build failure notifications:
 # https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners.md
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,27 @@
 # See for instructions on this file https://help.github.com/articles/about-codeowners/
 
-# Instructions for subscribing to scheduled build failure notifications:
-# https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners-notifications.md
+# Instructions for CODEOWNERS file format and automatic build failure notifications:
+# https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners.md
+
+###########
+# Eng Sys
+###########
+/eng/   @weshaggard @KarishmaGhiya @mikeharder
+
+/eng/pipelines/ @weshaggard @KarishmaGhiya @mikeharder @mitchdenny @danieljurek
+
+/eng/pipelines/client.yml   @mitchdenny @danieljurek
+/**/tests.yml   @danieljurek
+/**/ci.yml      @mitchdenny
+
+
+###########
+# SDK
+###########
+
+# Catch all
+# /sdk/ @ramya-rao-a
+
+# Service teams
+# /sdk/eventhub/
+# /sdk/keyvault/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,11 +6,7 @@
 ###########
 # Eng Sys
 ###########
-/eng/   @weshaggard @KarishmaGhiya @mikeharder
-
-/eng/pipelines/ @weshaggard @KarishmaGhiya @mikeharder @mitchdenny @danieljurek
-
-/eng/pipelines/client.yml   @mitchdenny @danieljurek
+/eng/   @weshaggard @KarishmaGhiya @mikeharder @mitchdenny @danieljurek
 /**/tests.yml   @danieljurek
 /**/ci.yml      @mitchdenny
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,14 @@
 # Catch all
 # /sdk/ @ramya-rao-a
 
+# Core
+# /sdk/core/
+
 # Service teams
 # /sdk/eventhub/
+# /sdk/identity/
 # /sdk/keyvault/
+# /sdk/storage/
 
 ###########
 # Eng Sys

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,14 +4,6 @@
 # https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/codeowners.md
 
 ###########
-# Eng Sys
-###########
-/eng/   @weshaggard @KarishmaGhiya @mikeharder @mitchdenny @danieljurek
-/**/tests.yml   @danieljurek
-/**/ci.yml      @mitchdenny
-
-
-###########
 # SDK
 ###########
 
@@ -21,3 +13,10 @@
 # Service teams
 # /sdk/eventhub/
 # /sdk/keyvault/
+
+###########
+# Eng Sys
+###########
+/eng/   @weshaggard @KarishmaGhiya @mikeharder @mitchdenny @danieljurek
+/**/tests.yml   @danieljurek
+/**/ci.yml      @mitchdenny


### PR DESCRIPTION
Adding link to documentation in the azure-sdk repo

@Azure/azure-sdk-eng 