### PR TITLE
[event-hubs] Make blob storage casing consistent

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-partition-manager.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-partition-manager.spec.ts
@@ -326,4 +326,20 @@ describe("Blob Partition Manager", function(): void {
       err.message.should.match(/.*Error occurred while upating the checkpoint for partition*/);
     });
   });
+  
+  it("blob prefix is always lowercased for case-insensitive fields", () => {
+    chai.assert.equal("namespace/eventhubname/consumergroupname/", BlobPartitionManager["getBlobPrefix"]({
+      fullyQualifiedNamespace: "nAmESpAce",
+      eventHubName: 'eVentHubNamE',
+      consumerGroupName: 'cOnsuMerGrouPNaMe',      
+      // partition ID is optional
+    }));
+
+    chai.assert.equal("namespace/eventhubname/consumergroupname/0", BlobPartitionManager["getBlobPrefix"]({
+      fullyQualifiedNamespace: "nAmESpAce",
+      eventHubName: 'eVentHubNamE',
+      consumerGroupName: 'cOnsuMerGrouPNaMe',      
+      partitionId: "0"
+    }));
+  });
 }).timeout(90000);


### PR DESCRIPTION
Makes the blob storage always use the same casing for the consumer group and other fields that are also not case-sensitive. Without this you'll get incorrect/inconsistent checkpointing depending on what casing the user passed in (very bad).