### PR TITLE
[Service Bus] Use timer for entire receiveMessages operation

### DIFF
--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -78,7 +78,7 @@ export class BatchingReceiver extends MessageReceiver {
 
     this.isReceivingMessages = true;
     return new Promise<ServiceBusMessage[]>((resolve, reject) => {
-      let firstMessageWaitTimer: NodeJS.Timer | undefined;
+      let totalWaitTimer: NodeJS.Timer | undefined;
 
       const onSessionError: OnAmqpEvent = (context: EventContext) => {
         this.isReceivingMessages = false;
@@ -99,8 +99,8 @@ export class BatchingReceiver extends MessageReceiver {
             error
           );
         }
-        if (firstMessageWaitTimer) {
-          clearTimeout(firstMessageWaitTimer);
+        if (totalWaitTimer) {
+          clearTimeout(totalWaitTimer);
         }
         if (this._newMessageReceivedTimer) {
           clearTimeout(this._newMessageReceivedTimer);
@@ -113,8 +113,8 @@ export class BatchingReceiver extends MessageReceiver {
         if (this._newMessageReceivedTimer) {
           clearTimeout(this._newMessageReceivedTimer);
         }
-        if (firstMessageWaitTimer) {
-          clearTimeout(firstMessageWaitTimer);
+        if (totalWaitTimer) {
+          clearTimeout(totalWaitTimer);
         }
 
         // Removing listeners, so that the next receiveMessages() call can set them again.
@@ -162,10 +162,6 @@ export class BatchingReceiver extends MessageReceiver {
 
       // Action to be performed on the "message" event.
       const onReceiveMessage: OnAmqpEventAsPromise = async (context: EventContext) => {
-        if (firstMessageWaitTimer) {
-          clearTimeout(firstMessageWaitTimer);
-          firstMessageWaitTimer = undefined;
-        }
         this.resetTimerOnNewMessageReceived();
         try {
           const data: ServiceBusMessage = new ServiceBusMessage(
@@ -274,8 +270,8 @@ export class BatchingReceiver extends MessageReceiver {
             error
           );
         }
-        if (firstMessageWaitTimer) {
-          clearTimeout(firstMessageWaitTimer);
+        if (totalWaitTimer) {
+          clearTimeout(totalWaitTimer);
         }
         if (this._newMessageReceivedTimer) {
           clearTimeout(this._newMessageReceivedTimer);
@@ -368,7 +364,7 @@ export class BatchingReceiver extends MessageReceiver {
         let msg: string = "[%s] Setting the wait timer for %d seconds for receiver '%s'.";
         if (reuse) msg += " Receiver link already present, hence reusing it.";
         log.batching(msg, this._context.namespace.connectionId, idleTimeoutInSeconds, this.name);
-        firstMessageWaitTimer = setTimeout(
+        totalWaitTimer = setTimeout(
           actionAfterWaitTimeout,
           (idleTimeoutInSeconds as number) * 1000
         );


### PR DESCRIPTION
The `receiveMessages()` call uses 2 timers internally
- The first is configurable by the user and is meant to be the max time that can be taken by the operation. Default is 60 seconds
- The second is hard-coded to 1 second. This timer gets reset every time a new message is received internally. This timer exists so that we don't wait too much for subsequent messages and return as soon as possible with non zero number of messages.

Currently we unset the first timer after receiving the first message.

Due to this, as long as a new message received within 1 second of the old message, we continue to receive messages until maxMessageCount is hit and the user provided timeout gets ignored.

In PeekLock mode, this problem is not seen much as the messages are received much faster than in ReceiveAndDelete mode. This problem is very much evident when we call `receiveMessages(2000)` in ReceiveAndDelete mode. 

This is the root cause for #4748

Now, why is receiving in ReceiveAndDelete mode is slower than PeekLock mode needs to be investigated. But this PR will at least ensure that the `receiveMessages()` call will respect the overall timeout value
