### PR TITLE
[app-configuration] Delete returns a response, not a ConfigurationSetting

### DIFF
--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -71,7 +71,7 @@ export interface DeleteConfigurationSettingOptions extends HttpConditionalFields
 }
 
 // @public
-export interface DeleteConfigurationSettingResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseFields, HttpResponseField<SyncTokenHeaderField> {
+export interface DeleteConfigurationSettingResponse extends SyncTokenHeaderField, HttpResponseFields, HttpResponseField<SyncTokenHeaderField> {
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -133,14 +133,6 @@ export class AppConfigurationClient {
       statusCode: originalResponse._response.status
     };
 
-    if (response._response.status == 204) {
-      // setting wasn't found (might have already been deleted). Users that care can check that the response
-      // code is not 200 but we don't consider this to be a fatal error.
-      makeConfigurationSettingsFieldsThrow(response,
-        "The resource was already deleted (or was missing). Only the _response and statusCode properties are valid for this object.",
-        "Resource already deleted or missing");  
-    }
-
     return response;
   }
 

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -163,8 +163,7 @@ export interface AddConfigurationSettingResponse
  * Response from deleting a ConfigurationSetting.
  */
 export interface DeleteConfigurationSettingResponse
-  extends ConfigurationSetting,
-    SyncTokenHeaderField,
+  extends SyncTokenHeaderField,
     HttpResponseFields,
     HttpResponseField<SyncTokenHeaderField> {}
 

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -156,22 +156,8 @@ describe("AppConfigurationClient", () => {
 
       // delete configuration
       const deletedSetting = await client.deleteConfigurationSetting(result);
-      assert.equal(
-        deletedSetting.key,
-        key,
-        "Unexpected key in result from deleteConfigurationSetting()."
-      );
-      assert.equal(
-        deletedSetting.label,
-        label,
-        "Unexpected label in result from deleteConfigurationSetting()."
-      );
-      assert.equal(
-        deletedSetting.value,
-        value,
-        "Unexpected value in result from deleteConfigurationSetting()."
-      );
-
+      assert.equal(200, deletedSetting._response.status);
+      
       // confirm setting no longer exists
       try {
         await client.getConfigurationSetting({ key, label });
@@ -206,22 +192,7 @@ describe("AppConfigurationClient", () => {
         key,
         label
       }, { onlyIfUnchanged: true });
-      assert.equal(
-        deletedSetting.key,
-        key,
-        "Unexpected key in result from deleteConfigurationSetting()."
-      );
-      assert.equal(
-        deletedSetting.label,
-        label,
-        "Unexpected label in result from deleteConfigurationSetting()."
-      );
-      assert.equal(
-        deletedSetting.value,
-        value,
-        "Unexpected value in result from deleteConfigurationSetting()."
-      );
-
+      
       // confirm setting no longer exists
       try {
         await client.getConfigurationSetting({ key, label });
@@ -244,16 +215,6 @@ describe("AppConfigurationClient", () => {
       // the user(status code: 204)
       assert.equal(response._response.status, response.statusCode);
       assert.equal(204, response.statusCode);
-
-      // also, fields throw on access
-      assert.throws(() => response.key, (err: ResponseBodyNotFoundError) => {
-        assert.equal("ResponseBodyNotFoundError", err.name);
-        
-        assert.equal("The resource was already deleted (or was missing). Only the _response and statusCode properties are valid for this object.", err.message);
-        assert.equal("Resource already deleted or missing", err.code);
-        
-        return true;
-      });
     });
 
     it("throws when deleting a configuration setting (invalid etag)", async () => {


### PR DESCRIPTION
As part of our final etag discussion we decided that deleteConfigurationSetting should just return the HTTP response but _not_ a model object. 

This simplifies things in a nice way - it's no longer ambiguous what the return value is for delete and they can still check the HTTP response if they need it.