### PR TITLE
[core-tracing] Add ThirdPartyNotices.txt

### DIFF
--- a/sdk/core/core-tracing/ThirdPartyNotices.txt
+++ b/sdk/core/core-tracing/ThirdPartyNotices.txt
@@ -1,0 +1,24 @@
+Third Party Notices for core-tracing
+
+This project incorporates material from the project(s) listed below (collectively, Third Party Code).
+Microsoft, Inc. Microsoft is not the original author of the Third Party Code.
+The original copyright notice and license, under which Microsoft received such Third Party Code,
+are set out below.  This Third Party Code is licensed to you under their original license terms set forth below.
+Microsoft reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.
+
+1. opentelemetry-js
+
+%% opentelemetry-js NOTICES AND INFORMATION BEGIN HERE
+=========================================
+Copyright 2019, OpenTelemetry Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+     https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+=========================================
+END OF opentelemetry-js NOTICES AND INFORMATION

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -39,7 +39,8 @@
     "dist/",
     "dist-esm/",
     "src/",
-    "types/core-tracing.d.ts"
+    "types/core-tracing.d.ts",
+    "ThirdPartyNotices.txt"
   ],
   "repository": "github:Azure/azure-sdk-for-js",
   "keywords": [


### PR DESCRIPTION
We need ThirdPartyNotices whenever we redistribute open source software in our package. Since core-tracing presently incorporates interfaces from opentelemetry-js, this PR includes the necessary notice. This can be deleted once we have an actual npm dependency on opentelemtry-js.