### PR TITLE
[EPH] adds support for processing multiple partitions

### DIFF
--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -28,6 +28,20 @@ export interface BatchOptions {
     partitionKey?: string;
 }
 
+// @public
+export class CheckpointManager {
+    // (undocumented)
+    updateCheckpoint(eventData: EventData): Promise<void>;
+    // (undocumented)
+    updateCheckpoint(offset: string, sequenceNumber: number): Promise<void>;
+}
+
+// @public
+export enum CloseReason {
+    OwnershipLost = "OwnershipLost",
+    Shutdown = "Shutdown"
+}
+
 export { DataTransformer }
 
 export { DefaultDataTransformer }
@@ -148,12 +162,19 @@ export class EventPosition {
 
 // @public
 export class EventProcessor {
-    // Warning: (ae-forgotten-export) The symbol "PartitionProcessorFactory" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "PartitionManager" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "EventProcessorOptions" needs to be exported by the entry point index.d.ts
     constructor(consumerGroupName: string, eventHubClient: EventHubClient, partitionProcessorFactory: PartitionProcessorFactory, partitionManager: PartitionManager, options?: EventProcessorOptions);
-    start(): Promise<void>;
+    start(): void;
     stop(): Promise<void>;
+}
+
+// @public (undocumented)
+export interface EventProcessorOptions {
+    // (undocumented)
+    initialEventPosition?: EventPosition;
+    // (undocumented)
+    maxBatchSize?: number;
+    // (undocumented)
+    maxWaitTimeInSeconds?: number;
 }
 
 export { MessagingError }
@@ -172,6 +193,54 @@ export interface PartitionContext {
     readonly eventHubName: string;
     // (undocumented)
     readonly partitionId: string;
+}
+
+// @public
+export interface PartitionManager {
+    // (undocumented)
+    claimOwnerships(partitionOwnerships: PartitionOwnership[]): Promise<PartitionOwnership[]>;
+    // Warning: (ae-forgotten-export) The symbol "Checkpoint" needs to be exported by the entry point index.d.ts
+    // 
+    // (undocumented)
+    createCheckpoint(checkpoint: Checkpoint): Promise<void>;
+    // (undocumented)
+    listOwnerships(eventHubName: string, consumerGroupName: string): Promise<PartitionOwnership[]>;
+}
+
+// @public
+export interface PartitionOwnership {
+    // (undocumented)
+    consumerGroupName: string;
+    // (undocumented)
+    ETag?: string;
+    // (undocumented)
+    eventHubName: string;
+    // (undocumented)
+    instanceId: string;
+    // (undocumented)
+    lastModifiedTime?: number;
+    // (undocumented)
+    offset?: number;
+    // (undocumented)
+    ownerLevel: number;
+    // (undocumented)
+    partitionId: string;
+    // (undocumented)
+    sequenceNumber?: number;
+}
+
+// @public (undocumented)
+export interface PartitionProcessor {
+    close?(reason: CloseReason): Promise<void>;
+    initialize?(): Promise<void>;
+    processError(error: Error): Promise<void>;
+    processEvents(events: EventData[]): Promise<void>;
+}
+
+// @public
+export interface PartitionProcessorFactory {
+    // (undocumented)
+    (context: PartitionContext, checkpointManager: CheckpointManager): PartitionProcessor;
 }
 
 // @public

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -13,7 +13,7 @@ import * as log from "./log";
 import { cancellableDelay } from "./util/cancellableDelay";
 
 /**
- * Reason for closing an EventProcessor.
+ * Reason for closing a PartitionProcessor.
  */
 export enum CloseReason {
   /**
@@ -23,7 +23,11 @@ export enum CloseReason {
   /**
    * The EventProcessor was shutdown.
    */
-  Shutdown = "Shutdown"
+  Shutdown = "Shutdown",
+  /**
+   * The PartitionProcessor was shutdown for an unknown reason.
+   */
+  Unknown = "Unknown"
 }
 
 export interface PartitionProcessor {

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -1,12 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import uuid from "uuid/v4";
 import { EventHubClient } from "./eventHubClient";
 import { EventPosition } from "./eventPosition";
 import { PartitionContext } from "./partitionContext";
 import { CheckpointManager, Checkpoint } from "./checkpointManager";
 import { EventData } from "./eventData";
-import { PartitionPump } from "./partitionPump";
+import { PumpManager } from "./pumpManager";
+import { AbortSignalLike, AbortController } from "@azure/abort-controller";
+import * as log from "./log";
+import { cancellableDelay } from "./util/cancellableDelay";
+
+/**
+ * Reason for closing an EventProcessor.
+ */
+export enum CloseReason {
+  /**
+   * Ownership of the partition was lost or transitioned to a new processor instance.
+   */
+  OwnershipLost = "OwnershipLost",
+  /**
+   * The EventProcessor was shutdown.
+   */
+  Shutdown = "Shutdown"
+}
 
 export interface PartitionProcessor {
   /**
@@ -18,7 +36,7 @@ export interface PartitionProcessor {
    * This may occur when control of the partition switches to another EPH or when user stops EPH
    * TODO: update string -> CloseReason
    */
-  close?(reason: string): Promise<void>;
+  close?(reason: CloseReason): Promise<void>;
   /**
    * Called when a batch of events have been received.
    */
@@ -79,7 +97,11 @@ export class EventProcessor {
   private _eventHubClient: EventHubClient;
   private _partitionProcessorFactory: PartitionProcessorFactory;
   private _processorOptions: EventProcessorOptions;
-  private _partitionPump?: PartitionPump;
+  private _pumpManager: PumpManager;
+  private _id: string = uuid();
+  private _isRunning: boolean = false;
+  private _loopTask?: PromiseLike<void>;
+  private _abortController?: AbortController;
 
   constructor(
     consumerGroupName: string,
@@ -94,6 +116,93 @@ export class EventProcessor {
     this._eventHubClient = eventHubClient;
     this._partitionProcessorFactory = partitionProcessorFactory;
     this._processorOptions = options;
+    this._pumpManager = new PumpManager(this._id, options);
+  }
+
+  private async _getInactivePartitions(): Promise<string[]> {
+    try {
+      // get all partition ids on the event hub
+      const partitionIds = await this._eventHubClient.getPartitionIds();
+      // get partitions this EventProcessor is actively processing
+      const activePartitionIds = this._pumpManager.receivingFromPartitions();
+
+      // get a list of partition ids that are not being processed by this EventProcessor
+      const inactivePartitionIds: string[] = partitionIds.filter(
+        (id) => activePartitionIds.indexOf(id) === -1
+      );
+      return inactivePartitionIds;
+    } catch (err) {
+      log.error(`[${this._id}] An error occured when retrieving partition ids: ${err}`);
+      throw err;
+    }
+  }
+
+  /**
+   * Starts the EventProcessor loop.
+   * Load-balancing and partition ownership should be checked inside the loop.
+   * @ignore
+   */
+  private async _runLoop(abortSignal: AbortSignalLike): Promise<void> {
+    // periodically check if there is any partition not being processed and process it
+    const waitIntervalInMs = 30000;
+    while (!abortSignal.aborted) {
+      try {
+        // get a list of partition ids that are not being processed by this EventProcessor
+        const partitionsToAdd = await this._getInactivePartitions();
+        // check if the loop has been cancelled
+        if (abortSignal.aborted) {
+          return;
+        }
+
+        const tasks: PromiseLike<void>[] = [];
+        // create partition pumps to process any partitions we should be processing
+        for (const partitionId of partitionsToAdd) {
+          const partitionContext: PartitionContext = {
+            consumerGroupName: this._consumerGroupName,
+            eventHubName: this._eventHubClient.eventHubName,
+            partitionId: partitionId
+          };
+
+          const checkpointManager = new CheckpointManager();
+
+          log.eventProcessor(
+            `[${this._id}] [${partitionId}] Calling user-provided PartitionProcessorFactory.`
+          );
+          const partitionProcessor = this._partitionProcessorFactory(
+            partitionContext,
+            checkpointManager
+          );
+
+          // eventually this will 1st check if the existing PartitionOwnership has a position
+          const eventPosition =
+            this._processorOptions.initialEventPosition || EventPosition.earliest();
+
+          tasks.push(
+            this._pumpManager.createPump(
+              this._eventHubClient,
+              partitionContext,
+              eventPosition,
+              partitionProcessor
+            )
+          );
+        }
+
+        // wait for all the new pumps to be created
+        await Promise.all(tasks);
+        log.eventProcessor(`[${this._id}] PartitionPumps created within EventProcessor.`);
+
+        // sleep
+        log.eventProcessor(
+          `[${this._id}] Pausing the EventProcessor loop for ${waitIntervalInMs} ms.`
+        );
+        await cancellableDelay(waitIntervalInMs, abortSignal);
+      } catch (err) {
+        log.error(`[${this._id}] An error occured within the EventProcessor loop: ${err}`);
+      }
+    }
+
+    // loop has completed, remove all existing pumps
+    return this._pumpManager.removeAllPumps(CloseReason.Shutdown);
   }
 
   /**
@@ -101,39 +210,18 @@ export class EventProcessor {
    * For each successful lease, it will get the details from the blob and start a receiver at the
    * point where it left off previously.
    *
-   * @return {Promise<void>}
+   * @return {void}
    */
-  async start(): Promise<void> {
-    const partitionIds = await this._eventHubClient.getPartitionIds();
-    const partitionContext: PartitionContext = {
-      partitionId: partitionIds[0],
-      consumerGroupName: this._consumerGroupName,
-      eventHubName: this._eventHubClient.eventHubName
-    };
-    const partitionProcessor = this._partitionProcessorFactory(
-      partitionContext,
-      new CheckpointManager()
-    );
-    if (partitionProcessor.initialize && typeof partitionProcessor.initialize !== "function") {
-      throw new TypeError("'initialize' must be of type 'function'.");
-    }
-    if (typeof partitionProcessor.processEvents !== "function") {
-      throw new TypeError("'processEvents' is required and must be of type 'function'.");
-    }
-    if (typeof partitionProcessor.processError !== "function") {
-      throw new TypeError("'processError' is required and must be of type 'function'.");
-    }
-    if (partitionProcessor.close && typeof partitionProcessor.close !== "function") {
-      throw new TypeError("'close' must be of type 'function'.");
+  start(): void {
+    if (this._isRunning) {
+      log.eventProcessor(`[${this._id}] Attempted to start an already running EventProcessor.`);
+      return;
     }
 
-    this._partitionPump = new PartitionPump(
-      this._eventHubClient,
-      partitionContext,
-      partitionProcessor,
-      this._processorOptions
-    );
-    await this._partitionPump.start(partitionIds[0]);
+    this._isRunning = true;
+    this._abortController = new AbortController();
+    log.eventProcessor(`[${this._id}] Starting an EventProcessor.`);
+    this._loopTask = this._runLoop(this._abortController.signal);
   }
 
   /**
@@ -141,8 +229,21 @@ export class EventProcessor {
    * @return {Promise<void>}
    */
   async stop(): Promise<void> {
-    if (this._partitionPump) {
-      await this._partitionPump.stop("Stopped processing");
+    log.eventProcessor(`[${this._id}] Stopping an EventProcessor.`);
+    if (this._abortController) {
+      // cancel the event processor loop
+      this._abortController.abort();
+    }
+
+    this._isRunning = false;
+    try {
+      // waits for the event processor loop to complete
+      // will complete immediately if _loopTask is undefined
+      await this._loopTask;
+    } catch (err) {
+      log.error(`[${this._id}] An error occured while stopping the EventProcessor: ${err}`);
+    } finally {
+      log.eventProcessor(`[${this._id}] EventProcessor stopped.`);
     }
   }
 }

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -21,7 +21,16 @@ export { PartitionProperties, EventHubProperties } from "./managementClient";
 export { EventHubProducer } from "./sender";
 export { EventHubConsumer, EventIteratorOptions } from "./receiver";
 export { EventDataBatch } from "./eventDataBatch";
-export { EventProcessor } from "./eventProcessor";
+export { CheckpointManager } from "./checkpointManager";
+export {
+  EventProcessor,
+  CloseReason,
+  EventProcessorOptions,
+  PartitionProcessor,
+  PartitionManager,
+  PartitionProcessorFactory,
+  PartitionOwnership
+} from "./eventProcessor";
 export { PartitionContext } from "./partitionContext";
 export {
   MessagingError,

--- a/sdk/eventhub/event-hubs/src/log.ts
+++ b/sdk/eventhub/event-hubs/src/log.ts
@@ -58,3 +58,13 @@ export const iotClient = debugModule("azure:event-hubs:iothubClient");
  * log statements for partitionManager
  */
 export const partitionPump = debugModule("azure:event-hubs:partitionPump");
+/**
+ * @ignore
+ * log statements for pumpManager
+ */
+export const pumpManager = debugModule("azure:event-hubs:pumpManager");
+/**
+ * @ignore
+ * log statements for eventProcessor
+ */
+export const eventProcessor = debugModule("azure:event-hubs:eventProcessor");

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -38,7 +38,7 @@ export class PartitionPump {
 
   async start(): Promise<void> {
     this._isReceiving = true;
-    if (this._partitionProcessor.initialize) {
+    if (typeof this._partitionProcessor.initialize === "function") {
       try {
         await this._partitionProcessor.initialize();
       } catch {
@@ -89,7 +89,7 @@ export class PartitionPump {
         await this._receiver.close();
       }
       this._abortController.abort();
-      if (this._partitionProcessor.close) {
+      if (typeof this._partitionProcessor.close === "function") {
         await this._partitionProcessor.close(reason);
       }
     } catch (err) {

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as log from "./log";
-import { EventProcessorOptions, PartitionProcessor } from "./eventProcessor";
+import { EventProcessorOptions, PartitionProcessor, CloseReason } from "./eventProcessor";
 import { PartitionContext } from "./partitionContext";
 import { EventHubClient } from "./eventHubClient";
 import { EventPosition } from "./eventPosition";
@@ -32,16 +32,24 @@ export class PartitionPump {
     this._abortController = new AbortController();
   }
 
-  async start(partitionId: string): Promise<void> {
+  public get isReceiving(): boolean {
+    return this._isReceiving;
+  }
+
+  async start(): Promise<void> {
+    this._isReceiving = true;
     if (this._partitionProcessor.initialize) {
-      await this._partitionProcessor.initialize();
+      try {
+        await this._partitionProcessor.initialize();
+      } catch {
+        this._isReceiving = false;
+      }
     }
-    this._receiveEvents(partitionId);
+    this._receiveEvents(this._partitionContext.partitionId);
     log.partitionPump("Successfully started the receiver.");
   }
 
   private async _receiveEvents(partitionId: string): Promise<void> {
-    this._isReceiving = true;
     try {
       this._receiver = await this._eventHubClient.createConsumer(
         this._partitionContext.consumerGroupName,
@@ -55,6 +63,9 @@ export class PartitionPump {
           this._processorOptions.maxWaitTimeInSeconds,
           this._abortController.signal
         );
+        if (!this._isReceiving) {
+          return;
+        }
         await this._partitionProcessor.processEvents(receivedEvents);
       }
     } catch (err) {
@@ -71,7 +82,7 @@ export class PartitionPump {
     }
   }
 
-  async stop(reason: string): Promise<void> {
+  async stop(reason: CloseReason): Promise<void> {
     this._isReceiving = false;
     try {
       if (this._receiver) {

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -42,7 +42,7 @@ export class PartitionPump {
       try {
         await this._partitionProcessor.initialize();
       } catch {
-        this._isReceiving = false;
+        // swallow the error from the user-defined code
       }
     }
     this._receiveEvents(this._partitionContext.partitionId);

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -68,7 +68,7 @@ export class PumpManager {
       log.pumpManager(
         `[${this._eventProcessorName}] [${partitionId}] The existing pump is not running.`
       );
-      await this.removePump(partitionId, CloseReason.OwnershipLost);
+      await this.removePump(partitionId, CloseReason.Unknown);
     }
 
     log.pumpManager(`[${this._eventProcessorName}] [${partitionId}] Creating a new pump.`);

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { EventHubClient } from "./eventHubClient";
+import { PartitionContext } from "./partitionContext";
+import { EventPosition } from "./eventPosition";
+import { PartitionProcessor, EventProcessorOptions, CloseReason } from "./eventProcessor";
+import { PartitionPump } from "./partitionPump";
+import * as log from "./log";
+
+/**
+ * The PumpManager handles the creation and removal of PartitionPumps.
+ * It also starts a PartitionPump when it is created, and stops a
+ * PartitionPump when it is removed.
+ * @ignore
+ */
+export class PumpManager {
+  private readonly _eventProcessorName: string;
+  private readonly _options: EventProcessorOptions;
+  private _partitionIdToPumps: {
+    [partitionId: string]: PartitionPump | undefined;
+  } = {};
+
+  /**
+   * @ignore
+   */
+  constructor(eventProcessorName: string, eventProcessorOptions: EventProcessorOptions = {}) {
+    this._eventProcessorName = eventProcessorName;
+    this._options = eventProcessorOptions;
+  }
+
+  /**
+   * Returns a list of partitionIds that are actively receiving messages.
+   * @ignore
+   */
+  public receivingFromPartitions(): string[] {
+    return Object.keys(this._partitionIdToPumps).filter((id) => {
+      const pump = this._partitionIdToPumps[id];
+      return Boolean(pump && pump.isReceiving);
+    });
+  }
+
+  /**
+   * Creates and starts a PartitionPump.
+   * @param eventHubClient The EventHubClient to forward to the PartitionPump.
+   * @param partitionContext The PartitionContext to forward to the PartitionPump.
+   * @param initialEventPosition The EventPosition to forward to the PartitionPump.
+   * @param partitionProcessor The PartitionProcessor to forward to the PartitionPump.
+   * @param abortSignal Used to cancel pump creation.
+   * @ignore
+   */
+  public async createPump(
+    eventHubClient: EventHubClient,
+    partitionContext: PartitionContext,
+    initialEventPosition: EventPosition,
+    partitionProcessor: PartitionProcessor
+  ): Promise<void> {
+    const partitionId = partitionContext.partitionId;
+    // attempt to get an existing pump
+    const existingPump = this._partitionIdToPumps[partitionId];
+    if (existingPump) {
+      if (existingPump.isReceiving) {
+        log.pumpManager(
+          `[${this._eventProcessorName}] [${partitionId}] The existing pump is running.`
+        );
+        return;
+      }
+      log.pumpManager(
+        `[${this._eventProcessorName}] [${partitionId}] The existing pump is not running.`
+      );
+      await this.removePump(partitionId, CloseReason.OwnershipLost);
+    }
+
+    log.pumpManager(`[${this._eventProcessorName}] [${partitionId}] Creating a new pump.`);
+
+    const pump = new PartitionPump(eventHubClient, partitionContext, partitionProcessor, {
+      ...this._options,
+      initialEventPosition
+    });
+
+    try {
+      await pump.start();
+      this._partitionIdToPumps[partitionId] = pump;
+    } catch (err) {
+      log.error(
+        `[${this._eventProcessorName}] [${partitionId}] An error occured while adding/updating a pump: ${err}`
+      );
+    }
+  }
+
+  /**
+   * Stop a PartitionPump and removes it from the internal map.
+   * @param partitionId The partitionId to remove the associated PartitionPump from.
+   * @param reason The reason for removing the pump.
+   * @ignore
+   */
+  public async removePump(partitionId: string, reason: CloseReason): Promise<void> {
+    try {
+      const pump = this._partitionIdToPumps[partitionId];
+      if (pump) {
+        delete this._partitionIdToPumps[partitionId];
+        log.pumpManager(`[${this._eventProcessorName}] [${partitionId}] Stopping the pump.`);
+        await pump.stop(reason);
+      } else {
+        log.pumpManager(
+          `[${this._eventProcessorName}] [${partitionId}] No pump was found to remove.`
+        );
+      }
+    } catch (err) {
+      log.error(
+        `[${this._eventProcessorName}] [${partitionId}] An error occured while removing a pump: ${err}`
+      );
+    }
+  }
+
+  /**
+   * Stops all PartitionPumps and removes them from the internal map.
+   * @param reason The reason for removing the pump.
+   * @ignore
+   */
+  public async removeAllPumps(reason: CloseReason): Promise<void> {
+    const partitionIds = Object.keys(this._partitionIdToPumps);
+
+    log.pumpManager(`[${this._eventProcessorName}] Removing all pumps due to reason ${reason}.`);
+
+    const tasks: PromiseLike<void>[] = [];
+    for (const partitionId of partitionIds) {
+      const pump = this._partitionIdToPumps[partitionId];
+      if (pump) {
+        tasks.push(pump.stop(reason));
+      }
+    }
+
+    try {
+      await Promise.all(tasks);
+    } catch (err) {
+      log.error(`[${this._eventProcessorName}] An error occured while removing all pumps: ${err}`);
+    } finally {
+      this._partitionIdToPumps = {};
+    }
+  }
+}

--- a/sdk/eventhub/event-hubs/src/util/cancellableDelay.ts
+++ b/sdk/eventhub/event-hubs/src/util/cancellableDelay.ts
@@ -1,0 +1,17 @@
+import { AbortSignalLike, AbortError } from "@azure/abort-controller";
+
+export function cancellableDelay(delayInMs: number, abortSignal?: AbortSignalLike): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (abortSignal && abortSignal.aborted) {
+      return reject(new AbortError(`The delay was cancelled by the user.`));
+    }
+
+    const timer = setTimeout(resolve, delayInMs);
+    if (abortSignal) {
+      abortSignal.addEventListener("abort", () => {
+        clearTimeout(timer);
+        reject(new AbortError(`The delay was cancelled by the user.`));
+      });
+    }
+  });
+}


### PR DESCRIPTION
Fixes #4464 

This change does a couple things:
1. Adds a `PumpManager` class that can create and remove `PartitionPumps`.
2. Updates the `EventProcessor` to have a loop. The loop is started when calling `eventProcessor.start()`.
Within the loop, the EventProcessor checks which partitions it is processing and starts processing any partitions it isn't already. Right now it does this check every 30 seconds but this could be configurable/based on some partition ownership rule in the future.

3. Updates `start` to no longer return a promise, since it just kicks off the loop.

I also temporarily removed the type validation that was being done on the PartitionProcessor because there isn't a way for the user to catch the error today. #4534 will address this.