### PR TITLE
[app-configuration] Use the newer design guidelines behavior for HTTP 304's

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.0.0-preview.5",
+  "version": "1.0.0-preview.6",
   "sdk-type": "client",
   "dependencies": {
     "@azure/core-arm": "1.0.0-preview.5",

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -98,6 +98,7 @@ export interface GetConfigurationSettingOptions extends RequestOptionsBase, Http
 
 // @public
 export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {
+    statusCode: number;
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -22,8 +22,6 @@ export async function run() {
   const addedSetting = await client.addConfigurationSetting({ key, value: "Initial value" });
 
   // now our application only wants to download the setting if it's changed
-  // when it's not changed we throw an error that you can inspect and deal
-  // with
   console.log("Checking to see if the value has changed using the etag and ifNoneMatch");
 
   const unchangedResponse = await client.getConfigurationSetting(
@@ -35,10 +33,13 @@ export async function run() {
   );
 
   // we return the response so you can still inspect the returned headers. The body, however, is blank
-  console.log(`Received a response code of ${unchangedResponse._response.status}`);
+  console.log(`Received a response code of ${unchangedResponse.statusCode}`);   // will be HTTP status 304
 
   try {
-    // however, to prevent any accidents or issues we do throw for the fields - this model really isn't usable
+    // To prevent any accidental usages of this model we throw on access to the properties - this model wasn't deserialized
+    // from an actual HTTP response body so it's invalid
+    //
+    // The _request and .statusCode properties, however, are valid and available
     unchangedResponse.key;
     throw new Error(
       "We won't get here - accessing .key (or any members) will throw a ResponseBodyNotFoundError"

--- a/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
@@ -13,7 +13,7 @@ import * as Models from "./models";
 
 const packageName = "app-configuration";
 export const
-  packageVersion = "1.0.0-preview.5";
+  packageVersion = "1.0.0-preview.6";
 
 export class AppConfigurationContext extends coreHttp.ServiceClient {
   syncToken?: string;

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -19,7 +19,7 @@ export {
   GetKeyValuesHeaders,
   GetRevisionsHeaders,
   PutKeyValueHeaders,
-  PutLockHeaders,
+  PutLockHeaders
 } from "./generated/src/models/index";
 
 /**
@@ -82,7 +82,7 @@ export interface ConfigurationSetting extends ConfigurationSettingParam {
 /**
  * Parameters for adding a new configuration setting
  */
-export interface AddConfigurationSettingParam extends ConfigurationSettingParam { }
+export interface AddConfigurationSettingParam extends ConfigurationSettingParam {}
 
 /**
  * Parameters for creating or updating a new configuration setting
@@ -160,27 +160,38 @@ export interface AddConfigurationSettingOptions extends RequestOptionsBase {}
 /**
  * Response from adding a ConfigurationSetting.
  */
-export interface AddConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface AddConfigurationSettingResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Response from deleting a ConfigurationSetting.
  */
-export interface DeleteConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface DeleteConfigurationSettingResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Options for deleting a ConfigurationSetting.
  */
-export interface DeleteConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface DeleteConfigurationSettingOptions
+  extends HttpConditionalFields,
+    RequestOptionsBase {}
 
 /**
  * Options used when saving a ConfigurationSetting.
  */
-export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {}
 
 /**
  * Response from setting a ConfigurationSetting.
  */
-export interface SetConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface SetConfigurationSettingResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Headers from getting a ConfigurationSetting.
@@ -196,12 +207,22 @@ export interface GetConfigurationHeaders extends SyncTokenHeaderField {
  * Response from retrieving a ConfigurationSetting.
  */
 export interface GetConfigurationSettingResponse
-  extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {}
+  extends ConfigurationSetting,
+    GetConfigurationHeaders,
+  HttpResponseField<GetConfigurationHeaders> {
+  /**
+   * The HTTP status code for the response
+   */
+  statusCode: number;
+}
 
 /**
  * Options for getting a ConfigurationSetting.
  */
-export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields, OptionalFields { 
+export interface GetConfigurationSettingOptions
+  extends RequestOptionsBase,
+    HttpConditionalFields,
+    OptionalFields {
   /**
    * Requests the server to respond with the state of the resource at the specified time.
    */
@@ -234,8 +255,7 @@ export interface ListSettingsOptions extends OptionalFields {
  * Also provides `fields` which allows you to selectively choose which fields are populated in the
  * result.
  */
-export interface ListConfigurationSettingsOptions extends RequestOptionsBase, ListSettingsOptions {
-}
+export interface ListConfigurationSettingsOptions extends RequestOptionsBase, ListSettingsOptions {}
 
 /**
  * A page of configuration settings and the corresponding HTTP response
@@ -246,14 +266,13 @@ export interface ListConfigurationSettingPage extends HttpResponseField<GetKeyVa
    */
   items: ConfigurationSetting[];
 }
-  
+
 /**
  * Options for listRevisions that allow for filtering based on keys, labels and other fields.
  * Also provides `fields` which allows you to selectively choose which fields are populated in the
  * result.
  */
-export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOptions {  
-}
+export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOptions {}
 
 /**
  * A page of configuration settings and the corresponding HTTP response
@@ -268,19 +287,25 @@ export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders
 /**
  * Options for clearReadOnly
  */
-export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
 
 /**
  * Response when clearing the read-only status from a value
  */
-export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface ClearReadOnlyResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Options for setReadOnly
  */
-export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
 
 /**
  * Response when setting a value to read-only.
  */
-export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface SetReadOnlyResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -80,6 +80,7 @@ describe("etags", () => {
     });
 
     assert.equal(response._response.status, 304);
+    assert.equal(response.statusCode, 304);
 
     assert.throws(() => response.contentType, /The requested value was not retrieved since it has not changed since the last request./, "");
     assert.throws(() => response.etag, /The requested value was not retrieved since it has not changed since the last request./, "");
@@ -94,11 +95,14 @@ describe("etags", () => {
     await client.setConfigurationSetting({ key: key, value: "new world" });
 
     const updatedSetting = await client.getConfigurationSetting({ key });
+    
     assert.notEqual(
       originalSetting.etag,
       updatedSetting.etag,
       "New content, new update, etags shouldn't match"
     );
+
+    assert.equal(200, updatedSetting.statusCode);
 
     // only get the setting if it changed (it has!)
     const configurationSetting = await client.getConfigurationSetting({ key }, {

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -68,7 +68,7 @@ describe("etags", () => {
     );
   });
 
-  it.only("get using ifNoneMatch to only get the setting if it's changed (ie: safe GET)", async () => {
+  it("get using ifNoneMatch to only get the setting if it's changed (ie: safe GET)", async () => {
     const originalSetting = await client.setConfigurationSetting({
       key: key,
       value: "world"
@@ -81,14 +81,14 @@ describe("etags", () => {
 
     assert.equal(response._response.status, 304);
 
-    assert.throws(() => response.contentType, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.etag, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.key, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.label, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.lastModified, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.locked, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.tags, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.value, /The requested setting's value has not changed since the last request./, "");
+    assert.throws(() => response.contentType, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.etag, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.key, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.label, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.lastModified, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.locked, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.tags, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.value, /The requested value was not retrieved since it has not changed since the last request./, "");
 
     // let's update it and then try again
     await client.setConfigurationSetting({ key: key, value: "new world" });

--- a/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
@@ -5,6 +5,7 @@ import {
   assertThrowsRestError
 } from "./testHelpers";
 import * as assert from "assert";
+import { ResponseBodyNotFoundError } from '@azure/core-http';
 
 // There's been discussion on other teams about what errors are thrown when. This
 // is the file where I've documented the throws/notThrows cases to make coordination
@@ -53,16 +54,16 @@ describe("Various error cases", () => {
       );
     });
 
-    it("get: value is unchanged from etag (304) using ifNoneMatch, throws ReponseBodyNotFoundError (derived from RestError)", async () => {
-      const errThrown = await assertThrowsRestError(
-        () =>
-          client.getConfigurationSetting({ key: addedSetting.key }, {
-            ifNoneMatch: addedSetting.etag
-          }),
-        304
-      );
+    it("get: value is unchanged from etag (304) using ifNoneMatch, throws ReponseBodyNotFoundError on property access (derived from RestError)", async () => {
+      // changed slightly - now it only throws when we access properties
+      const response = await client.getConfigurationSetting({ key: addedSetting.key }, {
+        ifNoneMatch: addedSetting.etag
+      });
 
-      assert.equal("ResponseBodyNotFoundError", errThrown.name);
+      assert.throws(() => response.key, (err: ResponseBodyNotFoundError) => {
+        assert.equal("ResponseBodyNotFoundError", err.name);
+        return true;
+      });
     });
 
     it("add: Setting already exists throws 412", async () => {


### PR DESCRIPTION
The newer design guidelines specify that a 304 should not result in an outright exception and should instead return the request. The returned object should then throw an exception if the user accesses members that would have been deserialized from the response body.

This implements that concept in TypeScript.