### PR TITLE
Record and playback - POC for skip functionality in common recorder

### DIFF
--- a/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_after_aborter_timeout.json
+++ b/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_after_aborter_timeout.json
@@ -1,0 +1,6 @@
+{
+ "recordings": [],
+ "uniqueTestInfo": {
+  "queue": "queue156332152913504024"
+ }
+}

--- a/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_after_parent_aborter_calls_abort.json
+++ b/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_after_parent_aborter_calls_abort.json
@@ -1,0 +1,6 @@
+{
+ "recordings": [],
+ "uniqueTestInfo": {
+  "queue": "queue156332152914004887"
+ }
+}

--- a/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_after_parent_aborter_timeout.json
+++ b/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_after_parent_aborter_timeout.json
@@ -1,0 +1,6 @@
+{
+ "recordings": [],
+ "uniqueTestInfo": {
+  "queue": "queue156332152914507000"
+ }
+}

--- a/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_when_calling_abort_before_request_finishes.json
+++ b/sdk/storage/storage-queue/recordings/browsers/aborter/recording_should_abort_when_calling_abort_before_request_finishes.json
@@ -1,0 +1,6 @@
+{
+ "recordings": [],
+ "uniqueTestInfo": {
+  "queue": "queue156332152881302622"
+ }
+}

--- a/sdk/storage/storage-queue/test/aborter.spec.ts
+++ b/sdk/storage/storage-queue/test/aborter.spec.ts
@@ -37,6 +37,7 @@ describe("Aborter", () => {
   });
 
   it("should abort when calling abort() before request finishes", async () => {
+    recorder.skip("browser");
     const aborter = Aborter.none;
     const response = queueClient.create({ abortSignal: aborter });
     aborter.abort();
@@ -54,6 +55,7 @@ describe("Aborter", () => {
   });
 
   it("should abort after aborter timeout", async () => {
+    recorder.skip("browser");
     try {
       await queueClient.create({ abortSignal: Aborter.timeout(1) });
       assert.fail();
@@ -61,6 +63,7 @@ describe("Aborter", () => {
   });
 
   it("should abort after parent aborter calls abort()", async () => {
+    recorder.skip("browser");
     try {
       const aborter = Aborter.none;
       const response = queueClient.create({ abortSignal: aborter.withTimeout(10 * 60 * 1000) });
@@ -71,6 +74,7 @@ describe("Aborter", () => {
   });
 
   it("should abort after parent aborter timeout", async () => {
+    recorder.skip("browser");
     try {
       const aborter = Aborter.timeout(1);
       const response = queueClient.create({ abortSignal: aborter.withTimeout(10 * 60 * 1000) });

--- a/sdk/storage/storage-queue/test/utils/recorder.ts
+++ b/sdk/storage/storage-queue/test/utils/recorder.ts
@@ -458,26 +458,18 @@ export function record(testContext: any) {
      */
     skip: function(runtime: string) {
       if (isRecording) {
-        if (runtime === "node") {
-          if (!isBrowser()) {
-            recorder.stop();
-            testContext.skip();
-          }
-        } else if (runtime === "browser") {
-          if (isBrowser()) {
-            recorder.stop();
-            testContext.skip();
-          }
+        if (runtime === "node" && !isBrowser()) {
+          recorder.stop();
+          testContext.skip();
+        } else if (runtime === "browser" && isBrowser()) {
+          recorder.stop();
+          testContext.skip();
         }
       } else if (isPlayingBack) {
-        if (runtime === "node") {
-          if (!isBrowser()) {
-            testContext.skip();
-          }
-        } else if (runtime === "browser") {
-          if (isBrowser()) {
-            testContext.skip();
-          }
+        if (runtime === "node" && !isBrowser()) {
+          testContext.skip();
+        } else if (runtime === "browser" && isBrowser()) {
+          testContext.skip();
         }
       }
     },

--- a/sdk/storage/storage-queue/test/utils/recorder.ts
+++ b/sdk/storage/storage-queue/test/utils/recorder.ts
@@ -93,18 +93,18 @@ export function delay(milliseconds: number): Promise<void> | null {
  * * Tempfile: the request makes use of a random tempfile created locally, and the recorder does not support recording it as unique information
  * * UUID: a UUID is randomly generated within the SDK and used in an HTTP request, resulting in Nock being unable to recognize it
  */
-const skip = [
-  // Abort
-  "browsers/aborter/recording_should_abort_after_aborter_timeout.json",
-  // Abort
-  "browsers/aborter/recording_should_abort_after_parent_aborter_calls_abort.json",
-  // Abort
-  "browsers/aborter/recording_should_abort_after_parent_aborter_timeout.json",
-  // Abort
-  "browsers/aborter/recording_should_abort_when_calling_abort_before_request_finishes.json",
-  // Character
-  "browsers/messagesurl/recording_enqueue_peek_dequeue_special_characters.json"
-];
+// const skip = [
+//   // Abort
+//   "browsers/aborter/recording_should_abort_after_aborter_timeout.json",
+//   // Abort
+//   "browsers/aborter/recording_should_abort_after_parent_aborter_calls_abort.json",
+//   // Abort
+//   "browsers/aborter/recording_should_abort_after_parent_aborter_timeout.json",
+//   // Abort
+//   "browsers/aborter/recording_should_abort_when_calling_abort_before_request_finishes.json",
+//   // Character
+//   "browsers/messagesurl/recording_enqueue_peek_dequeue_special_characters.json"
+// ];
 
 abstract class Recorder {
   protected readonly filepath: string;
@@ -153,9 +153,9 @@ abstract class Recorder {
     return updatedRecording;
   }
 
-  public skip(): boolean {
-    return skip.includes(this.filepath);
-  }
+  // public skip(): boolean {
+  //   return skip.includes(this.filepath);
+  // }
 
   public abstract record(): void;
   public abstract playback(): void;
@@ -436,9 +436,9 @@ export function record(testContext: any) {
     recorder = new NockRecorder(testHierarchy, testTitle);
   }
 
-  if (recorder.skip() && (isRecording || isPlayingBack)) {
-    testContext.skip();
-  }
+  // if (recorder.skip() && (isRecording || isPlayingBack)) {
+  //   testContext.skip();
+  // }
 
   // If neither recording nor playback is enabled, requests hit the live-service and no recordings are generated
   if (isRecording) {
@@ -451,6 +451,34 @@ export function record(testContext: any) {
     stop: function() {
       if (isRecording) {
         recorder.stop();
+      }
+    },
+    /**
+     * @param runtime [string] Let the recorder know when to skip the test - browser or node.js runtime.
+     */
+    skip: function(runtime: string) {
+      if (isRecording) {
+        if (runtime === "node") {
+          if (!isBrowser()) {
+            recorder.stop();
+            testContext.skip();
+          }
+        } else if (runtime === "browser") {
+          if (isBrowser()) {
+            recorder.stop();
+            testContext.skip();
+          }
+        }
+      } else if (isPlayingBack) {
+        if (runtime === "node") {
+          if (!isBrowser()) {
+            testContext.skip();
+          }
+        } else if (runtime === "browser") {
+          if (isBrowser()) {
+            testContext.skip();
+          }
+        }
       }
     },
     getUniqueName: function(prefix: string, recorderId?: string): string {


### PR DESCRIPTION
Managing the list of test names would mean that we should frequently update them whenever a test name changes or a new test is added.
The plan is to avoid the skip list becoming stale in the following way.

Providing a .skip() method with the recorder so that it can be called from the `it` block to skip a test.

Let us take a moment to understand what happens with this change.
- We no longer have to save/update the skip list
- Test can be skipped by calling `recorder.skip("browser");` or `recorder.skip("node");` in the `it` block based on the environment we want the test to be skipped
- In the record mode, the recording will be generated with the info right from when the recorder is invoked in beforeeach until the skip() method that is invoked in the `it` block.
   - We need to save(and commit) this recording for the playback mode since the recorder has no way to know that the test is being skipped until the skip() method is called.
   [ A small tradeoff for getting rid of skip list and still add the convenience of invoking the recorder in beforeeach ]


[WIP] Will rebase and merge this in the common recorder module which is in PR - https://github.com/Azure/azure-sdk-for-js/pull/4281


/cc - @ramya-rao-a @XiaoningLiu @kinelski @sadasant 