### PR TITLE
Replace mocha-multi-reporters with mocha-multi

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -119,7 +119,6 @@ dependencies:
   mocha-chrome: 2.0.0
   mocha-junit-reporter: 1.23.1_mocha@5.2.0
   mocha-multi: 1.1.0_mocha@5.2.0
-  mocha-multi-reporters: 1.1.7
   moment: 2.24.0
   msal: 1.1.3
   nise: 1.5.1
@@ -6187,13 +6186,6 @@ packages:
       mocha: '>=2.2.5'
     resolution:
       integrity: sha512-qeDvKlZyAH2YJE1vhryvjUQ06t2hcnwwu4k5Ddwn0GQINhgEYFhlGM0DwYCVUHq5cuo32qAW6HDsTHt7zz99Ng==
-  /mocha-multi-reporters/1.1.7:
-    dependencies:
-      debug: 3.2.6
-      lodash: 4.17.15
-    dev: false
-    resolution:
-      integrity: sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=
   /mocha-multi/1.1.0_mocha@5.2.0:
     dependencies:
       debug: 3.2.6
@@ -9661,7 +9653,7 @@ packages:
       karma-remap-coverage: 0.1.5_karma-coverage@1.1.2
       mocha: 5.2.0
       mocha-junit-reporter: 1.23.1_mocha@5.2.0
-      mocha-multi-reporters: 1.1.7
+      mocha-multi: 1.1.0_mocha@5.2.0
       nyc: 14.1.1
       prettier: 1.18.2
       rimraf: 2.7.1
@@ -9678,7 +9670,7 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-BoVxHViVS71lSi8IASIY6SKhDSjSoG1xLh/P1D8yG0LGNECg2BU9pm2WwXs5qIOWtg5+zIvJqA4YAWK7F/d0Ig==
+      integrity: sha512-LIc9cJYm9NCHuKFc7fCv6UZSd/WjF/pnCcp0yx2xDGDvKNu/uC1c8lXZ8fhnvhbfprqYaZEExq3qe4/Sdcdv/g==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
@@ -9764,7 +9756,7 @@ packages:
       eslint-plugin-promise: 4.2.1
       mocha: 5.2.0
       mocha-junit-reporter: 1.23.1_mocha@5.2.0
-      mocha-multi-reporters: 1.1.7
+      mocha-multi: 1.1.0_mocha@5.2.0
       npm-run-all: 4.1.5
       nyc: 14.1.1
       rimraf: 2.7.1
@@ -9781,7 +9773,7 @@ packages:
     dev: false
     name: '@rush-temp/core-arm'
     resolution:
-      integrity: sha512-JI2m7cTc6e8DV1ZOYmMgkdnbj8z8l1HAYfLblLd+ZztiDP4AMw9BxO1oDkbKorhCKJbY4g/uU/mwqqSCBv3pbw==
+      integrity: sha512-D3RlRvLMQwrLhsqM6Tjnxl9/594t3IFI1AZSjOyomQf0Z2BvHfgg61tCLHYEuBWAJCwNK7WE68+JezcRs47OIA==
       tarball: 'file:projects/core-arm.tgz'
     version: 0.0.0
   'file:projects/core-asynciterator-polyfill.tgz':
@@ -9883,7 +9875,7 @@ packages:
       mocha: 5.2.0
       mocha-chrome: 2.0.0
       mocha-junit-reporter: 1.23.1_mocha@5.2.0
-      mocha-multi-reporters: 1.1.7
+      mocha-multi: 1.1.0_mocha@5.2.0
       node-fetch: 2.6.0
       npm-run-all: 4.1.5
       nyc: 14.1.1
@@ -9920,7 +9912,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-pIlwOcrF8c5S7GeL8kjCnhUlwKvycLA8fEHlgz7YBXT8nP13TlR7FCTZJ//NXQ4YjOelX9hhr+nHuQz8s87LRg==
+      integrity: sha512-ph0PlxxS+dylhINIHyIFphskvAO7gHAKF52Y7kvARK/iMPTyTzH7bMXoL7gQG4fuM+kE39BblS8F5iwdvLyLDw==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -10847,7 +10839,6 @@ specifiers:
   mocha-chrome: ^2.0.0
   mocha-junit-reporter: ^1.18.0
   mocha-multi: 1.1.0
-  mocha-multi-reporters: ^1.1.7
   moment: ^2.24.0
   msal: ^1.0.2
   nise: ^1.4.10

--- a/sdk/core/abort-controller/mocha.reporter.config.json
+++ b/sdk/core/abort-controller/mocha.reporter.config.json
@@ -1,6 +1,0 @@
-{
-  "reporterEnabled": "spec, mocha-junit-reporter",
-  "mochaJunitReporterReporterOptions": {
-    "mochaFile": "test-results.xml"
-  }
-}

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -30,7 +30,7 @@
     "test:node": "npm run build:test && npm run unit-test:node && npm run integration-test:node",
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "karma start --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\": \\\"commonjs\\\"}\" mocha --require ts-node/register --require source-map-support/register --reporter mocha-multi-reporters --reporter-options configFile=mocha.reporter.config.json --full-trace --no-timeouts test/*.spec.ts",
+    "unit-test:node": "cross-env TS_NODE_FILES=true TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\": \\\"commonjs\\\"}\" mocha --require ts-node/register --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace --no-timeouts test/*.spec.ts",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "types": "./types/src/aborter.d.ts",
@@ -96,7 +96,7 @@
     "karma-remap-coverage": "^0.1.5",
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.18.0",
-    "mocha-multi-reporters": "^1.1.7",
+    "mocha-multi": "1.1.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
     "rimraf": "^2.6.2",

--- a/sdk/core/core-arm/mocha.config.json
+++ b/sdk/core/core-arm/mocha.config.json
@@ -1,3 +1,0 @@
-{
-  "reporterEnabled": "list, mocha-junit-reporter"
-}

--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -108,7 +108,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.18.0",
-    "mocha-multi-reporters": "^1.1.7",
+    "mocha-multi": "1.1.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.0.0",
     "rimraf": "^2.6.2",

--- a/sdk/core/core-arm/test/mocha.opts
+++ b/sdk/core/core-arm/test/mocha.opts
@@ -1,6 +1,6 @@
 --require ts-node/register
 --timeout 50000
---reporter mocha-multi-reporters
---reporter-options configFile=mocha.config.json
+--reporter mocha-multi
+--reporter-options spec=-,mocha-junit-reporter=-
 --colors
 test/**/*.ts

--- a/sdk/core/core-http/mocha.config.json
+++ b/sdk/core/core-http/mocha.config.json
@@ -1,3 +1,0 @@
-{
-  "reporterEnabled": "list, mocha-junit-reporter"
-}

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -162,7 +162,7 @@
     "mocha": "^5.2.0",
     "mocha-chrome": "^2.0.0",
     "mocha-junit-reporter": "^1.18.0",
-    "mocha-multi-reporters": "^1.1.7",
+    "mocha-multi": "1.1.0",
     "npm-run-all": "^4.1.5",
     "nyc": "^14.0.0",
     "puppeteer": "^1.11.0",

--- a/sdk/core/core-http/test/mocha.opts
+++ b/sdk/core/core-http/test/mocha.opts
@@ -1,6 +1,6 @@
 --require ts-node/register
 --timeout 50000
---reporter mocha-multi-reporters
---reporter-options configFile=mocha.config.json
+--reporter mocha-multi
+--reporter-options spec=-,mocha-junit-reporter=-
 --colors
 test/**/*.ts

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -37,7 +37,7 @@
     "bundle": "rollup -c",
     "bundle-types": "node bundle-types.js",
     "build": "npm run clean && npm run check-format && npm run lint && npm run compile && node writeSDKVersion.js && npm run docs && npm run bundle && npm run bundle-types",
-    "test": "tsc -b src test --verbose && mocha -r esm -r dotenv/config -r ./test/common/setup.js \"./test/**/*.spec.js\" --timeout 100000",
+    "test": "tsc -b src test --verbose && mocha --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- -r esm -r dotenv/config -r ./test/common/setup.js \"./test/**/*.spec.js\" --timeout 100000",
     "prepack": "npm install && npm run build",
     "test-browser": "karma start ./karma.config.js --single-run",
     "test-consumer": "node consumer-test.js"
@@ -70,7 +70,7 @@
     "karma-webpack": "^3.0.5",
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "1.23.1",
-    "mocha-multi-reporters": "^1.1.6",
+    "mocha-multi": "1.1.0",
     "prettier": "1.14.3",
     "proxy-agent": "3.0.3",
     "requirejs": "^2.3.5",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -54,7 +54,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --timeout 1200000 --reporter-options spec=-,mocha-junit-reporter=- --full-trace dist-test/index.node.js",
+    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 1200000 --full-trace dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint \"src/**/*.ts\" -c ../../.eslintrc.json --fix --fix-type [problem,suggestion]",
     "lint": "eslint -c ../../.eslintrc.json src tests samples --ext .ts -f html -o keyvault-certificates-lintReport.html || exit 0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -51,7 +51,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"tests/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --timeout 1200000 --reporter-options spec=-,mocha-junit-reporter=- --full-trace dist-test/index.node.js",
+    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 1200000 --full-trace dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.json src tests samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint -c ../../.eslintrc.json src tests samples --ext .ts -f html -o keyvault-keys-lintReport.html || exit 0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -51,7 +51,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"tests/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --timeout 1200000 --reporter-options spec=-,mocha-junit-reporter=- --full-trace dist-test/index.node.js",
+    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 1200000 --full-trace dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.json src tests samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint -c ../../.eslintrc.json src tests samples --ext .ts -f html -o keyvault-secrets-lintReport.html || exit 0",


### PR DESCRIPTION
- All packages
  - "mocha-multi-reporters" was replaced with "mocha-multi" to align with repo standard
- core-arm, core-http
  - Reporter "list" was replaced with "spec" to align with repo standard
- keyvault-*
  - Command-line options were moved to align with repo standard
