### PR TITLE
[Identity] Add InteractiveBrowserCredential for browser-based authentication

### DIFF
--- a/.docsettings.yml
+++ b/.docsettings.yml
@@ -4,6 +4,7 @@ omitted_paths:
   - eng/tools/select-packages/**
   - "sdk/*/arm-*"
   - "sdk/cognitiveservices/*"
+  - "sdk/identity/identity/test/manual/*"
 language: js
 root_check_enabled: True
 required_readme_sections:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -129,6 +129,7 @@ dependencies:
   mocha-multi: 1.1.0_mocha@5.2.0
   mocha-multi-reporters: 1.1.7
   moment: 2.24.0
+  msal: 1.0.2
   nise: 1.5.0
   nock: 10.0.6
   npm-run-all: 4.1.5
@@ -5224,6 +5225,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-o6vicYryQaKykE+EpiWXDzia4yo=
+  /js-base64/2.5.1:
+    dev: false
+    resolution:
+      integrity: sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
   /js-tokens/3.0.2:
     dev: false
     resolution:
@@ -6290,6 +6295,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+  /msal/1.0.2:
+    dependencies:
+      js-base64: 2.5.1
+      tslib: 1.10.0
+    dev: false
+    engines:
+      node: '>=0.8.0'
+    resolution:
+      integrity: sha512-jWbuqLg0jFWj/Wy9A9LbJahuDguQI1KI4y06HOG7OFKHWdXJ8DJCgbwlCSoq2nUM0cbGfhsYX6MRDxJ7R3ZrAg==
   /mute-stdout/1.0.1:
     dev: false
     engines:
@@ -10208,6 +10222,7 @@ packages:
       mocha: 5.2.0
       mocha-junit-reporter: 1.23.1_mocha@5.2.0
       mocha-multi: 1.1.0_mocha@5.2.0
+      msal: 1.0.2
       prettier: 1.18.2
       puppeteer: 1.19.0
       qs: 6.7.0
@@ -10228,7 +10243,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-G25flY7lWUBTWAEi0x7iwThTVeuRnSge58tKZQ9RYyrqARi5XxFXcmY5gCd8TpoOZT9snc0yE4huaTA7YDsvMA==
+      integrity: sha512-pnDGq1rSzKP0e0cpYJxX7QbSKZZMuIv0xkbuZPAIVrPJ2yOx4+/o4JPdoUmqnfvncEV7UTPxFPLgcoRnmhZeYw==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -10327,7 +10342,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-6KdME0JitnkaljwGxcLdk/uYv1+mndfahRShJhfjh4BIASk2az7u/lyrCr1k1pcdKRzHPuPFzKk7zEpY531pAg==
+      integrity: sha512-qtZvp4vZGbVq4gjrbN2fZTpAdf/zY6bs+jnHVIGg6jiRDKFKWxF0eIZp/zua51Ik7SBUrxzsr6+mCB1eWp5sCg==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10897,6 +10912,7 @@ specifiers:
   mocha-multi: ^1.0.1
   mocha-multi-reporters: ^1.1.7
   moment: ^2.24.0
+  msal: ~1.0.2
   nise: ^1.4.10
   nock: ^10.0.6
   npm-run-all: ^4.1.5

--- a/sdk/identity/identity/.eslintignore
+++ b/sdk/identity/identity/.eslintignore
@@ -1,0 +1,1 @@
+test/manual/

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -12,6 +12,7 @@
     "./dist-esm/src/credentials/managedIdentityCredential.js": "./dist-esm/src/credentials/managedIdentityCredential.browser.js",
     "./dist-esm/src/credentials/clientCertificateCredential.js": "./dist-esm/src/credentials/clientCertificateCredential.browser.js",
     "./dist-esm/src/credentials/deviceCodeCredential.js": "./dist-esm/src/credentials/deviceCodeCredential.browser.js",
+    "./dist-esm/src/credentials/interactiveBrowserCredential.js": "./dist-esm/src/credentials/interactiveBrowserCredential.browser.js",
     "./dist/index.js": "./browser/index.js"
   },
   "scripts": {
@@ -24,7 +25,7 @@
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
     "build": "tsc -p . && rollup -c 2>&1",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
-    "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log",
+    "clean": "rimraf dist dist-esm browser test-dist test-browser typings *.tgz *.log",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "echo skipped",
     "integration-test:node": "echo skipped",
@@ -72,6 +73,7 @@
     "@azure/core-http": "1.0.0-preview.2",
     "events": "^3.0.0",
     "jws": "~3.2.2",
+    "msal": "~1.0.2",
     "qs": "6.7.0",
     "tslib": "^1.9.3",
     "uuid": "^3.3.2"

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -37,7 +37,7 @@ export class IdentityClient extends ServiceClient {
     options = options || IdentityClient.getDefaultOptions();
     super(undefined, options);
 
-    this.baseUri = this.authorityHost = options.authorityHost;
+    this.baseUri = this.authorityHost = options.authorityHost || DefaultAuthorityHost;
 
     if (!this.baseUri.startsWith("https:")) {
       throw new Error("The authorityHost address must use the 'https' protocol.");
@@ -132,5 +132,5 @@ export class IdentityClient extends ServiceClient {
 }
 
 export interface IdentityClientOptions extends ServiceClientOptions {
-  authorityHost: string;
+  authorityHost?: string;
 }

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as msal from "msal";
+import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
+import { IdentityClient } from "../client/identityClient";
+import { BrowserLoginStyle, InteractiveBrowserCredentialOptions } from "./interactiveBrowserCredentialOptions";
+
+/**
+ * Enables authentication to Azure Active Directory inside of the web browser
+ * using the interactive login flow, either via browser redirects or a popup
+ * window.
+ */
+export class InteractiveBrowserCredential implements TokenCredential {
+  private loginStyle: BrowserLoginStyle;
+  private msalConfig: msal.Configuration;
+  private msalObject: msal.UserAgentApplication;
+
+  /**
+   * Creates an instance of the InteractiveBrowserCredential with the
+   * details needed to authenticate against Azure Active Directory with
+   * a user identity.
+   *
+   * @param tenantId The Azure Active Directory tenant (directory) ID.
+   * @param clientId The client (application) ID of an App Registration in the tenant.
+   * @param options Options for configuring the client which makes the authentication request.
+   */
+  constructor(
+    tenantId: string,
+    clientId: string,
+    options?: InteractiveBrowserCredentialOptions
+  ) {
+    options = { ...IdentityClient.getDefaultOptions(), ...options };
+
+    this.loginStyle = options.loginStyle || "popup";
+    if (["redirect", "popup"].indexOf(this.loginStyle) === -1) {
+        throw new Error(`Invalid loginStyle: ${options.loginStyle}`);
+    }
+
+    this.msalConfig = {
+      auth: {
+        clientId: clientId,
+        authority: `${options.authorityHost}/${tenantId}`,
+        ...options.redirectUri && { redirectUri: options.redirectUri},
+        ...options.postLogoutRedirectUri && { redirectUri: options.postLogoutRedirectUri }
+      },
+      cache: {
+        cacheLocation: "localStorage",
+        storeAuthStateInCookie: true
+      }
+    };
+
+    this.msalObject = new msal.UserAgentApplication(this.msalConfig);
+  }
+
+  private login(): Promise<msal.AuthResponse> {
+    switch (this.loginStyle) {
+      case "redirect":
+        let loginPromise: Promise<msal.AuthResponse> = new Promise((resolve, reject) => {
+          this.msalObject.handleRedirectCallback(resolve, reject);
+        });
+        this.msalObject.loginRedirect();
+        return loginPromise;
+      case "popup":
+        return this.msalObject.loginPopup();
+    }
+  }
+
+  private async acquireToken(authParams: msal.AuthenticationParameters): Promise<msal.AuthResponse | undefined> {
+    let authResponse: msal.AuthResponse | undefined;
+    try {
+      authResponse = await this.msalObject.acquireTokenSilent(authParams);
+    } catch (err) {
+      if (err instanceof msal.AuthError) {
+        switch (err.errorCode) {
+          case "consent_required":
+          case "interaction_required":
+          case "login_required":
+            break;
+          default:
+            throw err;
+        }
+      }
+    }
+
+    let authPromise: Promise<msal.AuthResponse> | undefined;
+    if (authResponse === undefined) {
+      switch (this.loginStyle) {
+        case "redirect":
+          authPromise = new Promise((resolve, reject) => {
+            this.msalObject.handleRedirectCallback(resolve, reject);
+          });
+          this.msalObject.acquireTokenRedirect(authParams);
+          break;
+        case "popup":
+          authPromise = this.msalObject.acquireTokenPopup(authParams);
+          break;
+      }
+
+      authResponse = authPromise && await authPromise;
+    }
+
+    return authResponse;
+  }
+
+  /**
+   *
+   * @param scopes The list of scopes for which the token will have access.
+   * @param options The options used to configure any requests this
+   *                TokenCredential implementation might make.
+   */
+  async getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<AccessToken | null> {
+    if (!this.msalObject.getAccount()) {
+      await this.login();
+    }
+
+    let authResponse = await this.acquireToken({
+      scopes: Array.isArray(scopes) ? scopes : scopes.split(',')
+    });
+
+    if (authResponse) {
+      return {
+        token: authResponse.accessToken,
+        expiresOnTimestamp: authResponse.expiresOn.getTime()
+      };
+    } else {
+      return null;
+    }
+  }
+}

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
@@ -55,12 +55,13 @@ export class InteractiveBrowserCredential implements TokenCredential {
 
   private login(): Promise<msal.AuthResponse> {
     switch (this.loginStyle) {
-      case "redirect":
-        let loginPromise: Promise<msal.AuthResponse> = new Promise((resolve, reject) => {
+      case "redirect": {
+        const loginPromise = new Promise<msal.AuthResponse>((resolve, reject) => {
           this.msalObject.handleRedirectCallback(resolve, reject);
         });
         this.msalObject.loginRedirect();
         return loginPromise;
+      }
       case "popup":
         return this.msalObject.loginPopup();
     }
@@ -117,7 +118,7 @@ export class InteractiveBrowserCredential implements TokenCredential {
       await this.login();
     }
 
-    let authResponse = await this.acquireToken({
+    const authResponse = await this.acquireToken({
       scopes: Array.isArray(scopes) ? scopes : scopes.split(',')
     });
 

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
+import { InteractiveBrowserCredentialOptions } from "./interactiveBrowserCredentialOptions";
+
+const BrowserNotSupportedError = new Error("InteractiveBrowserCredential is not supported in Node.js.");
+
+/**
+ * Enables authentication to Azure Active Directory inside of the web browser
+ * using the interactive login flow, either via browser redirects or a popup
+ * window.  This credential is not currently supported in Node.js.
+ */
+export class InteractiveBrowserCredential implements TokenCredential {
+  constructor(
+    tenantId: string,
+    clientId: string,
+    options?: InteractiveBrowserCredentialOptions
+  ) {
+    throw BrowserNotSupportedError;
+  }
+
+  public getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions
+  ): Promise<AccessToken | null> {
+    throw BrowserNotSupportedError;
+  }
+}

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredentialOptions.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredentialOptions.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IdentityClientOptions } from "../client/identityClient";
+
+export type BrowserLoginStyle = "redirect" | "popup";
+
+/**
+ * Defines options for the InteractiveBrowserCredential class.
+ */
+export interface InteractiveBrowserCredentialOptions extends IdentityClientOptions {
+  /**
+   * Specifies whether a redirect or a popup window should be used to
+   * initiate the user authentication flow. Possible values are "redirect"
+   * or "popup" (default).
+   */
+  loginStyle?: BrowserLoginStyle;
+
+  /**
+   * Gets the redirect URI of the application. This should be same as the value
+   * in the application registration portal.  Defaults to `window.location.href`.
+   */
+  redirectUri?: string | (() => string);
+
+  /**
+   * Gets the URI to which the user will be redirected when logging out.
+   * Defaults to `window.location.href`.
+   */
+  postLogoutRedirectUri?: string | (() => string);
+}

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -9,6 +9,8 @@ export { IdentityClientOptions } from "./client/identityClient";
 export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
+export { InteractiveBrowserCredential } from "./credentials/interactiveBrowserCredential";
+export { InteractiveBrowserCredentialOptions, BrowserLoginStyle } from "./credentials/interactiveBrowserCredentialOptions";
 export { ManagedIdentityCredential } from "./credentials/managedIdentityCredential";
 export { DeviceCodeCredential } from "./credentials/deviceCodeCredential";
 export { DefaultAzureCredential } from "./credentials/defaultAzureCredential";

--- a/sdk/identity/identity/test/manual/README.md
+++ b/sdk/identity/identity/test/manual/README.md
@@ -1,0 +1,36 @@
+# Identity Manual Browser Verification
+
+This package contains some simple manual verification for the use of Azure
+Identity with other Azure SDK libraries in the browser.  For now, it just tests
+that the `InteractiveBrowserCredential` works with the `@azure/keyvault-keys`
+library.
+
+## Usage
+
+Run the following commands:
+
+```
+npm install
+npm start
+```
+
+Webpack will compile the code and then host it in a local server at
+`http://localhost:8080`.  See the section below about CORS before attempting to
+navigate to this URL.
+
+You will need an AAD App Registration that has its redirect uri set to
+`http://localhost:8080`.  Its tenant ID and client (application) ID will need to
+be entered into the UI to initiate the authentication process.
+
+## Avoiding CORS errors
+
+Currently the Key Vault service does not provide a way to configure CORS origins
+so that requests against the service can be made from a browser (Storage and
+Cosmos DB services provide this capability).  To get around this issue, you can
+run Google Chrome with web security disabled:
+
+**NOTE:** Only do this for manual verification purposes!
+
+```
+google-chrome --disable-web-security
+```

--- a/sdk/identity/identity/test/manual/dist/index.html
+++ b/sdk/identity/identity/test/manual/dist/index.html
@@ -1,0 +1,6 @@
+<html>
+  <body>
+    <div id="app"></div>
+  </body>
+  <script type="text/javascript" src="index.js"></script>
+</html>

--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "identity-browser-manual-tests",
+  "version": "0.1.0",
+  "description": "Manual tests for Azure SDK browser use scenarios",
+  "main": "dist/bundle.js",
+  "scripts": {
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack-dev-server"
+  },
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "dependencies": {
+    "@azure/identity": "../..",
+    "@azure/keyvault-keys": "../../../../keyvault/keyvault-keys",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "tslib": "^1.9.3"
+  },
+  "devDependencies": {
+    "@types/express": "^4.16.0",
+    "@types/node": "^8.0.0",
+    "@types/react": "^16.8.24",
+    "@types/react-dom": "^16.8.5",
+    "@types/webpack": "^4.4.13",
+    "@types/webpack-dev-middleware": "^2.0.2",
+    "ts-loader": "^5.3.1",
+    "typescript": "^3.2.2",
+    "webpack": "^4.16.3",
+    "webpack-cli": "^3.2.3",
+    "webpack-dev-server": "^3.7.2"
+  }
+}

--- a/sdk/identity/identity/test/manual/src/index.tsx
+++ b/sdk/identity/identity/test/manual/src/index.tsx
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+
+import { InteractiveBrowserCredential, BrowserLoginStyle } from "@azure/identity";
+import { KeysClient, Key } from "@azure/keyvault-keys";
+
+interface ClientDetails {
+  tenantId: string,
+  clientId: string,
+  loginStyle: BrowserLoginStyle
+}
+
+interface ClientDetailsEditorProps {
+  clientDetails: ClientDetails,
+  onSetClientDetails: React.Dispatch<React.SetStateAction<ClientDetails>>
+}
+
+function storeClientDetails(clientDetails: ClientDetails) {
+  localStorage.setItem('clientDetails', JSON.stringify(clientDetails));
+}
+
+function readClientDetails(): ClientDetails {
+  const detailsJson = localStorage.getItem('clientDetails')
+  if (detailsJson) {
+    const details = JSON.parse(detailsJson)
+    details.credential = undefined;
+    return details;
+  }
+
+  return undefined;
+}
+
+function getCredential(clientDetails: ClientDetails): InteractiveBrowserCredential | undefined {
+  return clientDetails.tenantId.length > 0 && clientDetails.clientId.length > 0
+    ? new InteractiveBrowserCredential(clientDetails.tenantId, clientDetails.clientId, { loginStyle: clientDetails.loginStyle })
+    : undefined
+}
+
+function ClientDetailsEditor({ clientDetails , onSetClientDetails }: ClientDetailsEditorProps) {
+  const handleDetailsChange = (newDetails: ClientDetails) => {
+    storeClientDetails(newDetails)
+    onSetClientDetails(newDetails)
+  };
+
+  const setLoginStyle = (loginStyle: BrowserLoginStyle) => {
+    handleDetailsChange({
+      ...clientDetails,
+      loginStyle
+    });
+  }
+
+  return (
+    <div>
+      <h3>Enter the details of your Azure AD App Registration:</h3>
+      <form>
+        <label>
+          Tenant Id:
+          <input type="text" value={clientDetails.tenantId} onChange={({target}) => handleDetailsChange({ ...clientDetails, tenantId: target.value})} />
+        </label>
+        <br />
+        <label>
+          Client Id:
+          <input type="text" value={clientDetails.clientId} onChange={({target}) => handleDetailsChange({ ...clientDetails, clientId: target.value})} />
+        </label>
+        <h4>Login Flow Style</h4>
+        <div>
+          <label>
+            <input type="radio" value="popup" checked={clientDetails.loginStyle ==="popup" } onChange={({target}) => setLoginStyle(target.value as BrowserLoginStyle)} />
+            Popup
+          </label>
+        </div>
+        <div>
+          <label>
+            <input type="radio" value="redirect" checked={clientDetails.loginStyle === "redirect"} onChange={({target}) => setLoginStyle(target.value as BrowserLoginStyle)} />
+            Redirect
+          </label>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function useKeyVaultKeys(vaultName: string, clientDetails: ClientDetails) {
+  const [running, setRunning] = React.useState(false)
+  const [keys, setKeys] = React.useState<Key[]>(undefined)
+  const [error, setErrorInner] = React.useState(undefined);
+  const url = `https://${vaultName}.vault.azure.net`;
+
+  const setError = (err) => {
+    setRunning(false)
+    setErrorInner(err)
+  }
+
+  React.useEffect(() => {
+    const credential = getCredential(clientDetails);
+    if (vaultName.trim().length === 0) {
+      setError("You must enter a vault name to fetch keys.")
+    } else if (credential === undefined) {
+      setError("You must enter client details to fetch keys.")
+    } else if (running) {
+      // Kick off the request asynchronously.  The setKeys call will
+      // propagate the key list back to the UI state.
+      const keysClient = new KeysClient(url, credential);
+      (async () => {
+        const keyResult = [];
+        setKeys(keyResult);
+
+        for await (const keyAttributes of keysClient.listKeys()) {
+          keyResult.push(await keysClient.getKey(keyAttributes.name))
+        }
+
+        setKeys(keyResult);
+        setRunning(false)
+      })().catch(err => setError(err.toString()));
+    } else {
+      setError("")
+    }
+  }, [vaultName, clientDetails, running])
+
+  return { keys, fetchKeys: () => setRunning(true), error }
+}
+
+interface KeyVaultTestProps {
+  storedVaultName?: string,
+  clientDetails: ClientDetails
+}
+
+const KeyVaultTest = ({ storedVaultName, clientDetails }: KeyVaultTestProps) => {
+  const [vaultName, setVaultName] = React.useState(storedVaultName || "");
+  const { keys, fetchKeys, error } = useKeyVaultKeys(vaultName, clientDetails);
+
+  const handleVaultNameChange = (newVaultName) => {
+    localStorage.setItem('keyVaultName', newVaultName);
+    setVaultName(newVaultName);
+  };
+
+  return (
+    <div>
+      <h3>List Key Vault Keys</h3>
+      <form onSubmit={e => { fetchKeys(); e.preventDefault(); }}>
+        <label>
+          Vault Name:
+          <input type="text" value={vaultName} onChange={({target}) => handleVaultNameChange(target.value)} />
+        </label>
+        <input type="submit" value="Get Keys" />
+      </form>
+      {!error ? null : <h3 style={{color: "red"}}>{error}</h3> }
+      {!keys ? null :
+       (
+         <table>
+           <thead>
+             <tr>
+               <th>Key Name</th>
+               <th>Enabled</th>
+               <th>Expires</th>
+             </tr>
+           </thead>
+           <tbody>
+             {keys.map(key => <tr key={key.name}><td>{key.name}</td><td>{key.enabled.toString()}</td><td>{key.expires && key.expires.toDateString()}</td></tr>)}
+           </tbody>
+        </table>
+       )
+      }
+    </div>
+  );
+}
+
+function TestPage() {
+  const storedVaultName = localStorage.getItem('keyVaultName');
+  const [clientDetails, setClientDetails] = React.useState<ClientDetails>(readClientDetails() || { tenantId: "", clientId: "", loginStyle: "popup"})
+  return (
+    <div>
+      <h1>Azure SDK Browser Manual Tests</h1>
+      <hr />
+      <ClientDetailsEditor clientDetails={clientDetails} onSetClientDetails={setClientDetails} />
+      <KeyVaultTest storedVaultName={storedVaultName} clientDetails={clientDetails} />
+    </div>
+  );
+}
+
+ReactDOM.render(
+    <TestPage />,
+    document.getElementById("app")
+);

--- a/sdk/identity/identity/test/manual/tsconfig.json
+++ b/sdk/identity/identity/test/manual/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "sourceMap": true,
+    "module": "commonjs",
+    "target": "es6",
+    "jsx": "react",
+    "lib":[
+      "dom",
+      "es6",
+      "esnext.asynciterable"
+    ]
+  }
+}

--- a/sdk/identity/identity/test/manual/webpack.config.js
+++ b/sdk/identity/identity/test/manual/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  output: {
+    filename: 'index.js',
+    path: path.resolve(__dirname, 'dist')
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    extensions: [ '.tsx', '.ts', '.js' ],
+    aliasFields: ['browser']
+  },
+  mode: 'development',
+  devServer: {
+    contentBase: './dist',
+  },
+  optimization: {
+    usedExports: true
+  }
+};

--- a/sdk/identity/identity/tsconfig.json
+++ b/sdk/identity/identity/tsconfig.json
@@ -52,6 +52,10 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     "forceConsistentCasingInFileNames": true
   },
+  "include": [
+    "src/**/*",
+    "test/**/*",
+  ],
   "exclude": [
     "test/manual"
   ]

--- a/sdk/identity/identity/tsconfig.json
+++ b/sdk/identity/identity/tsconfig.json
@@ -51,5 +51,8 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
     "forceConsistentCasingInFileNames": true
-  }
+  },
+  "exclude": [
+    "test/manual"
+  ]
 }


### PR DESCRIPTION
This change adds a new `InteractiveBrowserCredential` to `@azure/identity` that leverages [MSAL.js](https://github.com/AzureAD/microsoft-authentication-library-for-js) to enable browser-based authentication for SDK libraries.O

Since it's almost impossible to write automated tests for this (without hooks provided from MSAL.js), I've put together a React-based manual testing UI to test that the authentication works in a "real" browser-based app.  I admit, I went a little overboard on this, but the idea is that this could be a foundation for a more full-fledged manual test / sample UI that all of our browser-supporting SDK libraries could plug into.

**Screenshot**

![image](https://user-images.githubusercontent.com/79405/62396655-92ef8200-b528-11e9-86b3-372912f3f9c3.png)
