### PR TITLE
Improve performance of CopyFiles

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -30,6 +30,8 @@ jobs:
           node common/scripts/install-run-rush.js pack --verbose $(GeneratedPackageTargetsTo)
         displayName: "Pack libraries"
 
+      # It's important for performance to pass "sdk" as "sourceFolder" rather than as a prefix in "contents".
+      # The task first enumerates all files under "sourceFolder", then matches them against the "contents" pattern.
       - task: CopyFiles@2
         inputs:
           sourceFolder: sdk
@@ -86,6 +88,8 @@ jobs:
           node common/scripts/install-run-rush.js lint $(GeneratedPackageTargetsTo)
         displayName: "Lint libraries"
 
+      # It's important for performance to pass "sdk" as "sourceFolder" rather than as a prefix in "contents".
+      # The task first enumerates all files under "sourceFolder", then matches them against the "contents" pattern.
       - task: CopyFiles@2
         inputs:
           sourceFolder: sdk

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -32,9 +32,10 @@ jobs:
 
       - task: CopyFiles@2
         inputs:
+          sourceFolder: sdk
           contents: |
-            sdk/**/$(coalesceResultFilter)/*.tgz
-            sdk/**/$(coalesceResultFilter)/browser/*.zip
+            **/$(coalesceResultFilter)/*.tgz
+            **/$(coalesceResultFilter)/browser/*.zip
           targetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
         displayName: "Copy packages"
@@ -87,7 +88,8 @@ jobs:
 
       - task: CopyFiles@2
         inputs:
-          contents: "sdk/**/**/*lintReport.html"
+          sourceFolder: sdk
+          contents: "**/**/*lintReport.html"
           targetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
         displayName: "Copy lint reports"


### PR DESCRIPTION
- Move "sdk" from "contents" to "sourceFolder"
- Logically equivalent to the previous configuration
- Improves perf because the "sourceFolder" filter is applied before the "contents" filter
- Without this change, CopyFiles can fail with an out-of-memory error in large repos
- Fixes #4847
