### PR TITLE
[core-http] Add text/plain to accepted MIME types for JSON output

### DIFF
--- a/sdk/core/core-http/lib/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/deserializationPolicy.ts
@@ -41,7 +41,7 @@ export function deserializationPolicy(deserializationContentTypes?: Deserializat
   };
 }
 
-export const defaultJsonContentTypes = ["application/json", "text/json"];
+export const defaultJsonContentTypes = ["application/json", "text/json", "text/plain"];
 export const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 
 /**


### PR DESCRIPTION
This is an attempt to fix #4844.  Leaving it as a draft to open conversation about possible implications of adding text/plain as an accepted MIME type.
