### PR TITLE
[app-configuration] Bring etag and HTTP status code 204/304 handling in line with latest design guidelines

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -86,7 +86,7 @@
     "swagger": "autorest --typescript swagger/swagger.md",
     "test": "npm run build:test && mocha -t 1200000 test-dist/index.node.js --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "echo skipped",
+    "unit-test:node": "npm run test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "sideEffects": false,

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.0.0-preview.5",
+  "version": "1.0.0-preview.6",
   "sdk-type": "client",
   "dependencies": {
     "@azure/core-arm": "1.0.0-preview.5",

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -75,18 +75,6 @@ export interface DeleteConfigurationSettingResponse extends ConfigurationSetting
 }
 
 // @public
-export interface DeleteKeyValueHeaders {
-    eTag?: string;
-    syncToken?: string;
-}
-
-// @public
-export interface DeleteLockHeaders {
-    eTag?: string;
-    syncToken?: string;
-}
-
-// @public
 export interface GetConfigurationHeaders extends SyncTokenHeaderField {
     lastModifiedHeader?: string;
 }
@@ -99,23 +87,6 @@ export interface GetConfigurationSettingOptions extends RequestOptionsBase, Http
 // @public
 export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {
     statusCode: number;
-}
-
-// @public
-export interface GetKeyValueHeaders {
-    eTag?: string;
-    lastModifiedHeader?: string;
-    syncToken?: string;
-}
-
-// @public
-export interface GetKeyValuesHeaders {
-    syncToken?: string;
-}
-
-// @public
-export interface GetRevisionsHeaders {
-    syncToken?: string;
 }
 
 // @public
@@ -133,7 +104,7 @@ export interface HttpResponseField<HeadersT> {
 }
 
 // @public
-export interface ListConfigurationSettingPage extends HttpResponseField<GetKeyValuesHeaders> {
+export interface ListConfigurationSettingPage extends HttpResponseField<SyncTokenHeaderField> {
     items: ConfigurationSetting[];
 }
 
@@ -146,7 +117,7 @@ export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOp
 }
 
 // @public
-export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders> {
+export interface ListRevisionsPage extends HttpResponseField<SyncTokenHeaderField> {
     items: ConfigurationSetting[];
 }
 
@@ -160,18 +131,6 @@ export interface ListSettingsOptions extends OptionalFields {
 // @public
 export interface OptionalFields {
     fields?: (keyof ConfigurationSetting)[];
-}
-
-// @public
-export interface PutKeyValueHeaders {
-    eTag?: string;
-    syncToken?: string;
-}
-
-// @public
-export interface PutLockHeaders {
-    eTag?: string;
-    syncToken?: string;
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -43,13 +43,13 @@ export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHe
 
 // @public
 export interface ConfigurationSetting extends ConfigurationSettingParam {
-    etag?: string;
     lastModified?: Date;
     locked?: boolean;
 }
 
 // @public
 export interface ConfigurationSettingId {
+    etag?: string;
     key: string;
     label?: string;
 }
@@ -91,8 +91,8 @@ export interface GetConfigurationSettingResponse extends ConfigurationSetting, G
 
 // @public
 export interface HttpConditionalFields {
-    ifMatch?: string;
-    ifNoneMatch?: string;
+    onlyIfChanged?: boolean;
+    onlyIfUnchanged?: boolean;
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -71,7 +71,7 @@ export interface DeleteConfigurationSettingOptions extends HttpConditionalFields
 }
 
 // @public
-export interface DeleteConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
+export interface DeleteConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseFields, HttpResponseField<SyncTokenHeaderField> {
 }
 
 // @public
@@ -85,8 +85,7 @@ export interface GetConfigurationSettingOptions extends RequestOptionsBase, Http
 }
 
 // @public
-export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {
-    statusCode: number;
+export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseFields, HttpResponseField<GetConfigurationHeaders> {
 }
 
 // @public
@@ -101,6 +100,11 @@ export interface HttpResponseField<HeadersT> {
         parsedHeaders: HeadersT;
         bodyAsText: string;
     };
+}
+
+// @public
+export interface HttpResponseFields {
+    statusCode: number;
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -98,6 +98,7 @@ export interface GetConfigurationSettingOptions extends RequestOptionsBase, Http
 
 // @public
 export interface GetConfigurationSettingResponse extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {
+    statusCode: number;
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -24,11 +24,11 @@ export async function run() {
   // now our application only wants to download the setting if it's changed
   console.log("Checking to see if the value has changed using the etag and ifNoneMatch");
 
-  const unchangedResponse = await client.getConfigurationSetting(
-    { key: key },
+  const unchangedResponse = await client.getConfigurationSetting(addedSetting,
     {
-      // ifNoneMatch allows us to say "get me the value so long as it doesn't match the etag I have"
-      ifNoneMatch: addedSetting.etag
+      // onlyIfUnchanged allows us to say "get me the value only if it doesn't match the one I already have"
+      // this allows us to avoid transferring the setting if nothing has changed.
+      onlyIfUnchanged: true
     }
   );
 

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -22,8 +22,6 @@ export async function run() {
   const addedSetting = await client.addConfigurationSetting({ key, value: "Initial value" });
 
   // now our application only wants to download the setting if it's changed
-  // when it's not changed we throw an error that you can inspect and deal
-  // with
   console.log("Checking to see if the value has changed using the etag and ifNoneMatch");
 
   const unchangedResponse = await client.getConfigurationSetting(
@@ -35,10 +33,13 @@ export async function run() {
   );
 
   // we return the response so you can still inspect the returned headers. The body, however, is blank
-  console.log(`Received a response code of ${unchangedResponse._response.status}`);
+  console.log(`Received a response code of ${unchangedResponse.statusCode}`);   // will be HTTP status 304
 
   try {
-    // however, to prevent any accidents or issues we do throw for the fields - this model really isn't usable
+    // To prevent any accidental usages of this model we throw on access to the properties - this model wasn't deserialized
+    // from an actual HTTP response body so it's invalid
+    //
+    // The _request and .statusCode properties, however, are valid and available
     unchangedResponse.key;
     throw new Error(
       "We won't get here - accessing .key (or any members) will throw a ResponseBodyNotFoundError"

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -26,9 +26,9 @@ export async function run() {
 
   const unchangedResponse = await client.getConfigurationSetting(addedSetting,
     {
-      // onlyIfUnchanged allows us to say "get me the value only if it doesn't match the one I already have"
+      // onlyIfChanged allows us to say "get me the value only if it doesn't match the one I already have"
       // this allows us to avoid transferring the setting if nothing has changed.
-      onlyIfUnchanged: true
+      onlyIfChanged: true
     }
   );
 

--- a/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
+++ b/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
@@ -49,9 +49,9 @@ export async function run() {
     key: key,
     value: "Beta has updated the value"
   }, {
-    // ifMatch allows Beta to say "only update the setting if the _current_ etag matches my etag"
+    // onlyIfUnchanged allows Beta to say "only update the setting if the _current_ etag matches my etag"
     // which is true for Beta since nobody has modified it since Beta got it.
-    ifMatch: betaSetting.etag
+    onlyIfUnchanged: true
   });
 
   console.log(`Beta has updated the setting. The setting's etag is now ${betaUpdatedSetting.etag}`);
@@ -70,7 +70,7 @@ export async function run() {
       // it.
       //
       // the 'catch' below will now incorporate the update
-      ifMatch: alphaSetting.etag
+      onlyIfUnchanged: true
     })
   } catch (err) {    
     if (err.statusCode === 412) {    // precondition failed
@@ -85,7 +85,7 @@ export async function run() {
 
       console.log(`Alpha is setting the value again with the new etag ${actualSetting.etag}`);
       await client.setConfigurationSetting(actualSetting, {
-        ifMatch: actualSetting.etag
+        onlyIfUnchanged: true
       });
     }
   }

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -123,7 +123,7 @@ export class AppConfigurationClient {
       return this.client.deleteKeyValue(id.key, {
         label: id.label,
         ...newOptions,
-        ...checkAndFormatIfAndIfNoneMatch(newOptions)
+        ...checkAndFormatIfAndIfNoneMatch(id, newOptions)
       });
     });
 
@@ -163,7 +163,7 @@ export class AppConfigurationClient {
         label: id.label,
         select: newOptions.fields,
         ...newOptions,
-        ...checkAndFormatIfAndIfNoneMatch(newOptions),
+        ...checkAndFormatIfAndIfNoneMatch(id, newOptions)
       });
 
       const response: GetConfigurationSettingResponse = {
@@ -367,7 +367,7 @@ export class AppConfigurationClient {
         ...newOptions,
         label: configurationSetting.label,
         entity: configurationSetting,
-        ...checkAndFormatIfAndIfNoneMatch(newOptions)
+        ...checkAndFormatIfAndIfNoneMatch(configurationSetting, newOptions)
       });
     });
   }

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -170,7 +170,7 @@ export class AppConfigurationClient {
         ...originalResponse,
         _response: originalResponse._response,
         statusCode: originalResponse._response.status
-      };
+      };      
 
       // 304 only comes back if the user has passed a conditional option in their
       // request _and_ the remote object has the same etag as what the user passed.

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -37,7 +37,7 @@ import {
   formatWildcards,
   makeConfigurationSettingsFieldsThrow
 } from "./internal/helpers";
-import { ResponseBodyNotFoundError, tracingPolicy } from "@azure/core-http";
+import { tracingPolicy } from "@azure/core-http";
 import { Spanner } from "./internal/tracingHelpers";
 import { GetKeyValuesResponse } from './generated/src/models';
 

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -137,7 +137,7 @@ export class AppConfigurationClient {
       // setting wasn't found (might have already been deleted). Users that care can check that the response
       // code is not 200 but we don't consider this to be an error.
       makeConfigurationSettingsFieldsThrow(response,
-        "The key that we were requested to delete was not found (data in the non-response properties will be invalid)",
+        "The key that we were requested to delete was not found. Only data in the _response and statusCode field are valid.",
         "Resource already deleted or missing");  
     }
 

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -135,9 +135,9 @@ export class AppConfigurationClient {
 
     if (response._response.status == 204) {
       // setting wasn't found (might have already been deleted). Users that care can check that the response
-      // code is not 200 but we don't consider this to be an error.
+      // code is not 200 but we don't consider this to be a fatal error.
       makeConfigurationSettingsFieldsThrow(response,
-        "The key that we were requested to delete was not found. Only data in the _response and statusCode field are valid.",
+        "The resource was already deleted (or was missing). Only the _response and statusCode properties are valid for this object.",
         "Resource already deleted or missing");  
     }
 

--- a/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
@@ -13,7 +13,7 @@ import * as Models from "./models";
 
 const packageName = "app-configuration";
 export const
-  packageVersion = "1.0.0-preview.5";
+  packageVersion = "1.0.0-preview.6";
 
 export class AppConfigurationContext extends coreHttp.ServiceClient {
   syncToken?: string;

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -4,7 +4,7 @@
 import { ListConfigurationSettingsOptions } from '..';
 import { URLBuilder, ResponseBodyNotFoundError } from '@azure/core-http';
 import { isArray } from 'util';
-import { ListRevisionsOptions, ConfigurationSettingId, ConfigurationSetting, HttpResponseField } from '../models';
+import { ListRevisionsOptions, ConfigurationSettingId, ConfigurationSetting, HttpResponseField, HttpConditionalFields } from '../models';
 import { AppConfigurationGetKeyValuesOptionalParams } from '../generated/src/models';
 
 /**

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -4,7 +4,7 @@
 import { ListConfigurationSettingsOptions } from '..';
 import { URLBuilder, ResponseBodyNotFoundError } from '@azure/core-http';
 import { isArray } from 'util';
-import { ListRevisionsOptions, ConfigurationSetting, HttpResponseField } from '../models';
+import { ListRevisionsOptions, ConfigurationSettingId, ConfigurationSetting, HttpResponseField } from '../models';
 import { AppConfigurationGetKeyValuesOptionalParams } from '../generated/src/models';
 
 /**
@@ -30,26 +30,26 @@ export function quoteETag(etag: string | undefined): string | undefined {
 }
 
 /**
- * Checks the ifMatch/ifNoneMatch properties to make sure we haven't specified both
+ * Checks the onlyIfChanged/onlyIfUnchanged properties to make sure we haven't specified both
  * and throws an Error. Otherwise, returns the properties properly quoted.
- * @param options An options object with ifMatch/ifNoneMatch fields 
+ * @param options An options object with onlyIfChanged/onlyIfUnchanged fields 
  * @internal
  * @ignore
  */
-export function checkAndFormatIfAndIfNoneMatch(options: { ifMatch?: string, ifNoneMatch?: string }): { ifMatch: string | undefined, ifNoneMatch: string | undefined } {
-  if (options.ifMatch && options.ifNoneMatch) {
-    throw new Error("ifMatch and ifNoneMatch are mutually-exclusive");
+export function checkAndFormatIfAndIfNoneMatch(configurationSetting: ConfigurationSettingId, options: HttpConditionalFields): { ifMatch: string | undefined, ifNoneMatch: string | undefined } {
+  if (options.onlyIfChanged && options.onlyIfUnchanged) {
+    throw new Error("onlyIfChanged and onlyIfUnchanged are mutually-exclusive");
   }
 
   let ifMatch;
   let ifNoneMatch;
 
-  if (options.ifMatch) {
-    ifMatch = quoteETag(options.ifMatch);
+  if (options.onlyIfUnchanged) {
+    ifMatch = quoteETag(configurationSetting.etag);
   }
 
-  if (options.ifNoneMatch) {
-    ifNoneMatch = quoteETag(options.ifNoneMatch);
+  if (options.onlyIfChanged) {
+    ifNoneMatch = quoteETag(configurationSetting.etag);
   }
 
   return {

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -18,8 +18,6 @@ export interface ConfigurationSettingId {
    */
   label?: string;
 
-  // TODO: might not be the right spot.
-
   /**
    * The etag for this setting
    */

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -19,7 +19,7 @@ export {
   GetKeyValuesHeaders,
   GetRevisionsHeaders,
   PutKeyValueHeaders,
-  PutLockHeaders,
+  PutLockHeaders
 } from "./generated/src/models/index";
 
 /**
@@ -82,7 +82,7 @@ export interface ConfigurationSetting extends ConfigurationSettingParam {
 /**
  * Parameters for adding a new configuration setting
  */
-export interface AddConfigurationSettingParam extends ConfigurationSettingParam { }
+export interface AddConfigurationSettingParam extends ConfigurationSettingParam {}
 
 /**
  * Parameters for creating or updating a new configuration setting
@@ -160,27 +160,38 @@ export interface AddConfigurationSettingOptions extends RequestOptionsBase {}
 /**
  * Response from adding a ConfigurationSetting.
  */
-export interface AddConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface AddConfigurationSettingResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Response from deleting a ConfigurationSetting.
  */
-export interface DeleteConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface DeleteConfigurationSettingResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Options for deleting a ConfigurationSetting.
  */
-export interface DeleteConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface DeleteConfigurationSettingOptions
+  extends HttpConditionalFields,
+    RequestOptionsBase {}
 
 /**
  * Options used when saving a ConfigurationSetting.
  */
-export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {}
 
 /**
  * Response from setting a ConfigurationSetting.
  */
-export interface SetConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface SetConfigurationSettingResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Headers from getting a ConfigurationSetting.
@@ -196,12 +207,22 @@ export interface GetConfigurationHeaders extends SyncTokenHeaderField {
  * Response from retrieving a ConfigurationSetting.
  */
 export interface GetConfigurationSettingResponse
-  extends ConfigurationSetting, GetConfigurationHeaders, HttpResponseField<GetConfigurationHeaders> {}
+  extends ConfigurationSetting,
+    GetConfigurationHeaders,
+  HttpResponseField<GetConfigurationHeaders> {
+  /**
+   * The HTTP status code for the response
+   */
+  statusCode: number;
+}
 
 /**
  * Options for getting a ConfigurationSetting.
  */
-export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields, OptionalFields { 
+export interface GetConfigurationSettingOptions
+  extends RequestOptionsBase,
+    HttpConditionalFields,
+    OptionalFields {
   /**
    * Requests the server to respond with the state of the resource at the specified time.
    */
@@ -234,8 +255,7 @@ export interface ListSettingsOptions extends OptionalFields {
  * Also provides `fields` which allows you to selectively choose which fields are populated in the
  * result.
  */
-export interface ListConfigurationSettingsOptions extends RequestOptionsBase, ListSettingsOptions {
-}
+export interface ListConfigurationSettingsOptions extends RequestOptionsBase, ListSettingsOptions {}
 
 /**
  * A page of configuration settings and the corresponding HTTP response
@@ -246,14 +266,13 @@ export interface ListConfigurationSettingPage extends HttpResponseField<GetKeyVa
    */
   items: ConfigurationSetting[];
 }
-  
+
 /**
  * Options for listRevisions that allow for filtering based on keys, labels and other fields.
  * Also provides `fields` which allows you to selectively choose which fields are populated in the
  * result.
  */
-export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOptions {  
-}
+export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOptions {}
 
 /**
  * A page of configuration settings and the corresponding HTTP response
@@ -268,19 +287,25 @@ export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders
 /**
  * Options for clearReadOnly
  */
-export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
 
 /**
  * Response when clearing the read-only status from a value
  */
-export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface ClearReadOnlyResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}
 
 /**
  * Options for setReadOnly
  */
-export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase { }
+export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
 
 /**
  * Response when setting a value to read-only.
  */
-export interface SetReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> { }
+export interface SetReadOnlyResponse
+  extends ConfigurationSetting,
+    SyncTokenHeaderField,
+    HttpResponseField<SyncTokenHeaderField> {}

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -17,6 +17,13 @@ export interface ConfigurationSettingId {
    * setting does not have a label.
    */
   label?: string;
+
+  // TODO: might not be the right spot.
+
+  /**
+   * The etag for this setting
+   */
+  etag?: string;
 }
 
 /**
@@ -45,19 +52,14 @@ export interface ConfigurationSettingParam extends ConfigurationSettingId {
  */
 export interface ConfigurationSetting extends ConfigurationSettingParam {
   /**
-   * The date when this setting was last modified
-   */
-  lastModified?: Date;
-
-  /**
    * Whether or not the setting is read-only
    */
   locked?: boolean;
 
   /**
-   * The etag for this setting
+   * The date when this setting was last modified
    */
-  etag?: string;
+  lastModified?: Date;
 }
 
 /**
@@ -116,12 +118,13 @@ export interface HttpConditionalFields {
   /**
    * Used to perform an operation only if the targeted resource's etag matches the value provided.
    */
-  ifMatch?: string;
+  onlyIfUnchanged?: boolean;
+
   /**
    * Used to perform an operation only if the targeted resource's etag does not match the value
    * provided.
    */
-  ifNoneMatch?: string;
+  onlyIfChanged?: boolean;
 }
 
 /**

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -80,6 +80,18 @@ export interface ConfigurationSetting extends ConfigurationSettingParam {
 }
 
 /**
+ * Fields that are hoisted up  from the _response field of the object
+ * Used in cases where individual HTTP response fields are important for
+ * the user to use in common-use cases like handling http status codes 204 or 304.
+ */
+export interface HttpResponseFields {
+  /**
+   * The HTTP status code for the response
+   */
+  statusCode: number;
+}
+
+/**
  * Parameters for adding a new configuration setting
  */
 export interface AddConfigurationSettingParam extends ConfigurationSettingParam {}
@@ -171,6 +183,7 @@ export interface AddConfigurationSettingResponse
 export interface DeleteConfigurationSettingResponse
   extends ConfigurationSetting,
     SyncTokenHeaderField,
+    HttpResponseFields,
     HttpResponseField<SyncTokenHeaderField> {}
 
 /**
@@ -209,11 +222,8 @@ export interface GetConfigurationHeaders extends SyncTokenHeaderField {
 export interface GetConfigurationSettingResponse
   extends ConfigurationSetting,
     GetConfigurationHeaders,
+    HttpResponseFields,
   HttpResponseField<GetConfigurationHeaders> {
-  /**
-   * The HTTP status code for the response
-   */
-  statusCode: number;
 }
 
 /**

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -1,26 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import {
-  DeleteKeyValueHeaders,
-  DeleteLockHeaders,
-  GetKeyValueHeaders,
-  PutKeyValueHeaders,
-  PutLockHeaders,
-  GetKeyValuesHeaders,
-  GetRevisionsHeaders
-} from "./generated/src/models/index";
 import { RequestOptionsBase, HttpResponse } from "@azure/core-http";
-
-export {
-  DeleteKeyValueHeaders,
-  DeleteLockHeaders,
-  GetKeyValueHeaders,
-  GetKeyValuesHeaders,
-  GetRevisionsHeaders,
-  PutKeyValueHeaders,
-  PutLockHeaders
-} from "./generated/src/models/index";
 
 /**
  * Fields that uniquely identify a configuration setting
@@ -270,7 +251,7 @@ export interface ListConfigurationSettingsOptions extends RequestOptionsBase, Li
 /**
  * A page of configuration settings and the corresponding HTTP response
  */
-export interface ListConfigurationSettingPage extends HttpResponseField<GetKeyValuesHeaders> {
+export interface ListConfigurationSettingPage extends HttpResponseField<SyncTokenHeaderField> {
   /**
    * The configuration settings for this page of results.
    */
@@ -287,7 +268,7 @@ export interface ListRevisionsOptions extends RequestOptionsBase, ListSettingsOp
 /**
  * A page of configuration settings and the corresponding HTTP response
  */
-export interface ListRevisionsPage extends HttpResponseField<GetRevisionsHeaders> {
+export interface ListRevisionsPage extends HttpResponseField<SyncTokenHeaderField> {
   /**
    * The configuration settings for this page of results.
    */

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -10,7 +10,7 @@ describe("etags", () => {
   let client: AppConfigurationClient;
   const key = `etags-${Date.now()}`;
 
-  before(async function () {
+  before(function () {
     client = createAppConfigurationClientForTests() || this.skip();
   });
 

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -1,6 +1,6 @@
 import { AppConfigurationClient } from "../src";
 import {
-  getConnectionStringFromEnvironment,
+  createAppConfigurationClientForTests,
   deleteKeyCompletely,
   assertThrowsRestError
 } from "./testHelpers";
@@ -10,8 +10,8 @@ describe("etags", () => {
   let client: AppConfigurationClient;
   const key = `etags-${Date.now()}`;
 
-  before(async () => {
-    client = new AppConfigurationClient(getConnectionStringFromEnvironment());
+  before(async function () {
+    client = createAppConfigurationClientForTests() || this.skip();
   });
 
   beforeEach(async () => {

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -80,6 +80,7 @@ describe("etags", () => {
     });
 
     assert.equal(response._response.status, 304);
+    assert.equal(response.statusCode, 304);
 
     assert.throws(() => response.contentType, /The requested value was not retrieved since it has not changed since the last request./, "");
     assert.throws(() => response.etag, /The requested value was not retrieved since it has not changed since the last request./, "");
@@ -94,11 +95,14 @@ describe("etags", () => {
     await client.setConfigurationSetting({ key: key, value: "new world" });
 
     const updatedSetting = await client.getConfigurationSetting({ key });
+    
     assert.notEqual(
       originalSetting.etag,
       updatedSetting.etag,
       "New content, new update, etags shouldn't match"
     );
+
+    assert.equal(200, updatedSetting.statusCode);
 
     // only get the setting if it changed (it has!)
     const configurationSetting = await client.getConfigurationSetting({ key }, {

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -76,8 +76,8 @@ describe("etags", () => {
     });
 
     // only get the setting if it changed (it hasn't)
-    const response = await client.getConfigurationSetting({ key }, {
-      ifNoneMatch: originalSetting.etag
+    const response = await client.getConfigurationSetting(originalSetting, {
+      onlyIfChanged: true
     });
 
     assert.equal(response._response.status, 304);
@@ -106,8 +106,8 @@ describe("etags", () => {
     assert.equal(200, updatedSetting.statusCode);
 
     // only get the setting if it changed (it has!)
-    const configurationSetting = await client.getConfigurationSetting({ key }, {
-      ifNoneMatch: originalSetting.etag
+    const configurationSetting = await client.getConfigurationSetting(originalSetting, {
+      onlyIfChanged: true
     });
 
     // now our retrieved setting matches what's on the server

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -25,7 +25,7 @@ describe("etags", () => {
     await deleteKeyCompletely([key], client);
   });
 
-  // etag usage is 'opt-in' via the ifMatch/ifNoneMatch options for certain calls
+  // etag usage is 'opt-in' via the onlyIfChanged/onlyIfUnchanged options for certain calls
   // by default no etags are used.
   it("Get and set by default doesn't use etags", async () => {
     const addedSetting = await client.getConfigurationSetting({ key });
@@ -36,12 +36,13 @@ describe("etags", () => {
     await client.setConfigurationSetting(addedSetting);
   });
 
-  it("Get and set, enabling etag checking using ifMatch", async () => {
+  it("Get and set, enabling etag checking using onlyIfUnchanged", async () => {
     const addedSetting = await client.getConfigurationSetting({ key });
 
     addedSetting.value = "some new value!";
 
-    await client.setConfigurationSetting(addedSetting, { ifMatch: addedSetting.etag });
+    const newlyUpdatedSetting = await client.setConfigurationSetting(addedSetting, { onlyIfUnchanged: true });
+    assert.equal(newlyUpdatedSetting.value, addedSetting.value);
   });
 
   it("set with an old etag will throw RestError", async () => {
@@ -61,7 +62,7 @@ describe("etags", () => {
     await assertThrowsRestError(
       () =>
         client.setConfigurationSetting(addedSetting, {
-          ifMatch: addedSetting.etag
+          onlyIfUnchanged: true
         }),
       412,
       "Old etag will result in a failed update and error"

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -68,7 +68,7 @@ describe("etags", () => {
     );
   });
 
-  it.only("get using ifNoneMatch to only get the setting if it's changed (ie: safe GET)", async () => {
+  it("get using ifNoneMatch to only get the setting if it's changed (ie: safe GET)", async () => {
     const originalSetting = await client.setConfigurationSetting({
       key: key,
       value: "world"
@@ -81,14 +81,14 @@ describe("etags", () => {
 
     assert.equal(response._response.status, 304);
 
-    assert.throws(() => response.contentType, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.etag, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.key, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.label, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.lastModified, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.locked, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.tags, /The requested setting's value has not changed since the last request./, "");
-    assert.throws(() => response.value, /The requested setting's value has not changed since the last request./, "");
+    assert.throws(() => response.contentType, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.etag, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.key, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.label, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.lastModified, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.locked, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.tags, /The requested value was not retrieved since it has not changed since the last request./, "");
+    assert.throws(() => response.value, /The requested value was not retrieved since it has not changed since the last request./, "");
 
     // let's update it and then try again
     await client.setConfigurationSetting({ key: key, value: "new world" });

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { checkAndFormatIfAndIfNoneMatch } from "../src/internal/helpers"
+import { checkAndFormatIfAndIfNoneMatch, formatWildcards, extractAfterTokenFromNextLink, quoteETag } from "../src/internal/helpers"
 import * as assert from "assert";
 
 describe("helper methods", () => {
@@ -35,3 +35,70 @@ describe("helper methods", () => {
     }), /onlyIfChanged and onlyIfUnchanged are mutually-exclusive/);    
   });
 })
+
+
+
+describe("quoteETag", () => {
+  it("undefined", () => {
+    assert.equal(
+      undefined,
+      quoteETag(undefined)
+    );
+
+    assert.equal(
+      '"etagishere"',
+      quoteETag("etagishere")
+    );
+
+    assert.equal(
+      "'etagishere'",
+      quoteETag("'etagishere'")
+    );
+
+    assert.equal(
+      "*",
+      quoteETag("*")
+    );
+  });
+});
+
+describe("formatWildcards", () => {
+  it("undefined", () => {
+    const result = formatWildcards({
+      keys: undefined,
+      labels: undefined
+    });
+
+    assert.ok(!result.key);
+    assert.ok(!result.label);
+  });
+
+  it("single values only", () => {
+    const result = formatWildcards({
+      keys: ["key1"],
+      labels: ["label1"]
+    });
+
+    assert.equal("key1", result.key);
+    assert.equal("label1", result.label);
+  });
+
+  it("multiple values", () => {
+    const result = formatWildcards({
+      keys: ["key1", "key2"],
+      labels: ["label1", "label2"]
+    });
+
+    assert.equal("key1,key2", result.key);
+    assert.equal("label1,label2", result.label);
+  });
+});
+
+describe("extractAfterTokenFromNextLink", () => {
+  it("token is extracted and properly unescaped", () => {
+    let token = extractAfterTokenFromNextLink(
+      "/kv?key=someKey&api-version=1.0&after=bGlah%3D"
+    );
+    assert.equal("bGlah=", token);
+  });
+});

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -5,32 +5,33 @@ import { checkAndFormatIfAndIfNoneMatch } from "../src/internal/helpers"
 import * as assert from "assert";
 
 describe("helper methods", () => {
-  it("checkAndFormatIfAndIfNoneMatch", () => {
+  const key = "ignored";
+
+  it("checkAndFormatIfAndIfNoneMatch", () => {    
     assert.deepEqual({
       ifMatch: undefined,
       ifNoneMatch: undefined
-    }, checkAndFormatIfAndIfNoneMatch({}));
+    }, checkAndFormatIfAndIfNoneMatch({ key }, {}));
 
     assert.deepEqual({
       ifMatch: "\"hello\"",
       ifNoneMatch: undefined
-    }, checkAndFormatIfAndIfNoneMatch({
-      ifMatch: "hello"
+    }, checkAndFormatIfAndIfNoneMatch({ key, etag: "hello" }, {
+      onlyIfUnchanged: true
     }));
 
     assert.deepEqual({
       ifNoneMatch: "\"hello\"",
       ifMatch: undefined
-    }, checkAndFormatIfAndIfNoneMatch({
-      ifNoneMatch: "\"hello\"",
-      ifMatch: undefined,
+    }, checkAndFormatIfAndIfNoneMatch({ key, etag: "hello" }, {
+      onlyIfChanged: true
     }));
   });
 
   it("checkAndFormatIfAndIfNoneMatch - mutually exclusive", () => {
-    assert.throws(() => checkAndFormatIfAndIfNoneMatch({
-      ifMatch: "'hello'",
-      ifNoneMatch: "\"world\""
-    }), /^Error: ifMatch and ifNoneMatch are mutually-exclusive/);    
+    assert.throws(() => checkAndFormatIfAndIfNoneMatch({ key, etag: "won't get used"}, {
+      onlyIfChanged: true,
+      onlyIfUnchanged: true
+    }), /onlyIfChanged and onlyIfUnchanged are mutually-exclusive/);    
   });
 })

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -5,9 +5,9 @@ import { checkAndFormatIfAndIfNoneMatch, formatWildcards, extractAfterTokenFromN
 import * as assert from "assert";
 
 describe("helper methods", () => {
-  const key = "ignored";
-
   it("checkAndFormatIfAndIfNoneMatch", () => {    
+    const key = "ignored";
+
     assert.deepEqual({
       ifMatch: undefined,
       ifNoneMatch: undefined
@@ -29,76 +29,76 @@ describe("helper methods", () => {
   });
 
   it("checkAndFormatIfAndIfNoneMatch - mutually exclusive", () => {
+    const key = "ignored";
+    
     assert.throws(() => checkAndFormatIfAndIfNoneMatch({ key, etag: "won't get used"}, {
       onlyIfChanged: true,
       onlyIfUnchanged: true
     }), /onlyIfChanged and onlyIfUnchanged are mutually-exclusive/);    
   });
+
+  describe("quoteETag", () => {
+    it("undefined", () => {
+      assert.equal(
+        undefined,
+        quoteETag(undefined)
+      );
+  
+      assert.equal(
+        '"etagishere"',
+        quoteETag("etagishere")
+      );
+  
+      assert.equal(
+        "'etagishere'",
+        quoteETag("'etagishere'")
+      );
+  
+      assert.equal(
+        "*",
+        quoteETag("*")
+      );
+    });
+  });
+  
+  describe("formatWildcards", () => {
+    it("undefined", () => {
+      const result = formatWildcards({
+        keys: undefined,
+        labels: undefined
+      });
+  
+      assert.ok(!result.key);
+      assert.ok(!result.label);
+    });
+  
+    it("single values only", () => {
+      const result = formatWildcards({
+        keys: ["key1"],
+        labels: ["label1"]
+      });
+  
+      assert.equal("key1", result.key);
+      assert.equal("label1", result.label);
+    });
+  
+    it("multiple values", () => {
+      const result = formatWildcards({
+        keys: ["key1", "key2"],
+        labels: ["label1", "label2"]
+      });
+  
+      assert.equal("key1,key2", result.key);
+      assert.equal("label1,label2", result.label);
+    });
+  });
+  
+  describe("extractAfterTokenFromNextLink", () => {
+    it("token is extracted and properly unescaped", () => {
+      let token = extractAfterTokenFromNextLink(
+        "/kv?key=someKey&api-version=1.0&after=bGlah%3D"
+      );
+      assert.equal("bGlah=", token);
+    });
+  });
 })
-
-
-
-describe("quoteETag", () => {
-  it("undefined", () => {
-    assert.equal(
-      undefined,
-      quoteETag(undefined)
-    );
-
-    assert.equal(
-      '"etagishere"',
-      quoteETag("etagishere")
-    );
-
-    assert.equal(
-      "'etagishere'",
-      quoteETag("'etagishere'")
-    );
-
-    assert.equal(
-      "*",
-      quoteETag("*")
-    );
-  });
-});
-
-describe("formatWildcards", () => {
-  it("undefined", () => {
-    const result = formatWildcards({
-      keys: undefined,
-      labels: undefined
-    });
-
-    assert.ok(!result.key);
-    assert.ok(!result.label);
-  });
-
-  it("single values only", () => {
-    const result = formatWildcards({
-      keys: ["key1"],
-      labels: ["label1"]
-    });
-
-    assert.equal("key1", result.key);
-    assert.equal("label1", result.label);
-  });
-
-  it("multiple values", () => {
-    const result = formatWildcards({
-      keys: ["key1", "key2"],
-      labels: ["label1", "label2"]
-    });
-
-    assert.equal("key1,key2", result.key);
-    assert.equal("label1,label2", result.label);
-  });
-});
-
-describe("extractAfterTokenFromNextLink", () => {
-  it("token is extracted and properly unescaped", () => {
-    let token = extractAfterTokenFromNextLink(
-      "/kv?key=someKey&api-version=1.0&after=bGlah%3D"
-    );
-    assert.equal("bGlah=", token);
-  });
-});

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { checkAndFormatIfAndIfNoneMatch, formatWildcards, extractAfterTokenFromNextLink, quoteETag } from "../src/internal/helpers"
+import { checkAndFormatIfAndIfNoneMatch, formatWildcards, extractAfterTokenFromNextLink, quoteETag, makeConfigurationSettingsFieldsThrow } from "../src/internal/helpers"
 import * as assert from "assert";
+import { ConfigurationSetting, HttpResponseField, AppConfigurationClient, HttpResponseFields } from '../src';
+import { HttpHeaders, ResponseBodyNotFoundError } from '@azure/core-http';
 
 describe("helper methods", () => {
   it("checkAndFormatIfAndIfNoneMatch", () => {    
@@ -30,7 +32,7 @@ describe("helper methods", () => {
 
   it("checkAndFormatIfAndIfNoneMatch - mutually exclusive", () => {
     const key = "ignored";
-    
+
     assert.throws(() => checkAndFormatIfAndIfNoneMatch({ key, etag: "won't get used"}, {
       onlyIfChanged: true,
       onlyIfUnchanged: true
@@ -101,4 +103,67 @@ describe("helper methods", () => {
       assert.equal("bGlah=", token);
     });
   });
+
+  it("makeConfigurationSettingsFieldsThrow", () => {
+    const response: ConfigurationSetting & HttpResponseField<any> & HttpResponseFields = {
+      key: "undefined",
+      _response: {
+        request: {
+          url: "unused",
+          abortSignal: {
+            aborted: true,
+            addEventListener: () => { },
+            removeEventListener: () => { }
+          },
+          method: "GET",
+          withCredentials: false,
+          headers: new HttpHeaders(),
+          timeout: 0,
+          clone: function () { return this; },
+          validateRequestProperties: () => { },
+          prepare: function (options) { return this; },
+        },
+        status: 204,
+        headers: new HttpHeaders(),
+        bodyAsText: "",
+        parsedHeaders: {}
+      },
+      statusCode: 204
+    };
+
+    makeConfigurationSettingsFieldsThrow(response,
+      "My error message",
+      "My error code");
+    
+    for (const name of getAllConfigurationSettingFields()) {
+      assert.throws(() => (<any>response)[name], (err: ResponseBodyNotFoundError) => {
+        assert.equal("ResponseBodyNotFoundError", err.name);
+        assert.equal("My error message", err.message);
+        assert.equal("My error code", err.code);
+        assert.strictEqual(response._response, err.response);
+        return true;
+      });
+    }
+
+    // These point is these properties are untouched and won't throw
+    // since they're the only properties the user is allowed to touch on these 
+    // "body empty" objects.
+    assert.equal(204, response._response.status);
+    assert.equal(204, response.statusCode);
+  });
+
+  function getAllConfigurationSettingFields() : string[] {
+    const configObjectWithAllFieldsRequired: Required<ConfigurationSetting> = {
+      contentType: "",
+      etag: "",
+      key: "",
+      label: "",
+      lastModified: new Date(),
+      locked: true,
+      tags: {},
+      value: ""
+    };   
+    
+    return Object.keys(configObjectWithAllFieldsRequired);
+  }
 })

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -136,7 +136,7 @@ describe("helper methods", () => {
       "My error code");
     
     for (const name of getAllConfigurationSettingFields()) {
-      assert.throws(() => (<any>response)[name], (err: ResponseBodyNotFoundError) => {
+      assert.throws(() => response[name], (err: ResponseBodyNotFoundError) => {
         assert.equal("ResponseBodyNotFoundError", err.name);
         assert.equal("My error message", err.message);
         assert.equal("My error code", err.code);
@@ -152,7 +152,7 @@ describe("helper methods", () => {
     assert.equal(204, response.statusCode);
   });
 
-  function getAllConfigurationSettingFields() : string[] {
+  function getAllConfigurationSettingFields() : (keyof ConfigurationSetting)[] {
     const configObjectWithAllFieldsRequired: Required<ConfigurationSetting> = {
       contentType: "",
       etag: "",
@@ -164,6 +164,6 @@ describe("helper methods", () => {
       value: ""
     };   
     
-    return Object.keys(configObjectWithAllFieldsRequired);
+    return Object.keys(configObjectWithAllFieldsRequired) as (keyof ConfigurationSetting)[];    
   }
 })

--- a/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
@@ -1,5 +1,5 @@
 import {
-  getConnectionStringFromEnvironment,
+  createAppConfigurationClientForTests,
   assertThrowsRestError,
   deleteKeyCompletely
 } from "./testHelpers";
@@ -14,12 +14,14 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     label: "some label"
   };
 
-  before(() => {
-    client = new AppConfigurationClient(getConnectionStringFromEnvironment());
+  before(function () {
+    client = createAppConfigurationClientForTests() || this.skip();
   });
 
-  after(() => {
-    deleteKeyCompletely([testConfigSetting.key], client);
+  after(async function () {
+    if (!this.currentTest!.isPending) {
+      await deleteKeyCompletely([testConfigSetting.key], client);
+    }
   });
 
   it("basic", async () => {

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -249,7 +249,7 @@ describe("AppConfigurationClient", () => {
       assert.throws(() => response.key, (err: ResponseBodyNotFoundError) => {
         assert.equal("ResponseBodyNotFoundError", err.name);
         
-        assert.equal("The key that we were requested to delete was not found (data in the non-response properties will be invalid)", err.message);
+        assert.equal("The resource was already deleted (or was missing). Only the _response and statusCode properties are valid for this object.", err.message);
         assert.equal("Resource already deleted or missing", err.code);
         
         return true;

--- a/sdk/appconfiguration/app-configuration/test/samples.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/samples.spec.ts
@@ -2,8 +2,13 @@
 // Licensed under the MIT license.
 
 import { runAll } from "../samples";
+import { getConnectionStringFromEnvironment } from './testHelpers';
 
 describe("AppConfiguration samples", () => {
+    before(function () {
+        getConnectionStringFromEnvironment() || this.skip();
+    });
+
     it("Make sure all the samples build and run", async () => {
         await runAll();
     });

--- a/sdk/appconfiguration/app-configuration/test/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/testHelpers.ts
@@ -12,16 +12,24 @@ import * as dotenv from "dotenv";
 import { RestError } from "@azure/core-http";
 dotenv.config();
 
-export function getConnectionStringFromEnvironment(): string {
-  const connectionString = process.env["AZ_CONFIG_CONNECTION"]!;
+export function getConnectionStringFromEnvironment(): (string | undefined) {
+  return process.env["AZ_CONFIG_CONNECTION"];
+}
+
+let connectionStringNotPresentWarning = false;
+
+export function createAppConfigurationClientForTests(): (AppConfigurationClient|undefined) {
+  const connectionString = getConnectionStringFromEnvironment();
 
   if (connectionString == null) {
-    throw Error(
-      `No connection string in environment - set AZ_CONFIG_CONNECTION with a connection string for your AppConfiguration instance.`
-    );
+    if (!connectionStringNotPresentWarning) {
+      connectionStringNotPresentWarning = true;
+      console.log("Functional tests not running - set AZ_CONFIG_CONNECTION to a valid AppConfig connection string to activate");
+    }
+    return undefined;
   }
 
-  return connectionString;
+  return new AppConfigurationClient(connectionString);
 }
 
 export async function deleteKeyCompletely(keys: string[], client: AppConfigurationClient) {

--- a/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
@@ -1,6 +1,6 @@
 import { AppConfigurationClient, ConfigurationSetting } from "../src";
 import {
-  getConnectionStringFromEnvironment,
+  createAppConfigurationClientForTests,
   deleteKeyCompletely,
   assertThrowsRestError
 } from "./testHelpers";
@@ -15,8 +15,8 @@ describe("Various error cases", () => {
   let client: AppConfigurationClient;
   const nonMatchingETag = "never-match-etag";
 
-  before(() => {
-    client = new AppConfigurationClient(getConnectionStringFromEnvironment());
+  before(function () {
+    client = createAppConfigurationClientForTests() || this.skip();
   });
 
   describe("throws", () => {

--- a/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
@@ -5,6 +5,7 @@ import {
   assertThrowsRestError
 } from "./testHelpers";
 import * as assert from "assert";
+import { ResponseBodyNotFoundError } from '@azure/core-http';
 
 // There's been discussion on other teams about what errors are thrown when. This
 // is the file where I've documented the throws/notThrows cases to make coordination
@@ -53,16 +54,16 @@ describe("Various error cases", () => {
       );
     });
 
-    it("get: value is unchanged from etag (304) using ifNoneMatch, throws ReponseBodyNotFoundError (derived from RestError)", async () => {
-      const errThrown = await assertThrowsRestError(
-        () =>
-          client.getConfigurationSetting({ key: addedSetting.key }, {
-            ifNoneMatch: addedSetting.etag
-          }),
-        304
-      );
+    it("get: value is unchanged from etag (304) using ifNoneMatch, throws ReponseBodyNotFoundError on property access (derived from RestError)", async () => {
+      // changed slightly - now it only throws when we access properties
+      const response = await client.getConfigurationSetting({ key: addedSetting.key }, {
+        ifNoneMatch: addedSetting.etag
+      });
 
-      assert.equal("ResponseBodyNotFoundError", errThrown.name);
+      assert.throws(() => response.key, (err: ResponseBodyNotFoundError) => {
+        assert.equal("ResponseBodyNotFoundError", err.name);
+        return true;
+      });
     });
 
     it("add: Setting already exists throws 412", async () => {


### PR DESCRIPTION
Two changes, both to align with the pending [design guideline changes](https://github.com/Azure/azure-sdk/pull/646) concerning specifying etags and how we handle 204/304 responses.

ETags are now extracted from the passed in model, rather than requiring them to be passed in via ifMatch/ifNoneMatch flags - we now provide onlyIfUnchanged and onlyIfChanged which are booleans, rather than strings.

HTTP 204/304 handling ("valid" responses but with empty response bodies) are now handled by:
* Adding a top level statusCode field for get and delete's responses
* Setting all the fields (aside from _response and statusCode) 
Also, updated the http status code 204 and 304 handling in getConfigurationSetting and deleteConfigurationSetting, which 