### PR TITLE
[KeyVault] dotenv fix

### DIFF
--- a/sdk/keyvault/keyvault-keys/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-keys/tests/utils/recorder.ts
@@ -7,7 +7,7 @@ import { retry as realRetry } from "./retry";
 import { isNode as coreIsNode, delay as coreDelay } from "@azure/core-http";
 import queryString from "query-string";
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../../.env" });
+dotenv.config({ path: "../.env" });
 
 export function isBrowser(): boolean {
   return typeof window !== "undefined";

--- a/sdk/keyvault/keyvault-secrets/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-secrets/tests/utils/recorder.ts
@@ -8,7 +8,7 @@ import { retry as realRetry } from "./retry";
 import { isNode as coreIsNode } from "@azure/core-http";
 import queryString from "query-string";
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../../.env" });
+dotenv.config({ path: "../.env" });
 
 export function isBrowser(): boolean {
   return typeof window !== "undefined";


### PR DESCRIPTION
With this change, we can have a `.env` file in `sdk/keyvault` (the parent
folder, as well as with other of our projects using dotenv) with the
following properties:

```
AZURE_CLIENT_ID=XXXXXXXX
AZURE_CLIENT_SECRET=XXXXXXXX
AZURE_TENANT_ID=XXXXXXXX
KEYVAULT_NAME=XXXXXXXX
TEST_MODE=["record" or "playback", without quotes]
```

And then run `rushx integration-test:node` to record (or playback) all
the tests with the Node environment, and also `rushx integration-test:browser`
to run the tests with the browser environment.

Would this help with #4389 ?

**Note:** The recorder already replaces all the environment variables with stub values! Only TEST_MODE=playback is needed to run the playback tests.

Please review 💙