### PR TITLE
Update GetTokenOptions to support tracing

### DIFF
--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -17,6 +17,7 @@ export interface AccessToken {
 // @public
 export interface GetTokenOptions {
     abortSignal?: AbortSignalLike;
+    spanOptions?: any;
     timeout?: number;
 }
 

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -30,6 +30,10 @@ export interface GetTokenOptions {
    * Timeout for pinging services
    */
   timeout?: number;
+  /**
+   * Options to create a span using the tracer if any was set.
+   */
+  spanOptions?: any;
 }
 
 /**


### PR DESCRIPTION
This PR updates the `GetTokenOptions` interface in `core-auth` to support the `spanOptions` that will be used in `@azure/identity` to create spans appropriately if a tracer was set.

This change has been pulled out of @sarangan12's PR #5019 in order to enable shipping of the `core-auth` package ahead of time when compared to `@azure/identity`.