### PR TITLE
[Identity] Fix IMDS endpoint detection false positive

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -136,7 +136,10 @@ export class ManagedIdentityCredential implements TokenCredential {
     try {
       await this.identityClient.sendRequest(webResource);
     } catch (err) {
-      if (err instanceof RestError && err.code === RestError.REQUEST_SEND_ERROR) {
+      if (
+        err instanceof RestError &&
+        (err.code === RestError.REQUEST_SEND_ERROR || err.code === RestError.REQUEST_ABORTED_ERROR)
+      ) {
         // Either request failed or IMDS endpoint isn't available
         return false;
       }


### PR DESCRIPTION
If the IMDS endpoint was not available, the request would time out, but this error code was not handled resulting in a false detection of the IMDS endpoint.