### PR TITLE
[WIP] [Storage] Add tests for credentials from @azure/identity

### DIFF
--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -139,7 +139,7 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["Chrome"],
+    browsers: ["ChromeHeadless"],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -51,7 +51,17 @@ module.exports = function(config) {
     // inject following environment values into browser testing with window.__env__
     // environment values MUST be exported or set with same console running "karma start"
     // https://www.npmjs.com/package/karma-env-preprocessor
-    envPreprocessor: ["ACCOUNT_NAME", "ACCOUNT_SAS", "TEST_MODE", "ACCOUNT_TOKEN"],
+    envPreprocessor: [
+      "ACCOUNT_NAME",
+      "ACCOUNT_SAS",
+      "TEST_MODE",
+      "ACCOUNT_TOKEN",
+      "AZURE_TENANT_ID",
+      "AZURE_CLIENT_ID",
+      "AZURE_CLIENT_SECRET",
+      "ACCOUNT_USERNAME",
+      "ACCOUNT_PASSWORD"
+    ],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
@@ -129,7 +139,7 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["ChromeHeadless"],
+    browsers: ["Chrome"],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/storage/storage-blob/test/browser/credentialsFromIdentity.spec.ts
+++ b/sdk/storage/storage-blob/test/browser/credentialsFromIdentity.spec.ts
@@ -34,7 +34,12 @@ describe("Test Credentials from @azure/identity - Browsers Only", () => {
   });
 
   // ChromeHeadless won't work because user needs to authenticate in the UI
-  // In browser, Fails with `AADSTS700054: response_type 'id_token' is not enabled for the application.`
+  // Issue 1 -
+  //    In browser, Fails with `AADSTS700054: response_type 'id_token' is not enabled for the application.`
+  //    Fixed as explained by David here - https://github.com/Azure/azure-sdk-for-js/pull/5287#discussion_r331717709
+  // Issue 2 -
+  //    New error, after providing the email address,
+  //            it fails with `AADSTS500113: No reply address is registered for the application.`
   it.skip("InteractiveBrowserCredential should be able to instantiate BlobServiceClient", async () => {
     await verifyCredential(
       new InteractiveBrowserCredential(env.AZURE_TENANT_ID || "", env.AZURE_CLIENT_ID)

--- a/sdk/storage/storage-blob/test/browser/credentialsFromIdentity.spec.ts
+++ b/sdk/storage/storage-blob/test/browser/credentialsFromIdentity.spec.ts
@@ -33,8 +33,9 @@ describe("Test Credentials from @azure/identity - Browsers Only", () => {
     }
   });
 
-  // Fails with `AADSTS700054: response_type 'id_token' is not enabled for the application.`
-  it("InteractiveBrowserCredential should be able to instantiate BlobServiceClient", async () => {
+  // ChromeHeadless won't work because user needs to authenticate in the UI
+  // In browser, Fails with `AADSTS700054: response_type 'id_token' is not enabled for the application.`
+  it.skip("InteractiveBrowserCredential should be able to instantiate BlobServiceClient", async () => {
     await verifyCredential(
       new InteractiveBrowserCredential(env.AZURE_TENANT_ID || "", env.AZURE_CLIENT_ID)
     );

--- a/sdk/storage/storage-blob/test/browser/credentialsFromIdentity.spec.ts
+++ b/sdk/storage/storage-blob/test/browser/credentialsFromIdentity.spec.ts
@@ -1,0 +1,42 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import { env, getUniqueName } from "../utils";
+import { BlobServiceClient } from "../../src";
+import { TokenCredential, InteractiveBrowserCredential } from "@azure/identity";
+dotenv.config({ path: "../.env" });
+
+describe("Test Credentials from @azure/identity - Browsers Only", () => {
+  async function verifyCredential(credential: TokenCredential) {
+    const blobServiceClient = new BlobServiceClient(
+      `https://${env.ACCOUNT_NAME}.blob.core.windows.net/`,
+      credential
+    );
+
+    const access = "container";
+    const metadata = { key: "value" };
+    const { containerClient } = await blobServiceClient.createContainer(
+      getUniqueName("container"),
+      {
+        access,
+        metadata
+      }
+    );
+    const result = await containerClient.getProperties();
+    assert.deepEqual(result.blobPublicAccess, access);
+    assert.deepEqual(result.metadata, metadata);
+  }
+
+  beforeEach(async function() {
+    if (env.TEST_MODE === "record" || env.TEST_MODE === "playback") {
+      // Not exectuing these tests in the record/playback modes. Is it required ?
+      this.skip();
+    }
+  });
+
+  // Fails with `AADSTS700054: response_type 'id_token' is not enabled for the application.`
+  it("InteractiveBrowserCredential should be able to instantiate BlobServiceClient", async () => {
+    await verifyCredential(
+      new InteractiveBrowserCredential(env.AZURE_TENANT_ID || "", env.AZURE_CLIENT_ID)
+    );
+  });
+});

--- a/sdk/storage/storage-blob/test/credentialsFromIdentity.spec.ts
+++ b/sdk/storage/storage-blob/test/credentialsFromIdentity.spec.ts
@@ -1,0 +1,106 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import { env, getUniqueName, isBrowser } from "./utils";
+import { BlobServiceClient } from "../src";
+import {
+  TokenCredential,
+  ClientSecretCredential,
+  ClientCertificateCredential,
+  DeviceCodeCredential,
+  UsernamePasswordCredential,
+  ManagedIdentityCredential
+} from "@azure/identity";
+dotenv.config({ path: "../.env" });
+
+describe("Test Credentials from @azure/identity", () => {
+  async function verifyCredential(credential: TokenCredential) {
+    const blobServiceClient = new BlobServiceClient(
+      `https://${env.ACCOUNT_NAME}.blob.core.windows.net/`,
+      credential
+    );
+
+    // const result = await newClient.getProperties();
+
+    // assert.ok(typeof result.requestId);
+    // assert.ok(result.requestId!.length > 0);
+    // assert.ok(typeof result.version);
+    // assert.ok(result.version!.length > 0);
+
+    const access = "container";
+    const metadata = { key: "value" };
+    const { containerClient } = await blobServiceClient.createContainer(
+      getUniqueName("container"),
+      {
+        access,
+        metadata
+      }
+    );
+    const result = await containerClient.getProperties();
+    assert.deepEqual(result.blobPublicAccess, access);
+    assert.deepEqual(result.metadata, metadata);
+  }
+
+  beforeEach(async function() {
+    if (env.TEST_MODE === "record" || env.TEST_MODE === "playback") {
+      // Not exectuing these tests in the record/playback modes. Is it required ?
+      this.skip();
+    }
+  });
+
+  // Works with node and failed in the browser with the following error
+  //    Error: Failed to send request to https://login.microsoftonline.com/<my-tenant-id>/oauth2/v2.0/token
+  it("ClientSecretCredential should be able to instantiate BlobServiceClient", async function() {
+    if (isBrowser()) this.skip();
+    await verifyCredential(
+      new ClientSecretCredential(
+        env.AZURE_TENANT_ID || "",
+        env.AZURE_CLIENT_ID || "",
+        env.AZURE_CLIENT_SECRET || ""
+      )
+    );
+  });
+
+  // Cannot test in the CI. Don't know how to test locally
+  it.skip("ManagedIdentityCredential should be able to instantiate BlobServiceClient", async () => {
+    await verifyCredential(new ManagedIdentityCredential());
+  });
+
+  // Don't know how to test
+  it.skip("ClientCertificateCredential should be able to instantiate BlobServiceClient", async () => {
+    await verifyCredential(
+      new ClientCertificateCredential(env.AZURE_TENANT_ID || "", env.AZURE_CLIENT_ID || "", ".")
+    );
+  });
+
+  // Cannot test in the CI. Tried testing locally, but stuck as explained below -
+  //
+  //    In node, after I entered the code in https://microsoft.com/devicelogin to authenticate,
+  //    the following popped up -
+  //       `<AAD-app-name> needs permission to access resources in your organization that only an admin can grant.
+  //        Please ask an admin to grant permission to this app before you can use it.`
+  it.skip("DeviceCodeCredential should be able to instantiate BlobServiceClient", async () => {
+    await verifyCredential(
+      new DeviceCodeCredential(env.AZURE_TENANT_ID || "", env.AZURE_CLIENT_ID, (response) =>
+        console.log(response)
+      )
+    );
+  });
+
+  // Failed in node with the following error
+  //        "error": "invalid_client",
+  //        "error_description": "AADSTS7000218: The request body must contain the following parameter: 'client_assertion' or 'client_secret'.
+  // Failed in browser with the following error
+  //        Error: Failed to send request to https://login.microsoftonline.com/<my-tenant-id>/oauth2/v2.0/token
+  //
+  // Also, the test didn't throw any error when I didn't provide any username/password in the environment for the browser
+  it.skip("UsernamePasswordCredential should be able to instantiate BlobServiceClient", async () => {
+    await verifyCredential(
+      new UsernamePasswordCredential(
+        env.AZURE_TENANT_ID || "",
+        env.AZURE_CLIENT_ID,
+        env.ACCOUNT_USERNAME,
+        env.ACCOUNT_PASSWORD
+      )
+    );
+  });
+});

--- a/sdk/storage/storage-blob/test/node/credentialsFromIdentity.spec.ts
+++ b/sdk/storage/storage-blob/test/node/credentialsFromIdentity.spec.ts
@@ -1,0 +1,45 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import { env, getUniqueName } from "../utils";
+import { BlobServiceClient } from "../../src";
+import { DefaultAzureCredential, EnvironmentCredential, TokenCredential } from "@azure/identity";
+dotenv.config({ path: "../.env" });
+
+describe("Test Credentials from @azure/identity - Node.js Only", () => {
+  async function verifyCredential(credential: TokenCredential) {
+    const blobServiceClient = new BlobServiceClient(
+      `https://${env.ACCOUNT_NAME}.blob.core.windows.net/`,
+      credential
+    );
+
+    const access = "container";
+    const metadata = { key: "value" };
+    const { containerClient } = await blobServiceClient.createContainer(
+      getUniqueName("container"),
+      {
+        access,
+        metadata
+      }
+    );
+    const result = await containerClient.getProperties();
+    assert.deepEqual(result.blobPublicAccess, access);
+    assert.deepEqual(result.metadata, metadata);
+  }
+
+  beforeEach(async function() {
+    if (env.TEST_MODE === "record" || env.TEST_MODE === "playback") {
+      // Not exectuing these tests in the record/playback modes
+      this.skip();
+    }
+  });
+
+  // Only for node, not for browsers
+  it("DefaultAzureCredential should be able to instantiate BlobServiceClient", async () => {
+    await verifyCredential(new DefaultAzureCredential());
+  });
+
+  // Only for node, not for browsers
+  it("EnvironmentCredential should be able to instantiate BlobServiceClient", async () => {
+    await verifyCredential(new EnvironmentCredential());
+  });
+});


### PR DESCRIPTION
I couldn't get all of the credentials working.
Added findings in inline comments mentioning the behaviour of each of the Credentials from @azure/identity in node and browser and the issues that I have encountered with each of them.

New environment variables needed in the CI(and locally)

      "AZURE_TENANT_ID",
      "AZURE_CLIENT_ID",
      "AZURE_CLIENT_SECRET",
      "ACCOUNT_USERNAME",
      "ACCOUNT_PASSWORD"