### PR TITLE
[Storage] Add missing files in `types` and `typings` folders for comsos

### DIFF
--- a/sdk/cosmosdb/cosmos/src/typings/atob.d.ts
+++ b/sdk/cosmosdb/cosmos/src/typings/atob.d.ts
@@ -1,0 +1,4 @@
+declare module "atob" {
+  const _atob: typeof atob;
+  export = _atob;
+}

--- a/sdk/cosmosdb/cosmos/src/typings/binary-search-bounds.d.ts
+++ b/sdk/cosmosdb/cosmos/src/typings/binary-search-bounds.d.ts
@@ -1,0 +1,4 @@
+declare module "binary-search-bounds" {
+  const _bs: any;
+  export = _bs;
+}

--- a/sdk/cosmosdb/cosmos/test/types/proxy-agent.ts
+++ b/sdk/cosmosdb/cosmos/test/types/proxy-agent.ts
@@ -1,0 +1,11 @@
+declare module "proxy-agent" {
+  import { Agent } from "http";
+  interface ProxyAgentConstructor {
+    (options: string): Agent;
+    new (options: string): Agent;
+  }
+
+  const proxy: ProxyAgentConstructor;
+
+  export = proxy;
+}


### PR DESCRIPTION
Build failed in the feature/storage branch because of the missing files in `types` and `typings` folders resulted from merging the mater.
This PR attempts to add the files and fix the build.