### PR TITLE
[Identity] Rethrow AuthenticationErrors in DeviceCodeCredential poll loop

### DIFF
--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -167,6 +167,8 @@ export class DeviceCodeCredential implements TokenCredential {
                 throw err;
               case "bad_verification_code":
                 throw err;
+              default: // Any other error should be rethrown
+                throw err;
             }
           } else {
             throw err;


### PR DESCRIPTION
This change fixes an issue in `DeviceCodeCredential` where an unexpected `AuthenticationError` response would not break the polling loop, causing the loop to poll indefinitely.  I ran across this issue because I was trying to authenticate with an AAD App Registration that was not configured as a "public client" so an `invalid_client` error was being returned.  The error-checking switch statement was not looking for this specific error type nor did it have a `default` case, so the error was ignored.

The fix is to add a `default` case which rethrows any error type that we aren't explicitly checking for.