### PR TITLE
[Storage] Increment client preview versions - storage packages

### DIFF
--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.0.0-preview.1",
+  "version": "12.0.0-preview.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -78,13 +78,13 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "^1.0.0-preview.1",
-    "@azure/core-paging": "^1.0.0-preview.1",
+    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-paging": "1.0.0-preview.1",
     "events": "^3.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@azure/identity": "^1.0.0-preview.1",
+    "@azure/identity": "1.0.0-preview.2",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "~7.0.0",

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.0.0-preview.1";
+export const SDK_VERSION: string = "12.0.0-preview.2";
 export const SERVICE_VERSION: string = "2018-03-28";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file",
   "sdk-type": "client",
-  "version": "12.0.0-preview.1",
+  "version": "12.0.0-preview.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -78,8 +78,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "^1.0.0-preview.1",
-    "@azure/core-paging": "^1.0.0-preview.1",
+    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-paging": "1.0.0-preview.1",
     "events": "^3.0.0",
     "tslib": "^1.9.3"
   },

--- a/sdk/storage/storage-file/src/utils/constants.ts
+++ b/sdk/storage/storage-file/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.0.0-preview.1";
+export const SDK_VERSION: string = "12.0.0-preview.2";
 export const SERVICE_VERSION: string = "2018-03-28";
 
 export const FILE_MAX_SIZE_BYTES: number = 1024 * 1024 * 1024 * 1024; // 1TB

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.0.0-preview.1",
+  "version": "12.0.0-preview.2",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -75,12 +75,12 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "^1.0.0-preview.1",
-    "@azure/core-paging": "^1.0.0-preview.1",
+    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-paging": "1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@azure/identity": "^1.0.0-preview.1",
+    "@azure/identity": "1.0.0-preview.2",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "~7.0.0",

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.0.0-preview.1";
+export const SDK_VERSION: string = "12.0.0-preview.2";
 export const SERVICE_VERSION: string = "2018-03-28";
 
 export const URLConstants = {


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-for-js/pull/4365

- Incrementing the versions of all preview client libraries which have already shipped (from preview.1 to preview.2)
- All dependencies on previews are in their latest versions and are pinned (e.g. ^1.0.0-preview.1 to 1.0.0-preview.1) since we allow breaking changes between previews.