### PR TITLE
Remove enginesStrict from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "webpack": "^4.26.1",
     "yargs": "^11.0.0"
   },
-  "engineStrict": true,
   "engines": {
     "node": ">=10.10.0"
   }


### PR DESCRIPTION
I'm not entirely sure what the purpose of this was, but support for it was removed in NPM 3.0 a while ago. Fixes #3898.