### PR TITLE
Make recorder test selection compatible with mocha@6

### DIFF
--- a/sdk/keyvault/keyvault-certificates/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-certificates/tests/utils/recorder.ts
@@ -391,7 +391,7 @@ export function record(testContext: any): any {
   let testHierarchy: string;
   let testTitle: string;
 
-  if (testContext.currentTest) {
+  if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;
   } else {

--- a/sdk/keyvault/keyvault-certificates/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-certificates/tests/utils/recorder.ts
@@ -391,6 +391,10 @@ export function record(testContext: any): any {
   let testHierarchy: string;
   let testTitle: string;
 
+  // In a hook ("before all" or "before each"), testContext.test points to the hook, while testContext.currentTest
+  // points to the individual test that will be run next.  A "before all" hook is run once before all tests,
+  // so the hook itself should be used to identify recordings.  However, a "before each" hook is run once before each
+  // test, so the individual test should be used instead.
   if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;

--- a/sdk/keyvault/keyvault-keys/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-keys/tests/utils/recorder.ts
@@ -391,7 +391,7 @@ export function record(testContext: any): any {
   let testHierarchy: string;
   let testTitle: string;
 
-  if (testContext.currentTest) {
+  if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;
   } else {

--- a/sdk/keyvault/keyvault-keys/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-keys/tests/utils/recorder.ts
@@ -391,6 +391,10 @@ export function record(testContext: any): any {
   let testHierarchy: string;
   let testTitle: string;
 
+  // In a hook ("before all" or "before each"), testContext.test points to the hook, while testContext.currentTest
+  // points to the individual test that will be run next.  A "before all" hook is run once before all tests,
+  // so the hook itself should be used to identify recordings.  However, a "before each" hook is run once before each
+  // test, so the individual test should be used instead.
   if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;

--- a/sdk/keyvault/keyvault-secrets/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-secrets/tests/utils/recorder.ts
@@ -392,6 +392,10 @@ export function record(testContext: any): any {
   let testHierarchy: string;
   let testTitle: string;
 
+  // In a hook ("before all" or "before each"), testContext.test points to the hook, while testContext.currentTest
+  // points to the individual test that will be run next.  A "before all" hook is run once before all tests,
+  // so the hook itself should be used to identify recordings.  However, a "before each" hook is run once before each
+  // test, so the individual test should be used instead.
   if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;

--- a/sdk/keyvault/keyvault-secrets/tests/utils/recorder.ts
+++ b/sdk/keyvault/keyvault-secrets/tests/utils/recorder.ts
@@ -392,7 +392,7 @@ export function record(testContext: any): any {
   let testHierarchy: string;
   let testTitle: string;
 
-  if (testContext.currentTest) {
+  if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;
   } else {

--- a/sdk/storage/storage-blob/test/utils/recorder.ts
+++ b/sdk/storage/storage-blob/test/utils/recorder.ts
@@ -413,6 +413,10 @@ export function record(testContext: any) {
   let testHierarchy: string;
   let testTitle: string;
 
+  // In a hook ("before all" or "before each"), testContext.test points to the hook, while testContext.currentTest
+  // points to the individual test that will be run next.  A "before all" hook is run once before all tests,
+  // so the hook itself should be used to identify recordings.  However, a "before each" hook is run once before each
+  // test, so the individual test should be used instead.
   if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;

--- a/sdk/storage/storage-blob/test/utils/recorder.ts
+++ b/sdk/storage/storage-blob/test/utils/recorder.ts
@@ -413,7 +413,7 @@ export function record(testContext: any) {
   let testHierarchy: string;
   let testTitle: string;
 
-  if (testContext.currentTest) {
+  if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;
   } else {

--- a/sdk/storage/storage-file/test/utils/recorder.ts
+++ b/sdk/storage/storage-file/test/utils/recorder.ts
@@ -407,6 +407,10 @@ export function record(testContext: any) {
   let testHierarchy: string;
   let testTitle: string;
 
+  // In a hook ("before all" or "before each"), testContext.test points to the hook, while testContext.currentTest
+  // points to the individual test that will be run next.  A "before all" hook is run once before all tests,
+  // so the hook itself should be used to identify recordings.  However, a "before each" hook is run once before each
+  // test, so the individual test should be used instead.
   if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;

--- a/sdk/storage/storage-file/test/utils/recorder.ts
+++ b/sdk/storage/storage-file/test/utils/recorder.ts
@@ -407,7 +407,7 @@ export function record(testContext: any) {
   let testHierarchy: string;
   let testTitle: string;
 
-  if (testContext.currentTest) {
+  if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;
   } else {

--- a/sdk/storage/storage-queue/test/utils/recorder.ts
+++ b/sdk/storage/storage-queue/test/utils/recorder.ts
@@ -365,7 +365,7 @@ export function record(testContext: any) {
   let testHierarchy: string;
   let testTitle: string;
 
-  if (testContext.currentTest) {
+  if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;
   } else {

--- a/sdk/storage/storage-queue/test/utils/recorder.ts
+++ b/sdk/storage/storage-queue/test/utils/recorder.ts
@@ -365,6 +365,10 @@ export function record(testContext: any) {
   let testHierarchy: string;
   let testTitle: string;
 
+  // In a hook ("before all" or "before each"), testContext.test points to the hook, while testContext.currentTest
+  // points to the individual test that will be run next.  A "before all" hook is run once before all tests,
+  // so the hook itself should be used to identify recordings.  However, a "before each" hook is run once before each
+  // test, so the individual test should be used instead.
   if (testContext.test.type == "hook" && testContext.test.title.includes("each")) {
     testHierarchy = testContext.currentTest.parent.fullTitle();
     testTitle = testContext.currentTest.title;


### PR DESCRIPTION
- The behavior of `testContext` changed slightly between mocha v5 and v6.
  - In mocha v5, `testContext.currentTest` was null for "before all" hooks, so it could be used to disambiguate between "before all" and "before each" hooks.
  - In mocha v6, `testContext.currentTest` points to the individual test that will be run next, for both "before all" and "before each" hooks.
- The new test selection logic is compatible with both mocha v5 and v6
