### PR TITLE
[core-http][core-tracing][keyvault keys] adds tracing policy

### DIFF
--- a/sdk/core/core-http/lib/coreHttp.ts
+++ b/sdk/core/core-http/lib/coreHttp.ts
@@ -28,6 +28,7 @@ export { redirectPolicy } from "./policies/redirectPolicy";
 export { signingPolicy } from "./policies/signingPolicy";
 export { userAgentPolicy, getDefaultUserAgentValue } from "./policies/userAgentPolicy";
 export { deserializationPolicy, deserializeResponseBody } from "./policies/deserializationPolicy";
+export { tracingPolicy } from "./policies/tracingPolicy";
 export {
   MapperType, SimpleMapperType, CompositeMapperType, DictionaryMapperType, SequenceMapperType, EnumMapperType,
   Mapper, BaseMapper, CompositeMapper, SequenceMapper, DictionaryMapper, EnumMapper,
@@ -51,3 +52,4 @@ export { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKey
 export { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 export { TopicCredentials } from "./credentials/topicCredentials";
 export { Authenticator } from "./credentials/credentials";
+export * from "@azure/core-tracing";

--- a/sdk/core/core-http/lib/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/lib/policies/tracingPolicy.ts
@@ -1,0 +1,54 @@
+import { TracerProxy, TraceOptions } from "@azure/core-tracing";
+import {
+  RequestPolicyFactory,
+  RequestPolicy,
+  RequestPolicyOptions,
+  BaseRequestPolicy
+} from "./requestPolicy";
+import { WebResource } from "../webResource";
+import { HttpOperationResponse } from "../httpOperationResponse";
+
+export function tracingPolicy(): RequestPolicyFactory {
+  return {
+    create(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
+      return new TracingPolicy(nextPolicy, options);
+    }
+  };
+}
+
+export class TracingPolicy extends BaseRequestPolicy {
+  constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
+    super(nextPolicy, options);
+  }
+
+  public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+    if (!request.spanOptions || !request.spanOptions.parent) {
+      return this._nextPolicy.sendRequest(request);
+    }
+
+    // create a new span
+    const tracer = TracerProxy.getTracer();
+    const span = tracer.startSpan("core-http", request.spanOptions);
+
+    span.start();
+
+    try {
+      // set headers
+      const spanContext = span.context();
+      request.headers.set(
+        "traceparent",
+        `${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceOptions || TraceOptions.UNSAMPLED}`
+      );
+      const traceState = spanContext.traceState && spanContext.traceState.serialize();
+      if (traceState) {
+        request.headers.set("tracestate", traceState);
+      }
+      const response = await this._nextPolicy.sendRequest(request);
+      span.end();
+      return response;
+    } catch (err) {
+      span.end();
+      throw err;
+    }
+  }
+}

--- a/sdk/core/core-http/lib/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/lib/policies/tracingPolicy.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { TracerProxy, TraceOptions } from "@azure/core-tracing";
 import {
   RequestPolicyFactory,

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -339,6 +339,10 @@ export class ServiceClient {
         if (options.onDownloadProgress) {
           httpRequest.onDownloadProgress = options.onDownloadProgress;
         }
+
+        if (options.spanOptions) {
+          httpRequest.spanOptions = options.spanOptions;
+        }
       }
 
       httpRequest.withCredentials = this._withCredentials;

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -66,6 +66,10 @@ export class WebResource {
 
   /** Callback which fires upon download progress. */
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
+  /**
+   * Options used to create a span when tracing is enabled.
+   */
+  spanOptions?: any;
 
   constructor(
     url?: string,

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -66,6 +66,7 @@ export class WebResource {
 
   /** Callback which fires upon download progress. */
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
+
   /**
    * Options used to create a span when tracing is enabled.
    */

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -112,6 +112,7 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
     "@azure/core-auth": "1.0.0-preview.3",
+    "@azure/core-tracing": "1.0.0-preview.2",
     "@types/node-fetch": "^2.5.0",
     "@types/tunnel": "^0.0.1",
     "form-data": "^2.5.0",

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { assert } from "chai";
 import sinon from "sinon";
 import { RequestPolicy, WebResource, HttpOperationResponse, HttpHeaders, Tracer, Span, TracerProxy, RequestPolicyOptions, TraceOptions } from "../../lib/coreHttp";

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -1,0 +1,204 @@
+import { assert } from "chai";
+import sinon from "sinon";
+import { RequestPolicy, WebResource, HttpOperationResponse, HttpHeaders, Tracer, Span, TracerProxy, RequestPolicyOptions, TraceOptions } from "../../lib/coreHttp";
+import { tracingPolicy } from "../../lib/policies/tracingPolicy";
+
+interface MockTracer extends Tracer {
+  getStartedSpans(): any[];
+  startSpanCalled(): boolean;
+}
+
+describe("tracingPolicy", function () {
+  function mockTracerFactory(
+    traceId?: string,
+    spanId?: string,
+    options?: TraceOptions,
+    state?: string
+  ): MockTracer {
+    let startedSpan = false;
+    const spans: any[] = [];
+    return {
+      // helper method for testing
+      getStartedSpans() {
+        return spans;
+      },
+      // helper method for testing
+      startSpanCalled() {
+        return startedSpan;
+      },
+      startSpan() {
+        startedSpan = true;
+        let started = false;
+        let ended = false;
+        const mockSpan = {
+          didStart() {
+            return started;
+          },
+          didEnd() {
+            return ended;
+          },
+          start() {
+            started = true;
+          },
+          end() {
+            ended = true;
+          },
+          context() {
+            return {
+              traceId,
+              spanId,
+              traceOptions: options,
+              traceState: {
+                serialize() {
+                  return state
+                }
+              }
+            }
+          }
+        };
+        spans.push(mockSpan);
+        return mockSpan as any as Span;
+      }
+    } as any;
+  }
+  const mockPolicy: RequestPolicy = {
+    sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+      return Promise.resolve({
+        request: request,
+        status: 200,
+        headers: new HttpHeaders()
+      });
+    }
+  };
+
+  afterEach(function () {
+    if (typeof (TracerProxy.getTracer as sinon.SinonStub).restore === "function") {
+      (TracerProxy.getTracer as sinon.SinonStub).restore();
+    }
+  });
+
+  it("will not create a span if spanOptions are missing", async () => {
+    const mockTracer = mockTracerFactory();
+    sinon.stub(TracerProxy, "getTracer").callsFake(() => {
+      return mockTracer;
+    });
+    const request = new WebResource();
+    const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
+    await policy.sendRequest(request);
+
+    assert.isFalse(mockTracer.startSpanCalled());
+  });
+
+  it("will create a span and correctly set trace headers if spanOptions are available", async () => {
+    const mockTraceId = "11111111111111111111111111111111";
+    const mockSpanId = "2222222222222222";
+    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceOptions.SAMPLED);
+    sinon.stub(TracerProxy, "getTracer").callsFake(() => {
+      return mockTracer;
+    });
+    const request = new WebResource();
+    request.spanOptions = {
+      parent: {} // stub a parent since we aren't testing the startSpan method
+    };
+    const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
+    await policy.sendRequest(request);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.isTrue(span.didStart());
+    assert.isTrue(span.didEnd());
+
+    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.SAMPLED}`);
+    assert.notExists(request.headers.get("tracestate"));
+  });
+
+  it("will create a span and correctly set trace headers if spanOptions are available (no TraceOptions)", async () => {
+    const mockTraceId = "11111111111111111111111111111111";
+    const mockSpanId = "2222222222222222";
+    // leave out the TraceOptions
+    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId);
+    sinon.stub(TracerProxy, "getTracer").callsFake(() => {
+      return mockTracer;
+    });
+    const request = new WebResource();
+    request.spanOptions = {
+      parent: {} // stub a parent since we aren't testing the startSpan method
+    };
+    const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
+    await policy.sendRequest(request);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.isTrue(span.didStart());
+    assert.isTrue(span.didEnd());
+
+    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.UNSAMPLED}`);
+    assert.notExists(request.headers.get("tracestate"));
+  });
+
+  it("will create a span and correctly set trace headers if spanOptions are available (TraceState)", async () => {
+    const mockTraceId = "11111111111111111111111111111111";
+    const mockSpanId = "2222222222222222";
+    const mockTraceState = "foo=bar";
+    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceOptions.SAMPLED, mockTraceState);
+    sinon.stub(TracerProxy, "getTracer").callsFake(() => {
+      return mockTracer;
+    });
+    const request = new WebResource();
+    request.spanOptions = {
+      parent: {} // stub a parent since we aren't testing the startSpan method
+    };
+    const policy = tracingPolicy().create(mockPolicy, new RequestPolicyOptions());
+    await policy.sendRequest(request);
+
+    assert.isTrue(mockTracer.startSpanCalled());
+    assert.lengthOf(mockTracer.getStartedSpans(), 1);
+    const span = mockTracer.getStartedSpans()[0];
+    assert.isTrue(span.didStart());
+    assert.isTrue(span.didEnd());
+
+    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.SAMPLED}`);
+    assert.equal(request.headers.get("tracestate"), mockTraceState);
+  });
+
+  it("will close a span if an error is encountered", async () => {
+    const mockTraceId = "11111111111111111111111111111111";
+    const mockSpanId = "2222222222222222";
+    const mockTraceState = "foo=bar";
+    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceOptions.SAMPLED, mockTraceState);
+    sinon.stub(TracerProxy, "getTracer").callsFake(() => {
+      return mockTracer;
+    });
+    const request = new WebResource();
+    request.spanOptions = {
+      parent: {} // stub a parent since we aren't testing the startSpan method
+    };
+    const policy = tracingPolicy().create({
+      sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+        return Promise.reject({
+          request: request,
+          status: 404,
+          headers: new HttpHeaders()
+        });
+      }
+    }, new RequestPolicyOptions());
+    try {
+      await policy.sendRequest(request);
+      throw new Error("Test Failure");
+    } catch (err) {
+      assert.notEqual(err.message, "Test Failure");
+      assert.isTrue(mockTracer.startSpanCalled());
+      assert.lengthOf(mockTracer.getStartedSpans(), 1);
+      const span = mockTracer.getStartedSpans()[0];
+      assert.isTrue(span.didStart());
+      assert.isTrue(span.didEnd());
+
+      assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.SAMPLED}`);
+      assert.equal(request.headers.get("tracestate"), mockTraceState);
+    }
+  });
+
+
+});

--- a/sdk/core/core-tracing/lib/plugins/noop/noOpSpanPlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/noop/noOpSpanPlugin.ts
@@ -11,7 +11,10 @@ export class NoOpSpanPlugin implements Span {
   }
 
   context(): SpanContext {
-    throw new Error("Method not implemented.");
+    return {
+      spanId: "",
+      traceId: ""
+    };
   }
 
   end(endTime?: number): void {

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
@@ -2,6 +2,7 @@ import { Span } from "../../interfaces/span";
 import { SpanContext } from "../../interfaces/span_context";
 import { Attributes } from "../../interfaces/attributes";
 import { Status } from "../../interfaces/status";
+import { OpenCensusTraceStatePlugin } from "./openCensusTraceStatePlugin";
 
 export class OpenCensusSpanPlugin implements Span {
   private _span: any;
@@ -23,7 +24,14 @@ export class OpenCensusSpanPlugin implements Span {
   }
 
   context(): SpanContext {
-    throw new Error("Method not implemented.");
+    const openCensusSpanContext = this._span.spanContext;
+
+    return {
+      spanId: openCensusSpanContext.spanId,
+      traceId: openCensusSpanContext.traceId,
+      traceOptions: openCensusSpanContext.options,
+      traceState: new OpenCensusTraceStatePlugin(openCensusSpanContext.traceState)
+    };
   }
 
   setAttribute(key: string, value: unknown): this {

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTraceStatePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTraceStatePlugin.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { TraceState } from "../../interfaces/trace_state";
 
 /**

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTraceStatePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTraceStatePlugin.ts
@@ -1,0 +1,29 @@
+import { TraceState } from "../../interfaces/trace_state";
+
+/**
+ * @ignore
+ * @internal
+ */
+export class OpenCensusTraceStatePlugin implements TraceState {
+  private readonly _state?: string;
+
+  constructor(state?: string) {
+    this._state = state;
+  }
+
+  get(key: string): string | undefined {
+    throw new Error("Method not implemented.");
+  }
+
+  set(key: string, value: string): void {
+    throw new Error("Method not implemented.");
+  }
+
+  unset(key: string): void {
+    throw new Error("Method not implemented");
+  }
+
+  serialize(): string {
+    return this._state || "";
+  }
+}

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -71,7 +71,6 @@
     "@azure/core-arm": "1.0.0-preview.3",
     "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.2",
-    "@azure/core-tracing": "1.0.0-preview.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -72,7 +72,6 @@
     "@azure/core-arm": "1.0.0-preview.3",
     "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.2",
-    "@azure/core-tracing": "1.0.0-preview.1",
     "@azure/identity": "1.0.0-preview.3",
     "@trust/keyto": "0.3.7",
     "tslib": "^1.9.3"

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -11,7 +11,10 @@ import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PageSettings } from '@azure/core-paging';
 import { ServiceClientCredentials } from '@azure/core-http';
 import { ServiceClientOptions } from '@azure/core-http';
+import { Span } from '@azure/core-http';
+import { SupportedPlugins } from '@azure/core-http';
 import { TokenCredential } from '@azure/core-http';
+import { TracerProxy } from '@azure/core-http';
 
 // @public
 export interface CreateEcKeyOptions extends CreateKeyOptions {
@@ -242,11 +245,17 @@ export interface SignResult {
     result: Uint8Array;
 }
 
+export { Span }
+
+export { SupportedPlugins }
+
 // @public (undocumented)
 export interface TelemetryOptions {
     // (undocumented)
     value: string;
 }
+
+export { TracerProxy }
 
 // @public
 export interface UnwrapResult {

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -11,7 +11,6 @@ import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { PageSettings } from '@azure/core-paging';
 import { ServiceClientCredentials } from '@azure/core-http';
 import { ServiceClientOptions } from '@azure/core-http';
-import { Span } from '@azure/core-http';
 import { SupportedPlugins } from '@azure/core-http';
 import { TokenCredential } from '@azure/core-http';
 import { TracerProxy } from '@azure/core-http';
@@ -244,8 +243,6 @@ export interface RetryOptions {
 export interface SignResult {
     result: Uint8Array;
 }
-
-export { Span }
 
 export { SupportedPlugins }
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -114,7 +114,7 @@ export {
 
 export { ProxyOptions, TelemetryOptions, RetryOptions };
 
-export { TracerProxy, Span, SupportedPlugins } from "@azure/core-http";
+export { TracerProxy, SupportedPlugins } from "@azure/core-http";
 
 /**
  * The client to interact with the KeyVault keys functionality

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -3,6 +3,7 @@
 /* eslint @typescript-eslint/member-ordering: 0 */
 
 import {
+  getDefaultUserAgentValue,
   TokenCredential,
   isTokenCredential,
   RequestPolicyFactory,
@@ -17,11 +18,13 @@ import {
   getDefaultProxySettings,
   isNode,
   userAgentPolicy,
-  RequestOptionsBase
+  RequestOptionsBase,
+  tracingPolicy,
+  TracerProxy,
+  Span,
+  SupportedPlugins
 } from "@azure/core-http";
 
-import { TracerProxy, Span, SupportedPlugins } from "@azure/core-tracing";
-import { getDefaultUserAgentValue } from "@azure/core-http";
 import "@azure/core-paging";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
 
@@ -111,6 +114,8 @@ export {
 
 export { ProxyOptions, TelemetryOptions, RetryOptions };
 
+export { TracerProxy, Span, SupportedPlugins } from "@azure/core-http";
+
 /**
  * The client to interact with the KeyVault keys functionality
  */
@@ -142,6 +147,7 @@ export class KeysClient {
       );
     }
     requestPolicyFactories = requestPolicyFactories.concat([
+      tracingPolicy(),
       userAgentPolicy({ value: userAgentString }),
       generateClientRequestIdPolicy(),
       deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer


### PR DESCRIPTION
This update is meant to add support for setting the `traceparent` and `tracestate` headers when keyvault keys is instrumented with tracing.

I created a new policy in `core-http` so that any package that depends on `core-http` can eventually support tracing. Note that it is not in the default pipeline right now.

## core-http
 - Added a dependency on `core-tracing`.
 - Updated `WebResource` to have a `spanOptions` field. This is needed when using manual tracing instrumentation.
- Added the `TracingPolicy` policy. This policy will check if `spanOptions` exists on the `WebResource`, and if it does it will:
  - create a new child span
  - set the `traceparent` and `tracestate` headers as appropriate
- reexports exports from `core-tracing`

## core-tracing
 - Added an opencensus plugin for span context. This wraps the span context that is returned from a span created by an opencensus tracer, and converts it into one core-tracing expects (based on open telemetry)

## keyvault-keys
- added `tracingPolicy` to the default pipeline.
- Removed dependency on `core-tracing`. There is an issue with the `TracerProxy` in `core-tracing` if the module happens to get loaded more than once. We see this happen often with our rush system, but a user could run into it as well. For now we expect the user to import `TracerProxy` from the `keyvault-keys` package directly.

# Follow-up
- [x] update dependency versions now that the core libraries have just been bumped
- [x] add tracingPolicy test for NoOpTracerPlugin.
 
# Manual Testing
I modified the existing hello world sample to include tracing, here's the gist if someone wants to see it for themselves:
https://gist.github.com/chradek/9f7677c7aabe8e5418a63ef2960a14b2

