### PR TITLE
adding to and from parameters according to the action

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -23,10 +23,11 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
         displayName: "Build libraries"
+
       - script: |
-          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
         displayName: "Pack libraries"
 
       - task: CopyFiles@2
@@ -71,7 +72,7 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargetsFrom)
         displayName: "Lint libraries"
 
       - task: CopyFiles@2
@@ -89,7 +90,7 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)
 
       - script: |
-          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
         condition: and(succeeded(), eq(variables['RunNpmAudit'], 'true'))
         displayName: "Audit libraries"
 
@@ -149,13 +150,13 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
         displayName: "Build libraries"
       - script: |
-          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
         displayName: "Build test assets"
       - script: |
-          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargetsFrom)
         displayName: "Test libraries"
 
       - task: PublishTestResults@2

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -153,7 +153,7 @@ jobs:
           node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
         displayName: "Build libraries"
       - script: |
-          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargetsFrom)
         displayName: "Build test assets"
       - script: |
           node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargetsFrom)

--- a/eng/tools/select-packages/index.js
+++ b/eng/tools/select-packages/index.js
@@ -28,7 +28,8 @@ glob(filter, (err, files) => {
     process.exit(1);
   }
 
-  let packageTargets = "";
+  let packageTargetsTo = "";
+  let packageTargetsFrom = "";
 
   if (files) {
     log(`Found ${files.length} packages under service directory.`);

--- a/eng/tools/select-packages/index.js
+++ b/eng/tools/select-packages/index.js
@@ -47,7 +47,8 @@ glob(filter, (err, files) => {
             packageContents["sdk-type"]
           }".`
         );
-        packageTargets += `--to "${packageContents.name}" `;
+        packageTargetsTo += `--to "${packageContents.name}" `;
+        packageTargetsFrom += `--from "${packageContents.name}" `;
       } else {
         log(
           `Package "${
@@ -58,17 +59,26 @@ glob(filter, (err, files) => {
     }
 
     log(
-      `Finished processing packages. Emitting variable using: ${packageTargets}`
+      `Finished processing packages. Emitting variable using: ${packageTargetsTo} and ${packageTargetsFrom}`
     );
 
     // Can't use regular logging here because the pattern for Azure Pipelines requires ##vso to be the first chars.
     console.log(
-      `##vso[task.setvariable variable=GeneratedPackageTargets]${packageTargets}`
+      `##vso[task.setvariable variable=GeneratedPackageTargetsTo]${packageTargetsTo}`
     );
 
     log(
-      `Emitted variable "GeneratedPackageTargets" with content: ${packageTargets}`
+      `Emitted variable "GeneratedPackageTargetsTo" with content: ${packageTargetsTo}`
     );
+
+    console.log(
+      `##vso[task.setvariable variable=GeneratedPackageTargetsFrom]${packageTargetsFrom}`
+    );
+
+    log(
+      `Emitted variable "GeneratedPackageTargetsFrom" with content: ${packageTargetsFrom}`
+    );
+
   } else {
     log("Did not find any packages under service directory.");
     process.exit(2);


### PR DESCRIPTION
- updating existing script for the to and from action for different rush tasks

For ex we want to run in our pipelines:
1. `rush build --to <package> --from <package>`
2. `rush test --from <package>`
3. `rush lint --from <package>`
@Azure/azure-sdk-eng 