### PR TITLE
Update GraphRBAC Client

### DIFF
--- a/sdk/graphrbac/graph/README.md
+++ b/sdk/graphrbac/graph/README.md
@@ -32,8 +32,8 @@ import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { GraphRbacManagementClient, GraphRbacManagementModels, GraphRbacManagementMappers } from "@azure/graph";
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 
-msRestNodeAuth.interactiveLogin().then((creds) => {
-  const client = new GraphRbacManagementClient(creds, subscriptionId);
+msRestNodeAuth.interactiveLogin({ tokenAudience: 'https://graph.microsoft.com' }).then((creds) => {
+  const client = new GraphRbacManagementClient(creds, tenantId);
   client.signedInUser.get().then((result) => {
     console.log("The result is:");
     console.log(result);

--- a/sdk/graphrbac/graph/src/graphRbacManagementClientContext.ts
+++ b/sdk/graphrbac/graph/src/graphRbacManagementClientContext.ts
@@ -37,7 +37,7 @@ export class GraphRbacManagementClientContext extends msRestAzure.AzureServiceCl
     if (!options) {
       options = {};
     }
-    if(!options.userAgent) {
+    if (!options.userAgent) {
       const defaultUserAgent = msRestAzure.getDefaultUserAgentValue();
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
@@ -47,15 +47,15 @@ export class GraphRbacManagementClientContext extends msRestAzure.AzureServiceCl
     this.apiVersion = '1.6';
     this.acceptLanguage = 'en-US';
     this.longRunningOperationRetryTimeout = 30;
-    this.baseUri = options.baseUri || this.baseUri || "https://graph.windows.net";
+    this.baseUri = options.baseUri || this.baseUri || "https://graph.microsoft.com";
     this.requestContentType = "application/json; charset=utf-8";
     this.credentials = credentials;
     this.tenantID = tenantID;
 
-    if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
+    if (options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
       this.acceptLanguage = options.acceptLanguage;
     }
-    if(options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
+    if (options.longRunningOperationRetryTimeout !== null && options.longRunningOperationRetryTimeout !== undefined) {
       this.longRunningOperationRetryTimeout = options.longRunningOperationRetryTimeout;
     }
   }

--- a/sdk/graphrbac/graph/src/graphRbacManagementClientContext.ts
+++ b/sdk/graphrbac/graph/src/graphRbacManagementClientContext.ts
@@ -44,7 +44,7 @@ export class GraphRbacManagementClientContext extends msRestAzure.AzureServiceCl
 
     super(credentials, options);
 
-    this.apiVersion = '1.6';
+    this.apiVersion = options.apiVersion || 'v1.0';
     this.acceptLanguage = 'en-US';
     this.longRunningOperationRetryTimeout = 30;
     this.baseUri = options.baseUri || this.baseUri || "https://graph.microsoft.com";

--- a/sdk/graphrbac/graph/src/models/index.ts
+++ b/sdk/graphrbac/graph/src/models/index.ts
@@ -455,7 +455,7 @@ export interface Application {
 export interface AddOwnerParameters {
   /**
    * @member {string} url A owner object URL, such as
-   * "https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd",
+   * "https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd",
    * where "0b1f9851-1bf0-433f-aec3-cb9272f093dc" is the tenantId and
    * "f260bbc4-c254-447b-94cf-293b5ec434dd" is the objectId of the owner (user,
    * application, servicePrincipal, group) to be added.
@@ -503,7 +503,7 @@ export interface PasswordCredentialsUpdateParameters {
 export interface GroupAddMemberParameters {
   /**
    * @member {string} url A member object URL, such as
-   * "https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd",
+   * "https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd",
    * where "0b1f9851-1bf0-433f-aec3-cb9272f093dc" is the tenantId and
    * "f260bbc4-c254-447b-94cf-293b5ec434dd" is the objectId of the member
    * (user, application, servicePrincipal, group) to be added.

--- a/sdk/graphrbac/graph/src/models/index.ts
+++ b/sdk/graphrbac/graph/src/models/index.ts
@@ -1327,6 +1327,10 @@ export interface GraphRbacManagementClientOptions extends AzureServiceClientOpti
    * @member {string} [baseUri]
    */
   baseUri?: string;
+  /**
+   * @member {string} [apiVersion]
+   */
+  apiVersion?: string;
 }
 
 
@@ -1466,15 +1470,15 @@ export type SignedInUserGetResponse = User & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: User;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: User;
+  };
 };
 
 /**
@@ -1485,15 +1489,15 @@ export type SignedInUserListOwnedObjectsResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1504,15 +1508,15 @@ export type SignedInUserListOwnedObjectsNextResponse = DirectoryObjectListResult
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1523,15 +1527,15 @@ export type ApplicationsCreateResponse = Application & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Application;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Application;
+  };
 };
 
 /**
@@ -1542,15 +1546,15 @@ export type ApplicationsListResponse = ApplicationListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ApplicationListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ApplicationListResult;
+  };
 };
 
 /**
@@ -1561,15 +1565,15 @@ export type ApplicationsGetResponse = Application & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Application;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Application;
+  };
 };
 
 /**
@@ -1580,15 +1584,15 @@ export type ApplicationsListOwnersResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1599,15 +1603,15 @@ export type ApplicationsListKeyCredentialsResponse = KeyCredentialListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: KeyCredentialListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: KeyCredentialListResult;
+  };
 };
 
 /**
@@ -1618,15 +1622,15 @@ export type ApplicationsListPasswordCredentialsResponse = PasswordCredentialList
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: PasswordCredentialListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: PasswordCredentialListResult;
+  };
 };
 
 /**
@@ -1637,15 +1641,15 @@ export type ApplicationsListNextResponse = ApplicationListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ApplicationListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ApplicationListResult;
+  };
 };
 
 /**
@@ -1656,15 +1660,15 @@ export type ApplicationsListOwnersNextResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1675,15 +1679,15 @@ export type DeletedApplicationsRestoreResponse = Application & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Application;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Application;
+  };
 };
 
 /**
@@ -1694,15 +1698,15 @@ export type DeletedApplicationsListResponse = ApplicationListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ApplicationListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ApplicationListResult;
+  };
 };
 
 /**
@@ -1713,15 +1717,15 @@ export type DeletedApplicationsListNextResponse = ApplicationListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ApplicationListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ApplicationListResult;
+  };
 };
 
 /**
@@ -1732,15 +1736,15 @@ export type GroupsIsMemberOfResponse = CheckGroupMembershipResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: CheckGroupMembershipResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: CheckGroupMembershipResult;
+  };
 };
 
 /**
@@ -1751,15 +1755,15 @@ export type GroupsCreateResponse = ADGroup & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ADGroup;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ADGroup;
+  };
 };
 
 /**
@@ -1770,15 +1774,15 @@ export type GroupsListResponse = GroupListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: GroupListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: GroupListResult;
+  };
 };
 
 /**
@@ -1789,15 +1793,15 @@ export type GroupsGetGroupMembersResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1808,15 +1812,15 @@ export type GroupsGetResponse = ADGroup & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ADGroup;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ADGroup;
+  };
 };
 
 /**
@@ -1827,15 +1831,15 @@ export type GroupsGetMemberGroupsResponse = GroupGetMemberGroupsResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: GroupGetMemberGroupsResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: GroupGetMemberGroupsResult;
+  };
 };
 
 /**
@@ -1846,15 +1850,15 @@ export type GroupsListOwnersResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1865,15 +1869,15 @@ export type GroupsListNextResponse = GroupListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: GroupListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: GroupListResult;
+  };
 };
 
 /**
@@ -1884,15 +1888,15 @@ export type GroupsGetGroupMembersNextResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1903,15 +1907,15 @@ export type GroupsListOwnersNextResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1922,15 +1926,15 @@ export type ServicePrincipalsCreateResponse = ServicePrincipal & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ServicePrincipal;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ServicePrincipal;
+  };
 };
 
 /**
@@ -1941,15 +1945,15 @@ export type ServicePrincipalsListResponse = ServicePrincipalListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ServicePrincipalListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ServicePrincipalListResult;
+  };
 };
 
 /**
@@ -1960,15 +1964,15 @@ export type ServicePrincipalsGetResponse = ServicePrincipal & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ServicePrincipal;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ServicePrincipal;
+  };
 };
 
 /**
@@ -1979,15 +1983,15 @@ export type ServicePrincipalsListOwnersResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -1998,15 +2002,15 @@ export type ServicePrincipalsListKeyCredentialsResponse = KeyCredentialListResul
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: KeyCredentialListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: KeyCredentialListResult;
+  };
 };
 
 /**
@@ -2017,15 +2021,15 @@ export type ServicePrincipalsListPasswordCredentialsResponse = PasswordCredentia
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: PasswordCredentialListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: PasswordCredentialListResult;
+  };
 };
 
 /**
@@ -2036,15 +2040,15 @@ export type ServicePrincipalsListNextResponse = ServicePrincipalListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ServicePrincipalListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ServicePrincipalListResult;
+  };
 };
 
 /**
@@ -2055,15 +2059,15 @@ export type ServicePrincipalsListOwnersNextResponse = DirectoryObjectListResult 
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -2074,15 +2078,15 @@ export type UsersCreateResponse = User & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: User;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: User;
+  };
 };
 
 /**
@@ -2093,15 +2097,15 @@ export type UsersListResponse = UserListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: UserListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: UserListResult;
+  };
 };
 
 /**
@@ -2112,15 +2116,15 @@ export type UsersGetResponse = User & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: User;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: User;
+  };
 };
 
 /**
@@ -2131,15 +2135,15 @@ export type UsersGetMemberGroupsResponse = UserGetMemberGroupsResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: UserGetMemberGroupsResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: UserGetMemberGroupsResult;
+  };
 };
 
 /**
@@ -2150,15 +2154,15 @@ export type UsersListNextResponse = UserListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: UserListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: UserListResult;
+  };
 };
 
 /**
@@ -2169,15 +2173,15 @@ export type ObjectsGetObjectsByObjectIdsResponse = DirectoryObjectListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -2188,15 +2192,15 @@ export type ObjectsGetObjectsByObjectIdsNextResponse = DirectoryObjectListResult
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DirectoryObjectListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DirectoryObjectListResult;
+  };
 };
 
 /**
@@ -2207,15 +2211,15 @@ export type DomainsListResponse = DomainListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DomainListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DomainListResult;
+  };
 };
 
 /**
@@ -2226,15 +2230,15 @@ export type DomainsGetResponse = Domain & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Domain;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Domain;
+  };
 };
 
 /**
@@ -2245,15 +2249,15 @@ export type OAuth2GetResponse = Permissions & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Permissions;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Permissions;
+  };
 };
 
 /**
@@ -2264,13 +2268,13 @@ export type OAuth2GrantResponse = Permissions & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Permissions;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Permissions;
+  };
 };

--- a/sdk/graphrbac/graph/src/models/parameters.ts
+++ b/sdk/graphrbac/graph/src/models/parameters.ts
@@ -24,7 +24,7 @@ export const apiVersion: msRest.OperationURLParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
-    serializedName: "api-version",
+    serializedName: "apiVersion",
     type: {
       name: "String"
     }

--- a/sdk/graphrbac/graph/src/models/parameters.ts
+++ b/sdk/graphrbac/graph/src/models/parameters.ts
@@ -20,7 +20,7 @@ export const acceptLanguage: msRest.OperationParameter = {
     }
   }
 };
-export const apiVersion: msRest.OperationQueryParameter = {
+export const apiVersion: msRest.OperationURLParameter = {
   parameterPath: "apiVersion",
   mapper: {
     required: true,
@@ -119,16 +119,6 @@ export const ownerObjectId: msRest.OperationURLParameter = {
   mapper: {
     required: true,
     serializedName: "ownerObjectId",
-    type: {
-      name: "String"
-    }
-  }
-};
-export const tenantID: msRest.OperationURLParameter = {
-  parameterPath: "tenantID",
-  mapper: {
-    required: true,
-    serializedName: "tenantID",
     type: {
       name: "String"
     }

--- a/sdk/graphrbac/graph/src/operations/applications.ts
+++ b/sdk/graphrbac/graph/src/operations/applications.ts
@@ -199,7 +199,7 @@ export class Applications {
    * Add an owner to an application.
    * @param applicationObjectId The object ID of the application to which to add the owner.
    * @param parameters The URL of the owner object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param [options] The optional parameters
    * @returns Promise<msRest.RestResponse>
    */
@@ -207,14 +207,14 @@ export class Applications {
   /**
    * @param applicationObjectId The object ID of the application to which to add the owner.
    * @param parameters The URL of the owner object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param callback The callback
    */
   addOwner(applicationObjectId: string, parameters: Models.AddOwnerParameters, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param applicationObjectId The object ID of the application to which to add the owner.
    * @param parameters The URL of the owner object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param options The optional parameters
    * @param callback The callback
    */
@@ -444,11 +444,8 @@ export class Applications {
 const serializer = new msRest.Serializer(Mappers);
 const createOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/applications",
+  path: "{apiVersion}/applications",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -474,13 +471,12 @@ const createOperationSpec: msRest.OperationSpec = {
 
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/applications",
+  path: "{apiVersion}/applications",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
-    Parameters.filter,
-    Parameters.apiVersion
+    Parameters.filter
   ],
   headerParameters: [
     Parameters.acceptLanguage
@@ -498,12 +494,9 @@ const listOperationSpec: msRest.OperationSpec = {
 
 const deleteMethodOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/applications/{applicationObjectId}",
+  path: "{apiVersion}/applications/{applicationObjectId}",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -520,12 +513,9 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
 
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/applications/{applicationObjectId}",
+  path: "{apiVersion}/applications/{applicationObjectId}",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -544,12 +534,9 @@ const getOperationSpec: msRest.OperationSpec = {
 
 const patchOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
-  path: "{tenantID}/applications/{applicationObjectId}",
+  path: "{apiVersion}/applications/{applicationObjectId}",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -573,12 +560,9 @@ const patchOperationSpec: msRest.OperationSpec = {
 
 const listOwnersOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/applications/{applicationObjectId}/owners",
+  path: "{apiVersion}/applications/{applicationObjectId}/owners",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -597,12 +581,9 @@ const listOwnersOperationSpec: msRest.OperationSpec = {
 
 const addOwnerOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/applications/{applicationObjectId}/$links/owners",
+  path: "{apiVersion}/applications/{applicationObjectId}/$links/owners",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -626,13 +607,10 @@ const addOwnerOperationSpec: msRest.OperationSpec = {
 
 const removeOwnerOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/applications/{applicationObjectId}/$links/owners/{ownerObjectId}",
+  path: "{apiVersion}/applications/{applicationObjectId}/$links/owners/{ownerObjectId}",
   urlParameters: [
     Parameters.applicationObjectId,
     Parameters.ownerObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -649,12 +627,9 @@ const removeOwnerOperationSpec: msRest.OperationSpec = {
 
 const listKeyCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/applications/{applicationObjectId}/keyCredentials",
+  path: "{apiVersion}/applications/{applicationObjectId}/keyCredentials",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -673,12 +648,9 @@ const listKeyCredentialsOperationSpec: msRest.OperationSpec = {
 
 const updateKeyCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
-  path: "{tenantID}/applications/{applicationObjectId}/keyCredentials",
+  path: "{apiVersion}/applications/{applicationObjectId}/keyCredentials",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -704,12 +676,9 @@ const updateKeyCredentialsOperationSpec: msRest.OperationSpec = {
 
 const listPasswordCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/applications/{applicationObjectId}/passwordCredentials",
+  path: "{apiVersion}/applications/{applicationObjectId}/passwordCredentials",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -728,12 +697,9 @@ const listPasswordCredentialsOperationSpec: msRest.OperationSpec = {
 
 const updatePasswordCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
-  path: "{tenantID}/applications/{applicationObjectId}/passwordCredentials",
+  path: "{apiVersion}/applications/{applicationObjectId}/passwordCredentials",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -759,12 +725,9 @@ const updatePasswordCredentialsOperationSpec: msRest.OperationSpec = {
 
 const listNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -783,7 +746,7 @@ const listNextOperationSpec: msRest.OperationSpec = {
 
 const listOwnersNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  baseUrl: "https://graph.windows.net",
+  baseUrl: "https://graph.microsoft.com",
   path: "{nextLink}",
   urlParameters: [
     Parameters.nextPageLink

--- a/sdk/graphrbac/graph/src/operations/deletedApplications.ts
+++ b/sdk/graphrbac/graph/src/operations/deletedApplications.ts
@@ -139,12 +139,9 @@ export class DeletedApplications {
 const serializer = new msRest.Serializer(Mappers);
 const restoreOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/deletedApplications/{objectId}/restore",
+  path: "{apiVersion}/deletedApplications/{objectId}/restore",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -163,13 +160,12 @@ const restoreOperationSpec: msRest.OperationSpec = {
 
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/deletedApplications",
+  path: "{apiVersion}/deletedApplications",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
-    Parameters.filter,
-    Parameters.apiVersion
+    Parameters.filter
   ],
   headerParameters: [
     Parameters.acceptLanguage
@@ -187,12 +183,9 @@ const listOperationSpec: msRest.OperationSpec = {
 
 const hardDeleteOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/deletedApplications/{applicationObjectId}",
+  path: "{apiVersion}/deletedApplications/{applicationObjectId}",
   urlParameters: [
     Parameters.applicationObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -209,12 +202,9 @@ const hardDeleteOperationSpec: msRest.OperationSpec = {
 
 const listNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [

--- a/sdk/graphrbac/graph/src/operations/domains.ts
+++ b/sdk/graphrbac/graph/src/operations/domains.ts
@@ -83,13 +83,12 @@ export class Domains {
 const serializer = new msRest.Serializer(Mappers);
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/domains",
+  path: "{apiVersion}/domains",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
-    Parameters.filter,
-    Parameters.apiVersion
+    Parameters.filter
   ],
   headerParameters: [
     Parameters.acceptLanguage
@@ -107,12 +106,9 @@ const listOperationSpec: msRest.OperationSpec = {
 
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/domains/{domainName}",
+  path: "{apiVersion}/domains/{domainName}",
   urlParameters: [
     Parameters.domainName,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [

--- a/sdk/graphrbac/graph/src/operations/groups.ts
+++ b/sdk/graphrbac/graph/src/operations/groups.ts
@@ -91,7 +91,7 @@ export class Groups {
    * Add a member to a group.
    * @param groupObjectId The object ID of the group to which to add the member.
    * @param parameters The URL of the member object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param [options] The optional parameters
    * @returns Promise<msRest.RestResponse>
    */
@@ -99,14 +99,14 @@ export class Groups {
   /**
    * @param groupObjectId The object ID of the group to which to add the member.
    * @param parameters The URL of the member object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param callback The callback
    */
   addMember(groupObjectId: string, parameters: Models.GroupAddMemberParameters, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param groupObjectId The object ID of the group to which to add the member.
    * @param parameters The URL of the member object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param options The optional parameters
    * @param callback The callback
    */
@@ -323,7 +323,7 @@ export class Groups {
    * Add an owner to a group.
    * @param objectId The object ID of the application to which to add the owner.
    * @param parameters The URL of the owner object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param [options] The optional parameters
    * @returns Promise<msRest.RestResponse>
    */
@@ -331,14 +331,14 @@ export class Groups {
   /**
    * @param objectId The object ID of the application to which to add the owner.
    * @param parameters The URL of the owner object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param callback The callback
    */
   addOwner(objectId: string, parameters: Models.AddOwnerParameters, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param objectId The object ID of the application to which to add the owner.
    * @param parameters The URL of the owner object, such as
-   * https://graph.windows.net/0b1f9851-1bf0-433f-aec3-cb9272f093dc/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
+   * https://graph.microsoft.com/v1.0/directoryObjects/f260bbc4-c254-447b-94cf-293b5ec434dd.
    * @param options The optional parameters
    * @param callback The callback
    */
@@ -476,11 +476,8 @@ export class Groups {
 const serializer = new msRest.Serializer(Mappers);
 const isMemberOfOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/isMemberOf",
+  path: "{apiVersion}/isMemberOf",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -506,13 +503,10 @@ const isMemberOfOperationSpec: msRest.OperationSpec = {
 
 const removeMemberOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/groups/{groupObjectId}/$links/members/{memberObjectId}",
+  path: "{apiVersion}/groups/{groupObjectId}/$links/members/{memberObjectId}",
   urlParameters: [
     Parameters.groupObjectId,
     Parameters.memberObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -529,12 +523,9 @@ const removeMemberOperationSpec: msRest.OperationSpec = {
 
 const addMemberOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/groups/{groupObjectId}/$links/members",
+  path: "{apiVersion}/groups/{groupObjectId}/$links/members",
   urlParameters: [
     Parameters.groupObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -558,11 +549,8 @@ const addMemberOperationSpec: msRest.OperationSpec = {
 
 const createOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/groups",
+  path: "{apiVersion}/groups",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -588,13 +576,12 @@ const createOperationSpec: msRest.OperationSpec = {
 
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/groups",
+  path: "{apiVersion}/groups",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
-    Parameters.filter,
-    Parameters.apiVersion
+    Parameters.filter
   ],
   headerParameters: [
     Parameters.acceptLanguage
@@ -612,12 +599,9 @@ const listOperationSpec: msRest.OperationSpec = {
 
 const getGroupMembersOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/groups/{objectId}/members",
+  path: "{apiVersion}/groups/{objectId}/members",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -636,12 +620,9 @@ const getGroupMembersOperationSpec: msRest.OperationSpec = {
 
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/groups/{objectId}",
+  path: "{apiVersion}/groups/{objectId}",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -660,12 +641,9 @@ const getOperationSpec: msRest.OperationSpec = {
 
 const deleteMethodOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/groups/{objectId}",
+  path: "{apiVersion}/groups/{objectId}",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -682,12 +660,9 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
 
 const getMemberGroupsOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/groups/{objectId}/getMemberGroups",
+  path: "{apiVersion}/groups/{objectId}/getMemberGroups",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -713,12 +688,9 @@ const getMemberGroupsOperationSpec: msRest.OperationSpec = {
 
 const listOwnersOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/groups/{objectId}/owners",
+  path: "{apiVersion}/groups/{objectId}/owners",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -737,12 +709,9 @@ const listOwnersOperationSpec: msRest.OperationSpec = {
 
 const addOwnerOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/groups/{objectId}/$links/owners",
+  path: "{apiVersion}/groups/{objectId}/$links/owners",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -766,13 +735,10 @@ const addOwnerOperationSpec: msRest.OperationSpec = {
 
 const removeOwnerOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/groups/{objectId}/$links/owners/{ownerObjectId}",
+  path: "{apiVersion}/groups/{objectId}/$links/owners/{ownerObjectId}",
   urlParameters: [
     Parameters.objectId,
     Parameters.ownerObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -789,12 +755,9 @@ const removeOwnerOperationSpec: msRest.OperationSpec = {
 
 const listNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -813,12 +776,9 @@ const listNextOperationSpec: msRest.OperationSpec = {
 
 const getGroupMembersNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -837,7 +797,7 @@ const getGroupMembersNextOperationSpec: msRest.OperationSpec = {
 
 const listOwnersNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  baseUrl: "https://graph.windows.net",
+  baseUrl: "https://graph.microsoft.com",
   path: "{nextLink}",
   urlParameters: [
     Parameters.nextPageLink

--- a/sdk/graphrbac/graph/src/operations/oAuth2.ts
+++ b/sdk/graphrbac/graph/src/operations/oAuth2.ts
@@ -79,13 +79,12 @@ export class OAuth2 {
 const serializer = new msRest.Serializer(Mappers);
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/oauth2PermissionGrants",
+  path: "{apiVersion}/oauth2PermissionGrants",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
-    Parameters.filter,
-    Parameters.apiVersion
+    Parameters.filter
   ],
   headerParameters: [
     Parameters.acceptLanguage
@@ -103,11 +102,8 @@ const getOperationSpec: msRest.OperationSpec = {
 
 const grantOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/oauth2PermissionGrants",
+  path: "{apiVersion}/oauth2PermissionGrants",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [

--- a/sdk/graphrbac/graph/src/operations/objects.ts
+++ b/sdk/graphrbac/graph/src/operations/objects.ts
@@ -89,11 +89,8 @@ export class Objects {
 const serializer = new msRest.Serializer(Mappers);
 const getObjectsByObjectIdsOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/getObjectsByObjectIds",
+  path: "{apiVersion}/getObjectsByObjectIds",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -119,12 +116,9 @@ const getObjectsByObjectIdsOperationSpec: msRest.OperationSpec = {
 
 const getObjectsByObjectIdsNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [

--- a/sdk/graphrbac/graph/src/operations/servicePrincipals.ts
+++ b/sdk/graphrbac/graph/src/operations/servicePrincipals.ts
@@ -378,11 +378,8 @@ export class ServicePrincipals {
 const serializer = new msRest.Serializer(Mappers);
 const createOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/servicePrincipals",
+  path: "{apiVersion}/servicePrincipals",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -408,13 +405,12 @@ const createOperationSpec: msRest.OperationSpec = {
 
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/servicePrincipals",
+  path: "{apiVersion}/servicePrincipals",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
-    Parameters.filter,
-    Parameters.apiVersion
+    Parameters.filter
   ],
   headerParameters: [
     Parameters.acceptLanguage
@@ -432,12 +428,9 @@ const listOperationSpec: msRest.OperationSpec = {
 
 const updateOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
-  path: "{tenantID}/servicePrincipals/{objectId}",
+  path: "{apiVersion}/servicePrincipals/{objectId}",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -461,12 +454,9 @@ const updateOperationSpec: msRest.OperationSpec = {
 
 const deleteMethodOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/servicePrincipals/{objectId}",
+  path: "{apiVersion}/servicePrincipals/{objectId}",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -483,12 +473,9 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
 
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/servicePrincipals/{objectId}",
+  path: "{apiVersion}/servicePrincipals/{objectId}",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -507,12 +494,9 @@ const getOperationSpec: msRest.OperationSpec = {
 
 const listOwnersOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/servicePrincipals/{objectId}/owners",
+  path: "{apiVersion}/servicePrincipals/{objectId}/owners",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -531,12 +515,9 @@ const listOwnersOperationSpec: msRest.OperationSpec = {
 
 const listKeyCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/servicePrincipals/{objectId}/keyCredentials",
+  path: "{apiVersion}/servicePrincipals/{objectId}/keyCredentials",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -555,12 +536,9 @@ const listKeyCredentialsOperationSpec: msRest.OperationSpec = {
 
 const updateKeyCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
-  path: "{tenantID}/servicePrincipals/{objectId}/keyCredentials",
+  path: "{apiVersion}/servicePrincipals/{objectId}/keyCredentials",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -586,12 +564,9 @@ const updateKeyCredentialsOperationSpec: msRest.OperationSpec = {
 
 const listPasswordCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/servicePrincipals/{objectId}/passwordCredentials",
+  path: "{apiVersion}/servicePrincipals/{objectId}/passwordCredentials",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -610,12 +585,9 @@ const listPasswordCredentialsOperationSpec: msRest.OperationSpec = {
 
 const updatePasswordCredentialsOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
-  path: "{tenantID}/servicePrincipals/{objectId}/passwordCredentials",
+  path: "{apiVersion}/servicePrincipals/{objectId}/passwordCredentials",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -641,12 +613,9 @@ const updatePasswordCredentialsOperationSpec: msRest.OperationSpec = {
 
 const listNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -665,7 +634,7 @@ const listNextOperationSpec: msRest.OperationSpec = {
 
 const listOwnersNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  baseUrl: "https://graph.windows.net",
+  baseUrl: "https://graph.microsoft.com",
   path: "{nextLink}",
   urlParameters: [
     Parameters.nextPageLink

--- a/sdk/graphrbac/graph/src/operations/signedInUser.ts
+++ b/sdk/graphrbac/graph/src/operations/signedInUser.ts
@@ -107,11 +107,8 @@ export class SignedInUser {
 const serializer = new msRest.Serializer(Mappers);
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/me",
+  path: "{apiVersion}/me",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -130,11 +127,8 @@ const getOperationSpec: msRest.OperationSpec = {
 
 const listOwnedObjectsOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/me/ownedObjects",
+  path: "{apiVersion}/me/ownedObjects",
   urlParameters: [
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -153,10 +147,10 @@ const listOwnedObjectsOperationSpec: msRest.OperationSpec = {
 
 const listOwnedObjectsNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
     Parameters.apiVersion

--- a/sdk/graphrbac/graph/src/operations/users.ts
+++ b/sdk/graphrbac/graph/src/operations/users.ts
@@ -231,9 +231,9 @@ export class Users {
 const serializer = new msRest.Serializer(Mappers);
 const createOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/users",
+  path: "{apiVersion}/users",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
     Parameters.apiVersion
@@ -261,13 +261,12 @@ const createOperationSpec: msRest.OperationSpec = {
 
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/users",
+  path: "{apiVersion}/users",
   urlParameters: [
-    Parameters.tenantID
+    Parameters.apiVersion
   ],
   queryParameters: [
-    Parameters.filter,
-    Parameters.apiVersion
+    Parameters.filter
   ],
   headerParameters: [
     Parameters.acceptLanguage
@@ -285,12 +284,9 @@ const listOperationSpec: msRest.OperationSpec = {
 
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/users/{upnOrObjectId}",
+  path: "{apiVersion}/users/{upnOrObjectId}",
   urlParameters: [
     Parameters.upnOrObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -309,12 +305,9 @@ const getOperationSpec: msRest.OperationSpec = {
 
 const updateOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
-  path: "{tenantID}/users/{upnOrObjectId}",
+  path: "{apiVersion}/users/{upnOrObjectId}",
   urlParameters: [
     Parameters.upnOrObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -338,12 +331,9 @@ const updateOperationSpec: msRest.OperationSpec = {
 
 const deleteMethodOperationSpec: msRest.OperationSpec = {
   httpMethod: "DELETE",
-  path: "{tenantID}/users/{upnOrObjectId}",
+  path: "{apiVersion}/users/{upnOrObjectId}",
   urlParameters: [
     Parameters.upnOrObjectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -360,12 +350,9 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
 
 const getMemberGroupsOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "{tenantID}/users/{objectId}/getMemberGroups",
+  path: "{apiVersion}/users/{objectId}/getMemberGroups",
   urlParameters: [
     Parameters.objectId,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [
@@ -391,12 +378,9 @@ const getMemberGroupsOperationSpec: msRest.OperationSpec = {
 
 const listNextOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "{tenantID}/{nextLink}",
+  path: "{apiVersion}/{nextLink}",
   urlParameters: [
     Parameters.nextLink,
-    Parameters.tenantID
-  ],
-  queryParameters: [
     Parameters.apiVersion
   ],
   headerParameters: [


### PR DESCRIPTION
This PR includes multiple changes to the code mechanism:
- Change the SDK to relay on `graph.microsoft.com` instead of `graph.windows.net`.
- Change the operations call structure to match the new URL format.
- Add the ability to choose the API version `v1.0` or `beta`.
- Update README to include a missing part about tokenAudience.