### PR TITLE
[EPH] Add support for Web Sockets and proxy 

### DIFF
--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,3 +1,7 @@
+### 2019-07-24 2.1.0
+- Added support for WebSockets. WebSockets enable Event processor Host to work over an HTTP proxy and in environments where the standard AMQP port 5671 is blocked.
+Refer to the [websockets](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-processor-host/samples/websockets.ts) sample to see how to use WebSockets. 
+
 ## 2019-07-16 2.0.0
 - Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has the following bug fixes
     - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
@@ -17,7 +21,6 @@ library instead of [ms-rest-azure](https://www.npmjs.com/package/ms-rest-azure) 
 the credentials that are needed by these functions.
     - Typescript: Replace `import * from "ms-rest-azure";` with `import * from "@azure/ms-rest-nodeauth";`
     - Javascript: Replace `require("ms-rest-azure")` with `require("@azure/ms-rest-nodeauth")`
-
 
 ## 2018-10-05 1.0.6
 - Remove `@azure/amqp-common` and `rhea-promise` as dependencies, since we use very little from 

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-processor-host",
   "sdk-type": "client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Azure Event Processor Host (Event Hubs) SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -106,6 +106,9 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-uglify": "^6.0.0",
     "ts-node": "^7.0.1",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.2",
+    "@types/ws": "^6.0.1",
+    "https-proxy-agent": "^2.2.1",
+    "ws": "^6.2.1"
   }
 }

--- a/sdk/eventhub/event-processor-host/samples/websockets.ts
+++ b/sdk/eventhub/event-processor-host/samples/websockets.ts
@@ -1,0 +1,59 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how to use WebSockets to enable Event Processor host to work over 
+  an HTTP proxy and in environments where the standard AMQP port 5671 is blocked. 
+
+  This sample uses 2 external libraries
+  - The `ws` library to provide a WebSocket implementation to the EPH library.
+  - The `https-proxy-agent` to enable the `ws` library to work with a proxy server.
+*/
+
+import { EventProcessorHost } from "@azure/event-processor-host";
+import WebSocket from "ws";
+const url = require("url");
+const httpsProxyAgent = require("https-proxy-agent");
+
+// Define storage connection string and Event Hubs connection string and related entity name here
+const ehConnectionString = "";
+const eventHubsName = "";
+const storageConnectionString = "";
+
+// if you want to create a unique storageContainer name for every run, use `createHostName` function, otherwise
+// provide storageContainer name here.
+// const storageContainerName = "my-container";
+const storageContainerName = EventProcessorHost.createHostName("test-container");
+const ephName = "my-eph";
+
+// Create an instance of the `HttpsProxyAgent` class with the proxy server information like
+// proxy url, username and password
+// Skip this section if you are not behind a proxy server
+const urlParts = url.parse("http://localhost:3128");
+urlParts.auth = "username:password"; // Skip this if proxy server does not need authentication.
+const proxyAgent = new httpsProxyAgent(urlParts);
+
+async function main(): Promise<void> {
+  const eph = EventProcessorHost.createFromConnectionString(
+    EventProcessorHost.createHostName(ephName),
+    storageConnectionString!,
+    storageContainerName,
+    ehConnectionString!,
+    {
+      eventHubPath: eventHubsName,
+      onEphError: (error: any) => {
+        console.log("[%s] Error: %O", ephName, error);
+      },
+      webSocket: WebSocket,
+      webSocketConstructorOptions: { agent: proxyAgent }
+    }
+  );
+  /*
+   Refer to other samples, and place your code here to receive events
+  */
+  await eph.stop();
+}
+
+main().catch((err) => {
+  console.log("Error occurred: ", err);
+});

--- a/sdk/eventhub/event-processor-host/samples/websockets.ts
+++ b/sdk/eventhub/event-processor-host/samples/websockets.ts
@@ -36,9 +36,9 @@ const proxyAgent = new httpsProxyAgent(urlParts);
 async function main(): Promise<void> {
   const eph = EventProcessorHost.createFromConnectionString(
     EventProcessorHost.createHostName(ephName),
-    storageConnectionString!,
+    storageConnectionString,
     storageContainerName,
-    ehConnectionString!,
+    ehConnectionString,
     {
       eventHubPath: eventHubsName,
       onEphError: (error: any) => {

--- a/sdk/eventhub/event-processor-host/src/hostContext.ts
+++ b/sdk/eventhub/event-processor-host/src/hostContext.ts
@@ -283,14 +283,20 @@ export namespace HostContext {
           ctxt.connectionConfig.host,
           ctxt.eventHubPath,
           ctxt.tokenProvider,
-          { userAgent: ctxt.userAgent }
+          {
+            userAgent: ctxt.userAgent,
+            webSocket: options && options.webSocket,
+            webSocketConstructorOptions: options && options.webSocketConstructorOptions
+          }
         );
       } else {
         return EventHubClient.createFromConnectionString(
           ctxt.eventHubConnectionString,
           ctxt.eventHubPath,
           {
-            userAgent: ctxt.userAgent
+            userAgent: ctxt.userAgent,
+            webSocket: options && options.webSocket,
+            webSocketConstructorOptions: options && options.webSocketConstructorOptions
           }
         );
       }

--- a/sdk/eventhub/event-processor-host/src/util/constants.ts
+++ b/sdk/eventhub/event-processor-host/src/util/constants.ts
@@ -18,5 +18,5 @@ export const leaseIdMismatchWithBlobOperation = "leaseidmismatchwithbloboperatio
 export const defaultConsumerGroup = "$default";
 export const packageInfo = {
   name: "@azure/event-processor-host",
-  version: "2.0.0"
+  version: "2.1.0"
 };


### PR DESCRIPTION
This PR Updates the following:

* Since Event Hubs 2.0.0 supports Websockets, updated EPH to send the web sockets info to Event hubs
* Updated package version to 2.1.0
* Updated changelog
* Added one sample for web socket.

For more info: https://github.com/Azure/azure-sdk-for-js/issues/3378