### PR TITLE
Update samples and readmes to use DefaultAzureCredential

### DIFF
--- a/sdk/core/core-amqp/samples/cbsAuthUsingAad.ts
+++ b/sdk/core/core-amqp/samples/cbsAuthUsingAad.ts
@@ -24,7 +24,7 @@ import {
   TokenType,
   Constants
 } from "@azure/core-amqp";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = "";
@@ -48,7 +48,7 @@ async function authenticate(
   closeConnection: boolean = false
 ): Promise<CbsResponse> {
   await connectionContext.cbsSession.init();
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
   const tokenObject = await credential.getToken(Constants.aadEventHubsScope);
   if (!tokenObject) {
     throw new Error("Aad token cannot be null");

--- a/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
@@ -23,7 +23,7 @@
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
 import { EventHubClient } from "@azure/event-hubs";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 // Define Event Hubs Endpoint and related entity name here here
 const evenHubsEndpoint = ""; // <your-eventhubs-namespace>.servicebus.windows.net
@@ -32,7 +32,7 @@ const eventHubName = "";
 // Define AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET of your AAD application in your environment
 
 async function main(): Promise<void> {
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
   const client = new EventHubClient(evenHubsEndpoint, eventHubName, credential);
   /*
    Refer to other samples, and place your code here

--- a/sdk/keyvault/keyvault-certificates/samples/singleCertificate.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/singleCertificate.ts
@@ -1,15 +1,15 @@
 import { CertificatesClient, SecretsClient } from "../src";
 import { CertificatePolicy } from "../src/models";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
   const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>"
   const url = `https://${vaultName}.vault.azure.net`;
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
 
   const cc = new CertificatesClient(url, credential);
   const sc = new SecretsClient(url, credential);
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
         }
       }
     });
-  
+
     console.log(result);
   */
   //let result = await cc.createCertificate("MyCert", { certificatePolicy: { issuerParameters: { name: "Self" }, x509CertificateProperties: { subject: "cn=MyCert" } } })

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -101,18 +101,18 @@ Use the [Azure Cloud Shell](https://shell.azure.com/bash) snippet below to creat
 To use the key vault from TypeScript/JavaScript, you need to first authenticate with the key vault service. To authenticate, first we import the identity and KeysClient, which will connect to the key vault.
 
 ```typescript
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import { KeysClient } from "@azure/keyvault-keys";
 ```
 
 Once these are imported, we can next connect to the key vault service. To do this, we'll need to copy some settings from the key vault we are connecting to into our environment variables. Once they are in our environment, we can access them with the following code:
 
 ```typescript
-// EnvironmentCredential expects the following three environment variables:
+// DefaultAzureCredential expects the following three environment variables:
 // * AZURE_TENANT_ID: The tenant ID in Azure Active Directory
 // * AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
 // * AZURE_CLIENT_SECRET: The client secret for the registered application
-const credential = new EnvironmentCredential();
+const credential = new DefaultAzureCredential();
 
 // Build the URL to reach your key vault
 const vaultName = "<YOUR KEYVAULT NAME>";
@@ -223,18 +223,18 @@ This library also offers a set of cryptographic utilities available through `Cry
 ### Authenticate the client
 
 ```typescript
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import { KeysClient, CryptographyClient } from "@azure/keyvault-keys";
 ```
 
 Once these are imported, we can next connect to the key vault service. To do this, we'll need to copy some settings from the key vault we are connecting to into our environment variables. Once they are in our environment, we can access them with the following code:
 
 ```typescript
-// EnvironmentCredential expects the following three environment variables:
+// DefaultAzureCredential expects the following three environment variables:
 // * AZURE_TENANT_ID: The tenant ID in Azure Active Directory
 // * AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
 // * AZURE_CLIENT_SECRET: The client secret for the registered application
-const credential = new EnvironmentCredential();
+const credential = new DefaultAzureCredential();
 
 // Build the URL to reach your key vault
 const vaultName = "<YOUR KEYVAULT NAME>";

--- a/sdk/keyvault/keyvault-keys/samples/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples/cryptography.ts
@@ -1,13 +1,13 @@
 import { KeysClient, CryptographyClient } from "../src";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import * as crypto from 'crypto';
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
 
   const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>"
   const url = `https://${vaultName}.vault.azure.net`;

--- a/sdk/keyvault/keyvault-keys/samples/helloWorld.ts
+++ b/sdk/keyvault/keyvault-keys/samples/helloWorld.ts
@@ -1,12 +1,12 @@
 import { KeysClient } from "../src";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
 
   const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>"
   const url = `https://${vaultName}.vault.azure.net`;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -559,10 +559,10 @@ export class CryptographyClient {
    * Example usage:
    * ```ts
    * import { CryptographyClient } from "@azure/keyvault-keys";
-   * import { EnvironmentCredential } from "@azure/identity";
+   * import { DefaultAzureCredential } from "@azure/identity";
    *
    * let url = `https://<MY KEYVAULT HERE>.vault.azure.net`;
-   * let credentials = new EnvironmentCredential();
+   * let credentials = new DefaultAzureCredential();
    *
    * let client = new CryptographyClient(url, keyUrl, credentials);
    * // or

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -67,7 +67,7 @@ import {
   KeyWrapAlgorithm,
   EncryptResult,
   DecryptResult,
-  SignResult, 
+  SignResult,
   VerifyResult,
   WrapResult,
   UnwrapResult
@@ -186,10 +186,10 @@ export class KeysClient {
    * Example usage:
    * ```ts
    * import { KeysClient } from "@azure/keyvault-keys";
-   * import { EnvironmentCredential } from "@azure/identity";
+   * import { DefaultAzureCredential } from "@azure/identity";
    *
    * let url = `https://<MY KEYVAULT HERE>.vault.azure.net`;
-   * let credentials = new EnvironmentCredential();
+   * let credentials = new DefaultAzureCredential();
    *
    * let client = new KeysClient(url, credentials);
    * ```

--- a/sdk/keyvault/keyvault-secrets/README.md
+++ b/sdk/keyvault/keyvault-secrets/README.md
@@ -90,18 +90,18 @@ Use the [Azure Cloud Shell](https://shell.azure.com/bash) snippet below to creat
 To use the key vault from TypeScript/JavaScript, you need to first authenticate with the key vault service. To authenticate, first we import the identity and SecretsClient, which will connect to the key vault.
 
 ```typescript
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 import { SecretsClient } from "@azure/keyvault-secrets";
 ```
 
 Once these are imported, we can next connect to the key vault service. To do this, we'll need to copy some settings from the key vault we are connecting to into our environment variables. Once they are in our environment, we can access them with the following code:
 
 ```typescript
-// EnvironmentCredential expects the following three environment variables:
+// DefaultAzureCredential expects the following three environment variables:
 // * AZURE_TENANT_ID: The tenant ID in Azure Active Directory
 // * AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
 // * AZURE_CLIENT_SECRET: The client secret for the registered application
-const credential = new EnvironmentCredential();
+const credential = new DefaultAzureCredential();
 
 // Build the URL to reach your key vault
 const vaultName = "<YOUR KEYVAULT NAME>";
@@ -229,6 +229,7 @@ export DEBUG=azure:keyvault-secrets:error,azure-amqp-common:error,rhea-promise:e
 ### Logging to a file
 
 - Set the `DEBUG` environment variable as shown above and then run your test script as follows:
+
   - Logging statements from your test script go to `out.log` and logging statements from the sdk go to `debug.log`.
     ```bash
     node your-test-script.js > out.log 2>debug.log

--- a/sdk/keyvault/keyvault-secrets/samples/backupAndRestore.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/backupAndRestore.ts
@@ -1,6 +1,6 @@
 import { SecretsClient } from "../src";
 import fs = require("fs");
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 function writeFile(filename: string, text: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -25,11 +25,11 @@ export function delay<T>(t: number, value?: T): Promise<T> {
 }
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
 
   const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>";
   const url = `https://${vaultName}.vault.azure.net`;

--- a/sdk/keyvault/keyvault-secrets/samples/challenge.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/challenge.ts
@@ -1,5 +1,5 @@
 import { SecretsClient } from "../src";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 import {
   ServiceClientCredentials,
@@ -21,19 +21,22 @@ import {
 } from "@azure/core-http";
 
 import { RetryConstants, SDK_VERSION } from "../src/core/utils/constants";
-import { ChallengeBasedAuthenticationPolicy, challengeBasedAuthenticationPolicy } from "../src/core/challengeBasedAuthenticationPolicy";
+import {
+  ChallengeBasedAuthenticationPolicy,
+  challengeBasedAuthenticationPolicy
+} from "../src/core/challengeBasedAuthenticationPolicy";
 
-import { TokenCredentials, } from "@azure/core-http";
+import { TokenCredentials } from "@azure/core-http";
 import { Pipeline } from "../src/core/keyVaultBase";
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new EnvironmentCredential();
-  let retryOptions: any = {};
-  let pipelineOptions: any = {};
+  const credential = new DefaultAzureCredential();
+  const retryOptions: any = {};
+  const pipelineOptions: any = {};
   const requestPolicyFactories: RequestPolicyFactory[] = [
     proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings)),
     userAgentPolicy({ value: "" }),
@@ -49,16 +52,16 @@ async function main(): Promise<void> {
     ),
     redirectPolicy(),
 
-    challengeBasedAuthenticationPolicy(credential),
+    challengeBasedAuthenticationPolicy(credential)
   ];
 
-  let pipeline: Pipeline = {
+  const pipeline: Pipeline = {
     httpClient: pipelineOptions.HTTPClient,
     httpPipelineLogger: pipelineOptions.logger,
     requestPolicyFactories
   };
 
-  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>"
+  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>";
   const url = `https://${vaultName}.vault.azure.net`;
 
   const client = new SecretsClient(url, credential, pipeline);
@@ -73,7 +76,9 @@ async function main(): Promise<void> {
   console.log("secret: ", secret);
 
   // Update the secret with different attributes
-  const updatedSecret = await client.updateSecretAttributes(secretName, result.version, { enabled: false });
+  const updatedSecret = await client.updateSecretAttributes(secretName, result.version, {
+    enabled: false
+  });
   console.log("updated secret: ", updatedSecret);
 
   // Delete the secret

--- a/sdk/keyvault/keyvault-secrets/samples/deleteAndRecover.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/deleteAndRecover.ts
@@ -1,18 +1,18 @@
 import { SecretsClient } from "../src";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 export function delay<T>(t: number, value?: T): Promise<T> {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));
 }
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
 
-  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>"
+  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>";
   const url = `https://${vaultName}.vault.azure.net`;
   const client = new SecretsClient(url, credential);
 

--- a/sdk/keyvault/keyvault-secrets/samples/helloWorld.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/helloWorld.ts
@@ -1,14 +1,14 @@
 import { SecretsClient } from "../src";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
 
-  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>"
+  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>";
   const url = `https://${vaultName}.vault.azure.net`;
 
   const client = new SecretsClient(url, credential);
@@ -23,7 +23,9 @@ async function main(): Promise<void> {
   console.log("secret: ", secret);
 
   // Update the secret with different attributes
-  const updatedSecret = await client.updateSecretAttributes(secretName, result.version, { enabled: false });
+  const updatedSecret = await client.updateSecretAttributes(secretName, result.version, {
+    enabled: false
+  });
   console.log("updated secret: ", updatedSecret);
 
   // Delete the secret

--- a/sdk/keyvault/keyvault-secrets/samples/listOperations.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/listOperations.ts
@@ -1,14 +1,14 @@
 import { SecretsClient } from "../src";
-import { EnvironmentCredential } from "@azure/identity";
+import { DefaultAzureCredential } from "@azure/identity";
 
 async function main(): Promise<void> {
-  // EnvironmentCredential expects the following three environment variables:
+  // DefaultAzureCredential expects the following three environment variables:
   // - AZURE_TENANT_ID: The tenant ID in Azure Active Directory
   // - AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
   // - AZURE_CLIENT_SECRET: The client secret for the registered application
-  const credential = new EnvironmentCredential();
+  const credential = new DefaultAzureCredential();
 
-  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>"
+  const vaultName = process.env["KEYVAULT_NAME"] || "<keyvault-name>";
   const url = `https://${vaultName}.vault.azure.net`;
   const client = new SecretsClient(url, credential);
 

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -144,10 +144,10 @@ export class SecretsClient {
    * Example usage:
    * ```ts
    * import { SecretsClient } from "@azure/keyvault-secrets";
-   * import { EnvironmentCredential } from "@azure/identity";
+   * import { DefaultAzureCredential } from "@azure/identity";
    *
    * let url = `https://<MY KEYVAULT HERE>.vault.azure.net`;
-   * let credentials = new EnvironmentCredential();
+   * let credentials = new DefaultAzureCredential();
    *
    * let client = new SecretsClient(url, credentials);
    * ```


### PR DESCRIPTION
This change updates all samples and READMEs that reference `EnvironmentCredential` to use `DefaultAzureCredential` instead.  We want to advertise this as the standard credential so that it will work for most users in most cases without extra configuration.  This also allows us to update the default credentials used inside of its chain over time.