### PR TITLE
[EPH] Fix index.js path in dist folder in package.json

### DIFF
--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/azure/azure-sdk-for-js/issues"
   },
-  "main": "./dist/src/index.js",
+  "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",
   "types": "./typings/event-processor-host.d.ts",
   "engine": {


### PR DESCRIPTION
Path for `index.js` for `dist` folder in `package.json` was incorrect!

This PR updates the correct path for `index.js` in `package.json`