### PR TITLE
Revert commit

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -25,11 +25,11 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargets)
         displayName: "Build libraries"
 
       - script: |
-          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargetsTo)
+          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargets)
         displayName: "Pack libraries"
 
 
@@ -75,7 +75,7 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargetsTo)
+          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargets)
         displayName: "Lint libraries"
 
       - task: CopyFiles@2
@@ -93,7 +93,7 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)
 
       - script: |
-          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargetsTo)
+          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargets)
         condition: and(succeeded(), eq(variables['RunNpmAudit'], 'true'))
         displayName: "Audit libraries"
 
@@ -153,13 +153,13 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargets)
         displayName: "Build libraries"
       - script: |
-          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargetsTo)
+          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargets)
         displayName: "Build test assets"
       - script: |
-          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargetsTo)
+          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargets)
         displayName: "Test libraries"
 
       - task: PublishTestResults@2

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -25,11 +25,11 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo)
         displayName: "Build libraries"
 
       - script: |
-          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargetsTo)
         displayName: "Pack libraries"
 
 
@@ -75,7 +75,7 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargetsTo)
         displayName: "Lint libraries"
 
       - task: CopyFiles@2
@@ -93,7 +93,7 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)
 
       - script: |
-          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargetsTo)
         condition: and(succeeded(), eq(variables['RunNpmAudit'], 'true'))
         displayName: "Audit libraries"
 
@@ -153,13 +153,13 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo)
         displayName: "Build libraries"
       - script: |
-          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargetsTo)
         displayName: "Build test assets"
       - script: |
-          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargetsFrom)
+          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargetsTo)
         displayName: "Test libraries"
 
       - task: PublishTestResults@2

--- a/eng/tools/select-packages/index.js
+++ b/eng/tools/select-packages/index.js
@@ -28,8 +28,7 @@ glob(filter, (err, files) => {
     process.exit(1);
   }
 
-  let packageTargetsTo = "";
-  let packageTargetsFrom = "";
+  let packageTargets = "";
 
   if (files) {
     log(`Found ${files.length} packages under service directory.`);
@@ -48,8 +47,7 @@ glob(filter, (err, files) => {
             packageContents["sdk-type"]
           }".`
         );
-        packageTargetsTo += `--to "${packageContents.name}" `;
-        packageTargetsFrom += `--from "${packageContents.name}" `;
+        packageTargets += `--to "${packageContents.name}" `;
       } else {
         log(
           `Package "${
@@ -60,24 +58,16 @@ glob(filter, (err, files) => {
     }
 
     log(
-      `Finished processing packages. Emitting variable using: ${packageTargetsTo} and ${packageTargetsFrom}`
+      `Finished processing packages. Emitting variable using: ${packageTargets}`
     );
 
     // Can't use regular logging here because the pattern for Azure Pipelines requires ##vso to be the first chars.
     console.log(
-      `##vso[task.setvariable variable=GeneratedPackageTargetsTo]${packageTargetsTo}`
+      `##vso[task.setvariable variable=GeneratedPackageTargets]${packageTargets}`
     );
 
     log(
-      `Emitted variable "GeneratedPackageTargetsTo" with content: ${packageTargetsTo}`
-    );
-
-    console.log(
-      `##vso[task.setvariable variable=GeneratedPackageTargetsFrom]${packageTargetsFrom}`
-    );
-
-    log(
-      `Emitted variable "GeneratedPackageTargetsFrom" with content: ${packageTargetsFrom}`
+      `Emitted variable "GeneratedPackageTargets" with content: ${packageTargets}`
     );
 
   } else {


### PR DESCRIPTION
- Remove the `from` tag from pipeline, as it doesn't actually build the packages that are dependent on the target package 
- Revert the changes in script select-packages/index.js for from env variable

cc: @Azure/azure-sdk-eng 
