### PR TITLE
Add retries to Invoke-WebRequest

### DIFF
--- a/eng/.prettierrc.json
+++ b/eng/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "singleQuote": false
+}

--- a/eng/pipelines/docs.yml
+++ b/eng/pipelines/docs.yml
@@ -45,7 +45,7 @@ jobs:
           npm install yargs
         displayName: "Install yargs"
 
-      - powershell: |
+      - pwsh: |
           cd $(Build.SourcesDirectory)
           node .\common\scripts\generate-doc.js --dgOp "dg" $(additionalArgs)
           Copy-Item -Path $(Build.SourcesDirectory)/docGen/* -Destination $(Build.ArtifactStagingDirectory) -Recurse -Force

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -1,6 +1,6 @@
 steps:
   - pwsh: |
-      Invoke-WebRequest -MaximumRetryCount 10 -UseBasicParsing -Uri "https://raw.githubusercontent.com/Azure/azure-sdk-tools/verify-agent-os_1.1.0/scripts/python/verify_agent_os.py" -OutFile "verify_agent_os.py" | Wait-Process
+      Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://raw.githubusercontent.com/Azure/azure-sdk-tools/verify-agent-os_1.1.0/scripts/python/verify_agent_os.py" -OutFile "verify_agent_os.py" | Wait-Process
     workingDirectory: "$(Build.BinariesDirectory)"
     displayName: "Download verify_agent_os.py"
 

--- a/eng/pipelines/templates/steps/common.yml
+++ b/eng/pipelines/templates/steps/common.yml
@@ -1,6 +1,6 @@
 steps:
-  - powershell: |
-      Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubusercontent.com/Azure/azure-sdk-tools/verify-agent-os_1.1.0/scripts/python/verify_agent_os.py" -OutFile "verify_agent_os.py" | Wait-Process
+  - pwsh: |
+      Invoke-WebRequest -MaximumRetryCount 10 -UseBasicParsing -Uri "https://raw.githubusercontent.com/Azure/azure-sdk-tools/verify-agent-os_1.1.0/scripts/python/verify_agent_os.py" -OutFile "verify_agent_os.py" | Wait-Process
     workingDirectory: "$(Build.BinariesDirectory)"
     displayName: "Download verify_agent_os.py"
 


### PR DESCRIPTION
Anytime `Invoke-WebRequest` is used in a pipeline or script, retries should be allowed to handle intermittent failures due to network or server issues.  I will make this change across all client-library pipelines and scripts in all repos.

Example pipeline failure:

```
##[command]"C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command ". 'D:\a\_temp\ba73e13b-9a3c-4388-a471-fd1ac4884a28.ps1'"
Invoke-WebRequest : Unable to connect to the remote server
At D:\a\_temp\ba73e13b-9a3c-4388-a471-fd1ac4884a28.ps1:2 char:1
+ Invoke-WebRequest -UseBasicParsing -Uri "https://raw.githubuserconten ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebExc 
   eption
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

https://dev.azure.com/azure-sdk/public/_build/results?buildId=74157&view=logs&jobId=0cac3d53-c604-5b5d-0b4e-ac2b7ffbaab5&taskId=60a41d80-98c5-5054-7eb3-8e76656b2cf2&lineStart=12&lineEnd=13&colStart=1&colEnd=1

CC: @Azure/azure-sdk-eng 