### PR TITLE
[Luis authoring] Update package version in user agent string

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-luis-authoring",
   "author": "Microsoft Corporation",
   "description": "LUISAuthoringClient Library with typescript type definitions for node.js and browser.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.3",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-luis-authoring/src/lUISAuthoringClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-luis-authoring/src/lUISAuthoringClientContext.ts
@@ -10,7 +10,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-luis-authoring";
-const packageVersion = "2.1.0";
+const packageVersion = "3.0.1";
 
 export class LUISAuthoringClientContext extends msRest.ServiceClient {
   endpoint: string;


### PR DESCRIPTION
We released version 3.0.0 of luis runtime as part of #4792 but forgot to update the user agent string.
This PR attempts to fix the user agent string