### PR TITLE
[app-configuration] Fixing contracts for typedoc and inconsistency with exposed APIs

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -5,8 +5,8 @@
 This release brings our interface a bit closer to what is offered in the
 Azure SDKs for C# and Java for AppConfig. 
 
-This affects the `getConfigurationSetting`, `setConfigurationSetting`, 
-`getConfigurationSetting` and `deleteConfigurationSetting` methods which 
+This affects the `getConfigurationSetting`, `addConfigurationSetting`, 
+`setConfigurationSetting` and `deleteConfigurationSetting` methods which 
 no longer take a `key` parameter and instead take an object.
 
 In previous previews:

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -5,22 +5,26 @@
 This release brings our interface a bit closer to what is offered in the
 Azure SDKs for C# and Java for AppConfig. 
 
-This affects the `setConfigurationSetting` and `getConfigurationSetting`
-methods which no longer take a `key` parameter and instead take 
-a `ConfigurationSetting`.
+This affects the `getConfigurationSetting`, `setConfigurationSetting`, 
+`getConfigurationSetting` and `deleteConfigurationSetting` methods which 
+no longer take a `key` parameter and instead take an object.
 
 In previous previews:
 ```typescript
 // 1.0.0-preview.3 and below
+await client.getConfigurationSetting("MyKey", { label: "MyLabel" });
 await client.addConfigurationSetting("MyKey", { label: "MyLabel", value: "MyValue" });
 await client.setConfigurationSetting("MyKey", { label: "MyLabel", value: "MyValue" });
+await client.deleteConfigurationSetting("MyKey", { label: "MyLabel" });
 ```
 
 Now in preview.4:
 ```typescript
 // 1.0.0-preview.4
+await client.getConfigurationSetting({ key: "MyKey", label: "MyLabel" });
 await client.addConfigurationSetting({ key: "MyKey", label: "MyLabel", value: "MyValue" });
 await client.setConfigurationSetting({ key: "MyKey", label: "MyLabel", value: "MyValue" });
+await client.deleteConfigurationSetting({ key: "MyKey", label: "MyLabel" });
 ```
 
 ### Enhancements

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -4,122 +4,74 @@
 
 ```ts
 
-import * as coreHttp from '@azure/core-http';
+import { HttpResponse } from '@azure/core-http';
 import { PagedAsyncIterableIterator } from '@azure/core-paging';
 import { RequestOptionsBase } from '@azure/core-http';
 
 // @public
+export interface AddConfigurationSettingOptions extends RequestOptionsBase {
+}
+
+// @public (undocumented)
+export interface AddConfigurationSettingParam extends ConfigurationSettingParam {
+}
+
+// @public
+export interface AddConfigurationSettingResponse extends ConfigurationSettingResponse<PutKeyValueHeaders> {
+}
+
+// @public
 export class AppConfigurationClient {
     constructor(connectionString: string);
-    addConfigurationSetting(configurationSetting: ConfigurationSettingParam, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
-    clearReadOnly(configurationSetting: ConfigurationSettingParam, options?: ClearReadOnlyOptions): Promise<DeleteLockResponse>;
-    deleteConfigurationSetting(key: string, options?: AppConfigurationDeleteKeyValueOptionalParams): Promise<DeleteKeyValueResponse>;
-    getConfigurationSetting(key: string, options?: AppConfigurationGetKeyValueOptionalParams): Promise<GetConfigurationSettingResponse>;
+    addConfigurationSetting(configurationSetting: AddConfigurationSettingParam, options?: AddConfigurationSettingOptions): Promise<AddConfigurationSettingResponse>;
+    clearReadOnly(id: ConfigurationSettingId, options?: ClearReadOnlyOptions): Promise<ClearReadOnlyResponse>;
+    deleteConfigurationSetting(id: ConfigurationSettingId, options?: DeleteConfigurationSettingOptions): Promise<DeleteConfigurationSettingResponse>;
+    getConfigurationSetting(id: ConfigurationSettingId, options?: GetConfigurationSettingOptions): Promise<GetConfigurationSettingResponse>;
     listConfigurationSettings(options?: ListConfigurationSettingsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListConfigurationSettingPage>;
     listRevisions(options?: ListRevisionsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListRevisionsPage>;
-    setConfigurationSetting(configurationSetting: ConfigurationSettingParam, options?: ConfigurationSettingOptions): Promise<PutKeyValueResponse>;
-    setReadOnly(configurationSetting: ConfigurationSettingParam, options?: SetReadOnlyOptions): Promise<PutLockResponse>;
+    setConfigurationSetting(configurationSetting: SetConfigurationSettingParam, options?: SetConfigurationSettingOptions): Promise<SetConfigurationSettingResponse>;
+    setReadOnly(id: ConfigurationSettingId, options?: SetReadOnlyOptions): Promise<SetReadOnlyResponse>;
     }
 
 // @public
-interface AppConfigurationDeleteKeyValueOptionalParams extends coreHttp.RequestOptionsBase {
-    ifMatch?: string;
-    label?: string;
+export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {
 }
 
-export { AppConfigurationDeleteKeyValueOptionalParams }
-
-export { AppConfigurationDeleteKeyValueOptionalParams as DeleteConfigurationSettingOptions }
-
-// @public
-export interface AppConfigurationDeleteLockOptionalParams extends coreHttp.RequestOptionsBase {
-    ifMatch?: string;
-    ifNoneMatch?: string;
-    label?: string;
+// @public (undocumented)
+export interface ClearReadOnlyResponse extends ConfigurationSettingResponse<DeleteLockHeaders> {
 }
 
 // @public
-interface AppConfigurationGetKeyValueOptionalParams extends coreHttp.RequestOptionsBase {
-    acceptDatetime?: string;
-    ifMatch?: string;
-    ifNoneMatch?: string;
-    label?: string;
-    select?: string[];
-}
-
-export { AppConfigurationGetKeyValueOptionalParams }
-
-export { AppConfigurationGetKeyValueOptionalParams as GetConfigurationSettingOptions }
-
-// @public
-export interface AppConfigurationGetKeyValuesOptionalParams extends coreHttp.RequestOptionsBase {
-    acceptDatetime?: string;
-    after?: string;
-    key?: string;
-    label?: string;
-    select?: string[];
-}
-
-// @public
-export interface AppConfigurationGetRevisionsOptionalParams extends coreHttp.RequestOptionsBase {
-    acceptDatetime?: string;
-    after?: string;
-    key?: string;
-    label?: string;
-    select?: string[];
-}
-
-// @public
-export interface AppConfigurationPutKeyValueOptionalParams extends coreHttp.RequestOptionsBase {
-    entity?: ConfigurationSetting;
-    ifMatch?: string;
-    ifNoneMatch?: string;
-    label?: string;
-}
-
-// @public
-export interface AppConfigurationPutLockOptionalParams extends coreHttp.RequestOptionsBase {
-    ifMatch?: string;
-    ifNoneMatch?: string;
-    label?: string;
-}
-
-// @public
-export interface ClearReadOnlyOptions extends Pick<AppConfigurationDeleteLockOptionalParams, Exclude<keyof AppConfigurationDeleteLockOptionalParams, 'label'>> {
-}
-
-// @public
-export interface ConfigurationSetting {
-    // (undocumented)
-    contentType?: string;
-    // (undocumented)
+export interface ConfigurationSetting extends ConfigurationSettingParam {
     etag?: string;
-    // (undocumented)
-    key: string;
-    // (undocumented)
-    label?: string;
-    // (undocumented)
     lastModified?: Date;
-    // (undocumented)
     locked?: boolean;
-    // (undocumented)
+}
+
+// @public
+export interface ConfigurationSettingId {
+    key: string;
+    label?: string;
+}
+
+// @public
+export interface ConfigurationSettingParam extends ConfigurationSettingId {
+    contentType?: string;
     tags?: {
         [propertyName: string]: string;
     };
-    // (undocumented)
     value?: string;
 }
 
-// @public
-export interface ConfigurationSettingId extends Pick<ConfigurationSetting, 'key' | 'label'> {
+// @public (undocumented)
+export type ConfigurationSettingResponse<HeadersT> = ConfigurationSetting & HttpResponseField<HeadersT> & Pick<HeadersT, Exclude<keyof HeadersT, "eTag">>;
+
+// @public (undocumented)
+export interface DeleteConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {
 }
 
 // @public
-export interface ConfigurationSettingOptions extends Pick<AppConfigurationPutKeyValueOptionalParams, Exclude<keyof AppConfigurationPutKeyValueOptionalParams, "label" | "entity">> {
-}
-
-// @public
-export interface ConfigurationSettingParam extends Pick<ConfigurationSetting, Exclude<keyof ConfigurationSetting, "locked" | "etag" | "lastModified">> {
+export interface DeleteConfigurationSettingResponse extends ConfigurationSettingResponse<DeleteKeyValueHeaders> {
 }
 
 // @public
@@ -129,39 +81,23 @@ export interface DeleteKeyValueHeaders {
 }
 
 // @public
-type DeleteKeyValueResponse = ConfigurationSetting & DeleteKeyValueHeaders & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: DeleteKeyValueHeaders;
-        bodyAsText: string;
-        parsedBody: ConfigurationSetting;
-    };
-};
-
-export { DeleteKeyValueResponse as DeleteConfigurationSettingResponse }
-
-export { DeleteKeyValueResponse }
-
-// @public
 export interface DeleteLockHeaders {
     eTag?: string;
     syncToken?: string;
 }
 
-// @public
-type DeleteLockResponse = ConfigurationSetting & DeleteLockHeaders & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: DeleteLockHeaders;
-        bodyAsText: string;
-        parsedBody: ConfigurationSetting;
-    };
-};
+// @public (undocumented)
+export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields {
+    acceptDatetime?: string;
+    select?: string[];
+}
 
-export { DeleteLockResponse as ClearReadOnlyResponse }
-
-export { DeleteLockResponse }
+// @public (undocumented)
+export interface GetConfigurationSettingResponse extends ConfigurationSettingResponse<GetKeyValueHeaders> {
+}
 
 // @public
-export interface GetConfigurationSettingResponse extends Pick<GetKeyValueResponse, Exclude<keyof GetKeyValueResponse, 'eTag'>> {
+export interface GetConfigurationSettingResponse extends ConfigurationSettingResponse<GetKeyValueHeaders> {
 }
 
 // @public
@@ -172,27 +108,9 @@ export interface GetKeyValueHeaders {
 }
 
 // @public
-export type GetKeyValueResponse = ConfigurationSetting & GetKeyValueHeaders & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: GetKeyValueHeaders;
-        bodyAsText: string;
-        parsedBody: ConfigurationSetting;
-    };
-};
-
-// @public
 export interface GetKeyValuesHeaders {
     syncToken?: string;
 }
-
-// @public
-export type GetKeyValuesResponse = KeyValueListResult & GetKeyValuesHeaders & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: GetKeyValuesHeaders;
-        bodyAsText: string;
-        parsedBody: KeyValueListResult;
-    };
-};
 
 // @public
 export interface GetRevisionsHeaders {
@@ -200,44 +118,44 @@ export interface GetRevisionsHeaders {
 }
 
 // @public
-export type GetRevisionsResponse = KeyValueListResult & GetRevisionsHeaders & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: GetRevisionsHeaders;
+export interface HttpConditionalFields {
+    ifMatch?: string;
+    ifNoneMatch?: string;
+}
+
+// @public (undocumented)
+export interface HttpResponseField<HeadersT> {
+    _response: HttpResponse & {
+        parsedHeaders: HeadersT;
         bodyAsText: string;
-        parsedBody: KeyValueListResult;
     };
-};
-
-// @public
-export interface KeyValueListResult {
-    items?: ConfigurationSetting[];
-    nextLink?: string;
 }
 
 // @public
-export interface ListConfigurationSettingPage extends Pick<GetKeyValuesResponse, Exclude<keyof GetKeyValuesResponse, "items">> {
+export interface ListConfigurationSettingPage extends HttpResponseField<GetKeyValuesHeaders> {
+    // (undocumented)
     items: ConfigurationSetting[];
 }
 
 // @public
-export interface ListConfigurationSettingsOptions extends RequestOptionsBase {
-    acceptDatetime?: string;
-    fields?: (keyof ConfigurationSetting)[];
-    keys?: string[];
-    labels?: string[];
+export interface ListConfigurationSettingsOptions extends RequestOptionsBase, ListSettingsOptions {
 }
 
 // @public
-export interface ListRevisionsOptions extends RequestOptionsBase {
-    acceptDatetime?: string;
-    fields?: (keyof ConfigurationSetting)[];
-    keys?: string[];
-    labels?: string[];
+export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOptions {
 }
 
 // @public
-export interface ListRevisionsPage extends Pick<GetRevisionsResponse, Exclude<keyof GetRevisionsResponse, "items">> {
+export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders> {
     items: ConfigurationSetting[];
+}
+
+// @public (undocumented)
+export interface ListSettingsOptions {
+    acceptDatetime?: string;
+    fields?: (keyof ConfigurationSetting)[];
+    keys?: string[];
+    labels?: string[];
 }
 
 // @public
@@ -247,41 +165,29 @@ export interface PutKeyValueHeaders {
 }
 
 // @public
-type PutKeyValueResponse = ConfigurationSetting & PutKeyValueHeaders & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: PutKeyValueHeaders;
-        bodyAsText: string;
-        parsedBody: ConfigurationSetting;
-    };
-};
-
-export { PutKeyValueResponse as AddConfigurationSettingResponse }
-
-export { PutKeyValueResponse }
-
-export { PutKeyValueResponse as SetConfigurationSettingResponse }
-
-// @public
 export interface PutLockHeaders {
     eTag?: string;
     syncToken?: string;
 }
 
 // @public
-type PutLockResponse = ConfigurationSetting & PutLockHeaders & {
-    _response: coreHttp.HttpResponse & {
-        parsedHeaders: PutLockHeaders;
-        bodyAsText: string;
-        parsedBody: ConfigurationSetting;
-    };
-};
+export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {
+}
 
-export { PutLockResponse }
+// @public (undocumented)
+export interface SetConfigurationSettingParam extends ConfigurationSettingParam {
+}
 
-export { PutLockResponse as SetReadOnlyResponse }
+// @public (undocumented)
+export interface SetConfigurationSettingResponse extends ConfigurationSettingResponse<PutKeyValueHeaders> {
+}
 
 // @public
-export interface SetReadOnlyOptions extends Pick<AppConfigurationPutLockOptionalParams, Exclude<keyof AppConfigurationPutLockOptionalParams, 'label'>> {
+export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {
+}
+
+// @public (undocumented)
+export interface SetReadOnlyResponse extends ConfigurationSettingResponse<PutLockHeaders> {
 }
 
 

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -12,7 +12,7 @@ import { RequestOptionsBase } from '@azure/core-http';
 export interface AddConfigurationSettingOptions extends RequestOptionsBase {
 }
 
-// @public (undocumented)
+// @public
 export interface AddConfigurationSettingParam extends ConfigurationSettingParam {
 }
 
@@ -37,7 +37,7 @@ export class AppConfigurationClient {
 export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {
 }
 
-// @public (undocumented)
+// @public
 export interface ClearReadOnlyResponse extends ConfigurationSettingResponse<DeleteLockHeaders> {
 }
 
@@ -63,10 +63,10 @@ export interface ConfigurationSettingParam extends ConfigurationSettingId {
     value?: string;
 }
 
-// @public (undocumented)
+// @public
 export type ConfigurationSettingResponse<HeadersT> = ConfigurationSetting & HttpResponseField<HeadersT> & Pick<HeadersT, Exclude<keyof HeadersT, "eTag">>;
 
-// @public (undocumented)
+// @public
 export interface DeleteConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {
 }
 
@@ -86,13 +86,12 @@ export interface DeleteLockHeaders {
     syncToken?: string;
 }
 
-// @public (undocumented)
-export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields {
+// @public
+export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields, OptionalFields {
     acceptDatetime?: string;
-    select?: string[];
 }
 
-// @public (undocumented)
+// @public
 export interface GetConfigurationSettingResponse extends ConfigurationSettingResponse<GetKeyValueHeaders> {
 }
 
@@ -133,7 +132,6 @@ export interface HttpResponseField<HeadersT> {
 
 // @public
 export interface ListConfigurationSettingPage extends HttpResponseField<GetKeyValuesHeaders> {
-    // (undocumented)
     items: ConfigurationSetting[];
 }
 
@@ -150,12 +148,16 @@ export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders
     items: ConfigurationSetting[];
 }
 
-// @public (undocumented)
-export interface ListSettingsOptions {
+// @public
+export interface ListSettingsOptions extends OptionalFields {
     acceptDatetime?: string;
-    fields?: (keyof ConfigurationSetting)[];
     keys?: string[];
     labels?: string[];
+}
+
+// @public
+export interface OptionalFields {
+    fields?: (keyof ConfigurationSetting)[];
 }
 
 // @public
@@ -174,11 +176,11 @@ export interface PutLockHeaders {
 export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {
 }
 
-// @public (undocumented)
+// @public
 export interface SetConfigurationSettingParam extends ConfigurationSettingParam {
 }
 
-// @public (undocumented)
+// @public
 export interface SetConfigurationSettingResponse extends ConfigurationSettingResponse<PutKeyValueHeaders> {
 }
 
@@ -186,7 +188,7 @@ export interface SetConfigurationSettingResponse extends ConfigurationSettingRes
 export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {
 }
 
-// @public (undocumented)
+// @public
 export interface SetReadOnlyResponse extends ConfigurationSettingResponse<PutLockHeaders> {
 }
 

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -17,7 +17,7 @@ export interface AddConfigurationSettingParam extends ConfigurationSettingParam 
 }
 
 // @public
-export interface AddConfigurationSettingResponse extends ConfigurationSettingResponse<PutKeyValueHeaders> {
+export interface AddConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
 }
 
 // @public
@@ -38,7 +38,7 @@ export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOpti
 }
 
 // @public
-export interface ClearReadOnlyResponse extends ConfigurationSettingResponse<DeleteLockHeaders> {
+export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
 }
 
 // @public
@@ -71,7 +71,7 @@ export interface DeleteConfigurationSettingOptions extends HttpConditionalFields
 }
 
 // @public
-export interface DeleteConfigurationSettingResponse extends ConfigurationSettingResponse<DeleteKeyValueHeaders> {
+export interface DeleteConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
 }
 
 // @public
@@ -87,16 +87,17 @@ export interface DeleteLockHeaders {
 }
 
 // @public
+export interface GetConfigurationHeaders extends SyncTokenHeaderField {
+    lastModifiedHeader?: string;
+}
+
+// @public
 export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields, OptionalFields {
     acceptDatetime?: string;
 }
 
 // @public
-export interface GetConfigurationSettingResponse extends ConfigurationSettingResponse<GetKeyValueHeaders> {
-}
-
-// @public
-export interface GetConfigurationSettingResponse extends ConfigurationSettingResponse<GetKeyValueHeaders> {
+export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {
 }
 
 // @public
@@ -181,7 +182,7 @@ export interface SetConfigurationSettingParam extends ConfigurationSettingParam 
 }
 
 // @public
-export interface SetConfigurationSettingResponse extends ConfigurationSettingResponse<PutKeyValueHeaders> {
+export interface SetConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
 }
 
 // @public
@@ -189,7 +190,12 @@ export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOption
 }
 
 // @public
-export interface SetReadOnlyResponse extends ConfigurationSettingResponse<PutLockHeaders> {
+export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
+}
+
+// @public
+export interface SyncTokenHeaderField {
+    syncToken?: string;
 }
 
 

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -122,7 +122,7 @@ export interface HttpConditionalFields {
     ifNoneMatch?: string;
 }
 
-// @public (undocumented)
+// @public
 export interface HttpResponseField<HeadersT> {
     _response: HttpResponse & {
         parsedHeaders: HeadersT;

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -26,7 +26,7 @@ export async function run() {
   // with
   console.log("Checking to see if the value has changed using the etag and ifNoneMatch");
   try {
-    await client.getConfigurationSetting(key, {
+    await client.getConfigurationSetting({ key: key }, {
       // ifNoneMatch allows us to say "get me the value so long as it doesn't match the etag I have"
       ifNoneMatch: addedSetting.etag
     });
@@ -52,7 +52,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
 
   for await (const setting of existingSettings) {
     await client.clearReadOnly(setting);
-    await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
+    await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
   }
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -52,7 +52,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
 
   for await (const setting of existingSettings) {
     await client.clearReadOnly(setting);
-    await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
+    await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/helloworld.ts
+++ b/sdk/appconfiguration/app-configuration/samples/helloworld.ts
@@ -23,17 +23,17 @@ export async function run() {
     console.log(`Adding in new setting ${greetingKey}`);
     await client.addConfigurationSetting({ key: greetingKey, value: "Hello!" });
 
-    const newSetting = await client.getConfigurationSetting(greetingKey);
+    const newSetting = await client.getConfigurationSetting({ key: greetingKey });
     console.log(`${greetingKey} has been set to ${newSetting.value}`);
 
     // changing the value of a setting
     await client.setConfigurationSetting({ key: greetingKey, value: "Goodbye!" });
 
-    const updatedSetting = await client.getConfigurationSetting(greetingKey);
+    const updatedSetting = await client.getConfigurationSetting({ key: greetingKey });
     console.log(`${greetingKey} has been set to ${updatedSetting.value}`);
 
     // removing the setting
-    await client.deleteConfigurationSetting(greetingKey, {});
+    await client.deleteConfigurationSetting({ key: greetingKey });
     console.log(`${greetingKey} has been deleted`);
 
     await cleanupSampleValues([greetingKey], client);
@@ -45,7 +45,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
     });
 
     for await (const setting of settingsIterator) {
-        await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
+        await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
     }    
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/helloworld.ts
+++ b/sdk/appconfiguration/app-configuration/samples/helloworld.ts
@@ -45,7 +45,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
     });
 
     for await (const setting of settingsIterator) {
-        await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
+        await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
     }    
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts
+++ b/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts
@@ -29,10 +29,10 @@ export async function run() {
     await client.addConfigurationSetting({ key: urlKey, label: "beta", value: "https://beta.example.com" });
     await client.addConfigurationSetting({ key: urlKey, label: "production", value: "https://example.com" });
 
-    const betaEndpoint = await client.getConfigurationSetting(urlKey, { label: "beta" });
+    const betaEndpoint = await client.getConfigurationSetting({ key: urlKey, label: "beta" });
     console.log(`Endpoint with beta label: ${betaEndpoint.value}`);
 
-    const productionEndpoint = await client.getConfigurationSetting(urlKey, { label: "production" });
+    const productionEndpoint = await client.getConfigurationSetting({ key: urlKey, label: "production" });
     console.log(`Endpoint with production label: ${productionEndpoint.value}`);
 
     await cleanupSampleValues([urlKey], client);
@@ -44,7 +44,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
     });
 
     for await (const setting of existingSettings) {
-        await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
+        await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
     }
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts
+++ b/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts
@@ -44,7 +44,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
     });
 
     for await (const setting of existingSettings) {
-        await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
+        await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
     }
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
+++ b/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
@@ -104,7 +104,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
 
   for await (const setting of existingSettings) {
     await client.clearReadOnly(setting);
-    await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
+    await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
+++ b/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
@@ -33,10 +33,10 @@ export async function run() {
   console.log("Starting Alpha and Beta updates");
 
   // Alpha is preparing to do an update - to do this properly they retrieve the setting from the server
-  let alphaSetting = await client.getConfigurationSetting(key);
+  let alphaSetting = await client.getConfigurationSetting({ key: key });
   
   // Beta would also like to do an update and will do the same thing as Alpha
-  let betaSetting = await client.getConfigurationSetting(key);
+  let betaSetting = await client.getConfigurationSetting({ key: key });
   
   console.log(`Alpha retrieves the setting and has etag ${alphaSetting.etag}`);
   console.log(`Beta retrieves the setting and has etag ${betaSetting.etag}`);
@@ -77,7 +77,7 @@ export async function run() {
       console.log(`Alpha's update failed because the etag has changed. Alpha will now need to update and merge.`);
 
       console.log("Alpha gets the newly updated value and is merging in their changes.");
-      const actualSetting = await client.getConfigurationSetting(key);      
+      const actualSetting = await client.getConfigurationSetting({ key: key });      
       
       // the setting has changed - Alpha chooses to merge their changes
       // rather than overwriting it.
@@ -91,7 +91,7 @@ export async function run() {
   }
 
   // and now that the dust has settled the value has been updated
-  const finalSetting = await client.getConfigurationSetting(key);
+  const finalSetting = await client.getConfigurationSetting({ key: key });
   console.log(`Final value with Alpha and Beta's updates: ${finalSetting.value}`);
   
   await cleanupSampleValues([key], client);
@@ -104,7 +104,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
 
   for await (const setting of existingSettings) {
     await client.clearReadOnly(setting);
-    await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
+    await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
   }
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
+++ b/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
@@ -34,7 +34,7 @@ export async function run() {
   }
     
   // clients that read from the key are unaffected
-  await client.getConfigurationSetting(readOnlySampleKey, { label: "a label" });
+  await client.getConfigurationSetting({ key: readOnlySampleKey, label: "a label" });
   
   // to make a key writable again we can clear the read-only status
   console.log("Clearing the read-only status on the key so we can update the value");
@@ -54,7 +54,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
 
   for await (const setting of existingSettings) {
     await client.clearReadOnly(setting);
-    await client.deleteConfigurationSetting(setting.key!, { label: setting.label });
+    await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
   }
 }
 

--- a/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
+++ b/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
@@ -54,7 +54,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
 
   for await (const setting of existingSettings) {
     await client.clearReadOnly(setting);
-    await client.deleteConfigurationSetting({ key: setting.key!, label: setting.label });
+    await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }
 

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -144,6 +144,7 @@ export class AppConfigurationClient {
     return await this.spanner.trace("getConfigurationSetting", options, async (newOptions) => {
       const response = (await this.client.getKeyValue(id.key, {
         label: id.label,
+        select: newOptions.fields,
         ...newOptions,
         ...checkAndFormatIfAndIfNoneMatch(newOptions)
       })) as GetConfigurationSettingResponse;

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -10,32 +10,35 @@ import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
 import "@azure/core-asynciterator-polyfill";
 
 import {
+  AddConfigurationSettingOptions,
+  AddConfigurationSettingParam,
   AddConfigurationSettingResponse,
   ClearReadOnlyOptions,
+  ClearReadOnlyResponse,
   ConfigurationSetting,
-  ConfigurationSettingOptions,
-  ConfigurationSettingParam,
+  ConfigurationSettingId,
   DeleteConfigurationSettingOptions,
   DeleteConfigurationSettingResponse,
   GetConfigurationSettingOptions,
   GetConfigurationSettingResponse,
-  GetKeyValuesResponse,
   ListConfigurationSettingPage,
   ListConfigurationSettingsOptions,
   ListRevisionsOptions,
   ListRevisionsPage,
+  SetConfigurationSettingOptions,
+  SetConfigurationSettingParam,
   SetConfigurationSettingResponse,
   SetReadOnlyOptions,
-  SetReadOnlyResponse,
-  ClearReadOnlyResponse
+  SetReadOnlyResponse
 } from "./models";
 import {
-  formatWildcards,
+  checkAndFormatIfAndIfNoneMatch,
   extractAfterTokenFromNextLink,
-  checkAndFormatIfAndIfNoneMatch
+  formatWildcards
 } from "./internal/helpers";
 import { ResponseBodyNotFoundError, tracingPolicy } from "@azure/core-http";
 import { Spanner } from "./internal/tracingHelpers";
+import { GetKeyValuesResponse } from './generated/src/models';
 
 const apiVersion = "1.0";
 const ConnectionStringRegex = /Endpoint=(.*);Id=(.*);Secret=(.*)/;
@@ -67,7 +70,7 @@ export class AppConfigurationClient {
       this.client = new AppConfiguration(appConfigCredential, apiVersion, {
         baseUri: regexMatch[1],
         deserializationContentTypes,
-        requestPolicyFactories: (defaults) => [ tracingPolicy(), ...defaults ]
+        requestPolicyFactories: (defaults) => [tracingPolicy(), ...defaults]
       });
     } else {
       throw new Error("You must provide a connection string.");
@@ -88,8 +91,8 @@ export class AppConfigurationClient {
    * @param options Optional parameters for the request.
    */
   addConfigurationSetting(
-    configurationSetting: ConfigurationSettingParam,
-    options: ConfigurationSettingOptions = {}
+    configurationSetting: AddConfigurationSettingParam,
+    options: AddConfigurationSettingOptions = {}
   ): Promise<AddConfigurationSettingResponse> {
     return this.spanner.trace("addConfigurationSetting", options, (_, newOptions) => {
       return this.client.putKeyValue(configurationSetting.key, {
@@ -106,21 +109,21 @@ export class AppConfigurationClient {
    *
    * Example usage:
    * ```ts
-   * const deletedSetting = await client.deleteConfigurationSetting("MyKey", { label: "MyLabel" });
+   * const deletedSetting = await client.deleteConfigurationSetting({ key: "MyKey", label: "MyLabel" });
    * ```
-   * @param key The name of the key.
+   * @param id The id of the configuration setting to delete.
    * @param options Optional parameters for the request (ex: etag, label)
    */
   async deleteConfigurationSetting(
-    key: string,
+    id: ConfigurationSettingId,
     options: DeleteConfigurationSettingOptions = {}
   ): Promise<DeleteConfigurationSettingResponse> {
-
     return this.spanner.trace("deleteConfigurationSetting", options, (newOptions) => {
-      return this.client.deleteKeyValue(key, {
+      return this.client.deleteKeyValue(id.key, {
+        label: id.label,
         ...newOptions,
         ...checkAndFormatIfAndIfNoneMatch(newOptions)
-      })
+      });
     });
   }
 
@@ -129,18 +132,18 @@ export class AppConfigurationClient {
    *
    * Example code:
    * ```ts
-   * const setting = await client.getConfigurationSetting("MyKey", { label: "MyLabel" });
+   * const setting = await client.getConfigurationSetting({ key: "MyKey", label: "MyLabel" });
    * ```
-   * @param key The name of the key.
+   * @param id The id of the configuration setting to get.
    * @param options Optional parameters for the request.
    */
   async getConfigurationSetting(
-    key: string,
+    id: ConfigurationSettingId,
     options: GetConfigurationSettingOptions = {}
   ): Promise<GetConfigurationSettingResponse> {
     return await this.spanner.trace("getConfigurationSetting", options, async (newOptions) => {
-      const response = (await this.client.getKeyValue(key, {
-        label: newOptions.label,
+      const response = (await this.client.getKeyValue(id.key, {
+        label: id.label,
         ...newOptions,
         ...checkAndFormatIfAndIfNoneMatch(newOptions)
       })) as GetConfigurationSettingResponse;
@@ -205,26 +208,33 @@ export class AppConfigurationClient {
   private async *listConfigurationSettingsByPage(
     options: ListConfigurationSettingsOptions = {}
   ): AsyncIterableIterator<ListConfigurationSettingPage> {
-
-    let currentResponse = await this.spanner.trace("listConfigurationSettings", options, (newOptions) => {
-       return this.client.getKeyValues({
-        ...newOptions,
-        ...formatWildcards(newOptions),
-        select: newOptions.fields
-      });
-    });    
+    let currentResponse = await this.spanner.trace(
+      "listConfigurationSettings",
+      options,
+      (newOptions) => {
+        return this.client.getKeyValues({
+          ...newOptions,
+          ...formatWildcards(newOptions),
+          select: newOptions.fields
+        });
+      }
+    );
 
     yield* this.createListConfigurationPageFromResponse(currentResponse);
 
     while (currentResponse.nextLink) {
-      currentResponse = await this.spanner.trace("listConfigurationSettings", options, (newOptions) => {
-        return this.client.getKeyValues({
-          ...newOptions,
-          ...formatWildcards(newOptions),
-          select: newOptions.fields,
-          after: extractAfterTokenFromNextLink(currentResponse.nextLink!)
-        });
-      });
+      currentResponse = await this.spanner.trace(
+        "listConfigurationSettings",
+        options,
+        (newOptions) => {
+          return this.client.getKeyValues({
+            ...newOptions,
+            ...formatWildcards(newOptions),
+            select: newOptions.fields,
+            after: extractAfterTokenFromNextLink(currentResponse.nextLink!)
+          });
+        }
+      );
 
       if (!currentResponse.items) {
         break;
@@ -330,8 +340,8 @@ export class AppConfigurationClient {
    * ```
    */
   setConfigurationSetting(
-    configurationSetting: ConfigurationSettingParam,
-    options: ConfigurationSettingOptions = {}
+    configurationSetting: SetConfigurationSettingParam,
+    options: SetConfigurationSettingOptions = {}
   ): Promise<SetConfigurationSettingResponse> {
     return this.spanner.trace("setConfigurationSetting", options, (newOptions) => {
       return this.client.putKeyValue(configurationSetting.key, {
@@ -345,34 +355,32 @@ export class AppConfigurationClient {
 
   /**
    * Sets a key's value to read only
-   * @param key The name of the setting.
-   * @param label The (optional) label of the setting.
+   * @param id The id of the configuration setting to set to read-only.
    */
   setReadOnly(
-    configurationSetting: ConfigurationSettingParam,
+    id: ConfigurationSettingId,
     options: SetReadOnlyOptions = {}
   ): Promise<SetReadOnlyResponse> {
     return this.spanner.trace("setReadOnly", options, (newOptions) => {
-      return this.client.putLock(configurationSetting.key, {
+      return this.client.putLock(id.key, {
         ...newOptions,
-        label: configurationSetting.label
+        label: id.label
       });
     });
   }
 
   /**
    * Makes the key's value writable again
-   * @param key The name of the setting.
-   * @param label The (optional) label of the setting.
+   * @param id The id of the configuration setting to make writable.
    */
   clearReadOnly(
-    configurationSetting: ConfigurationSettingParam,
+    id: ConfigurationSettingId,
     options: ClearReadOnlyOptions = {}
   ): Promise<ClearReadOnlyResponse> {
     return this.spanner.trace("clearReadOnly", options, (newOptions) => {
-      return this.client.deleteLock(configurationSetting.key, {
+      return this.client.deleteLock(id.key, {
         ...newOptions,
-        label: configurationSetting.label
+        label: id.label
       });
     });
   }

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ListConfigurationSettingsOptions, AppConfigurationGetKeyValuesOptionalParams } from '..';
+import { ListConfigurationSettingsOptions } from '..';
 import { URLBuilder } from '@azure/core-http';
 import { isArray } from 'util';
 import { ListRevisionsOptions } from '../models';
+import { AppConfigurationGetKeyValuesOptionalParams } from '../generated/src/models';
 
 /**
  * Formats the etag so it can be used with a If-Match/If-None-Match header

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -79,13 +79,26 @@ export interface ConfigurationSetting extends ConfigurationSettingParam {
   etag?: string;
 }
 
-export interface AddConfigurationSettingParam extends ConfigurationSettingParam {}
+/**
+ * Parameters for adding a new configuration setting
+ */
+export interface AddConfigurationSettingParam extends ConfigurationSettingParam { }
+
+/**
+ * Parameters for creating or updating a new configuration setting
+ */
 export interface SetConfigurationSettingParam extends ConfigurationSettingParam {}
 
+/**
+ * Standard base response for getting, deleting or updating a configuration setting
+ */
 export type ConfigurationSettingResponse<HeadersT> = ConfigurationSetting &
   HttpResponseField<HeadersT> &
   Pick<HeadersT, Exclude<keyof HeadersT, "eTag">>;
 
+/**
+ * HTTP response related information - headers and raw body.
+ */
 export interface HttpResponseField<HeadersT> {
   /**
    * The underlying HTTP response.
@@ -118,6 +131,19 @@ export interface HttpConditionalFields {
   ifNoneMatch?: string;
 }
 
+/**
+ * Used when the API supports selectively returning fields.
+ */
+export interface OptionalFields {
+  /**
+   * Which fields to return for each ConfigurationSetting
+   */
+  fields?: (keyof ConfigurationSetting)[];
+}
+
+/**
+ * Response from retrieving a ConfigurationSetting.
+ */
 export interface GetConfigurationSettingResponse
   extends ConfigurationSettingResponse<GetKeyValueHeaders> {}
 
@@ -127,17 +153,20 @@ export interface GetConfigurationSettingResponse
 export interface AddConfigurationSettingOptions extends RequestOptionsBase {}
 
 /**
- * Response from adding a configuration setting.
+ * Response from adding a ConfigurationSetting.
  */
 export interface AddConfigurationSettingResponse
   extends ConfigurationSettingResponse<PutKeyValueHeaders> {}
 
 /**
- * Response from deleting a configuration setting.
+ * Response from deleting a ConfigurationSetting.
  */
 export interface DeleteConfigurationSettingResponse
   extends ConfigurationSettingResponse<DeleteKeyValueHeaders> {}
 
+/**
+ * Options for deleting a ConfigurationSetting.
+ */
 export interface DeleteConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase { }
 
 /**
@@ -145,6 +174,9 @@ export interface DeleteConfigurationSettingOptions extends HttpConditionalFields
  */
 export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase { }
 
+/**
+ * Response from setting a ConfigurationSetting.
+ */
 export interface SetConfigurationSettingResponse
   extends ConfigurationSettingResponse<PutKeyValueHeaders> {}
 
@@ -153,18 +185,21 @@ export interface SetConfigurationSettingResponse
  */
 export interface GetConfigurationSettingResponse extends ConfigurationSettingResponse<GetKeyValueHeaders> { }
 
-export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields { 
+/**
+ * Options for getting a ConfigurationSetting.
+ */
+export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields, OptionalFields { 
   /**
    * Requests the server to respond with the state of the resource at the specified time.
    */
   acceptDatetime?: string;
-  /**
-   * Used to select what fields are present in the returned resource(s).
-   */
-  select?: string[];
-} 
+}
 
-export interface ListSettingsOptions {
+/**
+ * Common options for 'list' style APIs in AppConfig used to specify wildcards as well as
+ * the accept date time header.
+ */
+export interface ListSettingsOptions extends OptionalFields {
   /**
    * Requests the server to respond with the state of the resource at the specified time.
    */
@@ -179,11 +214,6 @@ export interface ListSettingsOptions {
    * Filters for wildcard matching (using *) against labels. These conditions are logically OR'd against each other.
    */
   labels?: string[];
-
-  /**
-   * Which fields to return for each ConfigurationSetting
-   */
-  fields?: (keyof ConfigurationSetting)[];
 }
 
 /**
@@ -198,6 +228,9 @@ export interface ListConfigurationSettingsOptions extends RequestOptionsBase, Li
  * A page of configuration settings and the corresponding HTTP response
  */
 export interface ListConfigurationSettingPage extends HttpResponseField<GetKeyValuesHeaders> {
+  /**
+   * The configuration settings for this page of results.
+   */
   items: ConfigurationSetting[];
 }
   
@@ -214,7 +247,7 @@ export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOp
  */
 export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders> {
   /**
-   * ConfigurationSettings for this page of results
+   * The configuration settings for this page of results.
    */
   items: ConfigurationSetting[];
 }
@@ -222,11 +255,19 @@ export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders
 /**
  * Options for clearReadOnly
  */
-export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
+export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase { }
+
+/**
+ * Response when clearing the read-only status from a value
+ */
 export interface ClearReadOnlyResponse extends ConfigurationSettingResponse<DeleteLockHeaders> { }
 
 /**
  * Options for setReadOnly
  */
-export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
+export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase { }
+
+/**
+ * Response when setting a value to read-only.
+ */
 export interface SetReadOnlyResponse extends ConfigurationSettingResponse<PutLockHeaders> {}

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -142,10 +142,15 @@ export interface OptionalFields {
 }
 
 /**
- * Response from retrieving a ConfigurationSetting.
+ * Sync token header field
  */
-export interface GetConfigurationSettingResponse
-  extends ConfigurationSettingResponse<GetKeyValueHeaders> {}
+export interface SyncTokenHeaderField {
+  /**
+   * Enables real-time consistency between requests by providing the returned value in the next
+   * request made to the server.
+   */
+  syncToken?: string;
+}
 
 /**
  * Options used when adding a ConfigurationSetting.
@@ -155,14 +160,12 @@ export interface AddConfigurationSettingOptions extends RequestOptionsBase {}
 /**
  * Response from adding a ConfigurationSetting.
  */
-export interface AddConfigurationSettingResponse
-  extends ConfigurationSettingResponse<PutKeyValueHeaders> {}
+export interface AddConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
 
 /**
  * Response from deleting a ConfigurationSetting.
  */
-export interface DeleteConfigurationSettingResponse
-  extends ConfigurationSettingResponse<DeleteKeyValueHeaders> {}
+export interface DeleteConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
 
 /**
  * Options for deleting a ConfigurationSetting.
@@ -177,13 +180,23 @@ export interface SetConfigurationSettingOptions extends HttpConditionalFields, R
 /**
  * Response from setting a ConfigurationSetting.
  */
-export interface SetConfigurationSettingResponse
-  extends ConfigurationSettingResponse<PutKeyValueHeaders> {}
+export interface SetConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
 
 /**
- * A configuration setting and associated HTTP information
+ * Headers from getting a ConfigurationSetting.
  */
-export interface GetConfigurationSettingResponse extends ConfigurationSettingResponse<GetKeyValueHeaders> { }
+export interface GetConfigurationHeaders extends SyncTokenHeaderField {
+  /**
+   * A UTC datetime that specifies the last time the resource was modified.
+   */
+  lastModifiedHeader?: string;
+}
+
+/**
+ * Response from retrieving a ConfigurationSetting.
+ */
+export interface GetConfigurationSettingResponse
+  extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {}
 
 /**
  * Options for getting a ConfigurationSetting.
@@ -260,7 +273,7 @@ export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOpti
 /**
  * Response when clearing the read-only status from a value
  */
-export interface ClearReadOnlyResponse extends ConfigurationSettingResponse<DeleteLockHeaders> { }
+export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
 
 /**
  * Options for setReadOnly
@@ -270,4 +283,4 @@ export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOption
 /**
  * Response when setting a value to read-only.
  */
-export interface SetReadOnlyResponse extends ConfigurationSettingResponse<PutLockHeaders> {}
+export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -29,7 +29,7 @@ describe("etags", () => {
   // etag usage is 'opt-in' via the ifMatch/ifNoneMatch options for certain calls
   // by default no etags are used.
   it("Get and set by default doesn't use etags", async () => {
-    const addedSetting = await client.getConfigurationSetting(key);
+    const addedSetting = await client.getConfigurationSetting({ key });
 
     // by default - ignores the etag in 'addedSetting.etag' so last one in
     // wins
@@ -38,7 +38,7 @@ describe("etags", () => {
   });
 
   it("Get and set, enabling etag checking using ifMatch", async () => {
-    const addedSetting = await client.getConfigurationSetting(key);
+    const addedSetting = await client.getConfigurationSetting({ key });
 
     addedSetting.value = "some new value!";
 
@@ -46,7 +46,7 @@ describe("etags", () => {
   });
 
   it("set with an old etag will throw RestError", async () => {
-    const addedSetting = await client.getConfigurationSetting(key);
+    const addedSetting = await client.getConfigurationSetting({ key });
 
     addedSetting.value = "some new value!";
 
@@ -77,7 +77,7 @@ describe("etags", () => {
 
     // only get the setting if it changed (it hasn't)
     try {
-      await client.getConfigurationSetting(key, {
+      await client.getConfigurationSetting({ key }, {
         ifNoneMatch: originalSetting.etag
       });
     } catch (err) {
@@ -90,7 +90,7 @@ describe("etags", () => {
     // let's update it and then try again
     await client.setConfigurationSetting({ key: key, value: "new world" });
 
-    const updatedSetting = await client.getConfigurationSetting(key);
+    const updatedSetting = await client.getConfigurationSetting({ key });
     assert.notEqual(
       originalSetting.etag,
       updatedSetting.etag,
@@ -98,7 +98,7 @@ describe("etags", () => {
     );
 
     // only get the setting if it changed (it has!)
-    const configurationSetting = await client.getConfigurationSetting(key, {
+    const configurationSetting = await client.getConfigurationSetting({ key }, {
       ifNoneMatch: originalSetting.etag
     });
 

--- a/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
@@ -26,14 +26,16 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     // before it's set to read only we can set it all we want
     await client.setConfigurationSetting(testConfigSetting);
 
-    let storedSetting = await client.getConfigurationSetting(testConfigSetting.key, {
+    let storedSetting = await client.getConfigurationSetting({
+      key: testConfigSetting.key,
       label: testConfigSetting.label
     });
     assert.ok(!storedSetting.locked);
 
     await client.setReadOnly(testConfigSetting);
 
-    storedSetting = await client.getConfigurationSetting(testConfigSetting.key, {
+    storedSetting = await client.getConfigurationSetting({
+      key: testConfigSetting.key,
       label: testConfigSetting.label
     });
     assert.ok(storedSetting.locked);
@@ -46,8 +48,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     );
     await assertThrowsRestError(
       () =>
-        client.deleteConfigurationSetting(testConfigSetting.key, {
-          label: testConfigSetting.label
+        client.deleteConfigurationSetting({ key: testConfigSetting.key, label: testConfigSetting.label
         }),
       409,
       "Delete should fail because the setting is read-only"

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -24,7 +24,7 @@ describe("AppConfigurationClient", () => {
 
   after("cleanup", async () => {
     for (const setting of settings) {
-      await client.deleteConfigurationSetting(setting.key, { label: setting.label });
+      await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
     }
   });
 
@@ -52,10 +52,10 @@ describe("AppConfigurationClient", () => {
       await compare({
         key,
         value: "added",
-        label: null
+        label: undefined
       });
 
-      await client.deleteConfigurationSetting(key, {});
+      await client.deleteConfigurationSetting({ key });
 
       // will recreate the setting
       await client.setConfigurationSetting({ key, value: "set" });
@@ -63,7 +63,7 @@ describe("AppConfigurationClient", () => {
       await compare({
         key,
         value: "set",
-        label: null
+        label: undefined
       });
 
       // and now acts as a wholesale update
@@ -72,14 +72,14 @@ describe("AppConfigurationClient", () => {
       await compare({
         key,
         value: "set a second time",
-        label: null
+        label: undefined
       });
 
-      await client.deleteConfigurationSetting(key, {});
+      await client.deleteConfigurationSetting({ key });
     });
 
-    async function compare(expected: { key: string; value: string; label: string | null }) {
-      const actualSettings = await client.getConfigurationSetting(expected.key);
+    async function compare(expected: { key: string; value: string; label?: string }) {
+      const actualSettings = await client.getConfigurationSetting(expected);
 
       assert.equal(expected.key, actualSettings.key);
       assert.equal(expected.value, actualSettings.value);
@@ -171,7 +171,7 @@ describe("AppConfigurationClient", () => {
       );
 
       // delete configuration
-      const deletedSetting = await client.deleteConfigurationSetting(key, { label });
+      const deletedSetting = await client.deleteConfigurationSetting(result);
       assert.equal(
         deletedSetting.key,
         key,
@@ -190,7 +190,7 @@ describe("AppConfigurationClient", () => {
 
       // confirm setting no longer exists
       try {
-        await client.getConfigurationSetting(key, { label });
+        await client.getConfigurationSetting({ key, label });
         throw new Error("Test failure");
       } catch (err) {
         assert.notEqual(err.message, "Test failure");
@@ -218,10 +218,10 @@ describe("AppConfigurationClient", () => {
       );
 
       // delete configuration
-      const deletedSetting = await client.deleteConfigurationSetting(key, {
-        label,
-        etag: result.etag
-      });
+      const deletedSetting = await client.deleteConfigurationSetting({
+        key,
+        label
+      }, { ifMatch: result.etag });
       assert.equal(
         deletedSetting.key,
         key,
@@ -240,7 +240,7 @@ describe("AppConfigurationClient", () => {
 
       // confirm setting no longer exists
       try {
-        await client.getConfigurationSetting(key, { label });
+        await client.getConfigurationSetting({ key, label });
         throw new Error("Test failure");
       } catch (err) {
         assert.notEqual(err.message, "Test failure");
@@ -252,7 +252,7 @@ describe("AppConfigurationClient", () => {
       const label = "test";
 
       // delete configuration
-      await client.deleteConfigurationSetting(key, { label });
+      await client.deleteConfigurationSetting({ key, label });
     });
 
     it("throws when deleting a configuration setting (invalid etag)", async () => {
@@ -278,7 +278,7 @@ describe("AppConfigurationClient", () => {
       settings.push({ key, label });
 
       // delete configuration
-      await assertThrowsRestError(() => client.deleteConfigurationSetting(key, { label, ifMatch: "incorrect" }), 412);
+      await assertThrowsRestError(() => client.deleteConfigurationSetting({ key, label }, { ifMatch: "incorrect" }), 412);
     });
   });
 
@@ -331,7 +331,7 @@ describe("AppConfigurationClient", () => {
       );
 
       // retrieve the value from the service
-      const remoteResult = await client.getConfigurationSetting(key, { label });
+      const remoteResult = await client.getConfigurationSetting({ key, label });
       assert.equal(
         remoteResult.key,
         key,
@@ -375,7 +375,7 @@ describe("AppConfigurationClient", () => {
 
       // retrieve the value from the service
       try {
-        await client.getConfigurationSetting(key, { label });
+        await client.getConfigurationSetting({ key, label });
         throw new Error("Test failure");
       } catch (err) {
         assert.notEqual(err.message, "Test failure");

--- a/sdk/appconfiguration/app-configuration/test/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/testHelpers.ts
@@ -34,7 +34,7 @@ export async function deleteKeyCompletely(keys: string[], client: AppConfigurati
       await client.clearReadOnly(setting);
     }
 
-    await client.deleteConfigurationSetting(setting.key, { label: setting.label });
+    await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }
 

--- a/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
@@ -36,19 +36,19 @@ describe("Various error cases", () => {
     });
 
     it("get: Non-existent key throws 404", async () => {
-      await assertThrowsRestError(() => client.getConfigurationSetting(nonExistentKey), 404);
+      await assertThrowsRestError(() => client.getConfigurationSetting({ key: nonExistentKey }), 404);
     });
 
     it("get: Non-existent key (ifMatch: non-matching etag) throws 404", async () => {
       await assertThrowsRestError(
-        () => client.getConfigurationSetting(nonExistentKey, { ifMatch: nonMatchingETag }),
+        () => client.getConfigurationSetting({ key: nonExistentKey }, { ifMatch: nonMatchingETag }),
         412
       );
     });
 
     it("get: Non-existent key (ifMatch: *) throws 412", async () => {
       await assertThrowsRestError(
-        () => client.getConfigurationSetting(nonExistentKey, { ifMatch: "*" }),
+        () => client.getConfigurationSetting({ key: nonExistentKey }, { ifMatch: "*" }),
         412
       );
     });
@@ -56,7 +56,7 @@ describe("Various error cases", () => {
     it("get: value is unchanged from etag (304) using ifNoneMatch, throws ReponseBodyNotFoundError (derived from RestError)", async () => {
       const errThrown = await assertThrowsRestError(
         () =>
-          client.getConfigurationSetting(addedSetting.key, {
+          client.getConfigurationSetting({ key: addedSetting.key }, {
             ifNoneMatch: addedSetting.etag
           }),
         304
@@ -92,7 +92,7 @@ describe("Various error cases", () => {
     // only if it matches any key)
     it("delete: Non-existent key (ifMatch: *) throws 412", async () => {
       await assertThrowsRestError(
-        () => client.deleteConfigurationSetting(nonExistentKey, { ifMatch: "*" }),
+        () => client.deleteConfigurationSetting({ key: nonExistentKey }, { ifMatch: "*" }),
         412
       );
     });
@@ -100,7 +100,7 @@ describe("Various error cases", () => {
     // again, a weird one - delete a non-existent key but only if the etag doesn't match
     it("delete: Non-existent key (ifMatch: non-matching etag) throws 412", async () => {
       await assertThrowsRestError(
-        () => client.deleteConfigurationSetting(nonExistentKey, { ifMatch: nonMatchingETag }),
+        () => client.deleteConfigurationSetting({ key: nonExistentKey }, { ifMatch: nonMatchingETag }),
         412
       );
     });
@@ -128,7 +128,7 @@ describe("Various error cases", () => {
     });
 
     it("delete: non-existent key (no etag)", async () => {
-      await client.deleteConfigurationSetting(nonExistentKey);
+      await client.deleteConfigurationSetting({ key: nonExistentKey });
     });
   });
 });

--- a/sdk/appconfiguration/app-configuration/typedoc.json
+++ b/sdk/appconfiguration/app-configuration/typedoc.json
@@ -7,5 +7,7 @@
   ],
   "ignoreCompilerErrors": true,
   "mode": "file",
-  "out": "./docs"
+  "out": "./docs",
+  "readme": "./README.md",
+  "name": "@azure/app-configuration"
 }

--- a/sdk/appconfiguration/app-configuration/typedoc.json
+++ b/sdk/appconfiguration/app-configuration/typedoc.json
@@ -1,0 +1,11 @@
+{
+  "includeDeclarations": true,
+  "excludePrivate": true,
+  "excludeNotExported": true,
+  "exclude": [
+    "node_modules/**/*"
+  ],
+  "ignoreCompilerErrors": true,
+  "mode": "file",
+  "out": "./docs"
+}


### PR DESCRIPTION
This PR fixes a few issues that would hamper release for preview.4:

1. Removed usages of Pick or type aliasing which were causing typedoc to have issues with discovering and documenting our types. Mostly, I just merged models together and used inheritance which does seem to work consistently.
2. The API surface was inconsistent with two function s- Get and Delete didn't take a ConfigurationSettingId as a parameter which meant they operated differently than everything else. Found this as I was merging models together.