### PR TITLE
[Event Hubs] Add trackLastEnqueuedInfo feature on EventProcessor

### DIFF
--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -178,6 +178,7 @@ export class EventProcessor {
 export interface EventProcessorOptions {
     maxBatchSize?: number;
     maxWaitTimeInSeconds?: number;
+    trackLastEnqueuedEventInfo?: boolean;
 }
 
 // @public
@@ -230,6 +231,7 @@ export class PartitionProcessor {
     eventHubName: string;
     eventProcessorId: string;
     initialize(): Promise<void>;
+    lastEnqueuedEventInfo: LastEnqueuedEventInfo;
     partitionId: string;
     partitionManager: PartitionManager;
     processError(error: Error): Promise<void>;

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -138,6 +138,17 @@ export interface EventProcessorOptions {
    * passing the data to user code for processing. If not provided, it defaults to 60 seconds.
    */
   maxWaitTimeInSeconds?: number;
+  /**
+   * @property
+   * Indicates whether or not the consumer should request information on the last enqueued event on its
+   * associated partition, and track that information as events are received.
+
+   * When information about the partition's last enqueued event is being tracked, each event received 
+   * from the Event Hubs service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+   * additional network bandwidth consumption that is generally a favorable trade-off when considered
+   * against periodically making requests for partition properties using the Event Hub client.
+   */
+  trackLastEnqueuedEventInfo?: boolean;
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -63,8 +63,9 @@ export class PartitionProcessor {
   private _lastEnqueuedEventInfo: LastEnqueuedEventInfo | undefined;
 
   /**
-   * @property The last enqueued event information. This property will only
-   * be enabled when `trackLastEnqueuedEventInfo` option is set to true when you create an instance of `EventProcessor`.
+   * @property Information on the last enqueued event in the partition that is being processed.
+   * This property is updated by the `EventProcessor` if the `trackLastEnqueuedEventInfo` option is set to true
+   * when creating an instance of EventProcessor
    * @readonly
    */
   public get lastEnqueuedEventInfo(): LastEnqueuedEventInfo {
@@ -72,8 +73,9 @@ export class PartitionProcessor {
   }
 
   /**
-   * @property The last enqueued event information. This property will only
-   * be enabled when `trackLastEnqueuedEventInfo` option is set to true when you create an instance of `EventProcessor`.
+   * @property Information on the last enqueued event in the partition that is being processed.
+   * This property is updated by the `EventProcessor` if the `trackLastEnqueuedEventInfo` option is set to true
+   * when creating an instance of EventProcessor
    */
   public set lastEnqueuedEventInfo(lastEnqueuedEventInfo: LastEnqueuedEventInfo) {
     this._lastEnqueuedEventInfo = lastEnqueuedEventInfo;

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -1,5 +1,6 @@
 import { CloseReason, PartitionManager } from "./eventProcessor";
 import { ReceivedEventData } from "./eventData";
+import { LastEnqueuedEventInfo } from "./eventHubReceiver";
 
 /**
  * A checkpoint is meant to represent the last successfully processed event by the user from a particular
@@ -59,6 +60,25 @@ export class PartitionProcessor {
   private _eventProcessorId: string | undefined;
   private _partitionId: string | undefined;
   private _eTag: string = "";
+  private _lastEnqueuedEventInfo: LastEnqueuedEventInfo | undefined;
+
+  /**
+   * @property The last enqueued event information. This property will only
+   * be enabled when `trackLastEnqueuedEventInfo` option is set to true when you create an instance of `EventProcessor`.
+   * @readonly
+   */
+  public get lastEnqueuedEventInfo(): LastEnqueuedEventInfo {
+    return this._lastEnqueuedEventInfo!;
+  }
+
+  /**
+   * @property The last enqueued event information. This property will only
+   * be enabled when `trackLastEnqueuedEventInfo` option is set to true when you create an instance of `EventProcessor`.
+   */
+  public set lastEnqueuedEventInfo(lastEnqueuedEventInfo: LastEnqueuedEventInfo) {
+    this._lastEnqueuedEventInfo = lastEnqueuedEventInfo;
+  }
+
   /**
    * @property The name of the consumer group from where the current partition is being processed. It is set by the `EventProcessor`
    * @readonly

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -53,7 +53,10 @@ export class PartitionPump {
       this._partitionProcessor.consumerGroupName,
       partitionId,
       this._initialEventPosition,
-      { ownerLevel: 0 }
+      {
+        ownerLevel: 0,
+        trackLastEnqueuedEventInfo: this._processorOptions.trackLastEnqueuedEventInfo
+      }
     );
 
     while (this._isReceiving) {
@@ -63,6 +66,12 @@ export class PartitionPump {
           this._processorOptions.maxWaitTimeInSeconds,
           this._abortController.signal
         );
+        if (
+          this._processorOptions.trackLastEnqueuedEventInfo &&
+          this._receiver.lastEnqueuedEventInfo
+        ) {
+          this._partitionProcessor.lastEnqueuedEventInfo = this._receiver.lastEnqueuedEventInfo;
+        }
         // avoid calling user's processEvents handler if the pump was stopped while receiving events
         if (!this._isReceiving) {
           return;

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -914,7 +914,7 @@ describe("Event Processor", function(): void {
       await processor.stop();
     });
 
-    it.only("should not have lastEnqueuedEventInfo populated when trackLastEnqueuedEventInfo is set to false", async function(): Promise<
+    it("should not have lastEnqueuedEventInfo populated when trackLastEnqueuedEventInfo is set to false", async function(): Promise<
       void
     > {
       const producer = client.createProducer({ partitionId: "0" });


### PR DESCRIPTION
The intent of these changes is to introduce the concept of partition metrics and piggy-backing last enqueued event info on received events. These metrics allow library consumers the opportunity for real-time inspection of the event processing backlog without the need to make dedicated requests for partition information.

Below are changes: 
*  Added `LastEnqueuedEventInfo` property and getter/setter for this on the PartitionProcessor class.
* Added `trackLastEnqueuedEventInfo`  in  an `EventHubConsumerOptions` interface.
* Added tests.
