### PR TITLE
[Cosmos] Moving copyright headers to the top of the file

### DIFF
--- a/sdk/cosmosdb/cosmos/samples/MultiRegionWrite/ConflictWorker.ts
+++ b/sdk/cosmosdb/cosmos/samples/MultiRegionWrite/ConflictWorker.ts
@@ -1,7 +1,6 @@
-// tslint:disable:no-console
-
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// tslint:disable:no-console
 import { v4 as guid } from "uuid";
 import { CosmosClient, Item, ItemDefinition, Items, OperationType, Resource, StatusCodes } from "../../dist";
 import logger from "./logger";

--- a/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/ChangeFeedIterator.ts
@@ -1,6 +1,6 @@
-/// <reference lib="esnext.asynciterable" />
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/// <reference lib="esnext.asynciterable" />
 import { ChangeFeedOptions } from "./ChangeFeedOptions";
 import { ChangeFeedResponse } from "./ChangeFeedResponse";
 import { Resource } from "./client";

--- a/sdk/cosmosdb/cosmos/src/ChangeFeedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/ChangeFeedOptions.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Specifies options for the change feed
  *
@@ -8,8 +10,6 @@
  *
  * If none of those options are set, it will start reading changes from the first `ChangeFeedIterator.fetchNext()` call.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export interface ChangeFeedOptions {
   /**
    * Max amount of items to return per page

--- a/sdk/cosmosdb/cosmos/src/LocationInfo.ts
+++ b/sdk/cosmosdb/cosmos/src/LocationInfo.ts
@@ -1,10 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Used to store the location info in Location Cache
  * @private
  * @hidden
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export class LocationInfo {
   public preferredLocations: ReadonlyArray<string>;
   public availableReadEndpointByLocation: ReadonlyMap<string, string>;

--- a/sdk/cosmosdb/cosmos/src/client/Container/PartitionKeyRange.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/PartitionKeyRange.ts
@@ -1,8 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * @ignore
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export interface PartitionKeyRange {
   id: string;
   minInclusive: string;

--- a/sdk/cosmosdb/cosmos/src/client/Container/UniqueKeyPolicy.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/UniqueKeyPolicy.ts
@@ -1,6 +1,6 @@
-/** Interface for setting unique keys on container creation */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/** Interface for setting unique keys on container creation */
 export interface UniqueKeyPolicy {
   uniqueKeys: UniqueKey[];
 }

--- a/sdk/cosmosdb/cosmos/src/common/statusCodes.ts
+++ b/sdk/cosmosdb/cosmos/src/common/statusCodes.ts
@@ -1,8 +1,8 @@
-﻿/**
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
  * @ignore
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export const StatusCodes = {
   // Success
   Ok: 200,

--- a/sdk/cosmosdb/cosmos/src/documents/ConnectionMode.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConnectionMode.ts
@@ -1,6 +1,6 @@
-/** Determines the connection behavior of the CosmosClient. Note, we currently only support Gateway Mode. */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/** Determines the connection behavior of the CosmosClient. Note, we currently only support Gateway Mode. */
 export enum ConnectionMode {
   /** Gateway mode talks to a intermediate gateway which handles the direct communicationi with your individual partitions. */
   Gateway = 0

--- a/sdk/cosmosdb/cosmos/src/documents/ConsistencyLevel.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/ConsistencyLevel.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Represents the consistency levels supported for Azure Cosmos DB client operations.<br>
  * The requested ConsistencyLevel must match or be weaker than that provisioned for the database account.
@@ -7,8 +9,6 @@
  *
  * See https://aka.ms/cosmos-consistency for more detailed documentation on Consistency Levels.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export enum ConsistencyLevel {
   /**
    * Strong Consistency guarantees that read operations always return the value that was last written.

--- a/sdk/cosmosdb/cosmos/src/documents/DataType.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/DataType.ts
@@ -1,6 +1,6 @@
-/** Defines a target data type of an index path specification in the Azure Cosmos DB service. */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/** Defines a target data type of an index path specification in the Azure Cosmos DB service. */
 export enum DataType {
   /** Represents a numeric data type. */
   Number = "Number",

--- a/sdk/cosmosdb/cosmos/src/documents/IndexKind.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/IndexKind.ts
@@ -1,8 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Specifies the supported Index types.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export enum IndexKind {
   /**
    * This is supplied for a path which requires sorting.

--- a/sdk/cosmosdb/cosmos/src/documents/IndexingMode.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/IndexingMode.ts
@@ -1,10 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Specifies the supported indexing modes.
  * @property Consistent
  * @property Lazy
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export enum IndexingMode {
   /**
    * Index is updated synchronously with a create or update operation.

--- a/sdk/cosmosdb/cosmos/src/documents/PermissionMode.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/PermissionMode.ts
@@ -1,8 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Enum for permission mode values.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export enum PermissionMode {
   /** Permission not valid. */
   None = "none",

--- a/sdk/cosmosdb/cosmos/src/documents/TriggerOperation.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/TriggerOperation.ts
@@ -1,9 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Enum for trigger operation values.
  * specifies the operations on which a trigger should be executed.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export enum TriggerOperation {
   /** All operations. */
   All = "all",

--- a/sdk/cosmosdb/cosmos/src/documents/TriggerType.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/TriggerType.ts
@@ -1,9 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Enum for trigger type values.
  * Specifies the type of the trigger.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export enum TriggerType {
   /** Trigger should be executed before the associated operation(s). */
   Pre = "pre",

--- a/sdk/cosmosdb/cosmos/src/documents/UserDefinedFunctionType.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/UserDefinedFunctionType.ts
@@ -1,9 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Enum for udf type values.
  * Specifies the types of user defined functions.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export enum UserDefinedFunctionType {
   /** The User Defined Function is written in JavaScript. This is currently the only option. */
   Javascript = "Javascript"

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/FetchResult.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/FetchResult.ts
@@ -1,6 +1,6 @@
-/** @hidden */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/** @hidden */
 export enum FetchResultType {
   "Done" = 0,
   "Exception" = 1,

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/SqlQuerySpec.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/SqlQuerySpec.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Represents a SQL query in the Azure Cosmos DB service.
  *
@@ -13,8 +15,6 @@
  * };
  * ```
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export interface SqlQuerySpec {
   /** The text of the SQL query */
   query: string;

--- a/sdk/cosmosdb/cosmos/src/request/LocationRouting.ts
+++ b/sdk/cosmosdb/cosmos/src/request/LocationRouting.ts
@@ -1,8 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * @ignore
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export class LocationRouting {
   private pIgnorePreferredLocation: boolean;
   private pLocationIndexToRoute: number;

--- a/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/SharedOptions.ts
@@ -1,6 +1,6 @@
-/// <reference lib="dom" />
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/// <reference lib="dom" />
 import { CosmosHeaders } from "../index";
 
 /**

--- a/sdk/cosmosdb/cosmos/src/request/StatusCodes.ts
+++ b/sdk/cosmosdb/cosmos/src/request/StatusCodes.ts
@@ -1,8 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * @ignore
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export const StatusCode = {
   // Success
   Ok: 200 as 200,

--- a/sdk/cosmosdb/cosmos/src/request/TimeoutError.ts
+++ b/sdk/cosmosdb/cosmos/src/request/TimeoutError.ts
@@ -1,8 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * @ignore
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export const TimeoutErrorCode = "TimeoutError";
 
 export class TimeoutError extends Error {

--- a/sdk/cosmosdb/cosmos/src/retry/retryOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryOptions.ts
@@ -1,8 +1,8 @@
-﻿/**
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+/**
  * Represents the Retry policy assocated with throttled requests in the Azure Cosmos DB database service.
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export interface RetryOptions {
   /** Max number of retries to be performed for a request. Default value 9. */
   maxRetryAttemptCount: number;

--- a/sdk/cosmosdb/cosmos/src/session/VectorSessionToken.ts
+++ b/sdk/cosmosdb/cosmos/src/session/VectorSessionToken.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 /**
  * Models vector clock bases session token. Session token has the following format:
  * {Version}#{GlobalLSN}#{RegionId1}={LocalLsn1}#{RegionId2}={LocalLsn2}....#{RegionIdN}={LocalLsnN}
@@ -10,8 +12,6 @@
  * @private
  *
  */
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
 export class VectorSessionToken {
   private static readonly SEGMENT_SEPARATOR = "#";
   private static readonly REGION_PROGRESS_SEPARATOR = "=";

--- a/sdk/cosmosdb/cosmos/test/common/MockQueryIterator.ts
+++ b/sdk/cosmosdb/cosmos/test/common/MockQueryIterator.ts
@@ -1,6 +1,6 @@
-/** @hidden */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/** @hidden */
 export class MockedQueryIterator {
   constructor(private results: any) {}
   public async fetchAll() {

--- a/sdk/cosmosdb/cosmos/test/common/TestData.ts
+++ b/sdk/cosmosdb/cosmos/test/common/TestData.ts
@@ -1,6 +1,6 @@
-/** @hidden */
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+/** @hidden */
 export class TestData {
   public numberOfDocuments: number;
   public field: string;

--- a/sdk/cosmosdb/cosmos/test/common/_testConfig.ts
+++ b/sdk/cosmosdb/cosmos/test/common/_testConfig.ts
@@ -1,6 +1,6 @@
-// [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine")]
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
+// [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine")]
 const masterKey =
   process.env.ACCOUNT_KEY ||
   "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";


### PR DESCRIPTION
Reference - https://github.com/Azure/azure-sdk-tools/issues/199

When a file starts with the JSDoc comments`(/** * * */)`, placement of copyright headers by the `eslint-plugin-azure-sdk`  is a bit off. (#5151)

This PR fixes the positioning of Copyright Headers for all the affected files in cosmos sdk.
