### PR TITLE
[core-auth] Change @azure/abort-controller to non-dev dependency in core-auth

### DIFF
--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -57,10 +57,10 @@
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/core/core-auth",
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^1.9.3"
+    "tslib": "^1.9.3",
+    "@azure/abort-controller": "1.0.0-preview.1"
   },
   "devDependencies": {
-    "@azure/abort-controller": "1.0.0-preview.1",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",


### PR DESCRIPTION
This change switches `@azure/abort-controller` from being a `devDependency` to a full `dependency` in `@azure/core-auth` so that the re-exported `AbortSignalLike` can be resolved by developers who use `@azure/core-auth` as a dependency in their own code.  Having this dependency set as a `devDependency` in `core-auth` causes compile-time issues due to the `AbortSignalLike` type not being resolvable by the TypeScript compiler.