### PR TITLE
Update version of Event Hubs as part of release prep

### DIFF
--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -1,6 +1,6 @@
 ### 2019-10-08 5.0.0-preview.5
 
-- Uses latest version of the `@azure/core-tracing` package that has the fix for the bug where the library wouldnt work in IE 11
+- Updated to use the latest version of the `@azure/core-tracing` package.
 
 ### 2019-10-07 5.0.0-preview.4
 

--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -1,3 +1,7 @@
+### 2019-10-09 5.0.0-preview.5
+
+- Uses latest version of the `@azure/core-tracing` package that has the fix for the bug where the library wouldnt work in IE 11
+
 ### 2019-10-07 5.0.0-preview.4
 
 - Current implementation of the Partition Manager takes the event hub name, consumer group name and partition id to ensure uniqueness for the checkpoint and ownership.

--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -1,4 +1,4 @@
-### 2019-10-09 5.0.0-preview.5
+### 2019-10-08 5.0.0-preview.5
 
 - Uses latest version of the `@azure/core-tracing` package that has the fix for the bug where the library wouldnt work in IE 11
 

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,5 +6,5 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.0.0-preview.4"
+  version: "5.0.0-preview.5"
 };

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
@@ -1,6 +1,6 @@
 ### 2019-10-08 1.0.0-preview.3
 
-- Uses latest version of the `@azure/event-hubs` package that has the fix for the bug where the library wouldnt work in IE 11
+- Updated to use the latest version of the `@azure/event-hubs` package.
 
 ### 2019-10-07 1.0.0-preview.2
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
@@ -1,4 +1,4 @@
-### 2019-10-09 1.0.0-preview.3
+### 2019-10-08 1.0.0-preview.3
 
 - Uses latest version of the `@azure/event-hubs` package that has the fix for the bug where the library wouldnt work in IE 11
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
@@ -1,3 +1,7 @@
+### 2019-10-09 1.0.0-preview.3
+
+- Uses latest version of the `@azure/event-hubs` package that has the fix for the bug where the library wouldnt work in IE 11
+
 ### 2019-10-07 1.0.0-preview.2
 
 - Current implementation of the Partition Manager takes the event hub name, consumer group name and partition id to ensure uniqueness for the checkpoint and ownership.

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/eventhubs-checkpointstore-blob",
   "sdk-type": "client",
-  "version": "1.0.0-preview.2",
+  "version": "1.0.0-preview.3",
   "description": "An Azure Storage Blob solution to store checkpoints when using Event Hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -62,7 +62,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "5.0.0-preview.4",
+    "@azure/event-hubs": "5.0.0-preview.5",
     "@azure/storage-blob": "12.0.0-preview.3",
     "debug": "^4.1.1",
     "events": "^3.0.0",


### PR DESCRIPTION
As part of #5472 we have to release Event Hubs.
This PR makes the update in constants.ts file to keep the version in sync.
Also updates the checkpoint store accordingly