### PR TITLE
[amqp-common] Remove ms-rest-node-auth dependency from getting included in final bundling

### DIFF
--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,3 +1,7 @@
+### 2019-9-11 1.0.0-preview.7
+
+- Removes dependency on `ms-rest-node-auth` package. The `credentials` passed in to constructor of `AadTokenProvider` is expected to implement `getToken()` method. [PR 5010](https://github.com/Azure/azure-sdk-for-js/pull/5010)
+
 ### 2019-7-3 1.0.0-preview.6
 
 - Include bug fix where token audience was being set to work only with Event Hubs. The appropriate token audience now needs to be explicitly set on the credentials at time of creation. [PR 4098](https://github.com/Azure/azure-sdk-for-js/pull/4098)

--- a/sdk/core/amqp-common/package.json
+++ b/sdk/core/amqp-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/amqp-common",
   "sdk-type": "client",
-  "version": "1.0.0-preview.6",
+  "version": "1.0.0-preview.7",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/amqp-common/src/auth/aad.ts
+++ b/sdk/core/amqp-common/src/auth/aad.ts
@@ -45,16 +45,7 @@ export class AadTokenProvider implements TokenProvider {
       | DeviceTokenCredentials
       | MSITokenCredentials
   ) {
-    if (
-      !credentials ||
-      (credentials &&
-        !(
-          credentials instanceof ApplicationTokenCredentials ||
-          credentials instanceof UserTokenCredentials ||
-          credentials instanceof DeviceTokenCredentials ||
-          credentials instanceof MSITokenCredentials
-        ))
-    ) {
+    if (!credentials || typeof credentials.getToken !== "function" ) {
       throw new TypeError(
         "'credentials' is a required parameter and must be an instance of " +
           "ApplicationTokenCredentials | UserTokenCredentials | DeviceTokenCredentials | MSITokenCredentials."


### PR DESCRIPTION
For more context refer to #4927 
This PR updates amqp-common and introduces the `TokenCredentialInterface` for use within amqp-common and dependents.