### PR TITLE
[Core Tracing] Add plugin type to tracer interface

### DIFF
--- a/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
+++ b/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
@@ -5,9 +5,8 @@ import { SpanNoOpImpl } from "./spanNoOpImpl";
 import { SupportedPlugins } from '../../utils/supportedPlugins';
 
 export class TracerNoOpImpl implements Tracer {
-  public get pluginType() : SupportedPlugins {
-    return SupportedPlugins.NOOP;
-  }
+  public readonly pluginType = SupportedPlugins.NOOP;
+  
   getCurrentSpan(): Span {
     throw new Error("Method not implemented.");
   }

--- a/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
+++ b/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
@@ -2,8 +2,12 @@ import { Tracer } from "../../interfaces/tracer";
 import { SpanOptions } from "../../interfaces/SpanOptions";
 import { Span } from "../../interfaces/span";
 import { SpanNoOpImpl } from "./spanNoOpImpl";
+import { SupportedPlugins } from '../../utils/supportedPlugins';
 
 export class TracerNoOpImpl implements Tracer {
+  public get pluginType() : SupportedPlugins {
+    return SupportedPlugins.NOOP;
+  }
   getCurrentSpan(): Span {
     throw new Error("Method not implemented.");
   }

--- a/sdk/core/core-tracing/lib/interfaces/tracer.ts
+++ b/sdk/core/core-tracing/lib/interfaces/tracer.ts
@@ -16,6 +16,7 @@
 
 import { Span } from './span';
 import { SpanOptions } from './SpanOptions';
+import { SupportedPlugins } from '../utils/supportedPlugins';
 
 /**
  * Tracer provides an interface for creating {@link Span}s and propagating
@@ -25,6 +26,11 @@ import { SpanOptions } from './SpanOptions';
  * that this class offers APIs to facilitate both usages.
  */
 export interface Tracer {
+  /**
+   * Returns the type of the plugin being used by the tracer.
+   * @returns the type of the plugin being used by the tracer. 
+   */
+  pluginType: SupportedPlugins
   /**
    * Returns the current Span from the current context if available.
    *

--- a/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
@@ -12,9 +12,7 @@ export class NoOpTracePlugin implements Tracer {
     this._tracer = tracer;
   }
 
-  public get pluginType() : SupportedPlugins {
-    return SupportedPlugins.NOOP;
-  }
+  public readonly pluginType = SupportedPlugins.NOOP;
 
   startSpan(name: string, options?: SpanOptions): Span {
     const span = new SpanNoOpImpl();

--- a/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
@@ -3,12 +3,17 @@ import { Span } from "../../interfaces/span";
 import { SpanOptions } from "../../interfaces/SpanOptions";
 import { NoOpSpanPlugin } from "./noOpSpanPlugin";
 import { SpanNoOpImpl } from "../../implementations/noop/spanNoOpImpl";
+import { SupportedPlugins } from '../../utils/supportedPlugins';
 
 export class NoOpTracePlugin implements Tracer {
   private _tracer: any;
 
   public constructor(tracer: any) {
     this._tracer = tracer;
+  }
+
+  public get pluginType() : SupportedPlugins {
+    return SupportedPlugins.NOOP;
   }
 
   startSpan(name: string, options?: SpanOptions): Span {

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
@@ -2,6 +2,7 @@ import { Tracer } from "../../interfaces/tracer";
 import { SpanOptions } from "../../interfaces/SpanOptions";
 import { Span } from "../../interfaces/span";
 import { OpenCensusSpanPlugin } from "../opencensus/openCensusSpanPlugin";
+import { SupportedPlugins } from '../../utils/supportedPlugins';
 
 export class OpenCensusTracePlugin implements Tracer {
   private _tracer: any;
@@ -9,7 +10,11 @@ export class OpenCensusTracePlugin implements Tracer {
   public constructor(tracer: any) {
     this._tracer = tracer;
   }
-
+  
+  public get pluginType() : SupportedPlugins {
+    return SupportedPlugins.OPENCENSUS
+  }
+  
   startSpan(name: string, options?: SpanOptions): Span {
     const parent = options
       ? options.parent

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
@@ -11,9 +11,7 @@ export class OpenCensusTracePlugin implements Tracer {
     this._tracer = tracer;
   }
   
-  public get pluginType() : SupportedPlugins {
-    return SupportedPlugins.OPENCENSUS
-  }
+  public readonly pluginType = SupportedPlugins.OPENCENSUS;
   
   startSpan(name: string, options?: SpanOptions): Span {
     const parent = options

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -78,6 +78,8 @@ export class NoOpTracePlugin implements Tracer {
     // (undocumented)
     getHttpTextFormat(): unknown;
     // (undocumented)
+    readonly pluginType: SupportedPlugins;
+    // (undocumented)
     recordSpanData(span: Span): void;
     // (undocumented)
     startSpan(name: string, options?: SpanOptions): Span;
@@ -121,6 +123,8 @@ export class OpenCensusTracePlugin implements Tracer {
     getCurrentSpan(): Span;
     // (undocumented)
     getHttpTextFormat(): unknown;
+    // (undocumented)
+    readonly pluginType: SupportedPlugins;
     // (undocumented)
     recordSpanData(span: Span): void;
     // (undocumented)
@@ -231,6 +235,7 @@ export interface Tracer {
     getBinaryFormat(): unknown;
     getCurrentSpan(): Span;
     getHttpTextFormat(): unknown;
+    pluginType: SupportedPlugins;
     recordSpanData(span: Span): void;
     startSpan(name: string, options?: SpanOptions): Span;
     withSpan<T extends (...args: unknown[]) => unknown>(span: Span, fn: T): ReturnType<T>;
@@ -244,6 +249,8 @@ export class TracerNoOpImpl implements Tracer {
     getCurrentSpan(): Span;
     // (undocumented)
     getHttpTextFormat(): unknown;
+    // (undocumented)
+    readonly pluginType: SupportedPlugins;
     // (undocumented)
     recordSpanData(span: Span): void;
     // (undocumented)


### PR DESCRIPTION
This PR adds a property to the `Tracer` interface to identify the plugin type being used.

This is useful when trying to decide whether or not tracer context should be added to the headers for a request