### PR TITLE
[Cosmos] Sign headers locally 

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -20,7 +20,8 @@
   "browser": {
     "./dist-esm/request/defaultAgent.js": "./dist-esm/request/defaultAgent.browser.js",
     "./dist-esm/utils/atob.js": "./dist-esm/utils/atob.browser.js",
-    "./dist-esm/utils/digest.js": "./dist-esm/utils/digest.browser.js"
+    "./dist-esm/utils/digest.js": "./dist-esm/utils/digest.browser.js",
+    "./dist-esm/utils/hmac.js": "./dist-esm/utils/hmac.browser.js"
   },
   "files": [
     "changelog.md",
@@ -73,7 +74,6 @@
   },
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
-    "@azure/cosmos-sign": "^1.0.2",
     "@types/debug": "^4.1.4",
     "debug": "^4.1.1",
     "fast-json-stable-stringify": "^2.0.0",

--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -1025,7 +1025,7 @@ export class RuntimeExecutionTimes {
 }
 
 // @public
-export function setAuthorizationTokenHeaderUsingMasterKey(verb: HTTPMethod, resourceId: string, resourceType: ResourceType, headers: CosmosHeaders, masterKey: string): void;
+export function setAuthorizationTokenHeaderUsingMasterKey(verb: HTTPMethod, resourceId: string, resourceType: ResourceType, headers: CosmosHeaders, masterKey: string): Promise<void>;
 
 // @public
 export interface SqlParameter {

--- a/sdk/cosmosdb/cosmos/rollup.config.js
+++ b/sdk/cosmosdb/cosmos/rollup.config.js
@@ -4,7 +4,6 @@ export default [
     input: "dist-esm/index.js",
     external: [
       "tslib",
-      "@azure/cosmos-sign",
       "universal-user-agent",
       "uuid/v4",
       "debug",
@@ -22,7 +21,6 @@ export default [
       sourcemap: true,
       globals: {
         "universal-user-agent": "universalUserAgent",
-        "@azure/cosmos-sign": "cosmosSign",
         "fast-json-stable-stringify": "stableStringify",
         "uuid/v4": "uuid",
         "@azure/abort-controller": "AbortController",

--- a/sdk/cosmosdb/cosmos/src/auth.ts
+++ b/sdk/cosmosdb/cosmos/src/auth.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { generateHeaders } from "@azure/cosmos-sign";
+import { generateHeaders } from "./utils/headers";
 import { Constants, getResourceIdFromPath, HTTPMethod, ResourceType } from "./common";
 import { CosmosClientOptions } from "./CosmosClientOptions";
 import { CosmosHeaders } from "./queryExecutionContext";
@@ -47,7 +47,7 @@ export async function setAuthorizationHeader(
   }
 
   if (clientOptions.key) {
-    setAuthorizationTokenHeaderUsingMasterKey(
+    await setAuthorizationTokenHeaderUsingMasterKey(
       verb,
       resourceId,
       resourceType,
@@ -69,7 +69,7 @@ export async function setAuthorizationHeader(
  * The default function for setting header token using the masterKey
  * @ignore
  */
-export function setAuthorizationTokenHeaderUsingMasterKey(
+export async function setAuthorizationTokenHeaderUsingMasterKey(
   verb: HTTPMethod,
   resourceId: string,
   resourceType: ResourceType,
@@ -80,7 +80,10 @@ export function setAuthorizationTokenHeaderUsingMasterKey(
   if (resourceType === ResourceType.offer) {
     resourceId = resourceId && resourceId.toLowerCase();
   }
-  headers = Object.assign(headers, generateHeaders(masterKey, verb, resourceType, resourceId));
+  headers = Object.assign(
+    headers,
+    await generateHeaders(masterKey, verb, resourceType, resourceId)
+  );
 }
 
 /**

--- a/sdk/cosmosdb/cosmos/src/utils/encode.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/encode.ts
@@ -14,7 +14,7 @@ export function encodeBase64(value: ArrayBuffer): string {
   let binary = "";
   const bytes = new Uint8Array(value);
   const len = bytes.byteLength;
-  for (var i = 0; i < len; i++) {
+  for (let i = 0; i < len; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
   return btoa(binary);

--- a/sdk/cosmosdb/cosmos/src/utils/encode.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/encode.ts
@@ -5,3 +5,17 @@ export function encodeUTF8(str: string): Uint8Array {
   }
   return bytes;
 }
+
+export function encodeBase64(value: ArrayBuffer): string {
+  if ("function" !== typeof btoa) {
+    throw new Error("Your browser environment is missing the global `btoa` function");
+  }
+
+  let binary = "";
+  const bytes = new Uint8Array(value);
+  const len = bytes.byteLength;
+  for (var i = 0; i < len; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}

--- a/sdk/cosmosdb/cosmos/src/utils/headers.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/headers.ts
@@ -1,0 +1,43 @@
+import { hmac } from "./hmac";
+import { HTTPMethod, ResourceType } from "../common";
+
+export async function generateHeaders(
+  masterKey: string,
+  method: HTTPMethod,
+  resourceType: ResourceType = ResourceType.none,
+  resourceId: string = "",
+  date = new Date()
+) {
+  const sig = await signature(masterKey, method, resourceType, resourceId, date);
+
+  return {
+    Authorization: sig,
+    "x-ms-date": date.toUTCString()
+  };
+}
+
+async function signature(
+  masterKey: string,
+  method: HTTPMethod,
+  resourceType: ResourceType,
+  resourceId: string = "",
+  date = new Date()
+) {
+  const type = "master";
+  const version = "1.0";
+  const text =
+    method.toLowerCase() +
+    "\n" +
+    resourceType.toLowerCase() +
+    "\n" +
+    resourceId +
+    "\n" +
+    date.toUTCString().toLowerCase() +
+    "\n" +
+    "" +
+    "\n";
+
+  const signed = await hmac(masterKey, text);
+
+  return encodeURIComponent("type=" + type + "&ver=" + version + "&sig=" + signed);
+}

--- a/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
@@ -2,16 +2,13 @@ import { encodeUTF8, encodeBase64 } from "./encode";
 import atob from "./atob";
 
 export async function hmac(key: string, message: string) {
+  const importParams: HmacImportParams = { name: "HMAC", hash: { name: "SHA-256" } };
   const encodedMessage = encodeUTF8(message);
   const encodedKey = encodeUTF8(atob(key));
-  const cryptoKey = await window.crypto.subtle.importKey(
-    "raw",
-    encodedKey,
-    { name: "HMAC", hash: { name: "SHA-256" } },
-    false,
-    ["sign"]
-  );
-  const signature = await window.crypto.subtle.sign("HMAC", cryptoKey, encodedMessage);
+  const cryptoKey = await window.crypto.subtle.importKey("raw", encodedKey, importParams, false, [
+    "sign"
+  ]);
+  const signature = await window.crypto.subtle.sign(importParams, cryptoKey, encodedMessage);
 
   return encodeBase64(signature);
 }

--- a/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hmac.browser.ts
@@ -1,0 +1,17 @@
+import { encodeUTF8, encodeBase64 } from "./encode";
+import atob from "./atob";
+
+export async function hmac(key: string, message: string) {
+  const encodedMessage = encodeUTF8(message);
+  const encodedKey = encodeUTF8(atob(key));
+  const cryptoKey = await window.crypto.subtle.importKey(
+    "raw",
+    encodedKey,
+    { name: "HMAC", hash: { name: "SHA-256" } },
+    false,
+    ["sign"]
+  );
+  const signature = await window.crypto.subtle.sign("HMAC", cryptoKey, encodedMessage);
+
+  return encodeBase64(signature);
+}

--- a/sdk/cosmosdb/cosmos/src/utils/hmac.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/hmac.ts
@@ -1,0 +1,7 @@
+import { createHmac } from "crypto";
+
+export async function hmac(key: string, message: string) {
+  return createHmac("sha256", Buffer.from(key, "base64"))
+    .update(message)
+    .digest("base64");
+}


### PR DESCRIPTION
Addresses problem **(2)** discussed in #5023.

Dropping dependency on @azure/cosmos-sign which depends on crypto-js in favor of signing locally using node/browser crypto libraries.