### PR TITLE
[Service Bus] Use new name for receiver only if creating a new receiver

### DIFF
--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -766,6 +766,11 @@ export class MessageReceiver extends LinkEntity {
           this.name,
           this.address
         );
+
+        if (options && options.name) {
+          this.name = options.name;
+        }
+
         this.isConnecting = true;
         await this._negotiateClaim();
         if (!options) {
@@ -917,19 +922,9 @@ export class MessageReceiver extends LinkEntity {
         );
       }
       if (shouldReopen) {
-        const disconnectedReceiverName = this.name;
         // provide a new name to the link while re-connecting it. This ensures that
         // the service does not send an error stating that the link is still open.
         const options: ReceiverOptions = this._createReceiverOptions(true);
-
-        this.name = options.name!;
-
-        log.receiver(
-          "[%s] Closing the disconnected Receiver '%s' and creating a new one with the name '%s'",
-          this._context.namespace.connectionId,
-          disconnectedReceiverName,
-          this.name
-        );
 
         // shall retry forever at an interval of 15 seconds if the error is a retryable error
         // else bail out when the error is not retryable or the oepration succeeds.


### PR DESCRIPTION
The `onDetached()` can be called multiple times on the same receiver. One such cases is when both a `receiver_close` and `session_close` event is fired.

In such cases, only one of the `onDetached()` calls should result in `init()` creating a new receiver link. This is handled today by the `isConnecting` boolean property which we use to ensure that when a new receiver is being created, another call to `init()` becomes a no-op.

But, since we update the `name` regardless of whether `init()` is creating a new link or it is a no-op, we can end up in a situation where the `name` property of the receiver is not the same name as the actual underlying receiver. This results in all message settlement request failing as the name of the receiver on the message will never match the name of the receiver in the clientEntityContext.

This PR fixes this issue by ensuring that the `name` is updated only when `init()` decides to create a new link 