### PR TITLE
[Event Hubs] Update `getHubRuntimeInformation()`  and `getPartitionInformation()` methods name in README

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -190,8 +190,8 @@ Most likely the associated connection string will not have send claims. Hence ge
 
 ```javascript
 const client = await EventHubClient.createFromIotHubConnectionString("connectionString");
-await client.getHubRuntimeInformation();
-await client.getPartitionInformation("partitionId");
+await client.getProperties();
+await client.getPartitionProperties("partitionId");
 ```
 
 **Notes:** For scalable and efficient receiving, please take a look at [azure-event-processor-host](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-processor-host). The Event Processor host, internally uses the streaming receiver to receive events.


### PR DESCRIPTION
This PR updates the methods name in README

`getHubRuntimeInformation()` renamed to `getProperties()` and `getPartitionInformation()` renamed to `getPartitionProperties()` in Event Hubs "5.0.0-preview.1"

