### PR TITLE
Update analyze-deps to detect releases from unified pipelines

### DIFF
--- a/eng/tools/analyze-deps/deps.html.hbs
+++ b/eng/tools/analyze-deps/deps.html.hbs
@@ -137,7 +137,7 @@
     <h1>{{ capitalize repo_name }} Dependency Report</h1>
     <h3>
       Generated at {{ curtime }}
-      {{#if release}}
+      {{#if isrelease}}
         for release <a href="{{ rel_url }}">{{ release }}</a>
       {{else if build}}
         for build <a href="{{ build_url }}">{{ build }}</a>

--- a/eng/tools/analyze-deps/index.js
+++ b/eng/tools/analyze-deps/index.js
@@ -87,8 +87,9 @@ const render = async (context, dest) => {
   context.build_url = `${process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI}${process.env.SYSTEM_TEAMPROJECT}/_build/results?buildId=${process.env.BUILD_BUILDID}`;
   context.commit = process.env.BUILD_SOURCEVERSION;
   context.isfork = process.env.SYSTEM_PULLREQUEST_ISFORK === "True";
-  context.rel_url = process.env.RELEASE_RELEASEWEBURL;
-  context.release = process.env.RELEASE_RELEASENAME;
+  context.isrelease = process.env.SYSTEM_HOSTTYPE === "release" || process.env.SYSTEM_HOSTTYPE === "deployment" || process.env.RELEASE_RELEASENAME != null;
+  context.rel_url = process.env.RELEASE_RELEASEWEBURL || context.build_url;
+  context.release = process.env.RELEASE_RELEASENAME || context.build;
   context.repo = context.isfork ? process.env.BUILD_REPOSITORY_NAME : `Azure/${context.repo_name}`;
   context.curtime = new Date().toISOString();
 


### PR DESCRIPTION
Releases from unified pipelines don't define the `Release.*` variables.