### PR TITLE
[Identity] Add UsernamePasswordCredential for username/password authentication

### DIFF
--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -21,7 +21,7 @@ export class IdentityClient extends ServiceClient {
 
     this.baseUri = this.authorityHost = options.authorityHost;
 
-    if (!this.baseUri.startsWith("https")) {
+    if (!this.baseUri.startsWith("https:")) {
       throw new Error("The authorityHost address must use the 'https' protocol.");
     }
   }

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -20,6 +20,10 @@ export class IdentityClient extends ServiceClient {
     super(undefined, options);
 
     this.baseUri = this.authorityHost = options.authorityHost;
+
+    if (!this.baseUri.startsWith("https")) {
+      throw new Error("The authorityHost address must use the 'https' protocol.");
+    }
   }
 
   createWebResource(requestOptions: RequestPrepareOptions): WebResource {

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import qs from "qs";
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
+import { IdentityClientOptions, IdentityClient } from "../client/identityClient";
+
+/**
+ * Enables authentication to Azure Active Directory using a user's
+ * username and password. This credential requires a high degree of
+ * trust you should only use it when other, more secure, credentials
+ * can't be used.
+ */
+export class UsernamePasswordCredential implements TokenCredential {
+  private identityClient: IdentityClient;
+  private tenantId: string;
+  private clientId: string;
+  private username: string;
+  private password: string;
+
+  /**
+   * Creates an instance of the UsernamePasswordCredential with the details
+   * needed to authenticate against Azure Active Directory with a username
+   * and password.
+   *
+   * @param tenantIdOrName The Azure Active Directory tenant (directory) ID or name.
+   * @param clientId The client (application) ID of an App Registration in the tenant.
+   * @param username The user account's e-mail address (user name).
+   * @param password The user account's account password
+   * @param options Options for configuring the client which makes the authentication request.
+   */
+  constructor(
+    tenantIdOrName: string,
+    clientId: string,
+    username: string,
+    password: string,
+    options?: IdentityClientOptions
+  ) {
+    this.identityClient = new IdentityClient(options);
+    this.tenantId = tenantIdOrName;
+    this.clientId = clientId;
+    this.username = username;
+    this.password = password;
+  }
+
+  /**
+   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * successful.  If authentication cannot be performed at this time, this method may
+   * return null.  If an error occurs during authentication, an {@link AuthenticationError}
+   * containing failure details will be thrown.
+   *
+   * @param scopes The list of scopes for which the token will have access.
+   * @param options The options used to configure any requests this
+   *                TokenCredential implementation might make.
+   */
+  public getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions
+  ): Promise<AccessToken | null> {
+    const webResource = this.identityClient.createWebResource({
+      url: `${this.identityClient.authorityHost}/${this.tenantId}/oauth2/v2.0/token`,
+      method: "POST",
+      disableJsonStringifyOnBody: true,
+      deserializationMapper: undefined,
+      body: qs.stringify({
+        response_type: "token",
+        grant_type: "password",
+        client_id: this.clientId,
+        username: this.username,
+        password: this.password,
+        scope: typeof scopes === "string" ? scopes : scopes.join(" ")
+      }),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      abortSignal: options && options.abortSignal
+    });
+
+    return this.identityClient.sendTokenRequest(webResource);
+  }
+}

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -11,6 +11,7 @@ export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { ManagedIdentityCredential } from "./credentials/managedIdentityCredential";
 export { DefaultAzureCredential } from "./credentials/defaultAzureCredential";
+export { UsernamePasswordCredential } from "./credentials/usernamePasswordCredential";
 export { AuthenticationError, AggregateAuthenticationError } from "./client/errors";
 
 export { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";

--- a/sdk/identity/identity/test/identityClient.spec.ts
+++ b/sdk/identity/identity/test/identityClient.spec.ts
@@ -5,6 +5,7 @@ import assert from "assert";
 import { assertRejects } from "./authTestUtils";
 import { MockAuthHttpClient } from "./authTestUtils";
 import { AuthenticationError } from "../src/";
+import { IdentityClient } from "../src/client/identityClient";
 import { ClientSecretCredential } from "../src";
 
 function isExpectedError(expectedErrorName: string): (error: any) => boolean {
@@ -33,6 +34,13 @@ describe("IdentityClient", function () {
         return true;
       }
     );
+  });
+
+  it("throws an exception when an authorityHost using 'http' is provided", async () => {
+    assert.throws(
+      () => { new IdentityClient({ authorityHost: "http://totallyinsecure.lol" }) },
+      Error,
+      "The authorityHost address must use the 'https' protocol.");
   });
 
   it("returns a usable error when the authentication response doesn't contain a body", async () => {

--- a/sdk/identity/identity/test/identityClient.spec.ts
+++ b/sdk/identity/identity/test/identityClient.spec.ts
@@ -41,6 +41,10 @@ describe("IdentityClient", function () {
       () => { new IdentityClient({ authorityHost: "http://totallyinsecure.lol" }) },
       Error,
       "The authorityHost address must use the 'https' protocol.");
+    assert.throws(
+      () => { new IdentityClient({ authorityHost: "httpsomg.com" }) },
+      Error,
+      "The authorityHost address must use the 'https' protocol.");
   });
 
   it("returns a usable error when the authentication response doesn't contain a body", async () => {

--- a/sdk/identity/identity/test/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/usernamePasswordCredential.spec.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from "assert";
+import { UsernamePasswordCredential } from "../src";
+import { MockAuthHttpClient } from "./authTestUtils";
+
+describe("UsernamePasswordCredential", function () {
+  it("sends an authorization request with the given username and password", async () => {
+    const mockHttpClient = new MockAuthHttpClient();
+
+    const credential = new UsernamePasswordCredential(
+      "tenant",
+      "client",
+      "user@domain.com",
+      "p4s$w0rd",
+      mockHttpClient.identityClientOptions
+    );
+
+    await credential.getToken("scope");
+
+    const authRequest = await mockHttpClient.getAuthRequest();
+    if (!authRequest) {
+      assert.fail("No authentication request was intercepted");
+    } else {
+      assert.strictEqual(
+        authRequest.url.startsWith(`https://authority/tenant`),
+        true,
+        "Request body doesn't contain expected tenantId"
+      );
+      assert.strictEqual(
+        authRequest.body.indexOf(`client_id=client`) > -1,
+        true,
+        "Request body doesn't contain expected clientId"
+      );
+      assert.strictEqual(
+        authRequest.body.indexOf(`username=user%40domain.com`) > -1,
+        true,
+        "Request body doesn't contain expected username"
+      );
+      assert.strictEqual(
+        authRequest.body.indexOf(`password=p4s%24w0rd`) > -1,
+        true,
+        "Request body doesn't contain expected username"
+      );
+    }
+  });
+});


### PR DESCRIPTION
This change adds username/password authentication as described in the AAD OAuth documentation:

https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth-ropc

Resolves #4310. 