### PR TITLE
[Luis runtime] Update package version in user agent string

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-luis-runtime/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-luis-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-luis-runtime",
   "author": "Microsoft Corporation",
   "description": "LUISRuntimeClient Library with typescript type definitions for node.js and browser.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.3",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-luis-runtime/src/lUISRuntimeClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-runtime/src/lUISRuntimeClientContext.ts
@@ -10,7 +10,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-luis-runtime";
-const packageVersion = "3.0.1";
+const packageVersion = "4.0.1";
 
 export class LUISRuntimeClientContext extends msRest.ServiceClient {
   endpoint: string;


### PR DESCRIPTION
We released version 4.0.0 of luis runtime as part of #4791 but forgot to update the user agent string.
This PR attempts to fix the user agent string