### PR TITLE
[KeyVault] Updated path of the types to point to the correct directory

### DIFF
--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -20,7 +20,7 @@
   },
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",
-  "types": "./types/keyvault-secrets.d.ts",
+  "types": "./types/src/",
   "engine": {
     "node": ">=6.0.0"
   },


### PR DESCRIPTION
### Problem
When installing the `keyvault-secrets` package by typing `yarn add @azure/keyvault-secrets` and then trying to use it like this:
````
import { DefaultAzureCredential } from "@azure/identity";
import { SecretsClient } from "@azure/keyvault-secrets";
````
the `tsc` (TypeScript compiler) raises the following error:
````
Could not find a declaration file for module '@azure/keyvault-secrets'. 'node_modules/@azure/keyvault-secrets/dist/index.js' implicitly has an 'any'     type. Try `npm install @types/azure__keyvault-secrets` if it exists or add a new declaration (.d.ts) file containing `declare module '@azure/keyvault-secrets';`
````

### What I think is causing this
This is not the correct path to the types: https://github.com/Azure/azure-sdk-for-js/commit/8e3c933875c33132778be7e60382c23afea75ec0#diff-9cb805b9c2b8f9e19a3d3937d6a28ce2R51. Here is the `tree` of the `types/src` directory:
````
node_modules/@azure/keyvault-secrets/types/src
├── core
├── index.d.ts
├── index.d.ts.map
├── secretsModels.d.ts
└── secretsModels.d.ts.map
````

### Suggested fix
Change the `types` parameter in `package.json` to point to the `types/src/` so that it implicitly uses `types/src/index.d.ts`. 