### PR TITLE
[Storage] Export storage OAuth scopes

### DIFF
--- a/sdk/storage/storage-blob/src/BatchRequest.ts
+++ b/sdk/storage/storage-blob/src/BatchRequest.ts
@@ -25,7 +25,7 @@ import {
   BATCH_MAX_REQUEST,
   HTTP_VERSION_1_1,
   HTTP_LINE_ENDING,
-  DefaultStorageScope
+  StorageOAuthScopes
 } from "./utils/constants";
 import { SharedKeyCredential } from "./credentials/SharedKeyCredential";
 
@@ -360,7 +360,7 @@ class InnerBatchRequest {
     factories[1] = new BatchHeaderFilterPolicyFactory(); // Use batch header filter policy to exclude unnecessary headers
     if (!isAnonymousCreds) {
       factories[2] = isTokenCredential(credential)
-        ? bearerTokenAuthenticationPolicy(credential, DefaultStorageScope)
+        ? bearerTokenAuthenticationPolicy(credential, StorageOAuthScopes)
         : credential;
     }
     factories[policyFactoryLength - 1] = new BatchRequestAssemblePolicyFactory(this); // Use batch assemble policy to assemble request and intercept request from going to wire

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -32,12 +32,13 @@ import { TelemetryOptions, TelemetryPolicyFactory } from "./TelemetryPolicyFacto
 import { UniqueRequestIDPolicyFactory } from "./UniqueRequestIDPolicyFactory";
 import { SharedKeyCredential } from "./credentials/SharedKeyCredential";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
-import { DefaultStorageScope } from "./utils/constants";
+import { StorageOAuthScopes } from "./utils/constants";
 
 // Export following interfaces and types for customers who want to implement their
 // own RequestPolicy or HTTPClient
 export {
   BaseRequestPolicy,
+  StorageOAuthScopes,
   deserializationPolicy,
   IHttpClient,
   IHttpPipelineLogger,
@@ -212,7 +213,7 @@ export function newPipeline(
   }
   factories.push(
     isTokenCredential(credential)
-      ? bearerTokenAuthenticationPolicy(credential, DefaultStorageScope)
+      ? bearerTokenAuthenticationPolicy(credential, StorageOAuthScopes)
       : credential
   );
 

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -9,7 +9,7 @@ export const BLOCK_BLOB_MAX_STAGE_BLOCK_BYTES: number = 100 * 1024 * 1024; // 10
 export const BLOCK_BLOB_MAX_BLOCKS: number = 50000;
 export const DEFAULT_BLOB_DOWNLOAD_BLOCK_BYTES: number = 4 * 1024 * 1024; // 4MB
 export const DEFAULT_MAX_DOWNLOAD_RETRY_REQUESTS: number = 5;
-export const DefaultStorageScope: string = "https://storage.azure.com/.default";
+export const StorageOAuthScopes: string | string[] = "https://storage.azure.com/.default";
 
 export const URLConstants = {
   Parameters: {

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -31,11 +31,13 @@ import { TelemetryOptions, TelemetryPolicyFactory } from "./TelemetryPolicyFacto
 import { UniqueRequestIDPolicyFactory } from "./UniqueRequestIDPolicyFactory";
 import { SharedKeyCredential } from "./credentials/SharedKeyCredential";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
+import { StorageOAuthScopes } from "./utils/constants";
 
 // Export following interfaces and types for customers who want to implement their
 // own RequestPolicy or HTTPClient
 export {
   BaseRequestPolicy,
+  StorageOAuthScopes,
   deserializationPolicy,
   IHttpClient,
   IHttpPipelineLogger,
@@ -213,7 +215,7 @@ export function newPipeline(
   }
   factories.push(
     isTokenCredential(credential)
-      ? bearerTokenAuthenticationPolicy(credential, "https://storage.azure.com/.default")
+      ? bearerTokenAuthenticationPolicy(credential, StorageOAuthScopes)
       : credential
   );
 

--- a/sdk/storage/storage-queue/src/utils/constants.ts
+++ b/sdk/storage/storage-queue/src/utils/constants.ts
@@ -4,6 +4,8 @@
 export const SDK_VERSION: string = "12.0.0-preview.4";
 export const SERVICE_VERSION: string = "2019-02-02";
 
+export const StorageOAuthScopes: string | string[] = "https://storage.azure.com/.default";
+
 export const URLConstants = {
   Parameters: {
     FORCE_BROWSER_NO_CACHE: "_",


### PR DESCRIPTION
so they can be customized for different Azure stacks.

Resolves #5097.