### PR TITLE
Update dev dependency mocha-chrome

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -123,7 +123,7 @@ dependencies:
   karma-webpack: 4.0.2_webpack@4.39.1
   long: 4.0.0
   mocha: 5.2.0
-  mocha-chrome: 1.1.0
+  mocha-chrome: 2.0.0
   mocha-junit-reporter: 1.23.1_mocha@5.2.0
   mocha-multi: 1.1.0_mocha@5.2.0
   mocha-multi-reporters: 1.1.7
@@ -1880,14 +1880,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
-  /babel-polyfill/6.26.0:
-    dependencies:
-      babel-runtime: 6.26.0
-      core-js: 2.6.9
-      regenerator-runtime: 0.10.5
-    dev: false
-    resolution:
-      integrity: sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=
   /babel-preset-env/1.7.0:
     dependencies:
       babel-plugin-check-es2015-constants: 6.22.0
@@ -2498,16 +2490,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==
-  /chrome-remote-interface/0.25.7:
+  /chrome-remote-interface/0.27.2:
     dependencies:
       commander: 2.11.0
-      ws: 3.3.3
+      ws: 6.2.1
     dev: false
-    engines:
-      node: '>=4'
     hasBin: true
     resolution:
-      integrity: sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==
+      integrity: sha512-pVLljQ29SAx8KIv5tSa9sIf8GrEsAZdPJoeWOmY3/nrIzFmE+EryNNHvDkddGod0cmAFTv+GmPG0uvzxi2NWsA==
   /chrome-trace-event/1.0.2:
     dependencies:
       tslib: 1.10.0
@@ -3013,14 +3003,15 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
-  /deep-assign/2.0.0:
+  /deep-assign/3.0.0:
     dependencies:
       is-obj: 1.0.1
+    deprecated: Check out `lodash.merge` or `merge-options` instead.
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha1-6+BrHwfwja5ZdiDj3RYi83GhxXI=
+      integrity: sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
   /deep-eql/3.0.1:
     dependencies:
       type-detect: 4.0.8
@@ -4660,16 +4651,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==
-  /import-local/1.0.0:
-    dependencies:
-      pkg-dir: 2.0.0
-      resolve-cwd: 2.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    hasBin: true
-    resolution:
-      integrity: sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==
   /import-local/2.0.0:
     dependencies:
       pkg-dir: 3.0.0
@@ -5981,22 +5962,22 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=
-  /meow/4.0.1:
+  /meow/5.0.0:
     dependencies:
       camelcase-keys: 4.2.0
       decamelize-keys: 1.1.0
       loud-rejection: 1.6.0
-      minimist: 1.2.0
       minimist-options: 3.0.2
       normalize-package-data: 2.5.0
       read-pkg-up: 3.0.0
       redent: 2.0.0
       trim-newlines: 2.0.0
+      yargs-parser: 10.1.0
     dev: false
     engines:
-      node: '>=4'
+      node: '>=6'
     resolution:
-      integrity: sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==
+      integrity: sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
   /merge-descriptors/1.0.1:
     dev: false
     resolution:
@@ -6170,29 +6151,24 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  /mocha-chrome/1.1.0:
+  /mocha-chrome/2.0.0:
     dependencies:
-      babel-plugin-transform-es2015-destructuring: 6.23.0
-      babel-plugin-transform-es2015-parameters: 6.24.1
-      babel-polyfill: 6.26.0
-      babel-preset-env: 1.7.0
-      babel-register: 6.26.0
       chalk: 2.4.2
       chrome-launcher: 0.10.7
-      chrome-remote-interface: 0.25.7
+      chrome-remote-interface: 0.27.2
       chrome-unmirror: 0.1.0
-      debug: 3.2.6
-      deep-assign: 2.0.0
-      import-local: 1.0.0
+      debug: 4.1.1
+      deep-assign: 3.0.0
+      import-local: 2.0.0
       loglevel: 1.6.3
-      meow: 4.0.1
+      meow: 5.0.0
       nanobus: 4.4.0
     dev: false
     engines:
-      node: '>= 7.6.0'
+      node: '>= 8.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-Zk1HvDF13TLOBH2sML+4T1o5Z3nwUYN9ah3gz4TUrnwx7Sdk0N+rq5n+uzw0/3BAQH9aejPCJILWoWi7HW0qyw==
+      integrity: sha512-Kq6W9jdXY3C2PhNHtSrk3GnDuoAKN+DbgJKCLfXtc5cql8oHB8+rUYlq9t1c8in6vQ6/X432E/U8h0pV5QlAug==
   /mocha-junit-reporter/1.23.1_mocha@5.2.0:
     dependencies:
       debug: 2.6.9
@@ -7031,14 +7007,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
-  /pkg-dir/2.0.0:
-    dependencies:
-      find-up: 2.1.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
   /pkg-dir/3.0.0:
     dependencies:
       find-up: 3.0.0
@@ -7445,10 +7413,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==
-  /regenerator-runtime/0.10.5:
-    dev: false
-    resolution:
-      integrity: sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
   /regenerator-runtime/0.11.1:
     dev: false
     resolution:
@@ -9517,6 +9481,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+  /yargs-parser/10.1.0:
+    dependencies:
+      camelcase: 4.1.0
+    dev: false
+    resolution:
+      integrity: sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
   /yargs-parser/13.1.1:
     dependencies:
       camelcase: 5.3.1
@@ -9882,7 +9852,7 @@ packages:
       karma-typescript-es6-transform: 4.1.1
       karma-webpack: 4.0.2_webpack@4.39.1
       mocha: 5.2.0
-      mocha-chrome: 1.1.0
+      mocha-chrome: 2.0.0
       mocha-junit-reporter: 1.23.1_mocha@5.2.0
       mocha-multi-reporters: 1.1.7
       npm-run-all: 4.1.5
@@ -9919,7 +9889,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-caXXYC9LfmiCewIDnlJUMxfxTDvkDUoVrySHWJ1He4/PGxDUGJAMnkazdFsXf4/rrF/tUtzYJ5WNokgZPYqLKw==
+      integrity: sha512-2x3r93OGjp7mx4hCbLEcXN1bTEWBXIc5d4DMbBNqwPF+sMzKRFsB6HAbuV1F+/+yvCo4djCzIZBoJEaAN5/rlA==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -10825,7 +10795,7 @@ specifiers:
   karma-webpack: ^4.0.0-rc.6
   long: ^4.0.0
   mocha: ^5.2.0
-  mocha-chrome: ^1.1.0
+  mocha-chrome: ^2.0.0
   mocha-junit-reporter: ^1.18.0
   mocha-multi: ^1.0.1
   mocha-multi-reporters: ^1.1.7

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -158,7 +158,7 @@
     "karma-typescript-es6-transform": "^4.0.0",
     "karma-webpack": "^4.0.0-rc.6",
     "mocha": "^5.2.0",
-    "mocha-chrome": "^1.1.0",
+    "mocha-chrome": "^2.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi-reporters": "^1.1.7",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Only breaking change I could see was dropping support for Node 6:

https://github.com/shellscape/mocha-chrome/compare/v1.1.0...v2.0.0