### PR TITLE
[Storage] Basic authentication support for storage-file and storage-queue

### DIFF
--- a/sdk/storage/storage-file/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-file/samples/javascript/proxyAuth.js
@@ -17,8 +17,10 @@ async function main() {
     `https://${account}.file.core.windows.net`,
     sharedKeyCredential,
     {
-      // Proxy is supported in Node.js environment only, not in browsers
-      proxy: { url: "http://localhost:3128" }
+      // proxy can either be a URL like "http://localhost:3128"
+      // or
+      // an option bag consisting {host, port, username, password }
+      proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
     }
   );
 

--- a/sdk/storage/storage-file/samples/typescript/proxyAuth.ts
+++ b/sdk/storage/storage-file/samples/typescript/proxyAuth.ts
@@ -17,8 +17,10 @@ async function main() {
     `https://${account}.file.core.windows.net`,
     sharedKeyCredential,
     {
-      // Proxy is supported in Node.js environment only, not in browsers
-      proxy: { url: "http://localhost:3128" }
+      // proxy can either be a URL like "http://localhost:3128"
+      // or
+      // an option bag consisting {host, port, username, password }
+      proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
     }
   );
 

--- a/sdk/storage/storage-queue/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-queue/samples/javascript/proxyAuth.js
@@ -17,8 +17,10 @@ async function main() {
     `https://${account}.queue.core.windows.net`,
     sharedKeyCredential,
     {
-      // Proxy is supported in Node.js environment only, not in browsers
-      proxy: { url: "http://localhost:3128" }
+      // proxy can either be a URL like "http://localhost:3128"
+      // or
+      // an option bag consisting {host, port, username, password }
+      proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
     }
   );
 

--- a/sdk/storage/storage-queue/samples/typescript/proxyAuth.ts
+++ b/sdk/storage/storage-queue/samples/typescript/proxyAuth.ts
@@ -17,8 +17,10 @@ async function main() {
     `https://${account}.queue.core.windows.net`,
     sharedKeyCredential,
     {
-      // Proxy is supported in Node.js environment only, not in browsers
-      proxy: { url: "http://localhost:3128" }
+      // proxy can either be a URL like "http://localhost:3128"
+      // or
+      // an option bag consisting {host, port, username, password }
+      proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
     }
   );
 

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -20,7 +20,8 @@ import {
   isNode,
   TokenCredential,
   isTokenCredential,
-  bearerTokenAuthenticationPolicy
+  bearerTokenAuthenticationPolicy,
+  ProxySettings
 } from "@azure/core-http";
 import { KeepAliveOptions, KeepAlivePolicyFactory } from "./KeepAlivePolicyFactory";
 import { BrowserPolicyFactory } from "./BrowserPolicyFactory";
@@ -47,27 +48,6 @@ export {
   RequestPolicy,
   RequestPolicyOptions
 };
-
-/**
- * Interface of proxy policy options.
- * @example
- *   // Use SharedKeyCredential with storage account and account key
- *   // SharedKeyCredential is only avaiable in Node.js runtime, not in browsers
- *   const sharedKeyCredential = new SharedKeyCredential(account, accountKey);
- *   const queueServiceClient = new QueueServiceClient(
- *     `https://${account}.queue.core.windows.net`,
- *     sharedKeyCredential,
- *     {
- *       proxy: { url: "http://localhost:3128" }
- *     }
- *   );
- *
- * @export
- * @interface ProxyOptions
- */
-export interface ProxyOptions {
-  url?: string;
-}
 
 /**
  * Option interface for Pipeline constructor.
@@ -153,7 +133,7 @@ export class Pipeline {
  * @interface NewPipelineOptions
  */
 export interface NewPipelineOptions {
-  proxy?: ProxyOptions;
+  proxy?: ProxySettings | string;
   /**
    * Telemetry configures the built-in telemetry policy behavior.
    *
@@ -223,11 +203,13 @@ export function newPipeline(
 
   if (isNode) {
     // ProxyPolicy is only avaiable in Node.js runtime, not in browsers
-    factories.push(
-      proxyPolicy(
-        getDefaultProxySettings(pipelineOptions.proxy ? pipelineOptions.proxy.url : undefined)
-      )
-    );
+    let proxySettings: ProxySettings | undefined;
+    if (typeof pipelineOptions.proxy === "string") {
+      proxySettings = getDefaultProxySettings(pipelineOptions.proxy);
+    } else {
+      proxySettings = pipelineOptions.proxy;
+    }
+    factories.push(proxyPolicy(proxySettings));
   }
   factories.push(
     isTokenCredential(credential)


### PR DESCRIPTION
Basic authentication support for storage-blob - https://github.com/Azure/azure-sdk-for-js/pull/5009

This PR adds similar support for file and queue.