### PR TITLE
[EPH] Update event-hub version to 2.1.1 and make it compatible with EPH

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,7 +1,8 @@
 dependencies:
   '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
   '@azure/arm-servicebus': 0.1.0
-  '@azure/event-hubs': 1.0.8
+  '@azure/event-hubs': 2.1.1
+  '@azure/event-processor-host': 1.0.6
   '@azure/logger-js': 1.3.2
   '@azure/ms-rest-azure-js': 1.3.8
   '@azure/ms-rest-js': 1.8.13
@@ -245,6 +246,33 @@ packages:
     dev: false
     resolution:
       integrity: sha512-iYaB08erq2Eg5sUOXD0GXn4OmkqC67xczLfnlaaF0fLtgk999ePTuFqj4LHYT5HHUdDumYZ+U3WjPSvb0ztHJw==
+  /@azure/event-hubs/2.1.1:
+    dependencies:
+      '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
+      '@azure/ms-rest-nodeauth': 0.9.3
+      async-lock: 1.2.2
+      debug: 3.2.6
+      is-buffer: 2.0.3
+      jssha: 2.3.1
+      rhea-promise: 0.1.15
+      tslib: 1.10.0
+      uuid: 3.3.2
+    dev: false
+    resolution:
+      integrity: sha512-nGnFBPcB/rs+5YWwmHJg+d3Cs7BrjtVfuD1eEv8j+ui2X6uXxB88wom1A2t/7xsSzkunQSrXJ2mCwdHxKI5aHw==
+  /@azure/event-processor-host/1.0.6:
+    dependencies:
+      '@azure/event-hubs': 1.0.8
+      async-lock: 1.2.2
+      azure-storage: 2.10.3
+      debug: 3.2.6
+      ms-rest-azure: 2.6.0
+      path-browserify: 1.0.0
+      tslib: 1.10.0
+      uuid: 3.3.2
+    dev: false
+    resolution:
+      integrity: sha512-SjlC+eXXeVWEU0oSK7Q6xVhbFd9G7tG+F6QK7orqpIYSzn0NPtDeKZasTO+nS0uvrUDKr3vs2DiK+fEjz8hm5g==
   /@azure/logger-js/1.3.2:
     dependencies:
       tslib: 1.10.0
@@ -10066,7 +10094,8 @@ packages:
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
     dependencies:
-      '@azure/event-hubs': 1.0.8
+      '@azure/event-hubs': 2.1.1
+      '@azure/ms-rest-nodeauth': 0.9.3
       '@microsoft/api-extractor': 7.3.2
       '@types/async-lock': 1.1.1
       '@types/chai': 4.1.7
@@ -10116,7 +10145,7 @@ packages:
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-kNXtALlFQOATlvSkSIJ2PU54lX/OY/yD33fxY4KXBUcEZ3fJTaH8iXmV0S89Ry/eaOHtHU/Iia1Yfs7u7d4avA==
+      integrity: sha512-YEltFsweWeV5/IHJyEd/kVz7RG4iRz2AWE6rsw23UIXJaMkEc3nhsw/FtJpWq8bGWs8Dp3pvzKx1VezkCFB9MQ==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -10623,7 +10652,8 @@ packages:
     version: 0.0.0
   'file:projects/testhub.tgz':
     dependencies:
-      '@azure/event-hubs': 1.0.8
+      '@azure/event-hubs': 2.1.1
+      '@azure/event-processor-host': 1.0.6
       '@types/node': 8.10.50
       '@types/uuid': 3.4.5
       '@types/yargs': 11.1.2
@@ -10643,13 +10673,15 @@ packages:
     dev: false
     name: '@rush-temp/testhub'
     resolution:
-      integrity: sha512-c3cFI0Our99carkgcyOFLmX5QRh5fIqyVv9S75VRX7woNtBGXPvWRE8VOxEN9o8N8FjSEQzc6PPEO6YRz7ok8Q==
+      integrity: sha512-Lt7NGJIhEbyVoQ1sJ4eUnUg7nGIkdgatRJJMWz18ZVWxKFXPxbBjxPsvIJNirR8QdA3efLv1FhyM4lszfJHcjw==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure/amqp-common': ^1.0.0-preview.6
   '@azure/arm-servicebus': ^0.1.0
-  '@azure/event-hubs': ^1.0.6
+  '@azure/event-hubs': ^2.1.1
+  '@azure/event-processor-host': ^1.0.6
   '@azure/logger-js': ^1.0.2
   '@azure/ms-rest-azure-js': ^1.3.2
   '@azure/ms-rest-js': ^1.2.6

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -50,7 +50,7 @@ export class EventDataBatch {
     constructor(context: ConnectionContext, maxSizeInBytes: number, partitionKey?: string);
     readonly batchMessage: Buffer | undefined;
     readonly partitionKey: string | undefined;
-    readonly size: number | undefined;
+    readonly size: number;
     tryAdd(eventData: EventData): boolean;
 }
 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -2,7 +2,7 @@
 - Minimum dependency on `@azure/event-hubs: "^2.1.1"`.
 
 #### Breaking Changes
-- If you have been using the `createFromAadTokenCredentials` function to create an instance of the 
+- If you have been using the `createFromAadTokenCredentials` function or the `createFromAadTokenCredentialsWithCustomCheckpointAndLeaseManager` function to create an instance of the 
 `EventProcessorHost`, you will now need to use the [@azure/ms-rest-nodeauth](https://www.npmjs.com/package/@azure/ms-rest-nodeauth) 
 library instead of [ms-rest-azure](https://www.npmjs.com/package/ms-rest-azure) library to create 
 the credentials that are needed by the `createFromAadTokenCredentials` function.

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,5 +1,7 @@
 ## 2019-07-16 2.0.0
-- Minimum dependency on `@azure/event-hubs: "^2.1.1"`.
+- Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has fixes for the following bugs
+        - TODO: Talk about the unhandled exception here
+        - TODO: Talk about the network related bug fixes that were done in Event Hubs
 
 #### Breaking Changes
 - If you have been using the `createFromAadTokenCredentials` function or the `createFromAadTokenCredentialsWithCustomCheckpointAndLeaseManager` function to create an instance of the 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -5,7 +5,7 @@
 - If you have been using the `createFromAadTokenCredentials` function or the `createFromAadTokenCredentialsWithCustomCheckpointAndLeaseManager` function to create an instance of the 
 `EventProcessorHost`, you will now need to use the [@azure/ms-rest-nodeauth](https://www.npmjs.com/package/@azure/ms-rest-nodeauth) 
 library instead of [ms-rest-azure](https://www.npmjs.com/package/ms-rest-azure) library to create 
-the credentials that are needed by the `createFromAadTokenCredentials` function.
+the credentials that are needed by these functions.
     - Typescript: Replace `import * from "ms-rest-azure";` with `import * from "@azure/ms-rest-nodeauth";`
     - Javascript: Replace `require("ms-rest-azure")` with `require("@azure/ms-rest-nodeauth")`
 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -2,7 +2,7 @@
 - Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has the following bug fixes
       - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
       - A network connection lost error is now treated as retryable error. A new error with name `ConnectionLostError` 
-      is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs#enable-logs).
+      is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-processor-host#debug-logs).
       - When recovering from an error that caused the underlying AMQP connection to get disconnected, 
       [rhea](https://github.com/amqp/rhea/issues/205) reconnects all the older AMQP links on the connection 
       resulting in the below 2 errors in the logs. We now clear rhea's internal map to avoid such reconnections. 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,3 +1,15 @@
+## 2019-07-16 2.0.0
+- Minimum dependency on `@azure/event-hubs: "^2.1.1"`.
+
+#### Breaking Changes
+- If you have been using the `createFromAadTokenCredentials` function to create an instance of the 
+`EventProcessorHost`, you will now need to use the [@azure/ms-rest-nodeauth](https://www.npmjs.com/package/@azure/ms-rest-nodeauth) 
+library instead of [ms-rest-azure](https://www.npmjs.com/package/ms-rest-azure) library to create 
+the credentials that are needed by the `createFromAadTokenCredentials` function.
+    - Typescript: Replace `import * from "ms-rest-azure";` with `import * from "@azure/ms-rest-nodeauth";`
+    - Javascript: Replace `require("ms-rest-azure")` with `require("@azure/ms-rest-nodeauth")`
+
+
 ## 2018-10-05 1.0.6
 - Remove `@azure/amqp-common` and `rhea-promise` as dependencies, since we use very little from 
 those libraries and there is a risk of having two instances of rhea in the dependency chain which 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,14 +1,14 @@
 ## 2019-07-16 2.0.0
 - Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has fixes for the following bugs
-        - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
-        - A network connection lost error is now treated as retryable error. A new error with name `ConnectionLostError` 
-        is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs#enable-logs).
-        - When recovering from an error that caused the underlying AMQP connection to get disconnected, 
-        [rhea](https://github.com/amqp/rhea/issues/205) reconnects all the older AMQP links on the connection 
-        resulting in the below 2 errors in the logs. We now clear rhea's internal map to avoid such reconnections. 
-        We already have code in place to create new AMQP links to resume send/receive operations.
-          - InvalidOperationError: A link to connection '.....' $cbs node has already been opened.
-          - UnauthorizedError: Unauthorized access. 'Listen' claim(s) are required to perform this operation.
+      - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
+      - A network connection lost error is now treated as retryable error. A new error with name `ConnectionLostError` 
+      is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs#enable-logs).
+      - When recovering from an error that caused the underlying AMQP connection to get disconnected, 
+      [rhea](https://github.com/amqp/rhea/issues/205) reconnects all the older AMQP links on the connection 
+      resulting in the below 2 errors in the logs. We now clear rhea's internal map to avoid such reconnections. 
+      We already have code in place to create new AMQP links to resume send/receive operations.
+         - InvalidOperationError: A link to connection '.....' $cbs node has already been opened.
+         - UnauthorizedError: Unauthorized access. 'Listen' claim(s) are required to perform this operation.
 
 #### Breaking Changes
 - If you have been using the `createFromAadTokenCredentials` function or the `createFromAadTokenCredentialsWithCustomCheckpointAndLeaseManager` function to create an instance of the 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,5 +1,5 @@
 ## 2019-07-16 2.0.0
-- Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has fixes for the following bugs
+- Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has the following bug fixes
       - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
       - A network connection lost error is now treated as retryable error. A new error with name `ConnectionLostError` 
       is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs#enable-logs).

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,7 +1,14 @@
 ## 2019-07-16 2.0.0
 - Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has fixes for the following bugs
-        - TODO: Talk about the unhandled exception here
-        - TODO: Talk about the network related bug fixes that were done in Event Hubs
+        - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
+        - A network connection lost error is now treated as retryable error. A new error with name `ConnectionLostError` 
+        is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs#enable-logs).
+        - When recovering from an error that caused the underlying AMQP connection to get disconnected, 
+        [rhea](https://github.com/amqp/rhea/issues/205) reconnects all the older AMQP links on the connection 
+        resulting in the below 2 errors in the logs. We now clear rhea's internal map to avoid such reconnections. 
+        We already have code in place to create new AMQP links to resume send/receive operations.
+          - InvalidOperationError: A link to connection '.....' $cbs node has already been opened.
+          - UnauthorizedError: Unauthorized access. 'Listen' claim(s) are required to perform this operation.
 
 #### Breaking Changes
 - If you have been using the `createFromAadTokenCredentials` function or the `createFromAadTokenCredentialsWithCustomCheckpointAndLeaseManager` function to create an instance of the 

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-processor-host",
   "sdk-type": "client",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Azure Event Processor Host (Event Hubs) SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -58,11 +58,11 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "^1.0.6",
+    "@azure/event-hubs": "^2.1.1",
     "async-lock": "^1.1.3",
     "azure-storage": "^2.10.2",
     "debug": "^3.1.0",
-    "ms-rest-azure": "^2.5.9",
+    "@azure/ms-rest-nodeauth": "^0.9.2",
     "path-browserify": "^1.0.0",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/sdk/eventhub/event-processor-host/review/event-processor-host.api.md
+++ b/sdk/eventhub/event-processor-host/review/event-processor-host.api.md
@@ -5,13 +5,13 @@
 ```ts
 
 import { aadEventHubsAudience } from '@azure/event-hubs';
-import { ApplicationTokenCredentials } from 'ms-rest-azure';
+import { ApplicationTokenCredentials } from '@azure/ms-rest-nodeauth';
 import AsyncLock from 'async-lock';
 import { BlobService as BlobService_2 } from 'azure-storage';
 import { ClientOptionsBase } from '@azure/event-hubs';
 import { DataTransformer } from '@azure/event-hubs';
 import { delay } from '@azure/event-hubs';
-import { DeviceTokenCredentials } from 'ms-rest-azure';
+import { DeviceTokenCredentials } from '@azure/ms-rest-nodeauth';
 import { Dictionary } from '@azure/event-hubs';
 import { EventData } from '@azure/event-hubs';
 import { EventHubClient } from '@azure/event-hubs';
@@ -20,11 +20,11 @@ import { EventHubPartitionRuntimeInformation } from '@azure/event-hubs';
 import { EventHubRuntimeInformation } from '@azure/event-hubs';
 import { EventPosition } from '@azure/event-hubs';
 import { MessagingError } from '@azure/event-hubs';
-import { MSITokenCredentials } from 'ms-rest-azure';
+import { MSITokenCredentials } from '@azure/ms-rest-nodeauth';
 import { OnError } from '@azure/event-hubs';
 import { ServiceResponse } from 'azure-storage';
 import { TokenProvider } from '@azure/event-hubs';
-import { UserTokenCredentials } from 'ms-rest-azure';
+import { UserTokenCredentials } from '@azure/ms-rest-nodeauth';
 
 export { aadEventHubsAudience }
 

--- a/sdk/eventhub/event-processor-host/src/eventProcessorHost.ts
+++ b/sdk/eventhub/event-processor-host/src/eventProcessorHost.ts
@@ -14,7 +14,7 @@ import {
   UserTokenCredentials,
   DeviceTokenCredentials,
   MSITokenCredentials
-} from "ms-rest-azure";
+} from "@azure/ms-rest-nodeauth";
 import * as log from "./log";
 import { LeaseManager } from "./leaseManager";
 import { HostContext } from "./hostContext";

--- a/sdk/eventhub/event-processor-host/src/util/constants.ts
+++ b/sdk/eventhub/event-processor-host/src/util/constants.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { name, version } from "../../package.json";
-
 export const minLeaseDurationInSeconds = 15;
 export const maxLeaseDurationInSeconds = 60;
 export const defaultLeaseDurationInSeconds = 30;
@@ -19,6 +17,6 @@ export const leaseIdMismatchWithLeaseOperation = "leaseidmismatchwithleaseoperat
 export const leaseIdMismatchWithBlobOperation = "leaseidmismatchwithbloboperation";
 export const defaultConsumerGroup = "$default";
 export const packageInfo = {
-  name: name,
-  version: version
+  name: "@azure/event-processor-host",
+  version: "2.0.0"
 };

--- a/sdk/eventhub/event-processor-host/src/util/constants.ts
+++ b/sdk/eventhub/event-processor-host/src/util/constants.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 import { name, version } from "../../package.json";
 
 export const minLeaseDurationInSeconds = 15;

--- a/sdk/eventhub/event-processor-host/src/util/constants.ts
+++ b/sdk/eventhub/event-processor-host/src/util/constants.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { name, version } from "../../package.json";
 
 export const minLeaseDurationInSeconds = 15;
 export const maxLeaseDurationInSeconds = 60;
@@ -17,6 +18,6 @@ export const leaseIdMismatchWithLeaseOperation = "leaseidmismatchwithleaseoperat
 export const leaseIdMismatchWithBlobOperation = "leaseidmismatchwithbloboperation";
 export const defaultConsumerGroup = "$default";
 export const packageInfo = {
-  name: "@azure/event-processor-host",
-  version: "1.0.5"
+  name: name,
+  version: version
 };

--- a/sdk/eventhub/event-processor-host/tsconfig.json
+++ b/sdk/eventhub/event-processor-host/tsconfig.json
@@ -30,7 +30,8 @@
 
     /* Other options */
     "newLine": "LF" /*	Use the specified end of line sequence to be used when emitting files: "crlf" (windows) or "lf" (unix).”*/,
-    "allowJs": false /* Don't allow JavaScript files to be compiled.*/
+    "allowJs": false /* Don't allow JavaScript files to be compiled.*/,
+    "resolveJsonModule": true
   },
   "compileOnSave": true,
   "exclude": ["node_modules", "typings/**", "./samples/**/*.ts"],

--- a/sdk/eventhub/event-processor-host/tsconfig.json
+++ b/sdk/eventhub/event-processor-host/tsconfig.json
@@ -30,8 +30,7 @@
 
     /* Other options */
     "newLine": "LF" /*	Use the specified end of line sequence to be used when emitting files: "crlf" (windows) or "lf" (unix).”*/,
-    "allowJs": false /* Don't allow JavaScript files to be compiled.*/,
-    "resolveJsonModule": true
+    "allowJs": false /* Don't allow JavaScript files to be compiled.*/
   },
   "compileOnSave": true,
   "exclude": ["node_modules", "typings/**", "./samples/**/*.ts"],

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -7,7 +7,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@azure/event-hubs": "^1.0.6",
+    "@azure/event-hubs": "^2.1.1",
     "@azure/event-processor-host": "^1.0.6",
     "@types/node": "^8.0.0",
     "@types/uuid": "^3.4.3",


### PR DESCRIPTION
* Updated event-hubs version to `@azure/event-hubs: "^2.1.1"` in EPH package.json
* Updated `ms-rest-azure` -> `@azure/ms-rest-nodeauth` to make EPH compatible with updated event hubs version
* Updated changelog
* Updated EPH version: 2.0.0



More more context: #4136, https://github.com/Azure/azure-sdk-for-js/pull/4318