### PR TITLE
[Storage] Leverage `this.skip();` instead of `return;` in the test for TokenCredential

### DIFF
--- a/sdk/storage/storage-blob/test/blobbatch.spec.ts
+++ b/sdk/storage/storage-blob/test/blobbatch.spec.ts
@@ -299,7 +299,7 @@ describe("BlobBatch", () => {
     }
   });
 
-  it("submitBatch should work with multiple types of credentials for subrequests", async () => {
+  it("submitBatch should work with multiple types of credentials for subrequests", async function() {
     // Try to get serviceURL object with TokenCredential
     // when ACCOUNT_TOKEN environment variable is set
     let tokenCredential;
@@ -310,7 +310,7 @@ describe("BlobBatch", () => {
     // Requires bearer token for this case which cannot be generated in the runtime
     // Make sure this case passed in sanity test
     if (tokenCredential === undefined) {
-      return;
+      this.skip();
     }
 
     // Upload blobs.

--- a/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
@@ -413,10 +413,10 @@ describe("BlobServiceClient", () => {
     assert.ok(result.requestId!.length > 0);
   });
 
-  it("getUserDelegationKey should work", async () => {
+  it("getUserDelegationKey should work", async function() {
     // Try to get serviceURL object with TokenCredential
     // when ACCOUNT_TOKEN environment variable is set
-    let serviceURLWithToken;
+    let serviceURLWithToken: BlobServiceClient | undefined;
     try {
       serviceURLWithToken = getTokenBSU();
     } catch {}
@@ -424,14 +424,14 @@ describe("BlobServiceClient", () => {
     // Requires bearer token for this case which cannot be generated in the runtime
     // Make sure this case passed in sanity test
     if (serviceURLWithToken === undefined) {
-      return;
+      this.skip();
     }
 
     const now = recorder.newDate("now");
     now.setHours(now.getHours() + 1);
     const tmr = recorder.newDate("tmr");
     tmr.setDate(tmr.getDate() + 1);
-    const response = await serviceURLWithToken.getUserDelegationKey(now, tmr);
+    const response = await serviceURLWithToken!.getUserDelegationKey(now, tmr);
     assert.notDeepStrictEqual(response.value, undefined);
     assert.notDeepStrictEqual(response.signedVersion, undefined);
     assert.notDeepStrictEqual(response.signedTid, undefined);

--- a/sdk/storage/storage-blob/test/browser/highlevel.browser.spec.ts
+++ b/sdk/storage/storage-blob/test/browser/highlevel.browser.spec.ts
@@ -144,13 +144,13 @@ describe("Highlevel", () => {
     assert.equal(uploadedString, downloadedString);
   });
 
-  it("uploadBrowserDataToBlockBlob should success when blob >= BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES", async () => {
+  it("uploadBrowserDataToBlockBlob should success when blob >= BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES", async function() {
     if (isIE()) {
       assert.ok(
         true,
         "Skip this case in IE11 which doesn't have enough memory for downloading validation"
       );
-      return;
+      this.skip();
     }
 
     await blockBlobClient.uploadBrowserData(tempFile1, {

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -481,7 +481,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await containerClient.delete();
   });
 
-  it("GenerateUserDelegationSAS should work for container with all configurations", async () => {
+  it("GenerateUserDelegationSAS should work for container with all configurations", async function() {
     // Try to get BlobServiceClient object with TokenCredential
     // when ACCOUNT_TOKEN environment variable is set
     let blobServiceClientWithToken: BlobServiceClient | undefined;
@@ -492,14 +492,14 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     // Requires bearer token for this case which cannot be generated in the runtime
     // Make sure this case passed in sanity test
     if (blobServiceClientWithToken === undefined) {
-      return;
+      this.skip();
     }
 
     const now = recorder.newDate("now");
     now.setHours(now.getHours() - 1);
     const tmr = recorder.newDate("tmr");
     tmr.setDate(tmr.getDate() + 1);
-    const userDelegationKey = await blobServiceClientWithToken.getUserDelegationKey(now, tmr);
+    const userDelegationKey = await blobServiceClientWithToken!.getUserDelegationKey(now, tmr);
 
     // By default, credential is always the last element of pipeline factories
     const factories = (blobServiceClient as any).pipeline.factories;
@@ -537,7 +537,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await containerClient.delete();
   });
 
-  it("GenerateUserDelegationSAS should work for container with minimum parameters", async () => {
+  it("GenerateUserDelegationSAS should work for container with minimum parameters", async function() {
     // Try to get BlobServiceClient object with TokenCredential
     // when ACCOUNT_TOKEN environment variable is set
     let blobServiceClientWithToken: BlobServiceClient | undefined;
@@ -548,14 +548,14 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     // Requires bearer token for this case which cannot be generated in the runtime
     // Make sure this case passed in sanity test
     if (blobServiceClientWithToken === undefined) {
-      return;
+      this.skip();
     }
 
     const now = recorder.newDate("now");
     now.setHours(now.getHours() - 1);
     const tmr = recorder.newDate("tmr");
     tmr.setDate(tmr.getDate() + 1);
-    const userDelegationKey = await blobServiceClientWithToken.getUserDelegationKey(now, tmr);
+    const userDelegationKey = await blobServiceClientWithToken!.getUserDelegationKey(now, tmr);
 
     // By default, credential is always the last element of pipeline factories
     const factories = (blobServiceClient as any).pipeline.factories;
@@ -589,7 +589,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await containerClient.delete();
   });
 
-  it("GenerateUserDelegationSAS should work for blob", async () => {
+  it("GenerateUserDelegationSAS should work for blob", async function() {
     // Try to get blobServiceClient object with TokenCredential
     // when ACCOUNT_TOKEN environment variable is set
     let blobServiceClientWithToken: BlobServiceClient | undefined;
@@ -600,14 +600,14 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     // Requires bearer token for this case which cannot be generated in the runtime
     // Make sure this case passed in sanity test
     if (blobServiceClientWithToken === undefined) {
-      return;
+      this.skip();
     }
 
     const now = recorder.newDate("now");
     now.setHours(now.getHours() - 1);
     const tmr = recorder.newDate("tmr");
     tmr.setDate(tmr.getDate() + 1);
-    const userDelegationKey = await blobServiceClientWithToken.getUserDelegationKey(now, tmr);
+    const userDelegationKey = await blobServiceClientWithToken!.getUserDelegationKey(now, tmr);
 
     // By default, credential is always the last element of pipeline factories
     const factories = (blobServiceClient as any).pipeline.factories;
@@ -658,7 +658,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await containerClient.delete();
   });
 
-  it("GenerateUserDelegationSAS should work for blob snapshot", async () => {
+  it("GenerateUserDelegationSAS should work for blob snapshot", async function() {
     // Try to get blobServiceClient object with TokenCredential
     // when ACCOUNT_TOKEN environment variable is set
     let blobServiceClientWithToken: BlobServiceClient | undefined;
@@ -669,14 +669,14 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     // Requires bearer token for this case which cannot be generated in the runtime
     // Make sure this case passed in sanity test
     if (blobServiceClientWithToken === undefined) {
-      return;
+      this.skip();
     }
 
     const now = recorder.newDate("now");
     now.setHours(now.getHours() - 1);
     const tmr = recorder.newDate("tmr");
     tmr.setDate(tmr.getDate() + 1);
-    const userDelegationKey = await blobServiceClientWithToken.getUserDelegationKey(now, tmr);
+    const userDelegationKey = await blobServiceClientWithToken!.getUserDelegationKey(now, tmr);
 
     // By default, credential is always the last element of pipeline factories
     const factories = (blobServiceClient as any).pipeline.factories;


### PR DESCRIPTION
Tests that depend on ACCOUNT_TOKEN are being skipped(by `return;`) in the CI integration tests due to the lack of a valid ACCOUNT_TOKEN.

Instead of "return"ing, this.skip() can be leveraged to skip the test.
That way we can be sure we are not testing it when we don't have a valid ACCOUNT_TOKEN.