### PR TITLE
Fix node-fetch require for webpack

### DIFF
--- a/sdk/core/core-http/lib/nodeFetchHttpClient.ts
+++ b/sdk/core/core-http/lib/nodeFetchHttpClient.ts
@@ -17,7 +17,7 @@ interface GlobalWithFetch extends NodeJS.Global {
 
 const globalWithFetch = global as GlobalWithFetch;
 if (typeof globalWithFetch.fetch !== "function") {
-  const fetch = require("node-fetch");
+  const fetch = require("node-fetch").default;
   globalWithFetch.fetch = fetch;
 }
 


### PR DESCRIPTION
Fixes the [same issue](https://github.com/Azure/ms-rest-js/issues/373) as in `@azure/ms-rest-js` when using webpack to bundle a server-side node project.