### PR TITLE
list-files break when trailing coma+end array|obj

### DIFF
--- a/common/scripts/list-files.js
+++ b/common/scripts/list-files.js
@@ -8,7 +8,8 @@ function read(filename) {
     .replace(/\n/gm, "«")
     .replace(/\/\*.*?\*\//gm, "")
     .replace(/«/gm, "\n")
-    .replace(/\s+\/\/.*/g, "");
+    .replace(/\s+\/\/.*/g, "")
+    .replace(/,[\s\n\r]+(\}|\])/g, "$1");
   return JSON.parse(txt);
 }
 


### PR DESCRIPTION
**Status** let's close this PR in favor of #4915 

---

When rush.json has commented line just before closing an object/array, and the lines above the comments has a trailing coma, `list-files` breaks.

One more RegEx to solve it.