### PR TITLE
[core-tracing] Store Tracer globally instead of in module scope

### DIFF
--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -6,7 +6,7 @@ import { Tracer } from "./interfaces/tracer";
 import { getCache } from "./utils/global";
 
 /**
- * Sets the global tracer, enabling tracing for the AzureSDK.
+ * Sets the global tracer, enabling tracing for the Azure SDK.
  * @param tracer An OpenTelemetry Tracer instance.
  */
 export function setTracer(tracer: Tracer) {

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -3,25 +3,25 @@
 
 import { NoOpTracer } from "./tracers/noop/noOpTracer";
 import { Tracer } from "./interfaces/tracer";
-
-
-let _tracerPlugin: Tracer;
+import { getCache } from "./utils/global";
 
 /**
-   * Sets the global tracer, enabling tracing for the AzureSDK.
-   * @param tracer An OpenTelemetry Tracer instance.
-   */
+ * Sets the global tracer, enabling tracing for the AzureSDK.
+ * @param tracer An OpenTelemetry Tracer instance.
+ */
 export function setTracer(tracer: Tracer) {
-  _tracerPlugin = tracer;
+  const cache = getCache();
+  cache.tracer = tracer;
 }
 
 /**
-   * Retrieves the active tracer, or returns a
-   * no-op implementation if one is not set.
-   */
+ * Retrieves the active tracer, or returns a
+ * no-op implementation if one is not set.
+ */
 export function getTracer() {
-  if (!_tracerPlugin) {
-    _tracerPlugin = new NoOpTracer();
+  const cache = getCache();
+  if (!cache.tracer) {
+    cache.tracer = new NoOpTracer();
   }
-  return _tracerPlugin;
+  return cache.tracer;
 }

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -3,7 +3,7 @@
 
 import { NoOpTracer } from "./tracers/noop/noOpTracer";
 import { Tracer } from "./interfaces/tracer";
-import { getCache } from "./utils/global";
+import { getCache } from "./utils/cache";
 
 /**
  * Sets the global tracer, enabling tracing for the Azure SDK.

--- a/sdk/core/core-tracing/lib/utils/cache.ts
+++ b/sdk/core/core-tracing/lib/utils/cache.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Tracer } from "../interfaces/tracer";
+import { getGlobalObject } from "./global";
+
+const GLOBAL_TRACER_VERSION = 1;
+const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache");
+
+export interface TracerCache {
+  version: number;
+  tracer?: Tracer;
+}
+
+let cache: TracerCache;
+
+function loadTracerCache(): void {
+  const globalObj = getGlobalObject();
+  const existingCache: TracerCache = globalObj[GLOBAL_TRACER_SYMBOL];
+  if (existingCache) {
+    if (existingCache.version !== GLOBAL_TRACER_VERSION) {
+      throw new Error(
+        `Two incompatible versions of @azure/core-tracing have been loaded.
+         This library is ${GLOBAL_TRACER_VERSION}, existing is ${existingCache.version}.`
+      );
+    }
+    cache = existingCache;
+  } else {
+    cache = {
+      tracer: undefined,
+      version: GLOBAL_TRACER_VERSION
+    };
+    globalObj[GLOBAL_TRACER_SYMBOL] = cache;
+  }
+}
+
+export function getCache(): TracerCache {
+  if (!cache) {
+    loadTracerCache();
+  }
+  return cache;
+}

--- a/sdk/core/core-tracing/lib/utils/global.browser.ts
+++ b/sdk/core/core-tracing/lib/utils/global.browser.ts
@@ -1,37 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Tracer } from "../interfaces/tracer";
-
-const GLOBAL_TRACER_VERSION = 1;
-const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache");
-
-export interface TracerCache {
-  version: number;
-  tracer?: Tracer;
-}
-
-let cache: TracerCache;
-
-function loadTracerCache(): void {
-  const existingCache = (self as any)[GLOBAL_TRACER_SYMBOL];
-  if (existingCache) {
-    if (existingCache.version !== GLOBAL_TRACER_VERSION) {
-      throw new Error("Two incompatible versions of @azure/core-tracing have been loaded.");
-    }
-    cache = existingCache;
-  } else {
-    cache = {
-      tracer: undefined,
-      version: GLOBAL_TRACER_VERSION
-    };
-    (self as any)[GLOBAL_TRACER_SYMBOL] = cache;
-  }
-}
-
-export function getCache(): TracerCache {
-  if (!cache) {
-    loadTracerCache();
-  }
-  return cache;
+export function getGlobalObject(): any {
+  return self;
 }

--- a/sdk/core/core-tracing/lib/utils/global.browser.ts
+++ b/sdk/core/core-tracing/lib/utils/global.browser.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Tracer } from "../interfaces/tracer";
+
+const GLOBAL_TRACER_VERSION = 1;
+const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache");
+
+export interface TracerCache {
+  version: number;
+  tracer?: Tracer;
+}
+
+let cache: TracerCache;
+
+function loadTracerCache(): void {
+  const existingCache = (self as any)[GLOBAL_TRACER_SYMBOL];
+  if (existingCache) {
+    if (existingCache.version !== GLOBAL_TRACER_VERSION) {
+      throw new Error("Two incompatible versions of @azure/core-tracing have been loaded.");
+    }
+    cache = existingCache;
+  } else {
+    cache = {
+      tracer: undefined,
+      version: GLOBAL_TRACER_VERSION
+    };
+    (self as any)[GLOBAL_TRACER_SYMBOL] = cache;
+  }
+}
+
+export function getCache(): TracerCache {
+  if (!cache) {
+    loadTracerCache();
+  }
+  return cache;
+}

--- a/sdk/core/core-tracing/lib/utils/global.ts
+++ b/sdk/core/core-tracing/lib/utils/global.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Tracer } from "../interfaces/tracer";
+
+const GLOBAL_TRACER_VERSION = 1;
+const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache");
+
+export interface TracerCache {
+  version: number;
+  tracer?: Tracer;
+}
+
+let cache: TracerCache;
+
+function loadTracerCache(): void {
+  const existingCache = (global as any)[GLOBAL_TRACER_SYMBOL];
+  if (existingCache) {
+    if (existingCache.version !== GLOBAL_TRACER_VERSION) {
+      throw new Error("Two incompatible versions of @azure/core-tracing have been loaded.");
+    }
+    cache = existingCache;
+  } else {
+    cache = {
+      tracer: undefined,
+      version: GLOBAL_TRACER_VERSION
+    };
+    (global as any)[GLOBAL_TRACER_SYMBOL] = cache;
+  }
+}
+
+export function getCache(): TracerCache {
+  if (!cache) {
+    loadTracerCache();
+  }
+  return cache;
+}

--- a/sdk/core/core-tracing/lib/utils/global.ts
+++ b/sdk/core/core-tracing/lib/utils/global.ts
@@ -14,10 +14,13 @@ export interface TracerCache {
 let cache: TracerCache;
 
 function loadTracerCache(): void {
-  const existingCache = (global as any)[GLOBAL_TRACER_SYMBOL];
+  const existingCache: TracerCache = (global as any)[GLOBAL_TRACER_SYMBOL];
   if (existingCache) {
     if (existingCache.version !== GLOBAL_TRACER_VERSION) {
-      throw new Error("Two incompatible versions of @azure/core-tracing have been loaded.");
+      throw new Error(
+        `Two incompatible versions of @azure/core-tracing have been loaded.
+         This library is ${GLOBAL_TRACER_VERSION}, existing is ${existingCache.version}.`
+      );
     }
     cache = existingCache;
   } else {

--- a/sdk/core/core-tracing/lib/utils/global.ts
+++ b/sdk/core/core-tracing/lib/utils/global.ts
@@ -1,40 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Tracer } from "../interfaces/tracer";
-
-const GLOBAL_TRACER_VERSION = 1;
-const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache");
-
-export interface TracerCache {
-  version: number;
-  tracer?: Tracer;
-}
-
-let cache: TracerCache;
-
-function loadTracerCache(): void {
-  const existingCache: TracerCache = (global as any)[GLOBAL_TRACER_SYMBOL];
-  if (existingCache) {
-    if (existingCache.version !== GLOBAL_TRACER_VERSION) {
-      throw new Error(
-        `Two incompatible versions of @azure/core-tracing have been loaded.
-         This library is ${GLOBAL_TRACER_VERSION}, existing is ${existingCache.version}.`
-      );
-    }
-    cache = existingCache;
-  } else {
-    cache = {
-      tracer: undefined,
-      version: GLOBAL_TRACER_VERSION
-    };
-    (global as any)[GLOBAL_TRACER_SYMBOL] = cache;
-  }
-}
-
-export function getCache(): TracerCache {
-  if (!cache) {
-    loadTracerCache();
-  }
-  return cache;
+export function getGlobalObject(): any {
+  return global;
 }

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "module": "dist-esm/lib/index.js",
   "browser": {
-    "./dist/index.js": "./browser/core-tracing.js"
+    "./dist/index.js": "./browser/core-tracing.js",
+    "./dist-esm/lib/utils/global.js": "./dist-esm/lib/utils/global.browser.js"
   },
   "types": "types/core-tracing.d.ts",
   "scripts": {


### PR DESCRIPTION
Recently we've dealt with the pain of versioning core-tracing consistently across package versions, since the global Tracer for the SDK was stored inside the module scope.

This PR removes the strict versioning requirement by instead introducing global variables accessed through a unique Symbol. This does require a Symbol polyfill for downlevel usage, but this was already required in other places (e.g. for asyncIterator.)