### PR TITLE
Revert "[Service Bus] Upgrade to use core-amqp (#4265)"

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,9 +1,9 @@
 dependencies:
+  '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
   '@azure/arm-servicebus': 0.1.0
   '@azure/event-hubs': 2.1.1
   '@azure/event-processor-host': 1.0.6
   '@azure/logger-js': 1.3.2
-  '@azure/ms-rest-azure-js': 1.3.8
   '@azure/ms-rest-js': 1.8.13
   '@azure/ms-rest-nodeauth': 0.9.3
   '@microsoft/api-extractor': 7.3.2
@@ -7872,6 +7872,20 @@ packages:
       rollup: '>=0.60.0'
     resolution:
       integrity: sha512-JUnhhL+LidPluCp5mq5PV9vfVCATe9mT+LOO4MH1hX/lf96LOXTdGStDJ7xtsflyOkHMNRpyHZ+C7UZYTbsoIA==
+  /rollup-plugin-visualizer/2.5.3_rollup@1.17.0:
+    dependencies:
+      mkdirp: 0.5.1
+      open: 6.4.0
+      pupa: 2.0.0
+      rollup: 1.17.0
+      source-map: 0.7.3
+    dev: false
+    engines:
+      node: '>=8.10'
+    peerDependencies:
+      rollup: '>=0.60.0'
+    resolution:
+      integrity: sha512-DIEN4EL/a1S6zq2AnoD8gkzN0jUR+rhQCKjyHFtocYWiaghOsXEtG+EPxp+4iGCoMvvvVUHrt4FK/inmktuyBQ==
   /rollup-pluginutils/2.8.1:
     dependencies:
       estree-walker: 0.6.1
@@ -9677,7 +9691,7 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-2+IDAPkc8w6F7v+Qtv+0QlKup7BbSj9/FJRqus2Fv6lv4Qwfhhl1dII2Ttv0Y3D1jF0IlqOecuzEef9zxLc/jA==
+      integrity: sha512-+6kIsx32k7nlN6uAwPS4JOrdVH8CuciXwOqL6DFCDjBdaJhMZ85z/WxMlAtLl/rNxgXlU41Ev3roYTR6U4g+Sw==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
@@ -9746,7 +9760,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-pH12zXk5V3XB+ZgCEfAwPIhOySH/1TOgwMRcPRGpjWewRNJNYZNL4dX/yu4Gq+ms8XKgK2u+Yl8lp7N/7CYmWw==
+      integrity: sha512-caA/MvdeqreoDzdyZogD3kBB8FpsrAWd2702NIOpNmUsRGnyrdZKXSoZV9KfB98UqrI/WbCwvoh5BB7im4YeAQ==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-arm.tgz':
@@ -9784,7 +9798,7 @@ packages:
     dev: false
     name: '@rush-temp/core-arm'
     resolution:
-      integrity: sha512-YxIiEW2CEs0tRVZmIrQNeWf3lIQBmCvf0Dol2mMICh7o9+tKCRarLLmtSSdqE7iGhrdQWWsZowmStccESjPkeQ==
+      integrity: sha512-5z6204Z461orM48pxBRsu504j7zBRo6A+zGwOnhubYd+QT8P4pBF1Z9o5zU6JzE/INb/+GBpJm1Sv2+Jz3wpOQ==
       tarball: 'file:projects/core-arm.tgz'
     version: 0.0.0
   'file:projects/core-asynciterator-polyfill.tgz':
@@ -9803,7 +9817,7 @@ packages:
     dev: false
     name: '@rush-temp/core-asynciterator-polyfill'
     resolution:
-      integrity: sha512-oJErNaXrpCzEEVyYVvv8gcBRnv36c76LBxalfW/l4wlABmUh9u+EuvwI46ig0V3m1bmIluW4S/9O08nO18uyGw==
+      integrity: sha512-v2OkkGp4BscubKnr7qikdSqLJttDTy5skuwpX+KeQv9H5aMDtfGU4CKUmqdwGsI/+vnXlPU57ZBVJ0BtucQBng==
       tarball: 'file:projects/core-asynciterator-polyfill.tgz'
     version: 0.0.0
   'file:projects/core-auth.tgz':
@@ -9842,7 +9856,7 @@ packages:
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-MhDSymfCLIHeHlYVi0KQ4oXsKUrRGUrEtwNYEbB8nq7BkXZRsiuEyv8LuffmWh+ipeHLWPhMnEW94EoRIqSiyw==
+      integrity: sha512-I2ldZcRfAUVEfQcBwmyNOKYg5se+63rvuGMsm9dIjkWDZHGnwB3/d/GI3RPH9rzQW/bbkNm4eAeBwtlDSThg9g==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -9924,7 +9938,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-j8oocZ+3uRVuagmj58ue9BHFKpv2fqQMJlL2LX3PQS4q0H2Rwv+z2kppAbFmAcORldCuShH8X2K61znVkFwCVw==
+      integrity: sha512-5gbfGOsO4iG1CJMM1iiF8RmprVXkj2Ozda4m25MZwW2H1DsJCeBjfcW0snlRp8c0ne4SHd2CU57Km6oWM9KPcA==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -9943,7 +9957,7 @@ packages:
     dev: false
     name: '@rush-temp/core-paging'
     resolution:
-      integrity: sha512-YuAVCVgDrwxv97SIkTM1n/hwYLjncsTgyooCUYQ4vw3o1WglSnpREVymQFVZ8Fa+S/ael7NdzsGaYp3lyTKXCg==
+      integrity: sha512-Cw6EIkpujQw6NoJ997kmGhTHYp+NyN1ANdUWlpisHR8eC8HUWhIenZ66XnwsUopIKDS7K+IFojGMi3nqukbSxg==
       tarball: 'file:projects/core-paging.tgz'
     version: 0.0.0
   'file:projects/cosmos.tgz':
@@ -9985,7 +9999,7 @@ packages:
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-rLhtUCCGnwzY3OigHd+TEJ4U0lyBKc2RpjKGMl9koha/aSUchKfm8qHWS+4XO/J2+WldP7yQx6gZY5C+t3cBvQ==
+      integrity: sha512-f7IyBbSYkZZ+guO7QopSGUb/7d5QYQiotA3hWoIvC0iUo4XhGa+DqlnQ/yn5zx+p8ogWU8pvIixA8GQU4nMUfA==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/event-hubs.tgz':
@@ -10059,7 +10073,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-E0udJXYTcWrpWxUM38hWHnk35qsmXDG5ywVW4j492xsASvwyE/lBUl0vXZ/IT+2w3GHnEQiydeNxysUw6EflQg==
+      integrity: sha512-YrOptMv6XuPgWmr8g6UM3J6yK9nHzGNfKCKjew+IIPF85VsLNVDTx3NR/M4TIlHF43pZc+umxeECKF9XU1t7gg==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -10114,7 +10128,7 @@ packages:
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-YEltFsweWeV5/IHJyEd/kVz7RG4iRz2AWE6rsw23UIXJaMkEc3nhsw/FtJpWq8bGWs8Dp3pvzKx1VezkCFB9MQ==
+      integrity: sha512-k8mxcOYOZDA0mVcFCRnJ5MD1mVfvY2mJ6sDI8KKAgTJ7lkVXx4yTTTP18Khap8KoSNlW5RLZLx6ximGCB8/+YQ==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -10165,7 +10179,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-aTY3uzVLj4sklLp1V6DUub81jrSYfIKZwnVBn/oUi7cKhBnjY7efgGVxxaRfNNi8tg5js+DBRFI6HDKSfOdABA==
+      integrity: sha512-jSn0u7fbO3c13jltF6uWWp8s0bWGXWkdUrcZaPtYmzzFTc2QOqSH9h8iGbEHvGYtyh84mFwcOqVwkE18JIA8hQ==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -10194,7 +10208,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-OnKHRTzszS738exvoRLs2jaUoM3n0EW/Vnuwh04GVxor6GUG7K2wo06C+qoq3sqI5VG6CuEwMKfsSTmkLJfaMg==
+      integrity: sha512-SXoGIO387Z2fAKTPMWdZlMBHubw7pFzQ/jDmZIp8kwUUFBs7nl85CBD2r13EACMSHvttc7Jp5srB0INhHz9I5g==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
@@ -10204,10 +10218,13 @@ packages:
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
+      '@types/nise': 1.4.0
       '@types/nock': 10.0.3
       '@types/node': 8.10.51
+      '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.12.0_db854cf46887ef4aa7b9323cccc417a5
       '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
+      assert: 1.5.0
       chai: 4.2.0
       cross-env: 5.2.0
       dotenv: 7.0.0
@@ -10218,13 +10235,39 @@ packages:
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.0.1
+      karma: 4.2.0
+      karma-chrome-launcher: 2.2.0
+      karma-coverage: 1.1.2
+      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-env-preprocessor: 0.1.1
+      karma-firefox-launcher: 1.1.0
+      karma-ie-launcher: 1.0.0_karma@4.2.0
+      karma-json-preprocessor: 0.3.3_karma@4.2.0
+      karma-json-to-file-reporter: 1.0.1
+      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-mocha: 1.3.0
+      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-remap-coverage: 0.1.5_karma-coverage@1.1.2
       mocha: 5.2.0
+      mocha-junit-reporter: 1.23.1_mocha@5.2.0
+      mocha-multi: 1.1.0_mocha@5.2.0
+      nise: 1.5.0
       nock: 10.0.6
+      nyc: 14.1.1
       prettier: 1.18.2
+      puppeteer: 1.18.1
+      query-string: 5.1.1
       rimraf: 2.6.3
       rollup: 1.17.0
       rollup-plugin-commonjs: 10.0.1_rollup@1.17.0
+      rollup-plugin-multi-entry: 2.1.0
       rollup-plugin-node-resolve: 5.2.0_rollup@1.17.0
+      rollup-plugin-replace: 2.2.0
+      rollup-plugin-shim: 1.0.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.17.0
+      rollup-plugin-terser: 5.1.1_rollup@1.17.0
+      rollup-plugin-visualizer: 2.5.3_rollup@1.17.0
+      source-map-support: 0.5.12
       ts-mocha: 6.0.0_mocha@5.2.0
       tslib: 1.10.0
       typescript: 3.5.3
@@ -10233,7 +10276,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-SzbKWp6oyF8Hei0WOcjyWSA92nCRPCBVh/xIuO7B8Oj71QFrRXWIVSAu1BnJec9ml0WMezbchRqXV3fbA5O6aw==
+      integrity: sha512-+SHTk2A9JVMx3y09RXhNy6ieF1e9GDArLuuFfu2DcGQMdF8/V4tzy+BKCbfriuuPwwoAOlX+bYBQ3ak2/ppjLQ==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10245,10 +10288,13 @@ packages:
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
+      '@types/nise': 1.4.0
       '@types/nock': 10.0.3
       '@types/node': 8.10.51
+      '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.12.0_db854cf46887ef4aa7b9323cccc417a5
       '@typescript-eslint/parser': 1.12.0_eslint@5.16.0+typescript@3.5.3
+      assert: 1.5.0
       chai: 4.2.0
       cross-env: 5.2.0
       dotenv: 7.0.0
@@ -10259,13 +10305,39 @@ packages:
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.0.1
+      karma: 4.2.0
+      karma-chrome-launcher: 2.2.0
+      karma-coverage: 1.1.2
+      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-env-preprocessor: 0.1.1
+      karma-firefox-launcher: 1.1.0
+      karma-ie-launcher: 1.0.0_karma@4.2.0
+      karma-json-preprocessor: 0.3.3_karma@4.2.0
+      karma-json-to-file-reporter: 1.0.1
+      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-mocha: 1.3.0
+      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-remap-coverage: 0.1.5_karma-coverage@1.1.2
       mocha: 5.2.0
+      mocha-junit-reporter: 1.23.1_mocha@5.2.0
+      mocha-multi: 1.1.0_mocha@5.2.0
+      nise: 1.5.0
       nock: 10.0.6
+      nyc: 14.1.1
       prettier: 1.18.2
+      puppeteer: 1.18.1
+      query-string: 5.1.1
       rimraf: 2.6.3
       rollup: 1.17.0
       rollup-plugin-commonjs: 10.0.1_rollup@1.17.0
+      rollup-plugin-multi-entry: 2.1.0
       rollup-plugin-node-resolve: 5.2.0_rollup@1.17.0
+      rollup-plugin-replace: 2.2.0
+      rollup-plugin-shim: 1.0.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.17.0
+      rollup-plugin-terser: 5.1.1_rollup@1.17.0
+      rollup-plugin-visualizer: 2.5.3_rollup@1.17.0
+      source-map-support: 0.5.12
       ts-mocha: 6.0.0_mocha@5.2.0
       tslib: 1.10.0
       typescript: 3.5.3
@@ -10274,11 +10346,12 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-xg2uDV+3HENU1oYRJWVee3NCqJLbRRk5mMyFKp05bH/1LQP3k8L0GDdTfvOUQyq0qSUAzDGndP/G//V1PUdgQg==
+      integrity: sha512-Xb8VDCPoCAbS0mkp2dd6Mt+2KZbpMpcWCH5pd0BM49L5gjMNaU3s8gLPZKkvIOsAhOeD7I8VwVZwbUqecAFL5Q==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
     dependencies:
+      '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
       '@azure/arm-servicebus': 0.1.0
       '@azure/ms-rest-nodeauth': 0.9.3
       '@microsoft/api-extractor': 7.3.2
@@ -10351,7 +10424,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-o962LA8aptMUN+SYwwHClIYMQjElKRPcdjVRQShYWWk+F5NJKdhAHzdhb9bq6UbDVzC/VZntlKumZY4Kc4oXhA==
+      integrity: sha512-I2+8qGoLDBzxLfcjovtbo/dIqoUHZEv3EArGbWyW27ndfftUDAe4iu8TKfKJOy/MZBvlr5PkDculHeytBpR4Zw==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
@@ -10422,7 +10495,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-4105iXB3hoaFSq5UdvNfztT1BgIPpS9xe/jnH5QPvhO5vxg7S0zIh7RuKqQE9BjpVpbNYU03ANCVnaymnDmZOQ==
+      integrity: sha512-KNp0iQwCm/S9NZEzJnzd1ES37i6N8Uqem3e97HdELUG/yZcXMi1G2nPrkBxCbbJsijt60ZPAMmCxCAwbtDRzTg==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file.tgz':
@@ -10493,7 +10566,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file'
     resolution:
-      integrity: sha512-juOCmmDWgZhQNzudPSlmhETCWJ2pXvezQg1oaVg+MNtkkz8uD2q03kXb7yfYOEM+w9cegsJZUp3jCXt61VkPtQ==
+      integrity: sha512-J8s4BR2MQXwtYf8Hm6NlaS4WYc0VKdVZapL478+44pNo5lab3u4sDECvFwxYL1BLPcmyrBm59iW8vCTbVfnJ4g==
       tarball: 'file:projects/storage-file.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -10563,7 +10636,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-s5r16h2hU8MIPBfqhtCgY59+GGhaRwA+vdgVyFzzlWvwd3IE3MDSc/GjVHDXFt0bHes3PU3AQQU6el2IURCm2w==
+      integrity: sha512-3xjQvHHk+zS/jRDwXqk9W/Y3fO9miaWGYJAdIpXEJuiIsKwfeCirGu988QSkHqjz7pv0v28joO8E1XSEPecovA==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
@@ -10615,7 +10688,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-Lbng6NWBk6fVPMUAdf3pqeb/y6PrAfaBE8BlVthaVo1FsUn1CnIYdCPJylV3q1WReebpXxvvoh7isVsDNvVZ+Q==
+      integrity: sha512-SsN1TzIAhjm92cBBvws295kBKgwb0Ck0VwXMKKxkohR2XGCjaIc6ypNNgHjPMV/cmyaOue3kd7KYDlNdrFBDpw==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/testhub.tgz':
@@ -10641,15 +10714,16 @@ packages:
     dev: false
     name: '@rush-temp/testhub'
     resolution:
-      integrity: sha512-Lt7NGJIhEbyVoQ1sJ4eUnUg7nGIkdgatRJJMWz18ZVWxKFXPxbBjxPsvIJNirR8QdA3efLv1FhyM4lszfJHcjw==
+      integrity: sha512-5aP/T4HsltLa6B6z0LQSHKjR/pM6y/sD4Y1gp4g/Nt35FzVnQVDkcAbSKTjr4DVb1a2pOwY3q5NDhv0CUDjYbQ==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
+  '@azure/amqp-common': ^1.0.0-preview.6
   '@azure/arm-servicebus': ^0.1.0
   '@azure/event-hubs': ^2.1.1
   '@azure/event-processor-host': ^1.0.6
   '@azure/logger-js': ^1.0.2
-  '@azure/ms-rest-azure-js': ^1.3.2
   '@azure/ms-rest-js': ^1.2.6
   '@azure/ms-rest-nodeauth': ^0.9.2
   '@microsoft/api-extractor': ^7.1.5

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -211,13 +211,13 @@ export DEBUG=azure*,rhea*
 - If you are **not interested in viewing the message transformation** (which consumes lot of console/disk space) then you can set the `DEBUG` environment variable as follows:
 
 ```bash
-export DEBUG=azure*,rhea*,-rhea:raw,-rhea:message,-azure:core-amqp:datatransformer
+export DEBUG=azure*,rhea*,-rhea:raw,-rhea:message,-azure:amqp-common:datatransformer
 ```
 
 - If you are interested only in **errors**, then you can set the `DEBUG` environment variable as follows:
 
 ```bash
-export DEBUG=azure:service-bus:error,azure-core-amqp:error,rhea-promise:error,rhea:events,rhea:frames,rhea:io,rhea:flow
+export DEBUG=azure:service-bus:error,azure-amqp-common:error,rhea-promise:error,rhea:events,rhea:frames,rhea:io,rhea:flow
 ```
 
 ### Logging to a file

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "2.0.0-preview.1",
+  "version": "1.0.3",
   "license": "MIT",
   "description": "Azure Service Bus SDK for Node.js",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus",
@@ -65,7 +65,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-amqp": "^1.0.0-preview.1",
+    "@azure/amqp-common": "^1.0.0-preview.6",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "@types/is-buffer": "^2.0.0",
     "@types/long": "^4.0.0",

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -4,14 +4,19 @@
 
 ```ts
 
-import { AmqpMessage } from '@azure/core-amqp';
-import { DataTransformer } from '@azure/core-amqp';
-import { delay } from '@azure/core-amqp';
+import { AmqpMessage } from '@azure/amqp-common';
+import { ApplicationTokenCredentials } from '@azure/ms-rest-nodeauth';
+import { DataTransformer } from '@azure/amqp-common';
+import { delay } from '@azure/amqp-common';
 import { Delivery } from 'rhea-promise';
+import { DeviceTokenCredentials } from '@azure/ms-rest-nodeauth';
 import Long from 'long';
-import { MessagingError } from '@azure/core-amqp';
-import { TokenCredential } from '@azure/core-amqp';
-import { TokenType } from '@azure/core-amqp';
+import { MessagingError } from '@azure/amqp-common';
+import { MSITokenCredentials } from '@azure/ms-rest-nodeauth';
+import { TokenInfo } from '@azure/amqp-common';
+import { TokenProvider } from '@azure/amqp-common';
+import { TokenType } from '@azure/amqp-common';
+import { UserTokenCredentials } from '@azure/ms-rest-nodeauth';
 import { WebSocketImpl } from 'rhea-promise';
 
 // @public
@@ -148,7 +153,9 @@ export class Sender {
 // @public
 export class ServiceBusClient {
     close(): Promise<any>;
+    static createFromAadTokenCredentials(host: string, credentials: ApplicationTokenCredentials | UserTokenCredentials | DeviceTokenCredentials | MSITokenCredentials, options?: ServiceBusClientOptions): ServiceBusClient;
     static createFromConnectionString(connectionString: string, options?: ServiceBusClientOptions): ServiceBusClient;
+    static createFromTokenProvider(host: string, tokenProvider: TokenProvider, options?: ServiceBusClientOptions): ServiceBusClient;
     createQueueClient(queueName: string): QueueClient;
     createSubscriptionClient(topicName: string, subscriptionName: string): SubscriptionClient;
     createTopicClient(topicName: string): TopicClient;
@@ -253,7 +260,9 @@ export class SubscriptionClient implements Client {
     readonly topicName: string;
 }
 
-export { TokenCredential }
+export { TokenInfo }
+
+export { TokenProvider }
 
 export { TokenType }
 

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -17,7 +17,7 @@ import { SessionManager } from "./session/sessionManager";
 /**
  * @interface ClientEntityContext
  * Provides contextual information like the underlying amqp connection, cbs session,
- * management session, tokenCredential, senders, receivers, etc. about the ServiceBus client.
+ * management session, tokenProvider, senders, receivers, etc. about the ServiceBus client.
  * @internal
  */
 export interface ClientEntityContextBase {

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -11,9 +11,8 @@ import {
   CreateConnectionContextBaseParameters,
   Dictionary,
   delay,
-  TokenCredential,
-  SharedKeyCredential
-} from "@azure/core-amqp";
+  TokenProvider
+} from "@azure/amqp-common";
 import { ServiceBusClientOptions } from "./serviceBusClient";
 import { ClientEntityContext } from "./clientEntityContext";
 import { OnAmqpEvent, EventContext, ConnectionEvents } from "rhea-promise";
@@ -22,7 +21,7 @@ import { OnAmqpEvent, EventContext, ConnectionEvents } from "rhea-promise";
  * @internal
  * @interface ConnectionContext
  * Provides contextual information like the underlying amqp connection, cbs session, management session,
- * tokenCredential, senders, receivers, etc. about the ServiceBus client.
+ * tokenProvider, senders, receivers, etc. about the ServiceBus client.
  */
 export interface ConnectionContext extends ConnectionContextBase {
   /**
@@ -46,13 +45,13 @@ export namespace ConnectionContext {
 
   export function create(
     config: ConnectionConfig,
-    tokenCredential: SharedKeyCredential | TokenCredential,
+    tokenProvider: TokenProvider,
     options?: ServiceBusClientOptions
   ): ConnectionContext {
     if (!options) options = {};
     const parameters: CreateConnectionContextBaseParameters = {
       config: config,
-      tokenCredential: tokenCredential,
+      tokenProvider: tokenProvider,
       dataTransformer: options.dataTransformer,
       isEntityPathRequired: false,
       connectionProperties: {

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as log from "../log";
-import { Constants, translate, MessagingError } from "@azure/core-amqp";
+import { Constants, translate, MessagingError } from "@azure/amqp-common";
 import { ReceiverEvents, EventContext, OnAmqpEvent, SessionEvents, AmqpError } from "rhea-promise";
 import { ServiceBusMessage } from "../serviceBusMessage";
 import {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -21,7 +21,7 @@ import {
   ConditionErrorNameMapper,
   AmqpMessage,
   SendRequestOptions
-} from "@azure/core-amqp";
+} from "@azure/amqp-common";
 import { ClientEntityContext } from "../clientEntityContext";
 import {
   ReceivedMessageInfo,
@@ -467,7 +467,7 @@ export class ManagementClient extends LinkEntity {
     if (!options) options = {};
     if (options.delayInSeconds == null) options.delayInSeconds = 1;
     if (options.timeoutInSeconds == null) options.timeoutInSeconds = 5;
-    if (options.maxRetries == null) options.maxRetries = 5;
+    if (options.times == null) options.times = 5;
 
     try {
       const messageBody: any = {};
@@ -878,7 +878,7 @@ export class ManagementClient extends LinkEntity {
     if (!options) options = {};
     if (options.delayInSeconds == null) options.delayInSeconds = 1;
     if (options.timeoutInSeconds == null) options.timeoutInSeconds = 5;
-    if (options.maxRetries == null) options.maxRetries = 5;
+    if (options.times == null) options.times = 5;
     try {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -10,7 +10,7 @@ import {
   RetryConfig,
   ConditionErrorNameMapper,
   ErrorNameConditionMapper
-} from "@azure/core-amqp";
+} from "@azure/amqp-common";
 import {
   Receiver,
   OnAmqpEvent,
@@ -955,7 +955,7 @@ export class MessageReceiver extends LinkEntity {
             }),
           connectionId: connectionId,
           operationType: RetryOperationType.receiverLink,
-          maxRetries: Constants.defaultMaxRetriesForConnection,
+          times: Constants.defaultConnectionRetryAttempts,
           connectionHost: this._context.namespace.config.host,
           delayInSeconds: 15
         };

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -24,7 +24,7 @@ import {
   RetryOperationType,
   Constants,
   randomNumberFromInterval
-} from "@azure/core-amqp";
+} from "@azure/amqp-common";
 import {
   SendableMessageInfo,
   toAmqpMessage,
@@ -395,7 +395,7 @@ export class MessageSender extends LinkEntity {
       operation: sendEventPromise,
       connectionId: this._context.namespace.connectionId!,
       operationType: RetryOperationType.sendMessage,
-      maxRetries: Constants.defaultMaxRetries,
+      times: Constants.defaultRetryAttempts,
       delayInSeconds: Constants.defaultDelayBetweenOperationRetriesInSeconds + jitterInSeconds
     };
 
@@ -537,7 +537,7 @@ export class MessageSender extends LinkEntity {
             operation: () => this._init(options),
             connectionId: this._context.namespace.connectionId!,
             operationType: RetryOperationType.senderLink,
-            maxRetries: Constants.defaultMaxRetriesForConnection,
+            times: Constants.defaultConnectionRetryAttempts,
             connectionHost: this._context.namespace.config.host,
             delayInSeconds: 15
           };

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -6,12 +6,13 @@
 
 export { ServiceBusClient, ServiceBusClientOptions } from "./serviceBusClient";
 export {
+  TokenInfo,
   TokenType,
-  TokenCredential,
+  TokenProvider,
   DataTransformer,
   delay,
   MessagingError
-} from "@azure/core-amqp";
+} from "@azure/amqp-common";
 
 export { QueueClient } from "./queueClient";
 export { TopicClient } from "./topicClient";

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -3,6 +3,13 @@
 
 import * as log from "./log";
 
+import {
+  ApplicationTokenCredentials,
+  DeviceTokenCredentials,
+  UserTokenCredentials,
+  MSITokenCredentials
+} from "@azure/ms-rest-nodeauth";
+
 import { WebSocketImpl } from "rhea-promise";
 import { ConnectionContext } from "./connectionContext";
 import { QueueClient } from "./queueClient";
@@ -10,9 +17,10 @@ import { TopicClient } from "./topicClient";
 import {
   ConnectionConfig,
   DataTransformer,
-  TokenCredential,
-  SharedKeyCredential
-} from "@azure/core-amqp";
+  TokenProvider,
+  AadTokenProvider,
+  SasTokenProvider
+} from "@azure/amqp-common";
 import { SubscriptionClient } from "./subscriptionClient";
 
 /**
@@ -62,18 +70,19 @@ export class ServiceBusClient {
    * @constructor
    * @param {ConnectionConfig} config - The connection configuration needed to connect to the
    * Service Bus Namespace.
-   * @param {TokenCredential} [credential] - SharedKeyCredential object or your credential that implements the TokenCredential interface.
+   * @param {TokenProvider} [tokenProvider] - The token provider that provides the token for
+   * authentication.
    * @param {ServiceBusClientOptions} - Options to control ways to interact with the Service Bus
    * Namespace.
    */
   private constructor(
     config: ConnectionConfig,
-    credential: SharedKeyCredential | TokenCredential,
+    tokenProvider: TokenProvider,
     options?: ServiceBusClientOptions
   ) {
     if (!options) options = {};
     this.name = config.endpoint;
-    this._context = ConnectionContext.create(config, credential, options);
+    this._context = ConnectionContext.create(config, tokenProvider, options);
   }
 
   /**
@@ -167,75 +176,76 @@ export class ServiceBusClient {
     config.webSocketEndpointPath = "$servicebus/websocket";
     config.webSocketConstructorOptions = options && options.webSocketConstructorOptions;
 
-    // Since connectionstring was passed, create a SharedKeyCredential
-    const credential = new SharedKeyCredential(config.sharedAccessKeyName, config.sharedAccessKey);
-
     ConnectionConfig.validate(config);
-
-    return new ServiceBusClient(config, credential, options);
+    const tokenProvider = new SasTokenProvider(
+      config.endpoint,
+      config.sharedAccessKeyName,
+      config.sharedAccessKey
+    );
+    return new ServiceBusClient(config, tokenProvider, options);
   }
 
-  //   /**
-  //    * Creates a ServiceBusClient for the Service Bus Namespace represented by the given host using
-  //    * the given TokenProvider.
-  //    * @param {string} host - Fully qualified domain name for Servicebus. Most likely,
-  //    * `<yournamespace>.servicebus.windows.net`.
-  //    * @param {TokenProvider} tokenProvider - Your custom implementation of the {@link https://github.com/Azure/amqp-common-js/blob/master/lib/auth/token.ts Token Provider}
-  //    * interface.
-  //    * @param {ServiceBusClientOptions} options - Options to control ways to interact with the
-  //    * Service Bus Namespace.
-  //    * @returns {ServiceBusClient}
-  //    */
-  //   static createFromTokenProvider(
-  //     host: string,
-  //     tokenProvider: TokenProvider,
-  //     options?: ServiceBusClientOptions
-  //   ): ServiceBusClient {
-  //     host = String(host);
-  //     if (!tokenProvider) {
-  //       throw new TypeError('Missing parameter "tokenProvider"');
-  //     }
-  //     if (!host.endsWith("/")) host += "/";
-  //     const connectionString =
-  //       `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;` +
-  //       `SharedAccessKey=defaultKeyValue`;
-  //     const config = ConnectionConfig.create(connectionString);
+  /**
+   * Creates a ServiceBusClient for the Service Bus Namespace represented by the given host using
+   * the given TokenProvider.
+   * @param {string} host - Fully qualified domain name for Servicebus. Most likely,
+   * `<yournamespace>.servicebus.windows.net`.
+   * @param {TokenProvider} tokenProvider - Your custom implementation of the {@link https://github.com/Azure/amqp-common-js/blob/master/lib/auth/token.ts Token Provider}
+   * interface.
+   * @param {ServiceBusClientOptions} options - Options to control ways to interact with the
+   * Service Bus Namespace.
+   * @returns {ServiceBusClient}
+   */
+  static createFromTokenProvider(
+    host: string,
+    tokenProvider: TokenProvider,
+    options?: ServiceBusClientOptions
+  ): ServiceBusClient {
+    host = String(host);
+    if (!tokenProvider) {
+      throw new TypeError('Missing parameter "tokenProvider"');
+    }
+    if (!host.endsWith("/")) host += "/";
+    const connectionString =
+      `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;` +
+      `SharedAccessKey=defaultKeyValue`;
+    const config = ConnectionConfig.create(connectionString);
 
-  //     config.webSocket = options && options.webSocket;
-  //     config.webSocketEndpointPath = "$servicebus/websocket";
-  //     config.webSocketConstructorOptions = options && options.webSocketConstructorOptions;
+    config.webSocket = options && options.webSocket;
+    config.webSocketEndpointPath = "$servicebus/websocket";
+    config.webSocketConstructorOptions = options && options.webSocketConstructorOptions;
 
-  //     ConnectionConfig.validate(config);
-  //     return new ServiceBusClient(config, tokenProvider, options);
-  //   }
+    ConnectionConfig.validate(config);
+    return new ServiceBusClient(config, tokenProvider, options);
+  }
 
-  //   /**
-  //    * Creates a ServiceBusClient for the Service Bus Namespace represented by the given host using
-  //    * the TokenCredentials generated using the `@azure/ms-rest-nodeauth` library.
-  //    * @param {string} host - Fully qualified domain name for ServiceBus.
-  //    * Most likely, {yournamespace}.servicebus.windows.net
-  //    * @param {ServiceClientCredentials} credentials - The Token credentials generated by using the
-  //    * `@azure/ms-rest-nodeauth` library. It can be one of the following:
-  //    *  - ApplicationTokenCredentials
-  //    *  - UserTokenCredentials
-  //    *  - DeviceTokenCredentials
-  //    *  - MSITokenCredentials
-  //    * Token audience (or resource in case of MSI based credentials) to use when creating the credentials is https://servicebus.azure.net/
-  //    * @param {ServiceBusClientOptions} options - Options to control ways to interact with the
-  //    * Service Bus Namespace.
-  //    * @returns {ServiceBusClient}
-  //    */
-  //   static createFromAadTokenCredentials(
-  //     host: string,
-  //     credentials:
-  //       | ApplicationTokenCredentials
-  //       | UserTokenCredentials
-  //       | DeviceTokenCredentials
-  //       | MSITokenCredentials,
-  //     options?: ServiceBusClientOptions
-  //   ): ServiceBusClient {
-  //     host = String(host);
-  //     const tokenProvider = new AadTokenProvider(credentials);
-  //     return ServiceBusClient.createFromTokenProvider(host, tokenProvider, options);
-  //   }
+  /**
+   * Creates a ServiceBusClient for the Service Bus Namespace represented by the given host using
+   * the TokenCredentials generated using the `@azure/ms-rest-nodeauth` library.
+   * @param {string} host - Fully qualified domain name for ServiceBus.
+   * Most likely, {yournamespace}.servicebus.windows.net
+   * @param {ServiceClientCredentials} credentials - The Token credentials generated by using the
+   * `@azure/ms-rest-nodeauth` library. It can be one of the following:
+   *  - ApplicationTokenCredentials
+   *  - UserTokenCredentials
+   *  - DeviceTokenCredentials
+   *  - MSITokenCredentials
+   * Token audience (or resource in case of MSI based credentials) to use when creating the credentials is https://servicebus.azure.net/
+   * @param {ServiceBusClientOptions} options - Options to control ways to interact with the
+   * Service Bus Namespace.
+   * @returns {ServiceBusClient}
+   */
+  static createFromAadTokenCredentials(
+    host: string,
+    credentials:
+      | ApplicationTokenCredentials
+      | UserTokenCredentials
+      | DeviceTokenCredentials
+      | MSITokenCredentials,
+    options?: ServiceBusClientOptions
+  ): ServiceBusClient {
+    host = String(host);
+    const tokenProvider = new AadTokenProvider(credentials);
+    return ServiceBusClient.createFromTokenProvider(host, tokenProvider, options);
+  }
 }

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -9,7 +9,7 @@ import {
   MessageAnnotations,
   DeliveryAnnotations
 } from "rhea-promise";
-import { Constants, AmqpMessage, translate, ErrorNameConditionMapper } from "@azure/core-amqp";
+import { Constants, AmqpMessage, translate, ErrorNameConditionMapper } from "@azure/amqp-common";
 import * as log from "./log";
 import { ClientEntityContext } from "./clientEntityContext";
 import { reorderLockToken, getAssociatedReceiverName } from "../src/util/utils";

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -7,7 +7,7 @@ import {
   ErrorNameConditionMapper,
   MessagingError,
   Func
-} from "@azure/core-amqp";
+} from "@azure/amqp-common";
 import {
   Receiver,
   OnAmqpEvent,
@@ -284,7 +284,7 @@ export class MessageSession extends LinkEntity {
             {
               delayInSeconds: 0,
               timeoutInSeconds: 10,
-              maxRetries: 4
+              times: 4
             }
           );
           log.receiver(

--- a/sdk/servicebus/service-bus/src/session/sessionManager.ts
+++ b/sdk/servicebus/service-bus/src/session/sessionManager.ts
@@ -7,7 +7,7 @@ import { ClientEntityContext } from "../clientEntityContext";
 import { getProcessorCount } from "../util/utils";
 import * as log from "../log";
 import { Semaphore } from "../util/semaphore";
-import { delay, ConditionErrorNameMapper, Constants } from "@azure/core-amqp";
+import { delay, ConditionErrorNameMapper, Constants } from "@azure/amqp-common";
 
 /**
  * @internal
@@ -178,7 +178,7 @@ export class SessionManager {
         // the Promise is rejected. The "microsoft.timeout" error occurs when timeout happens on
         // the server side and ServiceBus sends a detach frame due to which the Promise is rejected.
         if (
-          err.name === "OperationTimeoutError" ||
+          err.name === ConditionErrorNameMapper["amqp:operation-timeout"] ||
           err.name === ConditionErrorNameMapper["com.microsoft:timeout"] ||
           err.name === ConditionErrorNameMapper["com.microsoft:session-cannot-be-locked"]
         ) {

--- a/sdk/servicebus/service-bus/src/util/concurrentExpiringMap.ts
+++ b/sdk/servicebus/service-bus/src/util/concurrentExpiringMap.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { generate_uuid } from "rhea-promise";
-import { delay, AsyncLock } from "@azure/core-amqp";
+import { delay, AsyncLock } from "@azure/amqp-common";
 import * as log from "../log";
 
 /**

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -3,7 +3,7 @@
 
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "2.0.0-preview.1"
+  version: "1.0.3"
 };
 
 export const messageDispositionTimeout = 20000;


### PR DESCRIPTION
In order to support #1057 for service bus before moving on to making breaking changes in the library for Track 2, the commit fa7dbe6a2092c4d40e735c8726e97d94a574c671 has to be reverted.

The revert doesn't mean that we have lost the work done in the commit fa7dbe6a2092c4d40e735c8726e97d94a574c671. These changes are available in the [feature/service-bus-track-2](https://github.com/Azure/azure-sdk-for-js/tree/feature/service-bus-track-2) branch

