### PR TITLE
Use separate EventHubs namespace for browser tests in CI

### DIFF
--- a/sdk/eventhub/event-hubs/karma.conf.js
+++ b/sdk/eventhub/event-hubs/karma.conf.js
@@ -47,7 +47,7 @@ module.exports = function(config) {
     // inject following environment values into browser testing with window.__env__
     // environment values MUST be exported or set with same console running "karma start"
     // https://www.npmjs.com/package/karma-env-preprocessor
-    envPreprocessor: ["EVENTHUB_CONNECTION_STRING", "EVENTHUB_NAME", "IOTHUB_CONNECTION_STRING"],
+    envPreprocessor: ["EVENTHUB_CONNECTION_STRING_BROWSER", "EVENTHUB_NAME", "IOTHUB_CONNECTION_STRING_BROWSER"],
 
     // test results reporter to use
     // possible values: 'dots', 'progress'

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -22,7 +22,7 @@ import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
 import { EnvironmentCredential } from "@azure/identity";
 const env = getEnvVars();
 
-describe("Create EventHubClient #RunnableInBrowser", function(): void {
+describe("Create EventHubClient using connection string #RunnableInBrowser", function(): void {
   it("throws when it cannot find the Event Hub name", function(): void {
     const connectionString = "Endpoint=sb://abc";
     const test = function(): EventHubClient {
@@ -86,7 +86,9 @@ describe("Create EventHubClient #RunnableInBrowser", function(): void {
     client.should.be.an.instanceof(EventHubClient);
     should.equal(client.eventHubName, "my-event-hub-name");
   });
+});
 
+describe("Create EventHubClient using Azure Identity", function (): void {
   it("creates an EventHubClient from an Azure.Identity credential", async function(): Promise<
     void
   > {

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -129,7 +129,7 @@ describe("Create EventHubClient using Azure Identity", function (): void {
   });
 });
 
-describe("ServiceCommunicationError for non existent namespace", function(): void {
+describe("ServiceCommunicationError for non existent namespace #RunnableInBrowser", function(): void {
   let client: EventHubClient;
 
   beforeEach(() => {
@@ -197,7 +197,7 @@ describe("ServiceCommunicationError for non existent namespace", function(): voi
   });
 });
 
-describe("MessagingEntityNotFoundError for non existent eventhub", function(): void {
+describe("MessagingEntityNotFoundError for non existent eventhub #RunnableInBrowser", function(): void {
   let client: EventHubClient;
 
   beforeEach(() => {
@@ -322,7 +322,7 @@ describe("User Agent on EventHubClient on #RunnableInBrowser", function(): void 
   });
 });
 
-describe("Errors after close()", function(): void {
+describe("Errors after close() #RunnableInBrowser", function(): void {
   let client: EventHubClient;
   let sender: EventHubProducer;
   let receiver: EventHubConsumer;

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -49,7 +49,7 @@ describe("Event Processor", function(): void {
     await client.close();
   });
 
-  it("should expose an id", async function(): Promise<void> {
+  it("should expose an id #RunnableInBrowser", async function(): Promise<void> {
     const processor = new EventProcessor(
       EventHubClient.defaultConsumerGroupName,
       client,
@@ -61,7 +61,7 @@ describe("Event Processor", function(): void {
     id.length.should.be.gt(1);
   });
 
-  it("should match the fullyQualifiedNamespace, eventHubName and cosumerGroupName of partition processor with respective EventHubClient's properties", async function(): Promise<
+  it("should match the fullyQualifiedNamespace, eventHubName and cosumerGroupName of partition processor with respective EventHubClient's properties #RunnableInBrowser", async function(): Promise<
     void
   > {
     const producer = client.createProducer({ partitionId: `0` });
@@ -101,7 +101,7 @@ describe("Event Processor", function(): void {
     partitionProcessorInfo[2].should.equals(EventHubClient.defaultConsumerGroupName);
   });
 
-  it("should treat consecutive start invocations as idempotent", async function(): Promise<void> {
+  it("should treat consecutive start invocations as idempotent #RunnableInBrowser", async function(): Promise<void> {
     const partitionIds = await client.getPartitionIds();
 
     // ensure we have at least 2 partitions
@@ -184,7 +184,7 @@ describe("Event Processor", function(): void {
     }
   });
 
-  it("should not throw if stop is called without start", async function(): Promise<void> {
+  it("should not throw if stop is called without start #RunnableInBrowser", async function(): Promise<void> {
     let didPartitionProcessorStart = false;
 
     class FooPartitionProcessor extends PartitionProcessor {
@@ -215,7 +215,7 @@ describe("Event Processor", function(): void {
     didPartitionProcessorStart.should.be.false;
   });
 
-  it("should support start after stopping", async function(): Promise<void> {
+  it("should support start after stopping #RunnableInBrowser", async function(): Promise<void> {
     const partitionIds = await client.getPartitionIds();
     let partitionOwnerShip = new Set();
 
@@ -339,7 +339,7 @@ describe("Event Processor", function(): void {
     }
   });
 
-  describe("Partition processor", function(): void {
+  describe("Partition processor #RunnableInBrowser", function(): void {
     it("should support processing events across multiple partitions", async function(): Promise<
       void
     > {
@@ -550,7 +550,7 @@ describe("Event Processor", function(): void {
     });
   });
 
-  describe("InMemory Partition Manager", function(): void {
+  describe("InMemory Partition Manager #RunnableInBrowser", function(): void {
     it("should claim ownership, get a list of ownership and update checkpoint", async function(): Promise<
       void
     > {
@@ -916,7 +916,7 @@ describe("Event Processor", function(): void {
     });
   });
 
-  describe("with trackLastEnqueuedEventInfo", function(): void {
+  describe("with trackLastEnqueuedEventInfo #RunnableInBrowser", function(): void {
     it("should have lastEnqueuedEventInfo populated when trackLastEnqueuedEventInfo is set to true", async function(): Promise<
       void
     > {

--- a/sdk/eventhub/event-hubs/test/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/utils/testUtils.ts
@@ -16,20 +16,21 @@ export enum EnvVarKeys {
   AZURE_CLIENT_SECRET = "AZURE_CLIENT_SECRET"
 }
 
-function getEnvVarValue(name: string): string | undefined {
+function getEnvVarValue(name: string, addBrowserSuffix?: boolean): string | undefined {
   if (isNode) {
     return process.env[name];
   } else {
+    const nameForBrowser = addBrowserSuffix ? name + "_BROWSER" : name;
     // @ts-ignore
-    return window.__env__[name];
+    return window.__env__[nameForBrowser];
   }
 }
 
 export function getEnvVars(): { [key in EnvVarKeys]: any } {
   return {
-    [EnvVarKeys.EVENTHUB_CONNECTION_STRING]: getEnvVarValue(EnvVarKeys.EVENTHUB_CONNECTION_STRING),
+    [EnvVarKeys.EVENTHUB_CONNECTION_STRING]: getEnvVarValue(EnvVarKeys.EVENTHUB_CONNECTION_STRING, !isNode),
     [EnvVarKeys.EVENTHUB_NAME]: getEnvVarValue(EnvVarKeys.EVENTHUB_NAME),
-    [EnvVarKeys.IOTHUB_CONNECTION_STRING]: getEnvVarValue(EnvVarKeys.IOTHUB_CONNECTION_STRING),
+    [EnvVarKeys.IOTHUB_CONNECTION_STRING]: getEnvVarValue(EnvVarKeys.IOTHUB_CONNECTION_STRING, !isNode),
     [EnvVarKeys.AZURE_TENANT_ID]: getEnvVarValue(EnvVarKeys.AZURE_TENANT_ID),
     [EnvVarKeys.AZURE_CLIENT_ID]: getEnvVarValue(EnvVarKeys.AZURE_CLIENT_ID),
     [EnvVarKeys.AZURE_CLIENT_SECRET]: getEnvVarValue(EnvVarKeys.AZURE_CLIENT_SECRET)

--- a/sdk/eventhub/event-hubs/tests.yml
+++ b/sdk/eventhub/event-hubs/tests.yml
@@ -61,10 +61,15 @@ jobs:
           TestType: "node"
           NodeVersion: "8.x"
           EVENTHUB_NAME: "hub_mac_node8"
-
+        Windows_Browser:
+          OSVmImage: "windows-2019"
+          TestType: "browser"
+          EVENTHUB_NAME: "hub_windows_chrome"
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
         IOTHUB_CONNECTION_STRING: $(js-event-hubs-test-iothub-connection-string)
         EVENTHUB_CONNECTION_STRING: $(js-event-hubs-test-connection-string)
+        IOTHUB_CONNECTION_STRING_BROWSER: $(js-event-hubs-test-browser-iothub-connection-string)
+        EVENTHUB_CONNECTION_STRING_BROWSER: $(js-event-hubs-test-browser-connection-string)


### PR DESCRIPTION
This PR updates the test matrix to include browser test runs.

Since we need different connection strings for the browser tests, the env vars for them are pulled into the matrix