### PR TITLE
[Storage] config typedoc behavior

### DIFF
--- a/sdk/storage/storage-blob/typedoc.json
+++ b/sdk/storage/storage-blob/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "mode": "file",
+  "out": "../../../docGen/",
+  "excludePrivate": true,
+  "excludeNotExported": true,
+  "includeDeclarations": true,
+  "excludeExternals": false,
+  "name": "@azure/storage-blob",
+  "readme": "./README.md",
+  "exclude": ["src/generated/src/operations/**/*", "**/node_modules/**/*"]
+}

--- a/sdk/storage/storage-file/typedoc.json
+++ b/sdk/storage/storage-file/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "mode": "file",
+  "out": "../../../docGen/",
+  "excludePrivate": true,
+  "excludeNotExported": true,
+  "includeDeclarations": true,
+  "excludeExternals": false,
+  "name": "@azure/storage-file",
+  "readme": "./README.md",
+  "exclude": ["src/generated/src/operations/**/*", "**/node_modules/**/*"]
+}

--- a/sdk/storage/storage-queue/typedoc.json
+++ b/sdk/storage/storage-queue/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "mode": "file",
+  "out": "../../../docGen/",
+  "excludePrivate": true,
+  "excludeNotExported": true,
+  "includeDeclarations": true,
+  "excludeExternals": false,
+  "name": "@azure/storage-queue",
+  "readme": "./README.md",
+  "exclude": ["src/generated/src/operations/**/*", "**/node_modules/**/*"]
+}


### PR DESCRIPTION
We still want to be able to jump to types that we own even they are from other
packages. For example, `PagedAsyncIterableIterator` is from `@core-paging`.
Setting `excludeExternals` to `false` and excluding files under `node_modules`
so that we could still have docs for types from other libraries in the repo.

Also exclude storage-specific files for generated operations.