### PR TITLE
Fix circular dependencies in @azure/cosmos

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -578,12 +578,12 @@ export class Items {
     query<T>(query: string | SqlQuerySpec, options: FeedOptions): QueryIterator<T>;
     readAll(options?: FeedOptions): QueryIterator<ItemDefinition>;
     readAll<T extends ItemDefinition>(options?: FeedOptions): QueryIterator<T>;
+    readChangeFeed<T>(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<T>;
     // Warning: (ae-forgotten-export) The symbol "ChangeFeedOptions" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ChangeFeedIterator" needs to be exported by the entry point index.d.ts
     readChangeFeed(partitionKey: string | number | boolean, changeFeedOptions: ChangeFeedOptions): ChangeFeedIterator<any>;
     readChangeFeed(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<any>;
     readChangeFeed<T>(partitionKey: string | number | boolean, changeFeedOptions: ChangeFeedOptions): ChangeFeedIterator<T>;
-    readChangeFeed<T>(changeFeedOptions?: ChangeFeedOptions): ChangeFeedIterator<T>;
     upsert(body: any, options?: RequestOptions): Promise<ItemResponse<ItemDefinition>>;
     upsert<T extends ItemDefinition>(body: T, options?: RequestOptions): Promise<ItemResponse<T>>;
 }

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/defaultQueryExecutionContext.ts
@@ -185,6 +185,7 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
 
       // Add the request charge to the query metrics so that we can have per partition request charge.
       if (Constants.HttpHeaders.RequestCharge in responseHeaders) {
+        const requestCharge = Number(responseHeaders[Constants.HttpHeaders.RequestCharge]) || 0;
         queryMetrics = new QueryMetrics(
           queryMetrics.retrievedDocumentCount,
           queryMetrics.retrievedDocumentSize,
@@ -198,7 +199,7 @@ export class DefaultQueryExecutionContext implements ExecutionContext {
           queryMetrics.vmExecutionTime,
           queryMetrics.runtimeExecutionTimes,
           queryMetrics.documentWriteTime,
-          new ClientSideMetrics(responseHeaders[Constants.HttpHeaders.RequestCharge])
+          new ClientSideMetrics(requestCharge)
         );
       }
 

--- a/sdk/cosmosdb/cosmos/src/queryMetrics/clientSideMetrics.ts
+++ b/sdk/cosmosdb/cosmos/src/queryMetrics/clientSideMetrics.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { getRequestChargeIfAny } from "../queryExecutionContext/headerUtils";
 
 export class ClientSideMetrics {
   constructor(public readonly requestCharge: number) {}
@@ -15,7 +14,7 @@ export class ClientSideMetrics {
         throw new Error("clientSideMetrics has null or undefined item(s)");
       }
 
-      requestCharge += getRequestChargeIfAny(clientSideMetrics.requestCharge);
+      requestCharge += clientSideMetrics.requestCharge;
     }
 
     return new ClientSideMetrics(requestCharge);

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -17,8 +17,7 @@ import { TimeoutError } from "./TimeoutError";
 /** @hidden */
 const log = logger("RequestHandler");
 
-/** @hidden */
-export async function executeRequest(requestContext: RequestContext) {
+async function executeRequest(requestContext: RequestContext) {
   return executePlugins(requestContext, httpRequest, PluginOn.request);
 }
 
@@ -143,6 +142,7 @@ export async function request<T>(requestContext: RequestContext): Promise<Cosmos
   }
 
   return RetryUtility.execute({
-    requestContext
+    requestContext,
+    executeRequest
   });
 }

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -6,7 +6,6 @@ import { StatusCodes, SubStatusCodes } from "../common/statusCodes";
 import { Response } from "../request";
 import { LocationRouting } from "../request/LocationRouting";
 import { RequestContext } from "../request/RequestContext";
-import { executeRequest } from "../request/RequestHandler";
 import { DefaultRetryPolicy } from "./defaultRetryPolicy";
 import { EndpointDiscoveryRetryPolicy } from "./endpointDiscoveryRetryPolicy";
 import { ResourceThrottleRetryPolicy } from "./resourceThrottleRetryPolicy";
@@ -21,6 +20,7 @@ interface ExecuteArgs {
   retryContext?: RetryContext;
   retryPolicies?: RetryPolicies;
   requestContext: RequestContext;
+  executeRequest: (requestContext: RequestContext) => Promise<Response<any>>;
 }
 
 /**
@@ -41,7 +41,8 @@ interface RetryPolicies {
 export async function execute({
   retryContext = {},
   retryPolicies,
-  requestContext
+  requestContext,
+  executeRequest
 }: ExecuteArgs): Promise<Response<any>> {
   // TODO: any response
   if (!retryPolicies) {
@@ -121,6 +122,7 @@ export async function execute({
       }
       await sleep(retryPolicy.retryAfterInMilliseconds);
       return execute({
+        executeRequest,
         requestContext,
         retryContext,
         retryPolicies


### PR DESCRIPTION
There are 2 circular dependency problems

### RequestHandler -> RetryUtility -> RequestHandler

Problem: `RequestHandler.execute` calls `retryUtitlity.execute` to retry the request if there is an error. However `RetryUtility.execute` calls `RequestHandler.executeRequest` causing the circular dependency

There are a few options to fix this:
a) Move retryUtility.execute to RequestHandler
b) Have pass executeRequest to retryUtility.execute as a parameter
c)  Move executeRequest to retryUtility

I think option **(b)** would be preferable because it would provide flexibility of passing any other request to be retried if needed, without a hard dependency on RequestHandler

@ramya-rao-a , @southpolesteve, @HarshaNalluru  - What do you think? Do you have any other options in mind?

### HeaderUtils -> QueryMetrics -> ClientSideMetrics -> HeaderUtils

Problem: `headerUtils.getInitialHeader` uses `queryMetrics.zero` which also `clientSideMetrics.zero`. Since `clientSideMetrics.add` uses `headerUtils.getRequestChargeIfAny`.

`headerUtils.getRequestChargeIfAny` returns `headers` as is if it is a number

Since `clientSideMetrics.requestCharge` is always a number, we don't really need to call `headerUtils.getRequestChargeIfAny`, we can just use `clientSideMetrics.requestCharge` directly.

Fixes #5255 