### PR TITLE
[core-http] Creating a new Error type for signaling when a response body is empty (ResponseBodyNotFoundError)

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -138,7 +138,7 @@ export class AppConfigurationClient {
     // request _and_ the remote object has the same etag as what the user passed.
     if (response._response.status === 304) {
       throw new ResponseBodyNotFoundError(
-        "Remote resource matches local resource, no body returned.",
+        "The requested setting's value has not changed since the last request.",
         "Resource same as remote",
         response._response.status,
         response._response.request,

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -34,7 +34,7 @@ import {
   extractAfterTokenFromNextLink,
   checkAndFormatIfAndIfNoneMatch
 } from "./internal/helpers";
-import { ResponseBodyNotFoundError } from './responseBodyNotFoundError';
+import { ResponseBodyNotFoundError } from "@azure/core-http";
 
 const apiVersion = "1.0";
 const ConnectionStringRegex = /Endpoint=(.*);Id=(.*);Secret=(.*)/;
@@ -128,18 +128,25 @@ export class AppConfigurationClient {
     key: string,
     options: GetConfigurationSettingOptions = {}
   ): Promise<GetConfigurationSettingResponse> {
-    const response = await this.client.getKeyValue(key, {
+    const response = (await this.client.getKeyValue(key, {
       label: options.label,
       ...options,
       ...checkAndFormatIfAndIfNoneMatch(options)
-    }) as GetConfigurationSettingResponse;
+    })) as GetConfigurationSettingResponse;
 
     // 304 only comes back if the user has passed a conditional option in their
     // request _and_ the remote object has the same etag as what the user passed.
     if (response._response.status === 304) {
-      throw new ResponseBodyNotFoundError("Remote resource matches local resource, no body returned.", "Resource same as remote", response._response.status, response._response.request, response._response, null);
+      throw new ResponseBodyNotFoundError(
+        "Remote resource matches local resource, no body returned.",
+        "Resource same as remote",
+        response._response.status,
+        response._response.request,
+        response._response,
+        null
+      );
     }
-    
+
     return response;
   }
 

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -82,7 +82,7 @@ describe("etags", () => {
       });
     } catch (err) {
       assert.ok(err instanceof ResponseBodyNotFoundError);
-      assert.equal("Remote resource matches local resource, no body returned.", err.message);
+      assert.equal("The requested setting's value has not changed since the last request.", err.message);
       assert.equal("Resource same as remote", err.code);
       assert.equal(304, err.statusCode);
     }

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -5,7 +5,7 @@ import {
   assertThrowsRestError
 } from "./testHelpers";
 import * as assert from "assert";
-import { ResponseBodyNotFoundError } from '../src/responseBodyNotFoundError';
+import { ResponseBodyNotFoundError } from "@azure/core-http";
 
 describe("etags", () => {
   let client: AppConfigurationClient;

--- a/sdk/core/core-http/lib/coreHttp.ts
+++ b/sdk/core/core-http/lib/coreHttp.ts
@@ -17,6 +17,7 @@ export { HttpOperationResponse, HttpResponse, RestResponse } from "./httpOperati
 export { HttpPipelineLogger } from "./httpPipelineLogger";
 export { HttpPipelineLogLevel } from "./httpPipelineLogLevel";
 export { RestError } from "./restError";
+export { ResponseBodyNotFoundError } from "./responseBodyNotFoundError";
 export { OperationArguments } from "./operationArguments";
 export {
   OperationParameter,

--- a/sdk/core/core-http/lib/responseBodyNotFoundError.ts
+++ b/sdk/core/core-http/lib/responseBodyNotFoundError.ts
@@ -1,10 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { RestError, WebResource, HttpOperationResponse } from '@azure/core-http';
+import { RestError } from "./restError";
+import { HttpOperationResponse } from "./httpOperationResponse";
+import { WebResource } from "./webResource";
 
 export class ResponseBodyNotFoundError extends RestError {
-  constructor(message: string, code?: string, statusCode?: number, request?: WebResource, response?: HttpOperationResponse, body?: any) {
+  constructor(
+    message: string,
+    code?: string,
+    statusCode?: number,
+    request?: WebResource,
+    response?: HttpOperationResponse,
+    body?: any
+  ) {
     super(message);
     this.name = "ResponseBodyNotFoundError";
     this.code = code;

--- a/sdk/core/core-http/test/errorTests.ts
+++ b/sdk/core/core-http/test/errorTests.ts
@@ -10,6 +10,7 @@ describe("instanceof for RestError and derived classes works", () => {
 
   it("ResponseBodyNotFoundError", () => {
     const err = new ResponseBodyNotFoundError("message");
+    assert.ok("ResponseBodyNotFoundError", err.name);
     assert.ok(err instanceof Error);
     assert.ok(err instanceof RestError);
   });

--- a/sdk/core/core-http/test/errorTests.ts
+++ b/sdk/core/core-http/test/errorTests.ts
@@ -1,0 +1,16 @@
+import { RestError } from "../lib/coreHttp";
+import * as assert from "assert";
+import { ResponseBodyNotFoundError } from "../lib/responseBodyNotFoundError";
+
+describe("instanceof for RestError and derived classes works", () => {
+  it("RestError", () => {
+    const err = new RestError("message");
+    assert.ok(err instanceof Error);
+  });
+
+  it("ResponseBodyNotFoundError", () => {
+    const err = new ResponseBodyNotFoundError("message");
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof RestError);
+  });
+});


### PR DESCRIPTION
ResponseBodyNotFoundError can be used by applications to indicate that the response body is empty. 

Used (currently) in AppConfig to indicate when a request has no body which can potentially be actionable by a user.