### PR TITLE
Eslint should prevent us from using require()

### DIFF
--- a/sdk/.eslintrc.json
+++ b/sdk/.eslintrc.json
@@ -18,6 +18,7 @@
     "curly": ["error", "multi-line"],
     "eol-last": ["error", "always"],
     "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "global-require": "error",
     "no-console": "off",
     "no-dupe-class-members": "off",
     "no-empty": "error",


### PR DESCRIPTION
This eslint option disables require unless is used at the top level of a module. More details here: https://eslint.org/docs/rules/global-require

Fixes #4361