### PR TITLE
Trace storage http requests

### DIFF
--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -21,7 +21,8 @@ import {
   TokenCredential,
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
-  ProxySettings
+  ProxySettings,
+  tracingPolicy
 } from "@azure/core-http";
 
 import { KeepAliveOptions, KeepAlivePolicyFactory } from "./KeepAlivePolicyFactory";
@@ -192,6 +193,7 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
   const factories: RequestPolicyFactory[] = [
+    tracingPolicy(),
     new KeepAlivePolicyFactory(pipelineOptions.keepAliveOptions),
     new TelemetryPolicyFactory(pipelineOptions.telemetry),
     new UniqueRequestIDPolicyFactory(),

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -455,7 +455,12 @@ describe("BlobClient", () => {
           children: [
             {
               name: "Azure.Storage.Blob.BlobClient-download",
-              children: []
+              children: [
+                {
+                  name: "core-http",
+                  children: []
+                }
+              ]
             }
           ]
         }

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -587,7 +587,12 @@ describe("ContainerClient", () => {
               children: [
                 {
                   name: "Azure.Storage.Blob.BlockBlobClient-upload",
-                  children: []
+                  children: [
+                    {
+                      name: "core-http",
+                      children: []
+                    }
+                  ]
                 }
               ]
             }

--- a/sdk/storage/storage-file/src/Pipeline.ts
+++ b/sdk/storage/storage-file/src/Pipeline.ts
@@ -18,7 +18,8 @@ import {
   proxyPolicy,
   getDefaultProxySettings,
   isNode,
-  ProxySettings
+  ProxySettings,
+  tracingPolicy
 } from "@azure/core-http";
 import { BrowserPolicyFactory } from "./BrowserPolicyFactory";
 import { Credential } from "./credentials/Credential";
@@ -184,6 +185,7 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
   const factories: RequestPolicyFactory[] = [
+    tracingPolicy(),
     new KeepAlivePolicyFactory(pipelineOptions.keepAliveOptions),
     new TelemetryPolicyFactory(pipelineOptions.telemetry),
     new UniqueRequestIDPolicyFactory(),

--- a/sdk/storage/storage-file/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/directoryclient.spec.ts
@@ -618,7 +618,12 @@ describe("DirectoryClient", () => {
               children: [
                 {
                   name: "Azure.Storage.File.DirectoryClient-create",
-                  children: []
+                  children: [
+                    {
+                      name: "core-http",
+                      children: []
+                    }
+                  ]
                 }
               ]
             },
@@ -627,30 +632,55 @@ describe("DirectoryClient", () => {
               children: [
                 {
                   name: "Azure.Storage.File.FileClient-create",
-                  children: []
+                  children: [
+                    {
+                      name: "core-http",
+                      children: []
+                    }
+                  ]
                 }
               ]
             },
             {
               name: "Azure.Storage.File.FileClient-getProperties",
-              children: []
+              children: [
+                {
+                  name: "core-http",
+                  children: []
+                }
+              ]
             },
             {
               name: "Azure.Storage.File.DirectoryClient-deleteFile",
               children: [
                 {
                   name: "Azure.Storage.File.FileClient-delete",
-                  children: []
+                  children: [
+                    {
+                      name: "core-http",
+                      children: []
+                    }
+                  ]
                 }
               ]
             },
             {
               name: "Azure.Storage.File.FileClient-getProperties",
-              children: []
+              children: [
+                {
+                  name: "core-http",
+                  children: []
+                }
+              ]
             },
             {
               name: "Azure.Storage.File.DirectoryClient-delete",
-              children: []
+              children: [
+                {
+                  name: "core-http",
+                  children: []
+                }
+              ]
             }
           ]
         }

--- a/sdk/storage/storage-file/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileclient.spec.ts
@@ -538,7 +538,12 @@ describe("FileClient", () => {
           children: [
             {
               name: "Azure.Storage.File.FileClient-create",
-              children: []
+              children: [
+                {
+                  name: "core-http",
+                  children: []
+                }
+              ]
             }
           ]
         }

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -21,7 +21,8 @@ import {
   TokenCredential,
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
-  ProxySettings
+  ProxySettings,
+  tracingPolicy
 } from "@azure/core-http";
 import { KeepAliveOptions, KeepAlivePolicyFactory } from "./KeepAlivePolicyFactory";
 import { BrowserPolicyFactory } from "./BrowserPolicyFactory";
@@ -194,6 +195,7 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
   const factories: RequestPolicyFactory[] = [
+    tracingPolicy(),
     new KeepAlivePolicyFactory(pipelineOptions.keepAliveOptions),
     new TelemetryPolicyFactory(pipelineOptions.telemetry),
     new UniqueRequestIDPolicyFactory(),

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -183,7 +183,12 @@ describe("QueueClient", () => {
           children: [
             {
               name: "Azure.Storage.Queue.QueueClient-getProperties",
-              children: []
+              children: [
+                {
+                  name: "core-http",
+                  children: []
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
Adds the TracingPolicy from core-http so that we trace all HTTP requests made by the storage client.