### PR TITLE
[DEMO] Add eslint-plugin-azure-sdk

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 dependencies:
   '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
   '@azure/arm-servicebus': 0.1.0
+  '@azure/eslint-plugin-azure-sdk': 1.0.0_db854cf46887ef4aa7b9323cccc417a5
   '@azure/event-hubs': 1.0.8
   '@azure/logger-js': 1.3.2
   '@azure/ms-rest-azure-js': 1.3.8
@@ -231,6 +232,20 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mjfeTrEayb1koiy9hq/c9mfa5mys4P6zZdW2QAx4Ma0x4W6/f24O3p0109NHRkiHRay4QsOY3PaTy6CBlvIp+g==
+  /@azure/eslint-plugin-azure-sdk/1.0.0_db854cf46887ef4aa7b9323cccc417a5:
+    dependencies:
+      '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
+      eslint: 5.16.0
+      typescript: 3.5.3
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    peerDependencies:
+      '@typescript-eslint/parser': ^1.10.2
+      eslint: ^5.16.0
+      typescript: ^3.4.5
+    resolution:
+      integrity: sha512-iT0nTlv8/cEmgAlsywAFZxVt+F7tRNBOeG+mFBMgaYvNypNFkDlwi6bfh8igSkyuFd528x76obNYm5ISPBisUw==
   /@azure/event-hubs/1.0.8:
     dependencies:
       '@azure/amqp-common': 0.1.9_rhea-promise@0.1.15
@@ -10201,6 +10216,7 @@ packages:
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
     dependencies:
+      '@azure/eslint-plugin-azure-sdk': 1.0.0_db854cf46887ef4aa7b9323cccc417a5
       '@microsoft/api-extractor': 7.3.2
       '@types/chai': 4.1.7
       '@types/dotenv': 6.1.1
@@ -10235,7 +10251,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-K1QS7ykok+p7DjKnd3GUg6k9W9nTXkux6iJOvt6i/UyVBSMIJ9v/szsLAd/6Osofj9ZMUfeCF46PXKccYkszeA==
+      integrity: sha512-QLVB9aMW9ytjgWPbXhA9D+i24RNW8b1/TFkvYET5y53U5Zexlbl+exogJUWv5qp39WyLLUj1in3BYopRwtXOgg==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10646,9 +10662,11 @@ packages:
       integrity: sha512-c3cFI0Our99carkgcyOFLmX5QRh5fIqyVv9S75VRX7woNtBGXPvWRE8VOxEN9o8N8FjSEQzc6PPEO6YRz7ok8Q==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure/amqp-common': ^1.0.0-preview.6
   '@azure/arm-servicebus': ^0.1.0
+  '@azure/eslint-plugin-azure-sdk': ^1.0.0
   '@azure/event-hubs': ^1.0.6
   '@azure/logger-js': ^1.0.2
   '@azure/ms-rest-azure-js': ^1.3.2

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 dependencies:
   '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
   '@azure/arm-servicebus': 0.1.0
-  '@azure/eslint-plugin-azure-sdk': 1.0.0_db854cf46887ef4aa7b9323cccc417a5
+  '@azure/eslint-plugin-azure-sdk': 1.1.0-preview.2_86b9f28fab9d3e359385901d6d9d9397
   '@azure/event-hubs': 1.0.8
   '@azure/logger-js': 1.3.2
   '@azure/ms-rest-azure-js': 1.3.8
@@ -232,20 +232,20 @@ packages:
     dev: false
     resolution:
       integrity: sha512-mjfeTrEayb1koiy9hq/c9mfa5mys4P6zZdW2QAx4Ma0x4W6/f24O3p0109NHRkiHRay4QsOY3PaTy6CBlvIp+g==
-  /@azure/eslint-plugin-azure-sdk/1.0.0_db854cf46887ef4aa7b9323cccc417a5:
+  /@azure/eslint-plugin-azure-sdk/1.1.0-preview.2_86b9f28fab9d3e359385901d6d9d9397:
     dependencies:
       '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
       eslint: 5.16.0
+      path: 0.12.7
       typescript: 3.5.3
     dev: false
     engines:
-      node: '>=0.10.0'
+      node: '>=8.0.0'
     peerDependencies:
       '@typescript-eslint/parser': ^1.10.2
       eslint: ^5.16.0
-      typescript: ^3.4.5
     resolution:
-      integrity: sha512-iT0nTlv8/cEmgAlsywAFZxVt+F7tRNBOeG+mFBMgaYvNypNFkDlwi6bfh8igSkyuFd528x76obNYm5ISPBisUw==
+      integrity: sha512-2yfQFhuXgXLyZ11Esmt+FlP+NXsYDpWdyc+HmpXzhPbyVMH509EbbG7/EjxbRICFx9L3XLqPIPY3cXhLSH/7/g==
   /@azure/event-hubs/1.0.8:
     dependencies:
       '@azure/amqp-common': 0.1.9_rhea-promise@0.1.15
@@ -6982,6 +6982,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  /path/0.12.7:
+    dependencies:
+      process: 0.11.10
+      util: 0.10.4
+    dev: false
+    resolution:
+      integrity: sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=
   /pathval/1.1.0:
     dev: false
     resolution:
@@ -9137,6 +9144,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-evsa/lCAUkZInj23/g7TeTNqwPk=
+  /util/0.10.4:
+    dependencies:
+      inherits: 2.0.3
+    dev: false
+    resolution:
+      integrity: sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==
   /util/0.11.1:
     dependencies:
       inherits: 2.0.3
@@ -10216,7 +10229,7 @@ packages:
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
     dependencies:
-      '@azure/eslint-plugin-azure-sdk': 1.0.0_db854cf46887ef4aa7b9323cccc417a5
+      '@azure/eslint-plugin-azure-sdk': 1.1.0-preview.2_86b9f28fab9d3e359385901d6d9d9397
       '@microsoft/api-extractor': 7.3.2
       '@types/chai': 4.1.7
       '@types/dotenv': 6.1.1
@@ -10251,7 +10264,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-QLVB9aMW9ytjgWPbXhA9D+i24RNW8b1/TFkvYET5y53U5Zexlbl+exogJUWv5qp39WyLLUj1in3BYopRwtXOgg==
+      integrity: sha512-3yZGnlBUZYzpvwpeNi6bnJsOlF8RhGj3LFoz+vxCYklIIj/0eigF/NgkrAcWIApp+z/lXwbYJI1ebg0DLtX/vg==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10666,7 +10679,7 @@ registry: ''
 specifiers:
   '@azure/amqp-common': ^1.0.0-preview.6
   '@azure/arm-servicebus': ^0.1.0
-  '@azure/eslint-plugin-azure-sdk': ^1.0.0
+  '@azure/eslint-plugin-azure-sdk': ^1.1.0-preview.2
   '@azure/event-hubs': ^1.0.6
   '@azure/logger-js': ^1.0.2
   '@azure/ms-rest-azure-js': ^1.3.2

--- a/sdk/keyvault/keyvault-keys/.eslintrc.json
+++ b/sdk/keyvault/keyvault-keys/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["../../.eslintrc.json", "plugin:@azure/azure-sdk/recommended"]
+}

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -54,9 +54,9 @@
     "integration-test:browser": "echo skipped",
     "integration-test:node": "ts-mocha -p tests/tsconfig.test.json tests/*.test.ts tests/**/*.test.ts --timeout 1200000 --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint -c ../../.eslintrc.json src tests samples --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint -c ../../.eslintrc.json src tests samples --ext .ts -f node_modules/eslint-detailed-reporter/lib/detailed.js -o keyvault-keys-lintReport.html || exit 0",
-    "lint:terminal": "eslint -c ../../.eslintrc.json src tests samples --ext .ts",
+    "lint:fix": "eslint package.json tsconfig.json src tests samples --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json tsconfig.json src tests samples --ext .ts -f node_modules/eslint-detailed-reporter/lib/detailed.js -o keyvault-keys-lintReport.html || exit 0",
+    "lint:terminal": "eslint package.json tsconfig.json src tests samples --ext .ts",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
@@ -75,6 +75,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@azure/eslint-plugin-azure-sdk": "^1.0.0",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -75,7 +75,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@azure/eslint-plugin-azure-sdk": "^1.0.0",
+    "@azure/eslint-plugin-azure-sdk": "latest",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -75,7 +75,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@azure/eslint-plugin-azure-sdk": "latest",
+    "@azure/eslint-plugin-azure-sdk": "^1.1.0-preview.2",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",


### PR DESCRIPTION
# Overview

[eslint-plugin-azure-sdk](https://github.com/Azure/azure-sdk-tools/tree/master/tools/eslint-plugin-azure-sdk) is intended to automate reviewing a subset of the [JavaScript/TypeScript design guidelines](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html) by integrating directly into the existing CI workflow with ESLint.

This pull request shows the steps necessary to enabling the plugin at a package level, and is only for demonstration purposes.

## Integration

Without additional rule configuration (see plugin README for examples), the required steps at a package level are:

1. Add `@azure/eslint-plugin-azure-sdk` to `devDependencies` in `package.json`.
2. Add a `.eslintrc.json` file as follows:
```json
{
  "plugins": ["@azure/azure-sdk"],
  "extends": ["../../.eslintrc.json", "plugin:@azure/azure-sdk/recommended"]
}
```
3. Remove the config file specifier from any lint NPM scripts in `package.json` (ESLint will automatically pick up any `.eslintrc` files in the working directory) and add `package.json` and `tsconfig.json` as files for ESLint to run on, as this plugin validates configuration in both files.

See `Files changed` for how this looks in practice, using `keyvault-keys` as an example.

## Screenshots

### Running in terminal (`npm run lint:terminal`)

![image](https://user-images.githubusercontent.com/32147742/61396770-4e53bd80-a87d-11e9-887d-f90595f371fb.png)

![image](https://user-images.githubusercontent.com/32147742/61396810-61ff2400-a87d-11e9-8da2-0b958a2d5e12.png)

### ESLint report (`npm run lint`)

![image](https://user-images.githubusercontent.com/32147742/61396904-94a91c80-a87d-11e9-972f-5077c0f0d9a0.png)
