### PR TITLE
[core-http] undo change to pass keepAlive to clone()

### DIFF
--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -360,8 +360,7 @@ export class WebResource {
       this.timeout,
       this.onUploadProgress,
       this.onDownloadProgress,
-      this.proxySettings,
-      this.keepAlive
+      this.proxySettings
     );
 
     if (this.formData) {


### PR DESCRIPTION
PR #5047 fixed the issue where `proxySettings` and `keepAlive` are not passed to
the clone. However, this change surfaced a new issue where we always create new
agents (proxy agent or keepAlive agent) when sending requests. In the keepAlive
case it leads to increased memory usage since GC cannot recycle agents until
timeout expires.

This is a temporary workaround for the memory leak issue. We need a proper
design to fix the root issue.