### PR TITLE
[Storage] Add name properties on clients - storage-queue

### DIFF
--- a/sdk/storage/storage-queue/src/StorageClient.ts
+++ b/sdk/storage/storage-queue/src/StorageClient.ts
@@ -3,6 +3,7 @@
 
 import { StorageClientContext } from "./generated/src/storageClientContext";
 import { Pipeline } from "./Pipeline";
+import { getAccountNameFromUrl } from "./utils/utils.common";
 /**
  * A StorageClient represents a based client class for QueueServiceClient, QueueClient and etc.
  *
@@ -17,6 +18,7 @@ export abstract class StorageClient {
    * @memberof StorageClient
    */
   public readonly url: string;
+  public readonly accountName: string;
 
   /**
    * Request policy pipeline.
@@ -46,6 +48,7 @@ export abstract class StorageClient {
    */
   protected constructor(url: string, pipeline: Pipeline) {
     this.url = url;
+    this.accountName = getAccountNameFromUrl(url);
     this.pipeline = pipeline;
     this.storageClientContext = new StorageClientContext(url, pipeline.toServiceClientOptions());
 


### PR DESCRIPTION
Adds 
- messageId, queueName on MessageIdClient 
- queueName on MessagesClient 
- queueName on QueueClient
- accountName on StorageClient
- and the code to parse them from the URL