### PR TITLE
Pin autorest.typescript to 4.1.1 for management plane library generation

### DIFF
--- a/swagger_to_sdk_config.json
+++ b/swagger_to_sdk_config.json
@@ -5,7 +5,7 @@
       "typescript": "",
       "license-header": "MICROSOFT_MIT_NO_VERSION",
       "sdkrel:typescript-sdks-folder": ".",
-      "use": "@microsoft.azure/autorest.typescript"
+      "use": "@microsoft.azure/autorest.typescript@4.1.1"
     },
     "advanced_options": {
       "clone_dir": "./azure-sdk-for-js",


### PR DESCRIPTION
This change pins `autorest.typescript` to 4.1.1 in anticipation for the [upcoming release](https://github.com/Azure/autorest.typescript/pull/451) of `autorest.typescript` 5.0.0.  This version needs to be pinned so that management plane libraries don't get generated using `@azure/core-http` etc until they go GA.

/cc @ramya-rao-a