### PR TITLE
[KeyVault] Fix flaky tests around the getDeleted* tests

### DIFF
--- a/sdk/keyvault/keyvault-keys/tests/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/tests/list.test.ts
@@ -138,8 +138,10 @@ describe("Keys client - list keys in various ways", () => {
       await client.deleteKey(name);
     }
 
-    // Waiting until the key is deleted
-    await retry(async () => client.getDeletedKey(keyNames[0]));
+    // Waiting until the keys are deleted
+    for (const name of keyNames) {
+      await retry(async () => client.getDeletedKey(name));
+    }
 
     let found = 0;
     for await (const key of client.listDeletedKeys()) {
@@ -165,8 +167,10 @@ describe("Keys client - list keys in various ways", () => {
       await client.deleteKey(name);
     }
 
-    // Waiting until the key is deleted
-    await retry(async () => client.getDeletedKey(keyNames[0]));
+    // Waiting until the keys are deleted
+    for (const name of keyNames) {
+      await retry(async () => client.getDeletedKey(name));
+    }
 
     let found = 0;
     for await (const page of client.listDeletedKeys().byPage()) {

--- a/sdk/keyvault/keyvault-secrets/tests/list.test.ts
+++ b/sdk/keyvault/keyvault-secrets/tests/list.test.ts
@@ -66,8 +66,10 @@ describe("Secret client - list secrets in various ways", () => {
       await client.deleteSecret(name);
     }
 
-    // Waiting until the key is deleted
-    await retry(async () => client.getDeletedSecret(secretNames[0]));
+    // Waiting until the secrets are deleted
+    for (const name of secretNames) {
+      await retry(async () => client.getDeletedSecret(name));
+    }
 
     let found = 0;
     for await (const secret of client.listDeletedSecrets()) {

--- a/sdk/keyvault/keyvault-secrets/tests/list.test.ts
+++ b/sdk/keyvault/keyvault-secrets/tests/list.test.ts
@@ -166,8 +166,10 @@ describe("Secret client - list secrets in various ways", () => {
       await client.deleteSecret(name);
     }
 
-    // Waiting until the key is deleted
-    await retry(async () => client.getDeletedSecret(secretNames[0]));
+    // Waiting until the secrets are deleted
+    for (const name of secretNames) {
+      await retry(async () => client.getDeletedSecret(name));
+    }
 
     let found = 0;
     for await (const page of client.listDeletedSecrets().byPage()) {


### PR DESCRIPTION
The issue is likely to be that we weren't waiting for both entities to be deleted before we moved on.