### PR TITLE
Release storage SDKs

### DIFF
--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@4.1.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@4.2.3",
     "build:browserzip": "gulp zip",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "10.5.0",
+  "version": "11.0.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -4777,11 +4777,6 @@ export interface BlobCreateSnapshotHeaders {
    * provided in the request and encrypted with a customer-provided key.
    */
   isServerEncrypted?: boolean;
-  /**
-   * The SHA-256 hash of the encryption key used to encrypt the source blob. This header is only
-   * returned when the blob was encrypted with a customer-provided key.
-   */
-  encryptionKeySha256?: string;
   errorCode?: string;
 }
 

--- a/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
@@ -4535,12 +4535,6 @@ export const BlobCreateSnapshotHeaders: msRest.CompositeMapper = {
           name: "Boolean"
         }
       },
-      encryptionKeySha256: {
-        serializedName: "x-ms-encryption-key-sha256",
-        type: {
-          name: "String"
-        }
-      },
       errorCode: {
         serializedName: "x-ms-error-code",
         type: {

--- a/sdk/storage/storage-blob/src/generated/src/operations/appendBlob.ts
+++ b/sdk/storage/storage-blob/src/generated/src/operations/appendBlob.ts
@@ -161,7 +161,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.AppendBlobCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.AppendBlobCreateHeaders
     }
   },
   isXML: true,
@@ -211,7 +212,8 @@ const appendBlockOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.AppendBlobAppendBlockHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.AppendBlobAppendBlockHeaders
     }
   },
   isXML: true,
@@ -257,7 +259,8 @@ const appendBlockFromUrlOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.AppendBlobAppendBlockFromUrlHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.AppendBlobAppendBlockFromUrlHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-blob/src/generated/src/operations/blob.ts
+++ b/sdk/storage/storage-blob/src/generated/src/operations/blob.ts
@@ -655,7 +655,8 @@ const downloadOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobDownloadHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobDownloadHeaders
     }
   },
   isXML: true,
@@ -689,7 +690,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -721,7 +723,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobDeleteHeaders
     }
   },
   isXML: true,
@@ -756,7 +759,8 @@ const setAccessControlOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobSetAccessControlHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.BlobSetAccessControlHeaders
     }
   },
   isXML: true,
@@ -788,7 +792,8 @@ const getAccessControlOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobGetAccessControlHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.BlobGetAccessControlHeaders
     }
   },
   isXML: true,
@@ -833,7 +838,8 @@ const renameOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobRenameHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.BlobRenameHeaders
     }
   },
   isXML: true,
@@ -859,7 +865,8 @@ const undeleteOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobUndeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobUndeleteHeaders
     }
   },
   isXML: true,
@@ -896,7 +903,8 @@ const setHTTPHeadersOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobSetHTTPHeadersHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobSetHTTPHeadersHeaders
     }
   },
   isXML: true,
@@ -931,7 +939,8 @@ const setMetadataOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobSetMetadataHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobSetMetadataHeaders
     }
   },
   isXML: true,
@@ -964,7 +973,8 @@ const acquireLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobAcquireLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobAcquireLeaseHeaders
     }
   },
   isXML: true,
@@ -996,7 +1006,8 @@ const releaseLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobReleaseLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobReleaseLeaseHeaders
     }
   },
   isXML: true,
@@ -1028,7 +1039,8 @@ const renewLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobRenewLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobRenewLeaseHeaders
     }
   },
   isXML: true,
@@ -1061,7 +1073,8 @@ const changeLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobChangeLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobChangeLeaseHeaders
     }
   },
   isXML: true,
@@ -1093,7 +1106,8 @@ const breakLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobBreakLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobBreakLeaseHeaders
     }
   },
   isXML: true,
@@ -1128,7 +1142,8 @@ const createSnapshotOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobCreateSnapshotHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobCreateSnapshotHeaders
     }
   },
   isXML: true,
@@ -1166,7 +1181,8 @@ const startCopyFromURLOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobStartCopyFromURLHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobStartCopyFromURLHeaders
     }
   },
   isXML: true,
@@ -1204,7 +1220,8 @@ const copyFromURLOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobCopyFromURLHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobCopyFromURLHeaders
     }
   },
   isXML: true,
@@ -1233,7 +1250,8 @@ const abortCopyFromURLOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobAbortCopyFromURLHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobAbortCopyFromURLHeaders
     }
   },
   isXML: true,
@@ -1265,7 +1283,8 @@ const setTierOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobSetTierHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobSetTierHeaders
     }
   },
   isXML: true,
@@ -1290,7 +1309,8 @@ const getAccountInfoOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlobGetAccountInfoHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlobGetAccountInfoHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-blob/src/generated/src/operations/blockBlob.ts
+++ b/sdk/storage/storage-blob/src/generated/src/operations/blockBlob.ts
@@ -266,7 +266,8 @@ const uploadOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlockBlobUploadHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlockBlobUploadHeaders
     }
   },
   isXML: true,
@@ -311,7 +312,8 @@ const stageBlockOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlockBlobStageBlockHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlockBlobStageBlockHeaders
     }
   },
   isXML: true,
@@ -351,7 +353,8 @@ const stageBlockFromURLOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlockBlobStageBlockFromURLHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlockBlobStageBlockFromURLHeaders
     }
   },
   isXML: true,
@@ -403,7 +406,8 @@ const commitBlockListOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlockBlobCommitBlockListHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlockBlobCommitBlockListHeaders
     }
   },
   isXML: true,
@@ -433,7 +437,8 @@ const getBlockListOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.BlockBlobGetBlockListHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.BlockBlobGetBlockListHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-blob/src/generated/src/operations/container.ts
+++ b/sdk/storage/storage-blob/src/generated/src/operations/container.ts
@@ -431,7 +431,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerCreateHeaders
     }
   },
   isXML: true,
@@ -458,7 +459,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -487,7 +489,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerDeleteHeaders
     }
   },
   isXML: true,
@@ -517,7 +520,8 @@ const setMetadataOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerSetMetadataHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerSetMetadataHeaders
     }
   },
   isXML: true,
@@ -558,7 +562,8 @@ const getAccessPolicyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerGetAccessPolicyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerGetAccessPolicyHeaders
     }
   },
   isXML: true,
@@ -610,7 +615,8 @@ const setAccessPolicyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerSetAccessPolicyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerSetAccessPolicyHeaders
     }
   },
   isXML: true,
@@ -642,7 +648,8 @@ const acquireLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerAcquireLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerAcquireLeaseHeaders
     }
   },
   isXML: true,
@@ -673,7 +680,8 @@ const releaseLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerReleaseLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerReleaseLeaseHeaders
     }
   },
   isXML: true,
@@ -704,7 +712,8 @@ const renewLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerRenewLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerRenewLeaseHeaders
     }
   },
   isXML: true,
@@ -735,7 +744,8 @@ const breakLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerBreakLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerBreakLeaseHeaders
     }
   },
   isXML: true,
@@ -767,7 +777,8 @@ const changeLeaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerChangeLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerChangeLeaseHeaders
     }
   },
   isXML: true,
@@ -799,7 +810,8 @@ const listBlobFlatSegmentOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerListBlobFlatSegmentHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerListBlobFlatSegmentHeaders
     }
   },
   isXML: true,
@@ -832,7 +844,8 @@ const listBlobHierarchySegmentOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerListBlobHierarchySegmentHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerListBlobHierarchySegmentHeaders
     }
   },
   isXML: true,
@@ -857,7 +870,8 @@ const getAccountInfoOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ContainerGetAccountInfoHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ContainerGetAccountInfoHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-blob/src/generated/src/operations/directory.ts
+++ b/sdk/storage/storage-blob/src/generated/src/operations/directory.ts
@@ -206,7 +206,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.DirectoryCreateHeaders
     }
   },
   isXML: true,
@@ -252,7 +253,8 @@ const renameOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryRenameHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.DirectoryRenameHeaders
     }
   },
   isXML: true,
@@ -284,7 +286,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.DirectoryDeleteHeaders
     }
   },
   isXML: true,
@@ -319,7 +322,8 @@ const setAccessControlOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectorySetAccessControlHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.DirectorySetAccessControlHeaders
     }
   },
   isXML: true,
@@ -351,7 +355,8 @@ const getAccessControlOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryGetAccessControlHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.DirectoryGetAccessControlHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-blob/src/generated/src/operations/pageBlob.ts
+++ b/sdk/storage/storage-blob/src/generated/src/operations/pageBlob.ts
@@ -365,7 +365,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobCreateHeaders
     }
   },
   isXML: true,
@@ -418,7 +419,8 @@ const uploadPagesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobUploadPagesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobUploadPagesHeaders
     }
   },
   isXML: true,
@@ -458,7 +460,8 @@ const clearPagesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobClearPagesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobClearPagesHeaders
     }
   },
   isXML: true,
@@ -506,7 +509,8 @@ const uploadPagesFromURLOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobUploadPagesFromURLHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobUploadPagesFromURLHeaders
     }
   },
   isXML: true,
@@ -540,7 +544,8 @@ const getPageRangesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobGetPageRangesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobGetPageRangesHeaders
     }
   },
   isXML: true,
@@ -575,7 +580,8 @@ const getPageRangesDiffOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobGetPageRangesDiffHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobGetPageRangesDiffHeaders
     }
   },
   isXML: true,
@@ -610,7 +616,8 @@ const resizeOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobResizeHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobResizeHeaders
     }
   },
   isXML: true,
@@ -643,7 +650,8 @@ const updateSequenceNumberOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobUpdateSequenceNumberHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobUpdateSequenceNumberHeaders
     }
   },
   isXML: true,
@@ -674,7 +682,8 @@ const copyIncrementalOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PageBlobCopyIncrementalHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.PageBlobCopyIncrementalHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-blob/src/generated/src/operations/service.ts
+++ b/sdk/storage/storage-blob/src/generated/src/operations/service.ts
@@ -253,7 +253,8 @@ const setPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceSetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceSetPropertiesHeaders
     }
   },
   isXML: true,
@@ -280,7 +281,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -307,7 +309,8 @@ const getStatisticsOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceGetStatisticsHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceGetStatisticsHeaders
     }
   },
   isXML: true,
@@ -337,7 +340,8 @@ const listContainersSegmentOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceListContainersSegmentHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceListContainersSegmentHeaders
     }
   },
   isXML: true,
@@ -372,7 +376,8 @@ const getUserDelegationKeyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceGetUserDelegationKeyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceGetUserDelegationKeyHeaders
     }
   },
   isXML: true,
@@ -396,7 +401,8 @@ const getAccountInfoOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceGetAccountInfoHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceGetAccountInfoHeaders
     }
   },
   isXML: true,
@@ -440,7 +446,8 @@ const submitBatchOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceSubmitBatchHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceSubmitBatchHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -12,7 +12,7 @@ import * as msRest from "@azure/ms-rest-js";
 import * as Models from "./models";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "1.0.0";
+const packageVersion = "11.0.0";
 
 export class StorageClientContext extends msRest.ServiceClient {
   url: string;

--- a/sdk/storage/storage-datalake/package.json
+++ b/sdk/storage/storage-datalake/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/storage-datalake",
   "author": "Microsoft Corporation",
   "description": "DataLakeStorageClient Library with typescript type definitions for node.js and browser.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "dependencies": {
     "@azure/ms-rest-azure-js": "^2.0.1",
     "@azure/ms-rest-js": "^2.0.4",

--- a/sdk/storage/storage-datalake/src/dataLakeStorageClientContext.ts
+++ b/sdk/storage/storage-datalake/src/dataLakeStorageClientContext.ts
@@ -13,7 +13,7 @@ import * as msRest from "@azure/ms-rest-js";
 import * as msRestAzure from "@azure/ms-rest-azure-js";
 
 const packageName = "@azure/storage-datalake";
-const packageVersion = "0.2.0";
+const packageVersion = "0.3.0";
 
 export class DataLakeStorageClientContext extends msRestAzure.AzureServiceClient {
   credentials: msRest.ServiceClientCredentials;

--- a/sdk/storage/storage-datalake/src/models/index.ts
+++ b/sdk/storage/storage-datalake/src/models/index.ts
@@ -746,7 +746,8 @@ export interface PathGetPropertiesOptionalParams extends msRest.RequestOptionsBa
    * Optional. If the value is "getStatus" only the system defined properties for the path are
    * returned. If the value is "getAccessControl" the access control list is returned in the
    * response headers (Hierarchical Namespace must be enabled for the account), otherwise the
-   * properties are returned. Possible values include: 'getAccessControl', 'getStatus'
+   * properties are returned. Possible values include: 'getAccessControl', 'getStatus',
+   * 'checkAccess'
    */
   action?: PathGetPropertiesAction;
   /**
@@ -758,6 +759,12 @@ export interface PathGetPropertiesOptionalParams extends msRest.RequestOptionsBa
    * have unique friendly names.
    */
   upn?: boolean;
+  /**
+   * Required only for check access action. Valid only when Hierarchical Namespace is enabled for
+   * the account. File system operation read/write/execute in string form, matching regex pattern
+   * '[rwx-]{3}'
+   */
+  fsAction?: string;
   /**
    * Optional. If this header is specified, the operation will be performed only if both of the
    * following conditions are met: i) the path's lease is currently active and ii) the lease ID
@@ -1520,11 +1527,11 @@ export type PathLeaseAction = 'acquire' | 'break' | 'change' | 'renew' | 'releas
 
 /**
  * Defines values for PathGetPropertiesAction.
- * Possible values include: 'getAccessControl', 'getStatus'
+ * Possible values include: 'getAccessControl', 'getStatus', 'checkAccess'
  * @readonly
  * @enum {string}
  */
-export type PathGetPropertiesAction = 'getAccessControl' | 'getStatus';
+export type PathGetPropertiesAction = 'getAccessControl' | 'getStatus' | 'checkAccess';
 
 /**
  * Contains response data for the list operation.

--- a/sdk/storage/storage-datalake/src/models/parameters.ts
+++ b/sdk/storage/storage-datalake/src/models/parameters.ts
@@ -59,7 +59,8 @@ export const action1: msRest.OperationQueryParameter = {
       name: "Enum",
       allowedValues: [
         "getAccessControl",
-        "getStatus"
+        "getStatus",
+        "checkAccess"
       ]
     }
   }
@@ -197,6 +198,18 @@ export const filesystem: msRest.OperationURLParameter = {
       MinLength: 3,
       Pattern: /^[$a-z0-9](?!.*--)[-a-z0-9]{1,61}[a-z0-9]$/
     },
+    type: {
+      name: "String"
+    }
+  }
+};
+export const fsAction: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "fsAction"
+  ],
+  mapper: {
+    serializedName: "fsAction",
     type: {
       name: "String"
     }

--- a/sdk/storage/storage-datalake/src/operations/filesystemOperations.ts
+++ b/sdk/storage/storage-datalake/src/operations/filesystemOperations.ts
@@ -242,7 +242,8 @@ const listOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FilesystemListHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.FilesystemListHeaders
     }
   },
   serializer
@@ -272,7 +273,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FilesystemCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.FilesystemCreateHeaders
     }
   },
   serializer
@@ -304,7 +306,8 @@ const setPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FilesystemSetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.FilesystemSetPropertiesHeaders
     }
   },
   serializer
@@ -333,7 +336,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FilesystemGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.FilesystemGetPropertiesHeaders
     }
   },
   serializer
@@ -364,7 +368,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FilesystemDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.FilesystemDeleteHeaders
     }
   },
   serializer

--- a/sdk/storage/storage-datalake/src/operations/pathOperations.ts
+++ b/sdk/storage/storage-datalake/src/operations/pathOperations.ts
@@ -283,7 +283,7 @@ export class PathOperations {
    * for a path. This operation supports conditional HTTP requests.  For more information, see
    * [Specifying Conditional Headers for Blob Service
    * Operations](https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations).
-   * @summary Get Properties | Get Status | Get Access Control List
+   * @summary Get Properties | Get Status | Get Access Control List | Check Access
    * @param filesystem The filesystem identifier.
    * @param path The file or directory path.
    * @param [options] The optional parameters
@@ -381,7 +381,8 @@ const listOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PathListHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.PathListHeaders
     }
   },
   serializer
@@ -436,7 +437,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PathCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.PathCreateHeaders
     }
   },
   serializer
@@ -503,7 +505,8 @@ const updateOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PathUpdateHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.PathUpdateHeaders
     }
   },
   serializer
@@ -547,7 +550,8 @@ const leaseOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PathLeaseHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.PathLeaseHeaders
     }
   },
   serializer
@@ -598,7 +602,8 @@ const readOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PathReadHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.PathReadHeaders
     }
   },
   serializer
@@ -616,6 +621,7 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.action1,
     Parameters.upn,
+    Parameters.fsAction,
     Parameters.timeout
   ],
   headerParameters: [
@@ -634,7 +640,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PathGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.PathGetPropertiesHeaders
     }
   },
   serializer
@@ -670,7 +677,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.PathDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.DataLakeStorageError
+      bodyMapper: Mappers.DataLakeStorageError,
+      headersMapper: Mappers.PathDeleteHeaders
     }
   },
   serializer

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@4.1.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@4.2.3",
     "build:browserzip": "gulp zip",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",

--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file",
   "sdk-type": "client",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-file/src/generated/src/operations/directory.ts
+++ b/sdk/storage/storage-file/src/generated/src/operations/directory.ts
@@ -286,7 +286,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectoryCreateHeaders
     }
   },
   isXML: true,
@@ -312,7 +313,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectoryGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -337,7 +339,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectoryDeleteHeaders
     }
   },
   isXML: true,
@@ -368,7 +371,8 @@ const setPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectorySetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectorySetPropertiesHeaders
     }
   },
   isXML: true,
@@ -395,7 +399,8 @@ const setMetadataOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectorySetMetadataHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectorySetMetadataHeaders
     }
   },
   isXML: true,
@@ -426,7 +431,8 @@ const listFilesAndDirectoriesSegmentOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryListFilesAndDirectoriesSegmentHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectoryListFilesAndDirectoriesSegmentHeaders
     }
   },
   isXML: true,
@@ -456,7 +462,8 @@ const listHandlesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryListHandlesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectoryListHandlesHeaders
     }
   },
   isXML: true,
@@ -485,7 +492,8 @@ const forceCloseHandlesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.DirectoryForceCloseHandlesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.DirectoryForceCloseHandlesHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-file/src/generated/src/operations/file.ts
+++ b/sdk/storage/storage-file/src/generated/src/operations/file.ts
@@ -523,7 +523,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileCreateHeaders
     }
   },
   isXML: true,
@@ -564,7 +565,8 @@ const downloadOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileDownloadHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileDownloadHeaders
     }
   },
   isXML: true,
@@ -589,7 +591,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -613,7 +616,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileDeleteHeaders
     }
   },
   isXML: true,
@@ -650,7 +654,8 @@ const setHTTPHeadersOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileSetHTTPHeadersHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileSetHTTPHeadersHeaders
     }
   },
   isXML: true,
@@ -676,7 +681,8 @@ const setMetadataOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileSetMetadataHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileSetMetadataHeaders
     }
   },
   isXML: true,
@@ -718,7 +724,8 @@ const uploadRangeOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileUploadRangeHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileUploadRangeHeaders
     }
   },
   isXML: true,
@@ -751,7 +758,8 @@ const uploadRangeFromURLOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileUploadRangeFromURLHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileUploadRangeFromURLHeaders
     }
   },
   isXML: true,
@@ -791,7 +799,8 @@ const getRangeListOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileGetRangeListHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileGetRangeListHeaders
     }
   },
   isXML: true,
@@ -817,7 +826,8 @@ const startCopyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileStartCopyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileStartCopyHeaders
     }
   },
   isXML: true,
@@ -844,7 +854,8 @@ const abortCopyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileAbortCopyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileAbortCopyHeaders
     }
   },
   isXML: true,
@@ -873,7 +884,8 @@ const listHandlesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileListHandlesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileListHandlesHeaders
     }
   },
   isXML: true,
@@ -901,7 +913,8 @@ const forceCloseHandlesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.FileForceCloseHandlesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.FileForceCloseHandlesHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-file/src/generated/src/operations/service.ts
+++ b/sdk/storage/storage-file/src/generated/src/operations/service.ts
@@ -134,7 +134,8 @@ const setPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceSetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceSetPropertiesHeaders
     }
   },
   isXML: true,
@@ -160,7 +161,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -189,7 +191,8 @@ const listSharesSegmentOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceListSharesSegmentHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceListSharesSegmentHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-file/src/generated/src/operations/share.ts
+++ b/sdk/storage/storage-file/src/generated/src/operations/share.ts
@@ -327,7 +327,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareCreateHeaders
     }
   },
   isXML: true,
@@ -353,7 +354,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -380,7 +382,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareDeleteHeaders
     }
   },
   isXML: true,
@@ -407,7 +410,8 @@ const createSnapshotOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareCreateSnapshotHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareCreateSnapshotHeaders
     }
   },
   isXML: true,
@@ -441,10 +445,11 @@ const createPermissionOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareCreatePermissionHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareCreatePermissionHeaders
     }
   },
-  isXML: false,
+  isXML: true,
   serializer
 };
 
@@ -469,7 +474,8 @@ const getPermissionOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareGetPermissionHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareGetPermissionHeaders
     }
   },
   isXML: true,
@@ -496,7 +502,8 @@ const setQuotaOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareSetQuotaHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareSetQuotaHeaders
     }
   },
   isXML: true,
@@ -523,7 +530,8 @@ const setMetadataOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareSetMetadataHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareSetMetadataHeaders
     }
   },
   isXML: true,
@@ -562,7 +570,8 @@ const getAccessPolicyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareGetAccessPolicyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareGetAccessPolicyHeaders
     }
   },
   isXML: true,
@@ -609,7 +618,8 @@ const setAccessPolicyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareSetAccessPolicyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareSetAccessPolicyHeaders
     }
   },
   isXML: true,
@@ -636,7 +646,8 @@ const getStatisticsOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ShareGetStatisticsHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ShareGetStatisticsHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-file/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "azure-storage-file";
-const packageVersion = "1.0.0";
+const packageVersion = "10.3.1";
 
 export class StorageClientContext extends msRest.ServiceClient {
   version: string;

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@4.1.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@4.2.3",
     "build:browserzip": "gulp zip",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",

--- a/sdk/storage/storage-queue/src/generated/src/operations/messageId.ts
+++ b/sdk/storage/storage-queue/src/generated/src/operations/messageId.ts
@@ -142,7 +142,8 @@ const updateOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.MessageIdUpdateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.MessageIdUpdateHeaders
     }
   },
   isXML: true,
@@ -168,7 +169,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.MessageIdDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.MessageIdDeleteHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-queue/src/generated/src/operations/messages.ts
+++ b/sdk/storage/storage-queue/src/generated/src/operations/messages.ts
@@ -167,7 +167,8 @@ const dequeueOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.MessagesDequeueHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.MessagesDequeueHeaders
     }
   },
   isXML: true,
@@ -192,7 +193,8 @@ const clearOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.MessagesClearHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.MessagesClearHeaders
     }
   },
   isXML: true,
@@ -240,7 +242,8 @@ const enqueueOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.MessagesEnqueueHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.MessagesEnqueueHeaders
     }
   },
   isXML: true,
@@ -280,7 +283,8 @@ const peekOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.MessagesPeekHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.MessagesPeekHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-queue/src/generated/src/operations/queue.ts
+++ b/sdk/storage/storage-queue/src/generated/src/operations/queue.ts
@@ -198,7 +198,8 @@ const createOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.QueueCreateHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.QueueCreateHeaders
     }
   },
   isXML: true,
@@ -223,7 +224,8 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.QueueDeleteHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.QueueDeleteHeaders
     }
   },
   isXML: true,
@@ -249,7 +251,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.QueueGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.QueueGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -276,7 +279,8 @@ const setMetadataOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.QueueSetMetadataHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.QueueSetMetadataHeaders
     }
   },
   isXML: true,
@@ -315,7 +319,8 @@ const getAccessPolicyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.QueueGetAccessPolicyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.QueueGetAccessPolicyHeaders
     }
   },
   isXML: true,
@@ -362,7 +367,8 @@ const setAccessPolicyOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.QueueSetAccessPolicyHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.QueueSetAccessPolicyHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-queue/src/generated/src/operations/service.ts
+++ b/sdk/storage/storage-queue/src/generated/src/operations/service.ts
@@ -160,7 +160,8 @@ const setPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceSetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceSetPropertiesHeaders
     }
   },
   isXML: true,
@@ -187,7 +188,8 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceGetPropertiesHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceGetPropertiesHeaders
     }
   },
   isXML: true,
@@ -214,7 +216,8 @@ const getStatisticsOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceGetStatisticsHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceGetStatisticsHeaders
     }
   },
   isXML: true,
@@ -244,7 +247,8 @@ const listQueuesSegmentOperationSpec: msRest.OperationSpec = {
       headersMapper: Mappers.ServiceListQueuesSegmentHeaders
     },
     default: {
-      bodyMapper: Mappers.StorageError
+      bodyMapper: Mappers.StorageError,
+      headersMapper: Mappers.ServiceListQueuesSegmentHeaders
     }
   },
   isXML: true,

--- a/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "azure-storage-queue";
-const packageVersion = "1.0.0";
+const packageVersion = "10.3.1";
 
 export class StorageClientContext extends msRest.ServiceClient {
   url: string;


### PR DESCRIPTION
The Storage Data plane SDKs have been regenerated using autorest.typescript - v4.2.3 with changes published in this [PR](https://github.com/Azure/autorest.typescript/pull/469). This PR is created to fix this [issue](https://github.com/Azure/autorest.typescript/issues/464) and this [issue](https://github.com/Azure/azure-sdk-for-js/issues/4999).

The following SDKs have been regenerated and versions have been updated. 

| No | SDK Name                         | Existing Version | New Version |
|---|---------------------------|-----------------|--------------|
|  1 | @azure/storage-blob         |  10.5.0                |  11.0.0             |
|  2 | @azure/storage-file           |  10.3.0                |  10.3.1             |
|  3 | @azure/storage-queue     | 10.3.0                 |  10.3.1             |
|  4 | @azure/storage-datalake |  0.2.0                  |  0.3.0              |

**Commands Used**

**@azure/storage-blob**
```
autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.3 --package-version=11.0.0 /Users/saranganrajamanickam/Projects/Storage-XStore/src/XFE/OpenApi/Microsoft.BlobStorage/stable/2019-02-02/readme.md --output-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js/sdk/storage/storage-blob/src/generated/
```

**@azure/storage-file**
```
autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.3 --package-version=10.3.1 /Users/saranganrajamanickam/Projects/Storage-XStore/src/XFE/OpenApi/Microsoft.FileStorage/preview/2019-02-02/readme.md --output-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js/sdk/storage/storage-file/src/generated/
```

**@azure/storage-queue**
```
autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.3 --package-version=10.3.1 /Users/saranganrajamanickam/Projects/Storage-XStore/src/XFE/OpenApi/Microsoft.QueueStorage/preview/2019-02-02/README.md --output-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js/sdk/storage/storage-queue/src/generated/
```

**@azure/storage-datalake**
```
autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.3 --package-version=0.3.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/6d4e0d294d568a37b1f3421b789290934517d115/specification/storage/data-plane/readme.md
```

