### PR TITLE
[app-configuration] Handle ETags and ifMatch/ifNoneMatch conditionals

### DIFF
--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -12,11 +12,11 @@ export class AppConfigurationClient {
     constructor(connectionString: string);
     addConfigurationSetting(configurationSetting: ConfigurationSettingParam, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
     clearReadOnly(configurationSetting: ConfigurationSettingParam, options?: ClearReadOnlyOptions): Promise<DeleteLockResponse>;
-    deleteConfigurationSetting(key: string, options: AppConfigurationDeleteKeyValueOptionalParams & ETagOption): Promise<DeleteKeyValueResponse>;
-    getConfigurationSetting(key: string, options?: AppConfigurationGetKeyValueOptionalParams): Promise<GetKeyValueResponse>;
+    deleteConfigurationSetting(key: string, options?: AppConfigurationDeleteKeyValueOptionalParams): Promise<DeleteKeyValueResponse>;
+    getConfigurationSetting(key: string, options?: AppConfigurationGetKeyValueOptionalParams): Promise<GetConfigurationSettingResponse>;
     listConfigurationSettings(options?: ListConfigurationSettingsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListConfigurationSettingPage>;
     listRevisions(options?: ListRevisionsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListRevisionsPage>;
-    setConfigurationSetting(configurationSetting: ConfigurationSettingParam & ETagOption, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
+    setConfigurationSetting(configurationSetting: ConfigurationSettingParam, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
     setReadOnly(configurationSetting: ConfigurationSettingParam, options?: SetReadOnlyOptions): Promise<PutLockResponse>;
 }
 
@@ -159,9 +159,8 @@ export { DeleteLockResponse as ClearReadOnlyResponse }
 
 export { DeleteLockResponse }
 
-// @public (undocumented)
-export interface ETagOption {
-    etag?: string;
+// @public
+export interface GetConfigurationSettingResponse extends Pick<GetKeyValueResponse, Exclude<keyof GetKeyValueResponse, 'eTag'>> {
 }
 
 // @public
@@ -172,17 +171,13 @@ export interface GetKeyValueHeaders {
 }
 
 // @public
-type GetKeyValueResponse = ConfigurationSetting & GetKeyValueHeaders & {
+export type GetKeyValueResponse = ConfigurationSetting & GetKeyValueHeaders & {
     _response: coreHttp.HttpResponse & {
         parsedHeaders: GetKeyValueHeaders;
         bodyAsText: string;
         parsedBody: ConfigurationSetting;
     };
 };
-
-export { GetKeyValueResponse as GetConfigurationSettingResponse }
-
-export { GetKeyValueResponse }
 
 // @public
 export interface GetKeyValuesHeaders {

--- a/sdk/appconfiguration/app-configuration/samples/index.ts
+++ b/sdk/appconfiguration/app-configuration/samples/index.ts
@@ -3,8 +3,10 @@
 
 import * as helloworld from "./helloworld";
 import * as helloworldWithLabels from "./helloworldWithLabels";
+import * as setReadOnlySample from "./setReadOnlySample";
 
 export async function runAll() {
     await helloworld.run();
     await helloworldWithLabels.run();
+    await setReadOnlySample.run();
 }

--- a/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
+++ b/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// NOTE: replace with import { AppConfigurationClient } from "@azure/app-configuration"
+// in a standalone project
+import { AppConfigurationClient } from "../src";
+
+export async function run() {
+  console.log("Running setReadOnly sample");
+
+  // You will need to set this environment variable
+  const connectionString = process.env["AZ_CONFIG_CONNECTION"]!;
+  const client = new AppConfigurationClient(connectionString);
+
+  const readOnlySampleKey = "readOnlySampleKey";
+
+  await cleanupSampleValues([readOnlySampleKey], client);
+
+  console.log("Creating a new key. By default keys are writeable");
+  await client.addConfigurationSetting({ key: readOnlySampleKey, label: "a label", value: "Initial value" });
+
+  // now we'd like to prevent future modifications - let's set the key/label to read-only
+  await client.setReadOnly({ key: readOnlySampleKey, label: "a label" });
+
+  // any modifications to the key will now throw errors
+  try {
+    await client.setConfigurationSetting({ key: readOnlySampleKey, label: "a label", value: "new value" });
+  } catch (err) {
+    console.log(`Error thrown when trying to modifying a read-only key`, err.name);
+  }
+    
+  // clients that read from the key are unaffected
+  await client.getConfigurationSetting(readOnlySampleKey, { label: "a label" });
+
+  // to make a key writable again we can clear the read-only status
+  await client.clearReadOnly({ key: readOnlySampleKey, label: "a label" });
+
+  // and now clients can change the value again
+  await client.setConfigurationSetting({ key: readOnlySampleKey, label: "a label", value: "new value" });
+  
+  await cleanupSampleValues([readOnlySampleKey], client);
+}
+
+async function cleanupSampleValues(keys: string[], client: AppConfigurationClient) {
+  const existingSettings = await client.listConfigurationSettings({
+    keys: keys
+  });
+
+  for await (const setting of existingSettings) {
+    await client.clearReadOnly(setting);
+    await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
+  }
+}
+
+// If you want to run this sample from a console
+// uncomment these lines so run() will get called
+// run().catch(err => {
+//     console.log(`ERROR: ${err}`);
+// });

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -30,9 +30,9 @@ import {
   ClearReadOnlyResponse
 } from "./models";
 import {
-  quoteETag,
   formatWildcards,
-  extractAfterTokenFromNextLink
+  extractAfterTokenFromNextLink,
+  checkAndFormatIfAndIfNoneMatch
 } from "./internal/helpers";
 import { ResponseBodyNotFoundError } from './responseBodyNotFoundError';
 
@@ -110,8 +110,7 @@ export class AppConfigurationClient {
   ): Promise<DeleteConfigurationSettingResponse> {
     return this.client.deleteKeyValue(key, {
       ...options,
-      ifMatch: quoteETag(options.ifMatch),
-      ifNoneMatch: quoteETag(options.ifNoneMatch)
+      ...checkAndFormatIfAndIfNoneMatch(options)
     });
   }
 
@@ -132,8 +131,7 @@ export class AppConfigurationClient {
     const response = await this.client.getKeyValue(key, {
       label: options.label,
       ...options,
-      ifMatch: quoteETag(options.ifMatch),
-      ifNoneMatch: quoteETag(options.ifNoneMatch),
+      ...checkAndFormatIfAndIfNoneMatch(options)
     }) as GetConfigurationSettingResponse;
 
     // 304 only comes back if the user has passed a conditional option in their
@@ -311,8 +309,7 @@ export class AppConfigurationClient {
       ...options,
       label: configurationSetting.label,
       entity: configurationSetting,
-      ifMatch: quoteETag(options.ifMatch),
-      ifNoneMatch: quoteETag(options.ifNoneMatch)
+      ...checkAndFormatIfAndIfNoneMatch(options)
     });
   }
 

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -1,22 +1,31 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ETagOption, ListConfigurationSettingsOptions, AppConfigurationGetKeyValuesOptionalParams } from '..';
+import { ListConfigurationSettingsOptions, AppConfigurationGetKeyValuesOptionalParams } from '..';
 import { URLBuilder } from '@azure/core-http';
 import { isArray } from 'util';
 import { ListRevisionsOptions } from '../models';
 
 /**
- * Formats the etag so it can be used with a if-match header
+ * Formats the etag so it can be used with a If-Match/If-None-Match header
  * @internal
  * @ignore
  */
-export function formatETagForMatchHeaders(objectWithEtag: ETagOption): string | undefined {
-  if (objectWithEtag.etag) {
-    return `"${objectWithEtag.etag}"`;
+export function quoteETag(etag: string | undefined): string | undefined {
+  // https://tools.ietf.org/html/rfc7232#section-3.1
+  if (etag === undefined || etag === '*') {
+    return etag;
   }
 
-  return undefined;
+  if (etag.startsWith('"') && etag.endsWith('"')) {
+    return etag;
+  }
+
+  if (etag.startsWith("'") && etag.endsWith("'")) {
+    return etag;
+  }
+
+  return `"${etag}"`;
 }
 
 /**

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -29,6 +29,35 @@ export function quoteETag(etag: string | undefined): string | undefined {
 }
 
 /**
+ * Checks the ifMatch/ifNoneMatch properties to make sure we haven't specified both
+ * and throws an Error. Otherwise, returns the properties properly quoted.
+ * @param options An options object with ifMatch/ifNoneMatch fields 
+ * @internal
+ * @ignore
+ */
+export function checkAndFormatIfAndIfNoneMatch(options: { ifMatch?: string, ifNoneMatch?: string }): { ifMatch: string | undefined, ifNoneMatch: string | undefined } {
+  if (options.ifMatch && options.ifNoneMatch) {
+    throw new Error("ifMatch and ifNoneMatch are mutually-exclusive");
+  }
+
+  let ifMatch;
+  let ifNoneMatch;
+
+  if (options.ifMatch) {
+    ifMatch = quoteETag(options.ifMatch);
+  }
+
+  if (options.ifNoneMatch) {
+    ifNoneMatch = quoteETag(options.ifNoneMatch);
+  }
+
+  return {
+    ifMatch: ifMatch,
+    ifNoneMatch: ifNoneMatch
+  };
+}
+
+/**
  * Transforms the keys/labels parameters in the listConfigurationSettings and listRevisions
  * into the format the REST call will need.
  * 

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -5,6 +5,7 @@ import {
   AppConfigurationGetKeyValuesOptionalParams,
   AppConfigurationGetRevisionsOptionalParams,
   AppConfigurationPutKeyValueOptionalParams,
+  GetKeyValueResponse,
   GetKeyValuesResponse,
   GetRevisionsResponse,
   KeyValue as ConfigurationSetting,
@@ -28,8 +29,7 @@ export {
   DeleteLockHeaders,
   DeleteLockResponse as ClearReadOnlyResponse,
   DeleteLockResponse,
-  GetKeyValueHeaders,
-  GetKeyValueResponse as GetConfigurationSettingResponse,
+  GetKeyValueHeaders,  
   GetKeyValueResponse,
   GetKeyValuesHeaders,
   GetKeyValuesResponse,
@@ -74,7 +74,14 @@ export interface ConfigurationSettingOptions
   extends Pick<
     AppConfigurationPutKeyValueOptionalParams,
     Exclude<keyof AppConfigurationPutKeyValueOptionalParams, "label" | "entity">
-  > {}
+  > { }
+  
+
+  /**
+   * A configuration setting and associated HTTP information
+   */
+export interface GetConfigurationSettingResponse extends Pick<GetKeyValueResponse, Exclude<keyof GetKeyValueResponse, 'eTag'>> {
+}
 
 /**
  * Options for listConfigurationSettings that allow for filtering based on keys, labels and other fields.
@@ -159,10 +166,3 @@ export interface ClearReadOnlyOptions extends Pick<AppConfigurationDeleteLockOpt
  * Options for setReadOnly
  */
 export interface SetReadOnlyOptions extends Pick<AppConfigurationPutLockOptionalParams, Exclude<keyof AppConfigurationPutLockOptionalParams, 'label'>> { }
-
-export interface ETagOption {
-  /**
-   * Entity tag (etag) of the object
-   */
-  etag?: string;
-}

--- a/sdk/appconfiguration/app-configuration/src/responseBodyNotFoundError.ts
+++ b/sdk/appconfiguration/app-configuration/src/responseBodyNotFoundError.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { RestError, WebResource, HttpOperationResponse } from '@azure/core-http';
+
+export class ResponseBodyNotFoundError extends RestError {
+  constructor(message: string, code?: string, statusCode?: number, request?: WebResource, response?: HttpOperationResponse, body?: any) {
+    super(message);
+    this.name = "ResponseBodyNotFoundError";
+    this.code = code;
+    this.statusCode = statusCode;
+    this.request = request;
+    this.response = response;
+    this.body = body;
+
+    Object.setPrototypeOf(this, ResponseBodyNotFoundError.prototype);
+  }
+}

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -1,0 +1,109 @@
+import { AppConfigurationClient } from "../src";
+import {
+  getConnectionStringFromEnvironment,
+  deleteKeyCompletely,
+  assertThrowsRestError
+} from "./testHelpers";
+import * as assert from "assert";
+import { ResponseBodyNotFoundError } from '../src/responseBodyNotFoundError';
+
+describe("etags", () => {
+  let client: AppConfigurationClient;
+  const key = `etags-${Date.now()}`;
+
+  before(async () => {
+    client = new AppConfigurationClient(getConnectionStringFromEnvironment());
+  });
+
+  beforeEach(async () => {
+    await client.addConfigurationSetting({
+      key: key,
+      value: "some value"
+    });
+  });
+
+  afterEach(async () => {
+    await deleteKeyCompletely([key], client);
+  });
+
+  // etag usage is 'opt-in' via the ifMatch/ifNoneMatch options for certain calls
+  // by default no etags are used.
+  it("Get and set by default doesn't use etags", async () => {
+    const addedSetting = await client.getConfigurationSetting(key);
+
+    // by default - ignores the etag in 'addedSetting.etag' so last one in
+    // wins
+    addedSetting.value = "some new value!";
+    await client.setConfigurationSetting(addedSetting);
+  });
+
+  it("Get and set, enabling etag checking using ifMatch", async () => {
+    const addedSetting = await client.getConfigurationSetting(key);
+
+    addedSetting.value = "some new value!";
+
+    await client.setConfigurationSetting(addedSetting, { ifMatch: addedSetting.etag });
+  });
+
+  it("set with an old etag will throw RestError", async () => {
+    const addedSetting = await client.getConfigurationSetting(key);
+
+    addedSetting.value = "some new value!";
+
+    // sneaky process B comes in and does an update (ie, does NOT
+    // enable the etag)
+    await client.setConfigurationSetting({
+      ...addedSetting,
+      value: "sneaky user updated the field"
+    });
+
+    // the value (and thus the etag) was changed behind our backs
+    // so now this update (with the original etag) will throw.
+    await assertThrowsRestError(
+      () =>
+        client.setConfigurationSetting(addedSetting, {
+          ifMatch: addedSetting.etag
+        }),
+      412,
+      "Old etag will result in a failed update and error"
+    );
+  });
+
+  it("get using ifNoneMatch to only get the setting if it's changed", async () => {
+    const originalSetting = await client.setConfigurationSetting({
+      key: key,
+      value: "world"
+    });
+
+    // only get the setting if it changed (it hasn't)
+    try {
+      await client.getConfigurationSetting(key, {
+        ifNoneMatch: originalSetting.etag
+      });
+    } catch (err) {
+      assert.ok(err instanceof ResponseBodyNotFoundError);
+      assert.equal("Remote resource matches local resource, no body returned.", err.message);
+      assert.equal("Resource same as remote", err.code);
+      assert.equal(304, err.statusCode);
+    }
+
+    // let's update it and then try again
+    await client.setConfigurationSetting({ key: key, value: "new world" });
+
+    const updatedSetting = await client.getConfigurationSetting(key);
+    assert.notEqual(
+      originalSetting.etag,
+      updatedSetting.etag,
+      "New content, new update, etags shouldn't match"
+    );
+
+    // only get the setting if it changed (it has!)
+    const configurationSetting = await client.getConfigurationSetting(key, {
+      ifNoneMatch: originalSetting.etag
+    });
+
+    // now our retrieved setting matches what's on the server
+    assert.equal("new world", configurationSetting.value);
+    assert.equal(updatedSetting.etag, configurationSetting.etag);
+  });
+});

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { checkAndFormatIfAndIfNoneMatch } from "../src/internal/helpers"
+import * as assert from "assert";
+
+describe("helper methods", () => {
+  it("checkAndFormatIfAndIfNoneMatch", () => {
+    assert.deepEqual({
+      ifMatch: undefined,
+      ifNoneMatch: undefined
+    }, checkAndFormatIfAndIfNoneMatch({}));
+
+    assert.deepEqual({
+      ifMatch: "\"hello\"",
+      ifNoneMatch: undefined
+    }, checkAndFormatIfAndIfNoneMatch({
+      ifMatch: "hello"
+    }));
+
+    assert.deepEqual({
+      ifNoneMatch: "\"hello\"",
+      ifMatch: undefined
+    }, checkAndFormatIfAndIfNoneMatch({
+      ifNoneMatch: "\"hello\"",
+      ifMatch: undefined,
+    }));
+  });
+
+  it("checkAndFormatIfAndIfNoneMatch - mutually exclusive", () => {
+    assert.throws(() => checkAndFormatIfAndIfNoneMatch({
+      ifMatch: "'hello'",
+      ifNoneMatch: "\"world\""
+    }), /^Error: ifMatch and ifNoneMatch are mutually-exclusive/);    
+  });
+})

--- a/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
@@ -1,10 +1,18 @@
-import { getConnectionStringFromEnvironment, assertThrowsRestError, deleteKeyCompletely } from "./testHelpers";
+import {
+  getConnectionStringFromEnvironment,
+  assertThrowsRestError,
+  deleteKeyCompletely
+} from "./testHelpers";
 import { AppConfigurationClient } from "../src";
 import * as assert from "assert";
 
 describe("AppConfigurationClient (set|clear)ReadOnly", () => {
   let client: AppConfigurationClient;
-  const testConfigSetting = { key: `readOnlyTests-${Date.now()}`, value: "world", label: "some label" };
+  const testConfigSetting = {
+    key: `readOnlyTests-${Date.now()}`,
+    value: "world",
+    label: "some label"
+  };
 
   before(() => {
     client = new AppConfigurationClient(getConnectionStringFromEnvironment());
@@ -14,21 +22,35 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     deleteKeyCompletely([testConfigSetting.key], client);
   });
 
-  it("setReadOnly/clearReadOnly (formerly known as lock/unlock)", async () => {
-
+  it("basic", async () => {
     // before it's set to read only we can set it all we want
     await client.setConfigurationSetting(testConfigSetting);
-    
-    let storedSetting = await client.getConfigurationSetting(testConfigSetting.key, { label: testConfigSetting.label });
+
+    let storedSetting = await client.getConfigurationSetting(testConfigSetting.key, {
+      label: testConfigSetting.label
+    });
     assert.ok(!storedSetting.locked);
 
     await client.setReadOnly(testConfigSetting);
 
-    storedSetting = await client.getConfigurationSetting(testConfigSetting.key, { label: testConfigSetting.label });
+    storedSetting = await client.getConfigurationSetting(testConfigSetting.key, {
+      label: testConfigSetting.label
+    });
     assert.ok(storedSetting.locked);
 
     // any modification related methods throw exceptions
-    await assertThrowsRestError(() => client.setConfigurationSetting(testConfigSetting), 409, "Set should fail because the setting is read-only");
-    await assertThrowsRestError(() => client.deleteConfigurationSetting(testConfigSetting.key, { label: testConfigSetting.label }), 409, "Delete should fail because the setting is read-only");
+    await assertThrowsRestError(
+      () => client.setConfigurationSetting(testConfigSetting),
+      409,
+      "Set should fail because the setting is read-only"
+    );
+    await assertThrowsRestError(
+      () =>
+        client.deleteConfigurationSetting(testConfigSetting.key, {
+          label: testConfigSetting.label
+        }),
+      409,
+      "Delete should fail because the setting is read-only"
+    );
   });
 });

--- a/sdk/appconfiguration/app-configuration/test/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/testHelpers.ts
@@ -9,7 +9,7 @@ import * as assert from "assert";
 // allow loading from a .env file as an alternative to defining the variable
 // in the environment
 import * as dotenv from "dotenv";
-import { RestError } from '@azure/core-http';
+import { RestError } from "@azure/core-http";
 dotenv.config();
 
 export function getConnectionStringFromEnvironment(): string {
@@ -73,19 +73,26 @@ export function assertEqualSettings(
   actual = actual.map((setting) => {
     return { key: setting.key, label: setting.label, value: setting.value };
   });
+
   assert.deepEqual(expected, actual);
 }
 
-export async function assertThrowsRestError(testFunction: () => Promise<any>, expectedStatusCode: number, message: string) : Promise<void> {
+export async function assertThrowsRestError(
+  testFunction: () => Promise<any>,
+  expectedStatusCode: number,
+  message: string = ""
+): Promise<Error> {
   try {
     await testFunction();
-    assert.fail("No error thrown");
+    assert.fail(`${message}: No error thrown`);
   } catch (err) {
     if (err instanceof RestError) {
-      assert.equal(expectedStatusCode, err.statusCode);
-      return;
+      assert.equal(expectedStatusCode, err.statusCode, message);
+      return err;
     }
 
-    assert.fail(`${message}: Caught error: ${err}`);
+    assert.fail(`${message}: Caught error but wasn't a RestError: ${err}`);
   }
+  
+  return new Error("We won't reach this - both cases above throw because of assert.fail()");
 }

--- a/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
@@ -1,0 +1,134 @@
+import { AppConfigurationClient, ConfigurationSetting } from "../src";
+import {
+  getConnectionStringFromEnvironment,
+  deleteKeyCompletely,
+  assertThrowsRestError
+} from "./testHelpers";
+import * as assert from "assert";
+
+// There's been discussion on other teams about what errors are thrown when. This
+// is the file where I've documented the throws/notThrows cases to make coordination
+// with other teams simpler. (there's redundancy with other parts of the test suite but
+// that's okay)
+describe("Various error cases", () => {
+  let client: AppConfigurationClient;
+  const nonMatchingETag = "never-match-etag";
+
+  before(() => {
+    client = new AppConfigurationClient(getConnectionStringFromEnvironment());
+  });
+
+  describe("throws", () => {
+    let addedSetting: ConfigurationSetting;
+    let nonExistentKey: string;
+
+    beforeEach(async () => {
+      addedSetting = await client.addConfigurationSetting({
+        key: `etags-${Date.now()}`,
+        value: "world"
+      });
+
+      nonExistentKey = "non-existent key " + addedSetting.key;
+    });
+
+    afterEach(async () => {
+      await deleteKeyCompletely([addedSetting.key], client);
+    });
+
+    it("get: Non-existent key throws 404", async () => {
+      await assertThrowsRestError(() => client.getConfigurationSetting(nonExistentKey), 404);
+    });
+
+    it("get: Non-existent key (ifMatch: non-matching etag) throws 404", async () => {
+      await assertThrowsRestError(
+        () => client.getConfigurationSetting(nonExistentKey, { ifMatch: nonMatchingETag }),
+        412
+      );
+    });
+
+    it("get: Non-existent key (ifMatch: *) throws 412", async () => {
+      await assertThrowsRestError(
+        () => client.getConfigurationSetting(nonExistentKey, { ifMatch: "*" }),
+        412
+      );
+    });
+
+    it("get: value is unchanged from etag (304) using ifNoneMatch, throws ReponseBodyNotFoundError (derived from RestError)", async () => {
+      const errThrown = await assertThrowsRestError(
+        () =>
+          client.getConfigurationSetting(addedSetting.key, {
+            ifNoneMatch: addedSetting.etag
+          }),
+        304
+      );
+
+      assert.equal("ResponseBodyNotFoundError", errThrown.name);
+    });
+
+    it("add: Setting already exists throws 412", async () => {
+      await assertThrowsRestError(() => client.addConfigurationSetting(addedSetting), 412);
+    });
+
+    it("set: Existing key, (ifMatch: non-matching etag) throws 412", async () => {
+      await assertThrowsRestError(
+        () => client.setConfigurationSetting(addedSetting, { ifMatch: nonMatchingETag }),
+        412
+      );
+    });
+
+    it("set: trying to modify a read-only setting throws 409", async () => {
+      await client.setReadOnly(addedSetting);
+
+      await assertThrowsRestError(() => client.setConfigurationSetting(addedSetting), 409);
+    });
+  });
+
+  // these are just here for completeness so we understand what the failures are for some
+  // of the weirder, but possible, scenarios from our API.
+  describe("throws, but not mainline scenarios", () => {
+    const nonExistentKey = `non-existent-key-etags-${Date.now()}`;
+
+    // it's a bit non-sensical (delete a key that doesn't exist but
+    // only if it matches any key)
+    it("delete: Non-existent key (ifMatch: *) throws 412", async () => {
+      await assertThrowsRestError(
+        () => client.deleteConfigurationSetting(nonExistentKey, { ifMatch: "*" }),
+        412
+      );
+    });
+
+    // again, a weird one - delete a non-existent key but only if the etag doesn't match
+    it("delete: Non-existent key (ifMatch: non-matching etag) throws 412", async () => {
+      await assertThrowsRestError(
+        () => client.deleteConfigurationSetting(nonExistentKey, { ifMatch: nonMatchingETag }),
+        412
+      );
+    });
+  });
+
+  describe("doesn't throw", () => {
+    let addedSetting: ConfigurationSetting;
+    let nonExistentKey: string;
+
+    beforeEach(async () => {
+      // same setup for all tests:
+      // key: hello{date}, value: world
+
+      // the 'no label' value for 'hello'
+      addedSetting = await client.addConfigurationSetting({
+        key: `etags-${Date.now()}`,
+        value: "world"
+      });
+
+      nonExistentKey = "bogus key " + addedSetting.key;
+    });
+
+    afterEach(async () => {
+      await deleteKeyCompletely([addedSetting.key], client);
+    });
+
+    it("delete: non-existent key (no etag)", async () => {
+      await client.deleteConfigurationSetting(nonExistentKey);
+    });
+  });
+});


### PR DESCRIPTION
Update APIs to consistently handle etags via ifMatch/ifNoneMatch fields in the options parameter.
* Many tests added to get all the edge cases and to document the various status codes and errors
* Added an exception that might get moved into core (ResourceBodyNotFoundError). Hiding this away in my package for now since the name is still under discussion (but the concept is not).
