### PR TITLE
[Cosmos] Fix rollup warnings

### DIFF
--- a/sdk/cosmosdb/cosmos/rollup.config.js
+++ b/sdk/cosmosdb/cosmos/rollup.config.js
@@ -21,7 +21,22 @@ export default [
       file: "dist/index.js",
       format: "umd",
       name: "Microsoft.Azure.Cosmos",
-      sourcemap: true
+      sourcemap: true,
+      globals: {
+        "universal-user-agent": "universalUserAgent",
+        "@azure/cosmos-sign": "cosmosSign",
+        "binary-search-bounds": "bs",
+        "crypto-hash": "cryptoHash",
+        "fast-json-stable-stringify": "stableStringify",
+        "uuid/v4": "uuid",
+        "node-abort-controller": "AbortController",
+        "node-fetch": "fetch",
+        tslib: "tslib_1",
+        debug: "debugLib",
+        priorityqueuejs: "PriorityQueue",
+        semaphore: "semaphore",
+        atob: "atob"
+      }
     },
     plugins: [resolve()]
   }

--- a/sdk/cosmosdb/cosmos/rollup.config.js
+++ b/sdk/cosmosdb/cosmos/rollup.config.js
@@ -2,6 +2,21 @@ import resolve from "rollup-plugin-local-resolve";
 export default [
   {
     input: "dist-esm/index.js",
+    external: [
+      "tslib",
+      "@azure/cosmos-sign",
+      "universal-user-agent",
+      "uuid/v4",
+      "debug",
+      "node-abort-controller",
+      "node-fetch",
+      "atob",
+      "binary-search-bounds",
+      "priorityqueuejs",
+      "semaphore",
+      "crypto-hash",
+      "fast-json-stable-stringify"
+    ],
     output: {
       file: "dist/index.js",
       format: "umd",


### PR DESCRIPTION
This PR attempts to fix the rollup warnings(all of them except the warnings related to 'Circular Dependencies') of cosmos during the build step.

![image](https://user-images.githubusercontent.com/10452642/65644167-6a27be00-dfa8-11e9-85c2-027dfcfb36fc.png)
