### PR TITLE
Move the proxy to the last step of pipeline

### DIFF
--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -115,11 +115,6 @@ export class CertificatesClient {
     const userAgentString: string = CertificatesClient.getUserAgentString(pipelineOptions.telemetry);
 
     let requestPolicyFactories: RequestPolicyFactory[] = [];
-    if (isNode) {
-      requestPolicyFactories.push(
-        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
-      );
-    }
     requestPolicyFactories = requestPolicyFactories.concat([
       userAgentPolicy({ value: userAgentString }),
       generateClientRequestIdPolicy(),
@@ -137,6 +132,11 @@ export class CertificatesClient {
         ? challengeBasedAuthenticationPolicy(credential)
         : signingPolicy(credential)
     ]);
+    if (isNode) {
+      requestPolicyFactories.push(
+        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
+      );
+    }
 
     return {
       httpClient: pipelineOptions.HTTPClient,

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -442,11 +442,6 @@ export class CryptographyClient {
     const userAgentString: string = CryptographyClient.getUserAgentString(pipelineOptions.telemetry);
 
     let requestPolicyFactories: RequestPolicyFactory[] = [];
-    if (isNode) {
-      requestPolicyFactories.push(
-        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
-      );
-    }
     requestPolicyFactories = requestPolicyFactories.concat([
       userAgentPolicy({ value: userAgentString }),
       generateClientRequestIdPolicy(),
@@ -464,6 +459,11 @@ export class CryptographyClient {
         ? challengeBasedAuthenticationPolicy(credential)
         : signingPolicy(credential)
     ]);
+    if (isNode) {
+      requestPolicyFactories.push(
+        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
+      );
+    }
 
     return {
       httpClient: pipelineOptions.HTTPClient,

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -141,11 +141,6 @@ export class KeysClient {
     const userAgentString: string = KeysClient.getUserAgentString(pipelineOptions.telemetry);
 
     let requestPolicyFactories: RequestPolicyFactory[] = [];
-    if (isNode) {
-      requestPolicyFactories.push(
-        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
-      );
-    }
     requestPolicyFactories = requestPolicyFactories.concat([
       tracingPolicy(),
       userAgentPolicy({ value: userAgentString }),
@@ -164,6 +159,11 @@ export class KeysClient {
         ? challengeBasedAuthenticationPolicy(credential)
         : signingPolicy(credential)
     ]);
+    if (isNode) {
+      requestPolicyFactories.push(
+        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
+      );
+    }
 
     return {
       httpClient: pipelineOptions.HTTPClient,

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -92,11 +92,6 @@ export class SecretsClient {
     const userAgentString: string = SecretsClient.getUserAgentString(pipelineOptions.telemetry);
 
     let requestPolicyFactories: RequestPolicyFactory[] = [];
-    if (isNode) {
-      requestPolicyFactories.push(
-        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
-      );
-    }
     requestPolicyFactories = requestPolicyFactories.concat([
       userAgentPolicy({ value: userAgentString }),
       generateClientRequestIdPolicy(),
@@ -114,6 +109,11 @@ export class SecretsClient {
         ? challengeBasedAuthenticationPolicy(credential)
         : signingPolicy(credential)
     ]);
+    if (isNode) {
+      requestPolicyFactories.push(
+        proxyPolicy(getDefaultProxySettings((pipelineOptions.proxyOptions || {}).proxySettings))
+      );
+    }
 
     return {
       httpClient: pipelineOptions.HTTPClient,


### PR DESCRIPTION
This moves the proxy step to the last step of the pipeline, which should allow users to properly configure and use the proxy.

cc @mikeharder 