### PR TITLE
Remove trailing slash from namedExports

### DIFF
--- a/sdk/core/abort-controller/rollup.base.config.js
+++ b/sdk/core/abort-controller/rollup.base.config.js
@@ -94,12 +94,9 @@ export function browserConfig(test = false) {
         preferBuiltins: false
       }),
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
-          "events/": ["EventEmitter"],
-          "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
+          events: ["EventEmitter"],
+          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
         }
       })
     ]

--- a/sdk/core/core-amqp/rollup.base.config.js
+++ b/sdk/core/core-amqp/rollup.base.config.js
@@ -130,12 +130,9 @@ export function browserConfig(test = false) {
       }),
 
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
           chai: ["should"],
-          "assert/": ["equal", "deepEqual", "notEqual"]
+          assert: ["equal", "deepEqual", "notEqual"]
         }
       }),
 

--- a/sdk/eventhub/event-hubs/rollup.base.config.js
+++ b/sdk/eventhub/event-hubs/rollup.base.config.js
@@ -138,11 +138,8 @@ export function browserConfig(test = false) {
       }),
 
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
-          "events/": ["EventEmitter"]
+          events: ["EventEmitter"]
         }
       }),
 

--- a/sdk/eventhub/event-processor-host/rollup.base.config.js
+++ b/sdk/eventhub/event-processor-host/rollup.base.config.js
@@ -106,10 +106,7 @@ export function browserConfig(test = false) {
         preferBuiltins: false
       }),
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
-        namedExports: { "events/": ["EventEmitter"] }
+        namedExports: { events: ["EventEmitter"] }
       }),
       json()
     ]

--- a/sdk/identity/identity/rollup.base.config.js
+++ b/sdk/identity/identity/rollup.base.config.js
@@ -82,10 +82,7 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
-        namedExports: { "events/": ["EventEmitter"] }
+        namedExports: { events: ["EventEmitter"] }
       }),
       viz({ filename: "browser/browser-stats.html", sourcemap: false })
     ]

--- a/sdk/keyvault/keyvault-keys/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-keys/rollup.base.config.js
@@ -118,10 +118,7 @@ export function browserConfig(test = false) {
       }),
       cjs({
         namedExports: {
-          // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-          // modules with built-in names must have a trailing slash.
-          // https://github.com/rollup/rollup-plugin-commonjs/issues/394
-          "assert/": ["ok", "equal", "strictEqual"]
+          assert: ["ok", "equal", "strictEqual"]
         }
       })
     ]

--- a/sdk/keyvault/keyvault-secrets/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-secrets/rollup.base.config.js
@@ -118,10 +118,7 @@ export function browserConfig(test = false) {
       }),
       cjs({
         namedExports: {
-          // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-          // modules with built-in names must have a trailing slash.
-          // https://github.com/rollup/rollup-plugin-commonjs/issues/394
-          "assert/": ["ok", "equal", "strictEqual"]
+          assert: ["ok", "equal", "strictEqual"]
         }
       })
     ]

--- a/sdk/servicebus/service-bus/rollup.base.config.js
+++ b/sdk/servicebus/service-bus/rollup.base.config.js
@@ -143,10 +143,7 @@ export function browserConfig({ test = false, production = false } = {}) {
         dedupe: ["buffer"]
       }),
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
-        namedExports: { "events/": ["EventEmitter"], long: ["ZERO"] }
+        namedExports: { events: ["EventEmitter"], long: ["ZERO"] }
       }),
 
       // rhea and rhea-promise use the Buffer global which requires

--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -108,12 +108,9 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
-          "events/": ["EventEmitter"],
-          "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
+          events: ["EventEmitter"],
+          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "notDeepEqual"]
         }
       })
     ]

--- a/sdk/storage/storage-file/rollup.base.config.js
+++ b/sdk/storage/storage-file/rollup.base.config.js
@@ -108,12 +108,9 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
         namedExports: {
-          "events/": ["EventEmitter"],
-          "assert/": [
+          events: ["EventEmitter"],
+          assert: [
             "ok",
             "deepEqual",
             "equal",

--- a/sdk/storage/storage-queue/rollup.base.config.js
+++ b/sdk/storage/storage-queue/rollup.base.config.js
@@ -108,10 +108,7 @@ export function browserConfig(test = false, production = false) {
       }),
       cjs({
         namedExports: {
-          // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-          // modules with built-in names must have a trailing slash.
-          // https://github.com/rollup/rollup-plugin-commonjs/issues/394
-          "assert/": ["ok", "deepEqual", "equal", "fail", "deepStrictEqual"]
+          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual"]
         }
       })
     ]

--- a/sdk/template/template/rollup.base.config.js
+++ b/sdk/template/template/rollup.base.config.js
@@ -82,10 +82,7 @@ export function browserConfig(test = false, production = false) {
         preferBuiltins: false
       }),
       cjs({
-        // When "rollup-plugin-commonjs@10.0.0" is used with "resolve@1.11.1", named exports of
-        // modules with built-in names must have a trailing slash.
-        // https://github.com/rollup/rollup-plugin-commonjs/issues/394
-        namedExports: { "events/": ["EventEmitter"] }
+        namedExports: { events: ["EventEmitter"] }
       }),
       viz({ filename: "browser/browser-stats.html", sourcemap: false })
     ]


### PR DESCRIPTION
- Was required due to rollup/rollup-plugin-commonjs#394
- Fixed in rollup-plugin-commonjs@1.10.1