### PR TITLE
[core-http] Reintroduce ServiceClientCredentials as an accepted credential type

### DIFF
--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
-    "@azure/core-auth": "1.0.0-preview.2",
+    "@azure/core-auth": "1.0.0-preview.3",
     "@types/async-lock": "^1.1.0",
     "@types/is-buffer": "^2.0.0",
     "async-lock": "^1.1.3",
@@ -72,7 +72,7 @@
     "rhea-promise": "^1.0.0"
   },
   "devDependencies": {
-    "@azure/identity": "1.0.0-preview.2",
+    "@azure/identity": "1.0.0-preview.3",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/debug": "^0.0.31",

--- a/sdk/core/core-arm/lib/azureServiceClient.ts
+++ b/sdk/core/core-arm/lib/azureServiceClient.ts
@@ -27,8 +27,8 @@ export interface AzureServiceClientOptions extends ServiceClientOptions {
  * Initializes a new instance of the AzureServiceClient class.
  * @constructor
  *
- * @param {TokenCredential | ServiceClientCredentials} credentials - The TokenCredential used for authentication.
- * @param {AzureServiceClientOptions} options - The parameter options used by AzureServiceClient
+ * @param credentials The credentials used for authentication with the service.
+ * @param options The parameter options used by AzureServiceClient.
  */
 export class AzureServiceClient extends ServiceClient {
   public acceptLanguage: string = Constants.DEFAULT_LANGUAGE;

--- a/sdk/core/core-arm/lib/azureServiceClient.ts
+++ b/sdk/core/core-arm/lib/azureServiceClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-import { HttpOperationResponse, OperationArguments, OperationSpec, RequestOptionsBase, RequestPrepareOptions, ServiceClient, ServiceClientOptions, TokenCredential, WebResource, getDefaultUserAgentValue as getDefaultUserAgentValueFromMsRest } from "@azure/core-http";
+import { HttpOperationResponse, OperationArguments, OperationSpec, RequestOptionsBase, RequestPrepareOptions, ServiceClient, ServiceClientCredentials, ServiceClientOptions, TokenCredential, WebResource, getDefaultUserAgentValue as getDefaultUserAgentValueFromMsRest } from "@azure/core-http";
 import { createLROPollerFromInitialResponse, createLROPollerFromPollState, LROPoller } from "./lroPoller";
 import { LROPollState } from "./lroPollStrategy";
 import * as Constants from "./util/constants";
@@ -27,7 +27,7 @@ export interface AzureServiceClientOptions extends ServiceClientOptions {
  * Initializes a new instance of the AzureServiceClient class.
  * @constructor
  *
- * @param {TokenCredential} credentials - The TokenCredential used for authentication.
+ * @param {TokenCredential | ServiceClientCredentials} credentials - The TokenCredential used for authentication.
  * @param {AzureServiceClientOptions} options - The parameter options used by AzureServiceClient
  */
 export class AzureServiceClient extends ServiceClient {
@@ -37,7 +37,7 @@ export class AzureServiceClient extends ServiceClient {
    */
   public longRunningOperationRetryTimeout?: number;
 
-  constructor(credentials: TokenCredential, options?: AzureServiceClientOptions) {
+  constructor(credentials: TokenCredential | ServiceClientCredentials, options?: AzureServiceClientOptions) {
     super(credentials, options = updateOptionsWithDefaultValues(options));
 
     // For convenience, if the credentials have an associated AzureEnvironment,

--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -91,7 +91,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-http": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/core/core-http/lib/coreHttp.ts
+++ b/sdk/core/core-http/lib/coreHttp.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-export { WebResource, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase, TransferProgressEvent, AbortSignalLike } from "./webResource";
+export { WebResource, HttpRequestBody, RequestPrepareOptions, HttpMethods, ParameterValue, RequestOptionsBase, TransferProgressEvent } from "./webResource";
 export { DefaultHttpClient } from "./defaultHttpClient";
 export { HttpClient } from "./httpClient";
 export { HttpHeaders } from "./httpHeaders";
@@ -41,6 +41,7 @@ export {
   applyMixins, isNode, isDuration
 } from "./util/utils";
 export { URLBuilder, URLQuery } from "./url";
+export { AbortSignalLike } from "@azure/abort-controller";
 
 // Credentials
 export { TokenCredential, GetTokenOptions, AccessToken, isTokenCredential, SimpleTokenCredential } from "@azure/core-auth";

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -133,8 +133,8 @@ export class ServiceClient {
   /**
    * The ServiceClient constructor
    * @constructor
-   * @param {TokenCredential} [credentials] The credentials object used for authentication.
-   * @param {ServiceClientOptions} [options] The service client options that govern the behavior of the client.
+   * @param credentials The credentials used for authentication with the service.
+   * @param options The service client options that govern the behavior of the client.
    */
   constructor(credentials?: TokenCredential | ServiceClientCredentials, options?: ServiceClientOptions) {
     if (!options) {

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -28,6 +28,8 @@ import { OperationResponse } from "./operationResponse";
 import { ServiceCallback } from "./util/utils";
 import { proxyPolicy, getDefaultProxySettings } from "./policies/proxyPolicy";
 import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
+import { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
+import { signingPolicy } from './policies/signingPolicy';
 
 
 /**
@@ -134,7 +136,7 @@ export class ServiceClient {
    * @param {TokenCredential} [credentials] The credentials object used for authentication.
    * @param {ServiceClientOptions} [options] The service client options that govern the behavior of the client.
    */
-  constructor(credentials?: TokenCredential, options?: ServiceClientOptions) {
+  constructor(credentials?: TokenCredential | ServiceClientCredentials, options?: ServiceClientOptions) {
     if (!options) {
       options = {};
     }
@@ -170,6 +172,8 @@ export class ServiceClient {
         };
 
         authPolicyFactory = wrappedPolicyFactory();
+      } else if (credentials && typeof credentials.signRequest === "function") {
+        authPolicyFactory = signingPolicy(credentials);
       } else if (credentials !== undefined) {
         throw new Error("The credentials argument must implement the TokenCredential interface");
       }

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -28,8 +28,6 @@ export type TransferProgressEvent = {
  */
 export interface AbortSignalLike {
   readonly aborted: boolean;
-  dispatchEvent: (event: Event) => boolean;
-  onabort: ((this: AbortSignalLike, ev: Event) => any) | null;
   addEventListener: (type: "abort", listener: (this: AbortSignalLike, ev: Event) => any, options?: any) => void;
   removeEventListener: (type: "abort", listener: (this: AbortSignalLike, ev: Event) => any, options?: any) => void;
 }

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -8,6 +8,7 @@ import { generateUuid } from "./util/utils";
 import { HttpOperationResponse } from "./httpOperationResponse";
 import { OperationResponse } from "./operationResponse";
 import { ProxySettings } from "./serviceClient";
+import { AbortSignalLike } from "@azure/abort-controller";
 
 export type HttpMethods = "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "HEAD" | "OPTIONS" | "TRACE";
 export type HttpRequestBody = Blob | string | ArrayBuffer | ArrayBufferView | (() => NodeJS.ReadableStream);
@@ -21,16 +22,6 @@ export type TransferProgressEvent = {
    */
   loadedBytes: number
 };
-
-/**
- * Allows the request to be aborted upon firing of the "abort" event.
- * Compatible with the browser built-in AbortSignal and common polyfills.
- */
-export interface AbortSignalLike {
-  readonly aborted: boolean;
-  addEventListener: (type: "abort", listener: (this: AbortSignalLike, ev: Event) => any, options?: any) => void;
-  removeEventListener: (type: "abort", listener: (this: AbortSignalLike, ev: Event) => any, options?: any) => void;
-}
 
 /**
  * Creates a new WebResource object.

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
-    "@azure/core-auth": "1.0.0-preview.2",
+    "@azure/core-auth": "1.0.0-preview.3",
     "@types/node-fetch": "^2.5.0",
     "@types/tunnel": "^0.0.1",
     "form-data": "^2.5.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -76,7 +76,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@azure/identity": "1.0.0-preview.2",
+    "@azure/identity": "1.0.0-preview.3",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "1.0.0-preview.2",
+  "version": "1.0.0-preview.3",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
@@ -70,7 +70,7 @@
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/identity/identity",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-http": "1.0.0-preview.3",
     "events": "^3.0.0",
     "jws": "~3.2.2",
     "msal": "~1.0.2",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -70,14 +70,14 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-arm": "1.0.0-preview.2",
-    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-arm": "1.0.0-preview.3",
+    "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.1",
     "@azure/core-tracing": "1.0.0-preview.1",
-    "@azure/identity": "1.0.0-preview.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@azure/identity": "1.0.0-preview.3",
     "@microsoft/api-extractor": "^7.1.5",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -68,11 +68,11 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-arm": "1.0.0-preview.2",
-    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-arm": "1.0.0-preview.3",
+    "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.1",
     "@azure/core-tracing": "1.0.0-preview.1",
-    "@azure/identity": "1.0.0-preview.2",
+    "@azure/identity": "1.0.0-preview.3",
     "tslib": "^1.9.3",
     "@trust/keyto": "0.3.7"
   },

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -69,10 +69,10 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
-    "@azure/core-arm": "1.0.0-preview.2",
-    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-arm": "1.0.0-preview.3",
+    "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.1",
-    "@azure/identity": "1.0.0-preview.2",
+    "@azure/identity": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -60,7 +60,7 @@
   "sideEffects": false,
   "private": true,
   "dependencies": {
-    "@azure/core-http": "1.0.0-preview.2",
+    "@azure/core-http": "1.0.0-preview.3",
     "events": "^3.0.0",
     "tslib": "^1.9.3"
   },


### PR DESCRIPTION
This change reintroduces the `ServiceClientCredentials` interface as an accepted credential type for `ServiceClient` classes.  This is necessary because libraries like @azure/app-configuration and the various Cognitive Services libraries need to use their own custom (non-AAD) authentication schemes.  Without this change, users of those libraries would have to construct their own RequestPolicy pipeline just so that the `signingPolicy` can be used.

Since this affects a bunch of libraries I went ahead and bumped the core dependency versions of our various libraries so that everything is up to date (@chradek, this will affect your tracing PR).