### PR TITLE
[Storage] Only iterate with an undefined marker or a non-empty…

### DIFF
--- a/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
@@ -1,4 +1,4 @@
-/* 
+/*
  Setup: Enter your storage account name and shared key in main()
 */
 
@@ -36,6 +36,7 @@ async function main() {
   }
 
   // 1. List blobs
+  console.log("Listing all blobs using iter");
   let i = 1;
   let iter = await containerClient.listBlobsFlat();
   for await (const blob of iter) {
@@ -43,12 +44,14 @@ async function main() {
   }
 
   // 2. Same as the previous example
+  console.log("Listing all blobs");
   i = 1;
   for await (const blob of containerClient.listBlobsFlat()) {
     console.log(`Blob ${i++}: ${blob.name}`);
   }
 
   // 3. Generator syntax .next()
+  console.log("Listing all blobs using iter.next()");
   i = 1;
   iter = containerClient.listBlobsFlat();
   let blobItem = await iter.next();
@@ -62,6 +65,7 @@ async function main() {
   ////////////////////////////////////////////////////////
 
   // 4. list containers by page
+  console.log("Listing all blobs by page");
   i = 1;
   for await (const response of containerClient.listBlobsFlat().byPage()) {
     for (const blob of response.segment.blobItems) {
@@ -70,6 +74,7 @@ async function main() {
   }
 
   // 5. Same as the previous example - passing maxPageSize in the page settings
+  console.log("Listing all blobs by page, passing maxPageSize in the page settings");
   i = 1;
   for await (const response of containerClient.listBlobsFlat().byPage({ maxPageSize: 20 })) {
     for (const blob of response.segment.blobItems) {
@@ -78,6 +83,7 @@ async function main() {
   }
 
   // 6. Generator syntax .next()
+  console.log("Listing all blobs by page using iterator.next()");
   i = 1;
   let iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 20 });
   let response = await iterator.next();
@@ -90,8 +96,9 @@ async function main() {
   }
 
   // 7. Passing marker as an argument (similar to the previous example)
+  console.log("Listing all blobs by page, using iteartor.next() and continuation token");
   i = 1;
-  iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 2 });
+  iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 20 });
   response = await iterator.next();
   let segment = response.value.segment;
   // Prints 2 blob names
@@ -99,14 +106,16 @@ async function main() {
     console.log(`Blob ${i++}: ${blob.name}`);
   }
   // Gets next marker
+  console.log("\tContinuation")
   let marker = response.value.nextMarker;
   // Passing next marker as continuationToken
   iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });
   response = await iterator.next();
-  segment = response.value.segment;
   // Prints 5 blob names
-  for (const blob of segment.blobItems) {
-    console.log(`Blob ${i++}: ${blob.name}`);
+  if (!response.done) {
+    for (const blob of response.value.segment.blobItems) {
+      console.log(`Blob ${i++}: ${blob.name}`);
+    }
   }
 
   await containerClient.delete();

--- a/sdk/storage/storage-blob/samples/javascript/iterators-containers.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-containers.js
@@ -1,4 +1,4 @@
-/* 
+/*
  Setup: Enter your storage account name and shared key in main()
 */
 
@@ -20,6 +20,7 @@ async function main() {
   );
 
   // 1. List Containers
+  console.log("Listing all containers using iter");
   let i = 1;
   let iter = await blobServiceClient.listContainers();
   for await (const container of iter) {
@@ -27,12 +28,14 @@ async function main() {
   }
 
   // 2. Same as the previous example
+  console.log("Listing all containers without iter");
   i = 1;
   for await (const container of blobServiceClient.listContainers()) {
     console.log(`Container ${i++}: ${container.name}`);
   }
 
   // 3. Generator syntax .next()
+  console.log("Listing all containers using iter.next()");
   i = 1;
   iter = blobServiceClient.listContainers();
   let containerItem = await iter.next();
@@ -46,6 +49,7 @@ async function main() {
   ////////////////////////////////////////////////////////
 
   // 4. list containers by page
+  console.log("Listing all containers byPage()");
   i = 1;
   for await (const response of blobServiceClient.listContainers().byPage()) {
     if (response.containerItems) {
@@ -56,6 +60,7 @@ async function main() {
   }
 
   // 5. Same as the previous example - passing maxPageSize in the page settings
+  console.log("Listing all containers byPage(), passing maxPageSize in the page settings");
   i = 1;
   for await (const response of blobServiceClient.listContainers().byPage({ maxPageSize: 20 })) {
     if (response.containerItems) {
@@ -66,6 +71,7 @@ async function main() {
   }
 
   // 6. Generator syntax .next()
+  console.log("Listing all containers byPage(), using iterator.next()");
   i = 1;
   let iterator = blobServiceClient.listContainers().byPage({ maxPageSize: 20 });
   let response = await iterator.next();
@@ -79,6 +85,7 @@ async function main() {
   }
 
   // 7. Passing marker as an argument (similar to the previous example)
+  console.log("Listing all containers byPage(), using iteartor.next() and continuation token");
   i = 1;
   iterator = blobServiceClient.listContainers().byPage({ maxPageSize: 2 });
   response = await iterator.next();
@@ -89,6 +96,7 @@ async function main() {
     }
   }
   // Gets next marker
+  console.log("\tContinuation");
   let marker = response.value.nextMarker;
   // Passing next marker as continuationToken
   iterator = blobServiceClient
@@ -96,7 +104,7 @@ async function main() {
     .byPage({ continuationToken: marker, maxPageSize: 10 });
   response = await iterator.next();
   // Prints 10 container names
-  if (response.value.containerItems) {
+  if (!response.done) {
     for (const container of response.value.containerItems) {
       console.log(`Container ${i++}: ${container.name}`);
     }

--- a/sdk/storage/storage-blob/samples/typescript/iterators-blobs.ts
+++ b/sdk/storage/storage-blob/samples/typescript/iterators-blobs.ts
@@ -1,4 +1,4 @@
-/* 
+/*
  Setup: Enter your storage account name and shared key in main()
 */
 
@@ -36,6 +36,7 @@ async function main() {
   }
 
   // 1. List blobs
+  console.log("Listing all blobs using iter");
   let i = 1;
   let iter = await containerClient.listBlobsFlat();
   for await (const blob of iter) {
@@ -43,12 +44,14 @@ async function main() {
   }
 
   // 2. Same as the previous example
+  console.log("Listing all blobs");
   i = 1;
   for await (const blob of containerClient.listBlobsFlat()) {
     console.log(`Blob ${i++}: ${blob.name}`);
   }
 
   // 3. Generator syntax .next()
+  console.log("Listing all blobs using iter.next()");
   i = 1;
   iter = containerClient.listBlobsFlat();
   let blobItem = await iter.next();
@@ -62,6 +65,7 @@ async function main() {
   ////////////////////////////////////////////////////////
 
   // 4. list containers by page
+  console.log("Listing all blobs by page");
   i = 1;
   for await (const response of containerClient.listBlobsFlat().byPage()) {
     for (const blob of response.segment.blobItems) {
@@ -70,6 +74,7 @@ async function main() {
   }
 
   // 5. Same as the previous example - passing maxPageSize in the page settings
+  console.log("Listing all blobs by page, passing maxPageSize in the page settings");
   i = 1;
   for await (const response of containerClient.listBlobsFlat().byPage({ maxPageSize: 20 })) {
     for (const blob of response.segment.blobItems) {
@@ -78,6 +83,7 @@ async function main() {
   }
 
   // 6. Generator syntax .next()
+  console.log("Listing all blobs by page using iterator.next()");
   i = 1;
   let iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 20 });
   let response = await iterator.next();
@@ -90,6 +96,7 @@ async function main() {
   }
 
   // 7. Passing marker as an argument (similar to the previous example)
+  console.log("Listing all blobs by page, using iteartor.next() and continuation token");
   i = 1;
   iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 2 });
   response = await iterator.next();
@@ -99,14 +106,16 @@ async function main() {
     console.log(`Blob ${i++}: ${blob.name}`);
   }
   // Gets next marker
+  console.log("\tContinuation");
   let marker = response.value.nextMarker;
   // Passing next marker as continuationToken
   iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });
   response = await iterator.next();
-  segment = response.value.segment;
   // Prints 5 blob names
-  for (const blob of segment.blobItems) {
-    console.log(`Blob ${i++}: ${blob.name}`);
+  if (!response.done) {
+    for (const blob of response.value.segment.blobItems) {
+      console.log(`Blob ${i++}: ${blob.name}`);
+    }
   }
 
   await containerClient.delete();

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -553,11 +553,13 @@ export class BlobServiceClient extends StorageClient {
     options: ServiceListContainersSegmentOptions = {}
   ): AsyncIterableIterator<Models.ServiceListContainersSegmentResponse> {
     let listContainersSegmentResponse;
-    do {
-      listContainersSegmentResponse = await this.listContainersSegment(marker, options);
-      marker = listContainersSegmentResponse.nextMarker;
-      yield await listContainersSegmentResponse;
-    } while (marker);
+    if (!!marker || marker === undefined) {
+      do {
+        listContainersSegmentResponse = await this.listContainersSegment(marker, options);
+        marker = listContainersSegmentResponse.nextMarker;
+        yield await listContainersSegmentResponse;
+      } while (marker);
+    }
   }
 
   /**

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -989,11 +989,13 @@ export class ContainerClient extends StorageClient {
     options: ContainerListBlobsSegmentOptions = {}
   ): AsyncIterableIterator<Models.ContainerListBlobFlatSegmentResponse> {
     let listBlobsFlatSegmentResponse;
-    do {
-      listBlobsFlatSegmentResponse = await this.listBlobFlatSegment(marker, options);
-      marker = listBlobsFlatSegmentResponse.nextMarker;
-      yield await listBlobsFlatSegmentResponse;
-    } while (marker);
+    if (!!marker || marker === undefined) {
+      do {
+        listBlobsFlatSegmentResponse = await this.listBlobFlatSegment(marker, options);
+        marker = listBlobsFlatSegmentResponse.nextMarker;
+        yield await listBlobsFlatSegmentResponse;
+      } while (marker);
+    }
   }
 
   /**
@@ -1118,15 +1120,17 @@ export class ContainerClient extends StorageClient {
     options: ContainerListBlobsSegmentOptions = {}
   ): AsyncIterableIterator<Models.ContainerListBlobHierarchySegmentResponse> {
     let listBlobsHierarchySegmentResponse;
-    do {
-      listBlobsHierarchySegmentResponse = await this.listBlobHierarchySegment(
-        delimiter,
-        marker,
-        options
-      );
-      marker = listBlobsHierarchySegmentResponse.nextMarker;
-      yield await listBlobsHierarchySegmentResponse;
-    } while (marker);
+    if (!!marker || marker === undefined) {
+      do {
+        listBlobsHierarchySegmentResponse = await this.listBlobHierarchySegment(
+          delimiter,
+          marker,
+          options
+        );
+        marker = listBlobsHierarchySegmentResponse.nextMarker;
+        yield await listBlobsHierarchySegmentResponse;
+      } while (marker);
+    }
   }
 
   /**


### PR DESCRIPTION
When using the paged iterator next() function and the continuation token, we get
an next marker of empty string. The service happily takes the empty string and
iterates from the beginning.

This change fixes it by only iterating when the marker is non-empty (more items
available) or undefined (starting from the beginning).

Samples are updated to check for `done`.