### PR TITLE
[Storage] verify errors for tests that expect errors

### DIFF
--- a/sdk/storage/storage-blob/recordings/node/aborter/recording_should_abort_after_aborter_timeout.js
+++ b/sdk/storage/storage-blob/recordings/node/aborter/recording_should_abort_after_aborter_timeout.js
@@ -1,3 +1,3 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816827649300026"}
+module.exports.testInfo = {"container":"container156944560763601225"}

--- a/sdk/storage/storage-blob/recordings/node/aborter/recording_should_abort_after_father_aborter_calls_abort.js
+++ b/sdk/storage/storage-blob/recordings/node/aborter/recording_should_abort_after_father_aborter_calls_abort.js
@@ -1,24 +1,3 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816827650207422"}
-
-nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816827650207422')
-  .query(true)
-  .reply(201, "", [ 'Content-Length',
-  '0',
-  'Last-Modified',
-  'Wed, 11 Sep 2019 02:17:56 GMT',
-  'ETag',
-  '"0x8D7365E429A1332"',
-  'Server',
-  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id',
-  '816c911c-c01e-006b-4a47-683baa000000',
-  'x-ms-client-request-id',
-  '215d2349-19d7-436e-88ec-4c50ab8a211c',
-  'x-ms-version',
-  '2019-02-02',
-  'Date',
-  'Wed, 11 Sep 2019 02:17:56 GMT' ]);
-
+module.exports.testInfo = {"container":"container156944560852001456"}

--- a/sdk/storage/storage-blob/recordings/node/aborter/recording_should_abort_when_calling_abort_before_request_finishes.js
+++ b/sdk/storage/storage-blob/recordings/node/aborter/recording_should_abort_when_calling_abort_before_request_finishes.js
@@ -1,3 +1,3 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816827603600635"}
+module.exports.testInfo = {"container":"container156944560821605956"}

--- a/sdk/storage/storage-blob/recordings/node/aborter/recording_should_not_abort_after_calling_abort.js
+++ b/sdk/storage/storage-blob/recordings/node/aborter/recording_should_not_abort_after_calling_abort.js
@@ -1,24 +1,24 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816827540809115"}
+module.exports.testInfo = {"container":"container156944560781309591"}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816827540809115')
+  .put('/container156944560781309591')
   .query(true)
   .reply(201, "", [ 'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:17:55 GMT',
+  'Wed, 25 Sep 2019 21:06:47 GMT',
   'ETag',
-  '"0x8D7365E421231F5"',
+  '"0x8D741FC4712EEB5"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '25d55ac5-101e-002d-7f47-68e53c000000',
+  '1189b21b-701e-0039-67e5-7370d2000000',
   'x-ms-client-request-id',
-  '68a913b2-d2a0-4f8d-a9ed-e6db1ebdb84c',
+  '92eeadc0-510b-453d-bc0b-eeea502ae595',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 11 Sep 2019 02:17:55 GMT' ]);
+  'Wed, 25 Sep 2019 21:06:47 GMT' ]);
 

--- a/sdk/storage/storage-blob/recordings/node/aborter/recording_should_not_abort_when_calling_abort_after_request_finishes.js
+++ b/sdk/storage/storage-blob/recordings/node/aborter/recording_should_not_abort_when_calling_abort_after_request_finishes.js
@@ -1,24 +1,24 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816827604905460"}
+module.exports.testInfo = {"container":"container156944560822200795"}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816827604905460')
+  .put('/container156944560822200795')
   .query(true)
   .reply(201, "", [ 'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:17:56 GMT',
+  'Wed, 25 Sep 2019 21:06:48 GMT',
   'ETag',
-  '"0x8D7365E4255FDCE"',
+  '"0x8D741FC4756A33A"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '53c1c81c-f01e-002c-2847-68e4c1000000',
+  'c91db945-301e-009f-17e5-7348cc000000',
   'x-ms-client-request-id',
-  'efbe414d-375c-4297-8499-5fcac85a3e7e',
+  'f8a38b0b-2eb1-4cf3-bd43-aba8d7fb3217',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 11 Sep 2019 02:17:56 GMT' ]);
+  'Wed, 25 Sep 2019 21:06:47 GMT' ]);
 

--- a/sdk/storage/storage-blob/test/aborter.spec.ts
+++ b/sdk/storage/storage-blob/test/aborter.spec.ts
@@ -36,7 +36,9 @@ describe("Aborter", () => {
     try {
       await response;
       assert.fail();
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
   });
 
   it("Should not abort when calling abort() after request finishes", async () => {
@@ -49,18 +51,26 @@ describe("Aborter", () => {
     try {
       await containerClient.create({ abortSignal: AbortController.timeout(1) });
       assert.fail();
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
   });
 
   it("Should abort after father aborter calls abort()", async () => {
     try {
       const aborter = new AbortController();
+      const childAborter = new AbortController(
+        aborter.signal,
+        AbortController.timeout(10 * 60 * 1000)
+      );
       const response = containerClient.create({
-        abortSignal: AbortController.timeout(10 * 60 * 1000)
+        abortSignal: childAborter.signal
       });
       aborter.abort();
       await response;
       assert.fail();
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
   });
 });

--- a/sdk/storage/storage-blob/test/aborter.spec.ts
+++ b/sdk/storage/storage-blob/test/aborter.spec.ts
@@ -25,6 +25,16 @@ describe("Aborter", () => {
     recorder.stop();
   });
 
+  it("Should abort after aborter timeout", async () => {
+    try {
+      await containerClient.create({ abortSignal: AbortController.timeout(1) });
+      assert.fail();
+    } catch (err) {
+      console.log(err);
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
+  });
+
   it("Should not abort after calling abort()", async () => {
     await containerClient.create({ abortSignal: AbortSignal.none });
   });
@@ -45,15 +55,6 @@ describe("Aborter", () => {
     const aborter = new AbortController();
     await containerClient.create({ abortSignal: aborter.signal });
     aborter.abort();
-  });
-
-  it("Should abort after aborter timeout", async () => {
-    try {
-      await containerClient.create({ abortSignal: AbortController.timeout(1) });
-      assert.fail();
-    } catch (err) {
-      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
-    }
   });
 
   it("Should abort after father aborter calls abort()", async () => {

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -256,7 +256,7 @@ describe("BlobClient", () => {
         "AbortCopyFromClient should be failed and throw exception for an completed copy operation."
       );
     } catch (err) {
-      assert.ok(true);
+      assert.ok((err as any).body.Code === "InvalidHeaderValue");
     }
   });
 

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -264,7 +264,7 @@ describe("BlobClient Node.js only", () => {
         "AbortCopyFromClient should be failed and throw exception for an completed copy operation."
       );
     } catch (err) {
-      assert.ok(true);
+      assert.ok((err as any).body.Code === "InvalidHeaderValue");
     }
   });
 

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -46,7 +46,10 @@ describe("Utility Helpers Node.js only", () => {
       );
       assert.fail("Expecting an thrown error but didn't get one.");
     } catch (error) {
-      assert.ok(error);
+      assert.ok(
+        error.message ===
+          "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'"
+      );
     }
   });
 

--- a/sdk/storage/storage-file/recordings/node/aborter/recording_should_abort_after_parent_aborter_calls_abort.js
+++ b/sdk/storage/storage-file/recordings/node/aborter/recording_should_abort_after_parent_aborter_calls_abort.js
@@ -1,24 +1,3 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"share":"share156816827693507700"}
-
-nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/share156816827693507700')
-  .query(true)
-  .reply(201, "", [ 'Content-Length',
-  '0',
-  'Last-Modified',
-  'Wed, 11 Sep 2019 02:17:57 GMT',
-  'ETag',
-  '"0x8D7365E42DD1E42"',
-  'Server',
-  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
-  'x-ms-request-id',
-  'bf44a2a7-d01a-0056-1347-688e8c000000',
-  'x-ms-client-request-id',
-  'eba61ab7-59c7-4c43-8bc9-a68c5acf29de',
-  'x-ms-version',
-  '2019-02-02',
-  'Date',
-  'Wed, 11 Sep 2019 02:17:56 GMT' ]);
-
+module.exports.testInfo = {"share":"share156945328942205425"}

--- a/sdk/storage/storage-file/test/aborter.spec.ts
+++ b/sdk/storage/storage-file/test/aborter.spec.ts
@@ -37,7 +37,9 @@ describe("Aborter", () => {
     try {
       await response;
       assert.fail();
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
   });
 
   it("Should not abort when calling abort() after request finishes", async () => {
@@ -50,18 +52,23 @@ describe("Aborter", () => {
     try {
       await shareClient.create({ abortSignal: AbortController.timeout(1) });
       assert.fail();
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
   });
 
   it("Should abort after parent aborter calls abort()", async () => {
     try {
       const aborter = new AbortController();
+      const childAborter = new AbortController(aborter.signal, AbortController.timeout(100));
       const response = shareClient.create({
-        abortSignal: AbortController.timeout(10 * 60 * 1000)
+        abortSignal: childAborter.signal
       });
       aborter.abort();
       await response;
       assert.fail();
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
   });
 });

--- a/sdk/storage/storage-file/test/aborter.spec.ts
+++ b/sdk/storage/storage-file/test/aborter.spec.ts
@@ -25,6 +25,15 @@ describe("Aborter", () => {
     recorder.stop();
   });
 
+  it("Should abort after aborter timeout", async () => {
+    try {
+      await shareClient.create({ abortSignal: AbortController.timeout(1) });
+      assert.fail();
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
+  });
+
   it("Should not abort after calling abort()", async () => {
     await shareClient.create();
     await shareClient.delete();
@@ -46,15 +55,6 @@ describe("Aborter", () => {
     const aborter = new AbortController();
     await shareClient.create();
     aborter.abort();
-  });
-
-  it("Should abort after aborter timeout", async () => {
-    try {
-      await shareClient.create({ abortSignal: AbortController.timeout(1) });
-      assert.fail();
-    } catch (err) {
-      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
-    }
   });
 
   it("Should abort after parent aborter calls abort()", async () => {

--- a/sdk/storage/storage-file/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileclient.spec.ts
@@ -451,7 +451,9 @@ describe("FileClient", () => {
 
       assert.fail();
       // tslint:disable-next-line:no-empty
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.name, "AbortError", "Unexpected error caught: " + err);
+    }
     assert.ok(eventTriggered);
   });
 

--- a/sdk/storage/storage-file/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file/test/node/highlevel.node.spec.ts
@@ -138,7 +138,9 @@ describe("Highlevel Node.js only", () => {
         },
         rangeSize: 4 * 1024 * 1024
       });
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
     assert.ok(eventTriggered);
   });
 
@@ -157,7 +159,9 @@ describe("Highlevel Node.js only", () => {
         },
         rangeSize: 4 * 1024 * 1024
       });
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
     assert.ok(eventTriggered);
   });
 
@@ -293,7 +297,9 @@ describe("Highlevel Node.js only", () => {
         },
         rangeSize: 1 * 1024
       });
-    } catch (err) {}
+    } catch (err) {
+      assert.equal(err.message, "The request was aborted", "Unexpected error caught: " + err);
+    }
     assert.ok(eventTriggered);
   });
 
@@ -426,7 +432,6 @@ describe("Highlevel Node.js only", () => {
 
     let retirableReadableStreamOptions: RetriableReadableStreamOptions;
     let injectedErrors = 0;
-    let expectedError = false;
 
     try {
       const aborter = new AbortController();
@@ -446,10 +451,9 @@ describe("Highlevel Node.js only", () => {
       retirableReadableStreamOptions = (downloadResponse.readableStreamBody! as any).options;
       await readStreamToLocalFile(downloadResponse.readableStreamBody!, downloadedFile);
     } catch (error) {
-      expectedError = true;
+      assert.equal(error.name, "AbortError", "Unexpected error caught: " + error);
     }
 
-    assert.ok(expectedError);
     fs.unlinkSync(downloadedFile);
   });
 


### PR DESCRIPTION
Some tests currently do not verify expected errors properly. They just catch the
error then pass the tests. The problem is `assert.fail()` in the `try`-block
also throws error. Assertion error is swallowed if we don't check the caught
error.

This change adds verification for the expected errors.

Resolves #4580 