### PR TITLE
[Storage] Support for Development Connection String - storage-blob

### DIFF
--- a/sdk/storage/storage-blob/ChangeLog.md
+++ b/sdk/storage/storage-blob/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2019.09 12.0.0-preview.4
+
+- Added development connection string support to connect to the storage emulator [Azurite - Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=Azurite.azurite)
+  - Development Connection String
+    - `DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;`
+  - Shorthand notation is also supported
+    - `UseDevelopmentStorage=true` (or `UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://myProxyUri`)
+
 ## 2019.09 12.0.0-preview.3
 
 - [Breaking] `RawTokenCredential` is dropped. TokenCredential implementations can be found in the [@azure/identity](https://www.npmjs.com/package/@azure/identity) library for authentication.

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -45,7 +45,8 @@
     "test": "npm run clean && npm run build:test && npm run integration-test",
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node"
   },
   "files": [
     "BreakingChanges.md",

--- a/sdk/storage/storage-blob/src/AppendBlobClient.ts
+++ b/sdk/storage/storage-blob/src/AppendBlobClient.ts
@@ -279,6 +279,7 @@ export class AppendBlobClient extends BlobClient {
     // In TypeScript we cannot simply pass all parameters to super() like below so have to duplicate the code instead.
     //   super(s, credentialOrPipelineOrContainerNameOrOptions, blobNameOrOptions, options);
     let pipeline: Pipeline;
+    options = options || {};
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
@@ -307,10 +308,11 @@ export class AppendBlobClient extends BlobClient {
       if (extractedCreds.kind === "AccountConnString") {
         if (isNode) {
           const sharedKeyCredential = new SharedKeyCredential(
-            extractedCreds.accountName,
+            extractedCreds.accountName!,
             extractedCreds.accountKey
           );
           urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+          options.proxy = extractedCreds.proxyUri;
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -740,6 +740,7 @@ export class BlobClient extends StorageClient {
     blobNameOrOptions?: string | NewPipelineOptions,
     options?: NewPipelineOptions
   ) {
+    options = options || {};
     let pipeline: Pipeline;
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
       pipeline = credentialOrPipelineOrContainerName;
@@ -769,10 +770,11 @@ export class BlobClient extends StorageClient {
       if (extractedCreds.kind === "AccountConnString") {
         if (isNode) {
           const sharedKeyCredential = new SharedKeyCredential(
-            extractedCreds.accountName,
+            extractedCreds.accountName!,
             extractedCreds.accountKey
           );
           urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+          options.proxy = extractedCreds.proxyUri;
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -309,13 +309,15 @@ export class BlobServiceClient extends StorageClient {
    * @memberof BlobServiceClient
    */
   public static fromConnectionString(connectionString: string, options?: NewPipelineOptions) {
+    options = options || {};
     const extractedCreds = extractConnectionStringParts(connectionString);
     if (extractedCreds.kind === "AccountConnString") {
       if (isNode) {
         const sharedKeyCredential = new SharedKeyCredential(
-          extractedCreds.accountName,
+          extractedCreds.accountName!,
           extractedCreds.accountKey
         );
+        options.proxy = extractedCreds.proxyUri;
         const pipeline = newPipeline(sharedKeyCredential, options);
         return new BlobServiceClient(extractedCreds.url, pipeline);
       } else {

--- a/sdk/storage/storage-blob/src/BlockBlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlockBlobClient.ts
@@ -540,6 +540,7 @@ export class BlockBlobClient extends BlobClient {
     // In TypeScript we cannot simply pass all parameters to super() like below so have to duplicate the code instead.
     //   super(s, credentialOrPipelineOrContainerNameOrOptions, blobNameOrOptions, options);
     let pipeline: Pipeline;
+    options = options || {};
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
@@ -568,10 +569,11 @@ export class BlockBlobClient extends BlobClient {
       if (extractedCreds.kind === "AccountConnString") {
         if (isNode) {
           const sharedKeyCredential = new SharedKeyCredential(
-            extractedCreds.accountName,
+            extractedCreds.accountName!,
             extractedCreds.accountKey
           );
           urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+          options.proxy = extractedCreds.proxyUri;
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -513,6 +513,7 @@ export class ContainerClient extends StorageClient {
     options?: NewPipelineOptions
   ) {
     let pipeline: Pipeline;
+    options = options || {};
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
@@ -537,10 +538,11 @@ export class ContainerClient extends StorageClient {
       if (extractedCreds.kind === "AccountConnString") {
         if (isNode) {
           const sharedKeyCredential = new SharedKeyCredential(
-            extractedCreds.accountName,
+            extractedCreds.accountName!,
             extractedCreds.accountKey
           );
           urlOrConnectionString = extractedCreds.url + "/" + containerName + "/";
+          options.proxy = extractedCreds.proxyUri;
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/PageBlobClient.ts
+++ b/sdk/storage/storage-blob/src/PageBlobClient.ts
@@ -445,6 +445,7 @@ export class PageBlobClient extends BlobClient {
     // In TypeScript we cannot simply pass all parameters to super() like below so have to duplicate the code instead.
     //   super(s, credentialOrPipelineOrContainerNameOrOptions, blobNameOrOptions, options);
     let pipeline: Pipeline;
+    options = options || {};
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
       pipeline = credentialOrPipelineOrContainerName;
     } else if (
@@ -473,10 +474,11 @@ export class PageBlobClient extends BlobClient {
       if (extractedCreds.kind === "AccountConnString") {
         if (isNode) {
           const sharedKeyCredential = new SharedKeyCredential(
-            extractedCreds.accountName,
+            extractedCreds.accountName!,
             extractedCreds.accountKey
           );
           urlOrConnectionString = extractedCreds.url + "/" + containerName + "/" + blobName;
+          options.proxy = extractedCreds.proxyUri;
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -64,3 +64,5 @@ export const HTTP_LINE_ENDING = "\r\n";
 export const HTTP_VERSION_1_1 = "HTTP/1.1";
 
 export const EncryptionAlgorithmAES25 = "AES256";
+
+export const DevelopmentConnectionString = `DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;`;

--- a/sdk/storage/storage-blob/test/node/emulator-tests.spec.ts
+++ b/sdk/storage/storage-blob/test/node/emulator-tests.spec.ts
@@ -3,7 +3,6 @@ import * as dotenv from "dotenv";
 import {
   BlobClient,
   ContainerClient,
-  AppendBlobClient,
   BlobServiceClient,
   BlockBlobClient,
   PageBlobClient
@@ -54,17 +53,6 @@ describe("Emulator Tests", () => {
     await newClient.setMetadata(metadata);
     const result = await newClient.getProperties();
     assert.deepStrictEqual(result.metadata, metadata);
-  });
-
-  it("AppendBlobClient can be created with a connection string", async () => {
-    const newClient = new AppendBlobClient(
-      getConnectionStringFromEnvironment(),
-      containerName,
-      blobName
-    );
-
-    await newClient.create();
-    await newClient.download();
   });
 
   it("BlobServiceClient can be created from a connection string", async () => {

--- a/sdk/storage/storage-blob/test/node/emulator-tests.spec.ts
+++ b/sdk/storage/storage-blob/test/node/emulator-tests.spec.ts
@@ -1,0 +1,133 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import {
+  BlobClient,
+  ContainerClient,
+  AppendBlobClient,
+  BlobServiceClient,
+  BlockBlobClient,
+  PageBlobClient
+} from "../../src";
+import {
+  getBSU,
+  getConnectionStringFromEnvironment,
+  env,
+  bodyToString,
+  getUniqueName
+} from "../utils";
+dotenv.config({ path: "../.env" });
+
+// Expected environment variable to run this test-suite
+// STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true
+describe("Emulator Tests", () => {
+  const blobServiceClient = getBSU();
+  let containerName: string;
+  let blobName: string;
+  let containerClient: ContainerClient;
+  let blobClient: BlobClient;
+  let blockBlobClient: BlockBlobClient;
+  const content = "Hello World";
+
+  beforeEach(async function() {
+    if (!env.STORAGE_CONNECTION_STRING.startsWith("UseDevelopmentStorage=true")) {
+      this.skip();
+    }
+    containerName = getUniqueName("container");
+    blobName = getUniqueName("blob");
+    containerClient = blobServiceClient.getContainerClient(containerName);
+    await containerClient.create();
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
+    await blockBlobClient.upload(content, content.length);
+  });
+
+  afterEach(async function() {
+    await containerClient.delete();
+  });
+
+  it("BlobClient can be created with a connection string", async () => {
+    const newClient = new BlobClient(getConnectionStringFromEnvironment(), containerName, blobName);
+    const metadata = {
+      a: "a",
+      b: "b"
+    };
+    await newClient.setMetadata(metadata);
+    const result = await newClient.getProperties();
+    assert.deepStrictEqual(result.metadata, metadata);
+  });
+
+  it("AppendBlobClient can be created with a connection string", async () => {
+    const newClient = new AppendBlobClient(
+      getConnectionStringFromEnvironment(),
+      containerName,
+      blobName
+    );
+
+    await newClient.create();
+    await newClient.download();
+  });
+
+  it("BlobServiceClient can be created from a connection string", async () => {
+    const newClient = BlobServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
+
+    const result = await newClient.getProperties();
+
+    assert.ok(typeof result.requestId);
+    assert.ok(result.requestId!.length > 0);
+  });
+
+  it("BlockBlobClient can be created with a connection string", async () => {
+    const newClient = new BlockBlobClient(
+      getConnectionStringFromEnvironment(),
+      containerName,
+      blobName
+    );
+
+    const body: string = "randomstring";
+    await newClient.upload(body, body.length);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, body.length), body);
+  });
+
+  it("ContainerClient can be created with a connection string and a container name and an option bag", async () => {
+    const newClient = new ContainerClient(getConnectionStringFromEnvironment(), containerName, {
+      retryOptions: {
+        maxTries: 5
+      }
+    });
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(!result.leaseDuration);
+    assert.equal(result.leaseState, "available");
+    assert.equal(result.leaseStatus, "unlocked");
+    assert.ok(result.requestId);
+    assert.ok(result.version);
+    assert.ok(result.date);
+    assert.ok(!result.blobPublicAccess);
+  });
+
+  it("ContainerClient can be created from BSU()", async () => {
+    const newClient = blobServiceClient.getContainerClient(containerName);
+
+    const result = await newClient.getProperties();
+
+    assert.ok(result.eTag!.length > 0);
+    assert.ok(result.lastModified);
+    assert.ok(result.requestId);
+  });
+
+  it("PageBlobClient can be created with a connection string", async () => {
+    const newClient = new PageBlobClient(
+      getConnectionStringFromEnvironment(),
+      containerName,
+      blobName
+    );
+
+    await newClient.create(512);
+    const result = await newClient.download(0);
+    assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));
+  });
+});

--- a/sdk/storage/storage-blob/test/utils/index.ts
+++ b/sdk/storage/storage-blob/test/utils/index.ts
@@ -3,7 +3,7 @@ import * as dotenv from "dotenv";
 import * as fs from "fs";
 import * as path from "path";
 
-import { SimpleTokenCredential } from "./testutils.common";
+import { SimpleTokenCredential, env } from "./testutils.common";
 import { SharedKeyCredential } from "../../src/credentials/SharedKeyCredential";
 import { BlobServiceClient } from "../../src/BlobServiceClient";
 import { getUniqueName } from "./testutils.common";
@@ -45,14 +45,18 @@ export function getGenericBSU(
   accountType: string,
   accountNameSuffix: string = ""
 ): BlobServiceClient {
-  const credential = getGenericCredential(accountType) as SharedKeyCredential;
+  if (env.STORAGE_CONNECTION_STRING.startsWith("UseDevelopmentStorage=true")) {
+    return BlobServiceClient.fromConnectionString(getConnectionStringFromEnvironment());
+  } else {
+    const credential = getGenericCredential(accountType) as SharedKeyCredential;
 
-  const pipeline = newPipeline(credential, {
-    // Enable logger when debugging
-    // logger: new ConsoleHttpPipelineLogger(HttpPipelineLogLevel.INFO)
-  });
-  const blobPrimaryURL = `https://${credential.accountName}${accountNameSuffix}.blob.core.windows.net/`;
-  return new BlobServiceClient(blobPrimaryURL, pipeline);
+    const pipeline = newPipeline(credential, {
+      // Enable logger when debugging
+      // logger: new ConsoleHttpPipelineLogger(HttpPipelineLogLevel.INFO)
+    });
+    const blobPrimaryURL = `https://${credential.accountName}${accountNameSuffix}.blob.core.windows.net/`;
+    return new BlobServiceClient(blobPrimaryURL, pipeline);
+  }
 }
 
 export function getTokenCredential(): TokenCredential {

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -3,6 +3,8 @@ import { padStart } from "../../src/utils/utils.common";
 import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { BlobMetadata } from "../../src/generated/src/models";
 
+export const env = isBrowser() ? (window as any).__env__ : process.env;
+
 /**
  * A TokenCredential that always returns the given token. This class can be
  * used when the access token is already known or can be retrieved from an


### PR DESCRIPTION
This PR adds the support for Development connection string and some tests for the emulator(local).

  - Development Connection String
    - `DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;`
  - Shorthand notation is also supported
    - `UseDevelopmentStorage=true` or 
    - `UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://myProxyUri`

Added a separate set of Emulator tests(test suite in the node tests) which will be skipped if the `STORAGE_CONNECTION_STRING` environment variable doesn't start with `UseDevelopmentStorage=true`.