### PR TITLE
[Cosmos] Update .docsettings.yml to ignore cosmos/test/readme missing headers

### DIFF
--- a/.docsettings.yml
+++ b/.docsettings.yml
@@ -66,7 +66,7 @@ known_content_issues:
   - ["sdk/core/abort-controller/README.md", "#1583"]
   - ["sdk/core/core-auth/README.md", "#1583"]
   - ["sdk/cosmosdb/cosmos/README.md", "#1583"]
-  - ["sdk/cosmosdb/cosmos/src/test/readme.md", "#1583"]
+  - ["sdk/cosmosdb/cosmos/test/readme.md", "#1583"]
   - ["sdk/cosmosdb/cosmos/samples/readme.md", "#1583"]
   - ["sdk/cosmosdb/cosmos/samples/UserManagement/README.md", "#1583"]
   - ["sdk/cosmosdb/cosmos/samples/TodoApp/readme.md", "#1583"]

--- a/.docsettings.yml
+++ b/.docsettings.yml
@@ -5,6 +5,7 @@ omitted_paths:
   - "sdk/*/arm-*"
   - "sdk/cognitiveservices/*"
   - "sdk/identity/identity/test/manual/*"
+  - "sdk/cosmosdb/cosmos/samples/*"
 language: js
 root_check_enabled: True
 required_readme_sections:


### PR DESCRIPTION
Build failed because of the missing headers in test/readme

```
sdk/cosmosdb/cosmos/test/readme.md is missing headers with patterns: 

 * ^Azure (.+ client library for (JS|AMQP operations)|Smoke Test for JS) 

 * ^Getting started$ 

 * ^Key concepts$ 

 * ^Examples$ 

 * ^Troubleshooting$ 

 * ^Next steps$ 

 * ^Contributing$
```

Ignore readme for now.
Later, update Readme.md files by adding the missing headers - Issue to track #4799