### PR TITLE
Fix dependencies for @typescript-eslint/eslint-plugin

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -64,7 +64,7 @@ dependencies:
   '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
   abortcontroller-polyfill: 1.3.0
   assert: 1.5.0
-  async-lock: 1.2.1
+  async-lock: 1.2.2
   axios: 0.19.0
   axios-mock-adapter: 1.17.0_axios@0.19.0
   azure-storage: 2.10.3
@@ -189,7 +189,7 @@ lockfileVersion: 5.1
 packages:
   /@azure/amqp-common/0.1.9_rhea-promise@0.1.15:
     dependencies:
-      async-lock: 1.2.1
+      async-lock: 1.2.2
       debug: 3.2.6
       is-buffer: 2.0.3
       jssha: 2.3.1
@@ -206,7 +206,7 @@ packages:
       '@azure/ms-rest-nodeauth': 0.9.3
       '@types/async-lock': 1.1.1
       '@types/is-buffer': 2.0.0
-      async-lock: 1.2.1
+      async-lock: 1.2.2
       buffer: 5.2.1
       debug: 3.2.6
       events: 3.0.0
@@ -234,7 +234,7 @@ packages:
   /@azure/event-hubs/1.0.8:
     dependencies:
       '@azure/amqp-common': 0.1.9_rhea-promise@0.1.15
-      async-lock: 1.2.1
+      async-lock: 1.2.2
       debug: 3.2.6
       is-buffer: 2.0.2
       jssha: 2.3.1
@@ -732,6 +732,7 @@ packages:
     dependencies:
       '@typescript-eslint/experimental-utils': 1.12.0_eslint@5.16.0+typescript@3.5.3
       '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
+      '@typescript-eslint/typescript-estree': 1.12.0
       eslint: 5.16.0
       eslint-utils: 1.4.0
       functional-red-black-tree: 1.0.1
@@ -1362,12 +1363,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
-  /async-lock/1.2.1:
-    dependencies:
-      grunt-env: 0.4.4
+  /async-lock/1.2.2:
     dev: false
     resolution:
-      integrity: sha512-eHyJHqr7JivGaVfrpy7rJpTUVNoECFQFUL9ZVmaKDNaKa9IiYsnqNaYAiwU9AXtmDUE8LNjPdxvwMMJzW9vtVg==
+      integrity: sha512-uczz62z2fMWOFbyo6rG4NlV2SdxugJT6sZA2QcfB1XaSjEiOh8CuOb/TttyMnYQCda6nkWecJe465tGQDPJiKw==
   /async-settle/1.0.0:
     dependencies:
       async-done: 1.3.2
@@ -4302,13 +4301,6 @@ packages:
       node: '>=4.x'
     resolution:
       integrity: sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-  /grunt-env/0.4.4:
-    dependencies:
-      ini: 1.3.5
-      lodash: 2.4.2
-    dev: false
-    resolution:
-      integrity: sha1-OziEOo1zcXfdyfiTh5+2nOGgvC8=
   /gulp-cli/2.2.0:
     dependencies:
       ansi-colors: 1.1.0
@@ -5688,13 +5680,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
-  /lodash/2.4.2:
-    dev: false
-    engines:
-      '0': node
-      '1': rhino
-    resolution:
-      integrity: sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=
   /lodash/4.17.14:
     dev: false
     resolution:
@@ -6520,7 +6505,7 @@ packages:
       spawn-wrap: 1.4.2
       test-exclude: 5.2.3
       uuid: 3.3.2
-      yargs: 13.2.4
+      yargs: 13.3.0
       yargs-parser: 13.1.1
     dev: false
     engines:
@@ -9583,6 +9568,21 @@ packages:
     dev: false
     resolution:
       integrity: sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==
+  /yargs/13.3.0:
+    dependencies:
+      cliui: 5.0.0
+      find-up: 3.0.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 3.1.0
+      which-module: 2.0.0
+      y18n: 4.0.0
+      yargs-parser: 13.1.1
+    dev: false
+    resolution:
+      integrity: sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
   /yargs/7.1.0:
     dependencies:
       camelcase: 3.0.0
@@ -9704,7 +9704,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 1.12.0_db854cf46887ef4aa7b9323cccc417a5
       '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
       assert: 1.5.0
-      async-lock: 1.2.1
+      async-lock: 1.2.2
       buffer: 5.2.1
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
@@ -10007,7 +10007,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 1.12.0_db854cf46887ef4aa7b9323cccc417a5
       '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
       assert: 1.5.0
-      async-lock: 1.2.1
+      async-lock: 1.2.2
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
@@ -10079,7 +10079,7 @@ packages:
       '@types/uuid': 3.4.5
       '@typescript-eslint/eslint-plugin': 1.12.0_db854cf46887ef4aa7b9323cccc417a5
       '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
-      async-lock: 1.2.1
+      async-lock: 1.2.2
       azure-storage: 2.10.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
@@ -10627,7 +10627,7 @@ packages:
       '@types/node': 8.10.50
       '@types/uuid': 3.4.5
       '@types/yargs': 11.1.2
-      async-lock: 1.2.1
+      async-lock: 1.2.2
       death: 1.1.0
       debug: 3.2.6
       is-buffer: 2.0.3

--- a/common/config/rush/pnpmfile.js
+++ b/common/config/rush/pnpmfile.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /**
  * When using the PNPM package manager, you can use pnpmfile.js to workaround
@@ -28,12 +28,20 @@ module.exports = {
  * The return value is the updated object.
  */
 function readPackage(packageJson, context) {
-
   // // The karma types have a missing dependency on typings from the log4js package.
   // if (packageJson.name === '@types/karma') {
   //  context.log('Fixed up dependencies for @types/karma');
   //  packageJson.dependencies['log4js'] = '0.6.38';
   // }
+
+  // @typescript-eslint/eslint-plugin@1.12.0 introduced an implicit dependency on @typescript-eslint/typescript-estree.
+  // This should be fixed in a future release of @typescript-eslint/eslint-plugin.
+  // https://github.com/typescript-eslint/typescript-eslint/issues/705
+  if (packageJson.name === '@typescript-eslint/eslint-plugin') {
+    context.log('Fixed up dependencies for @typescript-eslint/eslint-plugin');
+    packageJson.dependencies['@typescript-eslint/typescript-estree'] =
+      '^1.11.0';
+  }
 
   return packageJson;
 }


### PR DESCRIPTION
- @typescript-eslint/eslint-plugin@1.12.0 introduced an implicit dependency on @typescript-eslint/typescript-estree
  - This should be fixed in a future release of @typescript-eslint/eslint-plugin
  - https://github.com/typescript-eslint/typescript-eslint/issues/705

This change allows `rush lint` to work with `@typescript-eslint/eslint-plugin@1.12.0`.  Without this change, `rush lint` fails with the following error:

```
Error: Cannot find module '@typescript-eslint/typescript-estree'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (D:\Git\typescript-eslint-test\node_modules\.registry.npmjs.org\@typescript-eslint\eslint-plugin\1.12.0_db854cf46887ef4aa7b9323cccc417a5\node_modules\@typescript-eslint\eslint-plugin\dist\rules\prefer-readonly.js:17:29)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
```