### PR TITLE
[KeyVault] Adds abortSignal to all the *Options we have in keys and secrets

### DIFF
--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -51,17 +51,20 @@ export type DeletionRecoveryLevel = "Purgeable" | "Recoverable+Purgeable" | "Rec
 
 // @public
 export interface GetKeyOptions {
+    abortSignal?: AbortSignalLike;
     requestOptions?: msRest.RequestOptionsBase;
     version?: string;
 }
 
 // @public
 export interface GetKeysOptions {
+    abortSignal?: AbortSignalLike;
     requestOptions?: msRest.RequestOptionsBase;
 }
 
 // @public
 export interface ImportKeyOptions {
+    abortSignal?: AbortSignalLike;
     enabled?: boolean;
     expires?: Date;
     hsm?: boolean;
@@ -177,6 +180,7 @@ export interface ProxyOptions {
 
 // @public
 export interface RequestOptions {
+    abortSignal?: AbortSignalLike;
     requestOptions?: msRest.RequestOptionsBase;
 }
 
@@ -195,6 +199,7 @@ export interface TelemetryOptions {
 
 // @public
 export interface UpdateKeyOptions {
+    abortSignal?: AbortSignalLike;
     enabled?: boolean;
     expires?: Date;
     keyOps?: JsonWebKeyOperation[];

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -201,6 +201,10 @@ export interface ImportKeyOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }
 
 /**
@@ -235,6 +239,10 @@ export interface UpdateKeyOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }
 
 /**
@@ -252,6 +260,10 @@ export interface GetKeyOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }
 
 /**
@@ -264,6 +276,10 @@ export interface ListKeysOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }
 
 /**
@@ -275,4 +291,8 @@ export interface RequestOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -27,12 +27,14 @@ export type DeletionRecoveryLevel = "Purgeable" | "Recoverable+Purgeable" | "Rec
 
 // @public
 export interface GetSecretOptions {
+    abortSignal?: AbortSignalLike;
     requestOptions?: msRest.RequestOptionsBase;
     version?: string;
 }
 
 // @public
 export interface GetSecretsOptions {
+    abortSignal?: AbortSignalLike;
     requestOptions?: msRest.RequestOptionsBase;
 }
 
@@ -137,6 +139,7 @@ export interface TelemetryOptions {
 
 // @public
 export interface UpdateSecretOptions {
+    abortSignal?: AbortSignalLike;
     contentType?: string;
     enabled?: boolean;
     expires?: Date;

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -183,6 +183,10 @@ export interface UpdateSecretOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }
 
 /**
@@ -200,6 +204,10 @@ export interface GetSecretOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }
 
 /**
@@ -212,4 +220,8 @@ export interface ListSecretsOptions {
    * @member {msRest.RequestOptionsBase} [requestOptions] Options for this request
    */
   requestOptions?: msRest.RequestOptionsBase;
+  /**
+   * @member {AbortSignalLike} [abortSignal] Abort signal
+   */
+  abortSignal?: AbortSignalLike;
 }


### PR DESCRIPTION
With these changes, our current API fully supports cancelling a request
before we get a response. The idea is that this feature is already
supported by the core dependencies we use, and by passing this property
through, we'll get the benefits right away without having to do other
changes.

keyvault-keys and keyvault-secrets currently have a unit test that
proves that this works for one of the functions that shares this
underlying APIs. This PR adds the support to the other similar methods.
We could also add other tests demonstrating this behavior for these
other functions.

Fixes #4357