### PR TITLE
[core-http] Fix WebResource.clone()

### DIFF
--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -354,7 +354,9 @@ export class WebResource {
       this.abortSignal,
       this.timeout,
       this.onUploadProgress,
-      this.onDownloadProgress
+      this.onDownloadProgress,
+      this.proxySettings,
+      this.keepAlive
     );
 
     if (this.formData) {


### PR DESCRIPTION
to pass the two missing fields `proxySettings` and `keepAlive` to the
constructor call.

Fixes #5020 