### PR TITLE
Add tracing to storage-file

### DIFF
--- a/sdk/storage/storage-file/package.json
+++ b/sdk/storage/storage-file/package.json
@@ -81,6 +81,7 @@
     "@azure/abort-controller": "1.0.0-preview.2",
     "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.2",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "events": "^3.0.0",
     "tslib": "^1.9.3"
   },

--- a/sdk/storage/storage-file/recordings/browsers/directoryclient/recording_createfile_and_deletefile_with_tracing.json
+++ b/sdk/storage/storage-file/recordings/browsers/directoryclient/recording_createfile_and_deletefile_with_tracing.json
@@ -1,0 +1,210 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:25 GMT",
+    "last-modified": "Thu, 03 Oct 2019 07:50:25 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D65A44649F\"",
+    "x-ms-request-id": "127353d9-401a-00dc-76bf-795253000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "23fd9509-a948-480f-9459-1083ef4991ef",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682/dir157008902641103201",
+   "query": {
+    "restype": "directory"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:25 GMT",
+    "x-ms-file-change-time": "2019-10-03T07:50:26.0424091Z",
+    "x-ms-file-attributes": "Directory",
+    "x-ms-file-id": "13835128424026341376",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-10-03T07:50:26.0424091Z",
+    "x-ms-file-parent-id": "0",
+    "x-ms-file-permission-key": "10601938801812273194*18156966929047809955",
+    "x-ms-client-request-id": "922c5e1e-9c6b-47b5-94ac-39d48c77b4b7",
+    "content-length": "0",
+    "last-modified": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D65A56C59B\"",
+    "x-ms-request-id": "127353dc-401a-00dc-78bf-795253000000",
+    "x-ms-file-last-write-time": "2019-10-03T07:50:26.0424091Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682/dir157008902641103201/directory157008902652205219",
+   "query": {
+    "restype": "directory"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "x-ms-file-change-time": "2019-10-03T07:50:26.1604916Z",
+    "x-ms-file-attributes": "Directory",
+    "x-ms-file-id": "11529285414812647424",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-10-03T07:50:26.1604916Z",
+    "x-ms-file-parent-id": "13835128424026341376",
+    "x-ms-file-permission-key": "10601938801812273194*18156966929047809955",
+    "x-ms-client-request-id": "7af0d550-aed6-4794-80b0-1b65c9dbb589",
+    "content-length": "0",
+    "last-modified": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D65A68CA34\"",
+    "x-ms-request-id": "127353de-401a-00dc-7abf-795253000000",
+    "x-ms-file-last-write-time": "2019-10-03T07:50:26.1604916Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682/dir157008902641103201/directory157008902652205219/file157008902663800316",
+   "query": {},
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "x-ms-file-change-time": "2019-10-03T07:50:26.2705685Z",
+    "x-ms-file-attributes": "Archive",
+    "x-ms-file-id": "16140971433240035328",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-10-03T07:50:26.2705685Z",
+    "x-ms-file-parent-id": "11529285414812647424",
+    "x-ms-file-permission-key": "6006229023213291309*18156966929047809955",
+    "x-ms-client-request-id": "cacbbb51-e1c6-4d46-bf9f-7757eb338958",
+    "content-length": "0",
+    "last-modified": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D65A799615\"",
+    "x-ms-request-id": "127353e0-401a-00dc-7cbf-795253000000",
+    "x-ms-file-last-write-time": "2019-10-03T07:50:26.2705685Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682/dir157008902641103201/directory157008902652205219/file157008902663800316",
+   "query": {},
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "last-modified": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "x-ms-file-attributes": "Archive",
+    "x-ms-file-id": "16140971433240035328",
+    "x-ms-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-10-03T07:50:26.2705685Z",
+    "x-ms-file-parent-id": "11529285414812647424",
+    "x-ms-file-permission-key": "6006229023213291309*18156966929047809955",
+    "x-ms-client-request-id": "2206054b-9fc0-4932-9a54-51e9a33ba89c",
+    "x-ms-type": "File",
+    "content-length": "256",
+    "x-ms-meta-key": "value",
+    "x-ms-file-change-time": "2019-10-03T07:50:26.2705685Z",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D65A799615\"",
+    "content-type": "application/octet-stream",
+    "x-ms-request-id": "127353e2-401a-00dc-7ebf-795253000000",
+    "x-ms-file-last-write-time": "2019-10-03T07:50:26.2705685Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682/dir157008902641103201/directory157008902652205219/file157008902663800316",
+   "query": {},
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "127353e5-401a-00dc-80bf-795253000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "c1d7b71a-05fc-4377-a9f1-cb4d2c35d22c",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682/dir157008902641103201/directory157008902652205219/file157008902663800316",
+   "query": {},
+   "requestBody": null,
+   "status": 404,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-error-code": "ResourceNotFound",
+    "transfer-encoding": "chunked",
+    "x-ms-request-id": "127353e7-401a-00dc-02bf-795253000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "a8607656-ca13-4bc2-adc3-81d873a074a7"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682/dir157008902641103201/directory157008902652205219",
+   "query": {
+    "restype": "directory"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "127353ea-401a-00dc-04bf-795253000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "b9b1b51e-8d70-4745-b95c-df4226365074",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008902598508682",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:50:26 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "127353ec-401a-00dc-06bf-795253000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "c73c326b-ab19-4573-bfe7-324bc405abf3",
+    "content-length": "0"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "share": "share157008902598508682",
+  "dir": "dir157008902641103201",
+  "directory": "directory157008902652205219",
+  "file": "file157008902663800316"
+ }
+}

--- a/sdk/storage/storage-file/recordings/browsers/fileclient/recording_create_with_tracing.json
+++ b/sdk/storage/storage-file/recordings/browsers/fileclient/recording_create_with_tracing.json
@@ -1,0 +1,101 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008773128100374",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:28:50 GMT",
+    "last-modified": "Thu, 03 Oct 2019 07:28:51 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D356851B72\"",
+    "x-ms-request-id": "9107613d-c01a-007b-12bc-79ba91000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "a4b94f83-271f-46fb-adaa-904cd58df677",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008773128100374/dir157008773165503232",
+   "query": {
+    "restype": "directory"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:28:50 GMT",
+    "x-ms-file-change-time": "2019-10-03T07:28:51.2995150Z",
+    "x-ms-file-attributes": "Directory",
+    "x-ms-file-id": "13835128424026341376",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-10-03T07:28:51.2995150Z",
+    "x-ms-file-parent-id": "0",
+    "x-ms-file-permission-key": "10601938801812273194*18156966929047809955",
+    "x-ms-client-request-id": "63ec792d-796d-4ed1-a0d4-e34d6e7c3735",
+    "content-length": "0",
+    "last-modified": "Thu, 03 Oct 2019 07:28:51 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D3569CAF4E\"",
+    "x-ms-request-id": "91076140-c01a-007b-14bc-79ba91000000",
+    "x-ms-file-last-write-time": "2019-10-03T07:28:51.2995150Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008773128100374/dir157008773165503232/file157008773176801350",
+   "query": {},
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:28:51 GMT",
+    "x-ms-file-change-time": "2019-10-03T07:28:51.4316073Z",
+    "x-ms-file-attributes": "Archive",
+    "x-ms-file-id": "11529285414812647424",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-10-03T07:28:51.4316073Z",
+    "x-ms-file-parent-id": "13835128424026341376",
+    "x-ms-file-permission-key": "6006229023213291309*18156966929047809955",
+    "x-ms-client-request-id": "3d28f40c-45cc-4378-b524-fe38a4da3f9b",
+    "content-length": "0",
+    "last-modified": "Thu, 03 Oct 2019 07:28:51 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D747D356B0D729\"",
+    "x-ms-request-id": "91076142-c01a-007b-16bc-79ba91000000",
+    "x-ms-file-last-write-time": "2019-10-03T07:28:51.4316073Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157008773128100374",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 03 Oct 2019 07:28:51 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "91076144-c01a-007b-18bc-79ba91000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "f8d7dea4-1723-4d5c-80fc-4119c4770d68",
+    "content-length": "0"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "share": "share157008773128100374",
+  "dir": "dir157008773165503232",
+  "file": "file157008773176801350"
+ }
+}

--- a/sdk/storage/storage-file/recordings/node/directoryclient/recording_createfile_and_deletefile_with_tracing.js
+++ b/sdk/storage/storage-file/recordings/node/directoryclient/recording_createfile_and_deletefile_with_tracing.js
@@ -1,0 +1,252 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"share":"share157008893947504191","dir":"dir157008894411606682","directory":"directory157008894430509739","file":"file157008894445507000"}
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157008893947504191')
+  .query(true)
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:49:03 GMT',
+  'ETag',
+  '"0x8D747D6292EE866"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'd04570cb-201a-0073-71bf-79a09e000000',
+  'x-ms-client-request-id',
+  '21b69fb7-5d9d-4541-a538-d888dd26a605',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:03 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157008893947504191/dir157008894411606682')
+  .query(true)
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:49:03 GMT',
+  'ETag',
+  '"0x8D747D629549DE8"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '7da158c1-e01a-007c-57bf-79d6f2000000',
+  'x-ms-client-request-id',
+  '052fcf14-449e-41b4-80ce-f697a881f7c9',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-10-03T07:49:03.8199272Z',
+  'x-ms-file-last-write-time',
+  '2019-10-03T07:49:03.8199272Z',
+  'x-ms-file-creation-time',
+  '2019-10-03T07:49:03.8199272Z',
+  'x-ms-file-permission-key',
+  '10601938801812273194*18156966929047809955',
+  'x-ms-file-attributes',
+  'Directory',
+  'x-ms-file-id',
+  '13835128424026341376',
+  'x-ms-file-parent-id',
+  '0',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:03 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157008893947504191/dir157008894411606682/directory157008894430509739')
+  .query(true)
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:49:03 GMT',
+  'ETag',
+  '"0x8D747D6296EE156"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'f835ce09-301a-0022-48bf-793d12000000',
+  'x-ms-client-request-id',
+  'd53a7bcf-1f40-4e72-bcae-d5373abe72ab',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-10-03T07:49:03.9920470Z',
+  'x-ms-file-last-write-time',
+  '2019-10-03T07:49:03.9920470Z',
+  'x-ms-file-creation-time',
+  '2019-10-03T07:49:03.9920470Z',
+  'x-ms-file-permission-key',
+  '10601938801812273194*18156966929047809955',
+  'x-ms-file-attributes',
+  'Directory',
+  'x-ms-file-id',
+  '13835093239654252544',
+  'x-ms-file-parent-id',
+  '13835128424026341376',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:03 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157008893947504191/dir157008894411606682/directory157008894430509739/file157008894445507000')
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:49:04 GMT',
+  'ETag',
+  '"0x8D747D62986652B"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'df180c40-b01a-002c-15bf-7914a2000000',
+  'x-ms-client-request-id',
+  'beb21b28-59f0-41ac-b789-29fc4c04a426',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-10-03T07:49:04.1461547Z',
+  'x-ms-file-last-write-time',
+  '2019-10-03T07:49:04.1461547Z',
+  'x-ms-file-creation-time',
+  '2019-10-03T07:49:04.1461547Z',
+  'x-ms-file-permission-key',
+  '6006229023213291309*18156966929047809955',
+  'x-ms-file-attributes',
+  'Archive',
+  'x-ms-file-id',
+  '13835163608398430208',
+  'x-ms-file-parent-id',
+  '13835093239654252544',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:03 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/share157008893947504191/dir157008894411606682/directory157008894430509739/file157008894445507000')
+  .reply(200, "", [ 'Content-Length',
+  '256',
+  'Content-Type',
+  'application/octet-stream',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:49:04 GMT',
+  'ETag',
+  '"0x8D747D62986652B"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '9f37a0db-901a-00ad-1ebf-79b478000000',
+  'x-ms-client-request-id',
+  'efd6e38c-260f-4053-9d61-60e0ae6e8791',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-meta-key',
+  'value',
+  'x-ms-type',
+  'File',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-file-change-time',
+  '2019-10-03T07:49:04.1461547Z',
+  'x-ms-file-last-write-time',
+  '2019-10-03T07:49:04.1461547Z',
+  'x-ms-file-creation-time',
+  '2019-10-03T07:49:04.1461547Z',
+  'x-ms-file-permission-key',
+  '6006229023213291309*18156966929047809955',
+  'x-ms-file-attributes',
+  'Archive',
+  'x-ms-file-id',
+  '13835163608398430208',
+  'x-ms-file-parent-id',
+  '13835093239654252544',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-meta-key,Content-Type,Last-Modified,ETag,x-ms-type,x-ms-server-encrypted,x-ms-file-change-time,x-ms-file-last-write-time,x-ms-file-creation-time,x-ms-file-permission-key,x-ms-file-attributes,x-ms-file-id,x-ms-file-parent-id,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:03 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share157008893947504191/dir157008894411606682/directory157008894430509739/file157008894445507000')
+  .reply(202, "", [ 'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '9107695a-c01a-007b-51bf-79ba91000000',
+  'x-ms-client-request-id',
+  '7e2d3fc5-728f-4061-98ac-1817d4a4cbd4',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:04 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/share157008893947504191/dir157008894411606682/directory157008894430509739/file157008894445507000')
+  .reply(404, "", [ 'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '94c5f31d-501a-00c0-12bf-790033000000',
+  'x-ms-client-request-id',
+  '24a2c7d0-7570-4852-b8b7-7f9b88a5b653',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-error-code',
+  'ResourceNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:04 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share157008893947504191/dir157008894411606682/directory157008894430509739')
+  .query(true)
+  .reply(202, "", [ 'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'bf33ca75-a01a-0052-43bf-7984e5000000',
+  'x-ms-client-request-id',
+  'd5dc9f3b-1281-4c69-9ae1-74066a917b08',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:05 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share157008893947504191')
+  .query(true)
+  .reply(202, "", [ 'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'cdc89a58-b01a-00e7-05bf-7917f7000000',
+  'x-ms-client-request-id',
+  'f0d46034-6432-4710-8428-175c60a44254',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 07:49:05 GMT' ]);
+

--- a/sdk/storage/storage-file/recordings/node/fileclient/recording_create_with_tracing.js
+++ b/sdk/storage/storage-file/recordings/node/fileclient/recording_create_with_tracing.js
@@ -1,0 +1,114 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"share":"share157008711292300407","dir":"dir157008711443400651","file":"file157008711460400420"}
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157008711292300407')
+  .query(true)
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:18:33 GMT',
+  'ETag',
+  '"0x8D747D1E67B202A"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'baf6ae35-001a-00af-44ba-790ac0000000',
+  'x-ms-client-request-id',
+  '93f3a4b8-4cfa-4dbc-acfd-6ce2a8285055',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 07:18:33 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157008711292300407/dir157008711443400651')
+  .query(true)
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:18:34 GMT',
+  'ETag',
+  '"0x8D747D1E6C4C85F"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '0cadeebf-b01a-0003-1eba-791969000000',
+  'x-ms-client-request-id',
+  '1d524f55-5945-426b-93bb-358978e4ed18',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-10-03T07:18:34.1607519Z',
+  'x-ms-file-last-write-time',
+  '2019-10-03T07:18:34.1607519Z',
+  'x-ms-file-creation-time',
+  '2019-10-03T07:18:34.1607519Z',
+  'x-ms-file-permission-key',
+  '10601938801812273194*18156966929047809955',
+  'x-ms-file-attributes',
+  'Directory',
+  'x-ms-file-id',
+  '13835128424026341376',
+  'x-ms-file-parent-id',
+  '0',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Thu, 03 Oct 2019 07:18:33 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157008711292300407/dir157008711443400651/file157008711460400420')
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 03 Oct 2019 07:18:34 GMT',
+  'ETag',
+  '"0x8D747D1E6E59CAF"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '70244f5e-201a-005c-04ba-79ad55000000',
+  'x-ms-client-request-id',
+  '47cbf030-bc63-49b9-8f68-b305f1e9be2b',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-10-03T07:18:34.3759023Z',
+  'x-ms-file-last-write-time',
+  '2019-10-03T07:18:34.3759023Z',
+  'x-ms-file-creation-time',
+  '2019-10-03T07:18:34.3759023Z',
+  'x-ms-file-permission-key',
+  '6006229023213291309*18156966929047809955',
+  'x-ms-file-attributes',
+  'Archive',
+  'x-ms-file-id',
+  '13835093239654252544',
+  'x-ms-file-parent-id',
+  '13835128424026341376',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Thu, 03 Oct 2019 07:18:34 GMT' ]);
+
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share157008711292300407')
+  .query(true)
+  .reply(202, "", [ 'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '7b727e17-201a-0001-2eba-79a7d1000000',
+  'x-ms-client-request-id',
+  'd9695e82-fa75-4feb-bfe4-9492b5e130b2',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 07:18:34 GMT' ]);
+

--- a/sdk/storage/storage-file/rollup.base.config.js
+++ b/sdk/storage/storage-file/rollup.base.config.js
@@ -23,7 +23,15 @@ const depNames = Object.keys(pkg.dependencies);
 const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
-  const externalNodeBuiltins = ["@azure/core-http", "crypto", "fs", "events", "os", "stream", "util"];
+  const externalNodeBuiltins = [
+    "@azure/core-http",
+    "crypto",
+    "fs",
+    "events",
+    "os",
+    "stream",
+    "util"
+  ];
   const baseConfig = {
     input: "dist-esm/src/index.js",
     external: depNames.concat(externalNodeBuiltins),
@@ -126,7 +134,8 @@ export function browserConfig(test = false, production = false) {
             "deepStrictEqual",
             "notDeepStrictEqual",
             "notDeepEqual",
-            "notEqual"
+            "notEqual",
+            "strictEqual"
           ]
         }
       })

--- a/sdk/storage/storage-file/src/FileServiceClient.ts
+++ b/sdk/storage/storage-file/src/FileServiceClient.ts
@@ -5,7 +5,7 @@ import { AbortSignalLike } from "@azure/abort-controller";
 import * as Models from "./generated/src/models";
 import { Service } from "./generated/src/operations";
 import { newPipeline, NewPipelineOptions, Pipeline } from "./Pipeline";
-import { StorageClient } from "./StorageClient";
+import { StorageClient, CommonOptions } from "./StorageClient";
 import { ShareClient, ShareCreateOptions, ShareDeleteMethodOptions } from "./ShareClient";
 import { appendToURLPath, extractConnectionStringParts } from "./utils/utils.common";
 import { Credential } from "./credentials/Credential";
@@ -14,13 +14,15 @@ import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import "@azure/core-paging";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
 import { isNode } from "@azure/core-http";
+import { CanonicalCode } from "@azure/core-tracing";
+import { createSpan } from "./utils/tracing";
 
 /**
  * Options to configure List Shares Segment operation.
  *
  * @interface ServiceListSharesSegmentOptions
  */
-interface ServiceListSharesSegmentOptions {
+interface ServiceListSharesSegmentOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -64,7 +66,7 @@ interface ServiceListSharesSegmentOptions {
  * @export
  * @interface ServiceListSharesOptions
  */
-export interface ServiceListSharesOptions {
+export interface ServiceListSharesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -97,7 +99,7 @@ export interface ServiceListSharesOptions {
  * @export
  * @interface ServiceGetPropertiesOptions
  */
-export interface ServiceGetPropertiesOptions {
+export interface ServiceGetPropertiesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -114,7 +116,7 @@ export interface ServiceGetPropertiesOptions {
  * @export
  * @interface ServiceSetPropertiesOptions
  */
-export interface ServiceSetPropertiesOptions {
+export interface ServiceSetPropertiesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -245,14 +247,25 @@ export class FileServiceClient extends StorageClient {
    */
   public async createShare(
     shareName: string,
-    options?: ShareCreateOptions
+    options: ShareCreateOptions = {}
   ): Promise<{ shareCreateResponse: Models.ShareCreateResponse; shareClient: ShareClient }> {
-    const shareClient = this.getShareClient(shareName);
-    const shareCreateResponse = await shareClient.create(options);
-    return {
-      shareCreateResponse,
-      shareClient
-    };
+    const { span, spanOptions } = createSpan("FileServiceClient-createShare", options.spanOptions);
+    try {
+      const shareClient = this.getShareClient(shareName);
+      const shareCreateResponse = await shareClient.create({ ...options, spanOptions });
+      return {
+        shareCreateResponse,
+        shareClient
+      };
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -265,10 +278,21 @@ export class FileServiceClient extends StorageClient {
    */
   public async deleteShare(
     shareName: string,
-    options?: ShareDeleteMethodOptions
+    options: ShareDeleteMethodOptions = {}
   ): Promise<Models.ShareDeleteResponse> {
-    const shareClient = this.getShareClient(shareName);
-    return await shareClient.delete(options);
+    const { span, spanOptions } = createSpan("FileServiceClient-deleteShare", options.spanOptions);
+    try {
+      const shareClient = this.getShareClient(shareName);
+      return await shareClient.delete({ ...options, spanOptions });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -283,9 +307,24 @@ export class FileServiceClient extends StorageClient {
   public async getProperties(
     options: ServiceGetPropertiesOptions = {}
   ): Promise<Models.ServiceGetPropertiesResponse> {
-    return this.serviceContext.getProperties({
-      abortSignal: options.abortSignal
-    });
+    const { span, spanOptions } = createSpan(
+      "FileServiceClient-getProperties",
+      options.spanOptions
+    );
+    try {
+      return this.serviceContext.getProperties({
+        abortSignal: options.abortSignal,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -302,9 +341,24 @@ export class FileServiceClient extends StorageClient {
     properties: Models.StorageServiceProperties,
     options: ServiceSetPropertiesOptions = {}
   ): Promise<Models.ServiceSetPropertiesResponse> {
-    return this.serviceContext.setProperties(properties, {
-      abortSignal: options.abortSignal
-    });
+    const { span, spanOptions } = createSpan(
+      "FileServiceClient-setProperties",
+      options.spanOptions
+    );
+    try {
+      return this.serviceContext.setProperties(properties, {
+        abortSignal: options.abortSignal,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -469,9 +523,24 @@ export class FileServiceClient extends StorageClient {
     marker?: string,
     options: ServiceListSharesSegmentOptions = {}
   ): Promise<Models.ServiceListSharesSegmentResponse> {
-    return this.serviceContext.listSharesSegment({
-      marker,
-      ...options
-    });
+    const { span, spanOptions } = createSpan(
+      "FileServiceClient-listSharesSegment",
+      options.spanOptions
+    );
+    try {
+      return this.serviceContext.listSharesSegment({
+        marker,
+        ...options,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 }

--- a/sdk/storage/storage-file/src/Pipeline.ts
+++ b/sdk/storage/storage-file/src/Pipeline.ts
@@ -18,8 +18,7 @@ import {
   proxyPolicy,
   getDefaultProxySettings,
   isNode,
-  ProxySettings,
-  tracingPolicy
+  ProxySettings
 } from "@azure/core-http";
 import { BrowserPolicyFactory } from "./BrowserPolicyFactory";
 import { Credential } from "./credentials/Credential";
@@ -185,7 +184,6 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
   const factories: RequestPolicyFactory[] = [
-    tracingPolicy(),
     new KeepAlivePolicyFactory(pipelineOptions.keepAliveOptions),
     new TelemetryPolicyFactory(pipelineOptions.telemetry),
     new UniqueRequestIDPolicyFactory(),

--- a/sdk/storage/storage-file/src/Pipeline.ts
+++ b/sdk/storage/storage-file/src/Pipeline.ts
@@ -18,7 +18,8 @@ import {
   proxyPolicy,
   getDefaultProxySettings,
   isNode,
-  ProxySettings
+  ProxySettings,
+  tracingPolicy
 } from "@azure/core-http";
 import { BrowserPolicyFactory } from "./BrowserPolicyFactory";
 import { Credential } from "./credentials/Credential";
@@ -184,6 +185,7 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
   const factories: RequestPolicyFactory[] = [
+    tracingPolicy(),
     new KeepAlivePolicyFactory(pipelineOptions.keepAliveOptions),
     new TelemetryPolicyFactory(pipelineOptions.telemetry),
     new UniqueRequestIDPolicyFactory(),

--- a/sdk/storage/storage-file/src/ShareClient.ts
+++ b/sdk/storage/storage-file/src/ShareClient.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 
 import { HttpResponse, isNode } from "@azure/core-http";
+import { CanonicalCode } from "@azure/core-tracing";
 import { AbortSignalLike } from "@azure/abort-controller";
 import * as Models from "./generated/src/models";
 import { Share } from "./generated/src/operations";
 import { Metadata } from "./models";
 import { newPipeline, NewPipelineOptions, Pipeline } from "./Pipeline";
-import { StorageClient } from "./StorageClient";
+import { StorageClient, CommonOptions } from "./StorageClient";
 import { URLConstants } from "./utils/constants";
 import {
   appendToURLPath,
@@ -20,6 +21,7 @@ import { FileCreateOptions, FileDeleteOptions, FileClient } from "./FileClient";
 import { Credential } from "./credentials/Credential";
 import { SharedKeyCredential } from "./credentials/SharedKeyCredential";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
+import { createSpan } from "./utils/tracing";
 
 /**
  * Options to configure Share - Create operation.
@@ -27,7 +29,7 @@ import { AnonymousCredential } from "./credentials/AnonymousCredential";
  * @export
  * @interface ShareCreateOptions
  */
-export interface ShareCreateOptions {
+export interface ShareCreateOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -60,7 +62,7 @@ export interface ShareCreateOptions {
  * @export
  * @interface ShareDeleteMethodOptions
  */
-export interface ShareDeleteMethodOptions {
+export interface ShareDeleteMethodOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -86,7 +88,7 @@ export interface ShareDeleteMethodOptions {
  * @export
  * @interface ShareSetMetadataOptions
  */
-export interface ShareSetMetadataOptions {
+export interface ShareSetMetadataOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -103,7 +105,7 @@ export interface ShareSetMetadataOptions {
  * @export
  * @interface ShareSetAccessPolicyOptions
  */
-export interface ShareSetAccessPolicyOptions {
+export interface ShareSetAccessPolicyOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -120,7 +122,7 @@ export interface ShareSetAccessPolicyOptions {
  * @export
  * @interface ShareGetAccessPolicyOptions
  */
-export interface ShareGetAccessPolicyOptions {
+export interface ShareGetAccessPolicyOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -137,7 +139,7 @@ export interface ShareGetAccessPolicyOptions {
  * @export
  * @interface ShareGetPropertiesOptions
  */
-export interface ShareGetPropertiesOptions {
+export interface ShareGetPropertiesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -154,7 +156,7 @@ export interface ShareGetPropertiesOptions {
  * @export
  * @interface ShareSetQuotaOptions
  */
-export interface ShareSetQuotaOptions {
+export interface ShareSetQuotaOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -171,7 +173,7 @@ export interface ShareSetQuotaOptions {
  * @export
  * @interface ShareGetStatisticsOptions
  */
-export interface ShareGetStatisticsOptions {
+export interface ShareGetStatisticsOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -241,7 +243,7 @@ export declare type ShareGetAccessPolicyResponse = {
  * @export
  * @interface ShareCreateSnapshotOptions
  */
-export interface ShareCreateSnapshotOptions {
+export interface ShareCreateSnapshotOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -265,7 +267,7 @@ export interface ShareCreateSnapshotOptions {
  * @export
  * @interface ShareCreatePermissionOptions
  */
-export interface ShareCreatePermissionOptions {
+export interface ShareCreatePermissionOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -281,7 +283,7 @@ export interface ShareCreatePermissionOptions {
  * @export
  * @interface ShareGetPermissionOptions
  */
-export interface ShareGetPermissionOptions {
+export interface ShareGetPermissionOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -442,9 +444,21 @@ export class ShareClient extends StorageClient {
    * @memberof ShareClient
    */
   public async create(options: ShareCreateOptions = {}): Promise<Models.ShareCreateResponse> {
-    return this.context.create({
-      ...options
-    });
+    const { span, spanOptions } = createSpan("ShareClient-create", options.spanOptions);
+    try {
+      return this.context.create({
+        ...options,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -484,17 +498,28 @@ export class ShareClient extends StorageClient {
    */
   public async createDirectory(
     directoryName: string,
-    options?: DirectoryCreateOptions
+    options: DirectoryCreateOptions = {}
   ): Promise<{
     directoryClient: DirectoryClient;
     directoryCreateResponse: Models.DirectoryCreateResponse;
   }> {
-    const directoryClient = this.getDirectoryClient(directoryName);
-    const directoryCreateResponse = await directoryClient.create(options);
-    return {
-      directoryClient,
-      directoryCreateResponse
-    };
+    const { span, spanOptions } = createSpan("ShareClient-createDirectory", options.spanOptions);
+    try {
+      const directoryClient = this.getDirectoryClient(directoryName);
+      const directoryCreateResponse = await directoryClient.create({ ...options, spanOptions });
+      return {
+        directoryClient,
+        directoryCreateResponse
+      };
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -509,10 +534,21 @@ export class ShareClient extends StorageClient {
    */
   public async deleteDirectory(
     directoryName: string,
-    options?: DirectoryDeleteOptions
+    options: DirectoryDeleteOptions = {}
   ): Promise<Models.DirectoryDeleteResponse> {
-    const directoryClient = this.getDirectoryClient(directoryName);
-    return await directoryClient.delete(options);
+    const { span, spanOptions } = createSpan("ShareClient-deleteDirectory", options.spanOptions);
+    try {
+      const directoryClient = this.getDirectoryClient(directoryName);
+      return await directoryClient.delete({ ...options, spanOptions });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -529,15 +565,26 @@ export class ShareClient extends StorageClient {
   public async createFile(
     fileName: string,
     size: number,
-    options?: FileCreateOptions
+    options: FileCreateOptions = {}
   ): Promise<{ fileClient: FileClient; fileCreateResponse: Models.FileCreateResponse }> {
-    const directoryClient = this.rootDirectoryClient;
-    const fileClient = directoryClient.getFileClient(fileName);
-    const fileCreateResponse = await fileClient.create(size, options);
-    return {
-      fileClient,
-      fileCreateResponse
-    };
+    const { span, spanOptions } = createSpan("ShareClient-createFile", options.spanOptions);
+    try {
+      const directoryClient = this.rootDirectoryClient;
+      const fileClient = directoryClient.getFileClient(fileName);
+      const fileCreateResponse = await fileClient.create(size, { ...options, spanOptions });
+      return {
+        fileClient,
+        fileCreateResponse
+      };
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -562,11 +609,22 @@ export class ShareClient extends StorageClient {
    */
   public async deleteFile(
     fileName: string,
-    options?: FileDeleteOptions
+    options: FileDeleteOptions = {}
   ): Promise<Models.FileDeleteResponse> {
-    const directoryClient = this.rootDirectoryClient;
-    const fileClient = directoryClient.getFileClient(fileName);
-    return await fileClient.delete(options);
+    const { span, spanOptions } = createSpan("ShareClient-deleteFile", options.spanOptions);
+    try {
+      const directoryClient = this.rootDirectoryClient;
+      const fileClient = directoryClient.getFileClient(fileName);
+      return await fileClient.delete({ ...options, spanOptions });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -580,9 +638,21 @@ export class ShareClient extends StorageClient {
   public async getProperties(
     options: ShareGetPropertiesOptions = {}
   ): Promise<Models.ShareGetPropertiesResponse> {
-    return this.context.getProperties({
-      abortSignal: options.abortSignal
-    });
+    const { span, spanOptions } = createSpan("ShareClient-getProperties", options.spanOptions);
+    try {
+      return this.context.getProperties({
+        abortSignal: options.abortSignal,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -595,9 +665,21 @@ export class ShareClient extends StorageClient {
    * @memberof ShareClient
    */
   public async delete(options: ShareDeleteMethodOptions = {}): Promise<Models.ShareDeleteResponse> {
-    return this.context.deleteMethod({
-      ...options
-    });
+    const { span, spanOptions } = createSpan("ShareClient-delete", options.spanOptions);
+    try {
+      return this.context.deleteMethod({
+        ...options,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -616,10 +698,22 @@ export class ShareClient extends StorageClient {
     metadata?: Metadata,
     options: ShareSetMetadataOptions = {}
   ): Promise<Models.ShareSetMetadataResponse> {
-    return this.context.setMetadata({
-      abortSignal: options.abortSignal,
-      metadata
-    });
+    const { span, spanOptions } = createSpan("ShareClient-setMetadata", options.spanOptions);
+    try {
+      return this.context.setMetadata({
+        abortSignal: options.abortSignal,
+        metadata,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -638,32 +732,44 @@ export class ShareClient extends StorageClient {
   public async getAccessPolicy(
     options: ShareGetAccessPolicyOptions = {}
   ): Promise<ShareGetAccessPolicyResponse> {
-    const response = await this.context.getAccessPolicy({
-      abortSignal: options.abortSignal
-    });
-
-    const res: ShareGetAccessPolicyResponse = {
-      _response: response._response,
-      date: response.date,
-      eTag: response.eTag,
-      lastModified: response.lastModified,
-      requestId: response.requestId,
-      signedIdentifiers: [],
-      version: response.version
-    };
-
-    for (const identifier of response) {
-      res.signedIdentifiers.push({
-        accessPolicy: {
-          expiry: new Date(identifier.accessPolicy!.expiry!),
-          permission: identifier.accessPolicy!.permission!,
-          start: new Date(identifier.accessPolicy!.start!)
-        },
-        id: identifier.id
+    const { span, spanOptions } = createSpan("ShareClient-getAccessPolicy", options.spanOptions);
+    try {
+      const response = await this.context.getAccessPolicy({
+        abortSignal: options.abortSignal,
+        spanOptions
       });
-    }
 
-    return res;
+      const res: ShareGetAccessPolicyResponse = {
+        _response: response._response,
+        date: response.date,
+        eTag: response.eTag,
+        lastModified: response.lastModified,
+        requestId: response.requestId,
+        signedIdentifiers: [],
+        version: response.version
+      };
+
+      for (const identifier of response) {
+        res.signedIdentifiers.push({
+          accessPolicy: {
+            expiry: new Date(identifier.accessPolicy!.expiry!),
+            permission: identifier.accessPolicy!.permission!,
+            start: new Date(identifier.accessPolicy!.start!)
+          },
+          id: identifier.id
+        });
+      }
+
+      return res;
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -684,22 +790,34 @@ export class ShareClient extends StorageClient {
     shareAcl?: SignedIdentifier[],
     options: ShareSetAccessPolicyOptions = {}
   ): Promise<Models.ShareSetAccessPolicyResponse> {
-    const acl: Models.SignedIdentifier[] = [];
-    for (const identifier of shareAcl || []) {
-      acl.push({
-        accessPolicy: {
-          expiry: truncatedISO8061Date(identifier.accessPolicy.expiry),
-          permission: identifier.accessPolicy.permission,
-          start: truncatedISO8061Date(identifier.accessPolicy.start)
-        },
-        id: identifier.id
-      });
-    }
+    const { span, spanOptions } = createSpan("ShareClient-setAccessPolicy", options.spanOptions);
+    try {
+      const acl: Models.SignedIdentifier[] = [];
+      for (const identifier of shareAcl || []) {
+        acl.push({
+          accessPolicy: {
+            expiry: truncatedISO8061Date(identifier.accessPolicy.expiry),
+            permission: identifier.accessPolicy.permission,
+            start: truncatedISO8061Date(identifier.accessPolicy.start)
+          },
+          id: identifier.id
+        });
+      }
 
-    return this.context.setAccessPolicy({
-      abortSignal: options.abortSignal,
-      shareAcl: acl
-    });
+      return this.context.setAccessPolicy({
+        abortSignal: options.abortSignal,
+        shareAcl: acl,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -712,10 +830,22 @@ export class ShareClient extends StorageClient {
   public async createSnapshot(
     options: ShareCreateSnapshotOptions = {}
   ): Promise<Models.ShareCreateSnapshotResponse> {
-    return this.context.createSnapshot({
-      abortSignal: options.abortSignal,
-      ...options
-    });
+    const { span, spanOptions } = createSpan("ShareClient-createSnapshot", options.spanOptions);
+    try {
+      return this.context.createSnapshot({
+        abortSignal: options.abortSignal,
+        ...options,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -730,15 +860,27 @@ export class ShareClient extends StorageClient {
     quotaInGB: number,
     options: ShareSetQuotaOptions = {}
   ): Promise<Models.ShareSetQuotaResponse> {
-    if (quotaInGB <= 0 || quotaInGB > 5120) {
-      throw new RangeError(
-        `Share quota must be greater than 0, and less than or equal to 5Tib (5120GB)`
-      );
+    const { span, spanOptions } = createSpan("ShareClient-setQuota", options.spanOptions);
+    try {
+      if (quotaInGB <= 0 || quotaInGB > 5120) {
+        throw new RangeError(
+          `Share quota must be greater than 0, and less than or equal to 5Tib (5120GB)`
+        );
+      }
+      return this.context.setQuota({
+        abortSignal: options.abortSignal,
+        quota: quotaInGB,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
     }
-    return this.context.setQuota({
-      abortSignal: options.abortSignal,
-      quota: quotaInGB
-    });
   }
 
   /**
@@ -751,10 +893,24 @@ export class ShareClient extends StorageClient {
   public async getStatistics(
     options: ShareGetStatisticsOptions = {}
   ): Promise<ShareGetStatisticsResponse> {
-    const response = await this.context.getStatistics({ abortSignal: options.abortSignal });
+    const { span, spanOptions } = createSpan("ShareClient-getStatistics", options.spanOptions);
+    try {
+      const response = await this.context.getStatistics({
+        abortSignal: options.abortSignal,
+        spanOptions
+      });
 
-    const GBBytes = 1024 * 1024 * 1024;
-    return { ...response, shareUsage: Math.ceil(response.shareUsageBytes / GBBytes) };
+      const GBBytes = 1024 * 1024 * 1024;
+      return { ...response, shareUsage: Math.ceil(response.shareUsageBytes / GBBytes) };
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -769,14 +925,26 @@ export class ShareClient extends StorageClient {
     filePermission: string,
     options: ShareCreatePermissionOptions = {}
   ): Promise<Models.ShareCreatePermissionResponse> {
-    return this.context.createPermission(
-      {
-        permission: filePermission
-      },
-      {
-        abortSignal: options.abortSignal
-      }
-    );
+    const { span, spanOptions } = createSpan("ShareClient-createPermission", options.spanOptions);
+    try {
+      return this.context.createPermission(
+        {
+          permission: filePermission
+        },
+        {
+          abortSignal: options.abortSignal,
+          spanOptions
+        }
+      );
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -791,8 +959,20 @@ export class ShareClient extends StorageClient {
     filePermissionKey: string,
     options: ShareGetPermissionOptions = {}
   ): Promise<Models.ShareGetPermissionResponse> {
-    return this.context.getPermission(filePermissionKey, {
-      aborterSignal: options.abortSignal
-    });
+    const { span, spanOptions } = createSpan("ShareClient-getPermission", options.spanOptions);
+    try {
+      return this.context.getPermission(filePermissionKey, {
+        aborterSignal: options.abortSignal,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 }

--- a/sdk/storage/storage-file/src/StorageClient.ts
+++ b/sdk/storage/storage-file/src/StorageClient.ts
@@ -5,6 +5,15 @@ import { StorageClientContext } from "./generated/src/storageClientContext";
 import { Pipeline } from "./Pipeline";
 import { escapeURLPath } from "./utils/utils.common";
 import { SERVICE_VERSION } from "./utils/constants";
+import { SpanOptions } from "@azure/core-tracing";
+
+/**
+ * An interface for options common to every remote operation.
+ */
+export interface CommonOptions {
+  spanOptions?: SpanOptions;
+}
+
 /**
  * A StorageClient represents a base client class for ServiceClient, ContainerClient and etc.
  *

--- a/sdk/storage/storage-file/src/utils/tracing.ts
+++ b/sdk/storage/storage-file/src/utils/tracing.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getTracer, Span, SpanOptions, SpanKind } from "@azure/core-tracing";
+
+/**
+ * Creates a span using the global tracer.
+ * @param name The name of the operation being performed.
+ * @param options The options for the underlying http request.
+ */
+export function createSpan(
+  operationName: string,
+  options: SpanOptions = {}
+): { span: Span; spanOptions: SpanOptions } {
+  const tracer = getTracer();
+  const spanOptions: SpanOptions = {
+    ...options,
+    kind: SpanKind.CLIENT
+  };
+
+  const span = tracer.startSpan(`Azure.Storage.File.${operationName}`, spanOptions);
+  span.setAttribute("component", "storage");
+
+  let newOptions = options;
+  if (span.isRecordingEvents()) {
+    newOptions = {
+      ...options,
+      parent: span
+    };
+  }
+
+  return {
+    span,
+    spanOptions: newOptions
+  };
+}

--- a/sdk/storage/storage-file/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileclient.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import { isNode } from "@azure/core-http";
+import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 import { AbortController } from "@azure/abort-controller";
 import { record, delay } from "./utils/recorder";
 import * as dotenv from "dotenv";
@@ -497,5 +498,36 @@ describe("FileClient", () => {
       const handle = result.handleList[0];
       await dirClient.forceCloseHandle(handle.handleId);
     }
+  });
+
+  it("create with tracing", async () => {
+    const tracer = new TestTracer();
+    setTracer(tracer);
+    const rootSpan = tracer.startSpan("root");
+    await fileClient.create(content.length, {
+      spanOptions: { parent: rootSpan }
+    });
+    rootSpan.end();
+
+    const rootSpans = tracer.getRootSpans();
+    assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
+    assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
+
+    const expectedGraph: SpanGraph = {
+      roots: [
+        {
+          name: rootSpan.name,
+          children: [
+            {
+              name: "Azure.Storage.File.FileClient-create",
+              children: []
+            }
+          ]
+        }
+      ]
+    };
+
+    assert.deepStrictEqual(tracer.getSpanGraph(rootSpan.context().traceId), expectedGraph);
+    assert.strictEqual(tracer.getActiveSpans().length, 0, "All spans should have had end called");
   });
 });


### PR DESCRIPTION
This PR adds a dependency on @azure/core-tracing and makes it possible to pass a parent `Span` to public facing operations.

Also included are a couple small tests that validate Spans are being created properly.