### PR TITLE
[Event Hubs] [Service Bus] Added event handlers for `error` and `protocolError` events on the connection object.

### DIFF
--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -237,9 +237,45 @@ export namespace ConnectionContext {
       }
     };
 
+    const protocolError: OnAmqpEvent = async (context: EventContext) => {
+      if (context.connection && context.connection.error) {
+        log.error(
+          "[%s] Error (context.connection.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.connection && context.connection.error
+        );
+      }
+      if (context.error) {
+        log.error(
+          "[%s] Error (context.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.error
+        );
+      }
+    };
+
+    const error: OnAmqpEvent = async (context: EventContext) => {
+      if (context.connection && context.connection.error) {
+        log.error(
+          "[%s] Error (context.connection.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.connection && context.connection.error
+        );
+      }
+      if (context.error) {
+        log.error(
+          "[%s] Error (context.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.error
+        );
+      }
+    };
+
     // Add listeners on the connection object.
     connectionContext.connection.on(ConnectionEvents.connectionOpen, onConnectionOpen);
     connectionContext.connection.on(ConnectionEvents.disconnected, disconnected);
+    connectionContext.connection.on(ConnectionEvents.protocolError, protocolError);
+    connectionContext.connection.on(ConnectionEvents.error, error);
 
     log.context("[%s] Created connection context successfully.", connectionContext.connectionId);
     return connectionContext;

--- a/sdk/servicebus/service-bus/changelog.md
+++ b/sdk/servicebus/service-bus/changelog.md
@@ -1,6 +1,7 @@
 # 2019-07-09 1.0.3
 
 - Update `amqp-common` dependency version to 1.0.0-preview.6. This includes fix for the [bug 3971](https://github.com/Azure/azure-sdk-for-js/issues/3971) where the token audience in the credential created during [MSI based login](https://www.npmjs.com/package/@azure/ms-rest-nodeauth/v/2.0.2#msi-managed-service-identity-based-login-from-a-virtual-machine-created-in-azure) was being ignored. [PR 4146](https://github.com/Azure/azure-sdk-for-js/pull/4146)
+- Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions like [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
 
 # 2019-05-21 1.0.2
 

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -146,9 +146,45 @@ export namespace ConnectionContext {
       }
     };
 
+    const protocolError: OnAmqpEvent = async (context: EventContext) => {
+      if (context.connection && context.connection.error) {
+        log.error(
+          "[%s] Error (context.connection.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.connection && context.connection.error
+        );
+      }
+      if (context.error) {
+        log.error(
+          "[%s] Error (context.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.error
+        );
+      }
+    };
+
+    const error: OnAmqpEvent = async (context: EventContext) => {
+      if (context.connection && context.connection.error) {
+        log.error(
+          "[%s] Error (context.connection.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.connection && context.connection.error
+        );
+      }
+      if (context.error) {
+        log.error(
+          "[%s] Error (context.error) occurred on the amqp connection: %O",
+          connectionContext.connection.id,
+          context.error
+        );
+      }
+    };
+
     // Add listeners on the connection object.
     connectionContext.connection.on(ConnectionEvents.connectionOpen, onConnectionOpen);
     connectionContext.connection.on(ConnectionEvents.disconnected, disconnected);
+    connectionContext.connection.on(ConnectionEvents.protocolError, protocolError);
+    connectionContext.connection.on(ConnectionEvents.error, error);
 
     log.connectionCtxt(
       "[%s] Created connection context successfully.",


### PR DESCRIPTION
Added event handlers for `error` and `protocolError` events on the connection object in `connectionContext.ts`  that will just log the error and take care of the unhandled exception.

More more context: https://github.com/Azure/azure-sdk-for-js/issues/4136