### PR TITLE
rush-runner.js: exit with failing status code on failures

### DIFF
--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -59,7 +59,11 @@ const spawnNode = (cwd, ...args) => {
   console.log(`Executing: "node ${args.join(' ')}" in ${cwd}\n\n`);
   const proc = spawnSync('node', args, { cwd, stdio: 'inherit' });
   console.log(`\n\nNode process exited with code ${proc.status}`);
-}
+
+  if (proc.status !== 0) {
+    process.exit(proc.status);
+  }
+};
 
 const flatMap = (arr, f) => {
   const result = arr.map(f);

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -61,7 +61,13 @@ const spawnNode = (cwd, ...args) => {
   console.log(`\n\nNode process exited with code ${proc.status}`);
 
   if (proc.status !== 0) {
-    process.exit(proc.status);
+    if (proc.status === null) {
+      // proc.status will be null if the subprocess terminated due to a signal, which I don't think
+      // should ever happen, but if it does it's safer to fail.
+      process.exitCode = 1;
+    } else {
+      process.exitCode = proc.status;
+    }
   }
 };
 

--- a/eng/tools/rush-runner.js
+++ b/eng/tools/rush-runner.js
@@ -61,13 +61,9 @@ const spawnNode = (cwd, ...args) => {
   console.log(`\n\nNode process exited with code ${proc.status}`);
 
   if (proc.status !== 0) {
-    if (proc.status === null) {
-      // proc.status will be null if the subprocess terminated due to a signal, which I don't think
-      // should ever happen, but if it does it's safer to fail.
-      process.exitCode = 1;
-    } else {
-      process.exitCode = proc.status;
-    }
+    // proc.status will be null if the subprocess terminated due to a signal, which I don't think
+    // should ever happen, but if it does it's safer to fail.
+    process.exitCode = proc.status || 1;
   }
 };
 

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -75,7 +75,8 @@ export class CertificatesClient {
     // Warning: (ae-forgotten-export) The symbol "BackupCertificateResult" needs to be exported by the entry point index.d.ts
     backupCertificate(name: string, options?: RequestOptionsBase): Promise<BackupCertificateResult>;
     cancelCertificateOperation(name: string, options?: RequestOptionsBase): Promise<CertificateOperation>;
-    createCertificate(name: string, certificatePolicy: CertificatePolicy, enabled?: boolean, tags?: CertificateTags, options?: RequestOptionsBase): Promise<Certificate>;
+    // Warning: (ae-forgotten-export) The symbol "CreateCertificateOptions" needs to be exported by the entry point index.d.ts
+    createCertificate(name: string, certificatePolicy: CertificatePolicy, options?: CreateCertificateOptions): Promise<Certificate>;
     protected readonly credential: TokenCredential;
     deleteCertificate(certificateName: string, options?: RequestOptionsBase): Promise<DeletedCertificate>;
     deleteCertificateContacts(options?: RequestOptionsBase): Promise<Contacts>;
@@ -86,8 +87,7 @@ export class CertificatesClient {
     getCertificateIssuer(issuerName: string, options?: RequestOptionsBase): Promise<CertificateIssuer>;
     getCertificateOperation(name: string, options?: RequestOptionsBase): Promise<CertificateOperation>;
     getCertificatePolicy(name: string, options?: RequestOptionsBase): Promise<CertificatePolicy>;
-    // Warning: (ae-forgotten-export) The symbol "CertificateWithPolicy" needs to be exported by the entry point index.d.ts
-    getCertificateWithPolicy(name: string, options?: RequestOptionsBase): Promise<CertificateWithPolicy>;
+    getCertificateWithPolicy(name: string, options?: RequestOptionsBase): Promise<Certificate>;
     static getDefaultPipeline(credential: TokenCredential, pipelineOptions?: NewPipelineOptions): ServiceClientOptions;
     getDeletedCertificate(name: string, options?: RequestOptionsBase): Promise<DeletedCertificate>;
     importCertificate(name: string, base64EncodedCertificate: string, options?: KeyVaultClientImportCertificateOptionalParams): Promise<Certificate>;
@@ -96,7 +96,7 @@ export class CertificatesClient {
     listCertificates(options?: RequestOptionsBase): PagedAsyncIterableIterator<Certificate, Certificate[]>;
     listCertificateVersions(name: string, options?: RequestOptionsBase): PagedAsyncIterableIterator<Certificate, Certificate[]>;
     listDeletedCertificates(options?: KeyVaultClientGetDeletedCertificatesOptionalParams): PagedAsyncIterableIterator<DeletedCertificate, DeletedCertificate[]>;
-    mergeCertificate(name: string, x509Certificates: Uint8Array[], options?: RequestOptionsBase): Promise<CertificateWithPolicy>;
+    mergeCertificate(name: string, x509Certificates: Uint8Array[], options?: RequestOptionsBase): Promise<Certificate>;
     readonly pipeline: ServiceClientOptions;
     purgeDeletedCertificate(name: string, options?: RequestOptionsBase): Promise<null>;
     recoverDeletedCertificate(name: string, options?: RequestOptionsBase): Promise<Certificate>;

--- a/sdk/keyvault/keyvault-certificates/samples/helloWorld.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/helloWorld.ts
@@ -16,8 +16,10 @@ async function main(): Promise<void> {
 
   const client = new CertificatesClient(url, credential);
 
+  const certificateName = "MyCertificate";
+
   // Creating a self-signed certificate
-  const certificate = await client.createCertificate("MyCertificate", {
+  const certificate = await client.createCertificate(certificateName, {
     issuerName: "Self",
     subjectName: "cn=MyCert"
   });
@@ -25,20 +27,20 @@ async function main(): Promise<void> {
   console.log("Certificate: ", certificate);
 
   // To read a certificate with their policy:
-  const certificateWithPolicy = await client.getCertificateWithPolicy("MyCertificate");
+  const certificateWithPolicy = await client.getCertificateWithPolicy(certificateName);
   // Note: It will always read the latest version of the certificate.
 
   console.log("Certificate with policy:", certificateWithPolicy);
 
   // To read a certificate from a specific version:
   const certificateFromVersion = await client.getCertificate(
-    "MyCertificate",
+    certificateName,
     certificateWithPolicy.properties.version
   );
   // Note: It will not retrieve the certificate's policy.
   console.log("Certificate from a specific version:", certificateFromVersion);
 
-  let updatedCertificate = await client.updateCertificate("MyCertificate", "", {
+  let updatedCertificate = await client.updateCertificate(certificateName, "", {
     tags: {
       customTag: "value"
     }
@@ -48,12 +50,12 @@ async function main(): Promise<void> {
   // Updating the certificate's policy:
   await client.updateCertificatePolicy(certificateName, {
     issuerName: "Self",
-    subjectName: "cn=MyOtherCert",
+    subjectName: "cn=MyOtherCert"
   });
   updatedCertificate = await client.getCertificateWithPolicy(certificateName);
-  console.log("updatedCertificate certificate's policy:", updated.policy);
+  console.log("updatedCertificate certificate's policy:", updatedCertificate.policy);
 
-  const result = await client.deleteCertificate("MyCertificate");
+  const result = await client.deleteCertificate(certificateName);
   console.log("Recovery Id: ", result.recoveryId);
   console.log("Deleted Date: ", result.deletedDate);
   console.log("Scheduled Purge Date: ", result.scheduledPurgeDate);


### PR DESCRIPTION
From docs: https://nodejs.org/docs/latest-v10.x/api/child_process.html#child_process_child_process_spawnsync_command_args_options

``` 
status <number> | <null> The exit code of the subprocess, or null if the subprocess terminated due to a signal.
```

Status is a `number` or `null` so I used `!==` 