### PR TITLE
Regenerate ARM resources libraries to use @azure/core-http

### DIFF
--- a/sdk/features/arm-features/README.md
+++ b/sdk/features/arm-features/README.md
@@ -26,8 +26,8 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```typescript
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { FeatureClient, FeatureModels, FeatureMappers } from "@azure/arm-features";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
@@ -61,8 +61,8 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 <html lang="en">
   <head>
     <title>@azure/arm-features sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
+    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
+    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/arm-features/dist/arm-features.js"></script>
     <script type="text/javascript">

--- a/sdk/features/arm-features/package.json
+++ b/sdk/features/arm-features/package.json
@@ -4,8 +4,8 @@
   "description": "FeatureClient Library with typescript type definitions for node.js and browser.",
   "version": "1.0.3",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/core-arm": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/features/arm-features/rollup.config.js
+++ b/sdk/features/arm-features/rollup.config.js
@@ -8,8 +8,8 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const config = {
   input: "./esm/featureClient.js",
   external: [
-    "@azure/ms-rest-js",
-    "@azure/ms-rest-azure-js"
+    "@azure/core-http",
+    "@azure/core-arm"
   ],
   output: {
     file: "./dist/arm-features.js",
@@ -17,8 +17,8 @@ const config = {
     name: "Azure.ArmFeatures",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest",
-      "@azure/ms-rest-azure-js": "msRestAzure"
+      "@azure/core-http": "coreHttp",
+      "@azure/core-arm": "coreArm"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/features/arm-features/src/featureClient.ts
+++ b/sdk/features/arm-features/src/featureClient.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as Parameters from "./models/parameters";
@@ -26,7 +26,7 @@ class FeatureClient extends FeatureClientContext {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.FeatureClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.FeatureClientOptions) {
     super(credentials, subscriptionId, options);
     this.features = new operations.Features(this);
   }
@@ -36,17 +36,17 @@ class FeatureClient extends FeatureClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.ListOperationsResponse>
    */
-  listOperations(options?: msRest.RequestOptionsBase): Promise<Models.ListOperationsResponse>;
+  listOperations(options?: coreHttp.RequestOptionsBase): Promise<Models.ListOperationsResponse>;
   /**
    * @param callback The callback
    */
-  listOperations(callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  listOperations(callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listOperations(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  listOperations(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsResponse> {
+  listOperations(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  listOperations(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsResponse> {
     return this.sendOperationRequest(
       {
         options
@@ -61,19 +61,19 @@ class FeatureClient extends FeatureClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.ListOperationsNextResponse>
    */
-  listOperationsNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ListOperationsNextResponse>;
+  listOperationsNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ListOperationsNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listOperationsNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  listOperationsNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listOperationsNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  listOperationsNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsNextResponse> {
+  listOperationsNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  listOperationsNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsNextResponse> {
     return this.sendOperationRequest(
       {
         nextPageLink,
@@ -85,8 +85,8 @@ class FeatureClient extends FeatureClientContext {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationsOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Features/operations",
   queryParameters: [
@@ -106,7 +106,7 @@ const listOperationsOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationsNextOperationSpec: msRest.OperationSpec = {
+const listOperationsNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/features/arm-features/src/featureClientContext.ts
+++ b/sdk/features/arm-features/src/featureClientContext.ts
@@ -9,14 +9,14 @@
  */
 
 import * as Models from "./models";
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-features";
 const packageVersion = "1.0.3";
 
-export class FeatureClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class FeatureClientContext extends coreArm.AzureServiceClient {
+  credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;
   subscriptionId: string;
   apiVersion?: string;
 
@@ -26,7 +26,7 @@ export class FeatureClientContext extends msRestAzure.AzureServiceClient {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.FeatureClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.FeatureClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -38,7 +38,7 @@ export class FeatureClientContext extends msRestAzure.AzureServiceClient {
       options = {};
     }
     if(!options.userAgent) {
-      const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
+      const defaultUserAgent = coreArm.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 

--- a/sdk/features/arm-features/src/models/index.ts
+++ b/sdk/features/arm-features/src/models/index.ts
@@ -6,8 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export { BaseResource, CloudError };
 
@@ -114,7 +114,7 @@ export type ListOperationsResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -134,7 +134,7 @@ export type ListOperationsNextResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -154,7 +154,7 @@ export type FeaturesListAllResponse = FeatureOperationsListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -174,7 +174,7 @@ export type FeaturesListResponse = FeatureOperationsListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -194,7 +194,7 @@ export type FeaturesGetResponse = FeatureResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -214,7 +214,7 @@ export type FeaturesRegisterResponse = FeatureResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -234,7 +234,7 @@ export type FeaturesListAllNextResponse = FeatureOperationsListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -254,7 +254,7 @@ export type FeaturesListNextResponse = FeatureOperationsListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */

--- a/sdk/features/arm-features/src/models/mappers.ts
+++ b/sdk/features/arm-features/src/models/mappers.ts
@@ -6,13 +6,13 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { CloudErrorMapper, BaseResourceMapper } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { CloudErrorMapper, BaseResourceMapper } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;
 
-export const FeatureProperties: msRest.CompositeMapper = {
+export const FeatureProperties: coreHttp.CompositeMapper = {
   serializedName: "FeatureProperties",
   type: {
     name: "Composite",
@@ -28,7 +28,7 @@ export const FeatureProperties: msRest.CompositeMapper = {
   }
 };
 
-export const FeatureResult: msRest.CompositeMapper = {
+export const FeatureResult: coreHttp.CompositeMapper = {
   serializedName: "FeatureResult",
   type: {
     name: "Composite",
@@ -63,7 +63,7 @@ export const FeatureResult: msRest.CompositeMapper = {
   }
 };
 
-export const OperationDisplay: msRest.CompositeMapper = {
+export const OperationDisplay: coreHttp.CompositeMapper = {
   serializedName: "Operation_display",
   type: {
     name: "Composite",
@@ -91,7 +91,7 @@ export const OperationDisplay: msRest.CompositeMapper = {
   }
 };
 
-export const Operation: msRest.CompositeMapper = {
+export const Operation: coreHttp.CompositeMapper = {
   serializedName: "Operation",
   type: {
     name: "Composite",
@@ -114,7 +114,7 @@ export const Operation: msRest.CompositeMapper = {
   }
 };
 
-export const OperationListResult: msRest.CompositeMapper = {
+export const OperationListResult: coreHttp.CompositeMapper = {
   serializedName: "OperationListResult",
   type: {
     name: "Composite",
@@ -142,7 +142,7 @@ export const OperationListResult: msRest.CompositeMapper = {
   }
 };
 
-export const FeatureOperationsListResult: msRest.CompositeMapper = {
+export const FeatureOperationsListResult: coreHttp.CompositeMapper = {
   serializedName: "FeatureOperationsListResult",
   type: {
     name: "Composite",

--- a/sdk/features/arm-features/src/models/parameters.ts
+++ b/sdk/features/arm-features/src/models/parameters.ts
@@ -8,9 +8,9 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 
-export const acceptLanguage: msRest.OperationParameter = {
+export const acceptLanguage: coreHttp.OperationParameter = {
   parameterPath: "acceptLanguage",
   mapper: {
     serializedName: "accept-language",
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion: msRest.OperationQueryParameter = {
+export const apiVersion: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -30,7 +30,7 @@ export const apiVersion: msRest.OperationQueryParameter = {
     }
   }
 };
-export const featureName: msRest.OperationURLParameter = {
+export const featureName: coreHttp.OperationURLParameter = {
   parameterPath: "featureName",
   mapper: {
     required: true,
@@ -40,7 +40,7 @@ export const featureName: msRest.OperationURLParameter = {
     }
   }
 };
-export const nextPageLink: msRest.OperationURLParameter = {
+export const nextPageLink: coreHttp.OperationURLParameter = {
   parameterPath: "nextPageLink",
   mapper: {
     required: true,
@@ -51,7 +51,7 @@ export const nextPageLink: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const resourceProviderNamespace: msRest.OperationURLParameter = {
+export const resourceProviderNamespace: coreHttp.OperationURLParameter = {
   parameterPath: "resourceProviderNamespace",
   mapper: {
     required: true,
@@ -61,7 +61,7 @@ export const resourceProviderNamespace: msRest.OperationURLParameter = {
     }
   }
 };
-export const subscriptionId: msRest.OperationURLParameter = {
+export const subscriptionId: coreHttp.OperationURLParameter = {
   parameterPath: "subscriptionId",
   mapper: {
     required: true,

--- a/sdk/features/arm-features/src/operations/features.ts
+++ b/sdk/features/arm-features/src/operations/features.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/featuresMappers";
 import * as Parameters from "../models/parameters";
@@ -31,17 +31,17 @@ export class Features {
    * @param [options] The optional parameters
    * @returns Promise<Models.FeaturesListAllResponse>
    */
-  listAll(options?: msRest.RequestOptionsBase): Promise<Models.FeaturesListAllResponse>;
+  listAll(options?: coreHttp.RequestOptionsBase): Promise<Models.FeaturesListAllResponse>;
   /**
    * @param callback The callback
    */
-  listAll(callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  listAll(callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAll(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
-  listAll(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.FeatureOperationsListResult>, callback?: msRest.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListAllResponse> {
+  listAll(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  listAll(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.FeatureOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListAllResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -57,19 +57,19 @@ export class Features {
    * @param [options] The optional parameters
    * @returns Promise<Models.FeaturesListResponse>
    */
-  list(resourceProviderNamespace: string, options?: msRest.RequestOptionsBase): Promise<Models.FeaturesListResponse>;
+  list(resourceProviderNamespace: string, options?: coreHttp.RequestOptionsBase): Promise<Models.FeaturesListResponse>;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider for getting features.
    * @param callback The callback
    */
-  list(resourceProviderNamespace: string, callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  list(resourceProviderNamespace: string, callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider for getting features.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceProviderNamespace: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
-  list(resourceProviderNamespace: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.FeatureOperationsListResult>, callback?: msRest.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListResponse> {
+  list(resourceProviderNamespace: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  list(resourceProviderNamespace: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.FeatureOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceProviderNamespace,
@@ -86,21 +86,21 @@ export class Features {
    * @param [options] The optional parameters
    * @returns Promise<Models.FeaturesGetResponse>
    */
-  get(resourceProviderNamespace: string, featureName: string, options?: msRest.RequestOptionsBase): Promise<Models.FeaturesGetResponse>;
+  get(resourceProviderNamespace: string, featureName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.FeaturesGetResponse>;
   /**
    * @param resourceProviderNamespace The resource provider namespace for the feature.
    * @param featureName The name of the feature to get.
    * @param callback The callback
    */
-  get(resourceProviderNamespace: string, featureName: string, callback: msRest.ServiceCallback<Models.FeatureResult>): void;
+  get(resourceProviderNamespace: string, featureName: string, callback: coreHttp.ServiceCallback<Models.FeatureResult>): void;
   /**
    * @param resourceProviderNamespace The resource provider namespace for the feature.
    * @param featureName The name of the feature to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceProviderNamespace: string, featureName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FeatureResult>): void;
-  get(resourceProviderNamespace: string, featureName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.FeatureResult>, callback?: msRest.ServiceCallback<Models.FeatureResult>): Promise<Models.FeaturesGetResponse> {
+  get(resourceProviderNamespace: string, featureName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.FeatureResult>): void;
+  get(resourceProviderNamespace: string, featureName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.FeatureResult>, callback?: coreHttp.ServiceCallback<Models.FeatureResult>): Promise<Models.FeaturesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceProviderNamespace,
@@ -118,21 +118,21 @@ export class Features {
    * @param [options] The optional parameters
    * @returns Promise<Models.FeaturesRegisterResponse>
    */
-  register(resourceProviderNamespace: string, featureName: string, options?: msRest.RequestOptionsBase): Promise<Models.FeaturesRegisterResponse>;
+  register(resourceProviderNamespace: string, featureName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.FeaturesRegisterResponse>;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider.
    * @param featureName The name of the feature to register.
    * @param callback The callback
    */
-  register(resourceProviderNamespace: string, featureName: string, callback: msRest.ServiceCallback<Models.FeatureResult>): void;
+  register(resourceProviderNamespace: string, featureName: string, callback: coreHttp.ServiceCallback<Models.FeatureResult>): void;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider.
    * @param featureName The name of the feature to register.
    * @param options The optional parameters
    * @param callback The callback
    */
-  register(resourceProviderNamespace: string, featureName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FeatureResult>): void;
-  register(resourceProviderNamespace: string, featureName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.FeatureResult>, callback?: msRest.ServiceCallback<Models.FeatureResult>): Promise<Models.FeaturesRegisterResponse> {
+  register(resourceProviderNamespace: string, featureName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.FeatureResult>): void;
+  register(resourceProviderNamespace: string, featureName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.FeatureResult>, callback?: coreHttp.ServiceCallback<Models.FeatureResult>): Promise<Models.FeaturesRegisterResponse> {
     return this.client.sendOperationRequest(
       {
         resourceProviderNamespace,
@@ -149,19 +149,19 @@ export class Features {
    * @param [options] The optional parameters
    * @returns Promise<Models.FeaturesListAllNextResponse>
    */
-  listAllNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.FeaturesListAllNextResponse>;
+  listAllNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.FeaturesListAllNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAllNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  listAllNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAllNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
-  listAllNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.FeatureOperationsListResult>, callback?: msRest.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListAllNextResponse> {
+  listAllNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  listAllNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.FeatureOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListAllNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -178,19 +178,19 @@ export class Features {
    * @param [options] The optional parameters
    * @returns Promise<Models.FeaturesListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.FeaturesListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.FeaturesListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FeatureOperationsListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.FeatureOperationsListResult>, callback?: msRest.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.FeatureOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.FeatureOperationsListResult>): Promise<Models.FeaturesListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -202,8 +202,8 @@ export class Features {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listAllOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listAllOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Features/features",
   urlParameters: [
@@ -226,7 +226,7 @@ const listAllOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Features/providers/{resourceProviderNamespace}/features",
   urlParameters: [
@@ -250,7 +250,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Features/providers/{resourceProviderNamespace}/features/{featureName}",
   urlParameters: [
@@ -275,7 +275,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const registerOperationSpec: msRest.OperationSpec = {
+const registerOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Features/providers/{resourceProviderNamespace}/features/{featureName}/register",
   urlParameters: [
@@ -300,7 +300,7 @@ const registerOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAllNextOperationSpec: msRest.OperationSpec = {
+const listAllNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -321,7 +321,7 @@ const listAllNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/links/arm-links/README.md
+++ b/sdk/links/arm-links/README.md
@@ -26,8 +26,8 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```typescript
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { ManagementLinkClient, ManagementLinkModels, ManagementLinkMappers } from "@azure/arm-links";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
@@ -61,8 +61,8 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 <html lang="en">
   <head>
     <title>@azure/arm-links sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
+    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
+    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/arm-links/dist/arm-links.js"></script>
     <script type="text/javascript">

--- a/sdk/links/arm-links/package.json
+++ b/sdk/links/arm-links/package.json
@@ -4,8 +4,8 @@
   "description": "ManagementLinkClient Library with typescript type definitions for node.js and browser.",
   "version": "1.0.2",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/core-arm": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/links/arm-links/rollup.config.js
+++ b/sdk/links/arm-links/rollup.config.js
@@ -8,8 +8,8 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const config = {
   input: "./esm/managementLinkClient.js",
   external: [
-    "@azure/ms-rest-js",
-    "@azure/ms-rest-azure-js"
+    "@azure/core-http",
+    "@azure/core-arm"
   ],
   output: {
     file: "./dist/arm-links.js",
@@ -17,8 +17,8 @@ const config = {
     name: "Azure.ArmLinks",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest",
-      "@azure/ms-rest-azure-js": "msRestAzure"
+      "@azure/core-http": "coreHttp",
+      "@azure/core-arm": "coreArm"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/links/arm-links/src/managementLinkClient.ts
+++ b/sdk/links/arm-links/src/managementLinkClient.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -26,7 +26,7 @@ class ManagementLinkClient extends ManagementLinkClientContext {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ManagementLinkClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ManagementLinkClientOptions) {
     super(credentials, subscriptionId, options);
     this.operations = new operations.Operations(this);
     this.resourceLinks = new operations.ResourceLinks(this);

--- a/sdk/links/arm-links/src/managementLinkClientContext.ts
+++ b/sdk/links/arm-links/src/managementLinkClientContext.ts
@@ -9,14 +9,14 @@
  */
 
 import * as Models from "./models";
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-links";
 const packageVersion = "1.0.2";
 
-export class ManagementLinkClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class ManagementLinkClientContext extends coreArm.AzureServiceClient {
+  credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;
   subscriptionId: string;
   apiVersion?: string;
 
@@ -26,7 +26,7 @@ export class ManagementLinkClientContext extends msRestAzure.AzureServiceClient 
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ManagementLinkClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ManagementLinkClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -38,7 +38,7 @@ export class ManagementLinkClientContext extends msRestAzure.AzureServiceClient 
       options = {};
     }
     if(!options.userAgent) {
-      const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
+      const defaultUserAgent = coreArm.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 

--- a/sdk/links/arm-links/src/models/index.ts
+++ b/sdk/links/arm-links/src/models/index.ts
@@ -6,8 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export { BaseResource, CloudError };
 
@@ -104,7 +104,7 @@ export interface Operation {
 /**
  * Optional Parameters.
  */
-export interface ResourceLinksListAtSubscriptionOptionalParams extends msRest.RequestOptionsBase {
+export interface ResourceLinksListAtSubscriptionOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the list resource links operation. The supported filter for list
    * resource links is targetId. For example, $filter=targetId eq {value}
@@ -115,7 +115,7 @@ export interface ResourceLinksListAtSubscriptionOptionalParams extends msRest.Re
 /**
  * Optional Parameters.
  */
-export interface ResourceLinksListAtSourceScopeOptionalParams extends msRest.RequestOptionsBase {
+export interface ResourceLinksListAtSourceScopeOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply when getting resource links. To get links only at the specified scope (not
    * below the scope), use Filter.atScope().
@@ -171,7 +171,7 @@ export type OperationsListResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -191,7 +191,7 @@ export type OperationsListNextResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -211,7 +211,7 @@ export type ResourceLinksCreateOrUpdateResponse = ResourceLink & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -231,7 +231,7 @@ export type ResourceLinksGetResponse = ResourceLink & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -251,7 +251,7 @@ export type ResourceLinksListAtSubscriptionResponse = ResourceLinkResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -271,7 +271,7 @@ export type ResourceLinksListAtSourceScopeResponse = ResourceLinkResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -291,7 +291,7 @@ export type ResourceLinksListAtSubscriptionNextResponse = ResourceLinkResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -311,7 +311,7 @@ export type ResourceLinksListAtSourceScopeNextResponse = ResourceLinkResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */

--- a/sdk/links/arm-links/src/models/mappers.ts
+++ b/sdk/links/arm-links/src/models/mappers.ts
@@ -6,13 +6,13 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { CloudErrorMapper, BaseResourceMapper } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { CloudErrorMapper, BaseResourceMapper } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;
 
-export const ResourceLinkFilter: msRest.CompositeMapper = {
+export const ResourceLinkFilter: coreHttp.CompositeMapper = {
   serializedName: "ResourceLinkFilter",
   type: {
     name: "Composite",
@@ -29,7 +29,7 @@ export const ResourceLinkFilter: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceLinkProperties: msRest.CompositeMapper = {
+export const ResourceLinkProperties: coreHttp.CompositeMapper = {
   serializedName: "ResourceLinkProperties",
   type: {
     name: "Composite",
@@ -59,7 +59,7 @@ export const ResourceLinkProperties: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceLink: msRest.CompositeMapper = {
+export const ResourceLink: coreHttp.CompositeMapper = {
   serializedName: "ResourceLink",
   type: {
     name: "Composite",
@@ -97,7 +97,7 @@ export const ResourceLink: msRest.CompositeMapper = {
   }
 };
 
-export const OperationDisplay: msRest.CompositeMapper = {
+export const OperationDisplay: coreHttp.CompositeMapper = {
   serializedName: "Operation_display",
   type: {
     name: "Composite",
@@ -131,7 +131,7 @@ export const OperationDisplay: msRest.CompositeMapper = {
   }
 };
 
-export const Operation: msRest.CompositeMapper = {
+export const Operation: coreHttp.CompositeMapper = {
   serializedName: "Operation",
   type: {
     name: "Composite",
@@ -154,7 +154,7 @@ export const Operation: msRest.CompositeMapper = {
   }
 };
 
-export const OperationListResult: msRest.CompositeMapper = {
+export const OperationListResult: coreHttp.CompositeMapper = {
   serializedName: "OperationListResult",
   type: {
     name: "Composite",
@@ -182,7 +182,7 @@ export const OperationListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceLinkResult: msRest.CompositeMapper = {
+export const ResourceLinkResult: coreHttp.CompositeMapper = {
   serializedName: "ResourceLinkResult",
   type: {
     name: "Composite",

--- a/sdk/links/arm-links/src/models/parameters.ts
+++ b/sdk/links/arm-links/src/models/parameters.ts
@@ -8,9 +8,9 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 
-export const acceptLanguage: msRest.OperationParameter = {
+export const acceptLanguage: coreHttp.OperationParameter = {
   parameterPath: "acceptLanguage",
   mapper: {
     serializedName: "accept-language",
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion: msRest.OperationQueryParameter = {
+export const apiVersion: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -30,7 +30,7 @@ export const apiVersion: msRest.OperationQueryParameter = {
     }
   }
 };
-export const filter: msRest.OperationQueryParameter = {
+export const filter: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "filter"
@@ -42,7 +42,7 @@ export const filter: msRest.OperationQueryParameter = {
     }
   }
 };
-export const linkId: msRest.OperationURLParameter = {
+export const linkId: coreHttp.OperationURLParameter = {
   parameterPath: "linkId",
   mapper: {
     required: true,
@@ -53,7 +53,7 @@ export const linkId: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const nextPageLink: msRest.OperationURLParameter = {
+export const nextPageLink: coreHttp.OperationURLParameter = {
   parameterPath: "nextPageLink",
   mapper: {
     required: true,
@@ -64,7 +64,7 @@ export const nextPageLink: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const scope: msRest.OperationURLParameter = {
+export const scope: coreHttp.OperationURLParameter = {
   parameterPath: "scope",
   mapper: {
     required: true,
@@ -75,7 +75,7 @@ export const scope: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const subscriptionId: msRest.OperationURLParameter = {
+export const subscriptionId: coreHttp.OperationURLParameter = {
   parameterPath: "subscriptionId",
   mapper: {
     required: true,

--- a/sdk/links/arm-links/src/operations/operations.ts
+++ b/sdk/links/arm-links/src/operations/operations.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/operationsMappers";
 import * as Parameters from "../models/parameters";
@@ -31,17 +31,17 @@ export class Operations {
    * @param [options] The optional parameters
    * @returns Promise<Models.OperationsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.OperationsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.OperationsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -56,19 +56,19 @@ export class Operations {
    * @param [options] The optional parameters
    * @returns Promise<Models.OperationsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.OperationsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.OperationsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -80,8 +80,8 @@ export class Operations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Resources/operations",
   queryParameters: [
@@ -101,7 +101,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/links/arm-links/src/operations/resourceLinks.ts
+++ b/sdk/links/arm-links/src/operations/resourceLinks.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/resourceLinksMappers";
 import * as Parameters from "../models/parameters";
@@ -33,9 +33,9 @@ export class ResourceLinks {
    * For example,
    * /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(linkId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteMethod(linkId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param linkId The fully qualified ID of the resource link. Use the format,
    * /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}.
@@ -43,7 +43,7 @@ export class ResourceLinks {
    * /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink
    * @param callback The callback
    */
-  deleteMethod(linkId: string, callback: msRest.ServiceCallback<void>): void;
+  deleteMethod(linkId: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param linkId The fully qualified ID of the resource link. Use the format,
    * /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}.
@@ -52,8 +52,8 @@ export class ResourceLinks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(linkId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteMethod(linkId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteMethod(linkId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteMethod(linkId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         linkId,
@@ -73,7 +73,7 @@ export class ResourceLinks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceLinksCreateOrUpdateResponse>
    */
-  createOrUpdate(linkId: string, parameters: Models.ResourceLink, options?: msRest.RequestOptionsBase): Promise<Models.ResourceLinksCreateOrUpdateResponse>;
+  createOrUpdate(linkId: string, parameters: Models.ResourceLink, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceLinksCreateOrUpdateResponse>;
   /**
    * @param linkId The fully qualified ID of the resource link. Use the format,
    * /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}.
@@ -82,7 +82,7 @@ export class ResourceLinks {
    * @param parameters Parameters for creating or updating a resource link.
    * @param callback The callback
    */
-  createOrUpdate(linkId: string, parameters: Models.ResourceLink, callback: msRest.ServiceCallback<Models.ResourceLink>): void;
+  createOrUpdate(linkId: string, parameters: Models.ResourceLink, callback: coreHttp.ServiceCallback<Models.ResourceLink>): void;
   /**
    * @param linkId The fully qualified ID of the resource link. Use the format,
    * /subscriptions/{subscription-id}/resourceGroups/{resource-group-name}/{provider-namespace}/{resource-type}/{resource-name}/Microsoft.Resources/links/{link-name}.
@@ -92,8 +92,8 @@ export class ResourceLinks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdate(linkId: string, parameters: Models.ResourceLink, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceLink>): void;
-  createOrUpdate(linkId: string, parameters: Models.ResourceLink, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceLink>, callback?: msRest.ServiceCallback<Models.ResourceLink>): Promise<Models.ResourceLinksCreateOrUpdateResponse> {
+  createOrUpdate(linkId: string, parameters: Models.ResourceLink, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceLink>): void;
+  createOrUpdate(linkId: string, parameters: Models.ResourceLink, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceLink>, callback?: coreHttp.ServiceCallback<Models.ResourceLink>): Promise<Models.ResourceLinksCreateOrUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         linkId,
@@ -111,21 +111,21 @@ export class ResourceLinks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceLinksGetResponse>
    */
-  get(linkId: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourceLinksGetResponse>;
+  get(linkId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceLinksGetResponse>;
   /**
    * @param linkId The fully qualified Id of the resource link. For example,
    * /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink
    * @param callback The callback
    */
-  get(linkId: string, callback: msRest.ServiceCallback<Models.ResourceLink>): void;
+  get(linkId: string, callback: coreHttp.ServiceCallback<Models.ResourceLink>): void;
   /**
    * @param linkId The fully qualified Id of the resource link. For example,
    * /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup/Microsoft.Web/sites/mySite/Microsoft.Resources/links/myLink
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(linkId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceLink>): void;
-  get(linkId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceLink>, callback?: msRest.ServiceCallback<Models.ResourceLink>): Promise<Models.ResourceLinksGetResponse> {
+  get(linkId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceLink>): void;
+  get(linkId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceLink>, callback?: coreHttp.ServiceCallback<Models.ResourceLink>): Promise<Models.ResourceLinksGetResponse> {
     return this.client.sendOperationRequest(
       {
         linkId,
@@ -144,13 +144,13 @@ export class ResourceLinks {
   /**
    * @param callback The callback
    */
-  listAtSubscription(callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSubscription(callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscription(options: Models.ResourceLinksListAtSubscriptionOptionalParams, callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
-  listAtSubscription(options?: Models.ResourceLinksListAtSubscriptionOptionalParams | msRest.ServiceCallback<Models.ResourceLinkResult>, callback?: msRest.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSubscriptionResponse> {
+  listAtSubscription(options: Models.ResourceLinksListAtSubscriptionOptionalParams, callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSubscription(options?: Models.ResourceLinksListAtSubscriptionOptionalParams | coreHttp.ServiceCallback<Models.ResourceLinkResult>, callback?: coreHttp.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSubscriptionResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -174,7 +174,7 @@ export class ResourceLinks {
    * /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup.
    * @param callback The callback
    */
-  listAtSourceScope(scope: string, callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSourceScope(scope: string, callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
   /**
    * @param scope The fully qualified ID of the scope for getting the resource links. For example, to
    * list resource links at and under a resource group, set the scope to
@@ -182,8 +182,8 @@ export class ResourceLinks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSourceScope(scope: string, options: Models.ResourceLinksListAtSourceScopeOptionalParams, callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
-  listAtSourceScope(scope: string, options?: Models.ResourceLinksListAtSourceScopeOptionalParams | msRest.ServiceCallback<Models.ResourceLinkResult>, callback?: msRest.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSourceScopeResponse> {
+  listAtSourceScope(scope: string, options: Models.ResourceLinksListAtSourceScopeOptionalParams, callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSourceScope(scope: string, options?: Models.ResourceLinksListAtSourceScopeOptionalParams | coreHttp.ServiceCallback<Models.ResourceLinkResult>, callback?: coreHttp.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSourceScopeResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -199,19 +199,19 @@ export class ResourceLinks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceLinksListAtSubscriptionNextResponse>
    */
-  listAtSubscriptionNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourceLinksListAtSubscriptionNextResponse>;
+  listAtSubscriptionNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceLinksListAtSubscriptionNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtSubscriptionNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSubscriptionNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscriptionNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
-  listAtSubscriptionNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceLinkResult>, callback?: msRest.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSubscriptionNextResponse> {
+  listAtSubscriptionNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSubscriptionNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceLinkResult>, callback?: coreHttp.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSubscriptionNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -227,19 +227,19 @@ export class ResourceLinks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceLinksListAtSourceScopeNextResponse>
    */
-  listAtSourceScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourceLinksListAtSourceScopeNextResponse>;
+  listAtSourceScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceLinksListAtSourceScopeNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtSourceScopeNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSourceScopeNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSourceScopeNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceLinkResult>): void;
-  listAtSourceScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceLinkResult>, callback?: msRest.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSourceScopeNextResponse> {
+  listAtSourceScopeNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceLinkResult>): void;
+  listAtSourceScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceLinkResult>, callback?: coreHttp.ServiceCallback<Models.ResourceLinkResult>): Promise<Models.ResourceLinksListAtSourceScopeNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -251,8 +251,8 @@ export class ResourceLinks {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const deleteMethodOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const deleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "{linkId}",
   urlParameters: [
@@ -274,7 +274,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateOperationSpec: msRest.OperationSpec = {
+const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "{linkId}",
   urlParameters: [
@@ -307,7 +307,7 @@ const createOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{linkId}",
   urlParameters: [
@@ -330,7 +330,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/links",
   urlParameters: [
@@ -354,7 +354,7 @@ const listAtSubscriptionOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSourceScopeOperationSpec: msRest.OperationSpec = {
+const listAtSourceScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{scope}/providers/Microsoft.Resources/links",
   urlParameters: [
@@ -378,7 +378,7 @@ const listAtSourceScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionNextOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -399,7 +399,7 @@ const listAtSubscriptionNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSourceScopeNextOperationSpec: msRest.OperationSpec = {
+const listAtSourceScopeNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/locks/arm-locks/README.md
+++ b/sdk/locks/arm-locks/README.md
@@ -26,8 +26,8 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```typescript
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { ManagementLockClient, ManagementLockModels, ManagementLockMappers } from "@azure/arm-locks";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
@@ -61,8 +61,8 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 <html lang="en">
   <head>
     <title>@azure/arm-locks sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
+    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
+    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/arm-locks/dist/arm-locks.js"></script>
     <script type="text/javascript">

--- a/sdk/locks/arm-locks/package.json
+++ b/sdk/locks/arm-locks/package.json
@@ -4,8 +4,8 @@
   "description": "ManagementLockClient Library with typescript type definitions for node.js and browser.",
   "version": "1.1.0",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/core-arm": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/locks/arm-locks/rollup.config.js
+++ b/sdk/locks/arm-locks/rollup.config.js
@@ -8,8 +8,8 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const config = {
   input: "./esm/managementLockClient.js",
   external: [
-    "@azure/ms-rest-js",
-    "@azure/ms-rest-azure-js"
+    "@azure/core-http",
+    "@azure/core-arm"
   ],
   output: {
     file: "./dist/arm-locks.js",
@@ -17,8 +17,8 @@ const config = {
     name: "Azure.ArmLocks",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest",
-      "@azure/ms-rest-azure-js": "msRestAzure"
+      "@azure/core-http": "coreHttp",
+      "@azure/core-arm": "coreArm"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/locks/arm-locks/src/managementLockClient.ts
+++ b/sdk/locks/arm-locks/src/managementLockClient.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -26,7 +26,7 @@ class ManagementLockClient extends ManagementLockClientContext {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ManagementLockClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ManagementLockClientOptions) {
     super(credentials, subscriptionId, options);
     this.authorizationOperations = new operations.AuthorizationOperations(this);
     this.managementLocks = new operations.ManagementLocks(this);

--- a/sdk/locks/arm-locks/src/managementLockClientContext.ts
+++ b/sdk/locks/arm-locks/src/managementLockClientContext.ts
@@ -9,14 +9,14 @@
  */
 
 import * as Models from "./models";
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-locks";
 const packageVersion = "1.1.0";
 
-export class ManagementLockClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class ManagementLockClientContext extends coreArm.AzureServiceClient {
+  credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;
   subscriptionId: string;
   apiVersion?: string;
 
@@ -26,7 +26,7 @@ export class ManagementLockClientContext extends msRestAzure.AzureServiceClient 
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ManagementLockClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ManagementLockClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -38,7 +38,7 @@ export class ManagementLockClientContext extends msRestAzure.AzureServiceClient 
       options = {};
     }
     if(!options.userAgent) {
-      const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
+      const defaultUserAgent = coreArm.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 

--- a/sdk/locks/arm-locks/src/models/index.ts
+++ b/sdk/locks/arm-locks/src/models/index.ts
@@ -6,8 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export { BaseResource, CloudError };
 
@@ -92,7 +92,7 @@ export interface Operation {
 /**
  * Optional Parameters.
  */
-export interface ManagementLocksListAtResourceGroupLevelOptionalParams extends msRest.RequestOptionsBase {
+export interface ManagementLocksListAtResourceGroupLevelOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.
    */
@@ -102,7 +102,7 @@ export interface ManagementLocksListAtResourceGroupLevelOptionalParams extends m
 /**
  * Optional Parameters.
  */
-export interface ManagementLocksListAtResourceLevelOptionalParams extends msRest.RequestOptionsBase {
+export interface ManagementLocksListAtResourceLevelOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.
    */
@@ -112,7 +112,7 @@ export interface ManagementLocksListAtResourceLevelOptionalParams extends msRest
 /**
  * Optional Parameters.
  */
-export interface ManagementLocksListAtSubscriptionLevelOptionalParams extends msRest.RequestOptionsBase {
+export interface ManagementLocksListAtSubscriptionLevelOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.
    */
@@ -122,7 +122,7 @@ export interface ManagementLocksListAtSubscriptionLevelOptionalParams extends ms
 /**
  * Optional Parameters.
  */
-export interface ManagementLocksListByScopeOptionalParams extends msRest.RequestOptionsBase {
+export interface ManagementLocksListByScopeOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.
    */
@@ -176,7 +176,7 @@ export type AuthorizationOperationsListResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -196,7 +196,7 @@ export type AuthorizationOperationsListNextResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -216,7 +216,7 @@ export type ManagementLocksCreateOrUpdateAtResourceGroupLevelResponse = Manageme
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -236,7 +236,7 @@ export type ManagementLocksGetAtResourceGroupLevelResponse = ManagementLockObjec
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -256,7 +256,7 @@ export type ManagementLocksCreateOrUpdateByScopeResponse = ManagementLockObject 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -276,7 +276,7 @@ export type ManagementLocksGetByScopeResponse = ManagementLockObject & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -296,7 +296,7 @@ export type ManagementLocksCreateOrUpdateAtResourceLevelResponse = ManagementLoc
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -316,7 +316,7 @@ export type ManagementLocksGetAtResourceLevelResponse = ManagementLockObject & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -336,7 +336,7 @@ export type ManagementLocksCreateOrUpdateAtSubscriptionLevelResponse = Managemen
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -356,7 +356,7 @@ export type ManagementLocksGetAtSubscriptionLevelResponse = ManagementLockObject
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -376,7 +376,7 @@ export type ManagementLocksListAtResourceGroupLevelResponse = ManagementLockList
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -396,7 +396,7 @@ export type ManagementLocksListAtResourceLevelResponse = ManagementLockListResul
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -416,7 +416,7 @@ export type ManagementLocksListAtSubscriptionLevelResponse = ManagementLockListR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -436,7 +436,7 @@ export type ManagementLocksListByScopeResponse = ManagementLockListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -456,7 +456,7 @@ export type ManagementLocksListAtResourceGroupLevelNextResponse = ManagementLock
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -476,7 +476,7 @@ export type ManagementLocksListAtResourceLevelNextResponse = ManagementLockListR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -496,7 +496,7 @@ export type ManagementLocksListAtSubscriptionLevelNextResponse = ManagementLockL
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -516,7 +516,7 @@ export type ManagementLocksListByScopeNextResponse = ManagementLockListResult & 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */

--- a/sdk/locks/arm-locks/src/models/mappers.ts
+++ b/sdk/locks/arm-locks/src/models/mappers.ts
@@ -6,13 +6,13 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { CloudErrorMapper, BaseResourceMapper } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { CloudErrorMapper, BaseResourceMapper } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;
 
-export const ManagementLockOwner: msRest.CompositeMapper = {
+export const ManagementLockOwner: coreHttp.CompositeMapper = {
   serializedName: "ManagementLockOwner",
   type: {
     name: "Composite",
@@ -28,7 +28,7 @@ export const ManagementLockOwner: msRest.CompositeMapper = {
   }
 };
 
-export const ManagementLockObject: msRest.CompositeMapper = {
+export const ManagementLockObject: coreHttp.CompositeMapper = {
   serializedName: "ManagementLockObject",
   type: {
     name: "Composite",
@@ -84,7 +84,7 @@ export const ManagementLockObject: msRest.CompositeMapper = {
   }
 };
 
-export const OperationDisplay: msRest.CompositeMapper = {
+export const OperationDisplay: coreHttp.CompositeMapper = {
   serializedName: "Operation_display",
   type: {
     name: "Composite",
@@ -112,7 +112,7 @@ export const OperationDisplay: msRest.CompositeMapper = {
   }
 };
 
-export const Operation: msRest.CompositeMapper = {
+export const Operation: coreHttp.CompositeMapper = {
   serializedName: "Operation",
   type: {
     name: "Composite",
@@ -135,7 +135,7 @@ export const Operation: msRest.CompositeMapper = {
   }
 };
 
-export const OperationListResult: msRest.CompositeMapper = {
+export const OperationListResult: coreHttp.CompositeMapper = {
   serializedName: "OperationListResult",
   type: {
     name: "Composite",
@@ -163,7 +163,7 @@ export const OperationListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ManagementLockListResult: msRest.CompositeMapper = {
+export const ManagementLockListResult: coreHttp.CompositeMapper = {
   serializedName: "ManagementLockListResult",
   type: {
     name: "Composite",

--- a/sdk/locks/arm-locks/src/models/parameters.ts
+++ b/sdk/locks/arm-locks/src/models/parameters.ts
@@ -8,9 +8,9 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 
-export const acceptLanguage: msRest.OperationParameter = {
+export const acceptLanguage: coreHttp.OperationParameter = {
   parameterPath: "acceptLanguage",
   mapper: {
     serializedName: "accept-language",
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion: msRest.OperationQueryParameter = {
+export const apiVersion: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -30,7 +30,7 @@ export const apiVersion: msRest.OperationQueryParameter = {
     }
   }
 };
-export const filter: msRest.OperationQueryParameter = {
+export const filter: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "filter"
@@ -42,7 +42,7 @@ export const filter: msRest.OperationQueryParameter = {
     }
   }
 };
-export const lockName: msRest.OperationURLParameter = {
+export const lockName: coreHttp.OperationURLParameter = {
   parameterPath: "lockName",
   mapper: {
     required: true,
@@ -52,7 +52,7 @@ export const lockName: msRest.OperationURLParameter = {
     }
   }
 };
-export const nextPageLink: msRest.OperationURLParameter = {
+export const nextPageLink: coreHttp.OperationURLParameter = {
   parameterPath: "nextPageLink",
   mapper: {
     required: true,
@@ -63,7 +63,7 @@ export const nextPageLink: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const parentResourcePath: msRest.OperationURLParameter = {
+export const parentResourcePath: coreHttp.OperationURLParameter = {
   parameterPath: "parentResourcePath",
   mapper: {
     required: true,
@@ -74,7 +74,7 @@ export const parentResourcePath: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const resourceGroupName: msRest.OperationURLParameter = {
+export const resourceGroupName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
     required: true,
@@ -89,7 +89,7 @@ export const resourceGroupName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceName: msRest.OperationURLParameter = {
+export const resourceName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceName",
   mapper: {
     required: true,
@@ -99,7 +99,7 @@ export const resourceName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceProviderNamespace: msRest.OperationURLParameter = {
+export const resourceProviderNamespace: coreHttp.OperationURLParameter = {
   parameterPath: "resourceProviderNamespace",
   mapper: {
     required: true,
@@ -109,7 +109,7 @@ export const resourceProviderNamespace: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceType: msRest.OperationURLParameter = {
+export const resourceType: coreHttp.OperationURLParameter = {
   parameterPath: "resourceType",
   mapper: {
     required: true,
@@ -120,7 +120,7 @@ export const resourceType: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const scope: msRest.OperationURLParameter = {
+export const scope: coreHttp.OperationURLParameter = {
   parameterPath: "scope",
   mapper: {
     required: true,
@@ -130,7 +130,7 @@ export const scope: msRest.OperationURLParameter = {
     }
   }
 };
-export const subscriptionId: msRest.OperationURLParameter = {
+export const subscriptionId: coreHttp.OperationURLParameter = {
   parameterPath: "subscriptionId",
   mapper: {
     required: true,

--- a/sdk/locks/arm-locks/src/operations/authorizationOperations.ts
+++ b/sdk/locks/arm-locks/src/operations/authorizationOperations.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/authorizationOperationsMappers";
 import * as Parameters from "../models/parameters";
@@ -31,17 +31,17 @@ export class AuthorizationOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.AuthorizationOperationsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.AuthorizationOperationsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.AuthorizationOperationsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.AuthorizationOperationsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.AuthorizationOperationsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -56,19 +56,19 @@ export class AuthorizationOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.AuthorizationOperationsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.AuthorizationOperationsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AuthorizationOperationsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.AuthorizationOperationsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.AuthorizationOperationsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -80,8 +80,8 @@ export class AuthorizationOperations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Authorization/operations",
   queryParameters: [
@@ -101,7 +101,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/locks/arm-locks/src/operations/managementLocks.ts
+++ b/sdk/locks/arm-locks/src/operations/managementLocks.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/managementLocksMappers";
 import * as Parameters from "../models/parameters";
@@ -39,7 +39,7 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksCreateOrUpdateAtResourceGroupLevelResponse>
    */
-  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateAtResourceGroupLevelResponse>;
+  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateAtResourceGroupLevelResponse>;
   /**
    * @param resourceGroupName The name of the resource group to lock.
    * @param lockName The lock name. The lock name can be a maximum of 260 characters. It cannot
@@ -47,7 +47,7 @@ export class ManagementLocks {
    * @param parameters The management lock parameters.
    * @param callback The callback
    */
-  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param resourceGroupName The name of the resource group to lock.
    * @param lockName The lock name. The lock name can be a maximum of 260 characters. It cannot
@@ -56,8 +56,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateAtResourceGroupLevelResponse> {
+  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateAtResourceGroupLevel(resourceGroupName: string, lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateAtResourceGroupLevelResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -77,23 +77,23 @@ export class ManagementLocks {
    * @param resourceGroupName The name of the resource group containing the lock.
    * @param lockName The name of lock to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param resourceGroupName The name of the resource group containing the lock.
    * @param lockName The name of lock to delete.
    * @param callback The callback
    */
-  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the lock.
    * @param lockName The name of lock to delete.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -111,21 +111,21 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksGetAtResourceGroupLevelResponse>
    */
-  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksGetAtResourceGroupLevelResponse>;
+  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksGetAtResourceGroupLevelResponse>;
   /**
    * @param resourceGroupName The name of the locked resource group.
    * @param lockName The name of the lock to get.
    * @param callback The callback
    */
-  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param resourceGroupName The name of the locked resource group.
    * @param lockName The name of the lock to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetAtResourceGroupLevelResponse> {
+  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  getAtResourceGroupLevel(resourceGroupName: string, lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetAtResourceGroupLevelResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -148,7 +148,7 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksCreateOrUpdateByScopeResponse>
    */
-  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateByScopeResponse>;
+  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateByScopeResponse>;
   /**
    * @param scope The scope for the lock. When providing a scope for the assignment, use
    * '/subscriptions/{subscriptionId}' for subscriptions,
@@ -159,7 +159,7 @@ export class ManagementLocks {
    * @param parameters Create or update management lock parameters.
    * @param callback The callback
    */
-  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param scope The scope for the lock. When providing a scope for the assignment, use
    * '/subscriptions/{subscriptionId}' for subscriptions,
@@ -171,8 +171,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateByScopeResponse> {
+  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateByScope(scope: string, lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateByScopeResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -189,23 +189,23 @@ export class ManagementLocks {
    * @param scope The scope for the lock.
    * @param lockName The name of lock.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteByScope(scope: string, lockName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteByScope(scope: string, lockName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param scope The scope for the lock.
    * @param lockName The name of lock.
    * @param callback The callback
    */
-  deleteByScope(scope: string, lockName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteByScope(scope: string, lockName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param scope The scope for the lock.
    * @param lockName The name of lock.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteByScope(scope: string, lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteByScope(scope: string, lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteByScope(scope: string, lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteByScope(scope: string, lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -223,21 +223,21 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksGetByScopeResponse>
    */
-  getByScope(scope: string, lockName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksGetByScopeResponse>;
+  getByScope(scope: string, lockName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksGetByScopeResponse>;
   /**
    * @param scope The scope for the lock.
    * @param lockName The name of lock.
    * @param callback The callback
    */
-  getByScope(scope: string, lockName: string, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  getByScope(scope: string, lockName: string, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param scope The scope for the lock.
    * @param lockName The name of lock.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getByScope(scope: string, lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  getByScope(scope: string, lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetByScopeResponse> {
+  getByScope(scope: string, lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  getByScope(scope: string, lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetByScopeResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -266,7 +266,7 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksCreateOrUpdateAtResourceLevelResponse>
    */
-  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateAtResourceLevelResponse>;
+  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateAtResourceLevelResponse>;
   /**
    * @param resourceGroupName The name of the resource group containing the resource to lock.
    * @param resourceProviderNamespace The resource provider namespace of the resource to lock.
@@ -278,7 +278,7 @@ export class ManagementLocks {
    * @param parameters Parameters for creating or updating a  management lock.
    * @param callback The callback
    */
-  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the resource to lock.
    * @param resourceProviderNamespace The resource provider namespace of the resource to lock.
@@ -291,8 +291,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateAtResourceLevelResponse> {
+  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateAtResourceLevelResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -322,9 +322,9 @@ export class ManagementLocks {
    * @param resourceName The name of the resource with the lock to delete.
    * @param lockName The name of the lock to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param resourceGroupName The name of the resource group containing the resource with the lock to
    * delete.
@@ -336,7 +336,7 @@ export class ManagementLocks {
    * @param lockName The name of the lock to delete.
    * @param callback The callback
    */
-  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the resource with the lock to
    * delete.
@@ -349,8 +349,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -376,7 +376,7 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksGetAtResourceLevelResponse>
    */
-  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksGetAtResourceLevelResponse>;
+  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksGetAtResourceLevelResponse>;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param resourceProviderNamespace The namespace of the resource provider.
@@ -386,7 +386,7 @@ export class ManagementLocks {
    * @param lockName The name of lock.
    * @param callback The callback
    */
-  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param resourceGroupName The name of the resource group.
    * @param resourceProviderNamespace The namespace of the resource provider.
@@ -397,8 +397,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetAtResourceLevelResponse> {
+  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  getAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetAtResourceLevelResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -425,14 +425,14 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksCreateOrUpdateAtSubscriptionLevelResponse>
    */
-  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateAtSubscriptionLevelResponse>;
+  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksCreateOrUpdateAtSubscriptionLevelResponse>;
   /**
    * @param lockName The name of lock. The lock name can be a maximum of 260 characters. It cannot
    * contain <, > %, &, :, \, ?, /, or any control characters.
    * @param parameters The management lock parameters.
    * @param callback The callback
    */
-  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param lockName The name of lock. The lock name can be a maximum of 260 characters. It cannot
    * contain <, > %, &, :, \, ?, /, or any control characters.
@@ -440,8 +440,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateAtSubscriptionLevelResponse> {
+  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  createOrUpdateAtSubscriptionLevel(lockName: string, parameters: Models.ManagementLockObject, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksCreateOrUpdateAtSubscriptionLevelResponse> {
     return this.client.sendOperationRequest(
       {
         lockName,
@@ -459,21 +459,21 @@ export class ManagementLocks {
    * @summary Deletes the management lock at the subscription level.
    * @param lockName The name of lock to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteAtSubscriptionLevel(lockName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteAtSubscriptionLevel(lockName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param lockName The name of lock to delete.
    * @param callback The callback
    */
-  deleteAtSubscriptionLevel(lockName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteAtSubscriptionLevel(lockName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param lockName The name of lock to delete.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteAtSubscriptionLevel(lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteAtSubscriptionLevel(lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteAtSubscriptionLevel(lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteAtSubscriptionLevel(lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         lockName,
@@ -489,19 +489,19 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksGetAtSubscriptionLevelResponse>
    */
-  getAtSubscriptionLevel(lockName: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksGetAtSubscriptionLevelResponse>;
+  getAtSubscriptionLevel(lockName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksGetAtSubscriptionLevelResponse>;
   /**
    * @param lockName The name of the lock to get.
    * @param callback The callback
    */
-  getAtSubscriptionLevel(lockName: string, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
+  getAtSubscriptionLevel(lockName: string, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
   /**
    * @param lockName The name of the lock to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtSubscriptionLevel(lockName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockObject>): void;
-  getAtSubscriptionLevel(lockName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockObject>, callback?: msRest.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetAtSubscriptionLevelResponse> {
+  getAtSubscriptionLevel(lockName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockObject>): void;
+  getAtSubscriptionLevel(lockName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockObject>, callback?: coreHttp.ServiceCallback<Models.ManagementLockObject>): Promise<Models.ManagementLocksGetAtSubscriptionLevelResponse> {
     return this.client.sendOperationRequest(
       {
         lockName,
@@ -522,14 +522,14 @@ export class ManagementLocks {
    * @param resourceGroupName The name of the resource group containing the locks to get.
    * @param callback The callback
    */
-  listAtResourceGroupLevel(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceGroupLevel(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the locks to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtResourceGroupLevel(resourceGroupName: string, options: Models.ManagementLocksListAtResourceGroupLevelOptionalParams, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listAtResourceGroupLevel(resourceGroupName: string, options?: Models.ManagementLocksListAtResourceGroupLevelOptionalParams | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceGroupLevelResponse> {
+  listAtResourceGroupLevel(resourceGroupName: string, options: Models.ManagementLocksListAtResourceGroupLevelOptionalParams, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceGroupLevel(resourceGroupName: string, options?: Models.ManagementLocksListAtResourceGroupLevelOptionalParams | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceGroupLevelResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -560,7 +560,7 @@ export class ManagementLocks {
    * @param resourceName The name of the locked resource.
    * @param callback The callback
    */
-  listAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the locked resource. The name
    * is case insensitive.
@@ -571,8 +571,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options: Models.ManagementLocksListAtResourceLevelOptionalParams, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options?: Models.ManagementLocksListAtResourceLevelOptionalParams | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceLevelResponse> {
+  listAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options: Models.ManagementLocksListAtResourceLevelOptionalParams, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceLevel(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options?: Models.ManagementLocksListAtResourceLevelOptionalParams | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceLevelResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -595,13 +595,13 @@ export class ManagementLocks {
   /**
    * @param callback The callback
    */
-  listAtSubscriptionLevel(callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtSubscriptionLevel(callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscriptionLevel(options: Models.ManagementLocksListAtSubscriptionLevelOptionalParams, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listAtSubscriptionLevel(options?: Models.ManagementLocksListAtSubscriptionLevelOptionalParams | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtSubscriptionLevelResponse> {
+  listAtSubscriptionLevel(options: Models.ManagementLocksListAtSubscriptionLevelOptionalParams, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtSubscriptionLevel(options?: Models.ManagementLocksListAtSubscriptionLevelOptionalParams | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtSubscriptionLevelResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -629,7 +629,7 @@ export class ManagementLocks {
    * for resources.
    * @param callback The callback
    */
-  listByScope(scope: string, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listByScope(scope: string, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param scope The scope for the lock. When providing a scope for the assignment, use
    * '/subscriptions/{subscriptionId}' for subscriptions,
@@ -639,8 +639,8 @@ export class ManagementLocks {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByScope(scope: string, options: Models.ManagementLocksListByScopeOptionalParams, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listByScope(scope: string, options?: Models.ManagementLocksListByScopeOptionalParams | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListByScopeResponse> {
+  listByScope(scope: string, options: Models.ManagementLocksListByScopeOptionalParams, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listByScope(scope: string, options?: Models.ManagementLocksListByScopeOptionalParams | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListByScopeResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -656,19 +656,19 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksListAtResourceGroupLevelNextResponse>
    */
-  listAtResourceGroupLevelNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksListAtResourceGroupLevelNextResponse>;
+  listAtResourceGroupLevelNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksListAtResourceGroupLevelNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtResourceGroupLevelNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceGroupLevelNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtResourceGroupLevelNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listAtResourceGroupLevelNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceGroupLevelNextResponse> {
+  listAtResourceGroupLevelNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceGroupLevelNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceGroupLevelNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -684,19 +684,19 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksListAtResourceLevelNextResponse>
    */
-  listAtResourceLevelNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksListAtResourceLevelNextResponse>;
+  listAtResourceLevelNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksListAtResourceLevelNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtResourceLevelNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceLevelNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtResourceLevelNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listAtResourceLevelNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceLevelNextResponse> {
+  listAtResourceLevelNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtResourceLevelNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtResourceLevelNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -712,19 +712,19 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksListAtSubscriptionLevelNextResponse>
    */
-  listAtSubscriptionLevelNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksListAtSubscriptionLevelNextResponse>;
+  listAtSubscriptionLevelNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksListAtSubscriptionLevelNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtSubscriptionLevelNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtSubscriptionLevelNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscriptionLevelNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listAtSubscriptionLevelNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtSubscriptionLevelNextResponse> {
+  listAtSubscriptionLevelNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listAtSubscriptionLevelNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListAtSubscriptionLevelNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -740,19 +740,19 @@ export class ManagementLocks {
    * @param [options] The optional parameters
    * @returns Promise<Models.ManagementLocksListByScopeNextResponse>
    */
-  listByScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ManagementLocksListByScopeNextResponse>;
+  listByScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ManagementLocksListByScopeNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByScopeNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
+  listByScopeNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByScopeNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ManagementLockListResult>): void;
-  listByScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ManagementLockListResult>, callback?: msRest.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListByScopeNextResponse> {
+  listByScopeNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ManagementLockListResult>): void;
+  listByScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ManagementLockListResult>, callback?: coreHttp.ServiceCallback<Models.ManagementLockListResult>): Promise<Models.ManagementLocksListByScopeNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -764,8 +764,8 @@ export class ManagementLocks {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const createOrUpdateAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const createOrUpdateAtResourceGroupLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -800,7 +800,7 @@ const createOrUpdateAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
+const deleteAtResourceGroupLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -824,7 +824,7 @@ const deleteAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
+const getAtResourceGroupLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -849,7 +849,7 @@ const getAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateByScopeOperationSpec: msRest.OperationSpec = {
+const createOrUpdateByScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "{scope}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -883,7 +883,7 @@ const createOrUpdateByScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteByScopeOperationSpec: msRest.OperationSpec = {
+const deleteByScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "{scope}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -906,7 +906,7 @@ const deleteByScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getByScopeOperationSpec: msRest.OperationSpec = {
+const getByScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{scope}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -930,7 +930,7 @@ const getByScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateAtResourceLevelOperationSpec: msRest.OperationSpec = {
+const createOrUpdateAtResourceLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -969,7 +969,7 @@ const createOrUpdateAtResourceLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteAtResourceLevelOperationSpec: msRest.OperationSpec = {
+const deleteAtResourceLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -997,7 +997,7 @@ const deleteAtResourceLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAtResourceLevelOperationSpec: msRest.OperationSpec = {
+const getAtResourceLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -1026,7 +1026,7 @@ const getAtResourceLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
+const createOrUpdateAtSubscriptionLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -1060,7 +1060,7 @@ const createOrUpdateAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
+const deleteAtSubscriptionLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -1083,7 +1083,7 @@ const deleteAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
+const getAtSubscriptionLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/locks/{lockName}",
   urlParameters: [
@@ -1107,7 +1107,7 @@ const getAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
+const listAtResourceGroupLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/locks",
   urlParameters: [
@@ -1132,7 +1132,7 @@ const listAtResourceGroupLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtResourceLevelOperationSpec: msRest.OperationSpec = {
+const listAtResourceLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/locks",
   urlParameters: [
@@ -1161,7 +1161,7 @@ const listAtResourceLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionLevelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/locks",
   urlParameters: [
@@ -1185,7 +1185,7 @@ const listAtSubscriptionLevelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByScopeOperationSpec: msRest.OperationSpec = {
+const listByScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{scope}/providers/Microsoft.Authorization/locks",
   urlParameters: [
@@ -1209,7 +1209,7 @@ const listByScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtResourceGroupLevelNextOperationSpec: msRest.OperationSpec = {
+const listAtResourceGroupLevelNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1230,7 +1230,7 @@ const listAtResourceGroupLevelNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtResourceLevelNextOperationSpec: msRest.OperationSpec = {
+const listAtResourceLevelNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1251,7 +1251,7 @@ const listAtResourceLevelNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionLevelNextOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionLevelNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1272,7 +1272,7 @@ const listAtSubscriptionLevelNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByScopeNextOperationSpec: msRest.OperationSpec = {
+const listByScopeNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/managedapplications/arm-managedapplications/README.md
+++ b/sdk/managedapplications/arm-managedapplications/README.md
@@ -26,8 +26,8 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```typescript
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { ManagedApplicationClient, ManagedApplicationModels, ManagedApplicationMappers } from "@azure/arm-managedapplications";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
@@ -61,8 +61,8 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 <html lang="en">
   <head>
     <title>@azure/arm-managedapplications sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
+    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
+    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/arm-managedapplications/dist/arm-managedapplications.js"></script>
     <script type="text/javascript">

--- a/sdk/managedapplications/arm-managedapplications/package.json
+++ b/sdk/managedapplications/arm-managedapplications/package.json
@@ -4,8 +4,8 @@
   "description": "ManagedApplicationClient Library with typescript type definitions for node.js and browser.",
   "version": "1.0.2",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/core-arm": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/managedapplications/arm-managedapplications/rollup.config.js
+++ b/sdk/managedapplications/arm-managedapplications/rollup.config.js
@@ -8,8 +8,8 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const config = {
   input: "./esm/managedApplicationClient.js",
   external: [
-    "@azure/ms-rest-js",
-    "@azure/ms-rest-azure-js"
+    "@azure/core-http",
+    "@azure/core-arm"
   ],
   output: {
     file: "./dist/arm-managedapplications.js",
@@ -17,8 +17,8 @@ const config = {
     name: "Azure.ArmManagedapplications",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest",
-      "@azure/ms-rest-azure-js": "msRestAzure"
+      "@azure/core-http": "coreHttp",
+      "@azure/core-arm": "coreArm"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/managedapplications/arm-managedapplications/src/managedApplicationClient.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/managedApplicationClient.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as Parameters from "./models/parameters";
@@ -27,7 +27,7 @@ class ManagedApplicationClient extends ManagedApplicationClientContext {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ManagedApplicationClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ManagedApplicationClientOptions) {
     super(credentials, subscriptionId, options);
     this.appliances = new operations.Appliances(this);
     this.applianceDefinitions = new operations.ApplianceDefinitions(this);
@@ -38,17 +38,17 @@ class ManagedApplicationClient extends ManagedApplicationClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.ListOperationsResponse>
    */
-  listOperations(options?: msRest.RequestOptionsBase): Promise<Models.ListOperationsResponse>;
+  listOperations(options?: coreHttp.RequestOptionsBase): Promise<Models.ListOperationsResponse>;
   /**
    * @param callback The callback
    */
-  listOperations(callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  listOperations(callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listOperations(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  listOperations(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsResponse> {
+  listOperations(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  listOperations(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsResponse> {
     return this.sendOperationRequest(
       {
         options
@@ -63,19 +63,19 @@ class ManagedApplicationClient extends ManagedApplicationClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.ListOperationsNextResponse>
    */
-  listOperationsNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ListOperationsNextResponse>;
+  listOperationsNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ListOperationsNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listOperationsNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  listOperationsNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listOperationsNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  listOperationsNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsNextResponse> {
+  listOperationsNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  listOperationsNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.ListOperationsNextResponse> {
     return this.sendOperationRequest(
       {
         nextPageLink,
@@ -87,8 +87,8 @@ class ManagedApplicationClient extends ManagedApplicationClientContext {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationsOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Solutions/operations",
   queryParameters: [
@@ -108,7 +108,7 @@ const listOperationsOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationsNextOperationSpec: msRest.OperationSpec = {
+const listOperationsNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/managedapplications/arm-managedapplications/src/managedApplicationClientContext.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/managedApplicationClientContext.ts
@@ -9,14 +9,14 @@
  */
 
 import * as Models from "./models";
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-managedapplications";
 const packageVersion = "1.0.2";
 
-export class ManagedApplicationClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class ManagedApplicationClientContext extends coreArm.AzureServiceClient {
+  credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;
   subscriptionId: string;
   apiVersion?: string;
 
@@ -26,7 +26,7 @@ export class ManagedApplicationClientContext extends msRestAzure.AzureServiceCli
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ManagedApplicationClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ManagedApplicationClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -38,7 +38,7 @@ export class ManagedApplicationClientContext extends msRestAzure.AzureServiceCli
       options = {};
     }
     if(!options.userAgent) {
-      const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
+      const defaultUserAgent = coreArm.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 

--- a/sdk/managedapplications/arm-managedapplications/src/models/index.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/models/index.ts
@@ -6,8 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export { BaseResource, CloudError };
 
@@ -364,7 +364,7 @@ export interface Operation {
 /**
  * Optional Parameters.
  */
-export interface AppliancesUpdateOptionalParams extends msRest.RequestOptionsBase {
+export interface AppliancesUpdateOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters supplied to update an existing appliance.
    */
@@ -374,7 +374,7 @@ export interface AppliancesUpdateOptionalParams extends msRest.RequestOptionsBas
 /**
  * Optional Parameters.
  */
-export interface AppliancesUpdateByIdOptionalParams extends msRest.RequestOptionsBase {
+export interface AppliancesUpdateByIdOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Parameters supplied to update an existing appliance.
    */
@@ -465,7 +465,7 @@ export type ListOperationsResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -485,7 +485,7 @@ export type ListOperationsNextResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -505,7 +505,7 @@ export type AppliancesGetResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -525,7 +525,7 @@ export type AppliancesCreateOrUpdateResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -545,7 +545,7 @@ export type AppliancesUpdateResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -565,7 +565,7 @@ export type AppliancesListByResourceGroupResponse = ApplianceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -585,7 +585,7 @@ export type AppliancesListBySubscriptionResponse = ApplianceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -605,7 +605,7 @@ export type AppliancesGetByIdResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -625,7 +625,7 @@ export type AppliancesCreateOrUpdateByIdResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -645,7 +645,7 @@ export type AppliancesUpdateByIdResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -665,7 +665,7 @@ export type AppliancesBeginCreateOrUpdateResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -685,7 +685,7 @@ export type AppliancesBeginCreateOrUpdateByIdResponse = Appliance & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -705,7 +705,7 @@ export type AppliancesListByResourceGroupNextResponse = ApplianceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -725,7 +725,7 @@ export type AppliancesListBySubscriptionNextResponse = ApplianceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -745,7 +745,7 @@ export type ApplianceDefinitionsGetResponse = ApplianceDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -765,7 +765,7 @@ export type ApplianceDefinitionsCreateOrUpdateResponse = ApplianceDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -785,7 +785,7 @@ export type ApplianceDefinitionsListByResourceGroupResponse = ApplianceDefinitio
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -805,7 +805,7 @@ export type ApplianceDefinitionsGetByIdResponse = ApplianceDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -825,7 +825,7 @@ export type ApplianceDefinitionsCreateOrUpdateByIdResponse = ApplianceDefinition
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -845,7 +845,7 @@ export type ApplianceDefinitionsBeginCreateOrUpdateResponse = ApplianceDefinitio
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -865,7 +865,7 @@ export type ApplianceDefinitionsBeginCreateOrUpdateByIdResponse = ApplianceDefin
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -885,7 +885,7 @@ export type ApplianceDefinitionsListByResourceGroupNextResponse = ApplianceDefin
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */

--- a/sdk/managedapplications/arm-managedapplications/src/models/mappers.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/models/mappers.ts
@@ -6,13 +6,13 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { CloudErrorMapper, BaseResourceMapper } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { CloudErrorMapper, BaseResourceMapper } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;
 
-export const Plan: msRest.CompositeMapper = {
+export const Plan: coreHttp.CompositeMapper = {
   serializedName: "Plan",
   type: {
     name: "Composite",
@@ -56,7 +56,7 @@ export const Plan: msRest.CompositeMapper = {
   }
 };
 
-export const Resource: msRest.CompositeMapper = {
+export const Resource: coreHttp.CompositeMapper = {
   serializedName: "Resource",
   type: {
     name: "Composite",
@@ -104,7 +104,7 @@ export const Resource: msRest.CompositeMapper = {
   }
 };
 
-export const GenericResource: msRest.CompositeMapper = {
+export const GenericResource: coreHttp.CompositeMapper = {
   serializedName: "GenericResource",
   type: {
     name: "Composite",
@@ -135,7 +135,7 @@ export const GenericResource: msRest.CompositeMapper = {
   }
 };
 
-export const Appliance: msRest.CompositeMapper = {
+export const Appliance: coreHttp.CompositeMapper = {
   serializedName: "Appliance",
   type: {
     name: "Composite",
@@ -201,7 +201,7 @@ export const Appliance: msRest.CompositeMapper = {
   }
 };
 
-export const PlanPatchable: msRest.CompositeMapper = {
+export const PlanPatchable: coreHttp.CompositeMapper = {
   serializedName: "PlanPatchable",
   type: {
     name: "Composite",
@@ -241,7 +241,7 @@ export const PlanPatchable: msRest.CompositeMapper = {
   }
 };
 
-export const AppliancePatchable: msRest.CompositeMapper = {
+export const AppliancePatchable: coreHttp.CompositeMapper = {
   serializedName: "AppliancePatchable",
   type: {
     name: "Composite",
@@ -306,7 +306,7 @@ export const AppliancePatchable: msRest.CompositeMapper = {
   }
 };
 
-export const ApplianceProviderAuthorization: msRest.CompositeMapper = {
+export const ApplianceProviderAuthorization: coreHttp.CompositeMapper = {
   serializedName: "ApplianceProviderAuthorization",
   type: {
     name: "Composite",
@@ -330,7 +330,7 @@ export const ApplianceProviderAuthorization: msRest.CompositeMapper = {
   }
 };
 
-export const ApplianceArtifact: msRest.CompositeMapper = {
+export const ApplianceArtifact: coreHttp.CompositeMapper = {
   serializedName: "ApplianceArtifact",
   type: {
     name: "Composite",
@@ -362,7 +362,7 @@ export const ApplianceArtifact: msRest.CompositeMapper = {
   }
 };
 
-export const ApplianceDefinition: msRest.CompositeMapper = {
+export const ApplianceDefinition: coreHttp.CompositeMapper = {
   serializedName: "ApplianceDefinition",
   type: {
     name: "Composite",
@@ -429,7 +429,7 @@ export const ApplianceDefinition: msRest.CompositeMapper = {
   }
 };
 
-export const Sku: msRest.CompositeMapper = {
+export const Sku: coreHttp.CompositeMapper = {
   serializedName: "Sku",
   type: {
     name: "Composite",
@@ -476,7 +476,7 @@ export const Sku: msRest.CompositeMapper = {
   }
 };
 
-export const Identity: msRest.CompositeMapper = {
+export const Identity: coreHttp.CompositeMapper = {
   serializedName: "Identity",
   type: {
     name: "Composite",
@@ -509,7 +509,7 @@ export const Identity: msRest.CompositeMapper = {
   }
 };
 
-export const ErrorResponse: msRest.CompositeMapper = {
+export const ErrorResponse: coreHttp.CompositeMapper = {
   serializedName: "ErrorResponse",
   type: {
     name: "Composite",
@@ -537,7 +537,7 @@ export const ErrorResponse: msRest.CompositeMapper = {
   }
 };
 
-export const OperationDisplay: msRest.CompositeMapper = {
+export const OperationDisplay: coreHttp.CompositeMapper = {
   serializedName: "Operation_display",
   type: {
     name: "Composite",
@@ -565,7 +565,7 @@ export const OperationDisplay: msRest.CompositeMapper = {
   }
 };
 
-export const Operation: msRest.CompositeMapper = {
+export const Operation: coreHttp.CompositeMapper = {
   serializedName: "Operation",
   type: {
     name: "Composite",
@@ -588,7 +588,7 @@ export const Operation: msRest.CompositeMapper = {
   }
 };
 
-export const OperationListResult: msRest.CompositeMapper = {
+export const OperationListResult: coreHttp.CompositeMapper = {
   serializedName: "OperationListResult",
   type: {
     name: "Composite",
@@ -616,7 +616,7 @@ export const OperationListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ApplianceListResult: msRest.CompositeMapper = {
+export const ApplianceListResult: coreHttp.CompositeMapper = {
   serializedName: "ApplianceListResult",
   type: {
     name: "Composite",
@@ -644,7 +644,7 @@ export const ApplianceListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ApplianceDefinitionListResult: msRest.CompositeMapper = {
+export const ApplianceDefinitionListResult: coreHttp.CompositeMapper = {
   serializedName: "ApplianceDefinitionListResult",
   type: {
     name: "Composite",

--- a/sdk/managedapplications/arm-managedapplications/src/models/parameters.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/models/parameters.ts
@@ -8,9 +8,9 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 
-export const acceptLanguage: msRest.OperationParameter = {
+export const acceptLanguage: coreHttp.OperationParameter = {
   parameterPath: "acceptLanguage",
   mapper: {
     serializedName: "accept-language",
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion: msRest.OperationQueryParameter = {
+export const apiVersion: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -30,7 +30,7 @@ export const apiVersion: msRest.OperationQueryParameter = {
     }
   }
 };
-export const applianceDefinitionId: msRest.OperationURLParameter = {
+export const applianceDefinitionId: coreHttp.OperationURLParameter = {
   parameterPath: "applianceDefinitionId",
   mapper: {
     required: true,
@@ -41,7 +41,7 @@ export const applianceDefinitionId: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const applianceDefinitionName: msRest.OperationURLParameter = {
+export const applianceDefinitionName: coreHttp.OperationURLParameter = {
   parameterPath: "applianceDefinitionName",
   mapper: {
     required: true,
@@ -55,7 +55,7 @@ export const applianceDefinitionName: msRest.OperationURLParameter = {
     }
   }
 };
-export const applianceId: msRest.OperationURLParameter = {
+export const applianceId: coreHttp.OperationURLParameter = {
   parameterPath: "applianceId",
   mapper: {
     required: true,
@@ -66,7 +66,7 @@ export const applianceId: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const applianceName: msRest.OperationURLParameter = {
+export const applianceName: coreHttp.OperationURLParameter = {
   parameterPath: "applianceName",
   mapper: {
     required: true,
@@ -80,7 +80,7 @@ export const applianceName: msRest.OperationURLParameter = {
     }
   }
 };
-export const nextPageLink: msRest.OperationURLParameter = {
+export const nextPageLink: coreHttp.OperationURLParameter = {
   parameterPath: "nextPageLink",
   mapper: {
     required: true,
@@ -91,7 +91,7 @@ export const nextPageLink: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const resourceGroupName: msRest.OperationURLParameter = {
+export const resourceGroupName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
     required: true,
@@ -106,7 +106,7 @@ export const resourceGroupName: msRest.OperationURLParameter = {
     }
   }
 };
-export const subscriptionId: msRest.OperationURLParameter = {
+export const subscriptionId: coreHttp.OperationURLParameter = {
   parameterPath: "subscriptionId",
   mapper: {
     required: true,

--- a/sdk/managedapplications/arm-managedapplications/src/operations/applianceDefinitions.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/operations/applianceDefinitions.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/applianceDefinitionsMappers";
 import * as Parameters from "../models/parameters";
@@ -34,21 +34,21 @@ export class ApplianceDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.ApplianceDefinitionsGetResponse>
    */
-  get(resourceGroupName: string, applianceDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<Models.ApplianceDefinitionsGetResponse>;
+  get(resourceGroupName: string, applianceDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ApplianceDefinitionsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceDefinitionName The name of the appliance definition.
    * @param callback The callback
    */
-  get(resourceGroupName: string, applianceDefinitionName: string, callback: msRest.ServiceCallback<Models.ApplianceDefinition>): void;
+  get(resourceGroupName: string, applianceDefinitionName: string, callback: coreHttp.ServiceCallback<Models.ApplianceDefinition>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceDefinitionName The name of the appliance definition.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, applianceDefinitionName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceDefinition>): void;
-  get(resourceGroupName: string, applianceDefinitionName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceDefinition>, callback?: msRest.ServiceCallback<Models.ApplianceDefinition>): Promise<Models.ApplianceDefinitionsGetResponse> {
+  get(resourceGroupName: string, applianceDefinitionName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceDefinition>): void;
+  get(resourceGroupName: string, applianceDefinitionName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceDefinition>, callback?: coreHttp.ServiceCallback<Models.ApplianceDefinition>): Promise<Models.ApplianceDefinitionsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -64,9 +64,9 @@ export class ApplianceDefinitions {
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceDefinitionName The name of the appliance definition to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, applianceDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, applianceDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,applianceDefinitionName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -79,7 +79,7 @@ export class ApplianceDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.ApplianceDefinitionsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, applianceDefinitionName: string, parameters: Models.ApplianceDefinition, options?: msRest.RequestOptionsBase): Promise<Models.ApplianceDefinitionsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, applianceDefinitionName: string, parameters: Models.ApplianceDefinition, options?: coreHttp.RequestOptionsBase): Promise<Models.ApplianceDefinitionsCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,applianceDefinitionName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ApplianceDefinitionsCreateOrUpdateResponse>;
   }
@@ -90,19 +90,19 @@ export class ApplianceDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.ApplianceDefinitionsListByResourceGroupResponse>
    */
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.ApplianceDefinitionsListByResourceGroupResponse>;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ApplianceDefinitionsListByResourceGroupResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceDefinitionListResult>, callback?: msRest.ServiceCallback<Models.ApplianceDefinitionListResult>): Promise<Models.ApplianceDefinitionsListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>): Promise<Models.ApplianceDefinitionsListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -120,14 +120,14 @@ export class ApplianceDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.ApplianceDefinitionsGetByIdResponse>
    */
-  getById(applianceDefinitionId: string, options?: msRest.RequestOptionsBase): Promise<Models.ApplianceDefinitionsGetByIdResponse>;
+  getById(applianceDefinitionId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ApplianceDefinitionsGetByIdResponse>;
   /**
    * @param applianceDefinitionId The fully qualified ID of the appliance definition, including the
    * appliance name and the appliance definition resource type. Use the format,
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/applianceDefinitions/{applianceDefinition-name}
    * @param callback The callback
    */
-  getById(applianceDefinitionId: string, callback: msRest.ServiceCallback<Models.ApplianceDefinition>): void;
+  getById(applianceDefinitionId: string, callback: coreHttp.ServiceCallback<Models.ApplianceDefinition>): void;
   /**
    * @param applianceDefinitionId The fully qualified ID of the appliance definition, including the
    * appliance name and the appliance definition resource type. Use the format,
@@ -135,8 +135,8 @@ export class ApplianceDefinitions {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getById(applianceDefinitionId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceDefinition>): void;
-  getById(applianceDefinitionId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceDefinition>, callback?: msRest.ServiceCallback<Models.ApplianceDefinition>): Promise<Models.ApplianceDefinitionsGetByIdResponse> {
+  getById(applianceDefinitionId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceDefinition>): void;
+  getById(applianceDefinitionId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceDefinition>, callback?: coreHttp.ServiceCallback<Models.ApplianceDefinition>): Promise<Models.ApplianceDefinitionsGetByIdResponse> {
     return this.client.sendOperationRequest(
       {
         applianceDefinitionId,
@@ -152,9 +152,9 @@ export class ApplianceDefinitions {
    * appliance name and the appliance definition resource type. Use the format,
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/applianceDefinitions/{applianceDefinition-name}
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteById(applianceDefinitionId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteById(applianceDefinitionId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteById(applianceDefinitionId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -168,7 +168,7 @@ export class ApplianceDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.ApplianceDefinitionsCreateOrUpdateByIdResponse>
    */
-  createOrUpdateById(applianceDefinitionId: string, parameters: Models.ApplianceDefinition, options?: msRest.RequestOptionsBase): Promise<Models.ApplianceDefinitionsCreateOrUpdateByIdResponse> {
+  createOrUpdateById(applianceDefinitionId: string, parameters: Models.ApplianceDefinition, options?: coreHttp.RequestOptionsBase): Promise<Models.ApplianceDefinitionsCreateOrUpdateByIdResponse> {
     return this.beginCreateOrUpdateById(applianceDefinitionId,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ApplianceDefinitionsCreateOrUpdateByIdResponse>;
   }
@@ -178,9 +178,9 @@ export class ApplianceDefinitions {
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceDefinitionName The name of the appliance definition to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, applianceDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, applianceDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -197,9 +197,9 @@ export class ApplianceDefinitions {
    * @param applianceDefinitionName The name of the appliance definition.
    * @param parameters Parameters supplied to the create or update an appliance definition.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, applianceDefinitionName: string, parameters: Models.ApplianceDefinition, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, applianceDefinitionName: string, parameters: Models.ApplianceDefinition, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -217,9 +217,9 @@ export class ApplianceDefinitions {
    * appliance name and the appliance definition resource type. Use the format,
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/applianceDefinitions/{applianceDefinition-name}
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteById(applianceDefinitionId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteById(applianceDefinitionId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         applianceDefinitionId,
@@ -236,9 +236,9 @@ export class ApplianceDefinitions {
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/applianceDefinitions/{applianceDefinition-name}
    * @param parameters Parameters supplied to the create or update an appliance definition.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdateById(applianceDefinitionId: string, parameters: Models.ApplianceDefinition, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdateById(applianceDefinitionId: string, parameters: Models.ApplianceDefinition, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         applianceDefinitionId,
@@ -255,19 +255,19 @@ export class ApplianceDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.ApplianceDefinitionsListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ApplianceDefinitionsListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ApplianceDefinitionsListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceDefinitionListResult>, callback?: msRest.ServiceCallback<Models.ApplianceDefinitionListResult>): Promise<Models.ApplianceDefinitionsListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.ApplianceDefinitionListResult>): Promise<Models.ApplianceDefinitionsListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -279,8 +279,8 @@ export class ApplianceDefinitions {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applianceDefinitions/{applianceDefinitionName}",
   urlParameters: [
@@ -306,7 +306,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applianceDefinitions",
   urlParameters: [
@@ -330,7 +330,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getByIdOperationSpec: msRest.OperationSpec = {
+const getByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{applianceDefinitionId}",
   urlParameters: [
@@ -354,7 +354,7 @@ const getByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applianceDefinitions/{applianceDefinitionName}",
   urlParameters: [
@@ -379,7 +379,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/applianceDefinitions/{applianceDefinitionName}",
   urlParameters: [
@@ -414,7 +414,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteByIdOperationSpec: msRest.OperationSpec = {
+const beginDeleteByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "{applianceDefinitionId}",
   urlParameters: [
@@ -437,7 +437,7 @@ const beginDeleteByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateByIdOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "{applianceDefinitionId}",
   urlParameters: [
@@ -470,7 +470,7 @@ const beginCreateOrUpdateByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/managedapplications/arm-managedapplications/src/operations/appliances.ts
+++ b/sdk/managedapplications/arm-managedapplications/src/operations/appliances.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/appliancesMappers";
 import * as Parameters from "../models/parameters";
@@ -34,21 +34,21 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesGetResponse>
    */
-  get(resourceGroupName: string, applianceName: string, options?: msRest.RequestOptionsBase): Promise<Models.AppliancesGetResponse>;
+  get(resourceGroupName: string, applianceName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceName The name of the appliance.
    * @param callback The callback
    */
-  get(resourceGroupName: string, applianceName: string, callback: msRest.ServiceCallback<Models.Appliance>): void;
+  get(resourceGroupName: string, applianceName: string, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceName The name of the appliance.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, applianceName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Appliance>): void;
-  get(resourceGroupName: string, applianceName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Appliance>, callback?: msRest.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesGetResponse> {
+  get(resourceGroupName: string, applianceName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
+  get(resourceGroupName: string, applianceName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Appliance>, callback?: coreHttp.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -64,9 +64,9 @@ export class Appliances {
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceName The name of the appliance.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, applianceName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, applianceName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,applianceName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -79,7 +79,7 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, applianceName: string, parameters: Models.Appliance, options?: msRest.RequestOptionsBase): Promise<Models.AppliancesCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, applianceName: string, parameters: Models.Appliance, options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,applianceName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.AppliancesCreateOrUpdateResponse>;
   }
@@ -98,15 +98,15 @@ export class Appliances {
    * @param applianceName The name of the appliance.
    * @param callback The callback
    */
-  update(resourceGroupName: string, applianceName: string, callback: msRest.ServiceCallback<Models.Appliance>): void;
+  update(resourceGroupName: string, applianceName: string, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceName The name of the appliance.
    * @param options The optional parameters
    * @param callback The callback
    */
-  update(resourceGroupName: string, applianceName: string, options: Models.AppliancesUpdateOptionalParams, callback: msRest.ServiceCallback<Models.Appliance>): void;
-  update(resourceGroupName: string, applianceName: string, options?: Models.AppliancesUpdateOptionalParams | msRest.ServiceCallback<Models.Appliance>, callback?: msRest.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesUpdateResponse> {
+  update(resourceGroupName: string, applianceName: string, options: Models.AppliancesUpdateOptionalParams, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
+  update(resourceGroupName: string, applianceName: string, options?: Models.AppliancesUpdateOptionalParams | coreHttp.ServiceCallback<Models.Appliance>, callback?: coreHttp.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -123,19 +123,19 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesListByResourceGroupResponse>
    */
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.AppliancesListByResourceGroupResponse>;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesListByResourceGroupResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
-  listByResourceGroup(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceListResult>, callback?: msRest.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
+  listByResourceGroup(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceListResult>, callback?: coreHttp.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -150,17 +150,17 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesListBySubscriptionResponse>
    */
-  listBySubscription(options?: msRest.RequestOptionsBase): Promise<Models.AppliancesListBySubscriptionResponse>;
+  listBySubscription(options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesListBySubscriptionResponse>;
   /**
    * @param callback The callback
    */
-  listBySubscription(callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
+  listBySubscription(callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBySubscription(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
-  listBySubscription(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceListResult>, callback?: msRest.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListBySubscriptionResponse> {
+  listBySubscription(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
+  listBySubscription(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceListResult>, callback?: coreHttp.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListBySubscriptionResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -177,14 +177,14 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesGetByIdResponse>
    */
-  getById(applianceId: string, options?: msRest.RequestOptionsBase): Promise<Models.AppliancesGetByIdResponse>;
+  getById(applianceId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesGetByIdResponse>;
   /**
    * @param applianceId The fully qualified ID of the appliance, including the appliance name and the
    * appliance resource type. Use the format,
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/appliances/{appliance-name}
    * @param callback The callback
    */
-  getById(applianceId: string, callback: msRest.ServiceCallback<Models.Appliance>): void;
+  getById(applianceId: string, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
   /**
    * @param applianceId The fully qualified ID of the appliance, including the appliance name and the
    * appliance resource type. Use the format,
@@ -192,8 +192,8 @@ export class Appliances {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getById(applianceId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Appliance>): void;
-  getById(applianceId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Appliance>, callback?: msRest.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesGetByIdResponse> {
+  getById(applianceId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
+  getById(applianceId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Appliance>, callback?: coreHttp.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesGetByIdResponse> {
     return this.client.sendOperationRequest(
       {
         applianceId,
@@ -209,9 +209,9 @@ export class Appliances {
    * appliance resource type. Use the format,
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/appliances/{appliance-name}
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteById(applianceId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteById(applianceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteById(applianceId,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -225,7 +225,7 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesCreateOrUpdateByIdResponse>
    */
-  createOrUpdateById(applianceId: string, parameters: Models.Appliance, options?: msRest.RequestOptionsBase): Promise<Models.AppliancesCreateOrUpdateByIdResponse> {
+  createOrUpdateById(applianceId: string, parameters: Models.Appliance, options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesCreateOrUpdateByIdResponse> {
     return this.beginCreateOrUpdateById(applianceId,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.AppliancesCreateOrUpdateByIdResponse>;
   }
@@ -246,7 +246,7 @@ export class Appliances {
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/appliances/{appliance-name}
    * @param callback The callback
    */
-  updateById(applianceId: string, callback: msRest.ServiceCallback<Models.Appliance>): void;
+  updateById(applianceId: string, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
   /**
    * @param applianceId The fully qualified ID of the appliance, including the appliance name and the
    * appliance resource type. Use the format,
@@ -254,8 +254,8 @@ export class Appliances {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateById(applianceId: string, options: Models.AppliancesUpdateByIdOptionalParams, callback: msRest.ServiceCallback<Models.Appliance>): void;
-  updateById(applianceId: string, options?: Models.AppliancesUpdateByIdOptionalParams | msRest.ServiceCallback<Models.Appliance>, callback?: msRest.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesUpdateByIdResponse> {
+  updateById(applianceId: string, options: Models.AppliancesUpdateByIdOptionalParams, callback: coreHttp.ServiceCallback<Models.Appliance>): void;
+  updateById(applianceId: string, options?: Models.AppliancesUpdateByIdOptionalParams | coreHttp.ServiceCallback<Models.Appliance>, callback?: coreHttp.ServiceCallback<Models.Appliance>): Promise<Models.AppliancesUpdateByIdResponse> {
     return this.client.sendOperationRequest(
       {
         applianceId,
@@ -270,9 +270,9 @@ export class Appliances {
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param applianceName The name of the appliance.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, applianceName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, applianceName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -289,9 +289,9 @@ export class Appliances {
    * @param applianceName The name of the appliance.
    * @param parameters Parameters supplied to the create or update an appliance.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, applianceName: string, parameters: Models.Appliance, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, applianceName: string, parameters: Models.Appliance, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -309,9 +309,9 @@ export class Appliances {
    * appliance resource type. Use the format,
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/appliances/{appliance-name}
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteById(applianceId: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteById(applianceId: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         applianceId,
@@ -328,9 +328,9 @@ export class Appliances {
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/Microsoft.Solutions/appliances/{appliance-name}
    * @param parameters Parameters supplied to the create or update an appliance.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdateById(applianceId: string, parameters: Models.Appliance, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdateById(applianceId: string, parameters: Models.Appliance, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         applianceId,
@@ -347,19 +347,19 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.AppliancesListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceListResult>, callback?: msRest.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceListResult>, callback?: coreHttp.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -375,19 +375,19 @@ export class Appliances {
    * @param [options] The optional parameters
    * @returns Promise<Models.AppliancesListBySubscriptionNextResponse>
    */
-  listBySubscriptionNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.AppliancesListBySubscriptionNextResponse>;
+  listBySubscriptionNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.AppliancesListBySubscriptionNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listBySubscriptionNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
+  listBySubscriptionNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBySubscriptionNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ApplianceListResult>): void;
-  listBySubscriptionNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ApplianceListResult>, callback?: msRest.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListBySubscriptionNextResponse> {
+  listBySubscriptionNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ApplianceListResult>): void;
+  listBySubscriptionNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ApplianceListResult>, callback?: coreHttp.ServiceCallback<Models.ApplianceListResult>): Promise<Models.AppliancesListBySubscriptionNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -399,8 +399,8 @@ export class Appliances {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/appliances/{applianceName}",
   urlParameters: [
@@ -426,7 +426,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const updateOperationSpec: msRest.OperationSpec = {
+const updateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/appliances/{applianceName}",
   urlParameters: [
@@ -458,7 +458,7 @@ const updateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/appliances",
   urlParameters: [
@@ -482,7 +482,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBySubscriptionOperationSpec: msRest.OperationSpec = {
+const listBySubscriptionOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Solutions/appliances",
   urlParameters: [
@@ -505,7 +505,7 @@ const listBySubscriptionOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getByIdOperationSpec: msRest.OperationSpec = {
+const getByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{applianceId}",
   urlParameters: [
@@ -529,7 +529,7 @@ const getByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const updateByIdOperationSpec: msRest.OperationSpec = {
+const updateByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "{applianceId}",
   urlParameters: [
@@ -559,7 +559,7 @@ const updateByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/appliances/{applianceName}",
   urlParameters: [
@@ -583,7 +583,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Solutions/appliances/{applianceName}",
   urlParameters: [
@@ -618,7 +618,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteByIdOperationSpec: msRest.OperationSpec = {
+const beginDeleteByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "{applianceId}",
   urlParameters: [
@@ -640,7 +640,7 @@ const beginDeleteByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateByIdOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "{applianceId}",
   urlParameters: [
@@ -673,7 +673,7 @@ const beginCreateOrUpdateByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -694,7 +694,7 @@ const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBySubscriptionNextOperationSpec: msRest.OperationSpec = {
+const listBySubscriptionNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/policy/arm-policy/README.md
+++ b/sdk/policy/arm-policy/README.md
@@ -26,8 +26,8 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```typescript
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { PolicyClient, PolicyModels, PolicyMappers } from "@azure/arm-policy";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
@@ -63,8 +63,8 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 <html lang="en">
   <head>
     <title>@azure/arm-policy sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
+    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
+    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/arm-policy/dist/arm-policy.js"></script>
     <script type="text/javascript">

--- a/sdk/policy/arm-policy/package.json
+++ b/sdk/policy/arm-policy/package.json
@@ -4,8 +4,8 @@
   "description": "PolicyClient Library with typescript type definitions for node.js and browser.",
   "version": "1.0.2",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/core-arm": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/policy/arm-policy/rollup.config.js
+++ b/sdk/policy/arm-policy/rollup.config.js
@@ -8,8 +8,8 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const config = {
   input: "./esm/policyClient.js",
   external: [
-    "@azure/ms-rest-js",
-    "@azure/ms-rest-azure-js"
+    "@azure/core-http",
+    "@azure/core-arm"
   ],
   output: {
     file: "./dist/arm-policy.js",
@@ -17,8 +17,8 @@ const config = {
     name: "Azure.ArmPolicy",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest",
-      "@azure/ms-rest-azure-js": "msRestAzure"
+      "@azure/core-http": "coreHttp",
+      "@azure/core-arm": "coreArm"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/policy/arm-policy/src/models/index.ts
+++ b/sdk/policy/arm-policy/src/models/index.ts
@@ -6,8 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export { BaseResource, CloudError };
 
@@ -239,7 +239,7 @@ export interface PolicySetDefinition extends BaseResource {
 /**
  * Optional Parameters.
  */
-export interface PolicyAssignmentsListForResourceGroupOptionalParams extends msRest.RequestOptionsBase {
+export interface PolicyAssignmentsListForResourceGroupOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation. Valid values for $filter are: 'atScope()' or
    * 'policyDefinitionId eq '{value}''. If $filter is not provided, no filtering is performed.
@@ -250,7 +250,7 @@ export interface PolicyAssignmentsListForResourceGroupOptionalParams extends msR
 /**
  * Optional Parameters.
  */
-export interface PolicyAssignmentsListForResourceOptionalParams extends msRest.RequestOptionsBase {
+export interface PolicyAssignmentsListForResourceOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation. Valid values for $filter are: 'atScope()' or
    * 'policyDefinitionId eq '{value}''. If $filter is not provided, no filtering is performed.
@@ -261,7 +261,7 @@ export interface PolicyAssignmentsListForResourceOptionalParams extends msRest.R
 /**
  * Optional Parameters.
  */
-export interface PolicyAssignmentsListOptionalParams extends msRest.RequestOptionsBase {
+export interface PolicyAssignmentsListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation. Valid values for $filter are: 'atScope()' or
    * 'policyDefinitionId eq '{value}''. If $filter is not provided, no filtering is performed.
@@ -343,7 +343,7 @@ export type PolicyAssignmentsDeleteMethodResponse = PolicyAssignment & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -363,7 +363,7 @@ export type PolicyAssignmentsCreateResponse = PolicyAssignment & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -383,7 +383,7 @@ export type PolicyAssignmentsGetResponse = PolicyAssignment & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -403,7 +403,7 @@ export type PolicyAssignmentsListForResourceGroupResponse = PolicyAssignmentList
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -423,7 +423,7 @@ export type PolicyAssignmentsListForResourceResponse = PolicyAssignmentListResul
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -443,7 +443,7 @@ export type PolicyAssignmentsListResponse = PolicyAssignmentListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -463,7 +463,7 @@ export type PolicyAssignmentsDeleteByIdResponse = PolicyAssignment & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -483,7 +483,7 @@ export type PolicyAssignmentsCreateByIdResponse = PolicyAssignment & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -503,7 +503,7 @@ export type PolicyAssignmentsGetByIdResponse = PolicyAssignment & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -523,7 +523,7 @@ export type PolicyAssignmentsListForResourceGroupNextResponse = PolicyAssignment
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -543,7 +543,7 @@ export type PolicyAssignmentsListForResourceNextResponse = PolicyAssignmentListR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -563,7 +563,7 @@ export type PolicyAssignmentsListNextResponse = PolicyAssignmentListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -583,7 +583,7 @@ export type PolicyDefinitionsCreateOrUpdateResponse = PolicyDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -603,7 +603,7 @@ export type PolicyDefinitionsGetResponse = PolicyDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -623,7 +623,7 @@ export type PolicyDefinitionsGetBuiltInResponse = PolicyDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -643,7 +643,7 @@ export type PolicyDefinitionsCreateOrUpdateAtManagementGroupResponse = PolicyDef
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -663,7 +663,7 @@ export type PolicyDefinitionsGetAtManagementGroupResponse = PolicyDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -683,7 +683,7 @@ export type PolicyDefinitionsListResponse = PolicyDefinitionListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -703,7 +703,7 @@ export type PolicyDefinitionsListBuiltInResponse = PolicyDefinitionListResult & 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -723,7 +723,7 @@ export type PolicyDefinitionsListByManagementGroupResponse = PolicyDefinitionLis
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -743,7 +743,7 @@ export type PolicyDefinitionsListNextResponse = PolicyDefinitionListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -763,7 +763,7 @@ export type PolicyDefinitionsListBuiltInNextResponse = PolicyDefinitionListResul
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -783,7 +783,7 @@ export type PolicyDefinitionsListByManagementGroupNextResponse = PolicyDefinitio
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -803,7 +803,7 @@ export type PolicySetDefinitionsCreateOrUpdateResponse = PolicySetDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -823,7 +823,7 @@ export type PolicySetDefinitionsGetResponse = PolicySetDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -843,7 +843,7 @@ export type PolicySetDefinitionsGetBuiltInResponse = PolicySetDefinition & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -863,7 +863,7 @@ export type PolicySetDefinitionsListResponse = PolicySetDefinitionListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -883,7 +883,7 @@ export type PolicySetDefinitionsListBuiltInResponse = PolicySetDefinitionListRes
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -903,7 +903,7 @@ export type PolicySetDefinitionsCreateOrUpdateAtManagementGroupResponse = Policy
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -923,7 +923,7 @@ export type PolicySetDefinitionsGetAtManagementGroupResponse = PolicySetDefiniti
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -943,7 +943,7 @@ export type PolicySetDefinitionsListByManagementGroupResponse = PolicySetDefinit
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -963,7 +963,7 @@ export type PolicySetDefinitionsListNextResponse = PolicySetDefinitionListResult
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -983,7 +983,7 @@ export type PolicySetDefinitionsListBuiltInNextResponse = PolicySetDefinitionLis
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1003,7 +1003,7 @@ export type PolicySetDefinitionsListByManagementGroupNextResponse = PolicySetDef
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */

--- a/sdk/policy/arm-policy/src/models/mappers.ts
+++ b/sdk/policy/arm-policy/src/models/mappers.ts
@@ -6,13 +6,13 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { CloudErrorMapper, BaseResourceMapper } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { CloudErrorMapper, BaseResourceMapper } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;
 
-export const PolicySku: msRest.CompositeMapper = {
+export const PolicySku: coreHttp.CompositeMapper = {
   serializedName: "PolicySku",
   type: {
     name: "Composite",
@@ -35,7 +35,7 @@ export const PolicySku: msRest.CompositeMapper = {
   }
 };
 
-export const Identity: msRest.CompositeMapper = {
+export const Identity: coreHttp.CompositeMapper = {
   serializedName: "Identity",
   type: {
     name: "Composite",
@@ -69,7 +69,7 @@ export const Identity: msRest.CompositeMapper = {
   }
 };
 
-export const PolicyAssignment: msRest.CompositeMapper = {
+export const PolicyAssignment: coreHttp.CompositeMapper = {
   serializedName: "PolicyAssignment",
   type: {
     name: "Composite",
@@ -167,7 +167,7 @@ export const PolicyAssignment: msRest.CompositeMapper = {
   }
 };
 
-export const ErrorResponse: msRest.CompositeMapper = {
+export const ErrorResponse: coreHttp.CompositeMapper = {
   serializedName: "ErrorResponse",
   type: {
     name: "Composite",
@@ -195,7 +195,7 @@ export const ErrorResponse: msRest.CompositeMapper = {
   }
 };
 
-export const PolicyDefinition: msRest.CompositeMapper = {
+export const PolicyDefinition: coreHttp.CompositeMapper = {
   serializedName: "PolicyDefinition",
   type: {
     name: "Composite",
@@ -268,7 +268,7 @@ export const PolicyDefinition: msRest.CompositeMapper = {
   }
 };
 
-export const PolicyDefinitionReference: msRest.CompositeMapper = {
+export const PolicyDefinitionReference: coreHttp.CompositeMapper = {
   serializedName: "PolicyDefinitionReference",
   type: {
     name: "Composite",
@@ -290,7 +290,7 @@ export const PolicyDefinitionReference: msRest.CompositeMapper = {
   }
 };
 
-export const PolicySetDefinition: msRest.CompositeMapper = {
+export const PolicySetDefinition: coreHttp.CompositeMapper = {
   serializedName: "PolicySetDefinition",
   type: {
     name: "Composite",
@@ -364,7 +364,7 @@ export const PolicySetDefinition: msRest.CompositeMapper = {
   }
 };
 
-export const PolicyAssignmentListResult: msRest.CompositeMapper = {
+export const PolicyAssignmentListResult: coreHttp.CompositeMapper = {
   serializedName: "PolicyAssignmentListResult",
   type: {
     name: "Composite",
@@ -392,7 +392,7 @@ export const PolicyAssignmentListResult: msRest.CompositeMapper = {
   }
 };
 
-export const PolicyDefinitionListResult: msRest.CompositeMapper = {
+export const PolicyDefinitionListResult: coreHttp.CompositeMapper = {
   serializedName: "PolicyDefinitionListResult",
   type: {
     name: "Composite",
@@ -420,7 +420,7 @@ export const PolicyDefinitionListResult: msRest.CompositeMapper = {
   }
 };
 
-export const PolicySetDefinitionListResult: msRest.CompositeMapper = {
+export const PolicySetDefinitionListResult: coreHttp.CompositeMapper = {
   serializedName: "PolicySetDefinitionListResult",
   type: {
     name: "Composite",

--- a/sdk/policy/arm-policy/src/models/parameters.ts
+++ b/sdk/policy/arm-policy/src/models/parameters.ts
@@ -8,9 +8,9 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 
-export const acceptLanguage: msRest.OperationParameter = {
+export const acceptLanguage: coreHttp.OperationParameter = {
   parameterPath: "acceptLanguage",
   mapper: {
     serializedName: "accept-language",
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion: msRest.OperationQueryParameter = {
+export const apiVersion: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -30,7 +30,7 @@ export const apiVersion: msRest.OperationQueryParameter = {
     }
   }
 };
-export const filter0: msRest.OperationQueryParameter = {
+export const filter0: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "filter"
@@ -43,7 +43,7 @@ export const filter0: msRest.OperationQueryParameter = {
   },
   skipEncoding: true
 };
-export const filter1: msRest.OperationQueryParameter = {
+export const filter1: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "filter"
@@ -55,7 +55,7 @@ export const filter1: msRest.OperationQueryParameter = {
     }
   }
 };
-export const managementGroupId: msRest.OperationURLParameter = {
+export const managementGroupId: coreHttp.OperationURLParameter = {
   parameterPath: "managementGroupId",
   mapper: {
     required: true,
@@ -65,7 +65,7 @@ export const managementGroupId: msRest.OperationURLParameter = {
     }
   }
 };
-export const nextPageLink: msRest.OperationURLParameter = {
+export const nextPageLink: coreHttp.OperationURLParameter = {
   parameterPath: "nextPageLink",
   mapper: {
     required: true,
@@ -76,7 +76,7 @@ export const nextPageLink: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const parentResourcePath: msRest.OperationURLParameter = {
+export const parentResourcePath: coreHttp.OperationURLParameter = {
   parameterPath: "parentResourcePath",
   mapper: {
     required: true,
@@ -87,7 +87,7 @@ export const parentResourcePath: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const policyAssignmentId: msRest.OperationURLParameter = {
+export const policyAssignmentId: coreHttp.OperationURLParameter = {
   parameterPath: "policyAssignmentId",
   mapper: {
     required: true,
@@ -98,7 +98,7 @@ export const policyAssignmentId: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const policyAssignmentName: msRest.OperationURLParameter = {
+export const policyAssignmentName: coreHttp.OperationURLParameter = {
   parameterPath: "policyAssignmentName",
   mapper: {
     required: true,
@@ -108,7 +108,7 @@ export const policyAssignmentName: msRest.OperationURLParameter = {
     }
   }
 };
-export const policyDefinitionName: msRest.OperationURLParameter = {
+export const policyDefinitionName: coreHttp.OperationURLParameter = {
   parameterPath: "policyDefinitionName",
   mapper: {
     required: true,
@@ -118,7 +118,7 @@ export const policyDefinitionName: msRest.OperationURLParameter = {
     }
   }
 };
-export const policySetDefinitionName: msRest.OperationURLParameter = {
+export const policySetDefinitionName: coreHttp.OperationURLParameter = {
   parameterPath: "policySetDefinitionName",
   mapper: {
     required: true,
@@ -128,7 +128,7 @@ export const policySetDefinitionName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceGroupName: msRest.OperationURLParameter = {
+export const resourceGroupName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
     required: true,
@@ -143,7 +143,7 @@ export const resourceGroupName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceName: msRest.OperationURLParameter = {
+export const resourceName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceName",
   mapper: {
     required: true,
@@ -153,7 +153,7 @@ export const resourceName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceProviderNamespace: msRest.OperationURLParameter = {
+export const resourceProviderNamespace: coreHttp.OperationURLParameter = {
   parameterPath: "resourceProviderNamespace",
   mapper: {
     required: true,
@@ -163,7 +163,7 @@ export const resourceProviderNamespace: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceType: msRest.OperationURLParameter = {
+export const resourceType: coreHttp.OperationURLParameter = {
   parameterPath: "resourceType",
   mapper: {
     required: true,
@@ -174,7 +174,7 @@ export const resourceType: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const scope: msRest.OperationURLParameter = {
+export const scope: coreHttp.OperationURLParameter = {
   parameterPath: "scope",
   mapper: {
     required: true,
@@ -185,7 +185,7 @@ export const scope: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const subscriptionId: msRest.OperationURLParameter = {
+export const subscriptionId: coreHttp.OperationURLParameter = {
   parameterPath: "subscriptionId",
   mapper: {
     required: true,

--- a/sdk/policy/arm-policy/src/operations/policyAssignments.ts
+++ b/sdk/policy/arm-policy/src/operations/policyAssignments.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/policyAssignmentsMappers";
 import * as Parameters from "../models/parameters";
@@ -40,7 +40,7 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsDeleteMethodResponse>
    */
-  deleteMethod(scope: string, policyAssignmentName: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsDeleteMethodResponse>;
+  deleteMethod(scope: string, policyAssignmentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsDeleteMethodResponse>;
   /**
    * @param scope The scope of the policy assignment. Valid scopes are: management group (format:
    * '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format:
@@ -50,7 +50,7 @@ export class PolicyAssignments {
    * @param policyAssignmentName The name of the policy assignment to delete.
    * @param callback The callback
    */
-  deleteMethod(scope: string, policyAssignmentName: string, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
+  deleteMethod(scope: string, policyAssignmentName: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
   /**
    * @param scope The scope of the policy assignment. Valid scopes are: management group (format:
    * '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format:
@@ -61,8 +61,8 @@ export class PolicyAssignments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(scope: string, policyAssignmentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
-  deleteMethod(scope: string, policyAssignmentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignment>, callback?: msRest.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsDeleteMethodResponse> {
+  deleteMethod(scope: string, policyAssignmentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
+  deleteMethod(scope: string, policyAssignmentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignment>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsDeleteMethodResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -88,7 +88,7 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsCreateResponse>
    */
-  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsCreateResponse>;
+  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsCreateResponse>;
   /**
    * @param scope The scope of the policy assignment. Valid scopes are: management group (format:
    * '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format:
@@ -99,7 +99,7 @@ export class PolicyAssignments {
    * @param parameters Parameters for the policy assignment.
    * @param callback The callback
    */
-  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
+  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
   /**
    * @param scope The scope of the policy assignment. Valid scopes are: management group (format:
    * '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format:
@@ -111,8 +111,8 @@ export class PolicyAssignments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
-  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignment>, callback?: msRest.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsCreateResponse> {
+  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
+  create(scope: string, policyAssignmentName: string, parameters: Models.PolicyAssignment, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignment>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsCreateResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -137,7 +137,7 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsGetResponse>
    */
-  get(scope: string, policyAssignmentName: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsGetResponse>;
+  get(scope: string, policyAssignmentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsGetResponse>;
   /**
    * @param scope The scope of the policy assignment. Valid scopes are: management group (format:
    * '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format:
@@ -147,7 +147,7 @@ export class PolicyAssignments {
    * @param policyAssignmentName The name of the policy assignment to get.
    * @param callback The callback
    */
-  get(scope: string, policyAssignmentName: string, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
+  get(scope: string, policyAssignmentName: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
   /**
    * @param scope The scope of the policy assignment. Valid scopes are: management group (format:
    * '/providers/Microsoft.Management/managementGroups/{managementGroup}'), subscription (format:
@@ -158,8 +158,8 @@ export class PolicyAssignments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(scope: string, policyAssignmentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
-  get(scope: string, policyAssignmentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignment>, callback?: msRest.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsGetResponse> {
+  get(scope: string, policyAssignmentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
+  get(scope: string, policyAssignmentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignment>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsGetResponse> {
     return this.client.sendOperationRequest(
       {
         scope,
@@ -192,14 +192,14 @@ export class PolicyAssignments {
    * @param resourceGroupName The name of the resource group that contains policy assignments.
    * @param callback The callback
    */
-  listForResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group that contains policy assignments.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listForResourceGroup(resourceGroupName: string, options: Models.PolicyAssignmentsListForResourceGroupOptionalParams, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
-  listForResourceGroup(resourceGroupName: string, options?: Models.PolicyAssignmentsListForResourceGroupOptionalParams | msRest.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceGroupResponse> {
+  listForResourceGroup(resourceGroupName: string, options: Models.PolicyAssignmentsListForResourceGroupOptionalParams, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResourceGroup(resourceGroupName: string, options?: Models.PolicyAssignmentsListForResourceGroupOptionalParams | coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -254,7 +254,7 @@ export class PolicyAssignments {
    * @param resourceName The name of the resource.
    * @param callback The callback
    */
-  listForResource(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResource(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the resource.
    * @param resourceProviderNamespace The namespace of the resource provider. For example, the
@@ -266,8 +266,8 @@ export class PolicyAssignments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  listForResource(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options: Models.PolicyAssignmentsListForResourceOptionalParams, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
-  listForResource(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options?: Models.PolicyAssignmentsListForResourceOptionalParams | msRest.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceResponse> {
+  listForResource(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options: Models.PolicyAssignmentsListForResourceOptionalParams, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResource(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, options?: Models.PolicyAssignmentsListForResourceOptionalParams | coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -300,13 +300,13 @@ export class PolicyAssignments {
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: Models.PolicyAssignmentsListOptionalParams, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
-  list(options?: Models.PolicyAssignmentsListOptionalParams | msRest.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListResponse> {
+  list(options: Models.PolicyAssignmentsListOptionalParams, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  list(options?: Models.PolicyAssignmentsListOptionalParams | coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -329,21 +329,21 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsDeleteByIdResponse>
    */
-  deleteById(policyAssignmentId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsDeleteByIdResponse>;
+  deleteById(policyAssignmentId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsDeleteByIdResponse>;
   /**
    * @param policyAssignmentId The ID of the policy assignment to delete. Use the format
    * '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.
    * @param callback The callback
    */
-  deleteById(policyAssignmentId: string, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
+  deleteById(policyAssignmentId: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
   /**
    * @param policyAssignmentId The ID of the policy assignment to delete. Use the format
    * '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteById(policyAssignmentId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
-  deleteById(policyAssignmentId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignment>, callback?: msRest.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsDeleteByIdResponse> {
+  deleteById(policyAssignmentId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
+  deleteById(policyAssignmentId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignment>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsDeleteByIdResponse> {
     return this.client.sendOperationRequest(
       {
         policyAssignmentId,
@@ -371,14 +371,14 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsCreateByIdResponse>
    */
-  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsCreateByIdResponse>;
+  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsCreateByIdResponse>;
   /**
    * @param policyAssignmentId The ID of the policy assignment to create. Use the format
    * '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.
    * @param parameters Parameters for policy assignment.
    * @param callback The callback
    */
-  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
+  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
   /**
    * @param policyAssignmentId The ID of the policy assignment to create. Use the format
    * '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.
@@ -386,8 +386,8 @@ export class PolicyAssignments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
-  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignment>, callback?: msRest.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsCreateByIdResponse> {
+  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
+  createById(policyAssignmentId: string, parameters: Models.PolicyAssignment, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignment>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsCreateByIdResponse> {
     return this.client.sendOperationRequest(
       {
         policyAssignmentId,
@@ -412,21 +412,21 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsGetByIdResponse>
    */
-  getById(policyAssignmentId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsGetByIdResponse>;
+  getById(policyAssignmentId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsGetByIdResponse>;
   /**
    * @param policyAssignmentId The ID of the policy assignment to get. Use the format
    * '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.
    * @param callback The callback
    */
-  getById(policyAssignmentId: string, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
+  getById(policyAssignmentId: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
   /**
    * @param policyAssignmentId The ID of the policy assignment to get. Use the format
    * '{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}'.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getById(policyAssignmentId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignment>): void;
-  getById(policyAssignmentId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignment>, callback?: msRest.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsGetByIdResponse> {
+  getById(policyAssignmentId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignment>): void;
+  getById(policyAssignmentId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignment>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignment>): Promise<Models.PolicyAssignmentsGetByIdResponse> {
     return this.client.sendOperationRequest(
       {
         policyAssignmentId,
@@ -453,19 +453,19 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsListForResourceGroupNextResponse>
    */
-  listForResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsListForResourceGroupNextResponse>;
+  listForResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsListForResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listForResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listForResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
-  listForResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceGroupNextResponse> {
+  listForResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -503,19 +503,19 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsListForResourceNextResponse>
    */
-  listForResourceNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsListForResourceNextResponse>;
+  listForResourceNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsListForResourceNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listForResourceNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResourceNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listForResourceNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
-  listForResourceNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceNextResponse> {
+  listForResourceNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listForResourceNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListForResourceNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -541,19 +541,19 @@ export class PolicyAssignments {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyAssignmentsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyAssignmentsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyAssignmentsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: msRest.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyAssignmentListResult>): Promise<Models.PolicyAssignmentsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -565,8 +565,8 @@ export class PolicyAssignments {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const deleteMethodOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const deleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}",
   urlParameters: [
@@ -591,7 +591,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOperationSpec: msRest.OperationSpec = {
+const createOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}",
   urlParameters: [
@@ -622,7 +622,7 @@ const createOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{scope}/providers/Microsoft.Authorization/policyAssignments/{policyAssignmentName}",
   urlParameters: [
@@ -646,7 +646,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listForResourceGroupOperationSpec: msRest.OperationSpec = {
+const listForResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/policyAssignments",
   urlParameters: [
@@ -671,7 +671,7 @@ const listForResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listForResourceOperationSpec: msRest.OperationSpec = {
+const listForResourceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/policyAssignments",
   urlParameters: [
@@ -700,7 +700,7 @@ const listForResourceOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyAssignments",
   urlParameters: [
@@ -724,7 +724,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteByIdOperationSpec: msRest.OperationSpec = {
+const deleteByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "{policyAssignmentId}",
   urlParameters: [
@@ -748,7 +748,7 @@ const deleteByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createByIdOperationSpec: msRest.OperationSpec = {
+const createByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "{policyAssignmentId}",
   urlParameters: [
@@ -778,7 +778,7 @@ const createByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getByIdOperationSpec: msRest.OperationSpec = {
+const getByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{policyAssignmentId}",
   urlParameters: [
@@ -801,7 +801,7 @@ const getByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listForResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listForResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -822,7 +822,7 @@ const listForResourceGroupNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listForResourceNextOperationSpec: msRest.OperationSpec = {
+const listForResourceNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -843,7 +843,7 @@ const listForResourceNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/policy/arm-policy/src/operations/policyDefinitions.ts
+++ b/sdk/policy/arm-policy/src/operations/policyDefinitions.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/policyDefinitionsMappers";
 import * as Parameters from "../models/parameters";
@@ -35,21 +35,21 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsCreateOrUpdateResponse>
    */
-  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsCreateOrUpdateResponse>;
+  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsCreateOrUpdateResponse>;
   /**
    * @param policyDefinitionName The name of the policy definition to create.
    * @param parameters The policy definition properties.
    * @param callback The callback
    */
-  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
+  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
   /**
    * @param policyDefinitionName The name of the policy definition to create.
    * @param parameters The policy definition properties.
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
-  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinition>, callback?: msRest.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsCreateOrUpdateResponse> {
+  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
+  createOrUpdate(policyDefinitionName: string, parameters: Models.PolicyDefinition, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsCreateOrUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         policyDefinitionName,
@@ -65,21 +65,21 @@ export class PolicyDefinitions {
    * @summary Deletes a policy definition in a subscription.
    * @param policyDefinitionName The name of the policy definition to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(policyDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteMethod(policyDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param policyDefinitionName The name of the policy definition to delete.
    * @param callback The callback
    */
-  deleteMethod(policyDefinitionName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteMethod(policyDefinitionName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param policyDefinitionName The name of the policy definition to delete.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(policyDefinitionName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteMethod(policyDefinitionName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteMethod(policyDefinitionName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteMethod(policyDefinitionName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         policyDefinitionName,
@@ -96,19 +96,19 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsGetResponse>
    */
-  get(policyDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsGetResponse>;
+  get(policyDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsGetResponse>;
   /**
    * @param policyDefinitionName The name of the policy definition to get.
    * @param callback The callback
    */
-  get(policyDefinitionName: string, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
+  get(policyDefinitionName: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
   /**
    * @param policyDefinitionName The name of the policy definition to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(policyDefinitionName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
-  get(policyDefinitionName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinition>, callback?: msRest.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsGetResponse> {
+  get(policyDefinitionName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
+  get(policyDefinitionName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsGetResponse> {
     return this.client.sendOperationRequest(
       {
         policyDefinitionName,
@@ -125,19 +125,19 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsGetBuiltInResponse>
    */
-  getBuiltIn(policyDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsGetBuiltInResponse>;
+  getBuiltIn(policyDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsGetBuiltInResponse>;
   /**
    * @param policyDefinitionName The name of the built-in policy definition to get.
    * @param callback The callback
    */
-  getBuiltIn(policyDefinitionName: string, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
+  getBuiltIn(policyDefinitionName: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
   /**
    * @param policyDefinitionName The name of the built-in policy definition to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getBuiltIn(policyDefinitionName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
-  getBuiltIn(policyDefinitionName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinition>, callback?: msRest.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsGetBuiltInResponse> {
+  getBuiltIn(policyDefinitionName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
+  getBuiltIn(policyDefinitionName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsGetBuiltInResponse> {
     return this.client.sendOperationRequest(
       {
         policyDefinitionName,
@@ -157,14 +157,14 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsCreateOrUpdateAtManagementGroupResponse>
    */
-  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsCreateOrUpdateAtManagementGroupResponse>;
+  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsCreateOrUpdateAtManagementGroupResponse>;
   /**
    * @param policyDefinitionName The name of the policy definition to create.
    * @param parameters The policy definition properties.
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
+  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
   /**
    * @param policyDefinitionName The name of the policy definition to create.
    * @param parameters The policy definition properties.
@@ -172,8 +172,8 @@ export class PolicyDefinitions {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
-  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinition>, callback?: msRest.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsCreateOrUpdateAtManagementGroupResponse> {
+  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
+  createOrUpdateAtManagementGroup(policyDefinitionName: string, parameters: Models.PolicyDefinition, managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsCreateOrUpdateAtManagementGroupResponse> {
     return this.client.sendOperationRequest(
       {
         policyDefinitionName,
@@ -191,23 +191,23 @@ export class PolicyDefinitions {
    * @param policyDefinitionName The name of the policy definition to delete.
    * @param managementGroupId The ID of the management group.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param policyDefinitionName The name of the policy definition to delete.
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, callback: msRest.ServiceCallback<void>): void;
+  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param policyDefinitionName The name of the policy definition to delete.
    * @param managementGroupId The ID of the management group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         policyDefinitionName,
@@ -227,21 +227,21 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsGetAtManagementGroupResponse>
    */
-  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsGetAtManagementGroupResponse>;
+  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsGetAtManagementGroupResponse>;
   /**
    * @param policyDefinitionName The name of the policy definition to get.
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
+  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
   /**
    * @param policyDefinitionName The name of the policy definition to get.
    * @param managementGroupId The ID of the management group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinition>): void;
-  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinition>, callback?: msRest.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsGetAtManagementGroupResponse> {
+  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinition>): void;
+  getAtManagementGroup(policyDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinition>): Promise<Models.PolicyDefinitionsGetAtManagementGroupResponse> {
     return this.client.sendOperationRequest(
       {
         policyDefinitionName,
@@ -258,17 +258,17 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -283,17 +283,17 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsListBuiltInResponse>
    */
-  listBuiltIn(options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsListBuiltInResponse>;
+  listBuiltIn(options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsListBuiltInResponse>;
   /**
    * @param callback The callback
    */
-  listBuiltIn(callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listBuiltIn(callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBuiltIn(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
-  listBuiltIn(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListBuiltInResponse> {
+  listBuiltIn(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listBuiltIn(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListBuiltInResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -309,19 +309,19 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsListByManagementGroupResponse>
    */
-  listByManagementGroup(managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsListByManagementGroupResponse>;
+  listByManagementGroup(managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsListByManagementGroupResponse>;
   /**
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  listByManagementGroup(managementGroupId: string, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listByManagementGroup(managementGroupId: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
   /**
    * @param managementGroupId The ID of the management group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByManagementGroup(managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
-  listByManagementGroup(managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListByManagementGroupResponse> {
+  listByManagementGroup(managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listByManagementGroup(managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListByManagementGroupResponse> {
     return this.client.sendOperationRequest(
       {
         managementGroupId,
@@ -338,19 +338,19 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -367,19 +367,19 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsListBuiltInNextResponse>
    */
-  listBuiltInNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsListBuiltInNextResponse>;
+  listBuiltInNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsListBuiltInNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listBuiltInNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listBuiltInNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBuiltInNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
-  listBuiltInNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListBuiltInNextResponse> {
+  listBuiltInNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listBuiltInNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListBuiltInNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -396,19 +396,19 @@ export class PolicyDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicyDefinitionsListByManagementGroupNextResponse>
    */
-  listByManagementGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicyDefinitionsListByManagementGroupNextResponse>;
+  listByManagementGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicyDefinitionsListByManagementGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByManagementGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listByManagementGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByManagementGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): void;
-  listByManagementGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListByManagementGroupNextResponse> {
+  listByManagementGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): void;
+  listByManagementGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicyDefinitionListResult>): Promise<Models.PolicyDefinitionsListByManagementGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -420,8 +420,8 @@ export class PolicyDefinitions {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const createOrUpdateOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}",
   urlParameters: [
@@ -452,7 +452,7 @@ const createOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteMethodOperationSpec: msRest.OperationSpec = {
+const deleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}",
   urlParameters: [
@@ -475,7 +475,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}",
   urlParameters: [
@@ -499,7 +499,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getBuiltInOperationSpec: msRest.OperationSpec = {
+const getBuiltInOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}",
   urlParameters: [
@@ -522,7 +522,7 @@ const getBuiltInOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateAtManagementGroupOperationSpec: msRest.OperationSpec = {
+const createOrUpdateAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}",
   urlParameters: [
@@ -553,7 +553,7 @@ const createOrUpdateAtManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteAtManagementGroupOperationSpec: msRest.OperationSpec = {
+const deleteAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}",
   urlParameters: [
@@ -576,7 +576,7 @@ const deleteAtManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAtManagementGroupOperationSpec: msRest.OperationSpec = {
+const getAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions/{policyDefinitionName}",
   urlParameters: [
@@ -600,7 +600,7 @@ const getAtManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policyDefinitions",
   urlParameters: [
@@ -623,7 +623,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBuiltInOperationSpec: msRest.OperationSpec = {
+const listBuiltInOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Authorization/policyDefinitions",
   queryParameters: [
@@ -643,7 +643,7 @@ const listBuiltInOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByManagementGroupOperationSpec: msRest.OperationSpec = {
+const listByManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policyDefinitions",
   urlParameters: [
@@ -666,7 +666,7 @@ const listByManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -687,7 +687,7 @@ const listNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBuiltInNextOperationSpec: msRest.OperationSpec = {
+const listBuiltInNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -708,7 +708,7 @@ const listBuiltInNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByManagementGroupNextOperationSpec: msRest.OperationSpec = {
+const listByManagementGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/policy/arm-policy/src/operations/policySetDefinitions.ts
+++ b/sdk/policy/arm-policy/src/operations/policySetDefinitions.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/policySetDefinitionsMappers";
 import * as Parameters from "../models/parameters";
@@ -35,21 +35,21 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsCreateOrUpdateResponse>
    */
-  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsCreateOrUpdateResponse>;
+  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsCreateOrUpdateResponse>;
   /**
    * @param policySetDefinitionName The name of the policy set definition to create.
    * @param parameters The policy set definition properties.
    * @param callback The callback
    */
-  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
+  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
   /**
    * @param policySetDefinitionName The name of the policy set definition to create.
    * @param parameters The policy set definition properties.
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
-  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinition>, callback?: msRest.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsCreateOrUpdateResponse> {
+  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
+  createOrUpdate(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsCreateOrUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         policySetDefinitionName,
@@ -65,21 +65,21 @@ export class PolicySetDefinitions {
    * @summary Deletes a policy set definition.
    * @param policySetDefinitionName The name of the policy set definition to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(policySetDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteMethod(policySetDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param policySetDefinitionName The name of the policy set definition to delete.
    * @param callback The callback
    */
-  deleteMethod(policySetDefinitionName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteMethod(policySetDefinitionName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param policySetDefinitionName The name of the policy set definition to delete.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(policySetDefinitionName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteMethod(policySetDefinitionName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteMethod(policySetDefinitionName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteMethod(policySetDefinitionName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         policySetDefinitionName,
@@ -97,19 +97,19 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsGetResponse>
    */
-  get(policySetDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsGetResponse>;
+  get(policySetDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsGetResponse>;
   /**
    * @param policySetDefinitionName The name of the policy set definition to get.
    * @param callback The callback
    */
-  get(policySetDefinitionName: string, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
+  get(policySetDefinitionName: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
   /**
    * @param policySetDefinitionName The name of the policy set definition to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(policySetDefinitionName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
-  get(policySetDefinitionName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinition>, callback?: msRest.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsGetResponse> {
+  get(policySetDefinitionName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
+  get(policySetDefinitionName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsGetResponse> {
     return this.client.sendOperationRequest(
       {
         policySetDefinitionName,
@@ -126,19 +126,19 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsGetBuiltInResponse>
    */
-  getBuiltIn(policySetDefinitionName: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsGetBuiltInResponse>;
+  getBuiltIn(policySetDefinitionName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsGetBuiltInResponse>;
   /**
    * @param policySetDefinitionName The name of the policy set definition to get.
    * @param callback The callback
    */
-  getBuiltIn(policySetDefinitionName: string, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
+  getBuiltIn(policySetDefinitionName: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
   /**
    * @param policySetDefinitionName The name of the policy set definition to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getBuiltIn(policySetDefinitionName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
-  getBuiltIn(policySetDefinitionName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinition>, callback?: msRest.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsGetBuiltInResponse> {
+  getBuiltIn(policySetDefinitionName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
+  getBuiltIn(policySetDefinitionName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsGetBuiltInResponse> {
     return this.client.sendOperationRequest(
       {
         policySetDefinitionName,
@@ -154,17 +154,17 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -179,17 +179,17 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsListBuiltInResponse>
    */
-  listBuiltIn(options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListBuiltInResponse>;
+  listBuiltIn(options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListBuiltInResponse>;
   /**
    * @param callback The callback
    */
-  listBuiltIn(callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listBuiltIn(callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBuiltIn(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
-  listBuiltIn(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListBuiltInResponse> {
+  listBuiltIn(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listBuiltIn(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListBuiltInResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -208,14 +208,14 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsCreateOrUpdateAtManagementGroupResponse>
    */
-  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsCreateOrUpdateAtManagementGroupResponse>;
+  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsCreateOrUpdateAtManagementGroupResponse>;
   /**
    * @param policySetDefinitionName The name of the policy set definition to create.
    * @param parameters The policy set definition properties.
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
+  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
   /**
    * @param policySetDefinitionName The name of the policy set definition to create.
    * @param parameters The policy set definition properties.
@@ -223,8 +223,8 @@ export class PolicySetDefinitions {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
-  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinition>, callback?: msRest.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsCreateOrUpdateAtManagementGroupResponse> {
+  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
+  createOrUpdateAtManagementGroup(policySetDefinitionName: string, parameters: Models.PolicySetDefinition, managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsCreateOrUpdateAtManagementGroupResponse> {
     return this.client.sendOperationRequest(
       {
         policySetDefinitionName,
@@ -243,23 +243,23 @@ export class PolicySetDefinitions {
    * @param policySetDefinitionName The name of the policy set definition to delete.
    * @param managementGroupId The ID of the management group.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param policySetDefinitionName The name of the policy set definition to delete.
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, callback: msRest.ServiceCallback<void>): void;
+  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param policySetDefinitionName The name of the policy set definition to delete.
    * @param managementGroupId The ID of the management group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         policySetDefinitionName,
@@ -279,21 +279,21 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsGetAtManagementGroupResponse>
    */
-  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsGetAtManagementGroupResponse>;
+  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsGetAtManagementGroupResponse>;
   /**
    * @param policySetDefinitionName The name of the policy set definition to get.
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
+  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
   /**
    * @param policySetDefinitionName The name of the policy set definition to get.
    * @param managementGroupId The ID of the management group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinition>): void;
-  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinition>, callback?: msRest.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsGetAtManagementGroupResponse> {
+  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinition>): void;
+  getAtManagementGroup(policySetDefinitionName: string, managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinition>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinition>): Promise<Models.PolicySetDefinitionsGetAtManagementGroupResponse> {
     return this.client.sendOperationRequest(
       {
         policySetDefinitionName,
@@ -312,19 +312,19 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsListByManagementGroupResponse>
    */
-  listByManagementGroup(managementGroupId: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListByManagementGroupResponse>;
+  listByManagementGroup(managementGroupId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListByManagementGroupResponse>;
   /**
    * @param managementGroupId The ID of the management group.
    * @param callback The callback
    */
-  listByManagementGroup(managementGroupId: string, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listByManagementGroup(managementGroupId: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
   /**
    * @param managementGroupId The ID of the management group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByManagementGroup(managementGroupId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
-  listByManagementGroup(managementGroupId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListByManagementGroupResponse> {
+  listByManagementGroup(managementGroupId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listByManagementGroup(managementGroupId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListByManagementGroupResponse> {
     return this.client.sendOperationRequest(
       {
         managementGroupId,
@@ -341,19 +341,19 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -370,19 +370,19 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsListBuiltInNextResponse>
    */
-  listBuiltInNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListBuiltInNextResponse>;
+  listBuiltInNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListBuiltInNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listBuiltInNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listBuiltInNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listBuiltInNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
-  listBuiltInNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListBuiltInNextResponse> {
+  listBuiltInNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listBuiltInNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListBuiltInNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -400,19 +400,19 @@ export class PolicySetDefinitions {
    * @param [options] The optional parameters
    * @returns Promise<Models.PolicySetDefinitionsListByManagementGroupNextResponse>
    */
-  listByManagementGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListByManagementGroupNextResponse>;
+  listByManagementGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.PolicySetDefinitionsListByManagementGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByManagementGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listByManagementGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByManagementGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
-  listByManagementGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: msRest.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListByManagementGroupNextResponse> {
+  listByManagementGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): void;
+  listByManagementGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>, callback?: coreHttp.ServiceCallback<Models.PolicySetDefinitionListResult>): Promise<Models.PolicySetDefinitionsListByManagementGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -424,8 +424,8 @@ export class PolicySetDefinitions {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const createOrUpdateOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}",
   urlParameters: [
@@ -459,7 +459,7 @@ const createOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteMethodOperationSpec: msRest.OperationSpec = {
+const deleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}",
   urlParameters: [
@@ -482,7 +482,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}",
   urlParameters: [
@@ -506,7 +506,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getBuiltInOperationSpec: msRest.OperationSpec = {
+const getBuiltInOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}",
   urlParameters: [
@@ -529,7 +529,7 @@ const getBuiltInOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Authorization/policySetDefinitions",
   urlParameters: [
@@ -552,7 +552,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBuiltInOperationSpec: msRest.OperationSpec = {
+const listBuiltInOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Authorization/policySetDefinitions",
   queryParameters: [
@@ -572,7 +572,7 @@ const listBuiltInOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateAtManagementGroupOperationSpec: msRest.OperationSpec = {
+const createOrUpdateAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}",
   urlParameters: [
@@ -606,7 +606,7 @@ const createOrUpdateAtManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteAtManagementGroupOperationSpec: msRest.OperationSpec = {
+const deleteAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}",
   urlParameters: [
@@ -629,7 +629,7 @@ const deleteAtManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAtManagementGroupOperationSpec: msRest.OperationSpec = {
+const getAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policySetDefinitions/{policySetDefinitionName}",
   urlParameters: [
@@ -653,7 +653,7 @@ const getAtManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByManagementGroupOperationSpec: msRest.OperationSpec = {
+const listByManagementGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementgroups/{managementGroupId}/providers/Microsoft.Authorization/policySetDefinitions",
   urlParameters: [
@@ -676,7 +676,7 @@ const listByManagementGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -697,7 +697,7 @@ const listNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listBuiltInNextOperationSpec: msRest.OperationSpec = {
+const listBuiltInNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -718,7 +718,7 @@ const listBuiltInNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByManagementGroupNextOperationSpec: msRest.OperationSpec = {
+const listByManagementGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/policy/arm-policy/src/policyClient.ts
+++ b/sdk/policy/arm-policy/src/policyClient.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -27,7 +27,7 @@ class PolicyClient extends PolicyClientContext {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.PolicyClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.PolicyClientOptions) {
     super(credentials, subscriptionId, options);
     this.policyAssignments = new operations.PolicyAssignments(this);
     this.policyDefinitions = new operations.PolicyDefinitions(this);

--- a/sdk/policy/arm-policy/src/policyClientContext.ts
+++ b/sdk/policy/arm-policy/src/policyClientContext.ts
@@ -9,14 +9,14 @@
  */
 
 import * as Models from "./models";
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-policy";
 const packageVersion = "1.0.2";
 
-export class PolicyClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class PolicyClientContext extends coreArm.AzureServiceClient {
+  credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;
   subscriptionId: string;
   apiVersion?: string;
 
@@ -26,7 +26,7 @@ export class PolicyClientContext extends msRestAzure.AzureServiceClient {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.PolicyClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.PolicyClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -38,7 +38,7 @@ export class PolicyClientContext extends msRestAzure.AzureServiceClient {
       options = {};
     }
     if(!options.userAgent) {
-      const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
+      const defaultUserAgent = coreArm.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 

--- a/sdk/resources/arm-resources/README.md
+++ b/sdk/resources/arm-resources/README.md
@@ -26,8 +26,8 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```typescript
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { ResourceManagementClient, ResourceManagementModels, ResourceManagementMappers } from "@azure/arm-resources";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
@@ -61,8 +61,8 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
 <html lang="en">
   <head>
     <title>@azure/arm-resources sample</title>
-    <script src="node_modules/@azure/ms-rest-js/dist/msRest.browser.js"></script>
-    <script src="node_modules/@azure/ms-rest-azure-js/dist/msRestAzure.js"></script>
+    <script src="node_modules/@azure/core-http/dist/coreHttp.browser.js"></script>
+    <script src="node_modules/@azure/core-arm/dist/coreArm.js"></script>
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/arm-resources/dist/arm-resources.js"></script>
     <script type="text/javascript">

--- a/sdk/resources/arm-resources/package.json
+++ b/sdk/resources/arm-resources/package.json
@@ -4,8 +4,8 @@
   "description": "ResourceManagementClient Library with typescript type definitions for node.js and browser.",
   "version": "1.1.0",
   "dependencies": {
-    "@azure/ms-rest-azure-js": "^1.3.2",
-    "@azure/ms-rest-js": "^1.8.1",
+    "@azure/core-arm": "^1.0.0-preview.1",
+    "@azure/core-http": "^1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/resources/arm-resources/rollup.config.js
+++ b/sdk/resources/arm-resources/rollup.config.js
@@ -8,8 +8,8 @@ import sourcemaps from "rollup-plugin-sourcemaps";
 const config = {
   input: "./esm/resourceManagementClient.js",
   external: [
-    "@azure/ms-rest-js",
-    "@azure/ms-rest-azure-js"
+    "@azure/core-http",
+    "@azure/core-arm"
   ],
   output: {
     file: "./dist/arm-resources.js",
@@ -17,8 +17,8 @@ const config = {
     name: "Azure.ArmResources",
     sourcemap: true,
     globals: {
-      "@azure/ms-rest-js": "msRest",
-      "@azure/ms-rest-azure-js": "msRestAzure"
+      "@azure/core-http": "coreHttp",
+      "@azure/core-arm": "coreArm"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/sdk/resources/arm-resources/src/models/index.ts
+++ b/sdk/resources/arm-resources/src/models/index.ts
@@ -6,8 +6,8 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { BaseResource, CloudError, AzureServiceClientOptions } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export { BaseResource, CloudError };
 
@@ -969,7 +969,7 @@ export interface Operation {
 /**
  * Optional Parameters.
  */
-export interface DeploymentsListAtManagementGroupScopeOptionalParams extends msRest.RequestOptionsBase {
+export interface DeploymentsListAtManagementGroupScopeOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation. For example, you can use $filter=provisioningState eq
    * '{state}'.
@@ -984,7 +984,7 @@ export interface DeploymentsListAtManagementGroupScopeOptionalParams extends msR
 /**
  * Optional Parameters.
  */
-export interface DeploymentsListAtSubscriptionScopeOptionalParams extends msRest.RequestOptionsBase {
+export interface DeploymentsListAtSubscriptionScopeOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation. For example, you can use $filter=provisioningState eq
    * '{state}'.
@@ -999,7 +999,7 @@ export interface DeploymentsListAtSubscriptionScopeOptionalParams extends msRest
 /**
  * Optional Parameters.
  */
-export interface DeploymentsListByResourceGroupOptionalParams extends msRest.RequestOptionsBase {
+export interface DeploymentsListByResourceGroupOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation. For example, you can use $filter=provisioningState eq
    * '{state}'.
@@ -1014,7 +1014,7 @@ export interface DeploymentsListByResourceGroupOptionalParams extends msRest.Req
 /**
  * Optional Parameters.
  */
-export interface ProvidersListOptionalParams extends msRest.RequestOptionsBase {
+export interface ProvidersListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The number of results to return. If null is passed returns all deployments.
    */
@@ -1030,7 +1030,7 @@ export interface ProvidersListOptionalParams extends msRest.RequestOptionsBase {
 /**
  * Optional Parameters.
  */
-export interface ProvidersGetOptionalParams extends msRest.RequestOptionsBase {
+export interface ProvidersGetOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The $expand query parameter. For example, to include property aliases in response, use
    * $expand=resourceTypes/aliases.
@@ -1041,7 +1041,7 @@ export interface ProvidersGetOptionalParams extends msRest.RequestOptionsBase {
 /**
  * Optional Parameters.
  */
-export interface ResourcesListByResourceGroupOptionalParams extends msRest.RequestOptionsBase {
+export interface ResourcesListByResourceGroupOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.<br><br>The properties you can use for eq (equals) or ne
    * (not equals) are: location, resourceType, name, resourceGroup, identity, identity/principalId,
@@ -1072,7 +1072,7 @@ export interface ResourcesListByResourceGroupOptionalParams extends msRest.Reque
 /**
  * Optional Parameters.
  */
-export interface ResourcesListOptionalParams extends msRest.RequestOptionsBase {
+export interface ResourcesListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.<br><br>The properties you can use for eq (equals) or ne
    * (not equals) are: location, resourceType, name, resourceGroup, identity, identity/principalId,
@@ -1103,7 +1103,7 @@ export interface ResourcesListOptionalParams extends msRest.RequestOptionsBase {
 /**
  * Optional Parameters.
  */
-export interface ResourceGroupsListOptionalParams extends msRest.RequestOptionsBase {
+export interface ResourceGroupsListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The filter to apply on the operation.<br><br>You can filter by tag names and values. For
    * example, to filter for a tag name and value, use $filter=tagName eq 'tag1' and tagValue eq
@@ -1119,7 +1119,7 @@ export interface ResourceGroupsListOptionalParams extends msRest.RequestOptionsB
 /**
  * Optional Parameters.
  */
-export interface DeploymentOperationsListAtManagementGroupScopeOptionalParams extends msRest.RequestOptionsBase {
+export interface DeploymentOperationsListAtManagementGroupScopeOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The number of results to return.
    */
@@ -1129,7 +1129,7 @@ export interface DeploymentOperationsListAtManagementGroupScopeOptionalParams ex
 /**
  * Optional Parameters.
  */
-export interface DeploymentOperationsListAtSubscriptionScopeOptionalParams extends msRest.RequestOptionsBase {
+export interface DeploymentOperationsListAtSubscriptionScopeOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The number of results to return.
    */
@@ -1139,7 +1139,7 @@ export interface DeploymentOperationsListAtSubscriptionScopeOptionalParams exten
 /**
  * Optional Parameters.
  */
-export interface DeploymentOperationsListOptionalParams extends msRest.RequestOptionsBase {
+export interface DeploymentOperationsListOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The number of results to return.
    */
@@ -1276,7 +1276,7 @@ export type OperationsListResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1296,7 +1296,7 @@ export type OperationsListNextResponse = OperationListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1321,7 +1321,7 @@ export type DeploymentsCheckExistenceAtManagementGroupScopeResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1341,7 +1341,7 @@ export type DeploymentsCreateOrUpdateAtManagementGroupScopeResponse = Deployment
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1361,7 +1361,7 @@ export type DeploymentsGetAtManagementGroupScopeResponse = DeploymentExtended & 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1381,7 +1381,7 @@ export type DeploymentsValidateAtManagementGroupScopeResponse = DeploymentValida
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1401,7 +1401,7 @@ export type DeploymentsExportTemplateAtManagementGroupScopeResponse = Deployment
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1421,7 +1421,7 @@ export type DeploymentsListAtManagementGroupScopeResponse = DeploymentListResult
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1446,7 +1446,7 @@ export type DeploymentsCheckExistenceAtSubscriptionScopeResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1466,7 +1466,7 @@ export type DeploymentsCreateOrUpdateAtSubscriptionScopeResponse = DeploymentExt
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1486,7 +1486,7 @@ export type DeploymentsGetAtSubscriptionScopeResponse = DeploymentExtended & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1506,7 +1506,7 @@ export type DeploymentsValidateAtSubscriptionScopeResponse = DeploymentValidateR
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1526,7 +1526,7 @@ export type DeploymentsExportTemplateAtSubscriptionScopeResponse = DeploymentExp
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1546,7 +1546,7 @@ export type DeploymentsListAtSubscriptionScopeResponse = DeploymentListResult & 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1571,7 +1571,7 @@ export type DeploymentsCheckExistenceResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1591,7 +1591,7 @@ export type DeploymentsCreateOrUpdateResponse = DeploymentExtended & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1611,7 +1611,7 @@ export type DeploymentsGetResponse = DeploymentExtended & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1631,7 +1631,7 @@ export type DeploymentsValidateResponse = DeploymentValidateResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1651,7 +1651,7 @@ export type DeploymentsExportTemplateResponse = DeploymentExportResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1671,7 +1671,7 @@ export type DeploymentsListByResourceGroupResponse = DeploymentListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1691,7 +1691,7 @@ export type DeploymentsBeginCreateOrUpdateAtManagementGroupScopeResponse = Deplo
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1711,7 +1711,7 @@ export type DeploymentsBeginCreateOrUpdateAtSubscriptionScopeResponse = Deployme
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1731,7 +1731,7 @@ export type DeploymentsBeginCreateOrUpdateResponse = DeploymentExtended & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1751,7 +1751,7 @@ export type DeploymentsListAtManagementGroupScopeNextResponse = DeploymentListRe
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1771,7 +1771,7 @@ export type DeploymentsListAtSubscriptionScopeNextResponse = DeploymentListResul
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1791,7 +1791,7 @@ export type DeploymentsListByResourceGroupNextResponse = DeploymentListResult & 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1811,7 +1811,7 @@ export type ProvidersUnregisterResponse = Provider & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1831,7 +1831,7 @@ export type ProvidersRegisterResponse = Provider & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1851,7 +1851,7 @@ export type ProvidersListResponse = ProviderListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1871,7 +1871,7 @@ export type ProvidersGetResponse = Provider & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1891,7 +1891,7 @@ export type ProvidersListNextResponse = ProviderListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1911,7 +1911,7 @@ export type ResourcesListByResourceGroupResponse = ResourceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1931,7 +1931,7 @@ export type ResourcesListResponse = ResourceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1956,7 +1956,7 @@ export type ResourcesCheckExistenceResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1976,7 +1976,7 @@ export type ResourcesCreateOrUpdateResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -1996,7 +1996,7 @@ export type ResourcesUpdateResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2016,7 +2016,7 @@ export type ResourcesGetResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2041,7 +2041,7 @@ export type ResourcesCheckExistenceByIdResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2061,7 +2061,7 @@ export type ResourcesCreateOrUpdateByIdResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2081,7 +2081,7 @@ export type ResourcesUpdateByIdResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2101,7 +2101,7 @@ export type ResourcesGetByIdResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2121,7 +2121,7 @@ export type ResourcesBeginCreateOrUpdateResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2141,7 +2141,7 @@ export type ResourcesBeginUpdateResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2161,7 +2161,7 @@ export type ResourcesBeginCreateOrUpdateByIdResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2181,7 +2181,7 @@ export type ResourcesBeginUpdateByIdResponse = GenericResource & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2201,7 +2201,7 @@ export type ResourcesListByResourceGroupNextResponse = ResourceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2221,7 +2221,7 @@ export type ResourcesListNextResponse = ResourceListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2246,7 +2246,7 @@ export type ResourceGroupsCheckExistenceResponse = {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2266,7 +2266,7 @@ export type ResourceGroupsCreateOrUpdateResponse = ResourceGroup & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2286,7 +2286,7 @@ export type ResourceGroupsGetResponse = ResourceGroup & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2306,7 +2306,7 @@ export type ResourceGroupsUpdateResponse = ResourceGroup & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2326,7 +2326,7 @@ export type ResourceGroupsExportTemplateResponse = ResourceGroupExportResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2346,7 +2346,7 @@ export type ResourceGroupsListResponse = ResourceGroupListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2366,7 +2366,7 @@ export type ResourceGroupsListNextResponse = ResourceGroupListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2386,7 +2386,7 @@ export type TagsCreateOrUpdateValueResponse = TagValue & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2406,7 +2406,7 @@ export type TagsCreateOrUpdateResponse = TagDetails & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2426,7 +2426,7 @@ export type TagsListResponse = TagsListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2446,7 +2446,7 @@ export type TagsListNextResponse = TagsListResult & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2466,7 +2466,7 @@ export type DeploymentOperationsGetAtManagementGroupScopeResponse = DeploymentOp
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2486,7 +2486,7 @@ export type DeploymentOperationsListAtManagementGroupScopeResponse = DeploymentO
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2506,7 +2506,7 @@ export type DeploymentOperationsGetAtSubscriptionScopeResponse = DeploymentOpera
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2526,7 +2526,7 @@ export type DeploymentOperationsListAtSubscriptionScopeResponse = DeploymentOper
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2546,7 +2546,7 @@ export type DeploymentOperationsGetResponse = DeploymentOperation & {
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2566,7 +2566,7 @@ export type DeploymentOperationsListResponse = DeploymentOperationsListResult & 
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2586,7 +2586,7 @@ export type DeploymentOperationsListAtManagementGroupScopeNextResponse = Deploym
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2606,7 +2606,7 @@ export type DeploymentOperationsListAtSubscriptionScopeNextResponse = Deployment
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */
@@ -2626,7 +2626,7 @@ export type DeploymentOperationsListNextResponse = DeploymentOperationsListResul
   /**
    * The underlying HTTP response.
    */
-  _response: msRest.HttpResponse & {
+  _response: coreHttp.HttpResponse & {
       /**
        * The response body as text (string format)
        */

--- a/sdk/resources/arm-resources/src/models/mappers.ts
+++ b/sdk/resources/arm-resources/src/models/mappers.ts
@@ -6,13 +6,13 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { CloudErrorMapper, BaseResourceMapper } from "@azure/ms-rest-azure-js";
-import * as msRest from "@azure/ms-rest-js";
+import { CloudErrorMapper, BaseResourceMapper } from "@azure/core-arm";
+import * as coreHttp from "@azure/core-http";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;
 
-export const DeploymentExtendedFilter: msRest.CompositeMapper = {
+export const DeploymentExtendedFilter: coreHttp.CompositeMapper = {
   serializedName: "DeploymentExtendedFilter",
   type: {
     name: "Composite",
@@ -28,7 +28,7 @@ export const DeploymentExtendedFilter: msRest.CompositeMapper = {
   }
 };
 
-export const GenericResourceFilter: msRest.CompositeMapper = {
+export const GenericResourceFilter: coreHttp.CompositeMapper = {
   serializedName: "GenericResourceFilter",
   type: {
     name: "Composite",
@@ -56,7 +56,7 @@ export const GenericResourceFilter: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceGroupFilter: msRest.CompositeMapper = {
+export const ResourceGroupFilter: coreHttp.CompositeMapper = {
   serializedName: "ResourceGroupFilter",
   type: {
     name: "Composite",
@@ -78,7 +78,7 @@ export const ResourceGroupFilter: msRest.CompositeMapper = {
   }
 };
 
-export const TemplateLink: msRest.CompositeMapper = {
+export const TemplateLink: coreHttp.CompositeMapper = {
   serializedName: "TemplateLink",
   type: {
     name: "Composite",
@@ -101,7 +101,7 @@ export const TemplateLink: msRest.CompositeMapper = {
   }
 };
 
-export const ParametersLink: msRest.CompositeMapper = {
+export const ParametersLink: coreHttp.CompositeMapper = {
   serializedName: "ParametersLink",
   type: {
     name: "Composite",
@@ -124,7 +124,7 @@ export const ParametersLink: msRest.CompositeMapper = {
   }
 };
 
-export const DebugSetting: msRest.CompositeMapper = {
+export const DebugSetting: coreHttp.CompositeMapper = {
   serializedName: "DebugSetting",
   type: {
     name: "Composite",
@@ -140,7 +140,7 @@ export const DebugSetting: msRest.CompositeMapper = {
   }
 };
 
-export const OnErrorDeployment: msRest.CompositeMapper = {
+export const OnErrorDeployment: coreHttp.CompositeMapper = {
   serializedName: "OnErrorDeployment",
   type: {
     name: "Composite",
@@ -166,7 +166,7 @@ export const OnErrorDeployment: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentProperties: msRest.CompositeMapper = {
+export const DeploymentProperties: coreHttp.CompositeMapper = {
   serializedName: "DeploymentProperties",
   type: {
     name: "Composite",
@@ -227,7 +227,7 @@ export const DeploymentProperties: msRest.CompositeMapper = {
   }
 };
 
-export const Deployment: msRest.CompositeMapper = {
+export const Deployment: coreHttp.CompositeMapper = {
   serializedName: "Deployment",
   type: {
     name: "Composite",
@@ -251,7 +251,7 @@ export const Deployment: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentExportResult: msRest.CompositeMapper = {
+export const DeploymentExportResult: coreHttp.CompositeMapper = {
   serializedName: "DeploymentExportResult",
   type: {
     name: "Composite",
@@ -267,7 +267,7 @@ export const DeploymentExportResult: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceManagementErrorWithDetails: msRest.CompositeMapper = {
+export const ResourceManagementErrorWithDetails: coreHttp.CompositeMapper = {
   serializedName: "ResourceManagementErrorWithDetails",
   type: {
     name: "Composite",
@@ -311,7 +311,7 @@ export const ResourceManagementErrorWithDetails: msRest.CompositeMapper = {
   }
 };
 
-export const AliasPathType: msRest.CompositeMapper = {
+export const AliasPathType: coreHttp.CompositeMapper = {
   serializedName: "AliasPathType",
   type: {
     name: "Composite",
@@ -338,7 +338,7 @@ export const AliasPathType: msRest.CompositeMapper = {
   }
 };
 
-export const AliasType: msRest.CompositeMapper = {
+export const AliasType: coreHttp.CompositeMapper = {
   serializedName: "AliasType",
   type: {
     name: "Composite",
@@ -366,7 +366,7 @@ export const AliasType: msRest.CompositeMapper = {
   }
 };
 
-export const ProviderResourceType: msRest.CompositeMapper = {
+export const ProviderResourceType: coreHttp.CompositeMapper = {
   serializedName: "ProviderResourceType",
   type: {
     name: "Composite",
@@ -433,7 +433,7 @@ export const ProviderResourceType: msRest.CompositeMapper = {
   }
 };
 
-export const Provider: msRest.CompositeMapper = {
+export const Provider: coreHttp.CompositeMapper = {
   serializedName: "Provider",
   type: {
     name: "Composite",
@@ -483,7 +483,7 @@ export const Provider: msRest.CompositeMapper = {
   }
 };
 
-export const BasicDependency: msRest.CompositeMapper = {
+export const BasicDependency: coreHttp.CompositeMapper = {
   serializedName: "BasicDependency",
   type: {
     name: "Composite",
@@ -511,7 +511,7 @@ export const BasicDependency: msRest.CompositeMapper = {
   }
 };
 
-export const Dependency: msRest.CompositeMapper = {
+export const Dependency: coreHttp.CompositeMapper = {
   serializedName: "Dependency",
   type: {
     name: "Composite",
@@ -551,7 +551,7 @@ export const Dependency: msRest.CompositeMapper = {
   }
 };
 
-export const OnErrorDeploymentExtended: msRest.CompositeMapper = {
+export const OnErrorDeploymentExtended: coreHttp.CompositeMapper = {
   serializedName: "OnErrorDeploymentExtended",
   type: {
     name: "Composite",
@@ -584,7 +584,7 @@ export const OnErrorDeploymentExtended: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentPropertiesExtended: msRest.CompositeMapper = {
+export const DeploymentPropertiesExtended: coreHttp.CompositeMapper = {
   serializedName: "DeploymentPropertiesExtended",
   type: {
     name: "Composite",
@@ -702,7 +702,7 @@ export const DeploymentPropertiesExtended: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentValidateResult: msRest.CompositeMapper = {
+export const DeploymentValidateResult: coreHttp.CompositeMapper = {
   serializedName: "DeploymentValidateResult",
   type: {
     name: "Composite",
@@ -726,7 +726,7 @@ export const DeploymentValidateResult: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentExtended: msRest.CompositeMapper = {
+export const DeploymentExtended: coreHttp.CompositeMapper = {
   serializedName: "DeploymentExtended",
   type: {
     name: "Composite",
@@ -770,7 +770,7 @@ export const DeploymentExtended: msRest.CompositeMapper = {
   }
 };
 
-export const Plan: msRest.CompositeMapper = {
+export const Plan: coreHttp.CompositeMapper = {
   serializedName: "Plan",
   type: {
     name: "Composite",
@@ -810,7 +810,7 @@ export const Plan: msRest.CompositeMapper = {
   }
 };
 
-export const Sku: msRest.CompositeMapper = {
+export const Sku: coreHttp.CompositeMapper = {
   serializedName: "Sku",
   type: {
     name: "Composite",
@@ -856,7 +856,7 @@ export const Sku: msRest.CompositeMapper = {
   }
 };
 
-export const IdentityUserAssignedIdentitiesValue: msRest.CompositeMapper = {
+export const IdentityUserAssignedIdentitiesValue: coreHttp.CompositeMapper = {
   serializedName: "Identity_userAssignedIdentitiesValue",
   type: {
     name: "Composite",
@@ -880,7 +880,7 @@ export const IdentityUserAssignedIdentitiesValue: msRest.CompositeMapper = {
   }
 };
 
-export const Identity: msRest.CompositeMapper = {
+export const Identity: coreHttp.CompositeMapper = {
   serializedName: "Identity",
   type: {
     name: "Composite",
@@ -928,7 +928,7 @@ export const Identity: msRest.CompositeMapper = {
   }
 };
 
-export const Resource: msRest.CompositeMapper = {
+export const Resource: coreHttp.CompositeMapper = {
   serializedName: "Resource",
   type: {
     name: "Composite",
@@ -976,7 +976,7 @@ export const Resource: msRest.CompositeMapper = {
   }
 };
 
-export const GenericResource: msRest.CompositeMapper = {
+export const GenericResource: coreHttp.CompositeMapper = {
   serializedName: "GenericResource",
   type: {
     name: "Composite",
@@ -1029,7 +1029,7 @@ export const GenericResource: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceGroupProperties: msRest.CompositeMapper = {
+export const ResourceGroupProperties: coreHttp.CompositeMapper = {
   serializedName: "ResourceGroupProperties",
   type: {
     name: "Composite",
@@ -1046,7 +1046,7 @@ export const ResourceGroupProperties: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceGroup: msRest.CompositeMapper = {
+export const ResourceGroup: coreHttp.CompositeMapper = {
   serializedName: "ResourceGroup",
   type: {
     name: "Composite",
@@ -1108,7 +1108,7 @@ export const ResourceGroup: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceGroupPatchable: msRest.CompositeMapper = {
+export const ResourceGroupPatchable: coreHttp.CompositeMapper = {
   serializedName: "ResourceGroupPatchable",
   type: {
     name: "Composite",
@@ -1148,7 +1148,7 @@ export const ResourceGroupPatchable: msRest.CompositeMapper = {
   }
 };
 
-export const ResourcesMoveInfo: msRest.CompositeMapper = {
+export const ResourcesMoveInfo: coreHttp.CompositeMapper = {
   serializedName: "ResourcesMoveInfo",
   type: {
     name: "Composite",
@@ -1175,7 +1175,7 @@ export const ResourcesMoveInfo: msRest.CompositeMapper = {
   }
 };
 
-export const ExportTemplateRequest: msRest.CompositeMapper = {
+export const ExportTemplateRequest: coreHttp.CompositeMapper = {
   serializedName: "ExportTemplateRequest",
   type: {
     name: "Composite",
@@ -1202,7 +1202,7 @@ export const ExportTemplateRequest: msRest.CompositeMapper = {
   }
 };
 
-export const TagCount: msRest.CompositeMapper = {
+export const TagCount: coreHttp.CompositeMapper = {
   serializedName: "TagCount",
   type: {
     name: "Composite",
@@ -1224,7 +1224,7 @@ export const TagCount: msRest.CompositeMapper = {
   }
 };
 
-export const TagValue: msRest.CompositeMapper = {
+export const TagValue: coreHttp.CompositeMapper = {
   serializedName: "TagValue",
   type: {
     name: "Composite",
@@ -1254,7 +1254,7 @@ export const TagValue: msRest.CompositeMapper = {
   }
 };
 
-export const TagDetails: msRest.CompositeMapper = {
+export const TagDetails: coreHttp.CompositeMapper = {
   serializedName: "TagDetails",
   type: {
     name: "Composite",
@@ -1296,7 +1296,7 @@ export const TagDetails: msRest.CompositeMapper = {
   }
 };
 
-export const TargetResource: msRest.CompositeMapper = {
+export const TargetResource: coreHttp.CompositeMapper = {
   serializedName: "TargetResource",
   type: {
     name: "Composite",
@@ -1324,7 +1324,7 @@ export const TargetResource: msRest.CompositeMapper = {
   }
 };
 
-export const HttpMessage: msRest.CompositeMapper = {
+export const HttpMessage: coreHttp.CompositeMapper = {
   serializedName: "HttpMessage",
   type: {
     name: "Composite",
@@ -1340,7 +1340,7 @@ export const HttpMessage: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentOperationProperties: msRest.CompositeMapper = {
+export const DeploymentOperationProperties: coreHttp.CompositeMapper = {
   serializedName: "DeploymentOperationProperties",
   type: {
     name: "Composite",
@@ -1416,7 +1416,7 @@ export const DeploymentOperationProperties: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentOperation: msRest.CompositeMapper = {
+export const DeploymentOperation: coreHttp.CompositeMapper = {
   serializedName: "DeploymentOperation",
   type: {
     name: "Composite",
@@ -1447,7 +1447,7 @@ export const DeploymentOperation: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceProviderOperationDisplayProperties: msRest.CompositeMapper = {
+export const ResourceProviderOperationDisplayProperties: coreHttp.CompositeMapper = {
   serializedName: "ResourceProviderOperationDisplayProperties",
   type: {
     name: "Composite",
@@ -1487,7 +1487,7 @@ export const ResourceProviderOperationDisplayProperties: msRest.CompositeMapper 
   }
 };
 
-export const SubResource: msRest.CompositeMapper = {
+export const SubResource: coreHttp.CompositeMapper = {
   serializedName: "SubResource",
   type: {
     name: "Composite",
@@ -1503,7 +1503,7 @@ export const SubResource: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceGroupExportResult: msRest.CompositeMapper = {
+export const ResourceGroupExportResult: coreHttp.CompositeMapper = {
   serializedName: "ResourceGroupExportResult",
   type: {
     name: "Composite",
@@ -1526,7 +1526,7 @@ export const ResourceGroupExportResult: msRest.CompositeMapper = {
   }
 };
 
-export const OperationDisplay: msRest.CompositeMapper = {
+export const OperationDisplay: coreHttp.CompositeMapper = {
   serializedName: "Operation_display",
   type: {
     name: "Composite",
@@ -1560,7 +1560,7 @@ export const OperationDisplay: msRest.CompositeMapper = {
   }
 };
 
-export const Operation: msRest.CompositeMapper = {
+export const Operation: coreHttp.CompositeMapper = {
   serializedName: "Operation",
   type: {
     name: "Composite",
@@ -1583,7 +1583,7 @@ export const Operation: msRest.CompositeMapper = {
   }
 };
 
-export const OperationListResult: msRest.CompositeMapper = {
+export const OperationListResult: coreHttp.CompositeMapper = {
   serializedName: "OperationListResult",
   type: {
     name: "Composite",
@@ -1611,7 +1611,7 @@ export const OperationListResult: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentListResult: msRest.CompositeMapper = {
+export const DeploymentListResult: coreHttp.CompositeMapper = {
   serializedName: "DeploymentListResult",
   type: {
     name: "Composite",
@@ -1640,7 +1640,7 @@ export const DeploymentListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ProviderListResult: msRest.CompositeMapper = {
+export const ProviderListResult: coreHttp.CompositeMapper = {
   serializedName: "ProviderListResult",
   type: {
     name: "Composite",
@@ -1669,7 +1669,7 @@ export const ProviderListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceListResult: msRest.CompositeMapper = {
+export const ResourceListResult: coreHttp.CompositeMapper = {
   serializedName: "ResourceListResult",
   type: {
     name: "Composite",
@@ -1698,7 +1698,7 @@ export const ResourceListResult: msRest.CompositeMapper = {
   }
 };
 
-export const ResourceGroupListResult: msRest.CompositeMapper = {
+export const ResourceGroupListResult: coreHttp.CompositeMapper = {
   serializedName: "ResourceGroupListResult",
   type: {
     name: "Composite",
@@ -1727,7 +1727,7 @@ export const ResourceGroupListResult: msRest.CompositeMapper = {
   }
 };
 
-export const TagsListResult: msRest.CompositeMapper = {
+export const TagsListResult: coreHttp.CompositeMapper = {
   serializedName: "TagsListResult",
   type: {
     name: "Composite",
@@ -1756,7 +1756,7 @@ export const TagsListResult: msRest.CompositeMapper = {
   }
 };
 
-export const DeploymentOperationsListResult: msRest.CompositeMapper = {
+export const DeploymentOperationsListResult: coreHttp.CompositeMapper = {
   serializedName: "DeploymentOperationsListResult",
   type: {
     name: "Composite",

--- a/sdk/resources/arm-resources/src/models/parameters.ts
+++ b/sdk/resources/arm-resources/src/models/parameters.ts
@@ -8,9 +8,9 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 
-export const acceptLanguage: msRest.OperationParameter = {
+export const acceptLanguage: coreHttp.OperationParameter = {
   parameterPath: "acceptLanguage",
   mapper: {
     serializedName: "accept-language",
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion: msRest.OperationQueryParameter = {
+export const apiVersion: coreHttp.OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -30,7 +30,7 @@ export const apiVersion: msRest.OperationQueryParameter = {
     }
   }
 };
-export const deploymentName: msRest.OperationURLParameter = {
+export const deploymentName: coreHttp.OperationURLParameter = {
   parameterPath: "deploymentName",
   mapper: {
     required: true,
@@ -45,7 +45,7 @@ export const deploymentName: msRest.OperationURLParameter = {
     }
   }
 };
-export const expand: msRest.OperationQueryParameter = {
+export const expand: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "expand"
@@ -57,7 +57,7 @@ export const expand: msRest.OperationQueryParameter = {
     }
   }
 };
-export const filter: msRest.OperationQueryParameter = {
+export const filter: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "filter"
@@ -69,7 +69,7 @@ export const filter: msRest.OperationQueryParameter = {
     }
   }
 };
-export const groupId: msRest.OperationURLParameter = {
+export const groupId: coreHttp.OperationURLParameter = {
   parameterPath: "groupId",
   mapper: {
     required: true,
@@ -83,7 +83,7 @@ export const groupId: msRest.OperationURLParameter = {
     }
   }
 };
-export const nextPageLink: msRest.OperationURLParameter = {
+export const nextPageLink: coreHttp.OperationURLParameter = {
   parameterPath: "nextPageLink",
   mapper: {
     required: true,
@@ -94,7 +94,7 @@ export const nextPageLink: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const operationId: msRest.OperationURLParameter = {
+export const operationId: coreHttp.OperationURLParameter = {
   parameterPath: "operationId",
   mapper: {
     required: true,
@@ -104,7 +104,7 @@ export const operationId: msRest.OperationURLParameter = {
     }
   }
 };
-export const parentResourcePath: msRest.OperationURLParameter = {
+export const parentResourcePath: coreHttp.OperationURLParameter = {
   parameterPath: "parentResourcePath",
   mapper: {
     required: true,
@@ -115,7 +115,7 @@ export const parentResourcePath: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const resourceGroupName: msRest.OperationURLParameter = {
+export const resourceGroupName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
     required: true,
@@ -130,7 +130,7 @@ export const resourceGroupName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceId: msRest.OperationURLParameter = {
+export const resourceId: coreHttp.OperationURLParameter = {
   parameterPath: "resourceId",
   mapper: {
     required: true,
@@ -141,7 +141,7 @@ export const resourceId: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const resourceName: msRest.OperationURLParameter = {
+export const resourceName: coreHttp.OperationURLParameter = {
   parameterPath: "resourceName",
   mapper: {
     required: true,
@@ -151,7 +151,7 @@ export const resourceName: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceProviderNamespace: msRest.OperationURLParameter = {
+export const resourceProviderNamespace: coreHttp.OperationURLParameter = {
   parameterPath: "resourceProviderNamespace",
   mapper: {
     required: true,
@@ -161,7 +161,7 @@ export const resourceProviderNamespace: msRest.OperationURLParameter = {
     }
   }
 };
-export const resourceType: msRest.OperationURLParameter = {
+export const resourceType: coreHttp.OperationURLParameter = {
   parameterPath: "resourceType",
   mapper: {
     required: true,
@@ -172,7 +172,7 @@ export const resourceType: msRest.OperationURLParameter = {
   },
   skipEncoding: true
 };
-export const sourceResourceGroupName: msRest.OperationURLParameter = {
+export const sourceResourceGroupName: coreHttp.OperationURLParameter = {
   parameterPath: "sourceResourceGroupName",
   mapper: {
     required: true,
@@ -187,7 +187,7 @@ export const sourceResourceGroupName: msRest.OperationURLParameter = {
     }
   }
 };
-export const subscriptionId: msRest.OperationURLParameter = {
+export const subscriptionId: coreHttp.OperationURLParameter = {
   parameterPath: "subscriptionId",
   mapper: {
     required: true,
@@ -197,7 +197,7 @@ export const subscriptionId: msRest.OperationURLParameter = {
     }
   }
 };
-export const tagName: msRest.OperationURLParameter = {
+export const tagName: coreHttp.OperationURLParameter = {
   parameterPath: "tagName",
   mapper: {
     required: true,
@@ -207,7 +207,7 @@ export const tagName: msRest.OperationURLParameter = {
     }
   }
 };
-export const tagValue: msRest.OperationURLParameter = {
+export const tagValue: coreHttp.OperationURLParameter = {
   parameterPath: "tagValue",
   mapper: {
     required: true,
@@ -217,7 +217,7 @@ export const tagValue: msRest.OperationURLParameter = {
     }
   }
 };
-export const top: msRest.OperationQueryParameter = {
+export const top: coreHttp.OperationQueryParameter = {
   parameterPath: [
     "options",
     "top"

--- a/sdk/resources/arm-resources/src/operations/deploymentOperations.ts
+++ b/sdk/resources/arm-resources/src/operations/deploymentOperations.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/deploymentOperationsMappers";
 import * as Parameters from "../models/parameters";
@@ -34,14 +34,14 @@ export class DeploymentOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentOperationsGetAtManagementGroupScopeResponse>
    */
-  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentOperationsGetAtManagementGroupScopeResponse>;
+  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentOperationsGetAtManagementGroupScopeResponse>;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param operationId The ID of the operation to get.
    * @param callback The callback
    */
-  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, callback: msRest.ServiceCallback<Models.DeploymentOperation>): void;
+  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperation>): void;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
@@ -49,8 +49,8 @@ export class DeploymentOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentOperation>): void;
-  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentOperation>, callback?: msRest.ServiceCallback<Models.DeploymentOperation>): Promise<Models.DeploymentOperationsGetAtManagementGroupScopeResponse> {
+  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentOperation>): void;
+  getAtManagementGroupScope(groupId: string, deploymentName: string, operationId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentOperation>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperation>): Promise<Models.DeploymentOperationsGetAtManagementGroupScopeResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -75,15 +75,15 @@ export class DeploymentOperations {
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  listAtManagementGroupScope(groupId: string, deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtManagementGroupScope(groupId: string, deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtManagementGroupScope(groupId: string, deploymentName: string, options: Models.DeploymentOperationsListAtManagementGroupScopeOptionalParams, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
-  listAtManagementGroupScope(groupId: string, deploymentName: string, options?: Models.DeploymentOperationsListAtManagementGroupScopeOptionalParams | msRest.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtManagementGroupScopeResponse> {
+  listAtManagementGroupScope(groupId: string, deploymentName: string, options: Models.DeploymentOperationsListAtManagementGroupScopeOptionalParams, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtManagementGroupScope(groupId: string, deploymentName: string, options?: Models.DeploymentOperationsListAtManagementGroupScopeOptionalParams | coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtManagementGroupScopeResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -101,21 +101,21 @@ export class DeploymentOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentOperationsGetAtSubscriptionScopeResponse>
    */
-  getAtSubscriptionScope(deploymentName: string, operationId: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentOperationsGetAtSubscriptionScopeResponse>;
+  getAtSubscriptionScope(deploymentName: string, operationId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentOperationsGetAtSubscriptionScopeResponse>;
   /**
    * @param deploymentName The name of the deployment.
    * @param operationId The ID of the operation to get.
    * @param callback The callback
    */
-  getAtSubscriptionScope(deploymentName: string, operationId: string, callback: msRest.ServiceCallback<Models.DeploymentOperation>): void;
+  getAtSubscriptionScope(deploymentName: string, operationId: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperation>): void;
   /**
    * @param deploymentName The name of the deployment.
    * @param operationId The ID of the operation to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtSubscriptionScope(deploymentName: string, operationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentOperation>): void;
-  getAtSubscriptionScope(deploymentName: string, operationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentOperation>, callback?: msRest.ServiceCallback<Models.DeploymentOperation>): Promise<Models.DeploymentOperationsGetAtSubscriptionScopeResponse> {
+  getAtSubscriptionScope(deploymentName: string, operationId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentOperation>): void;
+  getAtSubscriptionScope(deploymentName: string, operationId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentOperation>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperation>): Promise<Models.DeploymentOperationsGetAtSubscriptionScopeResponse> {
     return this.client.sendOperationRequest(
       {
         deploymentName,
@@ -137,14 +137,14 @@ export class DeploymentOperations {
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  listAtSubscriptionScope(deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtSubscriptionScope(deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
   /**
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscriptionScope(deploymentName: string, options: Models.DeploymentOperationsListAtSubscriptionScopeOptionalParams, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
-  listAtSubscriptionScope(deploymentName: string, options?: Models.DeploymentOperationsListAtSubscriptionScopeOptionalParams | msRest.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtSubscriptionScopeResponse> {
+  listAtSubscriptionScope(deploymentName: string, options: Models.DeploymentOperationsListAtSubscriptionScopeOptionalParams, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtSubscriptionScope(deploymentName: string, options?: Models.DeploymentOperationsListAtSubscriptionScopeOptionalParams | coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtSubscriptionScopeResponse> {
     return this.client.sendOperationRequest(
       {
         deploymentName,
@@ -162,14 +162,14 @@ export class DeploymentOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentOperationsGetResponse>
    */
-  get(resourceGroupName: string, deploymentName: string, operationId: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentOperationsGetResponse>;
+  get(resourceGroupName: string, deploymentName: string, operationId: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentOperationsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param operationId The ID of the operation to get.
    * @param callback The callback
    */
-  get(resourceGroupName: string, deploymentName: string, operationId: string, callback: msRest.ServiceCallback<Models.DeploymentOperation>): void;
+  get(resourceGroupName: string, deploymentName: string, operationId: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperation>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
@@ -177,8 +177,8 @@ export class DeploymentOperations {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, deploymentName: string, operationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentOperation>): void;
-  get(resourceGroupName: string, deploymentName: string, operationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentOperation>, callback?: msRest.ServiceCallback<Models.DeploymentOperation>): Promise<Models.DeploymentOperationsGetResponse> {
+  get(resourceGroupName: string, deploymentName: string, operationId: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentOperation>): void;
+  get(resourceGroupName: string, deploymentName: string, operationId: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentOperation>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperation>): Promise<Models.DeploymentOperationsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -203,15 +203,15 @@ export class DeploymentOperations {
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  list(resourceGroupName: string, deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  list(resourceGroupName: string, deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(resourceGroupName: string, deploymentName: string, options: Models.DeploymentOperationsListOptionalParams, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
-  list(resourceGroupName: string, deploymentName: string, options?: Models.DeploymentOperationsListOptionalParams | msRest.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListResponse> {
+  list(resourceGroupName: string, deploymentName: string, options: Models.DeploymentOperationsListOptionalParams, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  list(resourceGroupName: string, deploymentName: string, options?: Models.DeploymentOperationsListOptionalParams | coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -228,19 +228,19 @@ export class DeploymentOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentOperationsListAtManagementGroupScopeNextResponse>
    */
-  listAtManagementGroupScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentOperationsListAtManagementGroupScopeNextResponse>;
+  listAtManagementGroupScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentOperationsListAtManagementGroupScopeNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtManagementGroupScopeNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtManagementGroupScopeNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtManagementGroupScopeNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
-  listAtManagementGroupScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtManagementGroupScopeNextResponse> {
+  listAtManagementGroupScopeNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtManagementGroupScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtManagementGroupScopeNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -256,19 +256,19 @@ export class DeploymentOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentOperationsListAtSubscriptionScopeNextResponse>
    */
-  listAtSubscriptionScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentOperationsListAtSubscriptionScopeNextResponse>;
+  listAtSubscriptionScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentOperationsListAtSubscriptionScopeNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtSubscriptionScopeNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtSubscriptionScopeNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscriptionScopeNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
-  listAtSubscriptionScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtSubscriptionScopeNextResponse> {
+  listAtSubscriptionScopeNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listAtSubscriptionScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListAtSubscriptionScopeNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -284,19 +284,19 @@ export class DeploymentOperations {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentOperationsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentOperationsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentOperationsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: msRest.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentOperationsListResult>): Promise<Models.DeploymentOperationsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -308,8 +308,8 @@ export class DeploymentOperations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const getAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const getAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/operations/{operationId}",
   urlParameters: [
@@ -334,7 +334,7 @@ const getAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const listAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/operations",
   urlParameters: [
@@ -359,7 +359,7 @@ const listAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const getAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/operations/{operationId}",
   urlParameters: [
@@ -384,7 +384,7 @@ const getAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/operations",
   urlParameters: [
@@ -409,7 +409,7 @@ const listAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/deployments/{deploymentName}/operations/{operationId}",
   urlParameters: [
@@ -435,7 +435,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/deployments/{deploymentName}/operations",
   urlParameters: [
@@ -461,7 +461,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtManagementGroupScopeNextOperationSpec: msRest.OperationSpec = {
+const listAtManagementGroupScopeNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -482,7 +482,7 @@ const listAtManagementGroupScopeNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionScopeNextOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionScopeNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -503,7 +503,7 @@ const listAtSubscriptionScopeNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/resources/arm-resources/src/operations/deployments.ts
+++ b/sdk/resources/arm-resources/src/operations/deployments.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/deploymentsMappers";
 import * as Parameters from "../models/parameters";
@@ -39,9 +39,9 @@ export class Deployments {
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteAtManagementGroupScope(groupId,deploymentName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -53,21 +53,21 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsCheckExistenceAtManagementGroupScopeResponse>
    */
-  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsCheckExistenceAtManagementGroupScopeResponse>;
+  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsCheckExistenceAtManagementGroupScopeResponse>;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, callback: msRest.ServiceCallback<boolean>): void;
+  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, callback: coreHttp.ServiceCallback<boolean>): void;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<boolean>): void;
-  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.DeploymentsCheckExistenceAtManagementGroupScopeResponse> {
+  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<boolean>): void;
+  checkExistenceAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<boolean>, callback?: coreHttp.ServiceCallback<boolean>): Promise<Models.DeploymentsCheckExistenceAtManagementGroupScopeResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -87,7 +87,7 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsCreateOrUpdateAtManagementGroupScopeResponse>
    */
-  createOrUpdateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsCreateOrUpdateAtManagementGroupScopeResponse> {
+  createOrUpdateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsCreateOrUpdateAtManagementGroupScopeResponse> {
     return this.beginCreateOrUpdateAtManagementGroupScope(groupId,deploymentName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.DeploymentsCreateOrUpdateAtManagementGroupScopeResponse>;
   }
@@ -99,21 +99,21 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsGetAtManagementGroupScopeResponse>
    */
-  getAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsGetAtManagementGroupScopeResponse>;
+  getAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsGetAtManagementGroupScopeResponse>;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  getAtManagementGroupScope(groupId: string, deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentExtended>): void;
+  getAtManagementGroupScope(groupId: string, deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentExtended>): void;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtManagementGroupScope(groupId: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentExtended>): void;
-  getAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentExtended>, callback?: msRest.ServiceCallback<Models.DeploymentExtended>): Promise<Models.DeploymentsGetAtManagementGroupScopeResponse> {
+  getAtManagementGroupScope(groupId: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentExtended>): void;
+  getAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentExtended>, callback?: coreHttp.ServiceCallback<Models.DeploymentExtended>): Promise<Models.DeploymentsGetAtManagementGroupScopeResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -133,23 +133,23 @@ export class Deployments {
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  cancelAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  cancelAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  cancelAtManagementGroupScope(groupId: string, deploymentName: string, callback: msRest.ServiceCallback<void>): void;
+  cancelAtManagementGroupScope(groupId: string, deploymentName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  cancelAtManagementGroupScope(groupId: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  cancelAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  cancelAtManagementGroupScope(groupId: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  cancelAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -169,14 +169,14 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsValidateAtManagementGroupScopeResponse>
    */
-  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsValidateAtManagementGroupScopeResponse>;
+  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsValidateAtManagementGroupScopeResponse>;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param parameters Parameters to validate.
    * @param callback The callback
    */
-  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, callback: msRest.ServiceCallback<Models.DeploymentValidateResult>): void;
+  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, callback: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): void;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
@@ -184,8 +184,8 @@ export class Deployments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentValidateResult>): void;
-  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentValidateResult>, callback?: msRest.ServiceCallback<Models.DeploymentValidateResult>): Promise<Models.DeploymentsValidateAtManagementGroupScopeResponse> {
+  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): void;
+  validateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentValidateResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): Promise<Models.DeploymentsValidateAtManagementGroupScopeResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -204,21 +204,21 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsExportTemplateAtManagementGroupScopeResponse>
    */
-  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsExportTemplateAtManagementGroupScopeResponse>;
+  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsExportTemplateAtManagementGroupScopeResponse>;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentExportResult>): void;
+  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentExportResult>): void;
   /**
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentExportResult>): void;
-  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentExportResult>, callback?: msRest.ServiceCallback<Models.DeploymentExportResult>): Promise<Models.DeploymentsExportTemplateAtManagementGroupScopeResponse> {
+  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentExportResult>): void;
+  exportTemplateAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentExportResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentExportResult>): Promise<Models.DeploymentsExportTemplateAtManagementGroupScopeResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -240,14 +240,14 @@ export class Deployments {
    * @param groupId The management group ID.
    * @param callback The callback
    */
-  listAtManagementGroupScope(groupId: string, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtManagementGroupScope(groupId: string, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
   /**
    * @param groupId The management group ID.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtManagementGroupScope(groupId: string, options: Models.DeploymentsListAtManagementGroupScopeOptionalParams, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
-  listAtManagementGroupScope(groupId: string, options?: Models.DeploymentsListAtManagementGroupScopeOptionalParams | msRest.ServiceCallback<Models.DeploymentListResult>, callback?: msRest.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtManagementGroupScopeResponse> {
+  listAtManagementGroupScope(groupId: string, options: Models.DeploymentsListAtManagementGroupScopeOptionalParams, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtManagementGroupScope(groupId: string, options?: Models.DeploymentsListAtManagementGroupScopeOptionalParams | coreHttp.ServiceCallback<Models.DeploymentListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtManagementGroupScopeResponse> {
     return this.client.sendOperationRequest(
       {
         groupId,
@@ -268,9 +268,9 @@ export class Deployments {
    * @summary Deletes a deployment from the deployment history.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteAtSubscriptionScope(deploymentName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -281,19 +281,19 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsCheckExistenceAtSubscriptionScopeResponse>
    */
-  checkExistenceAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsCheckExistenceAtSubscriptionScopeResponse>;
+  checkExistenceAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsCheckExistenceAtSubscriptionScopeResponse>;
   /**
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  checkExistenceAtSubscriptionScope(deploymentName: string, callback: msRest.ServiceCallback<boolean>): void;
+  checkExistenceAtSubscriptionScope(deploymentName: string, callback: coreHttp.ServiceCallback<boolean>): void;
   /**
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  checkExistenceAtSubscriptionScope(deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<boolean>): void;
-  checkExistenceAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.DeploymentsCheckExistenceAtSubscriptionScopeResponse> {
+  checkExistenceAtSubscriptionScope(deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<boolean>): void;
+  checkExistenceAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<boolean>, callback?: coreHttp.ServiceCallback<boolean>): Promise<Models.DeploymentsCheckExistenceAtSubscriptionScopeResponse> {
     return this.client.sendOperationRequest(
       {
         deploymentName,
@@ -311,7 +311,7 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsCreateOrUpdateAtSubscriptionScopeResponse>
    */
-  createOrUpdateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsCreateOrUpdateAtSubscriptionScopeResponse> {
+  createOrUpdateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsCreateOrUpdateAtSubscriptionScopeResponse> {
     return this.beginCreateOrUpdateAtSubscriptionScope(deploymentName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.DeploymentsCreateOrUpdateAtSubscriptionScopeResponse>;
   }
@@ -322,19 +322,19 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsGetAtSubscriptionScopeResponse>
    */
-  getAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsGetAtSubscriptionScopeResponse>;
+  getAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsGetAtSubscriptionScopeResponse>;
   /**
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  getAtSubscriptionScope(deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentExtended>): void;
+  getAtSubscriptionScope(deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentExtended>): void;
   /**
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getAtSubscriptionScope(deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentExtended>): void;
-  getAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentExtended>, callback?: msRest.ServiceCallback<Models.DeploymentExtended>): Promise<Models.DeploymentsGetAtSubscriptionScopeResponse> {
+  getAtSubscriptionScope(deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentExtended>): void;
+  getAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentExtended>, callback?: coreHttp.ServiceCallback<Models.DeploymentExtended>): Promise<Models.DeploymentsGetAtSubscriptionScopeResponse> {
     return this.client.sendOperationRequest(
       {
         deploymentName,
@@ -352,21 +352,21 @@ export class Deployments {
    * @summary Cancels a currently running template deployment.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  cancelAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  cancelAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  cancelAtSubscriptionScope(deploymentName: string, callback: msRest.ServiceCallback<void>): void;
+  cancelAtSubscriptionScope(deploymentName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  cancelAtSubscriptionScope(deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  cancelAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  cancelAtSubscriptionScope(deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  cancelAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         deploymentName,
@@ -384,21 +384,21 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsValidateAtSubscriptionScopeResponse>
    */
-  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsValidateAtSubscriptionScopeResponse>;
+  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsValidateAtSubscriptionScopeResponse>;
   /**
    * @param deploymentName The name of the deployment.
    * @param parameters Parameters to validate.
    * @param callback The callback
    */
-  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, callback: msRest.ServiceCallback<Models.DeploymentValidateResult>): void;
+  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, callback: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): void;
   /**
    * @param deploymentName The name of the deployment.
    * @param parameters Parameters to validate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentValidateResult>): void;
-  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentValidateResult>, callback?: msRest.ServiceCallback<Models.DeploymentValidateResult>): Promise<Models.DeploymentsValidateAtSubscriptionScopeResponse> {
+  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): void;
+  validateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentValidateResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): Promise<Models.DeploymentsValidateAtSubscriptionScopeResponse> {
     return this.client.sendOperationRequest(
       {
         deploymentName,
@@ -415,19 +415,19 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsExportTemplateAtSubscriptionScopeResponse>
    */
-  exportTemplateAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsExportTemplateAtSubscriptionScopeResponse>;
+  exportTemplateAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsExportTemplateAtSubscriptionScopeResponse>;
   /**
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  exportTemplateAtSubscriptionScope(deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentExportResult>): void;
+  exportTemplateAtSubscriptionScope(deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentExportResult>): void;
   /**
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  exportTemplateAtSubscriptionScope(deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentExportResult>): void;
-  exportTemplateAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentExportResult>, callback?: msRest.ServiceCallback<Models.DeploymentExportResult>): Promise<Models.DeploymentsExportTemplateAtSubscriptionScopeResponse> {
+  exportTemplateAtSubscriptionScope(deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentExportResult>): void;
+  exportTemplateAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentExportResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentExportResult>): Promise<Models.DeploymentsExportTemplateAtSubscriptionScopeResponse> {
     return this.client.sendOperationRequest(
       {
         deploymentName,
@@ -446,13 +446,13 @@ export class Deployments {
   /**
    * @param callback The callback
    */
-  listAtSubscriptionScope(callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtSubscriptionScope(callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscriptionScope(options: Models.DeploymentsListAtSubscriptionScopeOptionalParams, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
-  listAtSubscriptionScope(options?: Models.DeploymentsListAtSubscriptionScopeOptionalParams | msRest.ServiceCallback<Models.DeploymentListResult>, callback?: msRest.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtSubscriptionScopeResponse> {
+  listAtSubscriptionScope(options: Models.DeploymentsListAtSubscriptionScopeOptionalParams, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtSubscriptionScope(options?: Models.DeploymentsListAtSubscriptionScopeOptionalParams | coreHttp.ServiceCallback<Models.DeploymentListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtSubscriptionScopeResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -475,9 +475,9 @@ export class Deployments {
    * is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,deploymentName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -490,14 +490,14 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsCheckExistenceResponse>
    */
-  checkExistence(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsCheckExistenceResponse>;
+  checkExistence(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsCheckExistenceResponse>;
   /**
    * @param resourceGroupName The name of the resource group with the deployment to check. The name
    * is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  checkExistence(resourceGroupName: string, deploymentName: string, callback: msRest.ServiceCallback<boolean>): void;
+  checkExistence(resourceGroupName: string, deploymentName: string, callback: coreHttp.ServiceCallback<boolean>): void;
   /**
    * @param resourceGroupName The name of the resource group with the deployment to check. The name
    * is case insensitive.
@@ -505,8 +505,8 @@ export class Deployments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  checkExistence(resourceGroupName: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<boolean>): void;
-  checkExistence(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.DeploymentsCheckExistenceResponse> {
+  checkExistence(resourceGroupName: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<boolean>): void;
+  checkExistence(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<boolean>, callback?: coreHttp.ServiceCallback<boolean>): Promise<Models.DeploymentsCheckExistenceResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -527,7 +527,7 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,deploymentName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.DeploymentsCreateOrUpdateResponse>;
   }
@@ -539,21 +539,21 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsGetResponse>
    */
-  get(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsGetResponse>;
+  get(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  get(resourceGroupName: string, deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentExtended>): void;
+  get(resourceGroupName: string, deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentExtended>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentExtended>): void;
-  get(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentExtended>, callback?: msRest.ServiceCallback<Models.DeploymentExtended>): Promise<Models.DeploymentsGetResponse> {
+  get(resourceGroupName: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentExtended>): void;
+  get(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentExtended>, callback?: coreHttp.ServiceCallback<Models.DeploymentExtended>): Promise<Models.DeploymentsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -573,23 +573,23 @@ export class Deployments {
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  cancel(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  cancel(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  cancel(resourceGroupName: string, deploymentName: string, callback: msRest.ServiceCallback<void>): void;
+  cancel(resourceGroupName: string, deploymentName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  cancel(resourceGroupName: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  cancel(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  cancel(resourceGroupName: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  cancel(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -610,7 +610,7 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsValidateResponse>
    */
-  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsValidateResponse>;
+  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsValidateResponse>;
   /**
    * @param resourceGroupName The name of the resource group the template will be deployed to. The
    * name is case insensitive.
@@ -618,7 +618,7 @@ export class Deployments {
    * @param parameters Parameters to validate.
    * @param callback The callback
    */
-  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, callback: msRest.ServiceCallback<Models.DeploymentValidateResult>): void;
+  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, callback: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): void;
   /**
    * @param resourceGroupName The name of the resource group the template will be deployed to. The
    * name is case insensitive.
@@ -627,8 +627,8 @@ export class Deployments {
    * @param options The optional parameters
    * @param callback The callback
    */
-  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentValidateResult>): void;
-  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentValidateResult>, callback?: msRest.ServiceCallback<Models.DeploymentValidateResult>): Promise<Models.DeploymentsValidateResponse> {
+  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): void;
+  validate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentValidateResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentValidateResult>): Promise<Models.DeploymentsValidateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -647,21 +647,21 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsExportTemplateResponse>
    */
-  exportTemplate(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsExportTemplateResponse>;
+  exportTemplate(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsExportTemplateResponse>;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param callback The callback
    */
-  exportTemplate(resourceGroupName: string, deploymentName: string, callback: msRest.ServiceCallback<Models.DeploymentExportResult>): void;
+  exportTemplate(resourceGroupName: string, deploymentName: string, callback: coreHttp.ServiceCallback<Models.DeploymentExportResult>): void;
   /**
    * @param resourceGroupName The name of the resource group. The name is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param options The optional parameters
    * @param callback The callback
    */
-  exportTemplate(resourceGroupName: string, deploymentName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentExportResult>): void;
-  exportTemplate(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentExportResult>, callback?: msRest.ServiceCallback<Models.DeploymentExportResult>): Promise<Models.DeploymentsExportTemplateResponse> {
+  exportTemplate(resourceGroupName: string, deploymentName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentExportResult>): void;
+  exportTemplate(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentExportResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentExportResult>): Promise<Models.DeploymentsExportTemplateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -685,15 +685,15 @@ export class Deployments {
    * case insensitive.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
   /**
    * @param resourceGroupName The name of the resource group with the deployments to get. The name is
    * case insensitive.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: Models.DeploymentsListByResourceGroupOptionalParams, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
-  listByResourceGroup(resourceGroupName: string, options?: Models.DeploymentsListByResourceGroupOptionalParams | msRest.ServiceCallback<Models.DeploymentListResult>, callback?: msRest.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: Models.DeploymentsListByResourceGroupOptionalParams, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
+  listByResourceGroup(resourceGroupName: string, options?: Models.DeploymentsListByResourceGroupOptionalParams | coreHttp.ServiceCallback<Models.DeploymentListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -715,9 +715,9 @@ export class Deployments {
    * @param groupId The management group ID.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteAtManagementGroupScope(groupId: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteAtManagementGroupScope(groupId: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         groupId,
@@ -735,9 +735,9 @@ export class Deployments {
    * @param deploymentName The name of the deployment.
    * @param parameters Additional parameters supplied to the operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdateAtManagementGroupScope(groupId: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         groupId,
@@ -760,9 +760,9 @@ export class Deployments {
    * @summary Deletes a deployment from the deployment history.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteAtSubscriptionScope(deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteAtSubscriptionScope(deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         deploymentName,
@@ -778,9 +778,9 @@ export class Deployments {
    * @param deploymentName The name of the deployment.
    * @param parameters Additional parameters supplied to the operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdateAtSubscriptionScope(deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         deploymentName,
@@ -805,9 +805,9 @@ export class Deployments {
    * is case insensitive.
    * @param deploymentName The name of the deployment.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, deploymentName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, deploymentName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -826,9 +826,9 @@ export class Deployments {
    * @param deploymentName The name of the deployment.
    * @param parameters Additional parameters supplied to the operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, deploymentName: string, parameters: Models.Deployment, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -846,19 +846,19 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsListAtManagementGroupScopeNextResponse>
    */
-  listAtManagementGroupScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsListAtManagementGroupScopeNextResponse>;
+  listAtManagementGroupScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsListAtManagementGroupScopeNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtManagementGroupScopeNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtManagementGroupScopeNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtManagementGroupScopeNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
-  listAtManagementGroupScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentListResult>, callback?: msRest.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtManagementGroupScopeNextResponse> {
+  listAtManagementGroupScopeNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtManagementGroupScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtManagementGroupScopeNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -874,19 +874,19 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsListAtSubscriptionScopeNextResponse>
    */
-  listAtSubscriptionScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsListAtSubscriptionScopeNextResponse>;
+  listAtSubscriptionScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsListAtSubscriptionScopeNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listAtSubscriptionScopeNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtSubscriptionScopeNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listAtSubscriptionScopeNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
-  listAtSubscriptionScopeNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentListResult>, callback?: msRest.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtSubscriptionScopeNextResponse> {
+  listAtSubscriptionScopeNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
+  listAtSubscriptionScopeNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListAtSubscriptionScopeNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -902,19 +902,19 @@ export class Deployments {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeploymentsListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.DeploymentsListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeploymentsListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.DeploymentListResult>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.DeploymentListResult>, callback?: msRest.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeploymentListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeploymentListResult>, callback?: coreHttp.ServiceCallback<Models.DeploymentListResult>): Promise<Models.DeploymentsListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -926,8 +926,8 @@ export class Deployments {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const checkExistenceAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const checkExistenceAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "HEAD",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -950,7 +950,7 @@ const checkExistenceAtManagementGroupScopeOperationSpec: msRest.OperationSpec = 
   serializer
 };
 
-const getAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const getAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -974,7 +974,7 @@ const getAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const cancelAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const cancelAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/cancel",
   urlParameters: [
@@ -996,7 +996,7 @@ const cancelAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const validateAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const validateAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
   urlParameters: [
@@ -1030,7 +1030,7 @@ const validateAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const exportTemplateAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const exportTemplateAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}/exportTemplate",
   urlParameters: [
@@ -1054,7 +1054,7 @@ const exportTemplateAtManagementGroupScopeOperationSpec: msRest.OperationSpec = 
   serializer
 };
 
-const listAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const listAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/",
   urlParameters: [
@@ -1079,7 +1079,7 @@ const listAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const checkExistenceAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const checkExistenceAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "HEAD",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1102,7 +1102,7 @@ const checkExistenceAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const getAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1126,7 +1126,7 @@ const getAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const cancelAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const cancelAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/cancel",
   urlParameters: [
@@ -1148,7 +1148,7 @@ const cancelAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const validateAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const validateAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
   urlParameters: [
@@ -1182,7 +1182,7 @@ const validateAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const exportTemplateAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const exportTemplateAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}/exportTemplate",
   urlParameters: [
@@ -1206,7 +1206,7 @@ const exportTemplateAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/",
   urlParameters: [
@@ -1231,7 +1231,7 @@ const listAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const checkExistenceOperationSpec: msRest.OperationSpec = {
+const checkExistenceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "HEAD",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1255,7 +1255,7 @@ const checkExistenceOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1280,7 +1280,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const cancelOperationSpec: msRest.OperationSpec = {
+const cancelOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/cancel",
   urlParameters: [
@@ -1303,7 +1303,7 @@ const cancelOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const validateOperationSpec: msRest.OperationSpec = {
+const validateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/validate",
   urlParameters: [
@@ -1338,7 +1338,7 @@ const validateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const exportTemplateOperationSpec: msRest.OperationSpec = {
+const exportTemplateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}/exportTemplate",
   urlParameters: [
@@ -1363,7 +1363,7 @@ const exportTemplateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/",
   urlParameters: [
@@ -1389,7 +1389,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const beginDeleteAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1412,7 +1412,7 @@ const beginDeleteAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateAtManagementGroupScopeOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "providers/Microsoft.Management/managementGroups/{groupId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1446,7 +1446,7 @@ const beginCreateOrUpdateAtManagementGroupScopeOperationSpec: msRest.OperationSp
   serializer
 };
 
-const beginDeleteAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const beginDeleteAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1469,7 +1469,7 @@ const beginDeleteAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateAtSubscriptionScopeOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1503,7 +1503,7 @@ const beginCreateOrUpdateAtSubscriptionScopeOperationSpec: msRest.OperationSpec 
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1527,7 +1527,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Resources/deployments/{deploymentName}",
   urlParameters: [
@@ -1562,7 +1562,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtManagementGroupScopeNextOperationSpec: msRest.OperationSpec = {
+const listAtManagementGroupScopeNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1583,7 +1583,7 @@ const listAtManagementGroupScopeNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listAtSubscriptionScopeNextOperationSpec: msRest.OperationSpec = {
+const listAtSubscriptionScopeNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1604,7 +1604,7 @@ const listAtSubscriptionScopeNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/resources/arm-resources/src/operations/operations.ts
+++ b/sdk/resources/arm-resources/src/operations/operations.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/operationsMappers";
 import * as Parameters from "../models/parameters";
@@ -31,17 +31,17 @@ export class Operations {
    * @param [options] The optional parameters
    * @returns Promise<Models.OperationsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.OperationsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.OperationsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -56,19 +56,19 @@ export class Operations {
    * @param [options] The optional parameters
    * @returns Promise<Models.OperationsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.OperationsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.OperationsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.OperationListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.OperationListResult>, callback?: msRest.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.OperationListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.OperationListResult>, callback?: coreHttp.ServiceCallback<Models.OperationListResult>): Promise<Models.OperationsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -80,8 +80,8 @@ export class Operations {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "providers/Microsoft.Resources/operations",
   queryParameters: [
@@ -101,7 +101,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/resources/arm-resources/src/operations/providers.ts
+++ b/sdk/resources/arm-resources/src/operations/providers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/providersMappers";
 import * as Parameters from "../models/parameters";
@@ -32,19 +32,19 @@ export class Providers {
    * @param [options] The optional parameters
    * @returns Promise<Models.ProvidersUnregisterResponse>
    */
-  unregister(resourceProviderNamespace: string, options?: msRest.RequestOptionsBase): Promise<Models.ProvidersUnregisterResponse>;
+  unregister(resourceProviderNamespace: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ProvidersUnregisterResponse>;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider to unregister.
    * @param callback The callback
    */
-  unregister(resourceProviderNamespace: string, callback: msRest.ServiceCallback<Models.Provider>): void;
+  unregister(resourceProviderNamespace: string, callback: coreHttp.ServiceCallback<Models.Provider>): void;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider to unregister.
    * @param options The optional parameters
    * @param callback The callback
    */
-  unregister(resourceProviderNamespace: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Provider>): void;
-  unregister(resourceProviderNamespace: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Provider>, callback?: msRest.ServiceCallback<Models.Provider>): Promise<Models.ProvidersUnregisterResponse> {
+  unregister(resourceProviderNamespace: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Provider>): void;
+  unregister(resourceProviderNamespace: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Provider>, callback?: coreHttp.ServiceCallback<Models.Provider>): Promise<Models.ProvidersUnregisterResponse> {
     return this.client.sendOperationRequest(
       {
         resourceProviderNamespace,
@@ -60,19 +60,19 @@ export class Providers {
    * @param [options] The optional parameters
    * @returns Promise<Models.ProvidersRegisterResponse>
    */
-  register(resourceProviderNamespace: string, options?: msRest.RequestOptionsBase): Promise<Models.ProvidersRegisterResponse>;
+  register(resourceProviderNamespace: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ProvidersRegisterResponse>;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider to register.
    * @param callback The callback
    */
-  register(resourceProviderNamespace: string, callback: msRest.ServiceCallback<Models.Provider>): void;
+  register(resourceProviderNamespace: string, callback: coreHttp.ServiceCallback<Models.Provider>): void;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider to register.
    * @param options The optional parameters
    * @param callback The callback
    */
-  register(resourceProviderNamespace: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Provider>): void;
-  register(resourceProviderNamespace: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Provider>, callback?: msRest.ServiceCallback<Models.Provider>): Promise<Models.ProvidersRegisterResponse> {
+  register(resourceProviderNamespace: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Provider>): void;
+  register(resourceProviderNamespace: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Provider>, callback?: coreHttp.ServiceCallback<Models.Provider>): Promise<Models.ProvidersRegisterResponse> {
     return this.client.sendOperationRequest(
       {
         resourceProviderNamespace,
@@ -91,13 +91,13 @@ export class Providers {
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.ProviderListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.ProviderListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: Models.ProvidersListOptionalParams, callback: msRest.ServiceCallback<Models.ProviderListResult>): void;
-  list(options?: Models.ProvidersListOptionalParams | msRest.ServiceCallback<Models.ProviderListResult>, callback?: msRest.ServiceCallback<Models.ProviderListResult>): Promise<Models.ProvidersListResponse> {
+  list(options: Models.ProvidersListOptionalParams, callback: coreHttp.ServiceCallback<Models.ProviderListResult>): void;
+  list(options?: Models.ProvidersListOptionalParams | coreHttp.ServiceCallback<Models.ProviderListResult>, callback?: coreHttp.ServiceCallback<Models.ProviderListResult>): Promise<Models.ProvidersListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -117,14 +117,14 @@ export class Providers {
    * @param resourceProviderNamespace The namespace of the resource provider.
    * @param callback The callback
    */
-  get(resourceProviderNamespace: string, callback: msRest.ServiceCallback<Models.Provider>): void;
+  get(resourceProviderNamespace: string, callback: coreHttp.ServiceCallback<Models.Provider>): void;
   /**
    * @param resourceProviderNamespace The namespace of the resource provider.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceProviderNamespace: string, options: Models.ProvidersGetOptionalParams, callback: msRest.ServiceCallback<Models.Provider>): void;
-  get(resourceProviderNamespace: string, options?: Models.ProvidersGetOptionalParams | msRest.ServiceCallback<Models.Provider>, callback?: msRest.ServiceCallback<Models.Provider>): Promise<Models.ProvidersGetResponse> {
+  get(resourceProviderNamespace: string, options: Models.ProvidersGetOptionalParams, callback: coreHttp.ServiceCallback<Models.Provider>): void;
+  get(resourceProviderNamespace: string, options?: Models.ProvidersGetOptionalParams | coreHttp.ServiceCallback<Models.Provider>, callback?: coreHttp.ServiceCallback<Models.Provider>): Promise<Models.ProvidersGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceProviderNamespace,
@@ -140,19 +140,19 @@ export class Providers {
    * @param [options] The optional parameters
    * @returns Promise<Models.ProvidersListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ProvidersListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ProvidersListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ProviderListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ProviderListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ProviderListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ProviderListResult>, callback?: msRest.ServiceCallback<Models.ProviderListResult>): Promise<Models.ProvidersListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ProviderListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ProviderListResult>, callback?: coreHttp.ServiceCallback<Models.ProviderListResult>): Promise<Models.ProvidersListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -164,8 +164,8 @@ export class Providers {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const unregisterOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const unregisterOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}/unregister",
   urlParameters: [
@@ -189,7 +189,7 @@ const unregisterOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const registerOperationSpec: msRest.OperationSpec = {
+const registerOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}/register",
   urlParameters: [
@@ -213,7 +213,7 @@ const registerOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers",
   urlParameters: [
@@ -238,7 +238,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/{resourceProviderNamespace}",
   urlParameters: [
@@ -263,7 +263,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/resources/arm-resources/src/operations/resourceGroups.ts
+++ b/sdk/resources/arm-resources/src/operations/resourceGroups.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/resourceGroupsMappers";
 import * as Parameters from "../models/parameters";
@@ -33,19 +33,19 @@ export class ResourceGroups {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceGroupsCheckExistenceResponse>
    */
-  checkExistence(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourceGroupsCheckExistenceResponse>;
+  checkExistence(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceGroupsCheckExistenceResponse>;
   /**
    * @param resourceGroupName The name of the resource group to check. The name is case insensitive.
    * @param callback The callback
    */
-  checkExistence(resourceGroupName: string, callback: msRest.ServiceCallback<boolean>): void;
+  checkExistence(resourceGroupName: string, callback: coreHttp.ServiceCallback<boolean>): void;
   /**
    * @param resourceGroupName The name of the resource group to check. The name is case insensitive.
    * @param options The optional parameters
    * @param callback The callback
    */
-  checkExistence(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<boolean>): void;
-  checkExistence(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.ResourceGroupsCheckExistenceResponse> {
+  checkExistence(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<boolean>): void;
+  checkExistence(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<boolean>, callback?: coreHttp.ServiceCallback<boolean>): Promise<Models.ResourceGroupsCheckExistenceResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -64,7 +64,7 @@ export class ResourceGroups {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceGroupsCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, options?: msRest.RequestOptionsBase): Promise<Models.ResourceGroupsCreateOrUpdateResponse>;
+  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceGroupsCreateOrUpdateResponse>;
   /**
    * @param resourceGroupName The name of the resource group to create or update. Can include
    * alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters
@@ -72,7 +72,7 @@ export class ResourceGroups {
    * @param parameters Parameters supplied to the create or update a resource group.
    * @param callback The callback
    */
-  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, callback: msRest.ServiceCallback<Models.ResourceGroup>): void;
+  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, callback: coreHttp.ServiceCallback<Models.ResourceGroup>): void;
   /**
    * @param resourceGroupName The name of the resource group to create or update. Can include
    * alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters
@@ -81,8 +81,8 @@ export class ResourceGroups {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceGroup>): void;
-  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceGroup>, callback?: msRest.ServiceCallback<Models.ResourceGroup>): Promise<Models.ResourceGroupsCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceGroup>): void;
+  createOrUpdate(resourceGroupName: string, parameters: Models.ResourceGroup, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceGroup>, callback?: coreHttp.ServiceCallback<Models.ResourceGroup>): Promise<Models.ResourceGroupsCreateOrUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -99,9 +99,9 @@ export class ResourceGroups {
    * @summary Deletes a resource group.
    * @param resourceGroupName The name of the resource group to delete. The name is case insensitive.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -112,19 +112,19 @@ export class ResourceGroups {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceGroupsGetResponse>
    */
-  get(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourceGroupsGetResponse>;
+  get(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceGroupsGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group to get. The name is case insensitive.
    * @param callback The callback
    */
-  get(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ResourceGroup>): void;
+  get(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.ResourceGroup>): void;
   /**
    * @param resourceGroupName The name of the resource group to get. The name is case insensitive.
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceGroup>): void;
-  get(resourceGroupName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceGroup>, callback?: msRest.ServiceCallback<Models.ResourceGroup>): Promise<Models.ResourceGroupsGetResponse> {
+  get(resourceGroupName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceGroup>): void;
+  get(resourceGroupName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceGroup>, callback?: coreHttp.ServiceCallback<Models.ResourceGroup>): Promise<Models.ResourceGroupsGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -144,21 +144,21 @@ export class ResourceGroups {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceGroupsUpdateResponse>
    */
-  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, options?: msRest.RequestOptionsBase): Promise<Models.ResourceGroupsUpdateResponse>;
+  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceGroupsUpdateResponse>;
   /**
    * @param resourceGroupName The name of the resource group to update. The name is case insensitive.
    * @param parameters Parameters supplied to update a resource group.
    * @param callback The callback
    */
-  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, callback: msRest.ServiceCallback<Models.ResourceGroup>): void;
+  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, callback: coreHttp.ServiceCallback<Models.ResourceGroup>): void;
   /**
    * @param resourceGroupName The name of the resource group to update. The name is case insensitive.
    * @param parameters Parameters supplied to update a resource group.
    * @param options The optional parameters
    * @param callback The callback
    */
-  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceGroup>): void;
-  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceGroup>, callback?: msRest.ServiceCallback<Models.ResourceGroup>): Promise<Models.ResourceGroupsUpdateResponse> {
+  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceGroup>): void;
+  update(resourceGroupName: string, parameters: Models.ResourceGroupPatchable, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceGroup>, callback?: coreHttp.ServiceCallback<Models.ResourceGroup>): Promise<Models.ResourceGroupsUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -176,21 +176,21 @@ export class ResourceGroups {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceGroupsExportTemplateResponse>
    */
-  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, options?: msRest.RequestOptionsBase): Promise<Models.ResourceGroupsExportTemplateResponse>;
+  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceGroupsExportTemplateResponse>;
   /**
    * @param resourceGroupName The name of the resource group to export as a template.
    * @param parameters Parameters for exporting the template.
    * @param callback The callback
    */
-  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, callback: msRest.ServiceCallback<Models.ResourceGroupExportResult>): void;
+  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, callback: coreHttp.ServiceCallback<Models.ResourceGroupExportResult>): void;
   /**
    * @param resourceGroupName The name of the resource group to export as a template.
    * @param parameters Parameters for exporting the template.
    * @param options The optional parameters
    * @param callback The callback
    */
-  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceGroupExportResult>): void;
-  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceGroupExportResult>, callback?: msRest.ServiceCallback<Models.ResourceGroupExportResult>): Promise<Models.ResourceGroupsExportTemplateResponse> {
+  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceGroupExportResult>): void;
+  exportTemplate(resourceGroupName: string, parameters: Models.ExportTemplateRequest, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceGroupExportResult>, callback?: coreHttp.ServiceCallback<Models.ResourceGroupExportResult>): Promise<Models.ResourceGroupsExportTemplateResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -210,13 +210,13 @@ export class ResourceGroups {
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.ResourceGroupListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.ResourceGroupListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: Models.ResourceGroupsListOptionalParams, callback: msRest.ServiceCallback<Models.ResourceGroupListResult>): void;
-  list(options?: Models.ResourceGroupsListOptionalParams | msRest.ServiceCallback<Models.ResourceGroupListResult>, callback?: msRest.ServiceCallback<Models.ResourceGroupListResult>): Promise<Models.ResourceGroupsListResponse> {
+  list(options: Models.ResourceGroupsListOptionalParams, callback: coreHttp.ServiceCallback<Models.ResourceGroupListResult>): void;
+  list(options?: Models.ResourceGroupsListOptionalParams | coreHttp.ServiceCallback<Models.ResourceGroupListResult>, callback?: coreHttp.ServiceCallback<Models.ResourceGroupListResult>): Promise<Models.ResourceGroupsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -231,9 +231,9 @@ export class ResourceGroups {
    * @summary Deletes a resource group.
    * @param resourceGroupName The name of the resource group to delete. The name is case insensitive.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -249,19 +249,19 @@ export class ResourceGroups {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourceGroupsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourceGroupsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourceGroupsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ResourceGroupListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ResourceGroupListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceGroupListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceGroupListResult>, callback?: msRest.ServiceCallback<Models.ResourceGroupListResult>): Promise<Models.ResourceGroupsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceGroupListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceGroupListResult>, callback?: coreHttp.ServiceCallback<Models.ResourceGroupListResult>): Promise<Models.ResourceGroupsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -273,8 +273,8 @@ export class ResourceGroups {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const checkExistenceOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const checkExistenceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "HEAD",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
   urlParameters: [
@@ -297,7 +297,7 @@ const checkExistenceOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateOperationSpec: msRest.OperationSpec = {
+const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
   urlParameters: [
@@ -331,7 +331,7 @@ const createOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
   urlParameters: [
@@ -355,7 +355,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const updateOperationSpec: msRest.OperationSpec = {
+const updateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
   urlParameters: [
@@ -386,7 +386,7 @@ const updateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const exportTemplateOperationSpec: msRest.OperationSpec = {
+const exportTemplateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/exportTemplate",
   urlParameters: [
@@ -417,7 +417,7 @@ const exportTemplateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups",
   urlParameters: [
@@ -442,7 +442,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
   urlParameters: [
@@ -465,7 +465,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/resources/arm-resources/src/operations/resources.ts
+++ b/sdk/resources/arm-resources/src/operations/resources.ts
@@ -8,8 +8,8 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 import * as Models from "../models";
 import * as Mappers from "../models/resourcesMappers";
 import * as Parameters from "../models/parameters";
@@ -38,14 +38,14 @@ export class Resources {
    * @param resourceGroupName The resource group with the resources to get.
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
+  listByResourceGroup(resourceGroupName: string, callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
   /**
    * @param resourceGroupName The resource group with the resources to get.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroup(resourceGroupName: string, options: Models.ResourcesListByResourceGroupOptionalParams, callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
-  listByResourceGroup(resourceGroupName: string, options?: Models.ResourcesListByResourceGroupOptionalParams | msRest.ServiceCallback<Models.ResourceListResult>, callback?: msRest.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListByResourceGroupResponse> {
+  listByResourceGroup(resourceGroupName: string, options: Models.ResourcesListByResourceGroupOptionalParams, callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
+  listByResourceGroup(resourceGroupName: string, options?: Models.ResourcesListByResourceGroupOptionalParams | coreHttp.ServiceCallback<Models.ResourceListResult>, callback?: coreHttp.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListByResourceGroupResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -64,9 +64,9 @@ export class Resources {
    * @param sourceResourceGroupName The name of the resource group containing the resources to move.
    * @param parameters Parameters for moving resources.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  moveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  moveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginMoveResources(sourceResourceGroupName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -83,9 +83,9 @@ export class Resources {
    * validate for move.
    * @param parameters Parameters for moving resources.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  validateMoveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  validateMoveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginValidateMoveResources(sourceResourceGroupName,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -99,13 +99,13 @@ export class Resources {
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: Models.ResourcesListOptionalParams, callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
-  list(options?: Models.ResourcesListOptionalParams | msRest.ServiceCallback<Models.ResourceListResult>, callback?: msRest.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListResponse> {
+  list(options: Models.ResourcesListOptionalParams, callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
+  list(options?: Models.ResourcesListOptionalParams | coreHttp.ServiceCallback<Models.ResourceListResult>, callback?: coreHttp.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -126,7 +126,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesCheckExistenceResponse>
    */
-  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesCheckExistenceResponse>;
+  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesCheckExistenceResponse>;
   /**
    * @param resourceGroupName The name of the resource group containing the resource to check. The
    * name is case insensitive.
@@ -137,7 +137,7 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param callback The callback
    */
-  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, callback: msRest.ServiceCallback<boolean>): void;
+  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, callback: coreHttp.ServiceCallback<boolean>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the resource to check. The
    * name is case insensitive.
@@ -149,8 +149,8 @@ export class Resources {
    * @param options The optional parameters
    * @param callback The callback
    */
-  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<boolean>): void;
-  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.ResourcesCheckExistenceResponse> {
+  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<boolean>): void;
+  checkExistence(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<boolean>, callback?: coreHttp.ServiceCallback<boolean>): Promise<Models.ResourcesCheckExistenceResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -175,9 +175,9 @@ export class Resources {
    * @param resourceName The name of the resource to delete.
    * @param apiVersion The API version to use for the operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteMethod(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteMethod(resourceGroupName,resourceProviderNamespace,parentResourcePath,resourceType,resourceName,apiVersion,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -195,7 +195,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesCreateOrUpdateResponse>
    */
-  createOrUpdate(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesCreateOrUpdateResponse> {
+  createOrUpdate(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesCreateOrUpdateResponse> {
     return this.beginCreateOrUpdate(resourceGroupName,resourceProviderNamespace,parentResourcePath,resourceType,resourceName,apiVersion,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ResourcesCreateOrUpdateResponse>;
   }
@@ -213,7 +213,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesUpdateResponse>
    */
-  update(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesUpdateResponse> {
+  update(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesUpdateResponse> {
     return this.beginUpdate(resourceGroupName,resourceProviderNamespace,parentResourcePath,resourceType,resourceName,apiVersion,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ResourcesUpdateResponse>;
   }
@@ -230,7 +230,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesGetResponse>
    */
-  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesGetResponse>;
+  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesGetResponse>;
   /**
    * @param resourceGroupName The name of the resource group containing the resource to get. The name
    * is case insensitive.
@@ -241,7 +241,7 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param callback The callback
    */
-  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, callback: msRest.ServiceCallback<Models.GenericResource>): void;
+  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, callback: coreHttp.ServiceCallback<Models.GenericResource>): void;
   /**
    * @param resourceGroupName The name of the resource group containing the resource to get. The name
    * is case insensitive.
@@ -253,8 +253,8 @@ export class Resources {
    * @param options The optional parameters
    * @param callback The callback
    */
-  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GenericResource>): void;
-  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GenericResource>, callback?: msRest.ServiceCallback<Models.GenericResource>): Promise<Models.ResourcesGetResponse> {
+  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GenericResource>): void;
+  get(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GenericResource>, callback?: coreHttp.ServiceCallback<Models.GenericResource>): Promise<Models.ResourcesGetResponse> {
     return this.client.sendOperationRequest(
       {
         resourceGroupName,
@@ -278,7 +278,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesCheckExistenceByIdResponse>
    */
-  checkExistenceById(resourceId: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesCheckExistenceByIdResponse>;
+  checkExistenceById(resourceId: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesCheckExistenceByIdResponse>;
   /**
    * @param resourceId The fully qualified ID of the resource, including the resource name and
    * resource type. Use the format,
@@ -286,7 +286,7 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param callback The callback
    */
-  checkExistenceById(resourceId: string, apiVersion: string, callback: msRest.ServiceCallback<boolean>): void;
+  checkExistenceById(resourceId: string, apiVersion: string, callback: coreHttp.ServiceCallback<boolean>): void;
   /**
    * @param resourceId The fully qualified ID of the resource, including the resource name and
    * resource type. Use the format,
@@ -295,8 +295,8 @@ export class Resources {
    * @param options The optional parameters
    * @param callback The callback
    */
-  checkExistenceById(resourceId: string, apiVersion: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<boolean>): void;
-  checkExistenceById(resourceId: string, apiVersion: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<boolean>, callback?: msRest.ServiceCallback<boolean>): Promise<Models.ResourcesCheckExistenceByIdResponse> {
+  checkExistenceById(resourceId: string, apiVersion: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<boolean>): void;
+  checkExistenceById(resourceId: string, apiVersion: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<boolean>, callback?: coreHttp.ServiceCallback<boolean>): Promise<Models.ResourcesCheckExistenceByIdResponse> {
     return this.client.sendOperationRequest(
       {
         resourceId,
@@ -314,9 +314,9 @@ export class Resources {
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/{resource-provider-namespace}/{resource-type}/{resource-name}
    * @param apiVersion The API version to use for the operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteById(resourceId: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
+  deleteById(resourceId: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse> {
     return this.beginDeleteById(resourceId,apiVersion,options)
       .then(lroPoller => lroPoller.pollUntilFinished());
   }
@@ -331,7 +331,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesCreateOrUpdateByIdResponse>
    */
-  createOrUpdateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesCreateOrUpdateByIdResponse> {
+  createOrUpdateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesCreateOrUpdateByIdResponse> {
     return this.beginCreateOrUpdateById(resourceId,apiVersion,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ResourcesCreateOrUpdateByIdResponse>;
   }
@@ -346,7 +346,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesUpdateByIdResponse>
    */
-  updateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesUpdateByIdResponse> {
+  updateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesUpdateByIdResponse> {
     return this.beginUpdateById(resourceId,apiVersion,parameters,options)
       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.ResourcesUpdateByIdResponse>;
   }
@@ -360,7 +360,7 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesGetByIdResponse>
    */
-  getById(resourceId: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesGetByIdResponse>;
+  getById(resourceId: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesGetByIdResponse>;
   /**
    * @param resourceId The fully qualified ID of the resource, including the resource name and
    * resource type. Use the format,
@@ -368,7 +368,7 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param callback The callback
    */
-  getById(resourceId: string, apiVersion: string, callback: msRest.ServiceCallback<Models.GenericResource>): void;
+  getById(resourceId: string, apiVersion: string, callback: coreHttp.ServiceCallback<Models.GenericResource>): void;
   /**
    * @param resourceId The fully qualified ID of the resource, including the resource name and
    * resource type. Use the format,
@@ -377,8 +377,8 @@ export class Resources {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getById(resourceId: string, apiVersion: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.GenericResource>): void;
-  getById(resourceId: string, apiVersion: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.GenericResource>, callback?: msRest.ServiceCallback<Models.GenericResource>): Promise<Models.ResourcesGetByIdResponse> {
+  getById(resourceId: string, apiVersion: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.GenericResource>): void;
+  getById(resourceId: string, apiVersion: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.GenericResource>, callback?: coreHttp.ServiceCallback<Models.GenericResource>): Promise<Models.ResourcesGetByIdResponse> {
     return this.client.sendOperationRequest(
       {
         resourceId,
@@ -398,9 +398,9 @@ export class Resources {
    * @param sourceResourceGroupName The name of the resource group containing the resources to move.
    * @param parameters Parameters for moving resources.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginMoveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginMoveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         sourceResourceGroupName,
@@ -423,9 +423,9 @@ export class Resources {
    * validate for move.
    * @param parameters Parameters for moving resources.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginValidateMoveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginValidateMoveResources(sourceResourceGroupName: string, parameters: Models.ResourcesMoveInfo, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         sourceResourceGroupName,
@@ -446,9 +446,9 @@ export class Resources {
    * @param resourceName The name of the resource to delete.
    * @param apiVersion The API version to use for the operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteMethod(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteMethod(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -474,9 +474,9 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param parameters Parameters for creating or updating the resource.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdate(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdate(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -503,9 +503,9 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param parameters Parameters for updating the resource.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdate(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdate(resourceGroupName: string, resourceProviderNamespace: string, parentResourcePath: string, resourceType: string, resourceName: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceGroupName,
@@ -528,9 +528,9 @@ export class Resources {
    * /subscriptions/{guid}/resourceGroups/{resource-group-name}/{resource-provider-namespace}/{resource-type}/{resource-name}
    * @param apiVersion The API version to use for the operation.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginDeleteById(resourceId: string, apiVersion: string, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginDeleteById(resourceId: string, apiVersion: string, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceId,
@@ -549,9 +549,9 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param parameters Create or update resource parameters.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginCreateOrUpdateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginCreateOrUpdateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceId,
@@ -571,9 +571,9 @@ export class Resources {
    * @param apiVersion The API version to use for the operation.
    * @param parameters Update resource parameters.
    * @param [options] The optional parameters
-   * @returns Promise<msRestAzure.LROPoller>
+   * @returns Promise<coreArm.LROPoller>
    */
-  beginUpdateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
+  beginUpdateById(resourceId: string, apiVersion: string, parameters: Models.GenericResource, options?: coreHttp.RequestOptionsBase): Promise<coreArm.LROPoller> {
     return this.client.sendLRORequest(
       {
         resourceId,
@@ -591,19 +591,19 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesListByResourceGroupNextResponse>
    */
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesListByResourceGroupNextResponse>;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesListByResourceGroupNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listByResourceGroupNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
-  listByResourceGroupNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceListResult>, callback?: msRest.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListByResourceGroupNextResponse> {
+  listByResourceGroupNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
+  listByResourceGroupNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceListResult>, callback?: coreHttp.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListByResourceGroupNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -619,19 +619,19 @@ export class Resources {
    * @param [options] The optional parameters
    * @returns Promise<Models.ResourcesListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.ResourcesListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.ResourcesListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ResourceListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ResourceListResult>, callback?: msRest.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.ResourceListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.ResourceListResult>, callback?: coreHttp.ServiceCallback<Models.ResourceListResult>): Promise<Models.ResourcesListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -643,8 +643,8 @@ export class Resources {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const listByResourceGroupOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/resources",
   urlParameters: [
@@ -671,7 +671,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resources",
   urlParameters: [
@@ -697,7 +697,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const checkExistenceOperationSpec: msRest.OperationSpec = {
+const checkExistenceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "HEAD",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
   urlParameters: [
@@ -724,7 +724,7 @@ const checkExistenceOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getOperationSpec: msRest.OperationSpec = {
+const getOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
   urlParameters: [
@@ -752,7 +752,7 @@ const getOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const checkExistenceByIdOperationSpec: msRest.OperationSpec = {
+const checkExistenceByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "HEAD",
   path: "{resourceId}",
   urlParameters: [
@@ -774,7 +774,7 @@ const checkExistenceByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getByIdOperationSpec: msRest.OperationSpec = {
+const getByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "{resourceId}",
   urlParameters: [
@@ -797,7 +797,7 @@ const getByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginMoveResourcesOperationSpec: msRest.OperationSpec = {
+const beginMoveResourcesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/moveResources",
   urlParameters: [
@@ -827,7 +827,7 @@ const beginMoveResourcesOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginValidateMoveResourcesOperationSpec: msRest.OperationSpec = {
+const beginValidateMoveResourcesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/resourceGroups/{sourceResourceGroupName}/validateMoveResources",
   urlParameters: [
@@ -858,7 +858,7 @@ const beginValidateMoveResourcesOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
+const beginDeleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
   urlParameters: [
@@ -886,7 +886,7 @@ const beginDeleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
   urlParameters: [
@@ -925,7 +925,7 @@ const beginCreateOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateOperationSpec: msRest.OperationSpec = {
+const beginUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}",
   urlParameters: [
@@ -961,7 +961,7 @@ const beginUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginDeleteByIdOperationSpec: msRest.OperationSpec = {
+const beginDeleteByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "{resourceId}",
   urlParameters: [
@@ -984,7 +984,7 @@ const beginDeleteByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginCreateOrUpdateByIdOperationSpec: msRest.OperationSpec = {
+const beginCreateOrUpdateByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "{resourceId}",
   urlParameters: [
@@ -1018,7 +1018,7 @@ const beginCreateOrUpdateByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const beginUpdateByIdOperationSpec: msRest.OperationSpec = {
+const beginUpdateByIdOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "{resourceId}",
   urlParameters: [
@@ -1049,7 +1049,7 @@ const beginUpdateByIdOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
+const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",
@@ -1070,7 +1070,7 @@ const listByResourceGroupNextOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/resources/arm-resources/src/operations/tags.ts
+++ b/sdk/resources/arm-resources/src/operations/tags.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "../models";
 import * as Mappers from "../models/tagsMappers";
 import * as Parameters from "../models/parameters";
@@ -31,23 +31,23 @@ export class Tags {
    * @param tagName The name of the tag.
    * @param tagValue The value of the tag to delete.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteValue(tagName: string, tagValue: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteValue(tagName: string, tagValue: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param tagName The name of the tag.
    * @param tagValue The value of the tag to delete.
    * @param callback The callback
    */
-  deleteValue(tagName: string, tagValue: string, callback: msRest.ServiceCallback<void>): void;
+  deleteValue(tagName: string, tagValue: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param tagName The name of the tag.
    * @param tagValue The value of the tag to delete.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteValue(tagName: string, tagValue: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteValue(tagName: string, tagValue: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteValue(tagName: string, tagValue: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteValue(tagName: string, tagValue: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         tagName,
@@ -65,21 +65,21 @@ export class Tags {
    * @param [options] The optional parameters
    * @returns Promise<Models.TagsCreateOrUpdateValueResponse>
    */
-  createOrUpdateValue(tagName: string, tagValue: string, options?: msRest.RequestOptionsBase): Promise<Models.TagsCreateOrUpdateValueResponse>;
+  createOrUpdateValue(tagName: string, tagValue: string, options?: coreHttp.RequestOptionsBase): Promise<Models.TagsCreateOrUpdateValueResponse>;
   /**
    * @param tagName The name of the tag.
    * @param tagValue The value of the tag to create.
    * @param callback The callback
    */
-  createOrUpdateValue(tagName: string, tagValue: string, callback: msRest.ServiceCallback<Models.TagValue>): void;
+  createOrUpdateValue(tagName: string, tagValue: string, callback: coreHttp.ServiceCallback<Models.TagValue>): void;
   /**
    * @param tagName The name of the tag.
    * @param tagValue The value of the tag to create.
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdateValue(tagName: string, tagValue: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.TagValue>): void;
-  createOrUpdateValue(tagName: string, tagValue: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.TagValue>, callback?: msRest.ServiceCallback<Models.TagValue>): Promise<Models.TagsCreateOrUpdateValueResponse> {
+  createOrUpdateValue(tagName: string, tagValue: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.TagValue>): void;
+  createOrUpdateValue(tagName: string, tagValue: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.TagValue>, callback?: coreHttp.ServiceCallback<Models.TagValue>): Promise<Models.TagsCreateOrUpdateValueResponse> {
     return this.client.sendOperationRequest(
       {
         tagName,
@@ -99,19 +99,19 @@ export class Tags {
    * @param [options] The optional parameters
    * @returns Promise<Models.TagsCreateOrUpdateResponse>
    */
-  createOrUpdate(tagName: string, options?: msRest.RequestOptionsBase): Promise<Models.TagsCreateOrUpdateResponse>;
+  createOrUpdate(tagName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.TagsCreateOrUpdateResponse>;
   /**
    * @param tagName The name of the tag to create.
    * @param callback The callback
    */
-  createOrUpdate(tagName: string, callback: msRest.ServiceCallback<Models.TagDetails>): void;
+  createOrUpdate(tagName: string, callback: coreHttp.ServiceCallback<Models.TagDetails>): void;
   /**
    * @param tagName The name of the tag to create.
    * @param options The optional parameters
    * @param callback The callback
    */
-  createOrUpdate(tagName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.TagDetails>): void;
-  createOrUpdate(tagName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.TagDetails>, callback?: msRest.ServiceCallback<Models.TagDetails>): Promise<Models.TagsCreateOrUpdateResponse> {
+  createOrUpdate(tagName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.TagDetails>): void;
+  createOrUpdate(tagName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.TagDetails>, callback?: coreHttp.ServiceCallback<Models.TagDetails>): Promise<Models.TagsCreateOrUpdateResponse> {
     return this.client.sendOperationRequest(
       {
         tagName,
@@ -126,21 +126,21 @@ export class Tags {
    * @summary Deletes a tag from the subscription.
    * @param tagName The name of the tag.
    * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
+   * @returns Promise<coreHttp.RestResponse>
    */
-  deleteMethod(tagName: string, options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  deleteMethod(tagName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param tagName The name of the tag.
    * @param callback The callback
    */
-  deleteMethod(tagName: string, callback: msRest.ServiceCallback<void>): void;
+  deleteMethod(tagName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param tagName The name of the tag.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteMethod(tagName: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteMethod(tagName: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+  deleteMethod(tagName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  deleteMethod(tagName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       {
         tagName,
@@ -155,17 +155,17 @@ export class Tags {
    * @param [options] The optional parameters
    * @returns Promise<Models.TagsListResponse>
    */
-  list(options?: msRest.RequestOptionsBase): Promise<Models.TagsListResponse>;
+  list(options?: coreHttp.RequestOptionsBase): Promise<Models.TagsListResponse>;
   /**
    * @param callback The callback
    */
-  list(callback: msRest.ServiceCallback<Models.TagsListResult>): void;
+  list(callback: coreHttp.ServiceCallback<Models.TagsListResult>): void;
   /**
    * @param options The optional parameters
    * @param callback The callback
    */
-  list(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.TagsListResult>): void;
-  list(options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.TagsListResult>, callback?: msRest.ServiceCallback<Models.TagsListResult>): Promise<Models.TagsListResponse> {
+  list(options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.TagsListResult>): void;
+  list(options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.TagsListResult>, callback?: coreHttp.ServiceCallback<Models.TagsListResult>): Promise<Models.TagsListResponse> {
     return this.client.sendOperationRequest(
       {
         options
@@ -180,19 +180,19 @@ export class Tags {
    * @param [options] The optional parameters
    * @returns Promise<Models.TagsListNextResponse>
    */
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase): Promise<Models.TagsListNextResponse>;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase): Promise<Models.TagsListNextResponse>;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param callback The callback
    */
-  listNext(nextPageLink: string, callback: msRest.ServiceCallback<Models.TagsListResult>): void;
+  listNext(nextPageLink: string, callback: coreHttp.ServiceCallback<Models.TagsListResult>): void;
   /**
    * @param nextPageLink The NextLink from the previous successful call to List operation.
    * @param options The optional parameters
    * @param callback The callback
    */
-  listNext(nextPageLink: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.TagsListResult>): void;
-  listNext(nextPageLink: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.TagsListResult>, callback?: msRest.ServiceCallback<Models.TagsListResult>): Promise<Models.TagsListNextResponse> {
+  listNext(nextPageLink: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.TagsListResult>): void;
+  listNext(nextPageLink: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.TagsListResult>, callback?: coreHttp.ServiceCallback<Models.TagsListResult>): Promise<Models.TagsListNextResponse> {
     return this.client.sendOperationRequest(
       {
         nextPageLink,
@@ -204,8 +204,8 @@ export class Tags {
 }
 
 // Operation Specifications
-const serializer = new msRest.Serializer(Mappers);
-const deleteValueOperationSpec: msRest.OperationSpec = {
+const serializer = new coreHttp.Serializer(Mappers);
+const deleteValueOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/tagNames/{tagName}/tagValues/{tagValue}",
   urlParameters: [
@@ -229,7 +229,7 @@ const deleteValueOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateValueOperationSpec: msRest.OperationSpec = {
+const createOrUpdateValueOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/tagNames/{tagName}/tagValues/{tagValue}",
   urlParameters: [
@@ -257,7 +257,7 @@ const createOrUpdateValueOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const createOrUpdateOperationSpec: msRest.OperationSpec = {
+const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "subscriptions/{subscriptionId}/tagNames/{tagName}",
   urlParameters: [
@@ -284,7 +284,7 @@ const createOrUpdateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteMethodOperationSpec: msRest.OperationSpec = {
+const deleteMethodOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "subscriptions/{subscriptionId}/tagNames/{tagName}",
   urlParameters: [
@@ -307,7 +307,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listOperationSpec: msRest.OperationSpec = {
+const listOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/tagNames",
   urlParameters: [
@@ -330,7 +330,7 @@ const listOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const listNextOperationSpec: msRest.OperationSpec = {
+const listNextOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   baseUrl: "https://management.azure.com",
   path: "{nextLink}",

--- a/sdk/resources/arm-resources/src/resourceManagementClient.ts
+++ b/sdk/resources/arm-resources/src/resourceManagementClient.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import * as msRest from "@azure/ms-rest-js";
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -31,7 +31,7 @@ class ResourceManagementClient extends ResourceManagementClientContext {
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ResourceManagementClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ResourceManagementClientOptions) {
     super(credentials, subscriptionId, options);
     this.operations = new operations.Operations(this);
     this.deployments = new operations.Deployments(this);

--- a/sdk/resources/arm-resources/src/resourceManagementClientContext.ts
+++ b/sdk/resources/arm-resources/src/resourceManagementClientContext.ts
@@ -9,14 +9,14 @@
  */
 
 import * as Models from "./models";
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
+import * as coreHttp from "@azure/core-http";
+import * as coreArm from "@azure/core-arm";
 
 const packageName = "@azure/arm-resources";
 const packageVersion = "1.1.0";
 
-export class ResourceManagementClientContext extends msRestAzure.AzureServiceClient {
-  credentials: msRest.ServiceClientCredentials;
+export class ResourceManagementClientContext extends coreArm.AzureServiceClient {
+  credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential;
   subscriptionId: string;
   apiVersion?: string;
 
@@ -26,7 +26,7 @@ export class ResourceManagementClientContext extends msRestAzure.AzureServiceCli
    * @param subscriptionId The ID of the target subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.ResourceManagementClientOptions) {
+  constructor(credentials: coreHttp.ServiceClientCredentials | coreHttp.TokenCredential, subscriptionId: string, options?: Models.ResourceManagementClientOptions) {
     if (credentials == undefined) {
       throw new Error('\'credentials\' cannot be null.');
     }
@@ -38,7 +38,7 @@ export class ResourceManagementClientContext extends msRestAzure.AzureServiceCli
       options = {};
     }
     if(!options.userAgent) {
-      const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
+      const defaultUserAgent = coreArm.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 


### PR DESCRIPTION
This change regenerates `@azure/arm-resources` to use the new changes to `autorest.typescript` that outputs code to use `@azure/core-http` and `@azure/core-arm`.  The other libraries are all generated as a result of this since their specs are all related.

This spec repo commit was used to generate them all to avoid unwanted API changes:

https://github.com/Azure/azure-rest-api-specs/commit/85ca88d23974f60963533605bc5a53fc44866652#diff-ac43489f896d1c83759d8fb63fc46175