### PR TITLE
[Record and Playback] Update lint step in the test-utils-recorder

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -23,7 +23,7 @@
     "integration-test:node": "echo skipped",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint \"src/**/*.ts\" \"test/**/*.ts\" -c ../../.eslintrc.json --fix --fix-type [problem,suggestion]",
-    "lint": "eslint -c ../../.eslintrc.json src test --ext .ts -f node_modules/eslint-detailed-reporter/lib/detailed.js -o template-lintReport.html || exit 0",
+    "lint": "eslint -c ../../.eslintrc.json src test --ext .ts -f html -o recorder-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",


### PR DESCRIPTION
Build failed for the PR https://github.com/Azure/azure-sdk-for-js/pull/4883 when test-utils-recorder is imported in keyvault packages because of the outdated lint step.
Thanks to @KarishmaGhiya for helping.


/cc - @sadasant 

 