### PR TITLE
[Abort Controller] adds changelog

### DIFF
--- a/sdk/core/abort-controller/changelog.md
+++ b/sdk/core/abort-controller/changelog.md
@@ -1,0 +1,3 @@
+Changelog
+1.0.0-preview.2 - 2019-09-09
+Listeners attached to an `AbortSignal` now receive an event with the type `abort`. (PR #4756)

--- a/sdk/core/abort-controller/changelog.md
+++ b/sdk/core/abort-controller/changelog.md
@@ -1,3 +1,2 @@
-Changelog
-1.0.0-preview.2 - 2019-09-09
+## 1.0.0-preview.2 - 2019-09-09
 Listeners attached to an `AbortSignal` now receive an event with the type `abort`. (PR #4756)


### PR DESCRIPTION
Adds the changelog.md file for abort-controller and adds an entry for the upcoming release.