### PR TITLE
[app-configuration] Bumping version for re-upload

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0-preview.2 (2019-09-13)
+
+Republishing as the readme is not properly showing up. No other changes.
+
 # 1.0.0-preview.1 (2019-09-12)
 
 This is the first release of the @azure/app-configuration package.

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.0.0-preview.2 (2019-09-13)
 
-Republishing as the readme is not properly showing up. No other changes.
+Republishing as the readme is not properly showing up on npmjs. No other changes.
 
 # 1.0.0-preview.1 (2019-09-12)
 

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.0.0-preview.1",
+  "version": "1.0.0-preview.2",
   "sdk-type": "client",
   "dependencies": {
     "@azure/core-arm": "1.0.0-preview.3",


### PR DESCRIPTION
NPMJS doesn't seem to be updating the readme displayed on the site - we're going to bump the version and upload the package again.