### PR TITLE
globFilter variable added

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -32,8 +32,8 @@ jobs:
       - task: CopyFiles@2
         inputs:
           contents: |
-            sdk/**/**/*.tgz
-            sdk/**/**/browser/*.zip
+            sdk/**/$(packageGlobFilter)/*.tgz
+            sdk/**/$(packageGlobFilter)/browser/*.zip
           targetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
         displayName: "Copy packages"


### PR DESCRIPTION
- rushFlags variable in our js-client pipeline actually is not being used currently
- added a glob filter variable which will filter the .tgz artifacts that we will actually want to publish
- we won't remove the filter variable in the release pipeline that we currently have, we'll let that be in

cc: @Azure/azure-sdk-eng 