### PR TITLE
[Storage] Fix test failure caused by the differences in node and browser

### DIFF
--- a/sdk/storage/storage-file/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileclient.spec.ts
@@ -452,7 +452,7 @@ describe("FileClient", () => {
       assert.fail();
       // tslint:disable-next-line:no-empty
     } catch (err) {
-      assert.equal(err.name, "AbortError", "Unexpected error caught: " + err);
+      assert.ok((err.message as string).toLowerCase().includes("aborted"));
     }
     assert.ok(eventTriggered);
   });


### PR DESCRIPTION
Reference - https://github.com/Azure/azure-sdk-for-js/issues/5326

Aborter error is different in both node and browser.
 
Browsers - `Error: The request was aborted`
Node - `AbortError: The user aborted a request`