### PR TITLE
[Identity] Include inner error messages in AggregateAuthenticationError message

### DIFF
--- a/sdk/identity/identity/src/client/errors.ts
+++ b/sdk/identity/identity/src/client/errors.ts
@@ -100,7 +100,9 @@ export const AggregateAuthenticationErrorName = "AggregateAuthenticationError";
 export class AggregateAuthenticationError extends Error {
   public errors: any[];
   constructor(errors: any[]) {
-    super("Authentication failed to complete due to errors");
+    super(
+      `Authentication failed to complete due to the following errors:\n\n${errors.join("\n\n")}`
+    );
     this.errors = errors;
 
     // Ensure that this type reports the correct name

--- a/sdk/identity/identity/test/errors.spec.ts
+++ b/sdk/identity/identity/test/errors.spec.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from "assert";
+import { AggregateAuthenticationError } from "../src";
+
+describe("AggregateAuthenticationError", function() {
+  it("produces a message containing details of the errors it contains", async () => {
+    const aggregateError = new AggregateAuthenticationError([
+      new Error("Boom."),
+      new Error("Boom again.")
+    ]);
+
+    assert.strictEqual(
+      aggregateError.message,
+      "Authentication failed to complete due to the following errors:\n\nError: Boom.\n\nError: Boom again."
+    );
+  });
+});


### PR DESCRIPTION
This change improves the exception message for `AggregateAuthenticationError` by including the messages from the inner exceptions in its message.  This improves clarity for a user who receives an exception from the `DefaultAzureCredential`.

Fixes #5275.