### PR TITLE
Add princiaplType to arm-authorization.

### DIFF
--- a/sdk/authorization/arm-authorization/src/models/index.ts
+++ b/sdk/authorization/arm-authorization/src/models/index.ts
@@ -187,6 +187,13 @@ export interface RoleAssignment {
    */
   principalId?: string;
   /**
+  * @member {PrincipalType} [principalType] The principal type of the assigned
+  * principal ID. Possible values include: 'User', 'Group',
+  * 'ServicePrincipal', 'Unknown', 'DirectoryRoleTemplate', 'ForeignGroup',
+  * 'Application', 'MSI', 'DirectoryObjectOrGroup', 'Everyone'.
+  */
+  principalType?: PrincipalType;
+  /**
    * @member {boolean} [canDelegate] The Delegation flag for the roleassignment
    */
   canDelegate?: boolean;
@@ -798,15 +805,15 @@ export type ClassicAdministratorsListResponse = ClassicAdministratorListResult &
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ClassicAdministratorListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ClassicAdministratorListResult;
+  };
 };
 
 /**
@@ -817,15 +824,15 @@ export type ClassicAdministratorsListNextResponse = ClassicAdministratorListResu
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ClassicAdministratorListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ClassicAdministratorListResult;
+  };
 };
 
 /**
@@ -836,15 +843,15 @@ export type ProviderOperationsMetadataGetResponse = ProviderOperationsMetadata &
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ProviderOperationsMetadata;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ProviderOperationsMetadata;
+  };
 };
 
 /**
@@ -855,15 +862,15 @@ export type ProviderOperationsMetadataListResponse = ProviderOperationsMetadataL
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ProviderOperationsMetadataListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ProviderOperationsMetadataListResult;
+  };
 };
 
 /**
@@ -874,15 +881,15 @@ export type ProviderOperationsMetadataListNextResponse = ProviderOperationsMetad
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ProviderOperationsMetadataListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ProviderOperationsMetadataListResult;
+  };
 };
 
 /**
@@ -893,15 +900,15 @@ export type RoleAssignmentsListForResourceResponse = RoleAssignmentListResult & 
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -912,15 +919,15 @@ export type RoleAssignmentsListForResourceGroupResponse = RoleAssignmentListResu
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -931,15 +938,15 @@ export type RoleAssignmentsDeleteMethodResponse = RoleAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignment;
+  };
 };
 
 /**
@@ -950,15 +957,15 @@ export type RoleAssignmentsCreateResponse = RoleAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignment;
+  };
 };
 
 /**
@@ -969,15 +976,15 @@ export type RoleAssignmentsGetResponse = RoleAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignment;
+  };
 };
 
 /**
@@ -988,15 +995,15 @@ export type RoleAssignmentsDeleteByIdResponse = RoleAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignment;
+  };
 };
 
 /**
@@ -1007,15 +1014,15 @@ export type RoleAssignmentsCreateByIdResponse = RoleAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignment;
+  };
 };
 
 /**
@@ -1026,15 +1033,15 @@ export type RoleAssignmentsGetByIdResponse = RoleAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignment;
+  };
 };
 
 /**
@@ -1045,15 +1052,15 @@ export type RoleAssignmentsListResponse = RoleAssignmentListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -1064,15 +1071,15 @@ export type RoleAssignmentsListForScopeResponse = RoleAssignmentListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -1083,15 +1090,15 @@ export type RoleAssignmentsListForResourceNextResponse = RoleAssignmentListResul
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -1102,15 +1109,15 @@ export type RoleAssignmentsListForResourceGroupNextResponse = RoleAssignmentList
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -1121,15 +1128,15 @@ export type RoleAssignmentsListNextResponse = RoleAssignmentListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -1140,15 +1147,15 @@ export type RoleAssignmentsListForScopeNextResponse = RoleAssignmentListResult &
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleAssignmentListResult;
+  };
 };
 
 /**
@@ -1159,15 +1166,15 @@ export type PermissionsListForResourceGroupResponse = PermissionGetResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: PermissionGetResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: PermissionGetResult;
+  };
 };
 
 /**
@@ -1178,15 +1185,15 @@ export type PermissionsListForResourceResponse = PermissionGetResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: PermissionGetResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: PermissionGetResult;
+  };
 };
 
 /**
@@ -1197,15 +1204,15 @@ export type PermissionsListForResourceGroupNextResponse = PermissionGetResult & 
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: PermissionGetResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: PermissionGetResult;
+  };
 };
 
 /**
@@ -1216,15 +1223,15 @@ export type PermissionsListForResourceNextResponse = PermissionGetResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: PermissionGetResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: PermissionGetResult;
+  };
 };
 
 /**
@@ -1235,15 +1242,15 @@ export type RoleDefinitionsDeleteMethodResponse = RoleDefinition & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleDefinition;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleDefinition;
+  };
 };
 
 /**
@@ -1254,15 +1261,15 @@ export type RoleDefinitionsGetResponse = RoleDefinition & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleDefinition;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleDefinition;
+  };
 };
 
 /**
@@ -1273,15 +1280,15 @@ export type RoleDefinitionsCreateOrUpdateResponse = RoleDefinition & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleDefinition;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleDefinition;
+  };
 };
 
 /**
@@ -1292,15 +1299,15 @@ export type RoleDefinitionsListResponse = RoleDefinitionListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleDefinitionListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleDefinitionListResult;
+  };
 };
 
 /**
@@ -1311,15 +1318,15 @@ export type RoleDefinitionsGetByIdResponse = RoleDefinition & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleDefinition;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleDefinition;
+  };
 };
 
 /**
@@ -1330,15 +1337,15 @@ export type RoleDefinitionsListNextResponse = RoleDefinitionListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: RoleDefinitionListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RoleDefinitionListResult;
+  };
 };
 
 /**
@@ -1349,15 +1356,15 @@ export type DenyAssignmentsListForResourceResponse = DenyAssignmentListResult & 
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };
 
 /**
@@ -1368,15 +1375,15 @@ export type DenyAssignmentsListForResourceGroupResponse = DenyAssignmentListResu
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };
 
 /**
@@ -1387,15 +1394,15 @@ export type DenyAssignmentsListResponse = DenyAssignmentListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };
 
 /**
@@ -1406,15 +1413,15 @@ export type DenyAssignmentsGetResponse = DenyAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignment;
+  };
 };
 
 /**
@@ -1425,15 +1432,15 @@ export type DenyAssignmentsGetByIdResponse = DenyAssignment & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignment;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignment;
+  };
 };
 
 /**
@@ -1444,15 +1451,15 @@ export type DenyAssignmentsListForScopeResponse = DenyAssignmentListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };
 
 /**
@@ -1463,15 +1470,15 @@ export type DenyAssignmentsListForResourceNextResponse = DenyAssignmentListResul
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };
 
 /**
@@ -1482,15 +1489,15 @@ export type DenyAssignmentsListForResourceGroupNextResponse = DenyAssignmentList
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };
 
 /**
@@ -1501,15 +1508,15 @@ export type DenyAssignmentsListNextResponse = DenyAssignmentListResult & {
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };
 
 /**
@@ -1520,13 +1527,13 @@ export type DenyAssignmentsListForScopeNextResponse = DenyAssignmentListResult &
    * The underlying HTTP response.
    */
   _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: DenyAssignmentListResult;
-    };
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DenyAssignmentListResult;
+  };
 };

--- a/sdk/authorization/arm-authorization/src/models/mappers.ts
+++ b/sdk/authorization/arm-authorization/src/models/mappers.ts
@@ -259,6 +259,12 @@ export const RoleAssignment: msRest.CompositeMapper = {
           name: "String"
         }
       },
+      principalType: {
+        serializedName: "properties.principalType",
+        type: {
+          name: "String"
+        }
+      },
       canDelegate: {
         serializedName: "properties.canDelegate",
         type: {


### PR DESCRIPTION
Include princiaplType in the parsed response and add it the model.
In my case, I tried to use AuthorizationManagmentClient to get the role assignments for a resource group, `authorizationManagmentClient.listForResourceGroup('NAME')`.
The response will include principal id and principal type, the SDK will only show the principal id.
It's helpful to parse the type and include it because it will help to get more information about the principal id.
So this PR is extending this part.