### PR TITLE
[Identity] Use the JS date parser for expiration

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -181,12 +181,7 @@ export class ManagedIdentityCredential implements TokenCredential {
         expiresInParser = (requestBody: any) => {
           // Parse a date format like "06/20/2019 02:57:58 +00:00" and
           // convert it into a JavaScript-formatted date
-          const m = requestBody.expires_on.match(
-            /(\d\d)\/(\d\d)\/(\d\d\d\d) (\d\d):(\d\d):(\d\d) (\+|-)(\d\d):(\d\d)/
-          );
-          return Date.parse(
-            `${m[3]}-${m[1]}-${m[2]}T${m[4]}:${m[5]}:${m[6]}${m[7]}${m[8]}:${m[9]}`
-          );
+          return Date.parse(requestBody.expires_on);
         };
       } else {
         // Running in Cloud Shell


### PR DESCRIPTION
Fixes #4965 
Switch to using default date parser for MSI access token expiration. This should accept more date formats that the original format. Should help address connecting with Azure Function Apps (and possibly Azure App Service as well).

Note: this will fix is also more lenient than the parsing we had originally.