### PR TITLE
[Storage] Improve comments for AAD setup - DefaultAzureCredential

### DIFF
--- a/sdk/storage/storage-blob/samples/javascript/azureAdAuth.js
+++ b/sdk/storage/storage-blob/samples/javascript/azureAdAuth.js
@@ -1,5 +1,21 @@
 /*
- Setup: Enter your Azure Active Directory credentials as described in main()
+  ONLY AVAILABLE IN NODE.JS RUNTIME
+
+  Setup :
+    - Reference - Authorize access to blobs and queues with Azure Active Directory from a client application 
+      - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app
+ 
+    - Register a new AAD application and give permissions to access Azure Storage on behalf of the signed-in user
+      - Register a new application in the Azure Active Directory(in the azure-portal) - https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
+      - In the `API permissions` section, select `Add a permission` and choose `Microsoft APIs`. 
+      - Pick `Azure Storage` and select the checkbox next to `user_impersonation` and then click `Add permissions`. This would allow the application to access Azure Storage on behalf of the signed-in user.
+    - Grant access to Azure Blob data with RBAC in the Azure Portal 
+      - RBAC roles for blobs and queues - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal.
+      - In the azure portal, go to your storage-account and assign **Storage Blob Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
+    
+    - Environment setup for the sample
+      - From the overview page of your AAD Application, note down the `CLIENT ID` and `TENANT ID`. In the "Certificates & Secrets" tab, create a secret and note that down.
+      - Make sure you have AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET as environment variables to successfully execute the sample(Can leverage process.env).
 */
 
 const { BlobServiceClient } = require("../.."); // Change to "@azure/storage-blob" in your package

--- a/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
@@ -1,5 +1,20 @@
 /*
- Setup: Enter your Azure Active Directory credentials as described in main()
+  ONLY AVAILABLE IN NODE.JS RUNTIME
+
+  Setup :
+    - Reference - [Authorize access to blobs and queues with Azure Active Directory from a client application](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app)
+ 
+    - Register a new AAD application and give permissions to access Azure Storage on behalf of the signed-in user
+      - Follow [Documentation to register a new application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) in the Azure Active Directory(in the azure-portal).
+      - In the API permissions section, select Add a permission and choose Microsoft APIs. 
+      - Pick `Azure Storage` and select the checkbox next to `user_impersonation` and then click `Add permissions`. This would allow the application to access Azure Storage on behalf of the signed-in user.
+    - Grant access to Azure Blob data with RBAC in the Azure Portal 
+      - [RBAC roles for blobs and queues](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal).
+      - In the azure-portal, go to your storage-account and assign **Storage Blob Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
+    
+    - Environment setup for the sample
+      - From the overview page of your AAD Application, note down the `CLIENT ID` and `TENANT ID`. In the "Certificates & Secrets" tab, create a secret and note that down.
+      - Make sure you have AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET as environment variables (Can leverage process.env).
 */
 
 import { BlobServiceClient } from "../../src"; // Change to "@azure/storage-blob" in your package

--- a/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
@@ -2,14 +2,15 @@
   ONLY AVAILABLE IN NODE.JS RUNTIME
 
   Setup :
-    - Reference - [Authorize access to blobs and queues with Azure Active Directory from a client application](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app)
+    - Reference - Authorize access to blobs and queues with Azure Active Directory from a client application 
+      - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app
  
     - Register a new AAD application and give permissions to access Azure Storage on behalf of the signed-in user
-      - Follow [Documentation to register a new application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) in the Azure Active Directory(in the azure-portal).
+      - Register a new application in the Azure Active Directory(in the azure-portal) - https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
       - In the API permissions section, select Add a permission and choose Microsoft APIs. 
       - Pick `Azure Storage` and select the checkbox next to `user_impersonation` and then click `Add permissions`. This would allow the application to access Azure Storage on behalf of the signed-in user.
     - Grant access to Azure Blob data with RBAC in the Azure Portal 
-      - [RBAC roles for blobs and queues](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal).
+      - RBAC roles for blobs and queues - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal.
       - In the azure-portal, go to your storage-account and assign **Storage Blob Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
     
     - Environment setup for the sample

--- a/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts
@@ -7,15 +7,15 @@
  
     - Register a new AAD application and give permissions to access Azure Storage on behalf of the signed-in user
       - Register a new application in the Azure Active Directory(in the azure-portal) - https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
-      - In the API permissions section, select Add a permission and choose Microsoft APIs. 
+      - In the `API permissions` section, select `Add a permission` and choose `Microsoft APIs`. 
       - Pick `Azure Storage` and select the checkbox next to `user_impersonation` and then click `Add permissions`. This would allow the application to access Azure Storage on behalf of the signed-in user.
     - Grant access to Azure Blob data with RBAC in the Azure Portal 
       - RBAC roles for blobs and queues - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal.
-      - In the azure-portal, go to your storage-account and assign **Storage Blob Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
+      - In the azure portal, go to your storage-account and assign **Storage Blob Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
     
     - Environment setup for the sample
       - From the overview page of your AAD Application, note down the `CLIENT ID` and `TENANT ID`. In the "Certificates & Secrets" tab, create a secret and note that down.
-      - Make sure you have AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET as environment variables (Can leverage process.env).
+      - Make sure you have AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET as environment variables to successfully execute the sample(Can leverage process.env).
 */
 
 import { BlobServiceClient } from "../../src"; // Change to "@azure/storage-blob" in your package

--- a/sdk/storage/storage-queue/samples/javascript/azureAdAuth.js
+++ b/sdk/storage/storage-queue/samples/javascript/azureAdAuth.js
@@ -1,5 +1,21 @@
 /*
- Setup: Enter your Azure Active Directory credentials as described in main()
+  ONLY AVAILABLE IN NODE.JS RUNTIME
+
+  Setup :
+    - Reference - Authorize access to blobs and queues with Azure Active Directory from a client application 
+      - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app
+ 
+    - Register a new AAD application and give permissions to access Azure Storage on behalf of the signed-in user
+      - Register a new application in the Azure Active Directory(in the azure-portal) - https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
+      - In the `API permissions` section, select `Add a permission` and choose `Microsoft APIs`. 
+      - Pick `Azure Storage` and select the checkbox next to `user_impersonation` and then click `Add permissions`. This would allow the application to access Azure Storage on behalf of the signed-in user.
+    - Grant access to Azure Storage Queue data with RBAC in the Azure Portal 
+      - RBAC roles for blobs and queues - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal.
+      - In the azure portal, go to your storage-account and assign **Storage Queue Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
+    
+    - Environment setup for the sample
+      - From the overview page of your AAD Application, note down the `CLIENT ID` and `TENANT ID`. In the "Certificates & Secrets" tab, create a secret and note that down.
+      - Make sure you have AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET as environment variables to successfully execute the sample(Can leverage process.env).
 */
 
 const { QueueServiceClient } = require("../.."); // Change to "@azure/storage-queue" in your package

--- a/sdk/storage/storage-queue/samples/typescript/azureAdAuth.ts
+++ b/sdk/storage/storage-queue/samples/typescript/azureAdAuth.ts
@@ -1,5 +1,21 @@
 /*
- Setup: Enter your Azure Active Directory credentials as described in main()
+  ONLY AVAILABLE IN NODE.JS RUNTIME
+
+  Setup :
+    - Reference - Authorize access to blobs and queues with Azure Active Directory from a client application 
+      - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app
+ 
+    - Register a new AAD application and give permissions to access Azure Storage on behalf of the signed-in user
+      - Register a new application in the Azure Active Directory(in the azure-portal) - https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
+      - In the `API permissions` section, select `Add a permission` and choose `Microsoft APIs`. 
+      - Pick `Azure Storage` and select the checkbox next to `user_impersonation` and then click `Add permissions`. This would allow the application to access Azure Storage on behalf of the signed-in user.
+    - Grant access to Azure Storage Queue data with RBAC in the Azure Portal 
+      - RBAC roles for blobs and queues - https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal.
+      - In the azure portal, go to your storage-account and assign **Storage Queue Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
+    
+    - Environment setup for the sample
+      - From the overview page of your AAD Application, note down the `CLIENT ID` and `TENANT ID`. In the "Certificates & Secrets" tab, create a secret and note that down.
+      - Make sure you have AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET as environment variables to successfully execute the sample(Can leverage process.env).
 */
 
 import { QueueServiceClient } from "../../src"; // Change to "@azure/storage-queue" in your package


### PR DESCRIPTION
Adding more description to the DefaultAzureCredential sample related to the setup in comments.

```
Setup :

- Reference - [Authorize access to blobs and queues with Azure Active Directory from a client application](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-app)
 
- Register a new AAD application and give permissions to access Azure Storage on behalf of the signed-in user
      - Follow [Documentation to register a new application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) in the Azure Active Directory(in the azure-portal).
      - In the API permissions section, select Add a permission and choose Microsoft APIs. 
      - Pick `Azure Storage` and select the checkbox next to `user_impersonation` and then click `Add permissions`. This would allow the application to access Azure Storage on behalf of the signed-in user.
- Grant access to Azure Blob data with RBAC in the Azure Portal 
      - [RBAC roles for blobs and queues](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad-rbac-portal).
      - In the azure-portal, go to your storage-account and assign **Storage Blob Data Contributor** role to the registered AAD application from `Access control (IAM)` tab (in the left-side-navbar of your storage account in the azure-portal). 
    
- Environment setup for the sample
      - From the overview page of your AAD Application, note down the `CLIENT ID` and `TENANT ID`. In the "Certificates & Secrets" tab, create a secret and note that down.
      - Make sure you have AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET as environment variables (Can leverage process.env).
```




/cc - @daviwil @jeremymeng let me know if I should rephrase something!