### PR TITLE
 [Event Hubs] Define classes and interfaces for EPH as per API design

### DIFF
--- a/sdk/eventhub/event-hubs/src/checkpointManager.ts
+++ b/sdk/eventhub/event-hubs/src/checkpointManager.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { PartitionContext } from "./partitionContext";
+// import { PartitionContext } from "./partitionContext";
 import { EventData } from "./eventData";
-import { PartitionManager } from "./eventProcessor";
+// import { PartitionManager } from "./eventProcessor";
 
 /**
  * Used by createCheckpoint in PartitionManager
@@ -21,21 +21,13 @@ export interface Checkpoint {
  * CheckPointManager is created by the library & passed to user's code to let them create a checkpoint
  */
 export class CheckpointManager {
-  private _partitionContext: PartitionContext; // for internal use by createCheckpoint
-  private _partitionManager: PartitionManager; // for internal use by createCheckpoint
+  // private _partitionContext: PartitionContext; // for internal use by createCheckpoint
+  // private _partitionManager: PartitionManager; // for internal use by createCheckpoint
 
-  get partitionContext(): PartitionContext {
-    return this._partitionContext;
-  }
-
-  get partitionManager(): PartitionManager {
-    return this._partitionManager;
-  }
-
-  constructor(partitionContext: PartitionContext, partitionManager: PartitionManager) {
-    this._partitionContext = partitionContext;
-    this._partitionManager = partitionManager;
-  }
+  // constructor(partitionContext: PartitionContext, partitionManager: PartitionManager) {
+  //   this._partitionContext = partitionContext;
+  //   this._partitionManager = partitionManager;
+  // }
 
   public async createCheckpoint(eventData: EventData): Promise<void>;
 

--- a/sdk/eventhub/event-hubs/src/checkpointManager.ts
+++ b/sdk/eventhub/event-hubs/src/checkpointManager.ts
@@ -21,12 +21,20 @@ export interface Checkpoint {
  * CheckPointManager is created by the library & passed to user's code to let them create a checkpoint
  */
 export class CheckpointManager {
-  private partitionContext: PartitionContext; // for internal use by createCheckpoint
-  private partitionManager: PartitionManager; // for internal use by createCheckpoint
+  private _partitionContext: PartitionContext; // for internal use by createCheckpoint
+  private _partitionManager: PartitionManager; // for internal use by createCheckpoint
+
+  get partitionContext(): PartitionContext {
+    return this._partitionContext;
+  }
+
+  get partitionManager(): PartitionManager {
+    return this._partitionManager;
+  }
 
   constructor(partitionContext: PartitionContext, partitionManager: PartitionManager) {
-    this.partitionContext = partitionContext;
-    this.partitionManager = partitionManager;
+    this._partitionContext = partitionContext;
+    this._partitionManager = partitionManager;
   }
 
   public async createCheckpoint(eventData: EventData): Promise<void>;

--- a/sdk/eventhub/event-hubs/src/checkpointManager.ts
+++ b/sdk/eventhub/event-hubs/src/checkpointManager.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { PartitionContext } from "./partitionContext";
+import { EventData } from "./eventData";
+import { PartitionManager } from "./eventProcessor";
+
+/**
+ *  used by createCheckpoint in PartitionManager
+ **/
+export interface Checkpoint {
+  eventHubName: string;
+  consumerGroupName: string;
+  instanceId: string;
+  partitionId: string;
+  sequenceNumber: number;
+  offset: number;
+}
+
+
+/**
+ * CheckPointManager is created by the library & passed to user's code to let them create a checkpoint
+ * This was not needed in Track 1 as the checkpoint() function was available on the PartitionContext
+ * This may not be needed in Track 2 if passing a lambda function works
+ */
+export class CheckpointManager {
+  private partitionContext: PartitionContext; // for internal use by createCheckpoint
+  private partitionManager: PartitionManager; // for internal use by createCheckpoint
+
+  constructor(partitionContext: PartitionContext, partitionManager: PartitionManager) {
+    this.partitionContext = partitionContext;
+    this.partitionManager = partitionManager;
+  }
+
+  public async createCheckpoint(eventData: EventData): Promise<void>;
+
+  public async createCheckpoint(offset: string, sequenceNumber: number): Promise<void>;
+
+  public async createCheckpoint(
+    eventDataOrOffset: EventData | string,
+    sequenceNumber?: number
+  ): Promise<void> {}
+}

--- a/sdk/eventhub/event-hubs/src/checkpointManager.ts
+++ b/sdk/eventhub/event-hubs/src/checkpointManager.ts
@@ -6,7 +6,7 @@ import { EventData } from "./eventData";
 import { PartitionManager } from "./eventProcessor";
 
 /**
- *  used by createCheckpoint in PartitionManager
+ * Used by createCheckpoint in PartitionManager
  **/
 export interface Checkpoint {
   eventHubName: string;
@@ -17,11 +17,8 @@ export interface Checkpoint {
   offset: number;
 }
 
-
 /**
  * CheckPointManager is created by the library & passed to user's code to let them create a checkpoint
- * This was not needed in Track 1 as the checkpoint() function was available on the PartitionContext
- * This may not be needed in Track 2 if passing a lambda function works
  */
 export class CheckpointManager {
   private partitionContext: PartitionContext; // for internal use by createCheckpoint

--- a/sdk/eventhub/event-hubs/src/checkpointManager.ts
+++ b/sdk/eventhub/event-hubs/src/checkpointManager.ts
@@ -29,11 +29,11 @@ export class CheckpointManager {
   //   this._partitionManager = partitionManager;
   // }
 
-  public async createCheckpoint(eventData: EventData): Promise<void>;
+  public async updateCheckpoint(eventData: EventData): Promise<void>;
 
-  public async createCheckpoint(offset: string, sequenceNumber: number): Promise<void>;
+  public async updateCheckpoint(offset: string, sequenceNumber: number): Promise<void>;
 
-  public async createCheckpoint(
+  public async updateCheckpoint(
     eventDataOrOffset: EventData | string,
     sequenceNumber?: number
   ): Promise<void> {}

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { EventHubClient } from "./eventHubClient";
+import { EventPosition } from "./eventPosition";
+import { PartitionContext } from "./partitionContext";
+import { CheckpointManager, Checkpoint } from "./checkpointManager";
+import { EventData } from "./eventData";
+
+export interface PartitionProcessor {
+  /**
+   * Optional. Called when EPH begins processing a partition.
+   */
+  initialize?(): Promise<void>;
+  /**
+   * Optional. Called when EPH stops processing a partition.
+   * This may occur when control of the partition switches to another EPH or when user stops EPH
+   * TODO: update string -> CloseReason
+   */
+  close?(reason: string): Promise<void>;
+  /**
+   * Called when a batch of events have been received.
+   */
+  processEvents(events: EventData[]): Promise<void>;
+  /**
+   * Called when the underlying client experiences an error while receiving.
+   */
+  processError(error: Error): Promise<void>;
+}
+
+/**
+ * used by PartitionManager to claim ownership.
+ * returned by listOwnerships
+ */
+export interface PartitionOwnership {
+  eventHubName: string;
+  consumerGroupName: string;
+  instanceId: string;
+  partitionId: string;
+  ownerLevel: number;
+  offset?: number;
+  sequenceNumber?: number;
+  lastModifiedTime?: number;
+  ETag?: string;
+}
+
+/**
+ * The PartitionProcessorFactory is called by EPH whenever a new partition is about to be processed.
+ */
+export interface PartitionProcessorFactory {
+  createPartitionProcessor(
+    context: PartitionContext,
+    checkpointManger: CheckpointManager
+  ): PartitionProcessor;
+}
+
+/**
+ * Interface for the plugin to be passed when creating the EventProcessorHost
+ * to manage partition ownership and checkpoint creation.
+ * Deals mainly with read/write to the chosen storage service
+ */
+export interface PartitionManager {
+  listOwnerships(eventHubName: string, consumerGroupName: string): Promise<PartitionOwnership[]>;
+  claimOwnerships(partitionOwnerships: PartitionOwnership[]): Promise<PartitionOwnership[]>;
+  createCheckpoint(checkpoint: Checkpoint): Promise<void>;
+}
+
+// Options passed when creating EventProcessor, everything is optional
+export interface EventProcessorOptions {
+  initialEventPosition?: EventPosition;
+  maxBatchSize?: number;
+  maxWaitTime?: number;
+}
+
+/**
+ * Describes the Event Processor Host to process events from an EventHub.
+ * @class EventProcessorHost
+ */
+export class EventProcessor {
+  constructor(
+    consumerGroupName: string,
+    eventHubClient: EventHubClient,
+    partitionProcessorFactory: PartitionProcessorFactory,
+    partitionManager: PartitionManager,
+    options?: EventProcessorOptions
+  ) {}
+
+  /**
+   * Starts the event processor, fetching the list of partitions, and attempting to grab leases
+   * For each successful lease, it will get the details from the blob and start a receiver at the
+   * point where it left off previously.
+   *
+   * @return {Promise<void>}
+   */
+  async start(): Promise<void> {}
+
+  /**
+   * Stops the EventProcessor from processing messages.
+   * @return {Promise<void>}
+   */
+  async stop(): Promise<void> {}
+}

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -48,10 +48,7 @@ export interface PartitionOwnership {
  * The PartitionProcessorFactory is called by EPH whenever a new partition is about to be processed.
  */
 export interface PartitionProcessorFactory {
-  createPartitionProcessor(
-    context: PartitionContext,
-    checkpointManger: CheckpointManager
-  ): PartitionProcessor;
+  (context: PartitionContext, checkpointManager: CheckpointManager): PartitionProcessor;
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/partitionContext.ts
+++ b/sdk/eventhub/event-hubs/src/partitionContext.ts
@@ -5,14 +5,8 @@
  * PartitionContext is passed into an EventProrcessor's initialization handler and contains information
  * about the partition, the EventProcessor will be processing events from.
  */
-export class PartitionContext {
-  public readonly partitionId: string;
-  public readonly eventHubName: string;
-  public readonly consumerGroupName: string;
-
-  constructor(partitionId: string, eventHubName: string, consumerGroupName: string) {
-    this.partitionId = partitionId;
-    this.eventHubName = eventHubName;
-    this.consumerGroupName = consumerGroupName;
-  }
+export interface PartitionContext {
+  readonly partitionId: string;
+  readonly eventHubName: string;
+  readonly consumerGroupName: string;
 }

--- a/sdk/eventhub/event-hubs/src/partitionContext.ts
+++ b/sdk/eventhub/event-hubs/src/partitionContext.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+/**
+* PartitionContext is passed into an EventProrcessor's initialization handler and contains information
+* about the partition, the EventProcessor will be processing events from.
+*/
+export class PartitionContext {
+ public readonly partitionId: string;
+ public readonly eventHubName: string;
+ public readonly consumerGroupName: string;
+
+ constructor(
+    partitionId: string,
+    eventHubName: string,
+    consumerGroupName: string
+  ) {
+      this.partitionId = partitionId;
+      this.eventHubName = eventHubName;
+      this.consumerGroupName = consumerGroupName;
+  }
+}

--- a/sdk/eventhub/event-hubs/src/partitionContext.ts
+++ b/sdk/eventhub/event-hubs/src/partitionContext.ts
@@ -2,21 +2,17 @@
 // Licensed under the MIT License.
 
 /**
-* PartitionContext is passed into an EventProrcessor's initialization handler and contains information
-* about the partition, the EventProcessor will be processing events from.
-*/
+ * PartitionContext is passed into an EventProrcessor's initialization handler and contains information
+ * about the partition, the EventProcessor will be processing events from.
+ */
 export class PartitionContext {
- public readonly partitionId: string;
- public readonly eventHubName: string;
- public readonly consumerGroupName: string;
+  public readonly partitionId: string;
+  public readonly eventHubName: string;
+  public readonly consumerGroupName: string;
 
- constructor(
-    partitionId: string,
-    eventHubName: string,
-    consumerGroupName: string
-  ) {
-      this.partitionId = partitionId;
-      this.eventHubName = eventHubName;
-      this.consumerGroupName = consumerGroupName;
+  constructor(partitionId: string, eventHubName: string, consumerGroupName: string) {
+    this.partitionId = partitionId;
+    this.eventHubName = eventHubName;
+    this.consumerGroupName = consumerGroupName;
   }
 }


### PR DESCRIPTION
As per feedback, we decided that EPH and Event Hubs client will ship in the same client library while the EPH plugins will each ship in their own separate client libraries.

This PR creates new classes and interfaces for Event processor host as per [Proposed API design for EPH](https://gist.github.com/ramya-rao-a/6ce030240112063e12a23477697b01f2#proposed-api-design-for-eph-in-typescript)