### PR TITLE
[core-auth] Prepare @azure/core-auth to be published

### DIFF
--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -6,8 +6,7 @@
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {
-    "./dist/index.js": "./browser/index.js",
-    "./dist-esm/src/print.js": "./dist-esm/src/print.browser.js"
+    "./dist/index.js": "./browser/index.js"
   },
   "types": "types/core-auth.d.ts",
   "scripts": {
@@ -57,7 +56,6 @@
   },
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/core/core-auth",
   "sideEffects": false,
-  "private": true,
   "dependencies": {
     "tslib": "^1.9.3"
   },


### PR DESCRIPTION
This PR removes `private: true` from `@azure/core-auth`'s `package.json` so that it can be published.  Also removed an unneeded line from the `browser` configuration.