### PR TITLE
from tags added for test step

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -23,11 +23,11 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo)
         displayName: "Build libraries"
 
       - script: |
-          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargetsTo)
         displayName: "Pack libraries"
 
       - task: CopyFiles@2
@@ -82,7 +82,7 @@ jobs:
         displayName: "Install library dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js lint $(GeneratedPackageTargetsTo)
         displayName: "Lint libraries"
 
       - task: CopyFiles@2
@@ -100,7 +100,7 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)
 
       - script: |
-          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js audit $(GeneratedPackageTargetsTo)
         condition: and(succeeded(), eq(variables['RunNpmAudit'], 'true'))
         displayName: "Audit libraries"
 
@@ -160,13 +160,13 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js build --verbose $(GeneratedPackageTargetsTo) $(GeneratedPackageTargetsFrom)
         displayName: "Build libraries"
       - script: |
-          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js build:test --verbose $(GeneratedPackageTargetsFrom)
         displayName: "Build test assets"
       - script: |
-          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargets)
+          node common/scripts/install-run-rush.js unit-test --verbose $(GeneratedPackageTargetsFrom)
         displayName: "Test libraries"
 
       - task: PublishTestResults@2

--- a/eng/tools/select-packages/index.js
+++ b/eng/tools/select-packages/index.js
@@ -28,7 +28,8 @@ glob(filter, (err, files) => {
     process.exit(1);
   }
 
-  let packageTargets = "";
+  let packageTargetsTo = "";
+  let packageTargetsFrom = "";
 
   if (files) {
     log(`Found ${files.length} packages under service directory.`);
@@ -47,7 +48,8 @@ glob(filter, (err, files) => {
             packageContents["sdk-type"]
           }".`
         );
-        packageTargets += `--to "${packageContents.name}" `;
+        packageTargetsTo += `--to "${packageContents.name}" `;
+        packageTargetsFrom += `--from "${packageContents.name}" `;
       } else {
         log(
           `Package "${
@@ -58,18 +60,25 @@ glob(filter, (err, files) => {
     }
 
     log(
-      `Finished processing packages. Emitting variable using: ${packageTargets}`
+      `Finished processing packages. Emitting variable using: ${packageTargetsTo}`
     );
 
     // Can't use regular logging here because the pattern for Azure Pipelines requires ##vso to be the first chars.
     console.log(
-      `##vso[task.setvariable variable=GeneratedPackageTargets]${packageTargets}`
+      `##vso[task.setvariable variable=GeneratedpackageTargetsTo]${packageTargetsTo}`
     );
 
     log(
-      `Emitted variable "GeneratedPackageTargets" with content: ${packageTargets}`
+      `Emitted variable "GeneratedpackageTargetsTo" with content: ${packageTargetsTo}`
     );
 
+    console.log(
+      `##vso[task.setvariable variable=GeneratedPackageTargetsFrom]${packageTargetsFrom}`
+    );
+
+    log(
+      `Emitted variable "GeneratedPackageTargetsFrom" with content: ${packageTargetsFrom}`
+    );
   } else {
     log("Did not find any packages under service directory.");
     process.exit(2);


### PR DESCRIPTION
Related issue: #4350 
Since rush doesn't build all transitive dependencies with the `--from` tag, we cannot use the from tag with build step. We will try with the from tag with just the `test` step
Reference to earlier commit that had to be reverted - https://github.com/Azure/azure-sdk-for-js/commit/70563f408cd9753d11b9ce29a8434a8765300043
cc: @Azure/azure-sdk-eng 