### PR TITLE
[Cosmos] Use local digest instead of crypto-hash

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -19,7 +19,8 @@
   "module": "./dist-esm/index.js",
   "browser": {
     "./dist-esm/request/defaultAgent.js": "./dist-esm/request/defaultAgent.browser.js",
-    "./dist-esm/utils/atob.js": "./dist-esm/utils/atob.browser.js"
+    "./dist-esm/utils/atob.js": "./dist-esm/utils/atob.browser.js",
+    "./dist-esm/utils/digest.js": "./dist-esm/utils/digest.browser.js"
   },
   "files": [
     "changelog.md",
@@ -74,7 +75,6 @@
     "@azure/abort-controller": "1.0.0-preview.2",
     "@azure/cosmos-sign": "^1.0.2",
     "@types/debug": "^4.1.4",
-    "crypto-hash": "^1.1.0",
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.0.0",
     "node-fetch": "^2.6.0",

--- a/sdk/cosmosdb/cosmos/rollup.config.js
+++ b/sdk/cosmosdb/cosmos/rollup.config.js
@@ -12,7 +12,7 @@ export default [
       "node-fetch",
       "priorityqueuejs",
       "semaphore",
-      "crypto-hash",
+      "crypto",
       "fast-json-stable-stringify"
     ],
     output: {
@@ -23,11 +23,11 @@ export default [
       globals: {
         "universal-user-agent": "universalUserAgent",
         "@azure/cosmos-sign": "cosmosSign",
-        "crypto-hash": "cryptoHash",
         "fast-json-stable-stringify": "stableStringify",
         "uuid/v4": "uuid",
         "@azure/abort-controller": "AbortController",
         "node-fetch": "fetch",
+        crypto: "crypto",
         tslib: "tslib_1",
         debug: "debugLib",
         priorityqueuejs: "PriorityQueue",

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderedDistinctEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/OrderedDistinctEndpointComponent.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { sha1 } from "crypto-hash";
+import { digest } from "../../utils/digest";
 import stableStringify from "fast-json-stable-stringify";
 import { Response } from "../../request";
 import { ExecutionContext } from "../ExecutionContext";
@@ -14,7 +14,7 @@ export class OrderedDistinctEndpointComponent implements ExecutionContext {
     const { headers, result } = await this.executionContext.nextItem();
     if (result) {
       const stringifiedResult = stableStringify(result);
-      const hashedResult = await sha1(stringifiedResult);
+      const hashedResult = await digest(stringifiedResult);
       if (hashedResult === this.hashedLastResult) {
         return { result: undefined, headers };
       }

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/UnorderedDistinctEndpointComponent.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/EndpointComponent/UnorderedDistinctEndpointComponent.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { sha1 } from "crypto-hash";
+import { digest } from "../../utils/digest";
 import stableStringify from "fast-json-stable-stringify";
 import { Response } from "../../request";
 import { ExecutionContext } from "../ExecutionContext";
@@ -16,7 +16,7 @@ export class UnorderedDistinctEndpointComponent implements ExecutionContext {
     const { headers, result } = await this.executionContext.nextItem();
     if (result) {
       const stringifiedResult = stableStringify(result);
-      const hashedResult = await sha1(stringifiedResult);
+      const hashedResult = await digest(stringifiedResult);
       if (this.hashedResults.has(hashedResult)) {
         return { result: undefined, headers };
       }

--- a/sdk/cosmosdb/cosmos/src/utils/digest.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/digest.browser.ts
@@ -1,0 +1,17 @@
+import { encodeUTF8 } from "./encode";
+
+export async function digest(str: string) {
+  if (!window || !window.crypto || !window.crypto.subtle) {
+    throw new Error("Browser does not support cryptography functions");
+  }
+
+  const data = encodeUTF8(str);
+  const hash = await window.crypto.subtle.digest("SHA-256", data);
+  return bufferToHex(hash);
+}
+
+function bufferToHex(buffer: ArrayBuffer) {
+  return Array.prototype.map
+    .call(new Uint8Array(buffer), (item: number) => ("00" + item.toString(16)).slice(-2))
+    .join("");
+}

--- a/sdk/cosmosdb/cosmos/src/utils/digest.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/digest.ts
@@ -1,0 +1,7 @@
+import { createHash } from "crypto";
+
+export async function digest(str: string) {
+  const hash = createHash("sha256");
+  hash.update(str, "utf8");
+  return hash.digest("hex");
+}

--- a/sdk/cosmosdb/cosmos/src/utils/encode.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/encode.ts
@@ -1,0 +1,7 @@
+export function encodeUTF8(str: string): Uint8Array {
+  const bytes = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) {
+    bytes[i] = str.charCodeAt(i);
+  }
+  return bytes;
+}


### PR DESCRIPTION
Addresses problem 1) discussed in #5023, fixing Cosmos in Edge.

This PR is changes the hashing algorithm previously used `SHA1` fro `SHA256` which is supported by Edge and all other browsers. Also removing the dependency on `crypto-hash`