### PR TITLE
Update dev dependency assert

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -67,7 +67,7 @@ dependencies:
   '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
   '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
   abortcontroller-polyfill: 1.3.0
-  assert: 1.5.0
+  assert: 2.0.0
   async-lock: 1.2.2
   axios: 0.19.0
   axios-mock-adapter: 1.17.0_axios@0.19.0
@@ -1393,6 +1393,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==
+  /assert/2.0.0:
+    dependencies:
+      es6-object-assign: 1.1.0
+      is-nan: 1.2.1
+      object-is: 1.0.1
+      util: 0.12.1
+    dev: false
+    resolution:
+      integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==
   /assertion-error/1.1.0:
     dev: false
     resolution:
@@ -4964,6 +4973,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+  /is-nan/1.2.1:
+    dependencies:
+      define-properties: 1.1.3
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha1-n69ltvttskt/XAYoR16nH5iEAeI=
   /is-negated-glob/1.0.0:
     dev: false
     engines:
@@ -6544,6 +6561,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+  /object-is/1.0.1:
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=
   /object-keys/1.1.1:
     dev: false
     engines:
@@ -9632,7 +9655,7 @@ packages:
       '@types/node': 8.10.51
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 5.2.0
       delay: 4.3.0
       eslint: 5.16.0
@@ -9671,7 +9694,7 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-YZB6V1xg82Kr6pXb7ROrUOn04B0z+uMjGfx3h01o1YlNs0nK1PWjUGxbv7S2W3jVqdtrigRrUCb0N7ssWt/qmg==
+      integrity: sha512-63oNJj7yhgu6fvJjHanCW6qjkfcyrFwSpiDN1HwtDchCr/mGxuJR8Z4GERupYwdt0GYmexkLTLZ2/9p/9lqeFg==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
@@ -9690,7 +9713,7 @@ packages:
       '@types/sinon': 7.0.13
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       async-lock: 1.2.2
       buffer: 5.2.1
       chai: 4.2.0
@@ -9742,7 +9765,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-P8CiVrSH6xDLznsrnE5Ml2Udf2c1kVSESkHPxfHgKkj3qo1w5CYK7WE6wtkLIkD31kPyFoHWsHBC5XyVs3GJLA==
+      integrity: sha512-621AKJ6qesyTh3X/S+LkaFiWqxsirBUZ+jFOEyqug8wdPtYp/VPRkyj1hgK+NKSyFhpUOH1N3nBdc25jQrDqZQ==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-arm.tgz':
@@ -9808,7 +9831,7 @@ packages:
       '@types/node': 8.10.51
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 5.2.0
       eslint: 5.16.0
       eslint-config-prettier: 4.3.0_eslint@5.16.0
@@ -9837,7 +9860,7 @@ packages:
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-3A4yvJDci4zsEaNhc5KDCr0gAwjKpH9EWw+pU1s6orOqh4RcEpssVPmUFoNKPk7+qDMRqS/IhAvWAjIgiI+Dag==
+      integrity: sha512-rMeAwcxEQBB3ykP9echK1mVTI7bgXBURDxivrLudT1gfDeLxNhFbgfjZbLcDZaqozSTRLOWHdPwn1Ypi+V3AWQ==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -10002,7 +10025,7 @@ packages:
       '@types/ws': 6.0.1
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       async-lock: 1.2.2
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
@@ -10057,7 +10080,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-oyo9iC0F31bWD+/p5AtfkUcnFIovsqgZUq/VAdsRDjPoRHmAU7g5V6hGy5XYHnjKSRbFMGjYN+Wz1e/mT1TxqQ==
+      integrity: sha512-pUamog+EYOXGm3eGQnyLfkd7BHUG7oC9chGJXoonDICTZhxIYTd2ucK6QNcdsFZ4R9O9GoMWUEpx3vuIObYJUg==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -10128,7 +10151,7 @@ packages:
       '@types/uuid': 3.4.5
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 5.2.0
       eslint: 5.16.0
       events: 3.0.0
@@ -10167,7 +10190,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-Ubsv7XiS4y1uj1PpXBvnOvQTJZW/UPdwEqGfQIWyKz7z0msyM/qrsTPe9qxVj4rDtbP33tCx9SOmqXH5qOWnTg==
+      integrity: sha512-vmlfxG96GYjjHIp3CK/73Bygntvxr+boyRLa/u1CJ8PUe2jw2lnAaz3TnU9oTN8I871OEpHw/9NW7GH/IQCMuw==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -10215,7 +10238,7 @@ packages:
       '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.2.0
       cross-env: 5.2.0
       dotenv: 8.0.0
@@ -10266,7 +10289,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-MyqA/8uu5hwV/QAJYyS0dKOpixsYXhqanHEaqgUr5MK3y+CfNKX1/PA5u7TqujiROxXgjeXoGiIPcRmblFOOxg==
+      integrity: sha512-qx9gUGcNPZTya95pmtN0U0g072jV0i7eBzL6KbiiqA9hvICbCWjTCxwut43t9aKYpv0kBwJ1ymfmqoZ8buJR/Q==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10284,7 +10307,7 @@ packages:
       '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       chai: 4.2.0
       cross-env: 5.2.0
       dotenv: 8.0.0
@@ -10335,7 +10358,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-Kflt5b838Qhaj+aJi0E24WrQX1LsBsvjhcCxP1cLaSB4kwwCyjWLzHithaomyK3DLY7G029+VtWojYYVlDjt1g==
+      integrity: sha512-+R89dtmWPw/oVZAgMHpjBfrM6MC5lxH+DIRWt7ddgkdMhxyxL3+VHM1xZgIT72w2KrsD7tvP+ci+HmzSHOHh/w==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -10356,7 +10379,7 @@ packages:
       '@types/ws': 6.0.1
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       buffer: 5.2.1
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
@@ -10413,7 +10436,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-pGmuhpiqNLjt0lRX/4q7hUdnFKpcT3OaYmGsq3I9sPEEYS6zn+Rr8kAX291NNHdEPBh6nyUUqftpalELJSq3Yg==
+      integrity: sha512-aYFEmqzI8smlgWHovtIWda9NkVcKVHE087NNksXSu7/sMH386ja7pO8Bj6GEiN0o9dCHFkSmdbFhQn3rmSyuBw==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
@@ -10429,7 +10452,7 @@ packages:
       '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 5.2.0
       dotenv: 8.0.0
       es6-promise: 4.2.8
@@ -10484,7 +10507,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-T4hbFg8h5S7RcyLHXW7HUXAQmpQ4IR3fyS43dlanQsxODisWkgkgEE/NpkLW6v4XG4nZLmUBJC3Rziz/vVqcjw==
+      integrity: sha512-ptqUNjly+WgbpgQul/XOu4p8E6VQypOOGJ8S3iU3qsg2Df/mJnz2mQt2aJOtu3pTe0VQKAYwlpfGs1Idj9u1vA==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file.tgz':
@@ -10500,7 +10523,7 @@ packages:
       '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 5.2.0
       dotenv: 8.0.0
       es6-promise: 4.2.8
@@ -10555,7 +10578,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file'
     resolution:
-      integrity: sha512-mddX2+fGdsOiO6MYnvgsXXY7iY5lkyqIJVn+UYpuJ0Hioxxaf16WBj/RtqTvV6+HHxBXKZ1Mgf+ERSyvJN3NBQ==
+      integrity: sha512-UoSEHs5ZKvy2OT4LMc4iGq24IL9ZTdvCbGPHW3JB5WKR5uMWpg5b0KYUV8b6ilgAKWHCCVr9IzbaWTnJN/TSlQ==
       tarball: 'file:projects/storage-file.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -10571,7 +10594,7 @@ packages:
       '@types/query-string': 6.2.0
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 5.2.0
       dotenv: 8.0.0
       es6-promise: 4.2.8
@@ -10625,7 +10648,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-vzHosalOlYTuZXeMq203NI3hVVkPV/Rj8pMvciVP7V52/pSocKHx69rO/ifHvBWzwQwLcJtCoQhxAkEGw9rVQA==
+      integrity: sha512-Gh3q42QHMhDk9mzcPswB7zgHUBjZyEq5DIJQT2e3IiR5E2o7QRlTtQRmzy3hqCa4kHm2qrGeAutCic2l/Ptjww==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
@@ -10635,7 +10658,7 @@ packages:
       '@types/node': 8.10.51
       '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
-      assert: 1.5.0
+      assert: 2.0.0
       cross-env: 5.2.0
       eslint: 5.16.0
       eslint-config-prettier: 4.3.0_eslint@5.16.0
@@ -10676,7 +10699,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-uPHAfdfuRcAzIkfBXfMawiZC8rXarqHPLodrKMLJX31JLlLIzdHXhHES0+bVNn2Jtse0erx0gNzWu2eAXTWEQA==
+      integrity: sha512-9WdwX64GQoWOVWLT9upDHymEFp5+z3DhCXnt1rtM76XJBl1JWaEIVzWf8E9diycFf7Wve9JPnjYu3JmV0EF7dw==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/testhub.tgz':
@@ -10700,6 +10723,7 @@ packages:
       integrity: sha512-VxrbDXfuJ6Nz4rm0DHlJ+0sMk4RMKRflIyu7WxXLZGBpri9KLivFyNA0TWfZBifpdy3T1kVXyLOccskpzczDvA==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure/abort-controller': 1.0.0-preview.1
   '@azure/amqp-common': 1.0.0-preview.6
@@ -10769,7 +10793,7 @@ specifiers:
   '@typescript-eslint/eslint-plugin': ^1.11.0
   '@typescript-eslint/parser': ^1.11.0
   abortcontroller-polyfill: ^1.1.9
-  assert: ^1.4.1
+  assert: ^2.0.0
   async-lock: ^1.1.3
   axios: ^0.19.0
   axios-mock-adapter: ^1.16.0

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -75,7 +75,7 @@
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^5.2.0",
     "delay": "^4.2.0",
     "eslint": "^5.16.0",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -83,7 +83,7 @@
     "@types/sinon": "^7.0.13",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "cross-env": "^5.2.0",

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -66,7 +66,7 @@
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.2.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -89,7 +89,7 @@
     "@types/ws": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -85,7 +85,7 @@
     "@types/uuid": "^3.4.3",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "inherits": "^2.0.3",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -77,6 +77,7 @@
   "devDependencies": {
     "@azure/abort-controller": "1.0.0-preview.1",
     "@microsoft/api-extractor": "^7.1.5",
+    "@trust/keyto": "0.3.7",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "^8.0.0",
@@ -87,8 +88,7 @@
     "@types/query-string": "6.2.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "@trust/keyto": "0.3.7",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^5.2.0",
     "dotenv": "^8.0.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -87,7 +87,7 @@
     "@types/query-string": "6.2.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "chai": "^4.2.0",
     "cross-env": "^5.2.0",
     "dotenv": "^8.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -90,7 +90,7 @@
     "@types/ws": "^6.0.1",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "buffer": "^5.2.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -89,7 +89,7 @@
     "@types/query-string": "6.2.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^5.2.0",
     "dotenv": "^8.0.0",
     "es6-promise": "^4.2.5",

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -89,7 +89,7 @@
     "@types/query-string": "6.2.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^5.2.0",
     "dotenv": "^8.0.0",
     "es6-promise": "^4.2.5",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -87,7 +87,7 @@
     "@types/query-string": "6.2.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^5.2.0",
     "dotenv": "^8.0.0",
     "es6-promise": "^4.2.5",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -70,7 +70,7 @@
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
-    "assert": "^1.4.1",
+    "assert": "^2.0.0",
     "cross-env": "^5.2.0",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.2.0",


### PR DESCRIPTION
Only listed breaking change is dropping support for IE 9 and 10:

https://github.com/browserify/commonjs-assert/blob/master/CHANGELOG.md#200

However, `2.0.0` has a lot of code changes, so I won't be too surprised if something breaks.
