### PR TITLE
[Comsos] Skip ItemManagement sample in PR validations

### DIFF
--- a/sdk/cosmosdb/cosmos/samples/package.json
+++ b/sdk/cosmosdb/cosmos/samples/package.json
@@ -14,6 +14,6 @@
     "IndexManagement": "npx ts-node ./IndexManagement",
     "ChangeFeed": "npx ts-node ./ChangeFeed",
     "BulkUpdateWithSproc": "npx ts-node ./BulkUpdateWithSproc",
-    "all-samples": "npm run ContainerManagement && npm run UserManagement && npm run ServerSideScripts && npm run ItemManagement && npm run DatabaseManagement && npm run ChangeFeed && npm run BulkUpdateWithSproc"
+    "all-samples": "npm run ContainerManagement && npm run UserManagement && npm run ServerSideScripts && npm run DatabaseManagement && npm run ChangeFeed && npm run BulkUpdateWithSproc"
   }
 }


### PR DESCRIPTION
js - cosmos - ci pipeline failed many times because of this `ItemManagement` sample due to which PR validations are failing.
https://dev.azure.com/azure-sdk/public/_build?definitionId=450&_a=summary

This PR skips that particular sample until more investigation is done. Keeping the issue https://github.com/Azure/azure-sdk-for-js/issues/5049 open until this is fixed.