### PR TITLE
[Event Hubs] Update sample in Readme to use js not ts

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -203,7 +203,7 @@ class SimplePartitionProcessor {
   async processError(error) { /* your code here */ }
 
   // Gets called when Event Processor stops processing events for current partition.
-  async close() { /* your code here */ }
+  async close(reason) { /* your code here */ }
 }
 
 const client = new EventHubClient("my-connection-string", "my-event-hub");

--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -192,14 +192,18 @@ While load balancing is a feature we will be adding in the next update, you can 
 
 ```javascript
 class SimplePartitionProcessor {
-  async processEvents(events) {
-    // your code to process events here
-    // you may choose to use the checkpoint manager to update checkpoints
-  }
+  // Gets called once before the processing of events from current partition starts.
+  async initialize() { /* your code here */ }
+  
+  // Gets called for each batch of events that are received.
+  // You may choose to use the checkpoint manager to update checkpoints.
+  async processEvents(events) { /* your code here */ }
 
-  async processError(error) {
-    // your error handler here
-  }
+  // Gets called for any error when receiving events.
+  async processError(error) { /* your code here */ }
+
+  // Gets called when Event Processor stops processing events for current partition.
+  async close() { /* your code here */ }
 }
 
 const client = new EventHubClient("my-connection-string", "my-event-hub");

--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -188,23 +188,25 @@ Using an `EventHubConsumer` to consume events like in the previous examples puts
 
 The `EventProcessor` will delegate the processing of events to a `PartitionProcessor` that you provide, allowing you to focus on business logic while the processor holds responsibility for managing the underlying consumer operations including checkpointing and load balancing. 
 
-While load balancing is a feature we will be adding in the next update, you can see how to use the `EventProcessor` in the below example, where we use an in memory `PartitionManager` that does checkpointing in memory.
+While load balancing is a feature we will be adding in the next update, you can see how to use the `EventProcessor` in the below example, where we use an `InMemoryPartitionManager` that does checkpointing in memory.
 
 ```javascript
 class SimplePartitionProcessor {
-  async processEvents(events: ReceivedEventData[]) {
-    // your code here
+  async processEvents(events) {
+    // your code to process events here
+    // you may choose to use the checkpoint manager to update checkpoints
   }
 
-  async processError(error: Error) {
+  async processError(error) {
     // your error handler here
   }
 }
 
+const client = new EventHubClient("my-connection-string", "my-event-hub");
 const processor = new EventProcessor(
   EventHubClient.defaultConsumerGroupName,
   client,
-  () => new SimplePartitionProcessor(),
+  (partitionContext, checkpointManager) => new SimplePartitionProcessor(),
   new InMemoryPartitionManager()
 );
 await processor.start();

--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -15,7 +15,7 @@
 
 #### Consuming events
 - Introduced a new class `EventProcessor` which replaces the older concept of [Event Processor Host](https://www.npmjs.com/package/@azure/event-processor-host). 
-  This early preview is intended to allow users to test the new design using a single instance of `EventProcessor`. The ability to checkpoints to a durable store will be added in future updates
+   - This early preview is intended to allow users to test the new design using a single instance of `EventProcessor`. The ability to store checkpoints to a durable store will be added in future updates
 
 #### Retries and timeouts
 - The properties on the `RetryOptions` interface have been renamed for ease of use. 

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -42,6 +42,7 @@ export interface Checkpoint {
 
 // @public
 export class CheckpointManager {
+    // @internal
     constructor(partitionContext: PartitionContext, partitionManager: PartitionManager, eventProcessorId: string);
     updateCheckpoint(eventData: ReceivedEventData): Promise<void>;
     updateCheckpoint(sequenceNumber: number, offset: number): Promise<void>;


### PR DESCRIPTION
Currently the sample for EventProcessor in the README uses types.
We need these samples to be in javascript to reduce the number of steps for the user to be able to run the code.