### PR TITLE
[Identity] Format all files

### DIFF
--- a/sdk/identity/identity/src/client/errors.ts
+++ b/sdk/identity/identity/src/client/errors.ts
@@ -19,9 +19,11 @@ export interface ErrorResponse {
 }
 
 function isErrorResponse(errorResponse: any): errorResponse is ErrorResponse {
-  return errorResponse &&
+  return (
+    errorResponse &&
     typeof errorResponse.error === "string" &&
-    typeof errorResponse.error_description === "string";
+    typeof errorResponse.error_description === "string"
+  );
 }
 
 /**

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -22,12 +22,12 @@ export interface TokenResponse {
   /**
    * The AccessToken to be returned from getToken.
    */
-  accessToken: AccessToken,
+  accessToken: AccessToken;
 
   /**
    * The refresh token if the 'offline_access' scope was used.
    */
-  refreshToken?: string
+  refreshToken?: string;
 }
 
 export class IdentityClient extends ServiceClient {
@@ -52,13 +52,15 @@ export class IdentityClient extends ServiceClient {
 
   async sendTokenRequest(
     webResource: WebResource,
-    expiresOnParser?: (responseBody: any) => number,
+    expiresOnParser?: (responseBody: any) => number
   ): Promise<TokenResponse | null> {
     const response = await this.sendRequest(webResource);
 
-    expiresOnParser = expiresOnParser || ((responseBody: any) => {
-      return Date.now() + responseBody.expires_in * 1000
-    });
+    expiresOnParser =
+      expiresOnParser ||
+      ((responseBody: any) => {
+        return Date.now() + responseBody.expires_in * 1000;
+      });
 
     if (response.status === 200 || response.status === 201) {
       return {
@@ -66,7 +68,7 @@ export class IdentityClient extends ServiceClient {
           token: response.parsedBody.access_token,
           expiresOnTimestamp: expiresOnParser(response.parsedBody)
         },
-        refreshToken: response.parsedBody.refresh_token,
+        refreshToken: response.parsedBody.refresh_token
       };
     } else {
       throw new AuthenticationError(response.status, response.parsedBody || response.bodyAsText);
@@ -113,7 +115,10 @@ export class IdentityClient extends ServiceClient {
     try {
       return await this.sendTokenRequest(webResource, expiresOnParser);
     } catch (err) {
-      if (err instanceof AuthenticationError && err.errorResponse.error === "interaction_required") {
+      if (
+        err instanceof AuthenticationError &&
+        err.errorResponse.error === "interaction_required"
+      ) {
         // It's likely that the refresh token has expired, so
         // return null so that the credential implementation will
         // initiate the authentication flow again.

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -20,7 +20,7 @@ export class ChainedTokenCredential implements TokenCredential {
    * {@link TokenCredential} implementations.  Throws an {@link AggregateAuthenticationError}
    * when one or more credentials throws an {@link AuthenticationError} and
    * no credentials have returned an {@link AccessToken}.
-   * 
+   *
    * @param scopes The list of scopes for which the token will have access.
    * @param options The options used to configure any requests this
    *                TokenCredential implementation might make.

--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.browser.ts
@@ -6,7 +6,9 @@
 import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { IdentityClientOptions } from "../client/identityClient";
 
-const BrowserNotSupportedError = new Error("ClientCertificateCredential is not supported in the browser.");
+const BrowserNotSupportedError = new Error(
+  "ClientCertificateCredential is not supported in the browser."
+);
 
 export class ClientCertificateCredential implements TokenCredential {
   constructor(

--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
@@ -61,9 +61,7 @@ export class ClientCertificateCredential implements TokenCredential {
     const matchCert = this.certificateString.match(certificatePattern);
     const publicKey = matchCert ? matchCert[3] : "";
     if (!publicKey) {
-      throw new Error(
-        "The file at the specified path does not contain a PEM-encoded certificate."
-      );
+      throw new Error("The file at the specified path does not contain a PEM-encoded certificate.");
     }
 
     this.certificateThumbprint = createHash("sha1")

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -10,17 +10,17 @@ import { ManagedIdentityCredential } from "./managedIdentityCredential";
  * Provides a default {@link ChainedTokenCredential} configuration for
  * applications that will be deployed to Azure.  The following credential
  * types will be tried, in order:
- * 
+ *
  * - {@link EnvironmentCredential}
  * - {@link ManagedIdentityCredential}
- * 
+ *
  * Consult the documentation of these credential types for more information
  * on how they attempt authentication.
  */
 export class DefaultAzureCredential extends ChainedTokenCredential {
   /**
    * Creates an instance of the DefaultAzureCredential class.
-   * 
+   *
    * @param options Options for configuring the client which makes the authentication request.
    */
   constructor(identityClientOptions?: IdentityClientOptions) {

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -12,12 +12,12 @@ import { AuthenticationError } from "../client/errors";
  * library.
  */
 export interface DeviceCodeResponse {
-  device_code: string,
-  user_code: string,
-  verification_uri: string,
-  expires_in: number,
-  interval: number,
-  message: string
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+  message: string;
 }
 
 /**
@@ -26,9 +26,9 @@ export interface DeviceCodeResponse {
  * contains an instruction with these details.
  */
 export interface DeviceCodeDetails {
-  userCode: string,
-  verificationUri: string,
-  message: string
+  userCode: string;
+  verificationUri: string;
+  message: string;
 }
 
 /**
@@ -182,7 +182,8 @@ export class DeviceCodeCredential implements TokenCredential {
         this.lastTokenResponse.refreshToken,
         undefined, // clientSecret not needed for device code auth
         undefined,
-        options);
+        options
+      );
     }
 
     if (tokenResponse === null) {

--- a/sdk/identity/identity/src/credentials/environmentCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.browser.ts
@@ -6,7 +6,9 @@
 import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
 import { IdentityClientOptions } from "../client/identityClient";
 
-const BrowserNotSupportedError = new Error("EnvironmentCredential is not supported in the browser.");
+const BrowserNotSupportedError = new Error(
+  "EnvironmentCredential is not supported in the browser."
+);
 
 export class EnvironmentCredential implements TokenCredential {
   constructor(options?: IdentityClientOptions) {

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
@@ -4,7 +4,10 @@
 import * as msal from "msal";
 import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
 import { IdentityClient } from "../client/identityClient";
-import { BrowserLoginStyle, InteractiveBrowserCredentialOptions } from "./interactiveBrowserCredentialOptions";
+import {
+  BrowserLoginStyle,
+  InteractiveBrowserCredentialOptions
+} from "./interactiveBrowserCredentialOptions";
 
 /**
  * Enables authentication to Azure Active Directory inside of the web browser
@@ -25,24 +28,20 @@ export class InteractiveBrowserCredential implements TokenCredential {
    * @param clientId The client (application) ID of an App Registration in the tenant.
    * @param options Options for configuring the client which makes the authentication request.
    */
-  constructor(
-    tenantId: string,
-    clientId: string,
-    options?: InteractiveBrowserCredentialOptions
-  ) {
+  constructor(tenantId: string, clientId: string, options?: InteractiveBrowserCredentialOptions) {
     options = { ...IdentityClient.getDefaultOptions(), ...options };
 
     this.loginStyle = options.loginStyle || "popup";
     if (["redirect", "popup"].indexOf(this.loginStyle) === -1) {
-        throw new Error(`Invalid loginStyle: ${options.loginStyle}`);
+      throw new Error(`Invalid loginStyle: ${options.loginStyle}`);
     }
 
     this.msalConfig = {
       auth: {
         clientId: clientId,
         authority: `${options.authorityHost}/${tenantId}`,
-        ...options.redirectUri && { redirectUri: options.redirectUri},
-        ...options.postLogoutRedirectUri && { redirectUri: options.postLogoutRedirectUri }
+        ...(options.redirectUri && { redirectUri: options.redirectUri }),
+        ...(options.postLogoutRedirectUri && { redirectUri: options.postLogoutRedirectUri })
       },
       cache: {
         cacheLocation: "localStorage",
@@ -67,7 +66,9 @@ export class InteractiveBrowserCredential implements TokenCredential {
     }
   }
 
-  private async acquireToken(authParams: msal.AuthenticationParameters): Promise<msal.AuthResponse | undefined> {
+  private async acquireToken(
+    authParams: msal.AuthenticationParameters
+  ): Promise<msal.AuthResponse | undefined> {
     let authResponse: msal.AuthResponse | undefined;
     try {
       authResponse = await this.msalObject.acquireTokenSilent(authParams);
@@ -98,7 +99,7 @@ export class InteractiveBrowserCredential implements TokenCredential {
           break;
       }
 
-      authResponse = authPromise && await authPromise;
+      authResponse = authPromise && (await authPromise);
     }
 
     return authResponse;
@@ -119,7 +120,7 @@ export class InteractiveBrowserCredential implements TokenCredential {
     }
 
     const authResponse = await this.acquireToken({
-      scopes: Array.isArray(scopes) ? scopes : scopes.split(',')
+      scopes: Array.isArray(scopes) ? scopes : scopes.split(",")
     });
 
     if (authResponse) {

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
@@ -6,7 +6,9 @@
 import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { InteractiveBrowserCredentialOptions } from "./interactiveBrowserCredentialOptions";
 
-const BrowserNotSupportedError = new Error("InteractiveBrowserCredential is not supported in Node.js.");
+const BrowserNotSupportedError = new Error(
+  "InteractiveBrowserCredential is not supported in Node.js."
+);
 
 /**
  * Enables authentication to Azure Active Directory inside of the web browser
@@ -14,11 +16,7 @@ const BrowserNotSupportedError = new Error("InteractiveBrowserCredential is not 
  * window.  This credential is not currently supported in Node.js.
  */
 export class InteractiveBrowserCredential implements TokenCredential {
-  constructor(
-    tenantId: string,
-    clientId: string,
-    options?: InteractiveBrowserCredentialOptions
-  ) {
+  constructor(tenantId: string, clientId: string, options?: InteractiveBrowserCredentialOptions) {
     throw BrowserNotSupportedError;
   }
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.browser.ts
@@ -6,7 +6,9 @@
 import { AccessToken, GetTokenOptions, TokenCredential } from "@azure/core-http";
 import { IdentityClientOptions } from "../client/identityClient";
 
-const BrowserNotSupportedError = new Error("ManagedIdentityCredential is not supported in the browser.");
+const BrowserNotSupportedError = new Error(
+  "ManagedIdentityCredential is not supported in the browser."
+);
 
 export class ManagedIdentityCredential implements TokenCredential {
   constructor(clientId?: string, options?: IdentityClientOptions) {

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -75,10 +75,13 @@ export class ManagedIdentityCredential implements TokenCredential {
     };
   }
 
-  private createAppServiceMsiAuthRequest(resource: string, clientId?: string): RequestPrepareOptions {
+  private createAppServiceMsiAuthRequest(
+    resource: string,
+    clientId?: string
+  ): RequestPrepareOptions {
     const queryParameters: any = {
       resource,
-      "api-version": AppServiceMsiApiVersion,
+      "api-version": AppServiceMsiApiVersion
     };
 
     if (clientId) {
@@ -96,7 +99,10 @@ export class ManagedIdentityCredential implements TokenCredential {
     };
   }
 
-  private createCloudShellMsiAuthRequest(resource: string, clientId?: string): RequestPrepareOptions {
+  private createCloudShellMsiAuthRequest(
+    resource: string,
+    clientId?: string
+  ): RequestPrepareOptions {
     const body: any = {
       resource
     };
@@ -117,7 +123,11 @@ export class ManagedIdentityCredential implements TokenCredential {
     };
   }
 
-  private async pingImdsEndpoint(resource: string, clientId?: string, timeout?: number): Promise<boolean> {
+  private async pingImdsEndpoint(
+    resource: string,
+    clientId?: string,
+    timeout?: number
+  ): Promise<boolean> {
     const request = this.createImdsAuthRequest(resource, clientId);
 
     // This will always be populated, but let's make TypeScript happy
@@ -171,8 +181,12 @@ export class ManagedIdentityCredential implements TokenCredential {
         expiresInParser = (requestBody: any) => {
           // Parse a date format like "06/20/2019 02:57:58 +00:00" and
           // convert it into a JavaScript-formatted date
-          const m = requestBody.expires_on.match(/(\d\d)\/(\d\d)\/(\d\d\d\d) (\d\d):(\d\d):(\d\d) (\+|-)(\d\d):(\d\d)/)
-          return Date.parse(`${m[3]}-${m[1]}-${m[2]}T${m[4]}:${m[5]}:${m[6]}${m[7]}${m[8]}:${m[9]}`)
+          const m = requestBody.expires_on.match(
+            /(\d\d)\/(\d\d)\/(\d\d\d\d) (\d\d):(\d\d):(\d\d) (\+|-)(\d\d):(\d\d)/
+          );
+          return Date.parse(
+            `${m[3]}-${m[1]}-${m[2]}T${m[4]}:${m[5]}:${m[6]}${m[7]}${m[8]}:${m[9]}`
+          );
         };
       } else {
         // Running in Cloud Shell
@@ -180,7 +194,14 @@ export class ManagedIdentityCredential implements TokenCredential {
       }
     } else {
       // Ping the IMDS endpoint to see if it's available
-      if (!checkIfImdsEndpointAvailable || await this.pingImdsEndpoint(resource, clientId, getTokenOptions ? getTokenOptions.timeout : undefined)) {
+      if (
+        !checkIfImdsEndpointAvailable ||
+        (await this.pingImdsEndpoint(
+          resource,
+          clientId,
+          getTokenOptions ? getTokenOptions.timeout : undefined
+        ))
+      ) {
         // Running in an Azure VM
         authRequestOptions = this.createImdsAuthRequest(resource, clientId);
       } else {
@@ -221,12 +242,12 @@ export class ManagedIdentityCredential implements TokenCredential {
     // the latter indicating that we don't yet know whether
     // the endpoint is available and need to check for it.
     if (this.isEndpointUnavailable !== true) {
-      result =
-        await this.authenticateManagedIdentity(
-          scopes,
-          this.isEndpointUnavailable === null,
-          this.clientId,
-          options);
+      result = await this.authenticateManagedIdentity(
+        scopes,
+        this.isEndpointUnavailable === null,
+        this.clientId,
+        options
+      );
 
       // If authenticateManagedIdentity returns null, it means no MSI
       // endpoints are available.  In this case, don't try them in future

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -10,7 +10,10 @@ export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { InteractiveBrowserCredential } from "./credentials/interactiveBrowserCredential";
-export { InteractiveBrowserCredentialOptions, BrowserLoginStyle } from "./credentials/interactiveBrowserCredentialOptions";
+export {
+  InteractiveBrowserCredentialOptions,
+  BrowserLoginStyle
+} from "./credentials/interactiveBrowserCredentialOptions";
 export { ManagedIdentityCredential } from "./credentials/managedIdentityCredential";
 export { DeviceCodeCredential } from "./credentials/deviceCodeCredential";
 export { DefaultAzureCredential } from "./credentials/defaultAzureCredential";

--- a/sdk/identity/identity/test/authTestUtils.ts
+++ b/sdk/identity/identity/test/authTestUtils.ts
@@ -3,7 +3,14 @@
 
 import assert from "assert";
 import { IdentityClientOptions } from "../src";
-import { HttpHeaders, HttpOperationResponse, WebResource, HttpClient, delay, RestError } from "@azure/core-http";
+import {
+  HttpHeaders,
+  HttpOperationResponse,
+  WebResource,
+  HttpClient,
+  delay,
+  RestError
+} from "@azure/core-http";
 
 export interface MockAuthResponse {
   status: number;
@@ -13,8 +20,8 @@ export interface MockAuthResponse {
 }
 
 export interface MockAuthHttpClientOptions {
-  authResponse?: MockAuthResponse | MockAuthResponse[],
-  mockTimeout?: boolean
+  authResponse?: MockAuthResponse | MockAuthResponse[];
+  mockTimeout?: boolean;
 }
 
 export class MockAuthHttpClient implements HttpClient {
@@ -32,22 +39,21 @@ export class MockAuthHttpClient implements HttpClient {
       if (options.authResponse.length === 0) {
         throw new Error("authResponse array must have at least one item");
       }
-      this.authResponses = options.authResponse
+      this.authResponses = options.authResponse;
     } else {
-      this.authResponses = [options.authResponse || {
-        status: 200,
-        headers: new HttpHeaders(),
-        parsedBody: {
-          access_token: "token",
-          expires_in: 120
+      this.authResponses = [
+        options.authResponse || {
+          status: 200,
+          headers: new HttpHeaders(),
+          parsedBody: {
+            access_token: "token",
+            expires_in: 120
+          }
         }
-      }];
+      ];
     }
 
-    this.mockTimeout =
-      options.mockTimeout !== undefined
-        ? options.mockTimeout
-        : false;
+    this.mockTimeout = options.mockTimeout !== undefined ? options.mockTimeout : false;
 
     this.identityClientOptions = {
       authorityHost: "https://authority",
@@ -65,7 +71,7 @@ export class MockAuthHttpClient implements HttpClient {
     }
 
     if (this.requests.length > this.authResponses.length) {
-      throw new Error("The number of requests has exceeded the number of authResponses")
+      throw new Error("The number of requests has exceeded the number of authResponses");
     }
 
     const response = {
@@ -116,6 +122,6 @@ export async function assertRejects(
   try {
     await promise;
   } catch (error) {
-    assert.ok(expected(error), message || "The error didn't pass the assertion predicate.")
+    assert.ok(expected(error), message || "The error didn't pass the assertion predicate.");
   }
 }

--- a/sdk/identity/identity/test/chainedTokenCredential.spec.ts
+++ b/sdk/identity/identity/test/chainedTokenCredential.spec.ts
@@ -16,7 +16,7 @@ function mockCredential(returnPromise: Promise<AccessToken | null>): TokenCreden
   };
 }
 
-describe("ChainedTokenCredential", function () {
+describe("ChainedTokenCredential", function() {
   it("returns the first token received from a credential", async () => {
     const chainedTokenCredential = new ChainedTokenCredential(
       mockCredential(Promise.resolve(null)),

--- a/sdk/identity/identity/test/clientSecretCredential.spec.ts
+++ b/sdk/identity/identity/test/clientSecretCredential.spec.ts
@@ -4,7 +4,7 @@
 import { ClientSecretCredential } from "../src";
 import { MockAuthHttpClient, assertClientCredentials } from "./authTestUtils";
 
-describe("ClientSecretCredential", function () {
+describe("ClientSecretCredential", function() {
   it("sends an authorization request with the given credentials", async () => {
     const mockHttpClient = new MockAuthHttpClient();
 

--- a/sdk/identity/identity/test/identityClient.spec.ts
+++ b/sdk/identity/identity/test/identityClient.spec.ts
@@ -11,13 +11,13 @@ import { ClientSecretCredential } from "../src";
 function isExpectedError(expectedErrorName: string): (error: any) => boolean {
   return (error: any) => {
     if (!(error instanceof AuthenticationError)) {
-      assert.ifError(error)
+      assert.ifError(error);
     }
-    return error.errorResponse.error === expectedErrorName
-  }
+    return error.errorResponse.error === expectedErrorName;
+  };
 }
 
-describe("IdentityClient", function () {
+describe("IdentityClient", function() {
   it("throws an exception when an authentication request fails", async () => {
     const mockHttp = new MockAuthHttpClient({
       authResponse: {
@@ -26,36 +26,49 @@ describe("IdentityClient", function () {
       }
     });
 
-    const credential = new ClientSecretCredential("tenant", "client", "secret", mockHttp.identityClientOptions);
-    await assertRejects(
-      credential.getToken("https://test/.default"),
-      error => {
-        assert.strictEqual(error.name, 'AuthenticationError')
-        return true;
-      }
+    const credential = new ClientSecretCredential(
+      "tenant",
+      "client",
+      "secret",
+      mockHttp.identityClientOptions
     );
+    await assertRejects(credential.getToken("https://test/.default"), (error) => {
+      assert.strictEqual(error.name, "AuthenticationError");
+      return true;
+    });
   });
 
   it("throws an exception when an authorityHost using 'http' is provided", async () => {
     assert.throws(
-      () => { new IdentityClient({ authorityHost: "http://totallyinsecure.lol" }) },
+      () => {
+        new IdentityClient({ authorityHost: "http://totallyinsecure.lol" });
+      },
       Error,
-      "The authorityHost address must use the 'https' protocol.");
+      "The authorityHost address must use the 'https' protocol."
+    );
     assert.throws(
-      () => { new IdentityClient({ authorityHost: "httpsomg.com" }) },
+      () => {
+        new IdentityClient({ authorityHost: "httpsomg.com" });
+      },
       Error,
-      "The authorityHost address must use the 'https' protocol.");
+      "The authorityHost address must use the 'https' protocol."
+    );
   });
 
   it("returns a usable error when the authentication response doesn't contain a body", async () => {
     const mockHttp = new MockAuthHttpClient({
       authResponse: {
         status: 500,
-        bodyAsText: ''
+        bodyAsText: ""
       }
     });
 
-    const credential = new ClientSecretCredential("tenant", "client", "secret", mockHttp.identityClientOptions);
+    const credential = new ClientSecretCredential(
+      "tenant",
+      "client",
+      "secret",
+      mockHttp.identityClientOptions
+    );
     await assertRejects(
       credential.getToken("https://test/.default"),
       isExpectedError("unknown_error")
@@ -74,7 +87,13 @@ describe("IdentityClient", function () {
     });
 
     const client = new IdentityClient(mockHttp.identityClientOptions);
-    const tokenResponse = await client.refreshAccessToken("tenant", "client", "scopes", "token", undefined)
+    const tokenResponse = await client.refreshAccessToken(
+      "tenant",
+      "client",
+      "scopes",
+      "token",
+      undefined
+    );
     assert.equal(tokenResponse, null);
   });
 

--- a/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
@@ -8,7 +8,7 @@ import assert from "assert";
 import { ClientCertificateCredential } from "../../src";
 import { MockAuthHttpClient } from "../authTestUtils";
 
-describe("ClientCertificateCredential", function () {
+describe("ClientCertificateCredential", function() {
   it("loads a PEM-formatted certificate from a file", () => {
     const credential = new ClientCertificateCredential(
       "tenant",

--- a/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
@@ -6,7 +6,10 @@ import { delay } from "@azure/core-http";
 import { AbortController } from "@azure/abort-controller";
 import { MockAuthHttpClient, assertRejects } from "../authTestUtils";
 import { AuthenticationError, ErrorResponse } from "../../src/client/errors";
-import { DeviceCodeCredential, DeviceCodeResponse } from '../../src/credentials/deviceCodeCredential';
+import {
+  DeviceCodeCredential,
+  DeviceCodeResponse
+} from "../../src/credentials/deviceCodeCredential";
 
 const deviceCodeResponse: DeviceCodeResponse = {
   interval: 1,
@@ -14,15 +17,15 @@ const deviceCodeResponse: DeviceCodeResponse = {
   verification_uri: "https://contoso.com/devicelogin",
   device_code: "XXXXXXXXXXXXXXXXXX",
   user_code: "B3920934",
-  message: "Visit https://contoso.com/devicelogin and enter code B3920934",
-}
+  message: "Visit https://contoso.com/devicelogin and enter code B3920934"
+};
 
 const pendingResponse: ErrorResponse = {
   error: "authorization_pending",
   error_description: "Waiting for user to authenticate"
 };
 
-describe("DeviceCodeCredential", function () {
+describe("DeviceCodeCredential", function() {
   this.timeout(10000); // eslint-disable-line no-invalid-this
 
   it("sends a device code request and returns a token when the user completes it", async function() {
@@ -32,14 +35,14 @@ describe("DeviceCodeCredential", function () {
         { status: 400, parsedBody: pendingResponse },
         { status: 400, parsedBody: pendingResponse },
         { status: 400, parsedBody: pendingResponse },
-        { status: 200, parsedBody: { access_token: "token", expires_in: 5 } },
+        { status: 200, parsedBody: { access_token: "token", expires_in: 5 } }
       ]
     });
 
     const credential = new DeviceCodeCredential(
       "tenant",
       "client",
-      details => assert.equal(details.message, deviceCodeResponse.message),
+      (details) => assert.equal(details.message, deviceCodeResponse.message),
       mockHttpClient.identityClientOptions
     );
 
@@ -47,13 +50,14 @@ describe("DeviceCodeCredential", function () {
     const currentTimestamp = Date.now() + 5000;
 
     if (accessToken === null) {
-      assert.fail("getToken did not return an AccessToken")
+      assert.fail("getToken did not return an AccessToken");
     } else {
-      assert.strictEqual(accessToken.token, "token")
+      assert.strictEqual(accessToken.token, "token");
       assert.ok(
-        accessToken.expiresOnTimestamp >= currentTimestamp - 1000
-        && accessToken.expiresOnTimestamp <= currentTimestamp,
-        `AccessToken.expiresOnTimestamp is not ~${currentTimestamp}: ${accessToken.expiresOnTimestamp}`);
+        accessToken.expiresOnTimestamp >= currentTimestamp - 1000 &&
+          accessToken.expiresOnTimestamp <= currentTimestamp,
+        `AccessToken.expiresOnTimestamp is not ~${currentTimestamp}: ${accessToken.expiresOnTimestamp}`
+      );
     }
   });
 
@@ -61,15 +65,21 @@ describe("DeviceCodeCredential", function () {
     const mockHttpClient = new MockAuthHttpClient({
       authResponse: [
         { status: 200, parsedBody: deviceCodeResponse },
-        { status: 200, parsedBody: { access_token: "token", expires_in: 5, refresh_token: "ABC123" } },
-        { status: 200, parsedBody: { access_token: "token", expires_in: 5, refresh_token: "ABC123" } },
+        {
+          status: 200,
+          parsedBody: { access_token: "token", expires_in: 5, refresh_token: "ABC123" }
+        },
+        {
+          status: 200,
+          parsedBody: { access_token: "token", expires_in: 5, refresh_token: "ABC123" }
+        }
       ]
     });
 
     const credential = new DeviceCodeCredential(
       "tenant",
       "client",
-      details => assert.equal(details.message, deviceCodeResponse.message),
+      (details) => assert.equal(details.message, deviceCodeResponse.message),
       mockHttpClient.identityClientOptions
     );
 
@@ -77,17 +87,19 @@ describe("DeviceCodeCredential", function () {
     const refreshedToken = await credential.getToken("scope");
 
     if (refreshedToken === null) {
-      assert.fail("getToken did not return a refreshed AccessToken")
+      assert.fail("getToken did not return a refreshed AccessToken");
     } else {
       // Basic verification that a refresh request was made with the
       // refresh_token returned by the previous request
       const refreshRequest = mockHttpClient.requests[2];
       assert.ok(
         refreshRequest.body.indexOf(`grant_type=refresh_token`) > -1,
-        "Request does not contain refresh_token grant type");
+        "Request does not contain refresh_token grant type"
+      );
       assert.ok(
         refreshRequest.body.indexOf(`refresh_token=ABC123`) > -1,
-        "Request does not contain refresh token");
+        "Request does not contain refresh token"
+      );
     }
   });
 
@@ -95,17 +107,23 @@ describe("DeviceCodeCredential", function () {
     const mockHttpClient = new MockAuthHttpClient({
       authResponse: [
         { status: 200, parsedBody: deviceCodeResponse },
-        { status: 200, parsedBody: { access_token: "token", expires_in: 5, refresh_token: "ABC123" } },
-        { status: 400, parsedBody: { error: "interaction_required", error_description: "Interaction required" } },
+        {
+          status: 200,
+          parsedBody: { access_token: "token", expires_in: 5, refresh_token: "ABC123" }
+        },
+        {
+          status: 400,
+          parsedBody: { error: "interaction_required", error_description: "Interaction required" }
+        },
         { status: 200, parsedBody: deviceCodeResponse },
-        { status: 200, parsedBody: { access_token: "token", expires_in: 5 } },
+        { status: 200, parsedBody: { access_token: "token", expires_in: 5 } }
       ]
     });
 
     const credential = new DeviceCodeCredential(
       "tenant",
       "client",
-      details => assert.equal(details.message, deviceCodeResponse.message),
+      (details) => assert.equal(details.message, deviceCodeResponse.message),
       mockHttpClient.identityClientOptions
     );
 
@@ -113,14 +131,15 @@ describe("DeviceCodeCredential", function () {
     const refreshedToken = await credential.getToken("scope");
 
     if (refreshedToken === null) {
-      assert.fail("getToken did not return a refreshed AccessToken")
+      assert.fail("getToken did not return a refreshed AccessToken");
     } else {
       // Basic verification that the device code flow was re-initiated
       // once the refresh token request failed with "interaction_required"
       const refreshRequest = mockHttpClient.requests[3];
       assert.ok(
         refreshRequest.url.endsWith("devicecode"),
-        "Device code authorization request was not re-initiated");
+        "Device code authorization request was not re-initiated"
+      );
     }
   });
 
@@ -130,25 +149,23 @@ describe("DeviceCodeCredential", function () {
         { status: 200, parsedBody: deviceCodeResponse },
         { status: 400, parsedBody: pendingResponse },
         { status: 400, parsedBody: pendingResponse },
-        { status: 400, parsedBody: { error: "authorization_declined", error_description: "" }},
+        { status: 400, parsedBody: { error: "authorization_declined", error_description: "" } }
       ]
     });
 
     const credential = new DeviceCodeCredential(
       "tenant",
       "client",
-      details => assert.equal(details.message, deviceCodeResponse.message),
+      (details) => assert.equal(details.message, deviceCodeResponse.message),
       mockHttpClient.identityClientOptions
     );
 
-    await assertRejects(
-      credential.getToken("scope"),
-      error => {
-        const authError = error as AuthenticationError;
-        assert.strictEqual(error.name, 'AuthenticationError')
-        assert.strictEqual(authError.errorResponse.error, "authorization_declined")
-        return true;
-      });
+    await assertRejects(credential.getToken("scope"), (error) => {
+      const authError = error as AuthenticationError;
+      assert.strictEqual(error.name, "AuthenticationError");
+      assert.strictEqual(authError.errorResponse.error, "authorization_declined");
+      return true;
+    });
   });
 
   it("throws an AuthenticationError when the authorization token expires", async function() {
@@ -157,50 +174,46 @@ describe("DeviceCodeCredential", function () {
         { status: 200, parsedBody: deviceCodeResponse },
         { status: 400, parsedBody: pendingResponse },
         { status: 400, parsedBody: pendingResponse },
-        { status: 400, parsedBody: { error: "expired_token", error_description: "" }},
+        { status: 400, parsedBody: { error: "expired_token", error_description: "" } }
       ]
     });
 
     const credential = new DeviceCodeCredential(
       "tenant",
       "client",
-      details => assert.equal(details.message, deviceCodeResponse.message),
+      (details) => assert.equal(details.message, deviceCodeResponse.message),
       mockHttpClient.identityClientOptions
     );
 
-    await assertRejects(
-      credential.getToken("scope"),
-      error => {
-        const authError = error as AuthenticationError;
-        assert.strictEqual(error.name, 'AuthenticationError')
-        assert.strictEqual(authError.errorResponse.error, "expired_token")
-        return true;
-      });
+    await assertRejects(credential.getToken("scope"), (error) => {
+      const authError = error as AuthenticationError;
+      assert.strictEqual(error.name, "AuthenticationError");
+      assert.strictEqual(authError.errorResponse.error, "expired_token");
+      return true;
+    });
   });
 
   it("throws an AuthenticationError when the client sends the wrong device code", async function() {
     const mockHttpClient = new MockAuthHttpClient({
       authResponse: [
         { status: 200, parsedBody: deviceCodeResponse },
-        { status: 400, parsedBody: { error: "bad_verification_code", error_description: "" }},
+        { status: 400, parsedBody: { error: "bad_verification_code", error_description: "" } }
       ]
     });
 
     const credential = new DeviceCodeCredential(
       "tenant",
       "client",
-      details => assert.equal(details.message, deviceCodeResponse.message),
+      (details) => assert.equal(details.message, deviceCodeResponse.message),
       mockHttpClient.identityClientOptions
     );
 
-    await assertRejects(
-      credential.getToken("scope"),
-      error => {
-        const authError = error as AuthenticationError;
-        assert.strictEqual(error.name, 'AuthenticationError')
-        assert.strictEqual(authError.errorResponse.error, "bad_verification_code")
-        return true;
-      });
+    await assertRejects(credential.getToken("scope"), (error) => {
+      const authError = error as AuthenticationError;
+      assert.strictEqual(error.name, "AuthenticationError");
+      assert.strictEqual(authError.errorResponse.error, "bad_verification_code");
+      return true;
+    });
   });
 
   it("cancels polling when abort signal is raised", async function() {
@@ -209,14 +222,14 @@ describe("DeviceCodeCredential", function () {
         { status: 200, parsedBody: deviceCodeResponse },
         { status: 400, parsedBody: pendingResponse },
         { status: 400, parsedBody: pendingResponse },
-        { status: 200, parsedBody: { access_token: "token", expires_in: 5 } },
+        { status: 200, parsedBody: { access_token: "token", expires_in: 5 } }
       ]
     });
 
     const credential = new DeviceCodeCredential(
       "tenant",
       "client",
-      details => assert.equal(details.message, deviceCodeResponse.message),
+      (details) => assert.equal(details.message, deviceCodeResponse.message),
       mockHttpClient.identityClientOptions
     );
 

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -4,7 +4,7 @@
 import { EnvironmentCredential } from "../../src";
 import { MockAuthHttpClient, assertClientCredentials } from "../authTestUtils";
 
-describe("EnvironmentCredential", function () {
+describe("EnvironmentCredential", function() {
   it("finds and uses client credential environment variables", async () => {
     process.env.AZURE_TENANT_ID = "tenant";
     process.env.AZURE_CLIENT_ID = "client";

--- a/sdk/identity/identity/test/usernamePasswordCredential.spec.ts
+++ b/sdk/identity/identity/test/usernamePasswordCredential.spec.ts
@@ -5,7 +5,7 @@ import assert from "assert";
 import { UsernamePasswordCredential } from "../src";
 import { MockAuthHttpClient } from "./authTestUtils";
 
-describe("UsernamePasswordCredential", function () {
+describe("UsernamePasswordCredential", function() {
   it("sends an authorization request with the given username and password", async () => {
     const mockHttpClient = new MockAuthHttpClient();
 


### PR DESCRIPTION
This PR runs the prettier formatter on all the files in the identity library.
This is done so that we can remove noise from PRs like #5019 