### PR TITLE
Update OpenTelemetry types

### DIFF
--- a/sdk/core/core-http/lib/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/lib/policies/tracingPolicy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { TracerProxy, TraceOptions } from "@azure/core-tracing";
+import { TracerProxy, TraceFlags } from "@azure/core-tracing";
 import {
   RequestPolicyFactory,
   RequestPolicy,
@@ -33,15 +33,13 @@ export class TracingPolicy extends BaseRequestPolicy {
     const tracer = TracerProxy.getTracer();
     const span = tracer.startSpan("core-http", request.spanOptions);
 
-    span.start();
-
     try {
       // set headers
       const spanContext = span.context();
       if (spanContext.spanId && spanContext.traceId) {
         request.headers.set(
           "traceparent",
-          `${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceOptions || TraceOptions.UNSAMPLED}`
+          `${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags || TraceFlags.UNSAMPLED}`
         );
         const traceState = spanContext.traceState && spanContext.traceState.serialize();
         // if tracestate is set, traceparent MUST be set, so only set tracestate after traceparent

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
     "@azure/core-auth": "1.0.0-preview.3",
-    "@azure/core-tracing": "1.0.0-preview.2",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "@types/node-fetch": "^2.5.0",
     "@types/tunnel": "^0.0.1",
     "form-data": "^2.5.0",

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -3,7 +3,7 @@
 
 import { assert } from "chai";
 import sinon from "sinon";
-import { RequestPolicy, WebResource, HttpOperationResponse, HttpHeaders, Tracer, Span, TracerProxy, RequestPolicyOptions, TraceOptions, NoOpTracePlugin, TracerNoOpImpl } from "../../lib/coreHttp";
+import { RequestPolicy, WebResource, HttpOperationResponse, HttpHeaders, Tracer, Span, TracerProxy, RequestPolicyOptions, TraceFlags, NoOpTracePlugin, TracerNoOpImpl } from "../../lib/coreHttp";
 import { tracingPolicy } from "../../lib/policies/tracingPolicy";
 
 interface MockTracer extends Tracer {
@@ -15,7 +15,7 @@ describe("tracingPolicy", function () {
   function mockTracerFactory(
     traceId?: string,
     spanId?: string,
-    options?: TraceOptions,
+    flags?: TraceFlags,
     state?: string
   ): MockTracer {
     let startedSpan = false;
@@ -31,17 +31,10 @@ describe("tracingPolicy", function () {
       },
       startSpan() {
         startedSpan = true;
-        let started = false;
         let ended = false;
         const mockSpan = {
-          didStart() {
-            return started;
-          },
           didEnd() {
             return ended;
-          },
-          start() {
-            started = true;
           },
           end() {
             ended = true;
@@ -50,17 +43,24 @@ describe("tracingPolicy", function () {
             return {
               traceId,
               spanId,
-              traceOptions: options,
+              traceFlags: flags,
               traceState: {
+                set(_key: string, _value: string) {
+                },
+                unset(_key: string) {
+                },
+                get(_key: string): string | undefined {
+                  return;
+                },
                 serialize() {
-                  return state
+                  return state;
                 }
               }
             }
           }
         };
         spans.push(mockSpan);
-        return mockSpan as any as Span;
+        return mockSpan as Partial<Span>;
       }
     } as any;
   }
@@ -95,7 +95,7 @@ describe("tracingPolicy", function () {
   it("will create a span and correctly set trace headers if spanOptions are available", async () => {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
-    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceOptions.SAMPLED);
+    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceFlags.SAMPLED);
     sinon.stub(TracerProxy, "getTracer").callsFake(() => {
       return mockTracer;
     });
@@ -109,10 +109,9 @@ describe("tracingPolicy", function () {
     assert.isTrue(mockTracer.startSpanCalled());
     assert.lengthOf(mockTracer.getStartedSpans(), 1);
     const span = mockTracer.getStartedSpans()[0];
-    assert.isTrue(span.didStart());
     assert.isTrue(span.didEnd());
 
-    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.SAMPLED}`);
+    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceFlags.SAMPLED}`);
     assert.notExists(request.headers.get("tracestate"));
   });
 
@@ -134,10 +133,9 @@ describe("tracingPolicy", function () {
     assert.isTrue(mockTracer.startSpanCalled());
     assert.lengthOf(mockTracer.getStartedSpans(), 1);
     const span = mockTracer.getStartedSpans()[0];
-    assert.isTrue(span.didStart());
     assert.isTrue(span.didEnd());
 
-    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.UNSAMPLED}`);
+    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceFlags.UNSAMPLED}`);
     assert.notExists(request.headers.get("tracestate"));
   });
 
@@ -145,7 +143,7 @@ describe("tracingPolicy", function () {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     const mockTraceState = "foo=bar";
-    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceOptions.SAMPLED, mockTraceState);
+    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceFlags.SAMPLED, mockTraceState);
     sinon.stub(TracerProxy, "getTracer").callsFake(() => {
       return mockTracer;
     });
@@ -159,10 +157,9 @@ describe("tracingPolicy", function () {
     assert.isTrue(mockTracer.startSpanCalled());
     assert.lengthOf(mockTracer.getStartedSpans(), 1);
     const span = mockTracer.getStartedSpans()[0];
-    assert.isTrue(span.didStart());
     assert.isTrue(span.didEnd());
 
-    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.SAMPLED}`);
+    assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceFlags.SAMPLED}`);
     assert.equal(request.headers.get("tracestate"), mockTraceState);
   });
 
@@ -170,7 +167,7 @@ describe("tracingPolicy", function () {
     const mockTraceId = "11111111111111111111111111111111";
     const mockSpanId = "2222222222222222";
     const mockTraceState = "foo=bar";
-    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceOptions.SAMPLED, mockTraceState);
+    const mockTracer = mockTracerFactory(mockTraceId, mockSpanId, TraceFlags.SAMPLED, mockTraceState);
     sinon.stub(TracerProxy, "getTracer").callsFake(() => {
       return mockTracer;
     });
@@ -195,10 +192,9 @@ describe("tracingPolicy", function () {
       assert.isTrue(mockTracer.startSpanCalled());
       assert.lengthOf(mockTracer.getStartedSpans(), 1);
       const span = mockTracer.getStartedSpans()[0];
-      assert.isTrue(span.didStart());
       assert.isTrue(span.didEnd());
 
-      assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceOptions.SAMPLED}`);
+      assert.equal(request.headers.get("traceparent"), `${mockTraceId}-${mockSpanId}-${TraceFlags.SAMPLED}`);
       assert.equal(request.headers.get("tracestate"), mockTraceState);
     }
   });

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -3,10 +3,10 @@
 
 import { assert } from "chai";
 import sinon from "sinon";
-import { RequestPolicy, WebResource, HttpOperationResponse, HttpHeaders, Tracer, Span, TracerProxy, RequestPolicyOptions, TraceFlags, NoOpTracePlugin, TracerNoOpImpl } from "../../lib/coreHttp";
+import { RequestPolicy, WebResource, HttpOperationResponse, HttpHeaders, Plugin, Span, TracerProxy, RequestPolicyOptions, TraceFlags, NoOpTracePlugin, TracerNoOpImpl } from "../../lib/coreHttp";
 import { tracingPolicy } from "../../lib/policies/tracingPolicy";
 
-interface MockTracer extends Tracer {
+interface MockTracer extends Plugin {
   getStartedSpans(): any[];
   startSpanCalled(): boolean;
 }

--- a/sdk/core/core-tracing/lib/implementations/noop/spanNoOpImpl.ts
+++ b/sdk/core/core-tracing/lib/implementations/noop/spanNoOpImpl.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { Span } from "../../interfaces/span";
 import { SpanContext } from "../../interfaces/span_context";
 import { Attributes } from "../../interfaces/attributes";
@@ -25,8 +27,8 @@ export class SpanNoOpImpl implements Span {
   updateName(name: string): this {
     throw new Error("Method not implemented.");
   }
-  start(startTime?: number): void {}
-  end(endTime?: number): void {}
+  start(startTime?: number): void { }
+  end(endTime?: number): void { }
   isRecordingEvents(): boolean {
     throw new Error("Method not implemented.");
   }

--- a/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
+++ b/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { Tracer } from "../../interfaces/tracer";
 import { SpanOptions } from "../../interfaces/SpanOptions";
 import { Span } from "../../interfaces/span";

--- a/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
+++ b/sdk/core/core-tracing/lib/implementations/noop/tracerNoOpImpl.ts
@@ -3,10 +3,12 @@ import { SpanOptions } from "../../interfaces/SpanOptions";
 import { Span } from "../../interfaces/span";
 import { SpanNoOpImpl } from "./spanNoOpImpl";
 import { SupportedPlugins } from '../../utils/supportedPlugins';
+import { BinaryFormat } from "../../interfaces/BinaryFormat";
+import { HttpTextFormat } from "../../interfaces/HttpTextFormat";
 
 export class TracerNoOpImpl implements Tracer {
   public readonly pluginType = SupportedPlugins.NOOP;
-  
+
   getCurrentSpan(): Span {
     throw new Error("Method not implemented.");
   }
@@ -16,13 +18,16 @@ export class TracerNoOpImpl implements Tracer {
   withSpan<T extends (...args: unknown[]) => unknown>(span: Span, fn: T): ReturnType<T> {
     throw new Error("Method not implemented.");
   }
+  bind<T>(target: T, span?: Span): T {
+    throw new Error("Method not implemented.");
+  }
   recordSpanData(span: Span): void {
     throw new Error("Method not implemented.");
   }
-  getBinaryFormat(): unknown {
+  getBinaryFormat(): BinaryFormat {
     throw new Error("Method not implemented.");
   }
-  getHttpTextFormat(): unknown {
+  getHttpTextFormat(): HttpTextFormat {
     throw new Error("Method not implemented.");
   }
 }

--- a/sdk/core/core-tracing/lib/index.ts
+++ b/sdk/core/core-tracing/lib/index.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 export { TracerProxy } from "./tracerProxy";
 
 // Utils

--- a/sdk/core/core-tracing/lib/index.ts
+++ b/sdk/core/core-tracing/lib/index.ts
@@ -15,13 +15,16 @@ export { TracerNoOpImpl } from "./implementations/noop/tracerNoOpImpl";
 
 // Interfaces
 export { Attributes } from "./interfaces/attributes";
+export { BinaryFormat } from "./interfaces/BinaryFormat";
 export { Event } from "./interfaces/Event";
+export { HttpTextFormat } from "./interfaces/HttpTextFormat";
 export { Link } from "./interfaces/link";
 export { Sampler } from "./interfaces/Sampler";
 export { SpanContext } from "./interfaces/span_context";
 export { SpanKind } from "./interfaces/span_kind";
 export { Span } from "./interfaces/span";
 export { SpanOptions } from "./interfaces/SpanOptions";
+export { HrTime, TimeInput } from "./interfaces/Time";
 export { Status, CanonicalCode } from "./interfaces/status";
 export { TimedEvent } from "./interfaces/TimedEvent";
 export { TraceFlags } from "./interfaces/trace_flags";

--- a/sdk/core/core-tracing/lib/index.ts
+++ b/sdk/core/core-tracing/lib/index.ts
@@ -19,6 +19,7 @@ export { BinaryFormat } from "./interfaces/BinaryFormat";
 export { Event } from "./interfaces/Event";
 export { HttpTextFormat } from "./interfaces/HttpTextFormat";
 export { Link } from "./interfaces/link";
+export { Plugin } from "./interfaces/plugin";
 export { Sampler } from "./interfaces/Sampler";
 export { SpanContext } from "./interfaces/span_context";
 export { SpanKind } from "./interfaces/span_kind";

--- a/sdk/core/core-tracing/lib/index.ts
+++ b/sdk/core/core-tracing/lib/index.ts
@@ -24,6 +24,6 @@ export { Span } from "./interfaces/span";
 export { SpanOptions } from "./interfaces/SpanOptions";
 export { Status, CanonicalCode } from "./interfaces/status";
 export { TimedEvent } from "./interfaces/TimedEvent";
-export { TraceOptions } from "./interfaces/trace_options";
+export { TraceFlags } from "./interfaces/trace_flags";
 export { TraceState } from "./interfaces/trace_state";
 export { Tracer } from "./interfaces/tracer";

--- a/sdk/core/core-tracing/lib/interfaces/BinaryFormat.ts
+++ b/sdk/core/core-tracing/lib/interfaces/BinaryFormat.ts
@@ -14,16 +14,23 @@
  * limitations under the License.
  */
 
-import { Attributes } from './attributes';
 import { SpanContext } from './span_context';
 
 /**
- * A pointer from the current {@link Span} to another span in the same trace or
- * in a different trace.
+ * Formatter to serializing and deserializing a value with into a binary format.
  */
-export interface Link {
-  /** The {@link SpanContext} of a linked span. */
-  spanContext: SpanContext;
-  /** A set of {@link Attributes} on the link. */
-  attributes?: Attributes;
+export interface BinaryFormat {
+  /**
+   * Serialize the given span context into a Buffer.
+   * @param spanContext The span context to serialize.
+   */
+  toBytes(spanContext: SpanContext): ArrayBuffer;
+
+  /**
+   * Deseralize the given span context from binary encoding. If the input is a
+   * Buffer of incorrect size or unexpected fields, then this function will
+   * return `null`.
+   * @param buffer The span context to deserialize.
+   */
+  fromBytes(buffer: ArrayBuffer): SpanContext | null;
 }

--- a/sdk/core/core-tracing/lib/interfaces/Event.ts
+++ b/sdk/core/core-tracing/lib/interfaces/Event.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/core/core-tracing/lib/interfaces/HttpTextFormat.ts
+++ b/sdk/core/core-tracing/lib/interfaces/HttpTextFormat.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright 2019, OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SpanContext } from './span_context';
+
+/**
+ * Injects and extracts a value as text into carriers that travel in-band
+ * across process boundaries. Encoding is expected to conform to the HTTP
+ * Header Field semantics. Values are often encoded as RPC/HTTP request headers.
+ *
+ * The carrier of propagated data on both the client (injector) and server
+ * (extractor) side is usually an http request. Propagation is usually
+ * implemented via library- specific request interceptors, where the
+ * client-side injects values and the server-side extracts them.
+ */
+export interface HttpTextFormat {
+  /**
+   * Injects the given {@link SpanContext} instance to transmit over the wire.
+   *
+   * OpenTelemetry defines a common set of format values (BinaryFormat and
+   * HTTPTextFormat), and each has an expected `carrier` type.
+   *
+   * @param spanContext the SpanContext to transmit over the wire.
+   * @param format the format of the carrier.
+   * @param carrier the carrier of propagation fields, such as an http request.
+   */
+  inject(spanContext: SpanContext, format: string, carrier: unknown): void;
+
+  /**
+   * Returns a {@link SpanContext} instance extracted from `carrier` in the
+   * given format from upstream.
+   *
+   * @param format the format of the carrier.
+   * @param carrier the carrier of propagation fields, such as an http request.
+   * @returns SpanContext The extracted SpanContext, or null if no such
+   *     SpanContext could be found in carrier.
+   */
+  extract(format: string, carrier: unknown): SpanContext | null;
+}

--- a/sdk/core/core-tracing/lib/interfaces/Sampler.ts
+++ b/sdk/core/core-tracing/lib/interfaces/Sampler.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/core/core-tracing/lib/interfaces/SpanOptions.ts
+++ b/sdk/core/core-tracing/lib/interfaces/SpanOptions.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/core/core-tracing/lib/interfaces/Time.ts
+++ b/sdk/core/core-tracing/lib/interfaces/Time.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-/** Defines a attributes interface. */
-export interface Attributes {
-  [attributeKey: string]: unknown;
-}
+/** High resolution HrTime: [seconds: number, nanoseconds: number] */
+export type HrTime = [number, number];
+
+/**
+ * Defines TimeInput.
+ *
+ * hrtime, expoch milliseconds, performance.now() or Date
+ */
+export type TimeInput = HrTime | number | Date;

--- a/sdk/core/core-tracing/lib/interfaces/TimedEvent.ts
+++ b/sdk/core/core-tracing/lib/interfaces/TimedEvent.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +15,12 @@
  */
 
 import { Event } from './Event';
+import { HrTime } from './Time';
 
 /**
  * Represents a timed event.
  * A timed event is an event with a timestamp.
  */
 export interface TimedEvent extends Event {
-  time: number;
+  time: HrTime;
 }

--- a/sdk/core/core-tracing/lib/interfaces/plugin.ts
+++ b/sdk/core/core-tracing/lib/interfaces/plugin.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { Tracer } from "./tracer";
 import { SupportedPlugins } from "../utils/supportedPlugins";
 

--- a/sdk/core/core-tracing/lib/interfaces/plugin.ts
+++ b/sdk/core/core-tracing/lib/interfaces/plugin.ts
@@ -1,0 +1,10 @@
+import { Tracer } from "./tracer";
+import { SupportedPlugins } from "../utils/supportedPlugins";
+
+export interface Plugin extends Tracer {
+  /**
+   * Returns the type of the plugin being used by the tracer.
+   * @returns the type of the plugin being used by the tracer. 
+   */
+  readonly pluginType: SupportedPlugins;
+}

--- a/sdk/core/core-tracing/lib/interfaces/span.ts
+++ b/sdk/core/core-tracing/lib/interfaces/span.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { Attributes } from "./attributes";
-import { SpanContext } from "./span_context";
-import { Status } from "./status";
+import { Attributes } from './attributes';
+import { SpanContext } from './span_context';
+import { Status } from './status';
+import { TimeInput } from './Time';
 
 /**
  * An interface that represents a span. A span represents a single operation
@@ -99,13 +100,11 @@ export interface Span {
    * Do not return `this`. The Span generally should not be used after it
    * is ended so chaining is not desired in this context.
    *
-   * @param [endTime] the timestamp to set as Span's end time. If not provided,
+   * @param [endTime] the time to set as Span's end time. If not provided,
    *     use the current time as the span's end time.
    *     TODO (Add timestamp format): https://github.com/open-telemetry/opentelemetry-js/issues/19
    */
-  end(endTime?: number): void;
-
-  start(startTime?: number): void;
+  end(endTime?: TimeInput): void;
 
   /**
    * Returns the flag whether this span will be recorded.

--- a/sdk/core/core-tracing/lib/interfaces/span_context.ts
+++ b/sdk/core/core-tracing/lib/interfaces/span_context.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TraceOptions } from './trace_options';
+import { TraceFlags } from './trace_flags';
 import { TraceState } from './trace_state';
 
 /**
@@ -36,7 +36,7 @@ export interface SpanContext {
    */
   spanId: string;
   /**
-   * Trace options to propagate.
+   * Trace flags to propagate.
    *
    * It is represented as 1 byte (bitmap). Bit to represent whether trace is
    * sampled or not. When set, the least significant bit documents that the
@@ -45,7 +45,7 @@ export interface SpanContext {
    *
    * SAMPLED = 0x1 and UNSAMPLED = 0x0;
    */
-  traceOptions?: TraceOptions;
+  traceFlags?: TraceFlags;
   /**
    * Tracing-system-specific info to propagate.
    *

--- a/sdk/core/core-tracing/lib/interfaces/span_kind.ts
+++ b/sdk/core/core-tracing/lib/interfaces/span_kind.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/core/core-tracing/lib/interfaces/status.ts
+++ b/sdk/core/core-tracing/lib/interfaces/status.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/core/core-tracing/lib/interfaces/trace_flags.ts
+++ b/sdk/core/core-tracing/lib/interfaces/trace_flags.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,13 +15,13 @@
  */
 
 /**
- * An enumeration that represents global trace options. These options are
+ * An enumeration that represents global trace flags. These flags are
  * propagated to all child {@link Span}. These determine features such as
  * whether a Span should be traced. It is implemented as a bitmask.
  */
-export enum TraceOptions {
-  /** Bit to represent whether trace is unsampled in trace options. */
+export enum TraceFlags {
+  /** Bit to represent whether trace is unsampled in trace flags. */
   UNSAMPLED = 0x0,
-  /** Bit to represent whether trace is sampled in trace options. */
+  /** Bit to represent whether trace is sampled in trace flags. */
   SAMPLED = 0x1,
 }

--- a/sdk/core/core-tracing/lib/interfaces/trace_state.ts
+++ b/sdk/core/core-tracing/lib/interfaces/trace_state.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/sdk/core/core-tracing/lib/interfaces/tracer.ts
+++ b/sdk/core/core-tracing/lib/interfaces/tracer.ts
@@ -1,4 +1,4 @@
-/**
+/*!
  * Copyright 2019, OpenTelemetry Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { HttpTextFormat } from './HttpTextFormat';
+import { BinaryFormat } from './BinaryFormat';
 import { Span } from './span';
 import { SpanOptions } from './SpanOptions';
-import { SupportedPlugins } from '../utils/supportedPlugins';
 
 /**
  * Tracer provides an interface for creating {@link Span}s and propagating
@@ -27,19 +28,13 @@ import { SupportedPlugins } from '../utils/supportedPlugins';
  */
 export interface Tracer {
   /**
-   * Returns the type of the plugin being used by the tracer.
-   * @returns the type of the plugin being used by the tracer. 
-   */
-  pluginType: SupportedPlugins
-  /**
    * Returns the current Span from the current context if available.
    *
-   * If there is no Span associated with the current context, a default Span
-   * with invalid SpanContext is returned.
+   * If there is no Span associated with the current context, null is returned.
    *
    * @returns Span The currently active Span
    */
-  getCurrentSpan(): Span;
+  getCurrentSpan(): Span | null;
 
   /**
    * Starts a new {@link Span}.
@@ -53,12 +48,22 @@ export interface Tracer {
    * Executes the function given by fn within the context provided by Span
    *
    * @param span The span that provides the context
-   * @param fn The function to be eexcuted inside the provided context
+   * @param fn The function to be executed inside the provided context
+   * @example
+   * tracer.withSpan(span, function() { ... });
    */
-  withSpan<T extends (...args: unknown[]) => unknown>(
+  withSpan<T extends (...args: unknown[]) => ReturnType<T>>(
     span: Span,
     fn: T
   ): ReturnType<T>;
+
+  /**
+   * Bind a span as the target's scope or propagate the current one.
+   *
+   * @param target Any object to which a scope need to be set
+   * @param [span] Optionally specify the span which you want to assign
+   */
+  bind<T>(target: T, span?: Span): T;
 
   /**
    * Send a pre-populated span object to the exporter.
@@ -79,10 +84,8 @@ export interface Tracer {
    * Context binary format ({@link BinaryFormat}). For more details see
    * <a href="https://w3c.github.io/trace-context-binary/">W3C Trace Context
    * binary protocol</a>.
-   *
-   * @todo: Change return type once BinaryFormat is available
    */
-  getBinaryFormat(): unknown;
+  getBinaryFormat(): BinaryFormat;
 
   /**
    * Returns the {@link HttpTextFormat} interface which can inject/extract
@@ -91,8 +94,6 @@ export interface Tracer {
    * If no tracer implementation is provided, this defaults to the W3C Trace
    * Context HTTP text format ({@link HttpTraceContext}). For more details see
    * <a href="https://w3c.github.io/trace-context/">W3C Trace Context</a>.
-   *
-   * @todo: Change return type once HttpTextFormat is available
    */
-  getHttpTextFormat(): unknown;
+  getHttpTextFormat(): HttpTextFormat;
 }

--- a/sdk/core/core-tracing/lib/plugins/noop/noOpSpanPlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/noop/noOpSpanPlugin.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { Span } from "../../interfaces/span";
 import { SpanContext } from "../../interfaces/span_context";
 import { Attributes } from "../../interfaces/attributes";

--- a/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
@@ -4,6 +4,8 @@ import { SpanOptions } from "../../interfaces/SpanOptions";
 import { NoOpSpanPlugin } from "./noOpSpanPlugin";
 import { SpanNoOpImpl } from "../../implementations/noop/spanNoOpImpl";
 import { SupportedPlugins } from '../../utils/supportedPlugins';
+import { BinaryFormat } from "../../interfaces/BinaryFormat";
+import { HttpTextFormat } from "../../interfaces/HttpTextFormat";
 
 export class NoOpTracePlugin implements Tracer {
   private _tracer: any;
@@ -26,13 +28,16 @@ export class NoOpTracePlugin implements Tracer {
   withSpan<T extends (...args: unknown[]) => unknown>(span: Span, fn: T): ReturnType<T> {
     throw new Error("Method not implemented.");
   }
+  bind<T>(target: T, span?: Span): T {
+    throw new Error("Method not implemented.");
+  }
   recordSpanData(span: Span): void {
     throw new Error("Method not implemented.");
   }
-  getBinaryFormat(): unknown {
+  getBinaryFormat(): BinaryFormat {
     throw new Error("Method not implemented.");
   }
-  getHttpTextFormat(): unknown {
+  getHttpTextFormat(): HttpTextFormat {
     throw new Error("Method not implemented.");
   }
 }

--- a/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/noop/noOpTracePlugin.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { Tracer } from "../../interfaces/tracer";
 import { Span } from "../../interfaces/span";
 import { SpanOptions } from "../../interfaces/SpanOptions";

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
@@ -29,7 +29,7 @@ export class OpenCensusSpanPlugin implements Span {
     return {
       spanId: openCensusSpanContext.spanId,
       traceId: openCensusSpanContext.traceId,
-      traceOptions: openCensusSpanContext.options,
+      traceFlags: openCensusSpanContext.options,
       traceState: new OpenCensusTraceStatePlugin(openCensusSpanContext.traceState)
     };
   }

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { Span } from "../../interfaces/span";
 import { SpanContext } from "../../interfaces/span_context";
 import { Attributes } from "../../interfaces/attributes";

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusSpanPlugin.ts
@@ -13,14 +13,11 @@ export class OpenCensusSpanPlugin implements Span {
 
   constructor(span: any) {
     this._span = span;
+    this._span.start();
   }
 
   end(endTime?: number): void {
     this._span.end(endTime);
-  }
-
-  start(startTime?: number): void {
-    this._span.start(startTime);
   }
 
   context(): SpanContext {

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { Tracer } from "../../interfaces/tracer";
 import { SpanOptions } from "../../interfaces/SpanOptions";
 import { Span } from "../../interfaces/span";

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
@@ -3,6 +3,8 @@ import { SpanOptions } from "../../interfaces/SpanOptions";
 import { Span } from "../../interfaces/span";
 import { OpenCensusSpanPlugin } from "../opencensus/openCensusSpanPlugin";
 import { SupportedPlugins } from '../../utils/supportedPlugins';
+import { BinaryFormat } from "../../interfaces/BinaryFormat";
+import { HttpTextFormat } from "../../interfaces/HttpTextFormat";
 
 export class OpenCensusTracePlugin implements Tracer {
   private _tracer: any;
@@ -10,9 +12,9 @@ export class OpenCensusTracePlugin implements Tracer {
   public constructor(tracer: any) {
     this._tracer = tracer;
   }
-  
+
   public readonly pluginType = SupportedPlugins.OPENCENSUS;
-  
+
   startSpan(name: string, options?: SpanOptions): Span {
     const parent = options
       ? options.parent
@@ -38,13 +40,16 @@ export class OpenCensusTracePlugin implements Tracer {
   withSpan<T extends (...args: unknown[]) => unknown>(span: Span, fn: T): ReturnType<T> {
     throw new Error("Method not implemented.");
   }
+  bind<T>(target: T, span?: Span): T {
+    throw new Error("Method not implemented.");
+  }
   recordSpanData(span: Span): void {
     throw new Error("Method not implemented.");
   }
-  getBinaryFormat(): unknown {
+  getBinaryFormat(): BinaryFormat {
     throw new Error("Method not implemented.");
   }
-  getHttpTextFormat(): unknown {
+  getHttpTextFormat(): HttpTextFormat {
     throw new Error("Method not implemented.");
   }
 }

--- a/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
+++ b/sdk/core/core-tracing/lib/plugins/opencensus/openCensusTracePlugin.ts
@@ -9,6 +9,10 @@ import { HttpTextFormat } from "../../interfaces/HttpTextFormat";
 export class OpenCensusTracePlugin implements Tracer {
   private _tracer: any;
 
+  public getWrappedTracer() {
+    return this._tracer;
+  }
+
   public constructor(tracer: any) {
     this._tracer = tracer;
   }
@@ -16,20 +20,7 @@ export class OpenCensusTracePlugin implements Tracer {
   public readonly pluginType = SupportedPlugins.OPENCENSUS;
 
   startSpan(name: string, options?: SpanOptions): Span {
-    const parent = options
-      ? options.parent
-        ? options.parent instanceof OpenCensusSpanPlugin
-          ? options.parent.getSpan()
-          : options.parent
-        : undefined
-      : undefined;
-
-    const span = this._tracer.startChildSpan({
-      name: name,
-      childOf: parent
-    });
-
-    const openCensusSpanPlugin = new OpenCensusSpanPlugin(span);
+    const openCensusSpanPlugin = new OpenCensusSpanPlugin(this, name, options);
     return openCensusSpanPlugin;
   }
 

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -2,12 +2,12 @@ import { SupportedPlugins } from "./utils/supportedPlugins";
 import { OpenCensusTracePlugin } from "./plugins/opencensus/openCensusTracePlugin";
 import { NoOpTracePlugin } from "./plugins/noop/noOpTracePlugin";
 import { TracerNoOpImpl } from "./implementations/noop/tracerNoOpImpl";
-import { Tracer } from "./interfaces/tracer";
+import { Plugin } from "./interfaces/plugin";
 
 export class TracerProxy {
-  private static _tracerPlugin: Tracer;
+  private static _tracerPlugin: Plugin;
 
-  private constructor() {}
+  private constructor() { }
 
   public static setTracer(tracer: any, tracerPluginType: SupportedPlugins) {
     if (tracerPluginType === SupportedPlugins.OPENCENSUS) {

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { SupportedPlugins } from "./utils/supportedPlugins";
 import { OpenCensusTracePlugin } from "./plugins/opencensus/openCensusTracePlugin";
 import { NoOpTracePlugin } from "./plugins/noop/noOpTracePlugin";

--- a/sdk/core/core-tracing/lib/utils/supportedPlugins.ts
+++ b/sdk/core/core-tracing/lib/utils/supportedPlugins.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 export enum SupportedPlugins {
   OPENCENSUS,
   NOOP

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-tracing",
-  "version": "1.0.0-preview.2",
+  "version": "1.0.0-preview.3",
   "description": "Provides low-level interfaces and helper methods for tracing in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -11,6 +11,12 @@ export interface Attributes {
 }
 
 // @public
+export interface BinaryFormat {
+    fromBytes(buffer: ArrayBuffer): SpanContext | null;
+    toBytes(spanContext: SpanContext): ArrayBuffer;
+}
+
+// @public
 export enum CanonicalCode {
     ABORTED = 10,
     ALREADY_EXISTS = 6,
@@ -35,6 +41,15 @@ export enum CanonicalCode {
 export interface Event {
     attributes?: Attributes;
     name: string;
+}
+
+// @public
+export type HrTime = [number, number];
+
+// @public
+export interface HttpTextFormat {
+    extract(format: string, carrier: unknown): SpanContext | null;
+    inject(spanContext: SpanContext, format: string, carrier: unknown): void;
 }
 
 // @public
@@ -72,11 +87,13 @@ export class NoOpSpanPlugin implements Span {
 export class NoOpTracePlugin implements Tracer {
     constructor(tracer: any);
     // (undocumented)
-    getBinaryFormat(): unknown;
+    bind<T>(target: T, span?: Span): T;
+    // (undocumented)
+    getBinaryFormat(): BinaryFormat;
     // (undocumented)
     getCurrentSpan(): Span;
     // (undocumented)
-    getHttpTextFormat(): unknown;
+    getHttpTextFormat(): HttpTextFormat;
     // (undocumented)
     readonly pluginType = SupportedPlugins.NOOP;
     // (undocumented)
@@ -118,11 +135,13 @@ export class OpenCensusSpanPlugin implements Span {
 export class OpenCensusTracePlugin implements Tracer {
     constructor(tracer: any);
     // (undocumented)
-    getBinaryFormat(): unknown;
+    bind<T>(target: T, span?: Span): T;
+    // (undocumented)
+    getBinaryFormat(): BinaryFormat;
     // (undocumented)
     getCurrentSpan(): Span;
     // (undocumented)
-    getHttpTextFormat(): unknown;
+    getHttpTextFormat(): HttpTextFormat;
     // (undocumented)
     readonly pluginType = SupportedPlugins.OPENCENSUS;
     // (undocumented)
@@ -144,21 +163,19 @@ export interface Span {
     addEvent(name: string, attributes?: Attributes): this;
     addLink(spanContext: SpanContext, attributes?: Attributes): this;
     context(): SpanContext;
-    end(endTime?: number): void;
+    end(endTime?: TimeInput): void;
     isRecordingEvents(): boolean;
     setAttribute(key: string, value: unknown): this;
     setAttributes(attributes: Attributes): this;
     setStatus(status: Status): this;
-    // (undocumented)
-    start(startTime?: number): void;
     updateName(name: string): this;
 }
 
 // @public
 export interface SpanContext {
     spanId: string;
+    traceFlags?: TraceFlags;
     traceId: string;
-    traceOptions?: TraceOptions;
     traceState?: TraceState;
 }
 
@@ -221,34 +238,39 @@ export enum SupportedPlugins {
 // @public
 export interface TimedEvent extends Event {
     // (undocumented)
-    time: number;
+    time: HrTime;
 }
 
 // @public
-export enum TraceOptions {
+export type TimeInput = HrTime | number | Date;
+
+// @public
+export enum TraceFlags {
     SAMPLED = 1,
     UNSAMPLED = 0
 }
 
 // @public
 export interface Tracer {
-    getBinaryFormat(): unknown;
-    getCurrentSpan(): Span;
-    getHttpTextFormat(): unknown;
-    pluginType: SupportedPlugins;
+    bind<T>(target: T, span?: Span): T;
+    getBinaryFormat(): BinaryFormat;
+    getCurrentSpan(): Span | null;
+    getHttpTextFormat(): HttpTextFormat;
     recordSpanData(span: Span): void;
     startSpan(name: string, options?: SpanOptions): Span;
-    withSpan<T extends (...args: unknown[]) => unknown>(span: Span, fn: T): ReturnType<T>;
+    withSpan<T extends (...args: unknown[]) => ReturnType<T>>(span: Span, fn: T): ReturnType<T>;
 }
 
 // @public (undocumented)
 export class TracerNoOpImpl implements Tracer {
     // (undocumented)
-    getBinaryFormat(): unknown;
+    bind<T>(target: T, span?: Span): T;
+    // (undocumented)
+    getBinaryFormat(): BinaryFormat;
     // (undocumented)
     getCurrentSpan(): Span;
     // (undocumented)
-    getHttpTextFormat(): unknown;
+    getHttpTextFormat(): HttpTextFormat;
     // (undocumented)
     readonly pluginType = SupportedPlugins.NOOP;
     // (undocumented)

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -106,7 +106,7 @@ export class NoOpTracePlugin implements Tracer {
 
 // @public (undocumented)
 export class OpenCensusSpanPlugin implements Span {
-    constructor(span: any);
+    constructor(tracer: OpenCensusTracePlugin, name: string, options?: SpanOptions);
     // (undocumented)
     addEvent(name: string, attributes?: Attributes): this;
     // (undocumented)
@@ -116,7 +116,7 @@ export class OpenCensusSpanPlugin implements Span {
     // (undocumented)
     end(endTime?: number): void;
     // (undocumented)
-    getSpan(): any;
+    getWrappedSpan(): any;
     // (undocumented)
     isRecordingEvents(): boolean;
     // (undocumented)
@@ -125,8 +125,6 @@ export class OpenCensusSpanPlugin implements Span {
     setAttributes(attributes: Attributes): this;
     // (undocumented)
     setStatus(status: Status): this;
-    // (undocumented)
-    start(startTime?: number): void;
     // (undocumented)
     updateName(name: string): this;
 }
@@ -142,6 +140,8 @@ export class OpenCensusTracePlugin implements Tracer {
     getCurrentSpan(): Span;
     // (undocumented)
     getHttpTextFormat(): HttpTextFormat;
+    // (undocumented)
+    getWrappedTracer(): any;
     // (undocumented)
     readonly pluginType = SupportedPlugins.OPENCENSUS;
     // (undocumented)

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -152,6 +152,11 @@ export class OpenCensusTracePlugin implements Tracer {
     withSpan<T extends (...args: unknown[]) => unknown>(span: Span, fn: T): ReturnType<T>;
 }
 
+// @public (undocumented)
+export interface Plugin extends Tracer {
+    readonly pluginType: SupportedPlugins;
+}
+
 // @public
 export interface Sampler {
     shouldSample(parentContext?: SpanContext): boolean;
@@ -284,7 +289,7 @@ export class TracerNoOpImpl implements Tracer {
 // @public (undocumented)
 export class TracerProxy {
     // (undocumented)
-    static getTracer(): Tracer;
+    static getTracer(): Plugin;
     // (undocumented)
     static setTracer(tracer: any, tracerPluginType: SupportedPlugins): void;
     }

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -284,7 +284,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): PagedAsyncIterableIterator<CertificateAttributes, CertificateAttributes[]> {
     const span = this.createSpan("listCertificates", options);
-    span.start();
 
     const iter = this.listCertificatesAll(options);
 
@@ -364,7 +363,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): PagedAsyncIterableIterator<CertificateAttributes, CertificateAttributes[]> {
     const span = this.createSpan("listCertificateVersions", options);
-    span.start();
 
     const iter = this.listCertificateVersionsAll(name, options);
 
@@ -406,7 +404,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<DeletedCertificate> {
     const span = this.createSpan("deleteCertificate", options);
-    span.start();
 
     const response = await this.client
       .deleteCertificate(this.vaultBaseUrl, certificateName, options)
@@ -438,7 +435,6 @@ export class CertificatesClient {
    */
   public async deleteCertificateContacts(options?: RequestOptionsBase): Promise<Contacts> {
     const span = this.createSpan("deleteCertificateContacts", options);
-    span.start();
 
     let result = await this.client
       .deleteCertificateContacts(this.vaultBaseUrl, options)
@@ -473,7 +469,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<Contacts> {
     const span = this.createSpan("setCertificateContacts", options);
-    span.start();
 
     let result = await this.client
       .setCertificateContacts(this.vaultBaseUrl, { contactList: contacts }, options)
@@ -506,7 +501,6 @@ export class CertificatesClient {
    */
   public async getCertificateContacts(options?: RequestOptionsBase): Promise<Contacts> {
     const span = this.createSpan("getCertificateContacts", options);
-    span.start();
 
     let result = await this.client
       .getCertificateContacts(this.vaultBaseUrl, options)
@@ -583,7 +577,6 @@ export class CertificatesClient {
     options?: KeyVaultClientGetCertificateIssuersOptionalParams
   ): PagedAsyncIterableIterator<CertificateIssuer, CertificateIssuer[]> {
     const span = this.createSpan("listCertificateIssuers", options);
-    span.start();
 
     const iter = this.listCertificateIssuersAll(options);
 
@@ -622,7 +615,6 @@ export class CertificatesClient {
     options?: KeyVaultClientSetCertificateIssuerOptionalParams
   ): Promise<CertificateIssuer> {
     const span = this.createSpan("setCertificateIssuer", options);
-    span.start();
 
     let result = await this.client
       .setCertificateIssuer(this.vaultBaseUrl, issuerName, provider, options)
@@ -657,7 +649,6 @@ export class CertificatesClient {
     options?: KeyVaultClientUpdateCertificateIssuerOptionalParams
   ): Promise<CertificateIssuer> {
     const span = this.createSpan("updateCertificateIssuer", options);
-    span.start();
 
     let result = await this.client
       .updateCertificateIssuer(this.vaultBaseUrl, issuerName, options)
@@ -692,7 +683,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificateIssuer> {
     const span = this.createSpan("getCertificateIssuer", options);
-    span.start();
 
     let result = await this.client
       .getCertificateIssuer(this.vaultBaseUrl, issuerName, options)
@@ -725,7 +715,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificateIssuer> {
     const span = this.createSpan("deleteCertificateIssuer", options);
-    span.start();
 
     let result = await this.client
       .deleteCertificateIssuer(this.vaultBaseUrl, issuerName, options)
@@ -765,7 +754,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<Certificate> {
     const span = this.createSpan("createCertificate", options);
-    span.start();
 
     let result = await this.client
       .createCertificate(this.vaultBaseUrl, name, {
@@ -808,7 +796,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificateWithPolicy> {
     const span = this.createSpan("getCertificateWithPolicy", options);
-    span.start();
 
     let result = await this.client
       .getCertificate(this.vaultBaseUrl, name, "", options)
@@ -851,7 +838,6 @@ export class CertificatesClient {
     }
 
     const span = this.createSpan("getCertificate", options);
-    span.start();
 
     let result = await this.client
       .getCertificate(this.vaultBaseUrl, name, version, options)
@@ -887,7 +873,6 @@ export class CertificatesClient {
     options?: KeyVaultClientImportCertificateOptionalParams
   ): Promise<Certificate> {
     const span = this.createSpan("importCertificate", options);
-    span.start();
 
     let result = await this.client
       .importCertificate(this.vaultBaseUrl, name, base64EncodedCertificate, options)
@@ -923,7 +908,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificatePolicy> {
     const span = this.createSpan("getCertificatePolicy", options);
-    span.start();
 
     let result = await this.client
       .getCertificatePolicy(this.vaultBaseUrl, name, options)
@@ -950,7 +934,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificatePolicy> {
     const span = this.createSpan("updateCertificatePolicy", options);
-    span.start();
 
     let result = await this.client
       .updateCertificatePolicy(this.vaultBaseUrl, name, policy, options)
@@ -992,7 +975,6 @@ export class CertificatesClient {
     options?: KeyVaultClientUpdateCertificateOptionalParams
   ): Promise<Certificate> {
     const span = this.createSpan("updateCertificate", options);
-    span.start();
 
     let result = await this.client
       .updateCertificate(this.vaultBaseUrl, name, version, options)
@@ -1028,7 +1010,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificateOperation> {
     const span = this.createSpan("cancelCertificateOperation", options);
-    span.start();
 
     let result = await this.client
       .updateCertificateOperation(this.vaultBaseUrl, name, true, options)
@@ -1064,7 +1045,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificateOperation> {
     const span = this.createSpan("getCertificateOperation", options);
-    span.start();
 
     let result = await this.client
       .getCertificateOperation(this.vaultBaseUrl, name, options)
@@ -1101,7 +1081,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<CertificateOperation> {
     const span = this.createSpan("deleteCertificateOperation", options);
-    span.start();
 
     let result = await this.client
       .deleteCertificateOperation(this.vaultBaseUrl, name, options)
@@ -1153,7 +1132,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<Certificate> {
     const span = this.createSpan("mergeCertificate", options);
-    span.start();
     let result = await this.client
       .mergeCertificate(this.vaultBaseUrl, name, x509Certificates, options)
       .catch((err) => {
@@ -1188,7 +1166,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<BackupCertificateResult> {
     const span = this.createSpan("backupCertificate", options);
-    span.start();
 
     let result = await this.client
       .backupCertificate(this.vaultBaseUrl, name, options)
@@ -1226,7 +1203,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<Certificate> {
     const span = this.createSpan("restoreCertificate", options);
-    span.start();
 
     let result = await this.client
       .restoreCertificate(this.vaultBaseUrl, certificateBackup, options)
@@ -1301,7 +1277,6 @@ export class CertificatesClient {
     options?: KeyVaultClientGetDeletedCertificatesOptionalParams
   ): PagedAsyncIterableIterator<DeletedCertificate, DeletedCertificate[]> {
     const span = this.createSpan("listDeletedCertificates", options);
-    span.start();
 
     const iter = this.listDeletedCertificatesAll(options);
 
@@ -1338,7 +1313,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<DeletedCertificate> {
     const span = this.createSpan("getDeletedCertificate", options);
-    span.start();
 
     let result = await this.client
       .getDeletedCertificate(this.vaultBaseUrl, name, options)
@@ -1368,7 +1342,6 @@ export class CertificatesClient {
    */
   public async purgeDeletedCertificate(name: string, options?: RequestOptionsBase): Promise<null> {
     const span = this.createSpan("purgeDeletedCertificate", options);
-    span.start();
 
     await this.client.purgeDeletedCertificate(this.vaultBaseUrl, name, options).catch((err) => {
       span.end();
@@ -1400,7 +1373,6 @@ export class CertificatesClient {
     options?: RequestOptionsBase
   ): Promise<Certificate> {
     const span = this.createSpan("recoverDeletedCertificate", options);
-    span.start();
 
     let result = await this.client
       .recoverDeletedCertificate(this.vaultBaseUrl, name, options)

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -285,7 +285,6 @@ export class KeysClient {
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("createKey", unflattenedOptions);
-      span.start();
 
       const response = await this.client
         .createKey(this.vaultBaseUrl, name, keyType, unflattenedOptions)
@@ -337,7 +336,6 @@ export class KeysClient {
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("createEcKey", unflattenedOptions);
-      span.start();
 
       const response = await this.client
         .createKey(this.vaultBaseUrl, name, options.hsm ? "EC-HSM" : "EC", unflattenedOptions)
@@ -389,7 +387,6 @@ export class KeysClient {
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("createRsaKey", unflattenedOptions);
-      span.start();
 
       const response = await this.client
         .createKey(this.vaultBaseUrl, name, options.hsm ? "RSA-HSM" : "RSA", unflattenedOptions)
@@ -441,7 +438,6 @@ export class KeysClient {
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("importKey", unflattenedOptions);
-      span.start();
 
       const response = await this.client
         .importKey(this.vaultBaseUrl, name, key, unflattenedOptions)
@@ -476,7 +472,6 @@ export class KeysClient {
   public async deleteKey(name: string, options?: RequestOptions): Promise<DeletedKey> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("deleteKey", requestOptions);
-    span.start();
 
     const response = await this.client
       .deleteKey(this.vaultBaseUrl, name, requestOptions)
@@ -529,7 +524,6 @@ export class KeysClient {
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("updateKey", unflattenedOptions);
-      span.start();
 
       const response = await this.client
         .updateKey(this.vaultBaseUrl, name, keyVersion, unflattenedOptions)
@@ -563,7 +557,6 @@ export class KeysClient {
   public async getKey(name: string, options?: GetKeyOptions): Promise<Key> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("getKey", requestOptions);
-    span.start();
 
     const response = await this.client
       .getKey(
@@ -599,7 +592,6 @@ export class KeysClient {
   public async getDeletedKey(name: string, options?: RequestOptions): Promise<DeletedKey> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("getDeletedKey", requestOptions);
-    span.start();
 
     const response = await this.client
       .getDeletedKey(this.vaultBaseUrl, name, requestOptions)
@@ -632,7 +624,6 @@ export class KeysClient {
   public async purgeDeletedKey(name: string, options?: RequestOptions): Promise<void> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("purgeDeletedKey", requestOptions);
-    span.start();
 
     await this.client.purgeDeletedKey(this.vaultBaseUrl, name, requestOptions).catch((err) => {
       span.end();
@@ -661,7 +652,6 @@ export class KeysClient {
   public async recoverDeletedKey(name: string, options?: RequestOptions): Promise<Key> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("recoverDeletedKey", requestOptions);
-    span.start();
 
     const response = await this.client
       .recoverDeletedKey(this.vaultBaseUrl, name, requestOptions)
@@ -691,7 +681,6 @@ export class KeysClient {
   public async backupKey(name: string, options?: RequestOptions): Promise<Uint8Array | undefined> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("backupKey", requestOptions);
-    span.start();
 
     const response = await this.client
       .backupKey(this.vaultBaseUrl, name, requestOptions)
@@ -723,7 +712,6 @@ export class KeysClient {
   public async restoreKey(backup: Uint8Array, options?: RequestOptions): Promise<Key> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("restoreKey", requestOptions);
-    span.start();
 
     const response = await this.client
       .restoreKey(this.vaultBaseUrl, backup, requestOptions)
@@ -804,7 +792,6 @@ export class KeysClient {
       options.requestOptions = {};
     }
     const span = this.createSpan("listKeyVersions", options.requestOptions);
-    span.start();
 
     const iter = this.listKeyVersionsAll(name, options);
 
@@ -879,7 +866,6 @@ export class KeysClient {
       options.requestOptions = {};
     }
     const span = this.createSpan("listKeys", options.requestOptions);
-    span.start();
 
     const iter = this.listKeysAll(options);
 
@@ -959,7 +945,6 @@ export class KeysClient {
       options.requestOptions = {};
     }
     const span = this.createSpan("listDeletedKeys", options.requestOptions);
-    span.start();
 
     const iter = this.listDeletedKeysAll(options);
 

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -242,7 +242,6 @@ export class SecretsClient {
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("setSecret", unflattenedOptions);
-      span.start();
 
       const response = await this.client.setSecret(
         this.vaultBaseUrl,
@@ -282,15 +281,14 @@ export class SecretsClient {
     options?: RequestOptionsBase
   ): Promise<DeletedSecret> {
     const span = this.createSpan("deleteSecret", options);
-    span.start();
- 
-    const response = await this.client.deleteSecret(this.vaultBaseUrl, secretName, options)
-    .catch((err) => {
-      span.end();
-      throw err;
-    });
 
-    span.end(); 
+    const response = await this.client.deleteSecret(this.vaultBaseUrl, secretName, options)
+      .catch((err) => {
+        span.end();
+        throw err;
+      });
+
+    span.end();
     return this.getDeletedSecretFromDeletedSecretBundle(response);
   }
 
@@ -334,7 +332,6 @@ export class SecretsClient {
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("updateSecretAttributes", unflattenedOptions);
-      span.start();
 
       const response = await this.client.updateSecret(
         this.vaultBaseUrl,
@@ -342,10 +339,10 @@ export class SecretsClient {
         secretVersion,
         unflattenedOptions
       )
-      .catch((err) => {
-        span.end();
-        throw err;
-      });
+        .catch((err) => {
+          span.end();
+          throw err;
+        });
 
       span.end();
       return this.getSecretFromSecretBundle(response);
@@ -376,18 +373,17 @@ export class SecretsClient {
    */
   public async getSecret(secretName: string, options?: GetSecretOptions): Promise<Secret> {
     const span = this.createSpan("getSecret", options && options.requestOptions);
-    span.start();
- 
+
     const response = await this.client.getSecret(
       this.vaultBaseUrl,
       secretName,
       options && options.version ? options.version : "",
       options ? options.requestOptions : undefined
     )
-    .catch((err) => {
-      span.end();
-      throw err;
-    });
+      .catch((err) => {
+        span.end();
+        throw err;
+      });
 
     span.end();
     return this.getSecretFromSecretBundle(response);
@@ -412,13 +408,12 @@ export class SecretsClient {
     options?: RequestOptionsBase
   ): Promise<DeletedSecret> {
     const span = this.createSpan("getDeletedSecret", options);
-    span.start();
- 
+
     const response = await this.client.getDeletedSecret(this.vaultBaseUrl, secretName, options)
-    .catch((err) => {
-      span.end();
-      throw err;
-    });
+      .catch((err) => {
+        span.end();
+        throw err;
+      });
 
     span.end();
     return this.getSecretFromSecretBundle(response);
@@ -442,13 +437,12 @@ export class SecretsClient {
    */
   public async purgeDeletedSecret(secretName: string, options?: RequestOptionsBase): Promise<void> {
     const span = this.createSpan("purgeDeletedSecret", options);
-    span.start();
- 
+
     await this.client.purgeDeletedSecret(this.vaultBaseUrl, secretName, options)
-    .catch((err) => {
-      span.end();
-      throw err;
-    });
+      .catch((err) => {
+        span.end();
+        throw err;
+      });
 
     span.end();
   }
@@ -473,13 +467,12 @@ export class SecretsClient {
     options?: RequestOptionsBase
   ): Promise<Secret> {
     const span = this.createSpan("recoverDeletedSecret", options);
-    span.start();
- 
+
     const response = await this.client.recoverDeletedSecret(this.vaultBaseUrl, secretName, options)
-    .catch((err) => {
-      span.end();
-      throw err;
-    });
+      .catch((err) => {
+        span.end();
+        throw err;
+      });
 
     span.end();
     return this.getSecretFromSecretBundle(response);
@@ -501,13 +494,12 @@ export class SecretsClient {
    */
   public async backupSecret(secretName: string, options?: RequestOptionsBase): Promise<Uint8Array> {
     const span = this.createSpan("backupSecret", options);
-    span.start();
- 
+
     const response: any = await this.client.backupSecret(this.vaultBaseUrl, secretName, options)
-    .catch((err) => {
-      span.end();
-      throw err;
-    });
+      .catch((err) => {
+        span.end();
+        throw err;
+      });
 
     span.end();
     return response.value;
@@ -534,17 +526,16 @@ export class SecretsClient {
     options?: RequestOptionsBase
   ): Promise<Secret> {
     const span = this.createSpan("restoreSecret", options);
-    span.start();
- 
+
     const response = await this.client.restoreSecret(
       this.vaultBaseUrl,
       secretBundleBackup,
       options
     )
-    .catch((err) => {
-      span.end();
-      throw err;
-    });
+      .catch((err) => {
+        span.end();
+        throw err;
+      });
 
     span.end();
     return this.getSecretFromSecretBundle(response);
@@ -612,8 +603,7 @@ export class SecretsClient {
     options?: ListSecretsOptions
   ): PagedAsyncIterableIterator<SecretAttributes, SecretAttributes[]> {
     const span = this.createSpan("listSecretVersions", options && options.requestOptions);
-    span.start();
- 
+
     const iter = this.listSecretVersionsAll(secretName, options);
 
     span.end();
@@ -684,8 +674,7 @@ export class SecretsClient {
     options?: ListSecretsOptions
   ): PagedAsyncIterableIterator<SecretAttributes, SecretAttributes[]> {
     const span = this.createSpan("listSecrets", options && options.requestOptions);
-    span.start();
- 
+
     const iter = this.listSecretsAll(options);
 
     span.end();
@@ -758,8 +747,7 @@ export class SecretsClient {
     options?: ListSecretsOptions
   ): PagedAsyncIterableIterator<SecretAttributes, SecretAttributes[]> {
     const span = this.createSpan("listDeletedSecrets", options && options.requestOptions);
-    span.start();
- 
+
     const iter = this.listDeletedSecretsAll(options);
 
     span.end();


### PR DESCRIPTION
This PR updates our typed interfaces from https://github.com/open-telemetry/opentelemetry-js to  revision `45be4b524ef65638ac1ab142c2b5e01e1af2b3fd`.

Unfortunately, OpenTelemetry doesn't have published packages we can depend on yet, so I can't switch over to that. The delta from the previous revision are pretty minimal/mechanical.