### PR TITLE
Add tracing to storage-queue

### DIFF
--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -79,6 +79,7 @@
     "@azure/abort-controller": "1.0.0-preview.2",
     "@azure/core-http": "1.0.0-preview.3",
     "@azure/core-paging": "1.0.0-preview.2",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/storage/storage-queue/recordings/browsers/queueclient/recording_getproperties_with_tracing.json
+++ b/sdk/storage/storage-queue/recordings/browsers/queueclient/recording_getproperties_with_tracing.json
@@ -1,0 +1,64 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.queue.core.windows.net/queue157014767384409654",
+   "query": {
+    "timeout": "30"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Fri, 04 Oct 2019 00:07:53 GMT",
+    "server": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "a0d100a2-2003-004c-4047-7a683d000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "d610c631-96ad-4ef5-b62a-b553d7b2ae5b",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.queue.core.windows.net/queue157014767384409654",
+   "query": {
+    "comp": "metadata",
+    "timeout": "30"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "date": "Fri, 04 Oct 2019 00:07:53 GMT",
+    "server": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-approximate-messages-count": "0",
+    "x-ms-request-id": "a0d100bb-2003-004c-5547-7a683d000000",
+    "cache-control": "no-cache",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "6bf7fa9a-6dcd-41fd-85ec-09d23a95b56a",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.queue.core.windows.net/queue157014767384409654",
+   "query": {
+    "timeout": "30"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "date": "Fri, 04 Oct 2019 00:07:54 GMT",
+    "server": "Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "a0d100bf-2003-004c-5947-7a683d000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "b8eb715d-9c51-4047-a554-698c8d4d651c",
+    "content-length": "0"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "queue": "queue157014767384409654"
+ }
+}

--- a/sdk/storage/storage-queue/recordings/node/queueclient/recording_getproperties_with_tracing.js
+++ b/sdk/storage/storage-queue/recordings/node/queueclient/recording_getproperties_with_tracing.js
@@ -1,0 +1,62 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"queue":"queue157014675414309143"}
+
+nock('https://fakestorageaccount.queue.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/queue157014675414309143')
+  .query(true)
+  .reply(201, "", [ 'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '6ee885bd-7003-009a-0a45-7a66d4000000',
+  'x-ms-client-request-id',
+  'de40052f-77a6-44fa-8751-4197df50c780',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 23:52:33 GMT' ]);
+
+
+nock('https://fakestorageaccount.queue.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/queue157014675414309143')
+  .query(true)
+  .reply(200, "", [ 'Cache-Control',
+  'no-cache',
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'f348a6dd-2003-0063-3f45-7a65f6000000',
+  'x-ms-client-request-id',
+  '4a5b71ab-bba2-4a6d-b218-fa9bd1d1a0e7',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-approximate-messages-count',
+  '0',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-approximate-messages-count,Cache-Control,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 03 Oct 2019 23:52:34 GMT' ]);
+
+
+nock('https://fakestorageaccount.queue.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/queue157014675414309143')
+  .query(true)
+  .reply(204, "", [ 'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'c37d9fad-c003-007b-4045-7aba91000000',
+  'x-ms-client-request-id',
+  '061f616c-a69d-4a6c-b567-f4cafdbd1276',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Thu, 03 Oct 2019 23:52:34 GMT' ]);
+

--- a/sdk/storage/storage-queue/rollup.base.config.js
+++ b/sdk/storage/storage-queue/rollup.base.config.js
@@ -108,7 +108,7 @@ export function browserConfig(test = false, production = false) {
       }),
       cjs({
         namedExports: {
-          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual"]
+          assert: ["ok", "deepEqual", "equal", "fail", "deepStrictEqual", "strictEqual"]
         }
       })
     ]

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -21,7 +21,8 @@ import {
   TokenCredential,
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
-  ProxySettings
+  ProxySettings,
+  tracingPolicy
 } from "@azure/core-http";
 import { KeepAliveOptions, KeepAlivePolicyFactory } from "./KeepAlivePolicyFactory";
 import { BrowserPolicyFactory } from "./BrowserPolicyFactory";
@@ -194,6 +195,7 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
   const factories: RequestPolicyFactory[] = [
+    tracingPolicy(),
     new KeepAlivePolicyFactory(pipelineOptions.keepAliveOptions),
     new TelemetryPolicyFactory(pipelineOptions.telemetry),
     new UniqueRequestIDPolicyFactory(),

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -21,8 +21,7 @@ import {
   TokenCredential,
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
-  ProxySettings,
-  tracingPolicy
+  ProxySettings
 } from "@azure/core-http";
 import { KeepAliveOptions, KeepAlivePolicyFactory } from "./KeepAlivePolicyFactory";
 import { BrowserPolicyFactory } from "./BrowserPolicyFactory";
@@ -195,7 +194,6 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
   const factories: RequestPolicyFactory[] = [
-    tracingPolicy(),
     new KeepAlivePolicyFactory(pipelineOptions.keepAliveOptions),
     new TelemetryPolicyFactory(pipelineOptions.telemetry),
     new UniqueRequestIDPolicyFactory(),

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -2,18 +2,20 @@
 // Licensed under the MIT License.
 
 import { TokenCredential, isTokenCredential, isNode } from "@azure/core-http";
+import { CanonicalCode } from "@azure/core-tracing";
 import * as Models from "./generated/src/models";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { ListQueuesIncludeType } from "./generated/src/models";
 import { Service } from "./generated/src/operations";
 import { newPipeline, NewPipelineOptions, Pipeline } from "./Pipeline";
-import { StorageClient } from "./StorageClient";
+import { StorageClient, CommonOptions } from "./StorageClient";
 import { QueueClient } from "./QueueClient";
 import "@azure/core-paging";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
 import { appendToURLPath, extractConnectionStringParts } from "./utils/utils.common";
 import { SharedKeyCredential } from "./credentials/SharedKeyCredential";
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
+import { createSpan } from "./utils/tracing";
 
 /**
  * Options to configure Queue Service - Get Properties operation
@@ -21,7 +23,7 @@ import { AnonymousCredential } from "./credentials/AnonymousCredential";
  * @export
  * @interface ServiceGetPropertiesOptions
  */
-export interface ServiceGetPropertiesOptions {
+export interface ServiceGetPropertiesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -38,7 +40,7 @@ export interface ServiceGetPropertiesOptions {
  * @export
  * @interface ServiceSetPropertiesOptions
  */
-export interface ServiceSetPropertiesOptions {
+export interface ServiceSetPropertiesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -55,7 +57,7 @@ export interface ServiceSetPropertiesOptions {
  * @export
  * @interface ServiceGetStatisticsOptions
  */
-export interface ServiceGetStatisticsOptions {
+export interface ServiceGetStatisticsOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -71,7 +73,7 @@ export interface ServiceGetStatisticsOptions {
  *
  * @interface ServiceListQueuesSegmentOptions
  */
-interface ServiceListQueuesSegmentOptions {
+interface ServiceListQueuesSegmentOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -109,7 +111,7 @@ interface ServiceListQueuesSegmentOptions {
  * @export
  * @interface ServiceListQueuesOptions
  */
-export interface ServiceListQueuesOptions {
+export interface ServiceListQueuesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -259,9 +261,24 @@ export class QueueServiceClient extends StorageClient {
   public async getProperties(
     options: ServiceGetPropertiesOptions = {}
   ): Promise<Models.ServiceGetPropertiesResponse> {
-    return this.serviceContext.getProperties({
-      abortSignal: options.abortSignal
-    });
+    const { span, spanOptions } = createSpan(
+      "QueueServiceClient-getProperties",
+      options.spanOptions
+    );
+    try {
+      return this.serviceContext.getProperties({
+        abortSignal: options.abortSignal,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -278,9 +295,24 @@ export class QueueServiceClient extends StorageClient {
     properties: Models.StorageServiceProperties,
     options: ServiceGetPropertiesOptions = {}
   ): Promise<Models.ServiceSetPropertiesResponse> {
-    return this.serviceContext.setProperties(properties, {
-      abortSignal: options.abortSignal
-    });
+    const { span, spanOptions } = createSpan(
+      "QueueServiceClient-setProperties",
+      options.spanOptions
+    );
+    try {
+      return this.serviceContext.setProperties(properties, {
+        abortSignal: options.abortSignal,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -296,9 +328,24 @@ export class QueueServiceClient extends StorageClient {
   public async getStatistics(
     options: ServiceGetStatisticsOptions = {}
   ): Promise<Models.ServiceGetStatisticsResponse> {
-    return this.serviceContext.getStatistics({
-      abortSignal: options.abortSignal
-    });
+    const { span, spanOptions } = createSpan(
+      "QueueServiceClient-getStatistics",
+      options.spanOptions
+    );
+    try {
+      return this.serviceContext.getStatistics({
+        abortSignal: options.abortSignal,
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**
@@ -320,13 +367,28 @@ export class QueueServiceClient extends StorageClient {
     marker?: string,
     options: ServiceListQueuesSegmentOptions = {}
   ): Promise<Models.ServiceListQueuesSegmentResponse> {
-    return this.serviceContext.listQueuesSegment({
-      abortSignal: options.abortSignal,
-      marker: marker,
-      maxresults: options.maxresults,
-      prefix: options.prefix,
-      include: options.include === undefined ? undefined : [options.include]
-    } as Models.ServiceListQueuesSegmentOptionalParams);
+    const { span, spanOptions } = createSpan(
+      "QueueServiceClient-listQueuesSegment",
+      options.spanOptions
+    );
+    try {
+      return this.serviceContext.listQueuesSegment({
+        abortSignal: options.abortSignal,
+        marker: marker,
+        maxresults: options.maxresults,
+        prefix: options.prefix,
+        include: options.include === undefined ? undefined : [options.include],
+        spanOptions
+      });
+    } catch (e) {
+      span.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: e.message
+      });
+      throw e;
+    } finally {
+      span.end();
+    }
   }
 
   /**

--- a/sdk/storage/storage-queue/src/StorageClient.ts
+++ b/sdk/storage/storage-queue/src/StorageClient.ts
@@ -4,6 +4,15 @@
 import { StorageClientContext } from "./generated/src/storageClientContext";
 import { Pipeline } from "./Pipeline";
 import { getAccountNameFromUrl } from "./utils/utils.common";
+import { SpanOptions } from "@azure/core-tracing";
+
+/**
+ * An interface for options common to every remote operation.
+ */
+export interface CommonOptions {
+  spanOptions?: SpanOptions;
+}
+
 /**
  * A StorageClient represents a based client class for QueueServiceClient, QueueClient and etc.
  *

--- a/sdk/storage/storage-queue/src/utils/tracing.ts
+++ b/sdk/storage/storage-queue/src/utils/tracing.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getTracer, Span, SpanOptions, SpanKind } from "@azure/core-tracing";
+
+/**
+ * Creates a span using the global tracer.
+ * @param name The name of the operation being performed.
+ * @param options The options for the underlying http request.
+ */
+export function createSpan(
+  operationName: string,
+  options: SpanOptions = {}
+): { span: Span; spanOptions: SpanOptions } {
+  const tracer = getTracer();
+  const spanOptions: SpanOptions = {
+    ...options,
+    kind: SpanKind.CLIENT
+  };
+
+  const span = tracer.startSpan(`Azure.Storage.Queue.${operationName}`, spanOptions);
+  span.setAttribute("component", "storage");
+
+  let newOptions = options;
+  if (span.isRecordingEvents()) {
+    newOptions = {
+      ...options,
+      parent: span
+    };
+  }
+
+  return {
+    span,
+    spanOptions: newOptions
+  };
+}

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -154,7 +154,7 @@ describe("QueueClient", () => {
     }
   });
 
-  it.only("getProperties with tracing", async () => {
+  it("getProperties with tracing", async () => {
     const tracer = new TestTracer();
     setTracer(tracer);
     const rootSpan = tracer.startSpan("root");


### PR DESCRIPTION
This PR adds a dependency on @azure/core-tracing and makes it possible to pass a parent Span to public facing operations.