### PR TITLE
[core-auth] Bump @azure/core-auth version and sort dependencies

### DIFF
--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-auth",
-  "version": "1.0.0-preview.2",
+  "version": "1.0.0-preview.3",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -57,8 +57,8 @@
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/core/core-auth",
   "sideEffects": false,
   "dependencies": {
-    "tslib": "^1.9.3",
-    "@azure/abort-controller": "1.0.0-preview.1"
+    "@azure/abort-controller": "1.0.0-preview.1",
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.1.5",


### PR DESCRIPTION
This change updates `@azure/core-auth` to `1.0.0-preview.3` following the release of `1.0.0-preview.2` and also sorts the `dependencies` list to be alphabetical.