### PR TITLE
[core-http] fixes traceparent header generation

### DIFF
--- a/sdk/core/core-http/lib/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/lib/policies/tracingPolicy.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { getTracer, TraceFlags } from "@azure/core-tracing";
+import { getTracer, getTraceParentHeader } from "@azure/core-tracing";
 import {
   RequestPolicyFactory,
   RequestPolicy,
@@ -36,11 +36,9 @@ export class TracingPolicy extends BaseRequestPolicy {
     try {
       // set headers
       const spanContext = span.context();
-      if (spanContext.spanId && spanContext.traceId) {
-        request.headers.set(
-          "traceparent",
-          `${spanContext.traceId}-${spanContext.spanId}-${spanContext.traceFlags || TraceFlags.UNSAMPLED}`
-        );
+      const traceParentHeader = getTraceParentHeader(spanContext);
+      if (traceParentHeader) {
+        request.headers.set("traceparent", traceParentHeader);
         const traceState = spanContext.traceState && spanContext.traceState.serialize();
         // if tracestate is set, traceparent MUST be set, so only set tracestate after traceparent
         if (traceState) {


### PR DESCRIPTION
The changes are smaller than they look...formatting changes are included.

I noticed while working on the event-hubs tracing that the `traceparent` header should start with a version number (always '00' for now), and the traceFlags should always be 2 digits.

Updating the TracingPolicy to use the function in `core-tracing` which handles this correctly.