### PR TITLE
Update dev dependency gulp-zip to latest

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -96,7 +96,7 @@ dependencies:
   fs-extra: 8.1.0
   glob: 7.1.4
   gulp: 4.0.2
-  gulp-zip: 4.2.0
+  gulp-zip: 5.0.0_gulp@4.0.2
   https-proxy-agent: 2.2.2
   inherits: 2.0.4
   is-buffer: 2.0.3
@@ -4185,6 +4185,14 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  /get-stream/5.1.0:
+    dependencies:
+      pump: 3.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
   /get-value/2.0.6:
     dev: false
     engines:
@@ -4377,18 +4385,21 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==
-  /gulp-zip/4.2.0:
+  /gulp-zip/5.0.0_gulp@4.0.2:
     dependencies:
-      get-stream: 3.0.0
-      plugin-error: 0.1.2
-      through2: 2.0.5
+      get-stream: 5.1.0
+      gulp: 4.0.2
+      plugin-error: 1.0.1
+      through2: 3.0.1
       vinyl: 2.2.0
       yazl: 2.5.1
     dev: false
     engines:
-      node: '>=4'
+      node: '>=8'
+    peerDependencies:
+      gulp: '>=4'
     resolution:
-      integrity: sha512-I+697f6jf+PncdTrqfuwoauxgnLG1yHRg3vlmvDgmJuEnlEHy4meBktJ/oHgfyg4tp6X25wuZqUOraVeVg97wQ==
+      integrity: sha512-oR3t8kn+ccHkSyRcBV5kBLPXrhqTh5d6wBAR7r7wqjNQNBhYvOwPedCwlAaGcNl1qSeXNDn6qOk1Qyxvx9Wrow==
   /gulp/4.0.2:
     dependencies:
       glob-watcher: 5.0.3
@@ -7120,6 +7131,17 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=
+  /plugin-error/1.0.1:
+    dependencies:
+      ansi-colors: 1.1.0
+      arr-diff: 4.0.0
+      arr-union: 3.1.0
+      extend-shallow: 3.0.2
+    dev: false
+    engines:
+      node: '>= 0.10'
+    resolution:
+      integrity: sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==
   /posix-character-classes/0.1.1:
     dev: false
     engines:
@@ -7437,6 +7459,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
+  /readable-stream/3.4.0:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.2.0
+      util-deprecate: 1.0.2
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
   /readdirp/2.2.1:
     dependencies:
       graceful-fs: 4.2.0
@@ -8734,6 +8766,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  /through2/3.0.1:
+    dependencies:
+      readable-stream: 3.4.0
+    dev: false
+    resolution:
+      integrity: sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
   /time-stamp/1.1.0:
     dev: false
     engines:
@@ -10499,7 +10537,7 @@ packages:
       events: 3.0.0
       fs-extra: 8.1.0
       gulp: 4.0.2
-      gulp-zip: 4.2.0
+      gulp-zip: 5.0.0_gulp@4.0.2
       inherits: 2.0.4
       karma: 4.2.0
       karma-chrome-launcher: 2.2.0
@@ -10541,7 +10579,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-5KC/oczG4OJCdu73WljXC+6DPQPqwzvbhMhtwmNSvNiW7jMM6eHzrzGJK0n/00vic5fvqhUThm6tu3XZG1ZTSw==
+      integrity: sha512-oMEqXqmiRF6HYkZXU4o93bKkibi5RGs4iYwnSXE1QXA5uIFqU1oGvVxUMvZedk9DUCKOssRYOTFSrf0HCjy9dQ==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file.tgz':
@@ -10570,7 +10608,7 @@ packages:
       events: 3.0.0
       fs-extra: 8.1.0
       gulp: 4.0.2
-      gulp-zip: 4.2.0
+      gulp-zip: 5.0.0_gulp@4.0.2
       inherits: 2.0.4
       karma: 4.2.0
       karma-chrome-launcher: 2.2.0
@@ -10612,7 +10650,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file'
     resolution:
-      integrity: sha512-fr9PugxrPIsBuXaXDe02j7E22Esqz+2e8lcbM0HIQDKRi3nxn+f4Hq60sQVOGsckT7weLB7XtQGS7dnEBNd2Cw==
+      integrity: sha512-Tld5tho72inYm+jDPhQ85HvUmtd08K/oVBddhWT5MfgLbT+6BM6ZKMkyPgjCa/o2RsSR0NYPQSGijmdpfiDXKA==
       tarball: 'file:projects/storage-file.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -10640,7 +10678,7 @@ packages:
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.1.0
       gulp: 4.0.2
-      gulp-zip: 4.2.0
+      gulp-zip: 5.0.0_gulp@4.0.2
       inherits: 2.0.4
       karma: 4.2.0
       karma-chrome-launcher: 2.2.0
@@ -10682,7 +10720,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-WP+VB28wLg441fESisDswzeIJEAkdEktRSBFSs1qhuT6e0jlSEzlkOjl6xbfVqvg4dlv/ra9TLH051E+lwrhCw==
+      integrity: sha512-71xJVOcx25+m4X852HbknjV1kMpt0itdtxhTPF804gVomy4Ymrj8AQhwAmMVzzt3Q/+5LU51VpLtH10FF5Hxfg==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
@@ -10860,7 +10898,7 @@ specifiers:
   fs-extra: ^8.1.0
   glob: ^7.1.2
   gulp: ^4.0.0
-  gulp-zip: ^4.2.0
+  gulp-zip: ^5.0.0
   https-proxy-agent: ^2.2.1
   inherits: ^2.0.3
   is-buffer: ^2.0.3

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -101,7 +101,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "fs-extra": "^8.1.0",
     "gulp": "^4.0.0",
-    "gulp-zip": "^4.2.0",
+    "gulp-zip": "^5.0.0",
     "inherits": "^2.0.3",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -101,7 +101,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "fs-extra": "^8.1.0",
     "gulp": "^4.0.0",
-    "gulp-zip": "^4.2.0",
+    "gulp-zip": "^5.0.0",
     "inherits": "^2.0.3",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -99,7 +99,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "fs-extra": "^8.1.0",
     "gulp": "^4.0.0",
-    "gulp-zip": "^4.2.0",
+    "gulp-zip": "^5.0.0",
     "inherits": "^2.0.3",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^2.2.0",


### PR DESCRIPTION
- The only listed breaking change is dropping support for Node 6
  - https://github.com/sindresorhus/gulp-zip/releases/tag/v5.0.0

Verified no changes to shipping packages or browser zips (except for `package.json`)