### PR TITLE
Fixes for a couple @azure/core-http issues found during arm-* migration

### DIFF
--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -49,5 +49,11 @@ export interface AccessToken {
  * @param credential The assumed TokenCredential to be tested.
  */
 export function isTokenCredential(credential: any): credential is TokenCredential {
-  return credential && typeof credential.getToken === "function";
+  // Check for an object with a 'getToken' function but without
+  // a 'signRequest' function.  We do this check to make sure that
+  // a ServiceClientCredentials implementor (like TokenClientCredentials
+  // in ms-rest-nodeauth) doesn't get mistaken for a TokenCredential.
+  return credential
+    && typeof credential.getToken === "function"
+    && credential.signRequest === undefined;
 }

--- a/sdk/core/core-auth/test/index.spec.ts
+++ b/sdk/core/core-auth/test/index.spec.ts
@@ -29,4 +29,11 @@ describe("isTokenCredential", function () {
       getToken: true
     }), false);
   });
+
+  it("should return false for an object that has a 'signRequest' field", () => {
+    assert.strictEqual(isTokenCredential({
+      getToken: function () { },
+      signRequest: function() { },
+    }), false);
+  })
 });


### PR DESCRIPTION
This change fixes two issues that were identified when trying to use `ms-rest-nodeauth` with `@azure/arm-resources` when testing PR #4315:

1. When a credential type from `ms-rest-nodeauth` which implements `TokenClientCredentials` was passed to the `ResourceManagementClient`, `isTokenCredential` was mistaking it for a `TokenCredential` (they both have a `getToken` method) and then used the wrong authentication policy.  This change checks whether the credential's `getToken` function accepts parameters before assuming it's a `TokenCredential` since the `TokenClientCredentials.getToken` method takes no parameters.

2. In Preview 1, `@azure/core-http`'s `ServiceClient` implementation was incorrectly hardcoding the scope of all authentication requests to `/.default` instead of using the service-qualified scope name (i.e. `https://management.azure.com/.default`).  This worked OK for data plane services but failed immediately for management plane services that do not accept the [backcompat `/.default` scope](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#the-default-scope).

The solution for #2 is unfortunately a bit of a necessary hack.  `ServiceClient` implementations that are generated for ARM libraries must set the `baseUri` of their subclass instance to the service URI _after_ the base `ServiceClient` constructor completes.  Because `baseUri` is set late, the `bearerTokenAuthenticationPolicy` factory cannot be given a `scope` which includes the `baseUri`.

The fix here is to use a factory wrapper which accesses the `ServiceClient.baseUri` property right at the time the `bearerTokenAuthenticationPolicy` factory is first invoked so that the populated value gets used to create the `scope` string.

The alternative would be to change the constructor (or options type) of `ServiceClient` to accept the `baseUri` so that it can be used earlier in the initialization process, but that would then require additional changes to `autorest.typescript` to wire up the `baseUri` assignment correctly.  I thought that this solution would be less trouble, but I'm happy to go for the full solution if folks think it's more appropriate.