### PR TITLE
[app-configuration] Adding distributed tracing

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -9,6 +9,7 @@
     "@azure/core-asynciterator-polyfill": "1.0.0-preview.1",
     "@azure/core-http": "1.0.0-preview.4",
     "@azure/core-paging": "1.0.0-preview.2",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "keywords": [

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -6,6 +6,7 @@
 
 import * as coreHttp from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
+import { RequestOptionsBase } from '@azure/core-http';
 
 // @public
 export class AppConfigurationClient {
@@ -18,7 +19,7 @@ export class AppConfigurationClient {
     listRevisions(options?: ListRevisionsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListRevisionsPage>;
     setConfigurationSetting(configurationSetting: ConfigurationSettingParam, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
     setReadOnly(configurationSetting: ConfigurationSettingParam, options?: SetReadOnlyOptions): Promise<PutLockResponse>;
-}
+    }
 
 // @public
 interface AppConfigurationDeleteKeyValueOptionalParams extends coreHttp.RequestOptionsBase {
@@ -219,14 +220,16 @@ export interface ListConfigurationSettingPage extends Pick<GetKeyValuesResponse,
 }
 
 // @public
-export interface ListConfigurationSettingsOptions extends Pick<AppConfigurationGetKeyValuesOptionalParams, Exclude<keyof AppConfigurationGetKeyValuesOptionalParams, "key" | "label" | "select" | "after">> {
+export interface ListConfigurationSettingsOptions extends RequestOptionsBase {
+    acceptDatetime?: string;
     fields?: (keyof ConfigurationSetting)[];
     keys?: string[];
     labels?: string[];
 }
 
 // @public
-export interface ListRevisionsOptions extends Pick<AppConfigurationGetRevisionsOptionalParams, Exclude<keyof AppConfigurationGetRevisionsOptionalParams, "key" | "label" | "select" | "after">> {
+export interface ListRevisionsOptions extends RequestOptionsBase {
+    acceptDatetime?: string;
     fields?: (keyof ConfigurationSetting)[];
     keys?: string[];
     labels?: string[];

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -67,7 +67,7 @@ export class AppConfigurationClient {
       this.client = new AppConfiguration(appConfigCredential, apiVersion, {
         baseUri: regexMatch[1],
         deserializationContentTypes,
-        requestPolicyFactories: (defaults) => [ ...defaults, tracingPolicy() ]
+        requestPolicyFactories: (defaults) => [ tracingPolicy(), ...defaults ]
       });
     } else {
       throw new Error("You must provide a connection string.");

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  getTracer,
+  Span,
+  SpanOptions,
+  SpanKind,
+  CanonicalCode,
+} from "@azure/core-tracing";
+
+import {
+  RestError
+} from "@azure/core-http";
+
+/**
+ * @internal
+ * @ignore
+ */
+export interface Spannable {
+  spanOptions?: SpanOptions;
+}
+
+/**
+ * @internal
+ * @ignore
+ */
+export class Spanner<TClient> {
+  constructor(private baseOperationName: string, private componentName: string) {    
+  }
+
+  /**
+   * Traces an operation and properly handles reporting start, end and errors for a given span
+   * 
+   * @param operationName Name of a method in the TClient type
+   * @param options An options class, typically derived from @azure/core-http/RequestOptionsBase
+   * @param fn The function to call with an options class that properly propagates the span context
+   * @param translateToCanonicalCodeFn An optional function to translate thrown errors into a CanonicalCode for the span
+   */
+  async trace<OptionsT extends Spannable, ReturnT>(
+    operationName: keyof TClient,
+    options: OptionsT,
+    fn: (options: OptionsT, span: Span) => Promise<ReturnT>,
+    translateToCanonicalCodeFn: (err: Error) => CanonicalCode = Spanner.getCanonicalCode    
+  ) : Promise<ReturnT> {
+    const { newOptions, span } = this.createSpan<OptionsT>(options, operationName);
+
+    try {
+      return await fn(newOptions, span);
+    } catch (err) {
+      span.setStatus({
+        code: translateToCanonicalCodeFn(err),
+        message: err.message
+      });
+      throw err;
+    } finally {
+      span.end();
+    }
+  }
+
+  private createSpan<T extends Spannable>(options: T, operationName: keyof TClient) {
+    const span = getTracer().startSpan(`${this.baseOperationName}.${operationName}`, {
+      ...options.spanOptions,
+      kind: SpanKind.CLIENT
+    });
+    
+    span.setAttribute("component", this.componentName);
+
+    let newOptions = options;
+    
+    if (span.isRecordingEvents()) {
+      newOptions = Spanner.addParentToOptions<T>(options, span);
+    }
+    return { span, newOptions };
+  }
+
+  static getCanonicalCode(err: Error) {
+    if (Spanner.isRestError(err)) {
+      switch (err.statusCode) {
+        case 401:
+          return CanonicalCode.PERMISSION_DENIED;
+        case 404:
+          return CanonicalCode.NOT_FOUND;
+        case 412:
+          return CanonicalCode.FAILED_PRECONDITION;
+      }
+    }
+
+    return CanonicalCode.UNKNOWN;
+  }
+
+  static isRestError(err: Error): err is RestError {
+    return err instanceof RestError;
+  }
+  
+  static addParentToOptions<T extends Spannable>(options: T, span: Span) {
+    return {
+      ...options,
+      spanOptions: {
+        ...options.spanOptions,
+        parent: span
+      }
+    };
+  }
+}

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -2,8 +2,6 @@
 // Licensed under the MIT license.
 
 import {
-  AppConfigurationGetKeyValuesOptionalParams,
-  AppConfigurationGetRevisionsOptionalParams,
   AppConfigurationPutKeyValueOptionalParams,
   GetKeyValueResponse,
   GetKeyValuesResponse,
@@ -12,6 +10,7 @@ import {
   AppConfigurationDeleteLockOptionalParams,
   AppConfigurationPutLockOptionalParams,
 } from "./generated/src/models/index";
+import { RequestOptionsBase } from '@azure/core-http';
 
 export {
   AppConfigurationDeleteKeyValueOptionalParams as DeleteConfigurationSettingOptions,
@@ -88,11 +87,12 @@ export interface GetConfigurationSettingResponse extends Pick<GetKeyValueRespons
  * Also provides `fields` which allows you to selectively choose which fields are populated in the
  * result.
  */
-export interface ListConfigurationSettingsOptions
-  extends Pick<
-    AppConfigurationGetKeyValuesOptionalParams,
-    Exclude<keyof AppConfigurationGetKeyValuesOptionalParams, "key" | "label" | "select" | "after">
-  > {
+export interface ListConfigurationSettingsOptions extends RequestOptionsBase {
+  /**
+   * Requests the server to respond with the state of the resource at the specified time.
+   */
+  acceptDatetime ?: string;
+  
   /**
    * Filters for wildcard matching (using *) against keys. These conditions are logically OR'd against each other.
    */
@@ -114,11 +114,12 @@ export interface ListConfigurationSettingsOptions
  * Also provides `fields` which allows you to selectively choose which fields are populated in the
  * result.
  */
-export interface ListRevisionsOptions
-  extends Pick<
-    AppConfigurationGetRevisionsOptionalParams,
-    Exclude<keyof AppConfigurationGetRevisionsOptionalParams, "key" | "label" | "select" | "after">
-  > {
+export interface ListRevisionsOptions extends RequestOptionsBase {
+  /**
+   * Requests the server to respond with the state of the resource at the specified time.
+   */
+  acceptDatetime?: string;
+
   /**
    * Filters for wildcard matching (using *) against keys. These conditions are logically OR'd against each other.
    */

--- a/sdk/appconfiguration/app-configuration/test/tracingHelpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/tracingHelpers.spec.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Spanner } from "../src/internal/tracingHelpers";
+import { RestError } from "@azure/core-http";
+import { getTracer, SpanKind, CanonicalCode, SpanOptions } from "@azure/core-tracing";
+import * as assert from "assert";
+
+interface FakeOptions {
+  name: string;
+  spanOptions?: SpanOptions;
+}
+
+describe("tracingHelpers", () => {
+  it("addParentToOptions", () => {
+    const fakeOptions: FakeOptions = {
+      name: "fakeName",
+      spanOptions: {
+        kind: SpanKind.PRODUCER
+      }
+    };
+
+    const parentSpan = getTracer().startSpan("test", {
+      kind: SpanKind.PRODUCER
+    });
+
+    const newOptions = Spanner["addParentToOptions"](fakeOptions, parentSpan);
+
+    assert.equal("fakeName", newOptions.name);
+    assert.equal(parentSpan, newOptions.spanOptions.parent);
+    assert.equal(SpanKind.PRODUCER, newOptions.spanOptions.kind);
+  });
+
+  it("getCanonicalCode", () => {
+    assert.equal(CanonicalCode.PERMISSION_DENIED, Spanner.getCanonicalCode(new RestError("hello", "", 401)));
+    assert.equal(CanonicalCode.NOT_FOUND, Spanner.getCanonicalCode(new RestError("hello", "", 404)));
+    assert.equal(CanonicalCode.UNKNOWN, Spanner.getCanonicalCode(new RestError("hello", "", 409)));
+    assert.equal(CanonicalCode.FAILED_PRECONDITION, Spanner.getCanonicalCode(new RestError("hello", "", 412)));    
+  });
+});


### PR DESCRIPTION
Some changes, mostly just refactoring.

One thing I discovered as I was doing this was that (not sure why) the listConfigurationSettingsOptions and listRevisionsOptions weren't exposing inherited properties from RequestOptionsBase (and thus I couldn't add the spanOptions). 

I fixed this by just flattening them out into their own classes which appears to have solved it and was going to happen anyways since I need to do something similar to improve doc generation.