### PR TITLE
[Graph] Fix code samples in README

### DIFF
--- a/sdk/graphrbac/graph/README.md
+++ b/sdk/graphrbac/graph/README.md
@@ -28,7 +28,7 @@ npm install @azure/ms-rest-nodeauth
 ```ts
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { GraphRbacManagementClient, GraphRbacManagementModels, GraphRbacManagementMappers } from "@azure/graph";
-const tenantId = process.env["DOMAIN"];
+const tenantId = "<Tenant_Id>";
 
 msRestNodeAuth.interactiveLogin({ 
   tokenAudience: "https://graph.windows.net",

--- a/sdk/graphrbac/graph/README.md
+++ b/sdk/graphrbac/graph/README.md
@@ -26,8 +26,6 @@ npm install @azure/ms-rest-nodeauth
 ##### Sample code
 
 ```ts
-import * as msRest from "@azure/ms-rest-js";
-import * as msRestAzure from "@azure/ms-rest-azure-js";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { GraphRbacManagementClient, GraphRbacManagementModels, GraphRbacManagementMappers } from "@azure/graph";
 const tenantId = process.env["DOMAIN"];

--- a/sdk/graphrbac/graph/README.md
+++ b/sdk/graphrbac/graph/README.md
@@ -30,10 +30,10 @@ import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
 import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { GraphRbacManagementClient, GraphRbacManagementModels, GraphRbacManagementMappers } from "@azure/graph";
-const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
+const tenantId = process.env["DOMAIN"];
 
 msRestNodeAuth.interactiveLogin({{ tokenAudience: "https://graph.windows.net" }}).then((creds) => {
-  const client = new GraphRbacManagementClient(creds, subscriptionId, {
+  const client = new GraphRbacManagementClient(creds, tenantId, {
     baseUri: "https://graph.windows.net"
   });
   client.signedInUser.get().then((result) => {
@@ -68,7 +68,7 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
     <script src="node_modules/@azure/ms-rest-browserauth/dist/msAuth.js"></script>
     <script src="node_modules/@azure/graph/dist/graph.js"></script>
     <script type="text/javascript">
-      const subscriptionId = "<Subscription_Id>";
+      const tenantId = "<Tenant_Id>";
       const authManager = new msAuth.AuthManager({
         clientId: "<client id for your Azure AD app>",
         tenant: "<optional tenant for your organization>"
@@ -78,7 +78,7 @@ See https://github.com/Azure/ms-rest-browserauth to learn how to authenticate to
           // may cause redirects
           authManager.login();
         }
-        const client = new Azure.Graph.GraphRbacManagementClient(res.creds, subscriptionId, {
+        const client = new Azure.Graph.GraphRbacManagementClient(res.creds, tenantId, {
           baseUri: "https://graph.windows.net"
         });
         client.signedInUser.get().then((result) => {

--- a/sdk/graphrbac/graph/README.md
+++ b/sdk/graphrbac/graph/README.md
@@ -32,7 +32,10 @@ import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { GraphRbacManagementClient, GraphRbacManagementModels, GraphRbacManagementMappers } from "@azure/graph";
 const tenantId = process.env["DOMAIN"];
 
-msRestNodeAuth.interactiveLogin({ tokenAudience: "https://graph.windows.net" }).then((creds) => {
+msRestNodeAuth.interactiveLogin({ 
+  tokenAudience: "https://graph.windows.net",
+  domain: tenantId
+}).then((creds) => {
   const client = new GraphRbacManagementClient(creds, tenantId, {
     baseUri: "https://graph.windows.net"
   });

--- a/sdk/graphrbac/graph/README.md
+++ b/sdk/graphrbac/graph/README.md
@@ -32,7 +32,7 @@ import * as msRestNodeAuth from "@azure/ms-rest-nodeauth";
 import { GraphRbacManagementClient, GraphRbacManagementModels, GraphRbacManagementMappers } from "@azure/graph";
 const tenantId = process.env["DOMAIN"];
 
-msRestNodeAuth.interactiveLogin({{ tokenAudience: "https://graph.windows.net" }}).then((creds) => {
+msRestNodeAuth.interactiveLogin({ tokenAudience: "https://graph.windows.net" }).then((creds) => {
   const client = new GraphRbacManagementClient(creds, tenantId, {
     baseUri: "https://graph.windows.net"
   });


### PR DESCRIPTION
Code samples for the Graph client do not work as written. This PR updates the samples with the necessary changes for them to run.

- [x] Uses `tenantId` vs `subscriptionId` in Node and browser code examples
- [x] Removes extraneous curly brackets from Node example
- [x] Adds `domain` to `interactiveLogin` call in Node example