### PR TITLE
Use Build.SourceBranch as the head ref for package change detection

### DIFF
--- a/.azure-pipelines/js-mgmt-pr.yml
+++ b/.azure-pipelines/js-mgmt-pr.yml
@@ -45,7 +45,7 @@ jobs:
         inputs:
           command: custom
           verbose: false
-          customCommand: 'run build -- --head-reference=origin/$(System.PullRequest.SourceBranch) --base-reference=origin/$(System.PullRequest.TargetBranch) --logging-level=trace'
+          customCommand: 'run build -- --head-reference=$(Build.SourceBranch) --base-reference=origin/$(System.PullRequest.TargetBranch) --logging-level=trace'
 
   - job: 'Check_everything'
     displayName: 'Check .only, .skip and version bump'
@@ -65,4 +65,4 @@ jobs:
         inputs:
           command: custom
           verbose: false
-          customCommand: 'run check:everything -- --head-reference=origin/$(System.PullRequest.SourceBranch) --base-reference=origin/$(System.PullRequest.TargetBranch) --azure-devops --verbose'
+          customCommand: 'run check:everything -- --head-reference=$(Build.SourceBranch) --base-reference=origin/$(System.PullRequest.TargetBranch) --azure-devops --verbose'


### PR DESCRIPTION
This change updates the `js - mgmt - pr` configuration to use the `Build.SourceBranch` pipeline variable to determine the head ref to use for determining changes against the target branch.  This will cause the correct PR ref (i.e. `refs/pull/1234/merge`) to be used.  Prior to this change the following error would be thrown in builds, presumably causing package changes to be detected incorrectly:

```
git diff --name-only origin/master origin/arm-compute-core-http 
Exit Code: 128 
Error: 
fatal: ambiguous argument 'origin/arm-compute-core-http': unknown revision or path not in the working tree. 
Use '--' to separate paths from revisions, like this: 
'git <command> [<revision>...] -- [<file>...]'
```