### PR TITLE
[core-http] Fix broken browser bundle due to Rollup config

### DIFF
--- a/sdk/core/core-http/rollup.config.ts
+++ b/sdk/core/core-http/rollup.config.ts
@@ -68,7 +68,7 @@ const browserConfig = {
   },
   plugins: [
     nodeResolve({
-      mainFields: ["module", "main", "browser"]
+      mainFields: ["module", "browser"]
     }),
     commonjs(),
     sourcemaps(),

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "module": "dist-esm/lib/index.js",
   "browser": {
-    "./dist/index.js": "./browser/index.js"
+    "./dist/index.js": "./browser/core-tracing.js"
   },
   "types": "types/core-tracing.d.ts",
   "scripts": {


### PR DESCRIPTION
This change fixes `core-http`'s browser bundle which started picking up Node-specific code after PR #5207.  The issue was actually caused by a combination of `core-tracing`'s `browser` configuration and `core-http`'s Rollup `nodeResolve` configuration, meaning that the wrong file was being pulled from `core-tracing` when `core-http`'s browser bundle was created.

The fix is to correct the `browser` path mapping for `core-tracing` and remove the `main` entrypoint from `core-http`'s `nodeResolve` configuration.