### PR TITLE
[core-amqp] fixes bug when making parallel send requests with RequestResponseLink

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -3,7 +3,6 @@ dependencies:
   '@azure/arm-servicebus': 3.2.0
   '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
   '@azure/cosmos-sign': 1.0.2
-  '@azure/event-hubs': 2.1.1
   '@azure/logger-js': 1.3.2
   '@azure/ms-rest-js': 2.0.4
   '@azure/ms-rest-nodeauth': 0.9.3
@@ -237,6 +236,29 @@ packages:
     dev: false
     resolution:
       integrity: sha512-e0nNyP0O802YMb4jq0nsVduIBHRWtmX/AtiWMCDI1f0KtcEmNRPfbP8DxU6iNgwnV09qy3EfaRfSY0vMsYs5cg==
+  /@azure/core-amqp/1.0.0-preview.3_rhea-promise@1.0.0:
+    dependencies:
+      '@azure/abort-controller': 1.0.0-preview.2
+      '@azure/core-auth': 1.0.0-preview.3
+      '@types/async-lock': 1.1.1
+      '@types/is-buffer': 2.0.0
+      async-lock: 1.2.2
+      buffer: 5.4.3
+      debug: 4.1.1
+      events: 3.0.0
+      is-buffer: 2.0.3
+      jssha: 2.3.1
+      process: 0.11.10
+      rhea-promise: 1.0.0
+      stream-browserify: 2.0.2
+      tslib: 1.10.0
+      url: 0.11.0
+      util: 0.12.1
+    dev: false
+    peerDependencies:
+      rhea-promise: ^1.0.0
+    resolution:
+      integrity: sha512-1CpgFoIIjzlwrYg+s4+1Lpe7IiErA/65DN+dO/A58r1nD+0QaBUJYmXrN7EftMHiCwEQF3PEzVx+hECPCxko1Q==
   /@azure/core-asynciterator-polyfill/1.0.0-preview.1:
     dev: false
     resolution:
@@ -310,6 +332,23 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nGnFBPcB/rs+5YWwmHJg+d3Cs7BrjtVfuD1eEv8j+ui2X6uXxB88wom1A2t/7xsSzkunQSrXJ2mCwdHxKI5aHw==
+  /@azure/event-hubs/5.0.0-preview.3:
+    dependencies:
+      '@azure/abort-controller': 1.0.0-preview.2
+      '@azure/core-amqp': 1.0.0-preview.3_rhea-promise@1.0.0
+      '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
+      async-lock: 1.2.2
+      buffer: 5.4.3
+      debug: 4.1.1
+      is-buffer: 2.0.3
+      jssha: 2.3.1
+      process: 0.11.10
+      rhea-promise: 1.0.0
+      tslib: 1.10.0
+      uuid: 3.3.3
+    dev: false
+    resolution:
+      integrity: sha512-iAMVlRiKbyd62rHA9AUyWPwjLOZToPPWVXv0fTg4j45qwF8+KzEsC/z9tIM8pXX+kTJ3tIh/etvo5hFgy0KcgA==
   /@azure/logger-js/1.3.2:
     dependencies:
       tslib: 1.10.0
@@ -2464,6 +2503,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==
+  /buffer/5.4.3:
+    dependencies:
+      base64-js: 1.3.1
+      ieee754: 1.1.13
+    dev: false
+    resolution:
+      integrity: sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
   /builtin-modules/3.1.0:
     dev: false
     engines:
@@ -11163,7 +11209,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-bPjNkHnC5Sq/ecnjbGhLTyQR9D/eoBsZvZUIevDEeUj9HYGmFGgA9kAOykDMkgo4anLKYt/m8sqnt9lQmX9/sw==
+      integrity: sha512-n99KsSk9JmZJ3GxLYLDkoqsrNx9ySKRAMpN11aexaw6MiG6phFl3g52aqvA6XRLfcxtnnK5Wi53UvaaiHDKnCA==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -11225,6 +11271,7 @@ packages:
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
     dependencies:
+      '@azure/event-hubs': 5.0.0-preview.3
       '@azure/storage-blob': 12.0.0-preview.3
       '@microsoft/api-extractor': 7.3.11
       '@types/chai': 4.2.1
@@ -11283,7 +11330,7 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-CrbYcZy31ilowc/g9ZfxxycRsXE/BXmniyd8s2nZLYTzgqSZy8JUY/mv+ZUfSi5jI1ZQ7aE+DJRStIOLcId4RA==
+      integrity: sha512-ti5aGtIrZB4gYyuqm+qC47KOAHJC8hAVDaULUVhxiJBQROi+zBJvkQJAfwkOftY6UCLFTzFgW9bvTvQIyhTUoQ==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -11933,7 +11980,6 @@ specifiers:
   '@azure/arm-servicebus': ^3.2.0
   '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
   '@azure/cosmos-sign': 1.0.2
-  '@azure/event-hubs': ^2.1.1
   '@azure/logger-js': ^1.0.2
   '@azure/ms-rest-js': ^2.0.0
   '@azure/ms-rest-nodeauth': ^0.9.2

--- a/sdk/core/core-amqp/changelog.md
+++ b/sdk/core/core-amqp/changelog.md
@@ -1,3 +1,7 @@
+## 1.0.0-preview.4 - TBD
+- Fixes bug where calling `sendRequest` from a `RequestResponseLink` mulitple
+times in parallel would result in all but 1 calls being retried.
+
 ## 1.0.0-preview.3 - 9th September, 2019
 Updates types for better compatibility with TypeScript 3.6.x. (PR #4928)
 

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "1.0.0-preview.3",
+  "version": "1.0.0-preview.4",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -154,35 +154,36 @@ export class RequestResponseLink implements ReqResLink {
           request.to || "$management",
           context.message
         );
+        if (
+          request.message_id !== responseCorrelationId &&
+          request.correlation_id !== responseCorrelationId
+        ) {
+          // do not remove message listener.
+          // parallel requests listen on the same receiver, so continue waiting until respose that matches
+          // request via correlationId is found.
+          log.error(
+            "[%s] request-messageId | '%s' != '%s' | response-correlationId. " +
+              "Hence dropping this response and waiting for the next one.",
+            this.connection.id,
+            request.message_id,
+            responseCorrelationId
+          );
+          return;
+        }
+
+        // remove the event listeners as they will be registered next time when someone makes a request.
+        this.receiver.removeListener(ReceiverEvents.message, messageCallback);
         if (info.statusCode > 199 && info.statusCode < 300) {
-          if (
-            request.message_id === responseCorrelationId ||
-            request.correlation_id === responseCorrelationId
-          ) {
-            if (!timeOver) {
-              clearTimeout(waitTimer);
-            }
-            log.reqres(
-              "[%s] request-messageId | '%s' == '%s' | response-correlationId.",
-              this.connection.id,
-              request.message_id,
-              responseCorrelationId
-            );
-            // remove the event listeners as they will be registered next time when someone makes a request.
-            this.receiver.removeListener(ReceiverEvents.message, messageCallback);
-            return resolve(context.message);
-          } else {
-            // do not remove message listener.
-            // parallel requests listen on the same receiver, so continue waiting until matching message
-            // per correlationId is found.
-            log.error(
-              "[%s] request-messageId | '%s' != '%s' | response-correlationId. " +
-                "Hence dropping this response and waiting for the next one.",
-              this.connection.id,
-              request.message_id,
-              responseCorrelationId
-            );
+          if (!timeOver) {
+            clearTimeout(waitTimer);
           }
+          log.reqres(
+            "[%s] request-messageId | '%s' == '%s' | response-correlationId.",
+            this.connection.id,
+            request.message_id,
+            responseCorrelationId
+          );
+          return resolve(context.message);
         } else {
           const condition =
             info.errorCondition || ConditionStatusMapper[info.statusCode] || "amqp:internal-error";
@@ -192,8 +193,6 @@ export class RequestResponseLink implements ReqResLink {
           };
           const error = translate(e);
           log.error(error);
-          // remove the event listeners as they will be registered next time when someone makes a request.
-          this.receiver.removeListener(ReceiverEvents.message, messageCallback);
           return reject(error);
         }
       };

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -60,6 +60,72 @@ describe("RequestResponseLink", function() {
     assert.equal(response.correlation_id, req.message_id);
   });
 
+  it("should send parellel requests and receive responses correctly", async function() {
+    const connectionStub = stub(new Connection());
+    const rcvr = new EventEmitter();
+    let reqs: AmqpMessage[] = [];
+    connectionStub.createSession.resolves({
+      connection: {
+        id: "connection-1"
+      },
+      createSender: () => {
+        return Promise.resolve({
+          send: (request: AmqpMessage) => {
+            reqs.push(request);
+          }
+        });
+      },
+      createReceiver: () => {
+        return Promise.resolve(rcvr);
+      }
+    } as any);
+    const sessionStub = await connectionStub.createSession();
+    const senderStub = await sessionStub.createSender();
+    const receiverStub = await sessionStub.createReceiver();
+    const link = new RequestResponseLink(sessionStub as any, senderStub, receiverStub);
+    const request1: AmqpMessage = {
+      body: "Hello World!!",
+      message_id: 1
+    };
+    const request2: AmqpMessage = {
+      body: "Hello again my old friend.",
+      message_id: 2
+    };
+    setTimeout(() => {
+      rcvr.emit("message", {
+        message: {
+          correlation_id: reqs[0].message_id,
+          application_properties: {
+            statusCode: 200,
+            errorCondition: null,
+            statusDescription: null,
+            "com.microsoft:tracking-id": null
+          },
+          body: "Hello World!!"
+        }
+      });
+    }, 2000);
+    setTimeout(() => {
+      rcvr.emit("message", {
+        message: {
+          correlation_id: reqs[1].message_id,
+          application_properties: {
+            statusCode: 200,
+            errorCondition: null,
+            statusDescription: null,
+            "com.microsoft:tracking-id": null
+          },
+          body: "Hello hello!"
+        }
+      });
+    }, 2100);
+
+    const responses = await Promise.all([link.sendRequest(request1), link.sendRequest(request2)]);
+
+    assert.equal(responses[0].correlation_id, reqs[0].message_id);
+    assert.equal(responses[1].correlation_id, reqs[1].message_id);
+  });
+
   it("should surface error up through retry", async function() {
     const connectionStub = stub(new Connection());
     const rcvr = new EventEmitter();

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -126,6 +126,82 @@ describe("RequestResponseLink", function() {
     assert.equal(responses[1].correlation_id, reqs[1].message_id);
   });
 
+  it("should send parellel requests and receive responses correctly (one failure)", async function() {
+    const connectionStub = stub(new Connection());
+    const rcvr = new EventEmitter();
+    let reqs: AmqpMessage[] = [];
+    connectionStub.createSession.resolves({
+      connection: {
+        id: "connection-1"
+      },
+      createSender: () => {
+        return Promise.resolve({
+          send: (request: AmqpMessage) => {
+            reqs.push(request);
+          }
+        });
+      },
+      createReceiver: () => {
+        return Promise.resolve(rcvr);
+      }
+    } as any);
+    const sessionStub = await connectionStub.createSession();
+    const senderStub = await sessionStub.createSender();
+    const receiverStub = await sessionStub.createReceiver();
+    const link = new RequestResponseLink(sessionStub as any, senderStub, receiverStub);
+    const request1: AmqpMessage = {
+      body: "Hello World!!",
+      message_id: 1
+    };
+    const request2: AmqpMessage = {
+      body: "Hello again my old friend.",
+      message_id: 2
+    };
+    setTimeout(() => {
+      rcvr.emit("message", {
+        message: {
+          correlation_id: reqs[0].message_id,
+          application_properties: {
+            statusCode: 200,
+            errorCondition: null,
+            statusDescription: null,
+            "com.microsoft:tracking-id": null
+          },
+          body: "Hello World!!"
+        }
+      });
+    }, 2000);
+    setTimeout(() => {
+      rcvr.emit("message", {
+        message: {
+          correlation_id: reqs[1].message_id,
+          application_properties: {
+            statusCode: 500,
+            errorCondition: ErrorNameConditionMapper.InternalServerError,
+            statusDescription: "Please try again later.",
+            "com.microsoft:tracking-id": 1
+          },
+          body: "Hello hello!"
+        }
+      });
+    }, 1500);
+
+    const successfulRequest = link.sendRequest(request1);
+    const failedRequest = link.sendRequest(request2);
+
+    // ensure that one request fails
+    try {
+      await failedRequest;
+      throw new Error("Test failure");
+    } catch (err) {
+      err.message.should.not.equal("Test failure");
+    }
+
+    // ensure the other request succeeds
+    const response = await successfulRequest;
+    assert.equal(response.correlation_id, request1.message_id);
+  });
+
   it("should surface error up through retry", async function() {
     const connectionStub = stub(new Connection());
     const rcvr = new EventEmitter();

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.0.0-preview.3",
+  "version": "5.0.0-preview.4",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
-    "@azure/core-amqp": "1.0.0-preview.3",
+    "@azure/core-amqp": "1.0.0-preview.4",
     "@azure/core-asynciterator-polyfill": "1.0.0-preview.1",
     "async-lock": "^1.1.3",
     "buffer": "^5.2.1",

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,5 +6,5 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.0.0-preview.3"
+  version: "5.0.0-preview.4"
 };

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -12,13 +12,13 @@ const env = getEnvVars();
 
 import { EventHubClient } from "../src";
 import { AbortController } from "@azure/abort-controller";
-describe("RuntimeInformation #RunnableInBrowser", function(): void {
+describe("RuntimeInformation #RunnableInBrowser", function (): void {
   let client: EventHubClient;
   const service = {
     connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
     path: env[EnvVarKeys.EVENTHUB_NAME]
   };
-  before("validate environment", function(): void {
+  before("validate environment", function (): void {
     should.exist(
       env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
       "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
@@ -29,7 +29,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
     );
   });
 
-  afterEach("close the connection", async function(): Promise<void> {
+  afterEach("close the connection", async function (): Promise<void> {
     await client.close();
   });
 
@@ -39,14 +39,14 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
     });
   }
 
-  describe("getPartitionIds", function(): void {
-    it("returns an array of partition IDs", async function(): Promise<void> {
+  describe("getPartitionIds", function (): void {
+    it("returns an array of partition IDs", async function (): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path);
       const ids = await client.getPartitionIds();
       ids.should.have.members(arrayOfIncreasingNumbersFromZero(ids.length));
     });
 
-    it("respects cancellationTokens", async function(): Promise<void> {
+    it("respects cancellationTokens", async function (): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path);
       try {
         const controller = new AbortController();
@@ -57,10 +57,26 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
         err.message.should.match(/The [\w]+ operation has been cancelled by the user.$/gi);
       }
     });
+
+    it("can be ran in parallel without retries", async function (): Promise<void> {
+      client = new EventHubClient(service.connectionString, service.path, {
+        retryOptions: {
+          maxRetries: 0
+        }
+      });
+      const results = await Promise.all([
+        client.getPartitionIds(),
+        client.getPartitionIds()
+      ]);
+
+      for (const result of results) {
+        result.should.have.members(arrayOfIncreasingNumbersFromZero(result.length));
+      }
+    });
   });
 
-  describe("hub runtime information", function(): void {
-    it("gets the hub runtime information", async function(): Promise<void> {
+  describe("hub runtime information", function (): void {
+    it("gets the hub runtime information", async function (): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path, {
         userAgent: "/js-event-processor-host=0.2.0"
       });
@@ -74,7 +90,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
       hubRuntimeInfo.createdAt.should.be.instanceof(Date);
     });
 
-    it("can cancel a request for hub runtime information", async function(): Promise<void> {
+    it("can cancel a request for hub runtime information", async function (): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path, {
         userAgent: "/js-event-processor-host=0.2.0"
       });
@@ -89,8 +105,8 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
     });
   });
 
-  describe("partition runtime information", function(): void {
-    it("should throw an error if partitionId is missing", async function(): Promise<void> {
+  describe("partition runtime information", function (): void {
+    it("should throw an error if partitionId is missing", async function (): Promise<void> {
       try {
         client = new EventHubClient(service.connectionString, service.path);
         await client.getPartitionProperties(undefined as any);
@@ -101,7 +117,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
       }
     });
 
-    it("gets the partition runtime information with partitionId as a string", async function(): Promise<
+    it("gets the partition runtime information with partitionId as a string", async function (): Promise<
       void
     > {
       client = new EventHubClient(service.connectionString, service.path);
@@ -114,7 +130,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
       should.exist(partitionRuntimeInfo.lastEnqueuedOffset);
     });
 
-    it("gets the partition runtime information with partitionId as a number", async function(): Promise<
+    it("gets the partition runtime information with partitionId as a number", async function (): Promise<
       void
     > {
       client = new EventHubClient(service.connectionString, service.path);
@@ -128,8 +144,8 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
     });
 
     const invalidIds = ["XYZ", -1, 1000, "-", " ", ""];
-    invalidIds.forEach(function(id: any): void {
-      it(`should fail the partition runtime information when partitionId is "${id}"`, async function(): Promise<void> {
+    invalidIds.forEach(function (id: any): void {
+      it(`should fail the partition runtime information when partitionId is "${id}"`, async function (): Promise<void> {
         try {
           client = new EventHubClient(service.connectionString, service.path);
           await client.getPartitionProperties(id as any);
@@ -144,7 +160,7 @@ describe("RuntimeInformation #RunnableInBrowser", function(): void {
       });
     });
 
-    it("can cancel a request for getPartitionInformation", async function(): Promise<void> {
+    it("can cancel a request for getPartitionInformation", async function (): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path);
       try {
         const controller = new AbortController();

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -12,13 +12,13 @@ const env = getEnvVars();
 
 import { EventHubClient } from "../src";
 import { AbortController } from "@azure/abort-controller";
-describe("RuntimeInformation #RunnableInBrowser", function (): void {
+describe("RuntimeInformation #RunnableInBrowser", function(): void {
   let client: EventHubClient;
   const service = {
     connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
     path: env[EnvVarKeys.EVENTHUB_NAME]
   };
-  before("validate environment", function (): void {
+  before("validate environment", function(): void {
     should.exist(
       env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
       "define EVENTHUB_CONNECTION_STRING in your environment before running integration tests."
@@ -29,7 +29,7 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
     );
   });
 
-  afterEach("close the connection", async function (): Promise<void> {
+  afterEach("close the connection", async function(): Promise<void> {
     await client.close();
   });
 
@@ -39,14 +39,14 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
     });
   }
 
-  describe("getPartitionIds", function (): void {
-    it("returns an array of partition IDs", async function (): Promise<void> {
+  describe("getPartitionIds", function(): void {
+    it("returns an array of partition IDs", async function(): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path);
       const ids = await client.getPartitionIds();
       ids.should.have.members(arrayOfIncreasingNumbersFromZero(ids.length));
     });
 
-    it("respects cancellationTokens", async function (): Promise<void> {
+    it("respects cancellationTokens", async function(): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path);
       try {
         const controller = new AbortController();
@@ -58,16 +58,13 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
       }
     });
 
-    it("can be ran in parallel without retries", async function (): Promise<void> {
+    it("can be ran in parallel without retries", async function(): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path, {
         retryOptions: {
           maxRetries: 0
         }
       });
-      const results = await Promise.all([
-        client.getPartitionIds(),
-        client.getPartitionIds()
-      ]);
+      const results = await Promise.all([client.getPartitionIds(), client.getPartitionIds()]);
 
       for (const result of results) {
         result.should.have.members(arrayOfIncreasingNumbersFromZero(result.length));
@@ -75,8 +72,8 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
     });
   });
 
-  describe("hub runtime information", function (): void {
-    it("gets the hub runtime information", async function (): Promise<void> {
+  describe("hub runtime information", function(): void {
+    it("gets the hub runtime information", async function(): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path, {
         userAgent: "/js-event-processor-host=0.2.0"
       });
@@ -90,7 +87,7 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
       hubRuntimeInfo.createdAt.should.be.instanceof(Date);
     });
 
-    it("can cancel a request for hub runtime information", async function (): Promise<void> {
+    it("can cancel a request for hub runtime information", async function(): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path, {
         userAgent: "/js-event-processor-host=0.2.0"
       });
@@ -105,8 +102,8 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
     });
   });
 
-  describe("partition runtime information", function (): void {
-    it("should throw an error if partitionId is missing", async function (): Promise<void> {
+  describe("partition runtime information", function(): void {
+    it("should throw an error if partitionId is missing", async function(): Promise<void> {
       try {
         client = new EventHubClient(service.connectionString, service.path);
         await client.getPartitionProperties(undefined as any);
@@ -117,7 +114,7 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
       }
     });
 
-    it("gets the partition runtime information with partitionId as a string", async function (): Promise<
+    it("gets the partition runtime information with partitionId as a string", async function(): Promise<
       void
     > {
       client = new EventHubClient(service.connectionString, service.path);
@@ -130,7 +127,7 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
       should.exist(partitionRuntimeInfo.lastEnqueuedOffset);
     });
 
-    it("gets the partition runtime information with partitionId as a number", async function (): Promise<
+    it("gets the partition runtime information with partitionId as a number", async function(): Promise<
       void
     > {
       client = new EventHubClient(service.connectionString, service.path);
@@ -144,8 +141,8 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
     });
 
     const invalidIds = ["XYZ", -1, 1000, "-", " ", ""];
-    invalidIds.forEach(function (id: any): void {
-      it(`should fail the partition runtime information when partitionId is "${id}"`, async function (): Promise<void> {
+    invalidIds.forEach(function(id: any): void {
+      it(`should fail the partition runtime information when partitionId is "${id}"`, async function(): Promise<void> {
         try {
           client = new EventHubClient(service.connectionString, service.path);
           await client.getPartitionProperties(id as any);
@@ -160,7 +157,7 @@ describe("RuntimeInformation #RunnableInBrowser", function (): void {
       });
     });
 
-    it("can cancel a request for getPartitionInformation", async function (): Promise<void> {
+    it("can cancel a request for getPartitionInformation", async function(): Promise<void> {
       client = new EventHubClient(service.connectionString, service.path);
       try {
         const controller = new AbortController();


### PR DESCRIPTION
Fixes #4767 

Details are in the issue above. This change only removes the message listener from an amqp receiver if the outer Promise can be either resolved or rejected by the response from the server.

 