### PR TITLE
Fix core-tracing duplication

### DIFF
--- a/sdk/core/core-http/lib/coreHttp.ts
+++ b/sdk/core/core-http/lib/coreHttp.ts
@@ -106,4 +106,3 @@ export { ApiKeyCredentials, ApiKeyCredentialOptions } from "./credentials/apiKey
 export { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 export { TopicCredentials } from "./credentials/topicCredentials";
 export { Authenticator } from "./credentials/credentials";
-export * from "@azure/core-tracing";

--- a/sdk/core/core-http/rollup.config.ts
+++ b/sdk/core/core-http/rollup.config.ts
@@ -31,7 +31,7 @@ const nodeConfig = {
     "tslib",
     "tunnel",
     "uuid/v4",
-    "xml2js",,
+    "xml2js",
     "@azure/core-tracing"
   ],
   output: {

--- a/sdk/core/core-http/rollup.config.ts
+++ b/sdk/core/core-http/rollup.config.ts
@@ -31,7 +31,8 @@ const nodeConfig = {
     "tslib",
     "tunnel",
     "uuid/v4",
-    "xml2js",
+    "xml2js",,
+    "@azure/core-tracing"
   ],
   output: {
     file: "./dist/coreHttp.node.js",

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -2,19 +2,8 @@
 // Licensed under the MIT License.
 
 import { assert } from "chai";
-import {
-  RequestPolicy,
-  WebResource,
-  HttpOperationResponse,
-  HttpHeaders,
-  setTracer,
-  RequestPolicyOptions,
-  TraceFlags,
-  NoOpTracer,
-  SpanOptions,
-  SpanContext,
-  NoOpSpan
-} from "../../lib/coreHttp";
+import { RequestPolicy, WebResource, HttpOperationResponse, HttpHeaders, RequestPolicyOptions } from "../../lib/coreHttp";
+import { setTracer, TraceFlags, NoOpTracer, SpanOptions, SpanContext, NoOpSpan } from "@azure/core-tracing";
 import { tracingPolicy } from "../../lib/policies/tracingPolicy";
 
 class MockSpan extends NoOpSpan {

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -72,6 +72,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-http": "1.0.0-preview.4",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "events": "^3.0.0",
     "jws": "^3.2.2",
     "msal": "^1.0.2",

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -9,10 +9,10 @@ import {
   WebResource,
   RequestPrepareOptions,
   GetTokenOptions,
-  CanonicalCode,
   tracingPolicy,
   RequestPolicyFactory
 } from "@azure/core-http";
+import { CanonicalCode } from "@azure/core-tracing";
 import { AuthenticationError, AuthenticationErrorName } from "./errors";
 import { createSpan } from "../util/tracing";
 

--- a/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
@@ -4,8 +4,9 @@
 import qs from "qs";
 import { createSpan } from "../util/tracing";
 import { AuthenticationErrorName } from "../client/errors";
-import { TokenCredential, GetTokenOptions, AccessToken, CanonicalCode } from "@azure/core-http";
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { IdentityClientOptions, IdentityClient, TokenResponse } from "../client/identityClient";
+import { CanonicalCode } from "@azure/core-tracing";
 
 /**
  * Enables authentication to Azure Active Directory using an authorization code

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AccessToken, TokenCredential, GetTokenOptions, CanonicalCode } from "@azure/core-http";
+import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
 import { AggregateAuthenticationError } from "../client/errors";
 import { createSpan } from "../util/tracing";
+import { CanonicalCode } from "@azure/core-tracing";
 
 /**
  * Enables multiple {@link TokenCredential} implementations to be tried in order

--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
@@ -6,10 +6,11 @@ import jws from "jws";
 import uuid from "uuid";
 import { readFileSync } from "fs";
 import { createHash } from "crypto";
-import { TokenCredential, GetTokenOptions, AccessToken, CanonicalCode } from "@azure/core-http";
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { IdentityClientOptions, IdentityClient } from "../client/identityClient";
 import { createSpan } from "../util/tracing";
 import { AuthenticationErrorName } from "../client/errors";
+import { CanonicalCode } from "@azure/core-tracing";
 
 const SelfSignedJwtLifetimeMins = 10;
 

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import qs from "qs";
-import { TokenCredential, GetTokenOptions, AccessToken, CanonicalCode } from "@azure/core-http";
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { IdentityClientOptions, IdentityClient } from "../client/identityClient";
 import { createSpan } from "../util/tracing";
 import { AuthenticationErrorName } from "../client/errors";
+import { CanonicalCode } from "@azure/core-tracing";
 
 /**
  * Enables authentication to Azure Active Directory using a client secret

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -2,16 +2,11 @@
 // Licensed under the MIT License.
 
 import qs from "qs";
-import {
-  TokenCredential,
-  GetTokenOptions,
-  AccessToken,
-  delay,
-  CanonicalCode
-} from "@azure/core-http";
+import { TokenCredential, GetTokenOptions, AccessToken, delay } from "@azure/core-http";
 import { IdentityClientOptions, IdentityClient, TokenResponse } from "../client/identityClient";
 import { AuthenticationError, AuthenticationErrorName } from "../client/errors";
 import { createSpan } from "../util/tracing";
+import { CanonicalCode } from "@azure/core-tracing";
 
 /**
  * An internal interface that contains the verbatim devicecode response.

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AccessToken, TokenCredential, GetTokenOptions, CanonicalCode } from "@azure/core-http";
+import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
 import { IdentityClientOptions } from "../client/identityClient";
 import { ClientSecretCredential } from "./clientSecretCredential";
 import { createSpan } from "../util/tracing";
 import { AuthenticationErrorName } from "../client/errors";
+import { CanonicalCode } from "@azure/core-tracing";
 
 /**
  * Enables authentication to Azure Active Directory using client secret

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 
 import * as msal from "msal";
-import { AccessToken, TokenCredential, GetTokenOptions, CanonicalCode } from "@azure/core-http";
+import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
 import { IdentityClient } from "../client/identityClient";
 import {
   BrowserLoginStyle,
   InteractiveBrowserCredentialOptions
 } from "./interactiveBrowserCredentialOptions";
 import { createSpan } from "../util/tracing";
+import { CanonicalCode } from "@azure/core-tracing";
 
 /**
  * Enables authentication to Azure Active Directory inside of the web browser

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -7,12 +7,12 @@ import {
   GetTokenOptions,
   RequestPrepareOptions,
   RestError,
-  TokenCredential,
-  CanonicalCode
+  TokenCredential
 } from "@azure/core-http";
 import { IdentityClientOptions, IdentityClient } from "../client/identityClient";
 import { createSpan } from "../util/tracing";
 import { AuthenticationErrorName } from "../client/errors";
+import { CanonicalCode } from "@azure/core-tracing";
 
 const DefaultScopeSuffix = "/.default";
 export const ImdsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 import qs from "qs";
-import { TokenCredential, GetTokenOptions, AccessToken, CanonicalCode } from "@azure/core-http";
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 import { IdentityClientOptions, IdentityClient } from "../client/identityClient";
 import { createSpan } from "../util/tracing";
 import { AuthenticationErrorName } from "../client/errors";
+import { CanonicalCode } from "@azure/core-tracing";
 
 /**
  * Enables authentication to Azure Active Directory with a user's

--- a/sdk/identity/identity/src/util/tracing.ts
+++ b/sdk/identity/identity/src/util/tracing.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getTracer, Span, GetTokenOptions, SpanOptions, SpanKind } from "@azure/core-http";
+import { GetTokenOptions } from "@azure/core-http";
+import { getTracer, Span, SpanOptions, SpanKind } from "@azure/core-tracing";
 
 /**
  * Creates a span using the global tracer.

--- a/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
@@ -3,7 +3,7 @@
 
 import assert from "assert";
 import { AuthorizationCodeCredential } from "../../src";
-import { TestTracer, setTracer, SpanGraph } from "@azure/core-http";
+import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 import { MockAuthHttpClient, assertClientCredentials } from "../authTestUtils";
 
 describe("AuthorizationCodeCredential", function() {

--- a/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
@@ -7,7 +7,7 @@ import path from "path";
 import assert from "assert";
 import { ClientCertificateCredential } from "../../src";
 import { MockAuthHttpClient } from "../authTestUtils";
-import { setTracer, TestTracer, SpanGraph } from "@azure/core-http";
+import { setTracer, TestTracer, SpanGraph } from "@azure/core-tracing";
 
 describe("ClientCertificateCredential", function() {
   it("loads a PEM-formatted certificate from a file", () => {

--- a/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 import assert from "assert";
-import { delay, TestTracer, setTracer, SpanGraph } from "@azure/core-http";
+import { delay } from "@azure/core-http";
+import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 import { AbortController } from "@azure/abort-controller";
 import { MockAuthHttpClient, assertRejects } from "../authTestUtils";
 import { AuthenticationError, ErrorResponse } from "../../src/client/errors";

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -4,7 +4,7 @@
 import assert from "assert";
 import { EnvironmentCredential } from "../../src";
 import { MockAuthHttpClient, assertClientCredentials } from "../authTestUtils";
-import { TestTracer, setTracer, SpanGraph } from "@azure/core-http";
+import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 
 describe("EnvironmentCredential", function() {
   it("finds and uses client credential environment variables", async () => {

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -71,6 +71,7 @@
     "@azure/core-arm": "1.0.0-preview.4",
     "@azure/core-http": "1.0.0-preview.4",
     "@azure/core-paging": "1.0.0-preview.3",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -15,10 +15,13 @@ import {
   isNode,
   userAgentPolicy,
   RequestOptionsBase,
-  tracingPolicy,
+  tracingPolicy
+} from "@azure/core-http";
+
+import {
   getTracer,
   Span
-} from "@azure/core-http";
+} from "@azure/core-tracing";
 
 import {
   Certificate,

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -73,6 +73,7 @@
     "@azure/core-http": "1.0.0-preview.4",
     "@azure/core-paging": "1.0.0-preview.3",
     "@azure/identity": "1.0.0-preview.4",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -19,10 +19,10 @@ import {
   isNode,
   userAgentPolicy,
   RequestOptionsBase,
-  tracingPolicy,
-  getTracer,
-  Span
+  tracingPolicy
 } from "@azure/core-http";
+
+import { getTracer, Span } from "@azure/core-tracing";
 
 import "@azure/core-paging";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -74,6 +74,7 @@
     "@azure/core-http": "1.0.0-preview.4",
     "@azure/core-paging": "1.0.0-preview.3",
     "@azure/identity": "1.0.0-preview.4",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -19,10 +19,10 @@ import {
   getDefaultProxySettings,
   isNode,
   userAgentPolicy,
-  tracingPolicy,
-  getTracer,
-  Span
+  tracingPolicy
 } from "@azure/core-http";
+
+import { getTracer, Span } from "@azure/core-tracing";
 
 import "@azure/core-paging";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
@@ -77,11 +77,7 @@ export {
   UpdateSecretOptions
 };
 
-export {
-  ProxyOptions,
-  RetryOptions,
-  TelemetryOptions
-};
+export { ProxyOptions, RetryOptions, TelemetryOptions };
 
 /**
  * The client to interact with the KeyVault secrets functionality


### PR DESCRIPTION
Currently we have an issue where core-http is re-exporting a private copy of core-tracing for node, which causes spans to not get created on the proper tracer.

This PR fixes this issue by correctly configuring rollup, which eliminates the need to re-export core-tracing types. The other changes in this PR are having other packages now correctly depend on core-tracing instead of consuming it via core-http.