### PR TITLE
bump versions after September preview release

### DIFF
--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.0.0-preview.3",
+  "version": "12.0.0-preview.4",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file",
   "sdk-type": "client",
-  "version": "12.0.0-preview.3",
+  "version": "12.0.0-preview.4",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.0.0-preview.3",
+  "version": "12.0.0-preview.4",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",


### PR DESCRIPTION
Cleaning up versions after the September release. See docs here: https://github.com/Azure/azure-sdk/blob/master/docs/policies/releases.md#javascript