### PR TITLE
Pass SpanOptions to getToken

### DIFF
--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -58,6 +58,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
+    "@azure/core-tracing": "1.0.0-preview.3",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -58,7 +58,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
-    "@azure/core-tracing": "1.0.0-preview.3",
+    "@azure/core-tracing": "1.0.0-preview.4",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { AbortSignalLike } from '@azure/abort-controller';
+import { SpanOptions } from '@azure/core-tracing';
 
 export { AbortSignalLike }
 
@@ -17,7 +18,7 @@ export interface AccessToken {
 // @public
 export interface GetTokenOptions {
     abortSignal?: AbortSignalLike;
-    spanOptions?: any;
+    spanOptions?: SpanOptions;
     timeout?: number;
 }
 

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { AbortSignalLike } from "@azure/abort-controller";
+import { SpanOptions } from "@azure/core-tracing";
 
 /**
  * Represents a credential capable of providing an authentication token.
@@ -33,7 +34,7 @@ export interface GetTokenOptions {
   /**
    * Options to create a span using the tracer if any was set.
    */
-  spanOptions?: any;
+  spanOptions?: SpanOptions;
 }
 
 /**
@@ -62,7 +63,9 @@ export function isTokenCredential(credential: any): credential is TokenCredentia
   // a ServiceClientCredentials implementor (like TokenClientCredentials
   // in ms-rest-nodeauth) doesn't get mistaken for a TokenCredential if
   // it doesn't actually implement TokenCredential also.
-  return credential
-    && typeof credential.getToken === "function"
-    && (credential.signRequest === undefined || credential.getToken.length > 0);
+  return (
+    credential &&
+    typeof credential.getToken === "function" &&
+    (credential.signRequest === undefined || credential.getToken.length > 0)
+  );
 }

--- a/sdk/core/core-http/lib/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/bearerTokenAuthenticationPolicy.ts
@@ -72,7 +72,8 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
   public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
     const token = await this.getToken({
-      abortSignal: webResource.abortSignal
+      abortSignal: webResource.abortSignal,
+      spanOptions: webResource.spanOptions
     });
     webResource.headers.set(Constants.HeaderConstants.AUTHORIZATION, `Bearer ${token}`);
     return this._nextPolicy.sendRequest(webResource);

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -39,7 +39,10 @@ describe("BearerTokenAuthenticationPolicy", function() {
     const bearerTokenAuthPolicy = createBearerTokenPolicy(tokenScopes, mockCredential);
     await bearerTokenAuthPolicy.sendRequest(request);
 
-    assert(fakeGetToken.calledWith(tokenScopes, { abortSignal: undefined }));
+    assert(
+      fakeGetToken.calledWith(tokenScopes, { abortSignal: undefined, spanOptions: undefined }),
+      "fakeGetToken called incorrectly."
+    );
     assert.strictEqual(
       request.headers.get(Constants.HeaderConstants.AUTHORIZATION),
       `Bearer ${mockToken}`


### PR DESCRIPTION

This PR is a small change to pass along SpanOptions on a WebRequest from a service library to Identity when it makes a getToken() call for a particular credential type.

I also added some typing information to core-auth to correctly type SpanOptions.

The rest is all whitespace changes from prettier. :)

**Merge *after* Preview 4 release**