### PR TITLE
[core-auth] Fix 'browser' path configuration in core-auth

### DIFF
--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {
-    "./dist/index.js": "./browser/index.js"
+    "./dist/index.js": "./browser/core-auth.js"
   },
   "types": "types/core-auth.d.ts",
   "scripts": {


### PR DESCRIPTION
This corrects the `browser` configuration in `core-auth`'s `package.json` file to ensure that it points to the correct browser output file.  Presumably this would only affect consumers who are trying to directly reference this library in a Rollup build.

It actually looks like `sdk/template/template` may have this [configured incorrectly](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/template/template/package.json#L10), that's where I copied it from.  @bterlson: do you know if this file remapping in `browser` is needed for consumers of our libraries?