### PR TITLE
SpanOptions in RequestOptionsBase to create span for tracing

### DIFF
--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -460,5 +460,10 @@ export interface RequestOptionsBase {
    */
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
 
+  /**
+   * Options used to create a span when tracing is enabled.
+   */
+  spanOptions?: any;
+
   [key: string]: any;
 }


### PR DESCRIPTION
This PR adds a new property by the name `spanOptions` to `RequestOptionsBase` in `core-http`

This gets used to create new spans when tracing is enabled.

To keep #4654 restricted to Keyvault related changes, this change has been pulled out of that PR