### PR TITLE
[Core Tracing] Remove private in package.json

### DIFF
--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -56,7 +56,6 @@
   },
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/core/core-tracing",
   "sideEffects": false,
-  "private": true,
   "dependencies": {
     "tslib": "^1.9.3"
   },


### PR DESCRIPTION
This PR removes the `private:true` in package.json that blocks us from publishing the package