### PR TITLE
listRevisions and listConfigurationSettings now return PagedAsyncIterableIterator

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -23,6 +23,12 @@ await client.addConfigurationSetting({ key: "MyKey", label: "MyLabel", value: "M
 await client.setConfigurationSetting({ key: "MyKey", label: "MyLabel", value: "MyValue" });
 ```
 
+### Enhancements
+
+- `listConfigurationSettings` and `listRevisions` have been changed to return `PagedAsyncIterableIterator`'s,
+  allowing their results to be iterated by page (also returning HTTP response information) or as an
+  iterator of ConfigurationSetting.
+
 # 1.0.0-preview.3 (2019-09-23)
 
 - Typings file was incorrectly packaged (#5217)

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -3,9 +3,10 @@
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
   "version": "1.0.0-preview.4",
-  "sdk-type": "client",
+  "sdk-type": "client",  
   "dependencies": {
     "@azure/core-arm": "1.0.0-preview.3",
+    "@azure/core-asynciterator-polyfill": "1.0.0-preview.1",
     "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.2",
     "tslib": "^1.9.3"

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import * as coreHttp from '@azure/core-http';
+import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { TokenCredential } from '@azure/core-http';
 
 // @public
@@ -14,10 +15,8 @@ export class AppConfigurationClient {
     addConfigurationSetting(configurationSetting: ConfigurationSettingParam, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
     deleteConfigurationSetting(key: string, options: AppConfigurationDeleteKeyValueOptionalParams & ETagOption): Promise<DeleteKeyValueResponse>;
     getConfigurationSetting(key: string, options?: AppConfigurationGetKeyValueOptionalParams): Promise<GetKeyValueResponse>;
-    listConfigurationSettings(options?: ListConfigurationSettingsOptions): Promise<ListConfigurationSettingsResponse>;
-    // (undocumented)
-    listConfigurationSettingsNext(nextLink: string, options?: ListConfigurationSettingsOptions): Promise<ListConfigurationSettingsResponse>;
-    listRevisions(options?: AppConfigurationGetRevisionsOptionalParams): Promise<GetRevisionsResponse>;
+    listConfigurationSettings(options?: ListConfigurationSettingsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListConfigurationSettingPage>;
+    listRevisions(options?: ListRevisionsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListRevisionsPage>;
     setConfigurationSetting(configurationSetting: ConfigurationSettingParam & ETagOption, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
 }
 
@@ -84,11 +83,11 @@ export interface ConfigurationSetting {
     value?: string;
 }
 
-// @public (undocumented)
+// @public
 export interface ConfigurationSettingOptions extends Pick<AppConfigurationPutKeyValueOptionalParams, Exclude<keyof AppConfigurationPutKeyValueOptionalParams, 'label' | 'entity'>> {
 }
 
-// @public (undocumented)
+// @public
 export interface ConfigurationSettingParam extends Pick<ConfigurationSetting, Exclude<keyof ConfigurationSetting, 'locked' | 'etag' | 'lastModified'>> {
 }
 
@@ -119,7 +118,22 @@ export type GetKeyValueResponse = ConfigurationSetting & GetKeyValueHeaders & {
     };
 };
 
+// @public
+export interface GetKeyValuesHeaders {
+    syncToken?: string;
+}
+
 // Warning: (ae-forgotten-export) The symbol "KeyValueListResult" needs to be exported by the entry point index.d.ts
+// 
+// @public
+export type GetKeyValuesResponse = KeyValueListResult & GetKeyValuesHeaders & {
+    _response: coreHttp.HttpResponse & {
+        parsedHeaders: GetKeyValuesHeaders;
+        bodyAsText: string;
+        parsedBody: KeyValueListResult;
+    };
+};
+
 // Warning: (ae-forgotten-export) The symbol "GetRevisionsHeaders" needs to be exported by the entry point index.d.ts
 // 
 // @public
@@ -131,17 +145,28 @@ export type GetRevisionsResponse = KeyValueListResult & GetRevisionsHeaders & {
     };
 };
 
-// @public (undocumented)
+// @public
+export interface ListConfigurationSettingPage extends Pick<GetKeyValuesResponse, Exclude<keyof GetKeyValuesResponse, 'items'>> {
+    items: ConfigurationSetting[];
+}
+
+// @public
 export interface ListConfigurationSettingsOptions extends Pick<AppConfigurationGetKeyValuesOptionalParams, Exclude<keyof AppConfigurationGetKeyValuesOptionalParams, 'key' | 'label' | 'select' | 'after'>> {
     fields?: (keyof ConfigurationSetting)[];
     keys?: string[];
     labels?: string[];
 }
 
-// Warning: (ae-forgotten-export) The symbol "GetKeyValuesResponse" needs to be exported by the entry point index.d.ts
-// 
-// @public (undocumented)
-export interface ListConfigurationSettingsResponse extends GetKeyValuesResponse {
+// @public
+export interface ListRevisionsOptions extends Pick<AppConfigurationGetRevisionsOptionalParams, Exclude<keyof AppConfigurationGetRevisionsOptionalParams, 'key' | 'label' | 'select' | 'after'>> {
+    fields?: (keyof ConfigurationSetting)[];
+    keys?: string[];
+    labels?: string[];
+}
+
+// @public
+export interface ListRevisionsPage extends Pick<GetRevisionsResponse, Exclude<keyof GetRevisionsResponse, 'items'>> {
+    items: ConfigurationSetting[];
 }
 
 // Warning: (ae-forgotten-export) The symbol "PutKeyValueHeaders" needs to be exported by the entry point index.d.ts

--- a/sdk/appconfiguration/app-configuration/samples/helloworld.ts
+++ b/sdk/appconfiguration/app-configuration/samples/helloworld.ts
@@ -37,15 +37,13 @@ export async function run() {
 }
 
 async function cleanupSampleValues(keys: string[], client: AppConfigurationClient) {
-    const existingSettings = await client.listConfigurationSettings({
+    const settingsIterator = await client.listConfigurationSettings({
         keys: keys
     });
 
-    if (existingSettings.items) {
-        for (const setting of existingSettings.items) {
-            await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
-        }
-    }
+    for await (const setting of settingsIterator) {
+        await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
+    }    
 }
 
 // If you want to run this sample from a console

--- a/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts
+++ b/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts
@@ -36,10 +36,8 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
         keys: keys
     });
 
-    if (existingSettings.items) {
-        for (const setting of existingSettings.items) {
-            await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
-        }
+    for await (const setting of existingSettings) {
+        await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
     }
 }
 

--- a/sdk/appconfiguration/app-configuration/src/index.ts
+++ b/sdk/appconfiguration/app-configuration/src/index.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+// https://azure.github.io/azure-sdk/typescript_design.html#ts-config-lib
+/// <reference lib="esnext.asynciterable" />
+
 import { AppConfigCredential } from "./appConfigCredential";
 import { TokenCredential, URLBuilder } from "@azure/core-http";
 import { AppConfiguration } from "./generated/src/appConfiguration";

--- a/sdk/appconfiguration/app-configuration/src/index.ts
+++ b/sdk/appconfiguration/app-configuration/src/index.ts
@@ -1,49 +1,62 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-  
+
 import { AppConfigCredential } from "./appConfigCredential";
 import { TokenCredential, URLBuilder } from "@azure/core-http";
 import { AppConfiguration } from "./generated/src/appConfiguration";
+import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
+import "@azure/core-asynciterator-polyfill";
 
 import {
-  KeyValue as ConfigurationSetting,
-  AppConfigurationGetKeyValuesOptionalParams,
-  GetKeyValuesResponse,
-
-  PutKeyValueResponse as AddConfigurationSettingResponse,
-  PutKeyValueResponse as SetConfigurationSettingResponse,
-
-  AppConfigurationPutKeyValueOptionalParams as GeneratedPutParams,
-
   AppConfigurationDeleteKeyValueOptionalParams as DeleteConfigurationSettingOptions,
-  DeleteKeyValueResponse as DeleteConfigurationSettingResponse,
-
   AppConfigurationGetKeyValueOptionalParams as GetConfigurationSettingOptions,
+  AppConfigurationGetKeyValuesOptionalParams,
+  AppConfigurationGetRevisionsOptionalParams,
+  AppConfigurationPutKeyValueOptionalParams as GeneratedPutParams,
+  DeleteKeyValueResponse as DeleteConfigurationSettingResponse,
   GetKeyValueResponse as GetConfigurationSettingResponse,
-
-  AppConfigurationGetRevisionsOptionalParams as ListRevisionsOptions,
-  GetRevisionsResponse as ListRevisionsResponse
+  GetKeyValuesResponse,
+  GetRevisionsResponse,
+  KeyValue as ConfigurationSetting,
+  PutKeyValueResponse as AddConfigurationSettingResponse,
+  PutKeyValueResponse as SetConfigurationSettingResponse
 } from "./generated/src/models/index";
 import { isArray } from 'util';
 
 export {
-  DeleteKeyValueResponse,
-  PutKeyValueResponse,
-  GetRevisionsResponse,
-  GetKeyValueResponse,
-  AppConfigurationGetKeyValueOptionalParams,
-  AppConfigurationPutKeyValueOptionalParams,
   AppConfigurationDeleteKeyValueOptionalParams,
+  AppConfigurationGetKeyValueOptionalParams,
+  AppConfigurationGetKeyValuesOptionalParams,
   AppConfigurationGetRevisionsOptionalParams,
-  AppConfigurationGetKeyValuesOptionalParams
+  AppConfigurationPutKeyValueOptionalParams,
+  DeleteKeyValueResponse,
+  GetKeyValueResponse,
+  GetKeyValuesHeaders,
+  GetKeyValuesResponse,
+  GetRevisionsResponse,
+  PutKeyValueResponse
 } from "./generated/src/models/index";
 
+/**
+ * A ConfigurationSetting minus any fields that are not settable in 
+ * addConfigurationSetting/setConfigurationSetting (ex: locked)
+ * 
+ * Any place that takes a ConfigurationSettingsParam will also take a ConfigurationSetting.
+ */
 export interface ConfigurationSettingParam extends Pick<ConfigurationSetting, Exclude<keyof ConfigurationSetting, 'locked' | 'etag' | 'lastModified'>> {
 }
 
+/**
+ * Options used when adding or saving a ConfigurationSetting.
+ */
 export interface ConfigurationSettingOptions extends Pick<GeneratedPutParams, Exclude<keyof GeneratedPutParams, 'label' | 'entity'>> {
 }
 
+/**
+ * Options for listConfigurationSettings that allow for filtering based on keys, labels and other fields.
+ * Also provides `fields` which allows you to selectively choose which fields are populated in the
+ * result.
+ */
 export interface ListConfigurationSettingsOptions extends Pick<AppConfigurationGetKeyValuesOptionalParams, Exclude<keyof AppConfigurationGetKeyValuesOptionalParams, 'key' | 'label' | 'select' | 'after'>> {
   /**
    * Filters for wildcard matching (using *) against keys. These conditions are logically OR'd against each other.
@@ -61,8 +74,47 @@ export interface ListConfigurationSettingsOptions extends Pick<AppConfigurationG
   fields?: (keyof ConfigurationSetting)[];
 }
 
-export interface ListConfigurationSettingsResponse extends GetKeyValuesResponse {
+/**
+ * Options for listRevisions that allow for filtering based on keys, labels and other fields.
+ * Also provides `fields` which allows you to selectively choose which fields are populated in the
+ * result.
+ */
+export interface ListRevisionsOptions extends Pick<AppConfigurationGetRevisionsOptionalParams, Exclude<keyof AppConfigurationGetRevisionsOptionalParams, 'key' | 'label' | 'select' | 'after'>> {
+  /**
+   * Filters for wildcard matching (using *) against keys. These conditions are logically OR'd against each other.
+   */
+  keys?: string[];
+
+  /**
+   * Filters for wildcard matching (using *) against labels. These conditions are logically OR'd against each other.
+   */
+  labels?: string[];
+
+  /**
+   * Which fields to return for each ConfigurationSetting
+   */
+  fields?: (keyof ConfigurationSetting)[];
 }
+
+/**
+ * A page of configuration settings and the corresponding HTTP response
+ */
+export interface ListConfigurationSettingPage extends Pick<GetKeyValuesResponse, Exclude<keyof GetKeyValuesResponse, 'items'>> {
+  /**
+    * ConfigurationSettings for this page of results
+    */
+  items: ConfigurationSetting[];
+}
+
+/**
+ * A page of configuration settings and the corresponding HTTP response
+ */
+export interface ListRevisionsPage extends Pick<GetRevisionsResponse, Exclude<keyof GetRevisionsResponse, 'items'>> {
+  /**
+     * ConfigurationSettings for this page of results
+     */
+    items: ConfigurationSetting[];
+  }
 
 export { ConfigurationSetting };
 
@@ -199,45 +251,148 @@ export class AppConfigurationClient {
   }
 
   /**
-   * Lists settings from the Azure App Configuration service, optionally filtered by label,
-   * accept date time or name.
+   * Lists settings from the Azure App Configuration service, optionally 
+   * filtered by key names, labels and accept datetime.
    *
    * Example code:
    * ```ts
-   * const allSettingsWithLabel = await client.listConfigurationSettings({ label: "MyLabel" });
+   * const allSettingsWithLabel = await client.listConfigurationSettings({ labels: [ "MyLabel" ] });
    * ```
    * @param options Optional parameters for the request.
    */
-  listConfigurationSettings(
+  listConfigurationSettings(options: ListConfigurationSettingsOptions = {}): PagedAsyncIterableIterator<ConfigurationSetting, ListConfigurationSettingPage> {
+    const iter = this.getListConfigurationSettingsIterator(options);
+
+    return {
+      next() {
+        return iter.next();
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      byPage: (_: PageSettings = {}) => {
+        // TODO: the appconfig service doesn't currently support letting you select a page size
+        // so we're ignoring their setting for now.
+        return this.listConfigurationSettingsByPage(options);
+      }
+    };
+  }
+
+  private async *getListConfigurationSettingsIterator(options: ListConfigurationSettingsOptions): AsyncIterableIterator<ConfigurationSetting> {
+    for await (const page of this.listConfigurationSettingsByPage(options)) {
+      for (const configurationSetting of page.items) {
+        yield configurationSetting;
+      }
+    }
+  }
+
+  private async *listConfigurationSettingsByPage(
     options: ListConfigurationSettingsOptions = {}
-  ): Promise<ListConfigurationSettingsResponse> {
-    return this.client.getKeyValues({
+  ): AsyncIterableIterator<ListConfigurationSettingPage> {
+
+    let currentResponse = await this.client.getKeyValues({
       ...options,
       ...AppConfigurationClient.formatWildcards(options),
       select: options.fields
     });
+
+    yield* this.createListConfigurationPageFromResponse(currentResponse);
+
+    while (currentResponse.nextLink) {
+      currentResponse = await this.client.getKeyValues({
+        ...options,
+        ...AppConfigurationClient.formatWildcards(options),
+        select: options.fields,
+        after: AppConfigurationClient.extractAfterTokenFromNextLink(currentResponse.nextLink)
+      });
+
+      // TODO: We can get one more "empty" response if we're on
+      // a page boundary but there's no data in the response that's useful
+      if (!currentResponse.items) {
+        break;
+      }
+
+      yield* this.createListConfigurationPageFromResponse(currentResponse);
+    }
   }
 
-  listConfigurationSettingsNext(nextLink: string, options?: ListConfigurationSettingsOptions): Promise<ListConfigurationSettingsResponse>  {
-
-    return this.client.getKeyValues({
-      ...options,
-      ...AppConfigurationClient.formatWildcards(options),
-      after: AppConfigurationClient.extractAfterTokenFromNextLink(nextLink)
-    });
+  private *createListConfigurationPageFromResponse(currentResponse: GetKeyValuesResponse) {
+    yield {
+      ...currentResponse,
+      items: currentResponse.items != null ? currentResponse.items : []
+    };
   }
 
   /**
-   * Lists revisions of a set of keys within the Azure App Configuration service.
+   * Lists revisions of a set of keys, optionally filtered by key names, 
+   * labels and accept datetime.
    *
    * Example code:
    * ```ts
-   * const revisionsForMyKey = await client.listRevisions({ key: ["MyKey"] });
+   * const revisionsIterator = await client.listRevisions({ keys: ["MyKey"] });
    * ```
    * @param options Optional parameters for the request.
    */
-  listRevisions(options?: ListRevisionsOptions): Promise<ListRevisionsResponse> {
-    return this.client.getRevisions(options);
+  listRevisions(options?: ListRevisionsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListRevisionsPage> {
+    const iter = this.getListRevisionsIterator(options);
+
+    return {
+      next() {
+        return iter.next();
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      byPage: (_: PageSettings = {}) => {
+        // TODO: the appconfig service doesn't currently support letting you select a page size
+        // so we're ignoring their setting for now.
+        return this.listRevisionsByPage(options);
+      }
+    };
+  }
+
+  private async*getListRevisionsIterator(options?: ListRevisionsOptions): AsyncIterableIterator<ConfigurationSetting> {
+    for await (const page of this.listRevisionsByPage(options)) {
+      for (const item of page.items) {
+        yield item;
+      }
+    }
+  }
+
+  private async *listRevisionsByPage(
+    options: ListRevisionsOptions = {}
+  ): AsyncIterableIterator<ListRevisionsPage> {
+
+    let currentResponse = await this.client.getRevisions({
+      ...options,
+      ...AppConfigurationClient.formatWildcards(options),
+      select: options.fields
+    });
+
+    yield {
+      ...currentResponse,
+      items: currentResponse.items != null ? currentResponse.items : []
+    };
+
+    while (currentResponse.nextLink) {
+      currentResponse = await this.client.getRevisions({
+        ...options,
+        ...AppConfigurationClient.formatWildcards(options),
+        select: options.fields,
+        after: AppConfigurationClient.extractAfterTokenFromNextLink(currentResponse.nextLink)
+      });
+
+      // TODO: We can get one more "empty" response if we're on
+      // a page boundary but there's no data in the response that's useful
+      if (!currentResponse.items) {
+        break;
+      }
+
+      yield {
+        ...currentResponse,
+        items: currentResponse.items != null ? currentResponse.items : []
+      };
+    }
   }
 
   /**

--- a/sdk/appconfiguration/app-configuration/test/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/testHelpers.ts
@@ -1,31 +1,72 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { AppConfigurationClient } from "../src"
+import { AppConfigurationClient } from "../src";
+import { PagedAsyncIterableIterator } from "@azure/core-paging";
+import { ConfigurationSetting, ListConfigurationSettingPage, ListRevisionsPage } from "../src";
+import * as assert from "assert";
 
-// allow loading from a .env file as an alternative to defining the variable 
+// allow loading from a .env file as an alternative to defining the variable
 // in the environment
 import * as dotenv from "dotenv";
 dotenv.config();
 
-export function getConnectionStringFromEnvironment() : string {
-    const connectionString = process.env["AZ_CONFIG_CONNECTION"]!;
+export function getConnectionStringFromEnvironment(): string {
+  const connectionString = process.env["AZ_CONFIG_CONNECTION"]!;
 
-    if (connectionString == null) {
-        throw Error(`No connection string in environment - set AZ_CONFIG_CONNECTION with a connection string for your AppConfiguration instance.`);
-    }
+  if (connectionString == null) {
+    throw Error(
+      `No connection string in environment - set AZ_CONFIG_CONNECTION with a connection string for your AppConfiguration instance.`
+    );
+  }
 
-    return connectionString;
+  return connectionString;
 }
 
 export async function deleteKeyCompletely(keys: string[], client: AppConfigurationClient) {
-    const existingSettings = await client.listConfigurationSettings({
-        keys: keys
-    });
+  const settingsIterator = await client.listConfigurationSettings({
+    keys: keys
+  });
 
-    if (existingSettings.items) {
-        for (const setting of existingSettings.items) {
-            await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
-        }
-    }
+  for await (const setting of settingsIterator) {
+    await client.deleteConfigurationSetting(setting.key, { label: setting.label });
+  }
+}
+
+export async function toSortedArray(
+  pagedIterator: PagedAsyncIterableIterator<
+    ConfigurationSetting,
+    ListConfigurationSettingPage | ListRevisionsPage
+  >
+): Promise<ConfigurationSetting[]> {
+  const settings: ConfigurationSetting[] = [];
+
+  for await (const setting of pagedIterator) {
+    settings.push(setting);
+  }
+
+  let settingsViaPageIterator: ConfigurationSetting[] = [];
+
+  for await (const page of pagedIterator.byPage()) {
+    settingsViaPageIterator = settingsViaPageIterator.concat(page.items);
+  }
+
+  // just a sanity-check
+  assert.deepEqual(settings, settingsViaPageIterator);
+
+  settings.sort((a, b) =>
+    `${a.key}-${a.label}-${a.value}`.localeCompare(`${b.key}-${b.label}-${b.value}`)
+  );
+
+  return settings;
+}
+
+export function assertEqualSettings(
+  expected: Pick<ConfigurationSetting, "key" | "value" | "label">[],
+  actual: ConfigurationSetting[]
+) {
+  actual = actual.map((setting) => {
+    return { key: setting.key, label: setting.label, value: setting.value };
+  });
+  assert.deepEqual(expected, actual);
 }

--- a/sdk/appconfiguration/app-configuration/tsconfig.json
+++ b/sdk/appconfiguration/app-configuration/tsconfig.json
@@ -13,8 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist-esm",
     "importHelpers": true,
-    "newLine": "LF",
-    "lib": ["dom", "es5", "es6", "es7", "esnext"]
+    "newLine": "LF"
   },
   "exclude": ["node_modules", "types/**", "./samples/**/*.ts"],
   "include": ["./src/**/*.ts", "./test/**/*.ts"]

--- a/sdk/appconfiguration/app-configuration/tsconfig.json
+++ b/sdk/appconfiguration/app-configuration/tsconfig.json
@@ -13,7 +13,8 @@
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist-esm",
     "importHelpers": true,
-    "newLine": "LF"
+    "newLine": "LF",
+    "lib": ["dom", "es5", "es6", "es7", "esnext"]
   },
   "exclude": ["node_modules", "types/**", "./samples/**/*.ts"],
   "include": ["./src/**/*.ts", "./test/**/*.ts"]


### PR DESCRIPTION
This allows you to iterate over the list of settings returned individually or, optionally, by page which also returns the HTTP responses.