### PR TITLE
[Storage] Get proxySettings from Environment when not defined in the code

### DIFF
--- a/sdk/storage/storage-blob/ChangeLog.md
+++ b/sdk/storage/storage-blob/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019.09 12.0.0-preview.4
+
+- Library tries to load the proxy settings from the environment variables like HTTP_PROXY if the proxy settings are not provided when clients like BlobServiceClient or BlobClient are instantiated.
+
 ## 2019.09 12.0.0-preview.3
 
 - [Breaking] `RawTokenCredential` is dropped. TokenCredential implementations can be found in the [@azure/identity](https://www.npmjs.com/package/@azure/identity) library for authentication.

--- a/sdk/storage/storage-blob/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-blob/samples/javascript/proxyAuth.js
@@ -21,6 +21,7 @@ async function main() {
       // or
       // an option bag consisting {host, port, username, password }
       proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
+      // if proxy is undefined, the library tries to load the proxy settings from the environment variables like HTTP_PROXY
     }
   );
 

--- a/sdk/storage/storage-blob/samples/typescript/proxyAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/proxyAuth.ts
@@ -21,6 +21,7 @@ async function main() {
       // or
       // an option bag consisting {host, port, username, password }
       proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
+      // if proxy is undefined, the library tries to load the proxy settings from the environment variables like HTTP_PROXY
     }
   );
 

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -203,7 +203,7 @@ export function newPipeline(
   if (isNode) {
     // ProxyPolicy is only avaiable in Node.js runtime, not in browsers
     let proxySettings: ProxySettings | undefined;
-    if (typeof pipelineOptions.proxy === "string") {
+    if (typeof pipelineOptions.proxy === "string" || !pipelineOptions.proxy) {
       proxySettings = getDefaultProxySettings(pipelineOptions.proxy);
     } else {
       proxySettings = pipelineOptions.proxy;

--- a/sdk/storage/storage-file/ChangeLog.md
+++ b/sdk/storage/storage-file/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019.09 12.0.0-preview.4
+
+- Library tries to load the proxy settings from the environment variables like HTTP_PROXY if the proxy settings are not provided when clients like FileServiceClient or FileClient are instantiated.
+
 ## 2019.08 12.0.0-preview.3
 
 - Updated Azure Storage Service API version to 2019-02-02.

--- a/sdk/storage/storage-file/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-file/samples/javascript/proxyAuth.js
@@ -21,6 +21,7 @@ async function main() {
       // or
       // an option bag consisting {host, port, username, password }
       proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
+      // if proxy is undefined, the library tries to load the proxy settings from the environment variables like HTTP_PROXY
     }
   );
 

--- a/sdk/storage/storage-file/samples/typescript/proxyAuth.ts
+++ b/sdk/storage/storage-file/samples/typescript/proxyAuth.ts
@@ -21,6 +21,7 @@ async function main() {
       // or
       // an option bag consisting {host, port, username, password }
       proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
+      // if proxy is undefined, the library tries to load the proxy settings from the environment variables like HTTP_PROXY
     }
   );
 

--- a/sdk/storage/storage-file/src/Pipeline.ts
+++ b/sdk/storage/storage-file/src/Pipeline.ts
@@ -196,7 +196,7 @@ export function newPipeline(
   if (isNode) {
     // ProxyPolicy is only avaiable in Node.js runtime, not in browsers
     let proxySettings: ProxySettings | undefined;
-    if (typeof pipelineOptions.proxy === "string") {
+    if (typeof pipelineOptions.proxy === "string" || !pipelineOptions.proxy) {
       proxySettings = getDefaultProxySettings(pipelineOptions.proxy);
     } else {
       proxySettings = pipelineOptions.proxy;

--- a/sdk/storage/storage-queue/ChangeLog.md
+++ b/sdk/storage/storage-queue/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019.09 12.0.0-preview.4
+
+- Library tries to load the proxy settings from the environment variables like HTTP_PROXY if the proxy settings are not provided when clients like QueueServiceClient or QueueClient are instantiated.
+
 ## 2019.08 12.0.0-preview.3
 
 - [Breaking] `RawTokenCredential` is dropped. TokenCredential implementations can be found in the [@azure/identity](https://www.npmjs.com/package/@azure/identity) library for authentication.

--- a/sdk/storage/storage-queue/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-queue/samples/javascript/proxyAuth.js
@@ -21,6 +21,7 @@ async function main() {
       // or
       // an option bag consisting {host, port, username, password }
       proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
+      // if proxy is undefined, the library tries to load the proxy settings from the environment variables like HTTP_PROXY
     }
   );
 

--- a/sdk/storage/storage-queue/samples/typescript/proxyAuth.ts
+++ b/sdk/storage/storage-queue/samples/typescript/proxyAuth.ts
@@ -21,6 +21,7 @@ async function main() {
       // or
       // an option bag consisting {host, port, username, password }
       proxy: { host: "http://localhost", port: 3128, username: "username", password: "password" }
+      // if proxy is undefined, the library tries to load the proxy settings from the environment variables like HTTP_PROXY
     }
   );
 

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -204,7 +204,7 @@ export function newPipeline(
   if (isNode) {
     // ProxyPolicy is only avaiable in Node.js runtime, not in browsers
     let proxySettings: ProxySettings | undefined;
-    if (typeof pipelineOptions.proxy === "string") {
+    if (typeof pipelineOptions.proxy === "string" || !pipelineOptions.proxy) {
       proxySettings = getDefaultProxySettings(pipelineOptions.proxy);
     } else {
       proxySettings = pipelineOptions.proxy;


### PR DESCRIPTION
When `pipelineOptions.proxy` is undefined, `getDefaultProxySettings()` in core-http tries to load the proxy settings from the environment 

(Example - `process.env.HTTP_PROXY = "http://127.0.0.1:8888";` can be set)