### PR TITLE
[Storage] Fix doc issues - broken link and example code blocks

### DIFF
--- a/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
@@ -160,6 +160,7 @@ export interface BlobSASSignatureValues {
  * this constructor.
  *
  * @example
+ * ```js
  * // Generate service level SAS for a container
  * const containerSAS = generateBlobSASQueryParameters({
  *     containerName, // Required
@@ -172,8 +173,10 @@ export interface BlobSASSignatureValues {
  *   },
  *   sharedKeyCredential // SharedKeyCredential
  * ).toString();
+ * ```
  *
  * @example
+ * ```js
  * // Generate service level SAS for a container with identifier
  * // startTime & permissions are optional when identifier is provided
  * const identifier = "unique-id";
@@ -195,8 +198,10 @@ export interface BlobSASSignatureValues {
  *   },
  *   sharedKeyCredential // SharedKeyCredential
  * ).toString();
+ * ```
  *
  * @example
+ * ```js
  * // Generate service level SAS for a blob
  * const blobSAS = generateBlobSASQueryParameters({
  *     containerName, // Required
@@ -215,6 +220,7 @@ export interface BlobSASSignatureValues {
  *   },
  *   sharedKeyCredential // SharedKeyCredential
  * ).toString();
+ * ```
  *
  * @export
  * @param {BlobSASSignatureValues} blobSASSignatureValues
@@ -233,6 +239,7 @@ export function generateBlobSASQueryParameters(
  * WARNING: identifier will be ignored when generating user delegation SAS, permissions and expiryTime are required.
  *
  * @example
+ * ```js
  * // Generate user delegation SAS for a container
  * const userDelegationKey = await blobServiceClient.getUserDelegationKey(aborter, startTime, expiryTime);
  * const containerSAS = generateBlobSASQueryParameters({
@@ -247,6 +254,7 @@ export function generateBlobSASQueryParameters(
  *   userDelegationKey, // UserDelegationKey
  *   accountName
  * ).toString();
+ * ```
  *
  * @export
  * @param {BlobSASSignatureValues} blobSASSignatureValues

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -437,7 +437,7 @@ export class BlobServiceClient extends StorageClient {
   /**
    * Gets the properties of a storage account’s Blob service, including properties
    * for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
-   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties}
+   * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-properties
    *
    * @param {ServiceGetPropertiesOptions} [options] Options to the Service Get Properties operation.
    * @returns {Promise<Models.ServiceGetPropertiesResponse>} Response data for the Service Get Properties operation.
@@ -584,12 +584,15 @@ export class BlobServiceClient extends StorageClient {
    * .byPage() returns an async iterable iterator to list the containers in pages.
    *
    * @example
+   * ```js
    *   let i = 1;
    *   for await (const container of blobServiceClient.listContainers()) {
    *     console.log(`Container ${i++}: ${container.name}`);
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Generator syntax .next()
    *   let i = 1;
    *   iter = blobServiceClient.listContainers();
@@ -598,8 +601,10 @@ export class BlobServiceClient extends StorageClient {
    *     console.log(`Container ${i++}: ${containerItem.value.name}`);
    *     containerItem = await iter.next();
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
    *   let i = 1;
@@ -610,8 +615,10 @@ export class BlobServiceClient extends StorageClient {
    *       }
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;
    *   let iterator = blobServiceClient.listContainers().byPage({ maxPageSize: 2 });
@@ -635,7 +642,7 @@ export class BlobServiceClient extends StorageClient {
    *        console.log(`Container ${i++}: ${container.name}`);
    *     }
    *   }
-   *
+   * ```
    *
    * @param {ServiceListContainersOptions} [options={}] Options to list containers.
    * @returns {PagedAsyncIterableIterator<Models.ContainerItem, Models.ServiceListContainersSegmentResponse>} An asyncIterableIterator that supports paging.
@@ -679,7 +686,6 @@ export class BlobServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key
    *
-   *                          goto documents of Aborter for more examples about request cancellation
    * @param {Date} start      The start time for the user delegation SAS. Must be within 7 days of the current time
    * @param {Date} expiry     The end time for the user delegation SAS. Must be within 7 days of the current time
    * @returns {Promise<ServiceGetUserDelegationKeyResponse>}
@@ -727,6 +733,7 @@ export class BlobServiceClient extends StorageClient {
    * Submit batch request which consists of multiple subrequests.
    *
    * @example
+   * ```js
    * let batchDeleteRequest = new BatchDeleteRequest();
    * await batchDeleteRequest.addSubRequest(urlInString0, credential0);
    * await batchDeleteRequest.addSubRequest(urlInString1, credential1, {
@@ -734,8 +741,10 @@ export class BlobServiceClient extends StorageClient {
    * });
    * const deleteBatchResp = await blobServiceClient.submitBatch(batchDeleteRequest);
    * console.log(deleteBatchResp.subResponsesSucceededCount);
+   * ```
    *
    * @example
+   * ```js
    * let batchSetTierRequest = new BatchSetTierRequest();
    * await batchSetTierRequest.addSubRequest(blockBlobClient0, "Cool");
    * await batchSetTierRequest.addSubRequest(blockBlobClient1, "Cool", {
@@ -743,6 +752,7 @@ export class BlobServiceClient extends StorageClient {
    * });
    * const setTierBatchResp = await blobServiceClient.submitBatch(batchSetTierRequest);
    * console.log(setTierBatchResp.subResponsesSucceededCount);
+   * ```
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch
    *

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -1020,12 +1020,15 @@ export class ContainerClient extends StorageClient {
    * .byPage() returns an async iterable iterator to list the blobs in pages.
    *
    * @example
+   * ```js
    *   let i = 1;
    *   for await (const blob of containerClient.listBlobsFlat()) {
    *     console.log(`Blob ${i++}: ${blob.name}`);
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Generator syntax .next()
    *   let i = 1;
    *   iter = containerClient.listBlobsFlat();
@@ -1034,8 +1037,10 @@ export class ContainerClient extends StorageClient {
    *     console.log(`Blob ${i++}: ${blobItem.value.name}`);
    *     blobItem = await iter.next();
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
    *   let i = 1;
@@ -1044,8 +1049,10 @@ export class ContainerClient extends StorageClient {
    *       console.log(`Blob ${i++}: ${blob.name}`);
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;
    *   let iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 2 });
@@ -1063,6 +1070,7 @@ export class ContainerClient extends StorageClient {
    *   for (const blob of response.segment.blobItems) {
    *     console.log(`Blob ${i++}: ${blob.name}`);
    *   }
+   * ```
    *
    * @param {ContainerListBlobsOptions} [options={}] Options to list blobs.
    * @returns {PagedAsyncIterableIterator<Models.BlobItem, Models.ContainerListBlobFlatSegmentResponse>} An asyncIterableIterator that supports paging.
@@ -1168,6 +1176,7 @@ export class ContainerClient extends StorageClient {
    * .byPage() returns an async iterable iterator to list the blobs by hierarchy in pages.
    *
    * @example
+   * ```js
    *   for await (const item of containerClient.listBlobsByHierarchy("/")) {
    *     if (item.kind === "prefix") {
    *       console.log(`\tBlobPrefix: ${item.name}`);
@@ -1175,8 +1184,10 @@ export class ContainerClient extends StorageClient {
    *       console.log(`\tBlobItem: name - ${item.name}, last modified - ${item.properties.lastModified}`);
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    * // Generator syntax .next() and passing a prefix
    * let iter = await containerClient.listBlobsByHierarchy("/", { prefix: "prefix1/" });
    * let entity = await iter.next();
@@ -1189,8 +1200,10 @@ export class ContainerClient extends StorageClient {
    *   }
    *   entity = await iter.next();
    * }
+   * ```js
    *
    * @example
+   * ```js
    *   // byPage()
    *   console.log("Listing blobs by hierarchy by page");
    *   for await (const response of containerClient.listBlobsByHierarchy("/").byPage()) {
@@ -1204,8 +1217,10 @@ export class ContainerClient extends StorageClient {
    *       console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // 4. byPage() and passing a prefix and max page size
    *   console.log("Listing blobs by hierarchy by page, specifying a prefix and a max page size");
    *   let i = 1;
@@ -1221,6 +1236,7 @@ export class ContainerClient extends StorageClient {
    *       console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
    *     }
    *   }
+   * ```
    *
    * @param {string} delimiter The charactor or string used to define the virtual hierarchy
    * @param {ContainerListBlobsOptions} [options={}] Options to list blobs operation.

--- a/sdk/storage/storage-file/src/DirectoryClient.ts
+++ b/sdk/storage/storage-file/src/DirectoryClient.ts
@@ -627,6 +627,7 @@ export class DirectoryClient extends StorageClient {
    * .byPage() returns an async iterable iterator to list the files and directories in pages.
    *
    * @example
+   * ```js
    *   let i = 1;
    *   for await (const entity of directoryClient.listFilesAndDirectories()) {
    *     if (entity.kind === "directory") {
@@ -635,8 +636,10 @@ export class DirectoryClient extends StorageClient {
    *       console.log(`${i++} - file\t: ${entity.name}`);
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Generator syntax .next()
    *   let i = 1;
    *   let iter = await directoryClient.listFilesAndDirectories();
@@ -649,8 +652,10 @@ export class DirectoryClient extends StorageClient {
    *     }
    *     entity = await iter.next();
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
    *   let i = 1;
@@ -664,8 +669,10 @@ export class DirectoryClient extends StorageClient {
    *       console.log(`${i++} - directory\t: ${dirItem.name}`);
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;
    *   let iterator = directoryClient.listFilesAndDirectories().byPage({ maxPageSize: 3 });
@@ -691,6 +698,7 @@ export class DirectoryClient extends StorageClient {
    *   for (const dirItem of response.segment.directoryItems) {
    *     console.log(`${i++} - directory\t: ${dirItem.name}`);
    *   }
+   * ```
    *
    * @param {DirectoryListFilesAndDirectoriesOptions} [options] Options to list files and directories operation.
    * @memberof DirectoryClient
@@ -805,12 +813,16 @@ export class DirectoryClient extends StorageClient {
    * .byPage() returns an async iterable iterator to list the handles in pages.
    *
    * @example
+   * ```js
    *   let i = 1;
    *   let iter = dirClient.listHandles();
    *   for await (const handle of iter) {
    *     console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
    *   }
+   * ```
+   *
    * @example
+   * ```js
    *   // Generator syntax .next()
    *   let i = 1;
    *   iter = await dirClient.listHandles();
@@ -819,8 +831,10 @@ export class DirectoryClient extends StorageClient {
    *     console.log(`Handle ${i++}: ${handleItem.value.path}, opened time ${handleItem.value.openTime}, clientIp ${handleItem.value.clientIp}`);
    *     handleItem = await iter.next();
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
    *   let i = 1;
@@ -831,8 +845,10 @@ export class DirectoryClient extends StorageClient {
    *       }
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;
    *   iterator = dirClient.listHandles().byPage({ maxPageSize: 2 });
@@ -855,6 +871,7 @@ export class DirectoryClient extends StorageClient {
    *       console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
    *     }
    *   }
+   * ```
    *
    * @param {DirectoryListHandlesOptions} [options] Options to list handles operation.
    * @memberof DirectoryClient

--- a/sdk/storage/storage-file/src/FileServiceClient.ts
+++ b/sdk/storage/storage-file/src/FileServiceClient.ts
@@ -358,12 +358,15 @@ export class FileServiceClient extends StorageClient {
    * .byPage() returns an async iterable iterator to list the shares in pages.
    *
    * @example
+   * ```js
    *   let i = 1;
    *   for await (const share of serviceClient.listShares()) {
    *     console.log(`Share ${i++}: ${share.name}`);
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Generator syntax .next()
    *   let i = 1;
    *   let iter = await serviceClient.listShares();
@@ -372,8 +375,10 @@ export class FileServiceClient extends StorageClient {
    *     console.log(`Share ${i++}: ${shareItem.value.name}`);
    *     shareItem = await iter.next();
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
    *   let i = 1;
@@ -384,8 +389,10 @@ export class FileServiceClient extends StorageClient {
    *       }
    *     }
    *   }
+   * ```
    *
    * @example
+   * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;
    *   let iterator = serviceClient.listShares().byPage({ maxPageSize: 2 });
@@ -407,6 +414,7 @@ export class FileServiceClient extends StorageClient {
    *       console.log(`Share ${i++}: ${share.name}`);
    *     }
    *   }
+   * ```
    *
    * @param {ServiceListSharesOptions} [options] Options to list shares operation.
    * @memberof FileServiceClient

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -378,13 +378,16 @@ export class QueueServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
    * @example
+   * ```js
    *    let i = 1;
    *    for await (const item of queueServiceClient.listQueues()) {
    *      console.log(`Queue${i}: ${item.name}`);
    *      i++;
    *    }
+   * ```
    *
    * @example
+   * ```js
    *    // Generator syntax .next()
    *    let i = 1;
    *    let iterator = queueServiceClient.listQueues();
@@ -394,8 +397,10 @@ export class QueueServiceClient extends StorageClient {
    *      i++;
    *      item = await iterator.next();
    *    }
+   * ```
    *
    * @example
+   * ```js
    *    // Example for .byPage()
    *    // passing optional maxPageSize in the page settings
    *    let i = 1;
@@ -407,8 +412,10 @@ export class QueueServiceClient extends StorageClient {
    *        }
    *      }
    *    }
+   * ```
    *
    * @example
+   * ```js
    *    let i = 1;
    *    let iterator = queueServiceClient.listQueues().byPage({ maxPageSize: 2 });
    *    let item = (await iterator.next()).value;
@@ -431,6 +438,7 @@ export class QueueServiceClient extends StorageClient {
    *        i++;
    *      }
    *    }
+   * ```
    *
    * @param {ServiceListQueuesOptions} [options] Options to list queues operation.
    * @memberof QueueServiceClient


### PR DESCRIPTION
- remove extra `}` after a link

- wrap code examples with js code block so the typedoc output correctly show example code in code blocks.