### PR TITLE
[Service Bus] Increase timeout for settling msgs to 60sec #3764

### DIFF
--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -25,7 +25,6 @@ import { ClientEntityContext } from "../clientEntityContext";
 import { ServiceBusMessage, DispositionType, ReceiveMode } from "../serviceBusMessage";
 import { getUniqueName, calculateRenewAfterDuration } from "../util/utils";
 import { MessageHandlerOptions } from "./streamingReceiver";
-import { messageDispositionTimeout } from "../util/constants";
 
 /**
  * @internal
@@ -1021,7 +1020,7 @@ export class MessageReceiver extends LinkEntity {
             "Hence rejecting the promise with timeout error.",
           this._context.namespace.connectionId,
           delivery.id,
-          messageDispositionTimeout
+          Constants.defaultOperationTimeoutInSeconds
         );
 
         const e: AmqpError = {
@@ -1031,7 +1030,7 @@ export class MessageReceiver extends LinkEntity {
             "message may or may not be successful"
         };
         return reject(translate(e));
-      }, messageDispositionTimeout);
+      }, Constants.defaultOperationTimeoutInSeconds);
       this._deliveryDispositionMap.set(delivery.id, {
         resolve: resolve,
         reject: reject,

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -30,7 +30,6 @@ import { ClientEntityContext } from "../clientEntityContext";
 import { convertTicksToDate, calculateRenewAfterDuration } from "../util/utils";
 import { throwErrorIfConnectionClosed } from "../util/errors";
 import { ServiceBusMessage, DispositionType, ReceiveMode } from "../serviceBusMessage";
-import { messageDispositionTimeout } from "../util/constants";
 
 /**
  * Enum to denote who is calling the session receiver
@@ -1159,7 +1158,7 @@ export class MessageSession extends LinkEntity {
             "Hence rejecting the promise with timeout error",
           this._context.namespace.connectionId,
           delivery.id,
-          messageDispositionTimeout
+          Constants.defaultOperationTimeoutInSeconds
         );
 
         const e: AmqpError = {
@@ -1169,7 +1168,7 @@ export class MessageSession extends LinkEntity {
             "message may or may not be successful"
         };
         return reject(translate(e));
-      }, messageDispositionTimeout);
+      }, Constants.defaultOperationTimeoutInSeconds);
       this._deliveryDispositionMap.set(delivery.id, {
         resolve: resolve,
         reject: reject,

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -6,6 +6,5 @@ export const packageJsonInfo = {
   version: "1.0.3"
 };
 
-export const messageDispositionTimeout = 20000;
 
 export const max32BitNumber = Math.pow(2, 31) - 1;


### PR DESCRIPTION
We currently have a timeout of 20 seconds for the message settle operation.
If the service does not acknowledge the result of the operation by then, we throw a timeout error.

It turns out that 60 sec is the default operation timeout to be used as per the libraries in other languages and as per the suggestion from the service team.

This PR makes this change for the timeout.

Related issue: #3764 