### PR TITLE
[Keyvault Keys] Options to getKey() takes requestOptions

### DIFF
--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -525,7 +525,7 @@ export class KeysClient {
       this.vaultBaseUrl,
       name,
       options && options.version ? options.version : "",
-      options
+      options ? options.requestOptions : {}
     );
     return this.getKeyFromKeyBundle(response);
   }


### PR DESCRIPTION
The getKey() method in the generated code in keyvaultClient.ts takes options of type `RequestOptionsBase`

This method is called from the hand written layer in index.ts. Here, instead of passing the request options, a higher level of options of type `GetKeyOptions` is passed instead.

This PR fixes this issue