### PR TITLE
Remove dev dependency opn-cli

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -133,7 +133,6 @@ dependencies:
   nock: 10.0.6
   npm-run-all: 4.1.5
   nyc: 14.1.1
-  opn-cli: 4.1.0
   path-browserify: 1.0.0
   prettier: 1.18.2
   priorityqueuejs: 1.0.0
@@ -2176,7 +2175,7 @@ packages:
   /browserslist/3.2.8:
     dependencies:
       caniuse-lite: 1.0.30000986
-      electron-to-chromium: 1.3.203
+      electron-to-chromium: 1.3.204
     dev: false
     hasBin: true
     resolution:
@@ -3225,10 +3224,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.203:
+  /electron-to-chromium/1.3.204:
     dev: false
     resolution:
-      integrity: sha512-Z1FjJKEBhYrCNmnususVk8khiBabVI/bSJB/295V4ghVt4MFmtbP+mXgRZLQZinEBI469U6FtiGgpXnlLs6qiQ==
+      integrity: sha512-T0eXE6hfbtpzRUaI7aHI/HYJ29Ndk84aVSborRAmXfWvBvz2EuB2OWYUxNcUX9d+jtqEIjgZjWMdoxS0hp5j1g==
   /elliptic/6.5.0:
     dependencies:
       bn.js: 4.11.8
@@ -3845,12 +3844,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
-  /file-type/10.11.0:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==
   /fill-range/4.0.0:
     dependencies:
       extend-shallow: 2.0.1
@@ -5832,14 +5825,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
-  /make-dir/1.3.0:
-    dependencies:
-      pify: 3.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==
   /make-dir/2.1.0:
     dependencies:
       pify: 4.0.1
@@ -6020,22 +6005,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==
-  /meow/5.0.0:
-    dependencies:
-      camelcase-keys: 4.2.0
-      decamelize-keys: 1.1.0
-      loud-rejection: 1.6.0
-      minimist-options: 3.0.2
-      normalize-package-data: 2.5.0
-      read-pkg-up: 3.0.0
-      redent: 2.0.0
-      trim-newlines: 2.0.0
-      yargs-parser: 10.1.0
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
   /merge-descriptors/1.0.1:
     dev: false
     resolution:
@@ -6696,19 +6665,6 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
-  /opn-cli/4.1.0:
-    dependencies:
-      file-type: 10.11.0
-      get-stdin: 6.0.0
-      meow: 5.0.0
-      open: 6.4.0
-      temp-write: 3.4.0
-    dev: false
-    engines:
-      node: '>=8'
-    hasBin: true
-    resolution:
-      integrity: sha512-nVJ9dVb4fEKtmACWxUql+hhQxVWMt7BSRT+6TnB85W3xs5Pgk9sKW3icYeCIwOtOKALBw/6WUCoNmI1+ADfAow==
   /optimist/0.6.1:
     dependencies:
       minimist: 0.0.10
@@ -8676,25 +8632,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-  /temp-dir/1.0.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=
-  /temp-write/3.4.0:
-    dependencies:
-      graceful-fs: 4.2.0
-      is-stream: 1.1.0
-      make-dir: 1.3.0
-      pify: 3.0.0
-      temp-dir: 1.0.0
-      uuid: 3.3.2
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=
   /terser-webpack-plugin/1.3.0_webpack@4.38.0:
     dependencies:
       cacache: 11.3.3
@@ -9589,12 +9526,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
-  /yargs-parser/10.1.0:
-    dependencies:
-      camelcase: 4.1.0
-    dev: false
-    resolution:
-      integrity: sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
   /yargs-parser/13.1.1:
     dependencies:
       camelcase: 5.3.1
@@ -9858,7 +9789,6 @@ packages:
       mocha-multi-reporters: 1.1.7
       npm-run-all: 4.1.5
       nyc: 14.1.1
-      opn-cli: 4.1.0
       rimraf: 2.6.3
       rollup: 1.17.0
       rollup-plugin-node-resolve: 5.2.0_rollup@1.17.0
@@ -9874,7 +9804,7 @@ packages:
     dev: false
     name: '@rush-temp/core-arm'
     resolution:
-      integrity: sha512-ydCkKGPwdsqk3cZtb5s+PlhnUJNHifGymT1Rh6PjJCVoOOXGTXqZYc4k/EI9DMk/sgI4Vo9cQknrmjG5hRz5dw==
+      integrity: sha512-1sOGfOod5UwbFF8cs0IekpFq9Zne5DIWp+lpG7Isjn7/io2udgugy3ciY7e2XcikZk34wctC8zHQiPul6G9nhg==
       tarball: 'file:projects/core-arm.tgz'
     version: 0.0.0
   'file:projects/core-asynciterator-polyfill.tgz':
@@ -9983,7 +9913,6 @@ packages:
       mocha-multi-reporters: 1.1.7
       npm-run-all: 4.1.5
       nyc: 14.1.1
-      opn-cli: 4.1.0
       process: 0.11.10
       puppeteer: 1.19.0
       rimraf: 2.6.3
@@ -10016,7 +9945,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-pYmI7WimQIGJwIiiOP0xeyV1gSAJfCzUEhrCOVNmG8jvYFqXYUuqHAlGq/N02i+oRh/c+wM07H3Mv/kyCScomQ==
+      integrity: sha512-ykXa+d0rGhwA3mG9JPPf+iKky71Qa2LjflLenGtR78FMTgcDkvq6QmGJ793uZUN5SKu5iXk0CMGYPrngzfx31g==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -10799,7 +10728,6 @@ packages:
       integrity: sha512-rdhMvXi7mvg+wP0vVdqhouZr17v9a3n4KDMSyuUPU9qhOvY6bMfqoeIXrzgWkCXtR9yjL15gwJHKWsBlByGE4A==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
   '@azure/abort-controller': 1.0.0-preview.1
   '@azure/amqp-common': 1.0.0-preview.6
@@ -10935,7 +10863,6 @@ specifiers:
   nock: ^10.0.6
   npm-run-all: ^4.1.5
   nyc: ^14.0.0
-  opn-cli: ^4.0.0
   path-browserify: ^1.0.0
   prettier: ^1.16.4
   priorityqueuejs: 1.0.0

--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -63,7 +63,6 @@
     "mocha-multi-reporters": "^1.1.7",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.0.0",
-    "opn-cli": "^4.0.0",
     "rimraf": "^2.6.2",
     "rollup": "^1.16.3",
     "rollup-plugin-node-resolve": "^5.0.2",
@@ -121,7 +120,6 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "nyc mocha",
-    "test:coverage": "npm run test && opn coverage/index.html",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean"
   },

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -163,7 +163,6 @@
     "mocha-multi-reporters": "^1.1.7",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.0.0",
-    "opn-cli": "^4.0.0",
     "puppeteer": "^1.11.0",
     "rimraf": "^2.6.2",
     "rollup": "^1.16.3",


### PR DESCRIPTION
- We'd like to keep our set of dev dependencies as small as possible.  This improves install time, reduces maintenance cost, etc.
- Since this dependency was only used to open a code-coverage HTML file, we don't think it's worth the cost.
