### PR TITLE
Add "sdk-type": "client" to more core libraries

### DIFF
--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -5,6 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-js"
   },
+  "sdk-type": "client",
   "version": "1.0.0-preview.1",
   "description": "Isomorphic Azure client runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -2,6 +2,7 @@
   "name": "@azure/core-auth",
   "version": "1.0.0-preview.1",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
+  "sdk-type": "client",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -5,6 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-js"
   },
+  "sdk-type": "client",
   "version": "1.0.0-preview.1",
   "description": "Core types for paging async iterable iterators",
   "tags": [

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -2,6 +2,7 @@
   "name": "@azure/template",
   "version": "0.1.0",
   "description": "Template Library with typescript type definitions for node.js and browser.",
+  "sdk-type": "client",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {


### PR DESCRIPTION
Looks like some newer core libraries didn't get the `"sdk-type": "client"` added and now it's being used to determine which packages get built in CI runs.  Perhaps we should also add this to the `sdk/template/template` project so that new libraries that copy/paste that template don't miss it?

/cc @ramya-rao-a 