### PR TITLE
[Event Hubs] use core logging

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -66,6 +66,7 @@
     "@azure/core-amqp": "1.0.0-preview.4",
     "@azure/core-asynciterator-polyfill": "1.0.0-preview.1",
     "@azure/core-tracing": "1.0.0-preview.3",
+    "@azure/logger": "1.0.0-preview.1",
     "async-lock": "^1.1.3",
     "buffer": "^5.2.1",
     "debug": "^4.1.1",

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -221,6 +221,9 @@ export interface LastEnqueuedEventInfo {
     sequenceNumber?: number;
 }
 
+// @public
+export const log: import("@azure/logger").AzureLogger;
+
 export { MessagingError }
 
 // @public

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 import * as os from "os";
 import { packageJsonInfo } from "./util/constants";
 import { EventHubReceiver } from "./eventHubReceiver";
@@ -122,7 +122,7 @@ export namespace ConnectionContext {
     // "connection_open" and "connection_error" events.
     const onConnectionOpen: OnAmqpEvent = (context: EventContext) => {
       connectionContext.wasConnectionCloseCalled = false;
-      log.context(
+      log.info(
         "[%s] setting 'wasConnectionCloseCalled' property of connection context to %s.",
         connectionContext.connection.id,
         connectionContext.wasConnectionCloseCalled
@@ -133,7 +133,7 @@ export namespace ConnectionContext {
       const connectionError =
         context.connection && context.connection.error ? context.connection.error : undefined;
       if (connectionError) {
-        log.error(
+        log.warning(
           "[%s] Error (context.connection.error) occurred on the amqp connection: %O",
           connectionContext.connection.id,
           connectionError
@@ -141,7 +141,7 @@ export namespace ConnectionContext {
       }
       const contextError = context.error;
       if (contextError) {
-        log.error(
+        log.warning(
           "[%s] Error (context.error) occurred on the amqp connection: %O",
           connectionContext.connection.id,
           contextError
@@ -168,9 +168,9 @@ export namespace ConnectionContext {
 
       // The connection should always be brought back up if the sdk did not call connection.close()
       // and there was atleast one sender/receiver link on the connection before it went down.
-      log.error("[%s] state: %O", connectionContext.connection.id, state);
+      log.verbose("[%s] state: %O", connectionContext.connection.id, state);
       if (!state.wasConnectionCloseCalled && (state.numSenders || state.numReceivers)) {
-        log.error(
+        log.verbose(
           "[%s] connection.close() was not called from the sdk and there were some " +
             "sender or receiver links or both. We should reconnect.",
           connectionContext.connection.id
@@ -180,23 +180,24 @@ export namespace ConnectionContext {
         for (const senderName of Object.keys(connectionContext.senders)) {
           const sender = connectionContext.senders[senderName];
           if (!sender.isConnecting) {
-            log.error(
+            log.info(
               "[%s] calling detached on sender '%s' with address '%s'.",
               connectionContext.connection.id,
               sender.name,
               sender.address
             );
             sender.onDetached(connectionError || contextError).catch((err) => {
-              log.error(
+              log.warning(
                 "[%s] An error occurred while reconnecting the sender '%s' with adress '%s' %O.",
                 connectionContext.connection.id,
                 sender.name,
                 sender.address,
                 err
               );
+              logErrorStackTrace(err);
             });
           } else {
-            log.error(
+            log.verbose(
               "[%s] sender '%s' with address '%s' is already reconnecting. Hence not " +
                 "calling detached on the sender.",
               connectionContext.connection.id,
@@ -209,23 +210,24 @@ export namespace ConnectionContext {
         for (const receiverName of Object.keys(connectionContext.receivers)) {
           const receiver = connectionContext.receivers[receiverName];
           if (!receiver.isConnecting) {
-            log.error(
+            log.info(
               "[%s] calling detached on receiver '%s' with address '%s'.",
               connectionContext.connection.id,
               receiver.name,
               receiver.address
             );
             receiver.onDetached(connectionError || contextError).catch((err) => {
-              log.error(
+              log.warning(
                 "[%s] An error occurred while reconnecting the receiver '%s' with adress '%s' %O.",
                 connectionContext.connection.id,
                 receiver.name,
                 receiver.address,
                 err
               );
+              logErrorStackTrace(err);
             });
           } else {
-            log.error(
+            log.verbose(
               "[%s] receiver '%s' with address '%s' is already reconnecting. Hence not " +
                 "calling detached on the receiver.",
               connectionContext.connection.id,
@@ -239,14 +241,14 @@ export namespace ConnectionContext {
 
     const protocolError: OnAmqpEvent = async (context: EventContext) => {
       if (context.connection && context.connection.error) {
-        log.error(
+        log.warning(
           "[%s] Error (context.connection.error) occurred on the amqp connection: %O",
           connectionContext.connection.id,
           context.connection && context.connection.error
         );
       }
       if (context.error) {
-        log.error(
+        log.warning(
           "[%s] Error (context.error) occurred on the amqp connection: %O",
           connectionContext.connection.id,
           context.error
@@ -256,18 +258,19 @@ export namespace ConnectionContext {
 
     const error: OnAmqpEvent = async (context: EventContext) => {
       if (context.connection && context.connection.error) {
-        log.error(
+        log.warning(
           "[%s] Error (context.connection.error) occurred on the amqp connection: %O",
           connectionContext.connection.id,
           context.connection && context.connection.error
         );
       }
       if (context.error) {
-        log.error(
+        log.warning(
           "[%s] Error (context.error) occurred on the amqp connection: %O",
           connectionContext.connection.id,
           context.error
         );
+        logErrorStackTrace(context.error);
       }
     };
 
@@ -277,7 +280,7 @@ export namespace ConnectionContext {
     connectionContext.connection.on(ConnectionEvents.protocolError, protocolError);
     connectionContext.connection.on(ConnectionEvents.error, error);
 
-    log.context("[%s] Created connection context successfully.", connectionContext.connectionId);
+    log.info("[%s] Created connection context successfully.", connectionContext.connectionId);
     return connectionContext;
   }
 }

--- a/sdk/eventhub/event-hubs/src/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 import { WebSocketImpl } from "rhea-promise";
 import {
   DataTransformer,
@@ -511,13 +511,14 @@ export class EventHubClient {
         await this._context.managementSession!.close();
         await this._context.connection.close();
         this._context.wasConnectionCloseCalled = true;
-        log.client("Closed the amqp connection '%s' on the client.", this._context.connectionId);
+        log.info("Closed the amqp connection '%s' on the client.", this._context.connectionId);
       }
     } catch (err) {
       err = err instanceof Error ? err : JSON.stringify(err);
-      log.error(
+      log.warning(
         `An error occurred while closing the connection "${this._context.connectionId}":\n${err}`
       );
+      logErrorStackTrace(err);
       throw err;
     }
   }
@@ -622,7 +623,8 @@ export class EventHubClient {
         code: CanonicalCode.UNKNOWN,
         message: err.message
       });
-      log.error("An error occurred while getting the hub runtime information: %O", err);
+      log.warning("An error occurred while getting the hub runtime information: %O", err);
+      logErrorStackTrace(err);
       throw err;
     } finally {
       clientSpan.end();
@@ -651,7 +653,8 @@ export class EventHubClient {
         code: CanonicalCode.UNKNOWN,
         message: err.message
       });
-      log.error("An error occurred while getting the partition ids: %O", err);
+      log.warning("An error occurred while getting the partition ids: %O", err);
+      logErrorStackTrace(err);
       throw err;
     } finally {
       clientSpan.end();
@@ -686,7 +689,8 @@ export class EventHubClient {
         code: CanonicalCode.UNKNOWN,
         message: err.message
       });
-      log.error("An error occurred while getting the partition information: %O", err);
+      log.warning("An error occurred while getting the partition information: %O", err);
+      logErrorStackTrace(err);
       throw err;
     } finally {
       clientSpan.end();

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import uuid from "uuid/v4";
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 import {
   Receiver,
   OnAmqpEvent,
@@ -233,7 +233,7 @@ export class EventHubReceiver extends LinkEntity {
       this.runtimeInfo.enqueuedTime = data.lastEnqueuedTime;
       this.runtimeInfo.offset = data.lastEnqueuedOffset;
       this.runtimeInfo.retrievalTime = data.retrievalTime;
-      log.receiver(
+      log.info(
         "[%s] RuntimeInfo of Receiver '%s' is %O",
         this._context.connectionId,
         this.name,
@@ -266,9 +266,9 @@ export class EventHubReceiver extends LinkEntity {
     }
 
     if (rheaReceiver.isItselfClosed()) {
-      log.error(
+      log.verbose(
         "[%s] The receiver was closed by the user." +
-        "Hence not notifying the user's error handler.",
+          "Hence not notifying the user's error handler.",
         this._context.connectionId
       );
       return;
@@ -276,15 +276,16 @@ export class EventHubReceiver extends LinkEntity {
 
     if (this._onError) {
       const error = translate(amqpError);
-      log.error(
+      log.warning(
         "[%s] An error occurred for Receiver '%s': %O.",
         this._context.connectionId,
         this.name,
         error
       );
-      log.error(
+      logErrorStackTrace(error);
+      log.verbose(
         "[%s] Since the user did not close the receiver " +
-        "we let the user know about it by calling the user's error handler.",
+          "we let the user know about it by calling the user's error handler.",
         this._context.connectionId
       );
       this._onError(error);
@@ -303,9 +304,9 @@ export class EventHubReceiver extends LinkEntity {
     }
 
     if (rheaReceiver.isSessionItselfClosed()) {
-      log.error(
+      log.verbose(
         "[%s] The receiver was closed by the user." +
-        "Hence not notifying the user's error handler.",
+          "Hence not notifying the user's error handler.",
         this._context.connectionId
       );
       return;
@@ -313,16 +314,17 @@ export class EventHubReceiver extends LinkEntity {
 
     if (this._onError) {
       const error = translate(sessionError);
-      log.error(
+      log.warning(
         "[%s] An error occurred on the session for Receiver '%s': %O.",
         this._context.connectionId,
         this.name,
         error
       );
+      logErrorStackTrace(error);
 
-      log.error(
+      log.verbose(
         "[%s] Since the user did not close the receiver, " +
-        "we let the user know about it by calling the user's error handler.",
+          "we let the user know about it by calling the user's error handler.",
         this._context.connectionId
       );
       this._onError(error);
@@ -332,10 +334,10 @@ export class EventHubReceiver extends LinkEntity {
   private async _onAmqpClose(context: EventContext): Promise<void> {
     const rheaReceiver = this._receiver || context.receiver;
     if (!rheaReceiver || rheaReceiver.isItselfClosed()) {
-      log.error(
+      log.verbose(
         "[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
-        "because the sdk initiated it. Hence not calling detached from the _onAmqpClose" +
-        "() handler.",
+          "because the sdk initiated it. Hence not calling detached from the _onAmqpClose" +
+          "() handler.",
         this._context.connectionId,
         this.name,
         this.address
@@ -345,9 +347,9 @@ export class EventHubReceiver extends LinkEntity {
 
     const amqpError = rheaReceiver.error;
     if (amqpError) {
-      log.error(
+      log.warning(
         "[%s] 'receiver_close' event occurred for receiver '%s' with address '%s'. " +
-        "The associated error is: %O",
+          "The associated error is: %O",
         this._context.connectionId,
         this.name,
         this.address,
@@ -356,20 +358,20 @@ export class EventHubReceiver extends LinkEntity {
     }
 
     if (!this.isConnecting) {
-      log.error(
+      log.info(
         "[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
-        "and the sdk did not initiate this. The receiver is not reconnecting. Hence, calling " +
-        "detached from the _onAmqpClose() handler.",
+          "and the sdk did not initiate this. The receiver is not reconnecting. Hence, calling " +
+          "detached from the _onAmqpClose() handler.",
         this._context.connectionId,
         this.name,
         this.address
       );
       await this.onDetached(amqpError);
     } else {
-      log.error(
+      log.info(
         "[%s] 'receiver_close' event occurred on the receiver '%s' with address '%s' " +
-        "and the sdk did not initate this. Moreover the receiver is already re-connecting. " +
-        "Hence not calling detached from the _onAmqpClose() handler.",
+          "and the sdk did not initate this. Moreover the receiver is already re-connecting. " +
+          "Hence not calling detached from the _onAmqpClose() handler.",
         this._context.connectionId,
         this.name,
         this.address
@@ -380,10 +382,10 @@ export class EventHubReceiver extends LinkEntity {
   private async _onAmqpSessionClose(context: EventContext): Promise<void> {
     const rheaReceiver = this._receiver || context.receiver;
     if (!rheaReceiver || rheaReceiver.isSessionItselfClosed()) {
-      log.error(
+      log.verbose(
         "[%s] 'session_close' event occurred on the session of receiver '%s' with " +
-        "address '%s' and the sdk did not initiate this. Moreover the receiver is already " +
-        "re-connecting. Hence not calling detached from the _onAmqpSessionClose() handler.",
+          "address '%s' and the sdk did not initiate this. Moreover the receiver is already " +
+          "re-connecting. Hence not calling detached from the _onAmqpSessionClose() handler.",
         this._context.connectionId,
         this.name,
         this.address
@@ -393,9 +395,9 @@ export class EventHubReceiver extends LinkEntity {
 
     const sessionError = context.session && context.session.error;
     if (sessionError) {
-      log.error(
+      log.warning(
         "[%s] 'session_close' event occurred for receiver '%s' with address '%s'. " +
-        "The associated error is: %O",
+          "The associated error is: %O",
         this._context.connectionId,
         this.name,
         this.address,
@@ -404,20 +406,20 @@ export class EventHubReceiver extends LinkEntity {
     }
 
     if (!this.isConnecting) {
-      log.error(
+      log.info(
         "[%s] 'session_close' event occurred on the session of receiver '%s' with " +
-        "address '%s' and the sdk did not initiate this. Hence calling detached from the " +
-        "_onAmqpSessionClose() handler.",
+          "address '%s' and the sdk did not initiate this. Hence calling detached from the " +
+          "_onAmqpSessionClose() handler.",
         this._context.connectionId,
         this.name,
         this.address
       );
       await this.onDetached(sessionError);
     } else {
-      log.error(
+      log.info(
         "[%s] 'session_close' event occurred on the session of receiver '%s' with " +
-        "address '%s' and the sdk did not initiate this. Moreover the receiver is already " +
-        "re-connecting. Hence not calling detached from the _onAmqpSessionClose() handler.",
+          "address '%s' and the sdk did not initiate this. Moreover the receiver is already " +
+          "re-connecting. Hence not calling detached from the _onAmqpSessionClose() handler.",
         this._context.connectionId,
         this.name,
         this.address
@@ -429,7 +431,7 @@ export class EventHubReceiver extends LinkEntity {
     const desc: string =
       `[${this._context.connectionId}] The receive operation on the Receiver "${this.name}" with ` +
       `address "${this.address}" has been cancelled by the user.`;
-    log.error(desc);
+    log.info(desc);
     if (this._onError) {
       const error = new AbortError("The receive operation has been cancelled by the user.");
       this._onError(error);
@@ -458,19 +460,19 @@ export class EventHubReceiver extends LinkEntity {
         const translatedError = translate(receiverError);
         if (translatedError.retryable) {
           shouldReopen = true;
-          log.error(
+          log.verbose(
             "[%s] close() method of Receiver '%s' with address '%s' was not called. There " +
-            "was an accompanying error and it is retryable. This is a candidate for re-establishing " +
-            "the receiver link.",
+              "was an accompanying error and it is retryable. This is a candidate for re-establishing " +
+              "the receiver link.",
             this._context.connectionId,
             this.name,
             this.address
           );
         } else {
-          log.error(
+          log.warning(
             "[%s] close() method of Receiver '%s' with address '%s' was not called. There " +
-            "was an accompanying error and it is NOT retryable. Hence NOT re-establishing " +
-            "the receiver link.",
+              "was an accompanying error and it is NOT retryable. Hence NOT re-establishing " +
+              "the receiver link.",
             this._context.connectionId,
             this.name,
             this.address
@@ -479,10 +481,10 @@ export class EventHubReceiver extends LinkEntity {
       } else if (!wasCloseInitiated) {
         // there wasn't an error, and the client didn't initialize the close; recreate the link
         shouldReopen = true;
-        log.error(
+        log.verbose(
           "[%s] close() method of Receiver '%s' with address '%s' was not called. " +
-          "There was no accompanying error as well. This is a candidate for re-establishing " +
-          "the receiver link.",
+            "There was no accompanying error as well. This is a candidate for re-establishing " +
+            "the receiver link.",
           this._context.connectionId,
           this.name,
           this.address
@@ -493,7 +495,7 @@ export class EventHubReceiver extends LinkEntity {
           receiverError: receiverError,
           _receiver: this._receiver
         };
-        log.error(
+        log.warning(
           "[%s] Something went wrong. State of Receiver '%s' with address '%s' is: %O",
           this._context.connectionId,
           this.name,
@@ -541,14 +543,15 @@ export class EventHubReceiver extends LinkEntity {
         this._addCredit(Constants.defaultPrefetchCount);
       }
     } catch (err) {
-      log.error(
+      log.warning(
         "[%s] An error occurred while processing onDetached() of Receiver '%s' with address " +
-        "'%s': %O",
+          "'%s': %O",
         this._context.connectionId,
         this.name,
         this.address,
         err
       );
+      logErrorStackTrace(err);
     }
   }
 
@@ -593,7 +596,7 @@ export class EventHubReceiver extends LinkEntity {
    */
   isOpen(): boolean {
     const result = Boolean(this._receiver && this._receiver.isOpen());
-    log.error(
+    log.info(
       "[%s] Receiver '%s' with address '%s' is open? -> %s",
       this._context.connectionId,
       this.name,
@@ -646,7 +649,7 @@ export class EventHubReceiver extends LinkEntity {
             return this._onError === onError && onError(err);
           }
         } else {
-          log.receiver(
+          log.verbose(
             "[%s] Receiver link already present, hence reusing it.",
             this._context.connectionId
           );
@@ -677,7 +680,7 @@ export class EventHubReceiver extends LinkEntity {
   private _deleteFromCache(): void {
     this._receiver = undefined;
     delete this._context.receivers[this.name];
-    log.error(
+    log.info(
       "[%s] Deleted the receiver '%s' from the client cache.",
       this._context.connectionId,
       this.name
@@ -727,9 +730,9 @@ export class EventHubReceiver extends LinkEntity {
   async initialize(options?: RheaReceiverOptions): Promise<void> {
     try {
       if (!this.isOpen() && !this.isConnecting) {
-        log.error(
+        log.info(
           "[%s] The receiver '%s' with address '%s' is not open and is not currently " +
-          "establishing itself. Hence let's try to connect.",
+            "establishing itself. Hence let's try to connect.",
           this._context.connectionId,
           this.name,
           this.address
@@ -751,7 +754,7 @@ export class EventHubReceiver extends LinkEntity {
           options = this._createReceiverOptions(receiverOptions);
         }
 
-        log.error(
+        log.info(
           "[%s] Trying to create receiver '%s' with options %O",
           this._context.connectionId,
           this.name,
@@ -759,17 +762,17 @@ export class EventHubReceiver extends LinkEntity {
         );
         this._receiver = await this._context.connection.createReceiver(options);
         this.isConnecting = false;
-        log.error(
+        log.info(
           "[%s] Receiver '%s' with address '%s' has established itself.",
           this._context.connectionId,
           this.name,
           this.address
         );
-        log.receiver(
+        log.info(
           "Promise to create the receiver resolved. Created receiver with name: ",
           this.name
         );
-        log.receiver(
+        log.info(
           "[%s] Receiver '%s' created with receiver options: %O",
           this._context.connectionId,
           this.name,
@@ -780,9 +783,9 @@ export class EventHubReceiver extends LinkEntity {
 
         await this._ensureTokenRenewal();
       } else {
-        log.error(
+        log.info(
           "[%s] The receiver '%s' with address '%s' is open -> %s and is connecting " +
-          "-> %s. Hence not reconnecting.",
+            "-> %s. Hence not reconnecting.",
           this._context.connectionId,
           this.name,
           this.address,
@@ -793,12 +796,13 @@ export class EventHubReceiver extends LinkEntity {
     } catch (err) {
       this.isConnecting = false;
       const error = translate(err);
-      log.error(
+      log.warning(
         "[%s] An error occured while creating the receiver '%s': %O",
         this._context.connectionId,
         this.name,
         error
       );
+      logErrorStackTrace(error);
       throw error;
     }
   }

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import uuid from "uuid/v4";
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 import {
   AwaitableSender,
   EventContext,
@@ -92,7 +92,7 @@ export class EventHubSender extends LinkEntity {
       const senderError = context.sender && context.sender.error;
       if (senderError) {
         const err = translate(senderError);
-        log.error(
+        log.verbose(
           "[%s] An error occurred for sender '%s': %O.",
           this._context.connectionId,
           this.name,
@@ -105,7 +105,7 @@ export class EventHubSender extends LinkEntity {
       const sessionError = context.session && context.session.error;
       if (sessionError) {
         const err = translate(sessionError);
-        log.error(
+        log.verbose(
           "[%s] An error occurred on the session of sender '%s': %O.",
           this._context.connectionId,
           this.name,
@@ -118,7 +118,7 @@ export class EventHubSender extends LinkEntity {
       const sender = this._sender || context.sender!;
       const senderError = context.sender && context.sender.error;
       if (senderError) {
-        log.error(
+        log.verbose(
           "[%s] 'sender_close' event occurred for sender '%s' with address '%s'. " +
             "The associated error is: %O",
           this._context.connectionId,
@@ -129,7 +129,7 @@ export class EventHubSender extends LinkEntity {
       }
       if (sender && !sender.isItselfClosed()) {
         if (!this.isConnecting) {
-          log.error(
+          log.verbose(
             "[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
               "and the sdk did not initiate this. The sender is not reconnecting. Hence, calling " +
               "detached from the _onAmqpClose() handler.",
@@ -139,7 +139,7 @@ export class EventHubSender extends LinkEntity {
           );
           await this.onDetached(senderError);
         } else {
-          log.error(
+          log.verbose(
             "[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
               "and the sdk did not initate this. Moreover the sender is already re-connecting. " +
               "Hence not calling detached from the _onAmqpClose() handler.",
@@ -149,7 +149,7 @@ export class EventHubSender extends LinkEntity {
           );
         }
       } else {
-        log.error(
+        log.verbose(
           "[%s] 'sender_close' event occurred on the sender '%s' with address '%s' " +
             "because the sdk initiated it. Hence not calling detached from the _onAmqpClose" +
             "() handler.",
@@ -164,7 +164,7 @@ export class EventHubSender extends LinkEntity {
       const sender = this._sender || context.sender!;
       const sessionError = context.session && context.session.error;
       if (sessionError) {
-        log.error(
+        log.verbose(
           "[%s] 'session_close' event occurred for sender '%s' with address '%s'. " +
             "The associated error is: %O",
           this._context.connectionId,
@@ -175,7 +175,7 @@ export class EventHubSender extends LinkEntity {
       }
       if (sender && !sender.isSessionItselfClosed()) {
         if (!this.isConnecting) {
-          log.error(
+          log.verbose(
             "[%s] 'session_close' event occurred on the session of sender '%s' with " +
               "address '%s' and the sdk did not initiate this. Hence calling detached from the " +
               "_onSessionClose() handler.",
@@ -185,7 +185,7 @@ export class EventHubSender extends LinkEntity {
           );
           await this.onDetached(sessionError);
         } else {
-          log.error(
+          log.verbose(
             "[%s] 'session_close' event occurred on the session of sender '%s' with " +
               "address '%s' and the sdk did not initiate this. Moreover the sender is already " +
               "re-connecting. Hence not calling detached from the _onSessionClose() handler.",
@@ -195,7 +195,7 @@ export class EventHubSender extends LinkEntity {
           );
         }
       } else {
-        log.error(
+        log.verbose(
           "[%s] 'session_close' event occurred on the session of sender '%s' with address " +
             "'%s' because the sdk initiated it. Hence not calling detached from the _onSessionClose" +
             "() handler.",
@@ -225,7 +225,7 @@ export class EventHubSender extends LinkEntity {
         const translatedError = translate(senderError);
         if (translatedError.retryable) {
           shouldReopen = true;
-          log.error(
+          log.verbose(
             "[%s] close() method of Sender '%s' with address '%s' was not called. There " +
               "was an accompanying error an it is retryable. This is a candidate for re-establishing " +
               "the sender link.",
@@ -234,7 +234,7 @@ export class EventHubSender extends LinkEntity {
             this.address
           );
         } else {
-          log.error(
+          log.warning(
             "[%s] close() method of Sender '%s' with address '%s' was not called. There " +
               "was an accompanying error and it is NOT retryable. Hence NOT re-establishing " +
               "the sender link.",
@@ -242,10 +242,11 @@ export class EventHubSender extends LinkEntity {
             this.name,
             this.address
           );
+          logErrorStackTrace(translatedError);
         }
       } else if (!wasCloseInitiated) {
         shouldReopen = true;
-        log.error(
+        log.verbose(
           "[%s] close() method of Sender '%s' with address '%s' was not called. There " +
             "was no accompanying error as well. This is a candidate for re-establishing " +
             "the sender link.",
@@ -259,7 +260,7 @@ export class EventHubSender extends LinkEntity {
           senderError: senderError,
           _sender: this._sender
         };
-        log.error(
+        log.verbose(
           "[%s] Something went wrong. State of sender '%s' with address '%s' is: %O",
           this._context.connectionId,
           this.name,
@@ -289,7 +290,7 @@ export class EventHubSender extends LinkEntity {
         });
       }
     } catch (err) {
-      log.error(
+      log.verbose(
         "[%s] An error occurred while processing onDetached() of Sender '%s' with address " +
           "'%s': %O",
         this._context.connectionId,
@@ -307,7 +308,7 @@ export class EventHubSender extends LinkEntity {
    */
   async close(): Promise<void> {
     if (this._sender) {
-      log.sender(
+      log.info(
         "[%s] Closing the Sender for the entity '%s'.",
         this._context.connectionId,
         this._context.config.entityPath
@@ -325,7 +326,7 @@ export class EventHubSender extends LinkEntity {
    */
   isOpen(): boolean {
     const result: boolean = this._sender! && this._sender!.isOpen();
-    log.error(
+    log.info(
       "[%s] Sender '%s' with address '%s' is open? -> %s",
       this._context.connectionId,
       this.name,
@@ -355,7 +356,7 @@ export class EventHubSender extends LinkEntity {
     return new Promise<number>(async (resolve, reject) => {
       const rejectOnAbort = () => {
         const desc: string = `[${this._context.connectionId}] The create batch operation has been cancelled by the user.`;
-        log.error(desc);
+        log.info(desc);
         const error = new AbortError(`The create batch operation has been cancelled by the user.`);
         reject(error);
       };
@@ -376,7 +377,7 @@ export class EventHubSender extends LinkEntity {
         abortSignal.addEventListener("abort", onAbort);
       }
       try {
-        log.sender(
+        log.info(
           "Acquiring lock %s for initializing the session, sender and " +
             "possibly the connection.",
           this.senderLock
@@ -395,12 +396,13 @@ export class EventHubSender extends LinkEntity {
         });
         resolve(this._sender!.maxMessageSize);
       } catch (err) {
-        log.error(
+        log.warning(
           "[%s] An error occurred while creating the sender %s",
           this._context.connectionId,
           this.name,
           err
         );
+        logErrorStackTrace(err);
         reject(err);
       } finally {
         if (abortSignal) {
@@ -433,11 +435,12 @@ export class EventHubSender extends LinkEntity {
         const error = new Error(
           "Partition key is not supported when using producers that were created using a partition id."
         );
-        log.error(
+        log.warning(
           "[%s] Partition key is not supported when using producers that were created using a partition id. %O",
           this._context.connectionId,
           error
         );
+        log.verbose(error.stack);
         throw error;
       }
 
@@ -446,15 +449,16 @@ export class EventHubSender extends LinkEntity {
         const error = new Error(
           "Partition key is not supported when sending a batch message. Pass the partition key when creating the batch message instead."
         );
-        log.error(
+        log.warning(
           "[%s] Partition key is not supported when sending a batch message. Pass the partition key when creating the batch message instead. %O",
           this._context.connectionId,
           error
         );
+        log.verbose(error.stack);
         throw error;
       }
 
-      log.sender(
+      log.info(
         "[%s] Sender '%s', trying to send EventData[].",
         this._context.connectionId,
         this.name
@@ -486,7 +490,7 @@ export class EventHubSender extends LinkEntity {
         // Finally encode the envelope (batch message).
         encodedBatchMessage = message.encode(batchMessage);
       }
-      log.sender(
+      log.info(
         "[%s] Sender '%s', sending encoded batch message.",
         this._context.connectionId,
         this.name,
@@ -494,7 +498,8 @@ export class EventHubSender extends LinkEntity {
       );
       return await this._trySendBatch(encodedBatchMessage, options);
     } catch (err) {
-      log.error("An error occurred while sending the batch message %O", err);
+      log.warning("An error occurred while sending the batch message %O", err);
+      logErrorStackTrace(err);
       throw err;
     }
   }
@@ -502,7 +507,7 @@ export class EventHubSender extends LinkEntity {
   private _deleteFromCache(): void {
     this._sender = undefined;
     delete this._context.senders[this.name];
-    log.error(
+    log.info(
       "[%s] Deleted the sender '%s' with address '%s' from the client cache.",
       this._context.connectionId,
       this.name,
@@ -523,7 +528,7 @@ export class EventHubSender extends LinkEntity {
       onSessionClose: this._onSessionClose,
       sendTimeoutInSeconds: timeoutInMs / 1000
     };
-    log.sender("Creating sender with options: %O", srOptions);
+    log.info("Creating sender with options: %O", srOptions);
     return srOptions;
   }
 
@@ -549,7 +554,7 @@ export class EventHubSender extends LinkEntity {
           const desc: string =
             `[${this._context.connectionId}] The send operation on the Sender "${this.name}" with ` +
             `address "${this.address}" has been cancelled by the user.`;
-          log.error(desc);
+          log.info(desc);
           return reject(new AbortError("The send operation has been cancelled by the user."));
         };
 
@@ -580,7 +585,7 @@ export class EventHubSender extends LinkEntity {
             `[${this._context.connectionId}] Sender "${this.name}" with ` +
             `address "${this.address}", was not able to send the message right now, due ` +
             `to operation timeout.`;
-          log.error(desc);
+          log.warning(desc);
           const e: Error = {
             name: "OperationTimeoutError",
             message: desc
@@ -594,7 +599,7 @@ export class EventHubSender extends LinkEntity {
         );
 
         if (!this.isOpen()) {
-          log.sender(
+          log.info(
             "Acquiring lock %s for initializing the session, sender and " +
               "possibly the connection.",
             this.senderLock
@@ -610,17 +615,18 @@ export class EventHubSender extends LinkEntity {
           } catch (err) {
             removeListeners();
             err = translate(err);
-            log.error(
+            log.warning(
               "[%s] An error occurred while creating the sender %s",
               this._context.connectionId,
               this.name,
               err
             );
+            logErrorStackTrace(err);
             return reject(err);
           }
         }
 
-        log.sender(
+        log.info(
           "[%s] Sender '%s', credit: %d available: %d",
           this._context.connectionId,
           this.name,
@@ -628,7 +634,7 @@ export class EventHubSender extends LinkEntity {
           this._sender!.session.outgoing.available()
         );
         if (this._sender!.sendable()) {
-          log.sender(
+          log.info(
             "[%s] Sender '%s', sending message with id '%s'.",
             this._context.connectionId,
             this.name
@@ -636,7 +642,7 @@ export class EventHubSender extends LinkEntity {
 
           try {
             const delivery = await this._sender!.send(message, undefined, 0x80013700);
-            log.sender(
+            log.info(
               "[%s] Sender '%s', sent message with delivery id: %d",
               this._context.connectionId,
               this.name,
@@ -645,11 +651,12 @@ export class EventHubSender extends LinkEntity {
             return resolve();
           } catch (err) {
             err = translate(err.innerError || err);
-            log.error(
+            log.warning(
               "[%s] An error occurred while sending the message",
               this._context.connectionId,
               err
             );
+            logErrorStackTrace(err);
             return reject(err);
           } finally {
             removeListeners();
@@ -659,7 +666,7 @@ export class EventHubSender extends LinkEntity {
           const msg =
             `[${this._context.connectionId}] Sender "${this.name}", ` +
             `cannot send the message right now. Please try later.`;
-          log.error(msg);
+          log.verbose(msg);
           const amqpError: AmqpError = {
             condition: ErrorNameConditionMapper.SenderBusyError,
             description: msg
@@ -691,7 +698,7 @@ export class EventHubSender extends LinkEntity {
       // false    true           No
       // false    false          Yes
       if (!this.isOpen() && !this.isConnecting) {
-        log.error(
+        log.info(
           "[%s] The sender '%s' with address '%s' is not open and is not currently " +
             "establishing itself. Hence let's try to connect.",
           this._context.connectionId,
@@ -700,23 +707,23 @@ export class EventHubSender extends LinkEntity {
         );
         this.isConnecting = true;
         await this._negotiateClaim();
-        log.error("[%s] Trying to create sender '%s'...", this._context.connectionId, this.name);
+        log.verbose("[%s] Trying to create sender '%s'...", this._context.connectionId, this.name);
 
         this._sender = await this._context.connection.createAwaitableSender(options);
         this.isConnecting = false;
-        log.error(
+        log.info(
           "[%s] Sender '%s' with address '%s' has established itself.",
           this._context.connectionId,
           this.name,
           this.address
         );
         this._sender.setMaxListeners(1000);
-        log.error(
+        log.info(
           "[%s] Promise to create the sender resolved. Created sender with name: %s",
           this._context.connectionId,
           this.name
         );
-        log.error(
+        log.info(
           "[%s] Sender '%s' created with sender options: %O",
           this._context.connectionId,
           this.name,
@@ -727,7 +734,7 @@ export class EventHubSender extends LinkEntity {
         if (!this._context.senders[this.name]) this._context.senders[this.name] = this;
         await this._ensureTokenRenewal();
       } else {
-        log.error(
+        log.verbose(
           "[%s] The sender '%s' with address '%s' is open -> %s and is connecting " +
             "-> %s. Hence not reconnecting.",
           this._context.connectionId,
@@ -740,12 +747,13 @@ export class EventHubSender extends LinkEntity {
     } catch (err) {
       this.isConnecting = false;
       err = translate(err);
-      log.error(
+      log.warning(
         "[%s] An error occurred while creating the sender %s",
         this._context.connectionId,
         this.name,
         err
       );
+      logErrorStackTrace(err);
       throw err;
     }
   }

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -6,7 +6,7 @@ import { EventHubClient } from "./eventHubClient";
 import { EventPosition } from "./eventPosition";
 import { PumpManager } from "./pumpManager";
 import { AbortController, AbortSignalLike } from "@azure/abort-controller";
-import * as log from "./log";
+import { log } from "./log";
 import { PartitionLoadBalancer } from "./partitionLoadBalancer";
 import { delay } from "@azure/core-amqp";
 import { PartitionProcessor, Checkpoint } from "./partitionProcessor";
@@ -274,22 +274,16 @@ export class EventProcessor {
     partitionOwnershipMap: Map<string, PartitionOwnership>,
     partitionIdToClaim: string
   ): Promise<void> {
-    log.partitionLoadBalancer(
-      `[${this._id}] Attempting to claim ownership of partition ${partitionIdToClaim}.`
-    );
+    log.info(`[${this._id}] Attempting to claim ownership of partition ${partitionIdToClaim}.`);
     const ownershipRequest = this._createPartitionOwnershipRequest(
       partitionOwnershipMap,
       partitionIdToClaim
     );
     try {
       await this._partitionManager.claimOwnership([ownershipRequest]);
-      log.partitionLoadBalancer(
-        `[${this._id}] Successfully claimed ownership of partition ${partitionIdToClaim}.`
-      );
+      log.info(`[${this._id}] Successfully claimed ownership of partition ${partitionIdToClaim}.`);
 
-      log.partitionLoadBalancer(
-        `[${this._id}] [${partitionIdToClaim}] Calling user-provided PartitionProcessorFactory.`
-      );
+      log.info(`[${this._id}] [${partitionIdToClaim}] Calling user-provided PartitionProcessor.`);
       const partitionProcessor = new this._partitionProcessorClass();
       partitionProcessor.fullyQualifiedNamespace = this._eventHubClient.fullyQualifiedNamespace;
       partitionProcessor.eventHubName = this._eventHubClient.eventHubName;
@@ -303,10 +297,11 @@ export class EventProcessor {
         : EventPosition.earliest();
 
       await this._pumpManager.createPump(this._eventHubClient, eventPosition, partitionProcessor);
-      log.partitionLoadBalancer(`[${this._id}] PartitionPump created successfully.`);
+      log.info(`[${this._id}] PartitionPump created successfully.`);
     } catch (err) {
-      log.error(
-        `[${this.id}] Failed to claim ownership of partition ${ownershipRequest.partitionId}`
+      log.verbose(
+        `[${this.id}] Failed to claim ownership of partition ${ownershipRequest.partitionId}`,
+        err
       );
     }
   }
@@ -353,12 +348,10 @@ export class EventProcessor {
         }
 
         // sleep
-        log.eventProcessor(
-          `[${this._id}] Pausing the EventProcessor loop for ${waitIntervalInMs} ms.`
-        );
+        log.info(`[${this._id}] Pausing the EventProcessor loop for ${waitIntervalInMs} ms.`);
         await delay(waitIntervalInMs, abortSignal);
       } catch (err) {
-        log.error(`[${this._id}] An error occured within the EventProcessor loop: ${err}`);
+        log.verbose(`[${this._id}] An error occured within the EventProcessor loop:`, err);
       }
     }
   }
@@ -376,13 +369,13 @@ export class EventProcessor {
    */
   start(): void {
     if (this._isRunning) {
-      log.eventProcessor(`[${this._id}] Attempted to start an already running EventProcessor.`);
+      log.verbose(`[${this._id}] Attempted to start an already running EventProcessor.`);
       return;
     }
 
     this._isRunning = true;
     this._abortController = new AbortController();
-    log.eventProcessor(`[${this._id}] Starting an EventProcessor.`);
+    log.info(`[${this._id}] Starting an EventProcessor.`);
     this._loopTask = this._runLoop(this._abortController.signal);
   }
 
@@ -394,7 +387,7 @@ export class EventProcessor {
    *
    */
   async stop(): Promise<void> {
-    log.eventProcessor(`[${this._id}] Stopping an EventProcessor.`);
+    log.info(`[${this._id}] Stopping an EventProcessor.`);
     if (this._abortController) {
       // cancel the event processor loop
       this._abortController.abort();
@@ -409,9 +402,9 @@ export class EventProcessor {
       // will complete immediately if _loopTask is undefined
       await this._loopTask;
     } catch (err) {
-      log.error(`[${this._id}] An error occured while stopping the EventProcessor: ${err}`);
+      log.verbose(`[${this._id}] An error occured while stopping the EventProcessor:`, err);
     } finally {
-      log.eventProcessor(`[${this._id}] EventProcessor stopped.`);
+      log.info(`[${this._id}] EventProcessor stopped.`);
     }
   }
 }

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -35,6 +35,7 @@ export {
 export { InMemoryPartitionManager } from "./inMemoryPartitionManager";
 export { PartitionProcessor, Checkpoint } from "./partitionProcessor";
 export { extractSpanContextFromEventData } from "./diagnostics/instrumentEventData";
+export { log } from "./log";
 export {
   MessagingError,
   DataTransformer,

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -11,7 +11,7 @@ import {
 } from "@azure/core-amqp";
 import { ConnectionContext } from "./connectionContext";
 import { AwaitableSender, Receiver } from "rhea-promise";
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 
 /**
  * @ignore
@@ -129,7 +129,7 @@ export class LinkEntity {
     // Although node.js is single threaded, we need a locking mechanism to ensure that a
     // race condition does not happen while creating a shared resource (in this case the
     // cbs session, since we want to have exactly 1 cbs session per connection).
-    log.link(
+    log.info(
       "[%s] Acquiring cbs lock: '%s' for creating the cbs session while creating the %s: " +
         "'%s' with address: '%s'.",
       this._context.connectionId,
@@ -158,14 +158,8 @@ export class LinkEntity {
       this._tokenTimeoutInMs = tokenObject.expiresOnTimestamp - Date.now() - 2 * 60 * 1000;
     }
 
-    log.link(
-      "[%s] %s: calling negotiateClaim for audience '%s'.",
-      this._context.connectionId,
-      this._type,
-      this.audience
-    );
     // Acquire the lock to negotiate the CBS claim.
-    log.link(
+    log.info(
       "[%s] Acquiring cbs lock: '%s' for cbs auth for %s: '%s' with address '%s'.",
       this._context.connectionId,
       this._context.negotiateClaimLock,
@@ -174,9 +168,15 @@ export class LinkEntity {
       this.address
     );
     await defaultLock.acquire(this._context.negotiateClaimLock, () => {
+      log.info(
+        "[%s] %s: calling negotiateClaim for audience '%s'.",
+        this._context.connectionId,
+        this._type,
+        this.audience
+      );
       return this._context.cbsSession.negotiateClaim(this.audience, tokenObject, tokenType);
     });
-    log.link(
+    log.info(
       "[%s] Negotiated claim for %s '%s' with with address: %s",
       this._context.connectionId,
       this._type,
@@ -202,7 +202,7 @@ export class LinkEntity {
       try {
         await this._negotiateClaim(true);
       } catch (err) {
-        log.error(
+        log.warning(
           "[%s] %s '%s' with address %s, an error occurred while renewing the token: %O",
           this._context.connectionId,
           this._type,
@@ -210,9 +210,10 @@ export class LinkEntity {
           this.address,
           err
         );
+        logErrorStackTrace(err);
       }
     }, this._tokenTimeoutInMs);
-    log.link(
+    log.info(
       "[%s] %s '%s' with address %s, has next token renewal in %d milliseconds @(%s).",
       this._context.connectionId,
       this._type,
@@ -237,7 +238,7 @@ export class LinkEntity {
         // Closing the link and its underlying session if the link is open. This should also
         // remove them from the internal map.
         await link.close();
-        log.link(
+        log.info(
           "[%s] %s '%s' with address '%s' closed.",
           this._context.connectionId,
           this._type,
@@ -245,7 +246,7 @@ export class LinkEntity {
           this.address
         );
       } catch (err) {
-        log.error(
+        log.verbose(
           "[%s] An error occurred while closing the %s '%s' with address '%s': %O",
           this._context.connectionId,
           this._type,

--- a/sdk/eventhub/event-hubs/src/log.ts
+++ b/sdk/eventhub/event-hubs/src/log.ts
@@ -1,75 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import debugModule from "debug";
-/**
- * @ignore
- * log statements for error
- */
-export const error = debugModule("azure:event-hubs:error");
-/**
- * @ignore
- * log statements for management
- */
-export const mgmt = debugModule("azure:event-hubs:management");
-/**
- * @ignore
- * log statements for sender
- */
-export const sender = debugModule("azure:event-hubs:sender");
-/**
- * @ignore
- * log statements for receiver
- */
-export const receiver = debugModule("azure:event-hubs:receiver");
-/**
- * @ignore
- * log statements for receiverbatching
- */
-export const batching = debugModule("azure:event-hubs:receiverbatching");
-/**
- * @ignore
- * log statements for receiverstreaming
- */
-export const streaming = debugModule("azure:event-hubs:receiverstreaming");
-/**
- * @ignore
- * log statements for linkEntity
- */
-export const link = debugModule("azure:event-hubs:linkEntity");
-/**
- * @ignore
- * log statements for connectionContext
- */
-export const context = debugModule("azure:event-hubs:connectionContext");
-/**
- * @ignore
- * log statements for client
- */
-export const client = debugModule("azure:event-hubs:client");
+import { createClientLogger } from "@azure/logger";
 
 /**
- * @ignore
- * log statements for iothub client
+ * A logger that can be used to log under the azure:event-hubs namespace.
  */
-export const iotClient = debugModule("azure:event-hubs:iothubClient");
+export const log = createClientLogger("event-hubs");
+
 /**
+ * Logs the error's stack trace to "verbose" if a stack trace is available.
+ * @param error Error containing a stack trace.
  * @ignore
- * log statements for partitionManager
  */
-export const partitionPump = debugModule("azure:event-hubs:partitionPump");
-/**
- * @ignore
- * log statements for pumpManager
- */
-export const pumpManager = debugModule("azure:event-hubs:pumpManager");
-/**
- * @ignore
- * log statements for eventProcessor
- */
-export const eventProcessor = debugModule("azure:event-hubs:eventProcessor");
-/**
- * @ignore
- * log statements for partitionLoadBalancer
- */
-export const partitionLoadBalancer = debugModule("azure:event-hubs:partitionLoadBalancer");
+export function logErrorStackTrace(error: any) {
+  if (error && error.stack) {
+    log.verbose(error.stack);
+  }
+}

--- a/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
+++ b/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { PartitionOwnership } from "./eventProcessor";
-import * as log from "./log";
+import { log } from "./log";
 
 /**
  * This class is responsible for balancing the load of processing events from all partitions of an Event Hub by
@@ -45,7 +45,7 @@ export class PartitionLoadBalancer {
         ownerId = ownerId;
       }
     });
-    log.partitionLoadBalancer(
+    log.info(
       `[${this._ownerId}] Owner id ${ownerId} owns ${maxList.length} partitions, stealing a partition from it.`
     );
     return maxList[Math.floor(Math.random() * maxList.length)].partitionId;
@@ -140,7 +140,7 @@ export class PartitionLoadBalancer {
     const activePartitionOwnershipMap = this._removeInactivePartitionOwnerships(
       partitionOwnershipMap
     );
-    log.partitionLoadBalancer(
+    log.info(
       `[${this._ownerId}] Number of active ownership records: ${activePartitionOwnershipMap.size}.`
     );
     if (activePartitionOwnershipMap.size === 0) {
@@ -162,9 +162,7 @@ export class PartitionLoadBalancer {
     if (!ownerPartitionMap.has(this._ownerId)) {
       ownerPartitionMap.set(this._ownerId, []);
     }
-    log.partitionLoadBalancer(
-      `[${this._ownerId}] Number of active event processors: ${ownerPartitionMap.size}.`
-    );
+    log.verbose(`[${this._ownerId}] Number of active event processors: ${ownerPartitionMap.size}.`);
 
     // Find the minimum number of partitions every event processor should own when the load is
     // evenly distributed.
@@ -177,7 +175,7 @@ export class PartitionLoadBalancer {
     const numberOfEventProcessorsWithAdditionalPartition =
       partitionsToAdd.length % ownerPartitionMap.size;
 
-    log.partitionLoadBalancer(
+    log.verbose(
       `[${this._ownerId}] Expected minimum number of partitions per event processor: ${minPartitionsPerEventProcessor}, 
       expected number of event processors with additional partition: ${numberOfEventProcessorsWithAdditionalPartition}.`
     );
@@ -189,7 +187,7 @@ export class PartitionLoadBalancer {
         ownerPartitionMap
       )
     ) {
-      log.partitionLoadBalancer(`[${this._ownerId}] Load is balanced.`);
+      log.info(`[${this._ownerId}] Load is balanced.`);
       // If the partitions are evenly distributed among all active event processors, no change required.
       return "";
     }
@@ -201,7 +199,7 @@ export class PartitionLoadBalancer {
         ownerPartitionMap
       )
     ) {
-      log.partitionLoadBalancer(
+      log.info(
         `[${this._ownerId}] This event processor owns ${
           ownerPartitionMap.get(this._ownerId)!.length
         } partitions and shouldn't own more.`
@@ -209,7 +207,7 @@ export class PartitionLoadBalancer {
       // This event processor already has enough partitions and shouldn't own more yet
       return "";
     }
-    log.partitionLoadBalancer(
+    log.info(
       `[${this._ownerId}] Load is unbalanced and this event processor should own more partitions.`
     );
     // If we have reached this stage, this event processor has to claim/steal ownership of at least 1 more partition
@@ -231,7 +229,7 @@ export class PartitionLoadBalancer {
       }
     }
     if (unOwnedPartitionIds.length === 0) {
-      log.partitionLoadBalancer(
+      log.info(
         `[${this._ownerId}] No unclaimed partitions, stealing from another event processor.`
       );
       partitionToClaim = this._findPartitionToSteal(ownerPartitionMap);

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 import { EventProcessorOptions, CloseReason } from "./eventProcessor";
 import { EventHubClient } from "./eventHubClient";
 import { EventPosition } from "./eventPosition";
@@ -45,7 +45,7 @@ export class PartitionPump {
       // swallow the error from the user-defined code
     }
     this._receiveEvents(this._partitionProcessor.partitionId);
-    log.partitionPump("Successfully started the receiver.");
+    log.info("Successfully started the receiver.");
   }
 
   private async _receiveEvents(partitionId: string): Promise<void> {
@@ -89,7 +89,7 @@ export class PartitionPump {
         try {
           await this._partitionProcessor.processError(err);
         } catch (err) {
-          log.error("An error was thrown by user's processError method: ", err);
+          log.verbose("An error was thrown by user's processError method: ", err);
         }
 
         // close the partition processor if a non-retryable error was encountered
@@ -103,7 +103,7 @@ export class PartitionPump {
             // this will close the pump and will break us out of the while loop
             return await this.stop(CloseReason.Shutdown);
           } catch (err) {
-            log.error(
+            log.verbose(
               `An error occurred while closing the receiver with reason ${CloseReason.Shutdown}: `,
               err
             );
@@ -122,7 +122,8 @@ export class PartitionPump {
       this._abortController.abort();
       await this._partitionProcessor.close(reason);
     } catch (err) {
-      log.error("An error occurred while closing the receiver.", err);
+      log.warning("An error occurred while closing the receiver.", err.message);
+      logErrorStackTrace(err);
       throw err;
     }
   }

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -6,7 +6,7 @@ import { EventPosition } from "./eventPosition";
 import { EventProcessorOptions, CloseReason } from "./eventProcessor";
 import { PartitionProcessor } from "./partitionProcessor";
 import { PartitionPump } from "./partitionPump";
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 
 /**
  * The PumpManager handles the creation and removal of PartitionPumps.
@@ -58,18 +58,14 @@ export class PumpManager {
     const existingPump = this._partitionIdToPumps[partitionId];
     if (existingPump) {
       if (existingPump.isReceiving) {
-        log.pumpManager(
-          `[${this._eventProcessorName}] [${partitionId}] The existing pump is running.`
-        );
+        log.info(`[${this._eventProcessorName}] [${partitionId}] The existing pump is running.`);
         return;
       }
-      log.pumpManager(
-        `[${this._eventProcessorName}] [${partitionId}] The existing pump is not running.`
-      );
+      log.info(`[${this._eventProcessorName}] [${partitionId}] The existing pump is not running.`);
       await this.removePump(partitionId, CloseReason.OwnershipLost);
     }
 
-    log.pumpManager(`[${this._eventProcessorName}] [${partitionId}] Creating a new pump.`);
+    log.info(`[${this._eventProcessorName}] [${partitionId}] Creating a new pump.`);
 
     const pump = new PartitionPump(
       eventHubClient,
@@ -82,9 +78,10 @@ export class PumpManager {
       await pump.start();
       this._partitionIdToPumps[partitionId] = pump;
     } catch (err) {
-      log.error(
+      log.warning(
         `[${this._eventProcessorName}] [${partitionId}] An error occured while adding/updating a pump: ${err}`
       );
+      logErrorStackTrace(err);
     }
   }
 
@@ -99,17 +96,16 @@ export class PumpManager {
       const pump = this._partitionIdToPumps[partitionId];
       if (pump) {
         delete this._partitionIdToPumps[partitionId];
-        log.pumpManager(`[${this._eventProcessorName}] [${partitionId}] Stopping the pump.`);
+        log.info(`[${this._eventProcessorName}] [${partitionId}] Stopping the pump.`);
         await pump.stop(reason);
       } else {
-        log.pumpManager(
-          `[${this._eventProcessorName}] [${partitionId}] No pump was found to remove.`
-        );
+        log.verbose(`[${this._eventProcessorName}] [${partitionId}] No pump was found to remove.`);
       }
     } catch (err) {
-      log.error(
+      log.warning(
         `[${this._eventProcessorName}] [${partitionId}] An error occured while removing a pump: ${err}`
       );
+      logErrorStackTrace(err);
     }
   }
 
@@ -121,7 +117,7 @@ export class PumpManager {
   public async removeAllPumps(reason: CloseReason): Promise<void> {
     const partitionIds = Object.keys(this._partitionIdToPumps);
 
-    log.pumpManager(`[${this._eventProcessorName}] Removing all pumps due to reason ${reason}.`);
+    log.info(`[${this._eventProcessorName}] Removing all pumps due to reason ${reason}.`);
 
     const tasks: PromiseLike<void>[] = [];
     for (const partitionId of partitionIds) {
@@ -134,7 +130,10 @@ export class PumpManager {
     try {
       await Promise.all(tasks);
     } catch (err) {
-      log.error(`[${this._eventProcessorName}] An error occured while removing all pumps: ${err}`);
+      log.warning(
+        `[${this._eventProcessorName}] An error occured while removing all pumps: ${err}`
+      );
+      logErrorStackTrace(err);
     } finally {
       this._partitionIdToPumps = {};
     }

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { EventHubReceiver } from "./eventHubReceiver";
-import * as log from "./log";
+import { log, logErrorStackTrace } from "./log";
 
 /**
  * Describes the receive handler object that is returned from the receive() method with handlers.
@@ -61,12 +61,13 @@ export class ReceiveHandler {
       try {
         await this._receiver.close();
       } catch (err) {
-        log.error(
+        log.warning(
           "An error occurred while stopping the receiver '%s' with address '%s': %O",
           this._receiver.name,
           this._receiver.address,
           err
         );
+        logErrorStackTrace(err);
       }
     }
   }

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as log from "../log";
+import { log, logErrorStackTrace } from "../log";
 import { ConnectionContext } from "../connectionContext";
 
 /**
@@ -14,7 +14,8 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
   if (context && context.wasConnectionCloseCalled) {
     const errorMessage = "The underlying AMQP connection is closed.";
     const error = new Error(errorMessage);
-    log.error(`[${context.connectionId}] %O`, error);
+    log.warning(`[${context.connectionId}] %O`, error);
+    logErrorStackTrace(error);
     throw error;
   }
 }
@@ -34,7 +35,8 @@ export function throwTypeErrorIfParameterMissing(
 ): void {
   if (parameterValue === undefined || parameterValue === null) {
     const error = new TypeError(`Missing parameter "${parameterName}"`);
-    log.error(`[${connectionId}] %O`, error);
+    log.warning(`[${connectionId}] %O`, error);
+    logErrorStackTrace(error);
     throw error;
   }
 }


### PR DESCRIPTION
Fixes #2845

Event Hubs currently creates debugging namespaces for nearly every class. These changes bring us in-line with the Azure SDK guidelines by consolidating namespaces to the package name with 4 log levels.

I also pulled in the core-logging package that @bterlson worked on to get support for setting log levels. The 1st commit cherry-picking Brian's core-logging from his PR with some minor changes to get it to build in the monorepo's current state.

Edit: I did not remove any of our existing logs. While we should consider if our logging is too verbose, these changes update the existing logging to use the new azure:event-hubs:[log-level] namespaces while taking into consideration the SDK guidelines for which log levels to use.

ToDo:
 update README troubleshooting section