### PR TITLE
[Cosmos] Set paths property to fix compilation error

### DIFF
--- a/sdk/cosmosdb/cosmos/src/tsconfig.json
+++ b/sdk/cosmosdb/cosmos/src/tsconfig.json
@@ -18,7 +18,11 @@
     "composite": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "stripInternal": true
+    "stripInternal": true,
+    "baseUrl": ".",
+    "paths": {
+      "binary-search-bounds": ["./typings/binary-search-bounds"]
+    }
   },
   "include": ["./**/*"]
 }


### PR DESCRIPTION
Not sure if this is a proper fix but without this change, `npm run build` fails with compilation errors of `tsc` for me.