### PR TITLE
Blob remove encrypted property from BlobMetadata

### DIFF
--- a/sdk/storage/storage-blob/src/generated/src/models/containerMappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/containerMappers.ts
@@ -11,7 +11,6 @@ export {
   BlobFlatListSegment,
   BlobHierarchyListSegment,
   BlobItem,
-  BlobMetadata,
   BlobPrefix,
   BlobProperties,
   ContainerAcquireLeaseHeaders,

--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -177,18 +177,6 @@ export interface BlobProperties {
 }
 
 /**
- * An interface representing BlobMetadata.
- */
-export interface BlobMetadata {
-  encrypted?: string;
-  /**
-   * Describes unknown properties. The value of an unknown property MUST be of type "string". Due
-   * to valid TS constraints we have modeled this as a union of `string | any`.
-   */
-  [property: string]: string | any;
-}
-
-/**
  * An Azure Storage blob
  */
 export interface BlobItem {
@@ -196,7 +184,7 @@ export interface BlobItem {
   deleted: boolean;
   snapshot: string;
   properties: BlobProperties;
-  metadata?: BlobMetadata;
+  metadata?: { [propertyName: string]: string };
 }
 
 /**

--- a/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
@@ -450,30 +450,6 @@ export const BlobProperties: coreHttp.CompositeMapper = {
   }
 };
 
-export const BlobMetadata: coreHttp.CompositeMapper = {
-  xmlName: "Metadata",
-  serializedName: "BlobMetadata",
-  type: {
-    name: "Composite",
-    className: "BlobMetadata",
-    modelProperties: {
-      encrypted: {
-        xmlIsAttribute: true,
-        xmlName: "Encrypted",
-        serializedName: "Encrypted",
-        type: {
-          name: "String"
-        }
-      }
-    },
-    additionalProperties: {
-      type: {
-        name: "String"
-      }
-    }
-  }
-};
-
 export const BlobItem: coreHttp.CompositeMapper = {
   xmlName: "Blob",
   serializedName: "BlobItem",
@@ -518,9 +494,8 @@ export const BlobItem: coreHttp.CompositeMapper = {
         xmlName: "Metadata",
         serializedName: "Metadata",
         type: {
-          name: "Composite",
-          className: "BlobMetadata",
-          additionalProperties: {
+          name: "Dictionary",
+          value: {
             type: {
               name: "String"
             }

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -2,7 +2,6 @@
 
 > see https://aka.ms/autorest
 
-
 ## Configuration
 
 ```yaml
@@ -19,208 +18,218 @@ optional-response-headers: true
 ```
 
 ## Customizations for Track 2 Generator
+
 See the [AutoRest samples](https://github.com/Azure/autorest/tree/master/Samples/3b-custom-transformations)
 for more about how we're customizing things.
 
 ### /?restype=service&comp=properties (StorageServiceProperties renamed to BlobServiceProperties)
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions
-  transform: >
-    if (!$.BlobServiceProperties) {
-        $.BlobServiceProperties = $.StorageServiceProperties;
-        delete $.StorageServiceProperties;
-        $.BlobServiceProperties.xml = { "name": "StorageServiceProperties" };
-    }
-- from: swagger-document
-  where: $.parameters
-  transform: >
-    if (!$.BlobServiceProperties) {
-        const props = $.BlobServiceProperties = $.StorageServiceProperties;
-        props.name = "BlobServiceProperties";
-        props.schema = { "$ref": props.schema.$ref.replace(/[#].*$/, "#/definitions/BlobServiceProperties") };
-        delete $.StorageServiceProperties;
-    }
-- from: swagger-document
-  where: $["x-ms-paths"]["/?restype=service&comp=properties"]
-  transform: >
-    const param = $.put.parameters[0];
-    if (param && param["$ref"] && param["$ref"].endsWith("StorageServiceProperties")) {
-        const path = param["$ref"].replace(/[#].*$/, "#/parameters/BlobServiceProperties");
-        $.put.parameters[0] = { "$ref": path };
-    }
-    const def = $.get.responses["200"].schema;
-    if (def && def["$ref"] && def["$ref"].endsWith("StorageServiceProperties")) {
-        const path = def["$ref"].replace(/[#].*$/, "#/definitions/BlobServiceProperties");
-        $.get.responses["200"].schema = { "$ref": path };
-    }
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+      if (!$.BlobServiceProperties) {
+          $.BlobServiceProperties = $.StorageServiceProperties;
+          delete $.StorageServiceProperties;
+          $.BlobServiceProperties.xml = { "name": "StorageServiceProperties" };
+      }
+  - from: swagger-document
+    where: $.parameters
+    transform: >
+      if (!$.BlobServiceProperties) {
+          const props = $.BlobServiceProperties = $.StorageServiceProperties;
+          props.name = "BlobServiceProperties";
+          props.schema = { "$ref": props.schema.$ref.replace(/[#].*$/, "#/definitions/BlobServiceProperties") };
+          delete $.StorageServiceProperties;
+      }
+  - from: swagger-document
+    where: $["x-ms-paths"]["/?restype=service&comp=properties"]
+    transform: >
+      const param = $.put.parameters[0];
+      if (param && param["$ref"] && param["$ref"].endsWith("StorageServiceProperties")) {
+          const path = param["$ref"].replace(/[#].*$/, "#/parameters/BlobServiceProperties");
+          $.put.parameters[0] = { "$ref": path };
+      }
+      const def = $.get.responses["200"].schema;
+      if (def && def["$ref"] && def["$ref"].endsWith("StorageServiceProperties")) {
+          const path = def["$ref"].replace(/[#].*$/, "#/definitions/BlobServiceProperties");
+          $.get.responses["200"].schema = { "$ref": path };
+      }
 ```
 
 ### /?restype=service&comp=stats (StorageServiceStats renamed to BlobServiceStatistics)
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions
-  transform: >
-    if (!$.BlobServiceStatistics) {
-        $.BlobServiceStatistics = $.StorageServiceStats;
-        delete $.StorageServiceStats;
-        $.BlobServiceStatistics.xml = { "name": "StorageServiceStats" };
-    }
-- from: swagger-document
-  where: $["x-ms-paths"]["/?restype=service&comp=stats"]
-  transform: >
-    const def = $.get.responses["200"].schema;
-    if (def && def["$ref"] && def["$ref"].endsWith("StorageServiceStats")) {
-        const path = def["$ref"].replace(/[#].*$/, "#/definitions/BlobServiceStatistics");
-        $.get.responses["200"].schema = { "$ref": path };
-    }
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+      if (!$.BlobServiceStatistics) {
+          $.BlobServiceStatistics = $.StorageServiceStats;
+          delete $.StorageServiceStats;
+          $.BlobServiceStatistics.xml = { "name": "StorageServiceStats" };
+      }
+  - from: swagger-document
+    where: $["x-ms-paths"]["/?restype=service&comp=stats"]
+    transform: >
+      const def = $.get.responses["200"].schema;
+      if (def && def["$ref"] && def["$ref"].endsWith("StorageServiceStats")) {
+          const path = def["$ref"].replace(/[#].*$/, "#/definitions/BlobServiceStatistics");
+          $.get.responses["200"].schema = { "$ref": path };
+      }
 ```
 
-
 ### Rename maxresults -> maxResults
-``` yaml
-directive:
-- from: swagger-document
-  where: $.parameters.MaxResults
-  transform: >
-     $["x-ms-client-name"] = "maxResults";
 
+```yaml
+directive:
+  - from: swagger-document
+    where: $.parameters.MaxResults
+    transform: >
+      $["x-ms-client-name"] = "maxResults";
 ```
 
 ### Rename timeoutParameter -> timeout
-``` yaml
-directive:
-- from: swagger-document
-  where: $.parameters.Timeout
-  transform: >
-     $["x-ms-client-name"] = "timeoutInSeconds";
 
+```yaml
+directive:
+  - from: swagger-document
+    where: $.parameters.Timeout
+    transform: >
+      $["x-ms-client-name"] = "timeoutInSeconds";
 ```
 
 ### Rename NextMarker -> ContinuationToken
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions..properties.NextMarker
-  transform: >
-     $["x-ms-client-name"] = "continuationToken";
-- from: swagger-document
-  where: $.parameters..description
-  transform: return $.replace(/(?:NextMarker)+/, "ContinuationToken")
-     
+  - from: swagger-document
+    where: $.definitions..properties.NextMarker
+    transform: >
+      $["x-ms-client-name"] = "continuationToken";
+  - from: swagger-document
+    where: $.parameters..description
+    transform: return $.replace(/(?:NextMarker)+/, "ContinuationToken")
 ```
 
 ### Rename LastSyncTime -> LastSyncOn
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions..properties.LastSyncTime
-  transform: >
-     $["x-ms-client-name"] = "lastSyncOn"
-- from: swagger-document
-  where: $.parameters..description
-  transform: return $.replace(/(?:NextMarker)+/, "ContinuationToken")
-     
+  - from: swagger-document
+    where: $.definitions..properties.LastSyncTime
+    transform: >
+      $["x-ms-client-name"] = "lastSyncOn"
 ```
 
 ### Rename permission -> permissions
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions.AccessPolicy.properties.Permission
-  transform: >
-     $["x-ms-client-name"] = "permissions";
-     
+  - from: swagger-document
+    where: $.definitions.AccessPolicy.properties.Permission
+    transform: >
+      $["x-ms-client-name"] = "permissions";
 ```
 
-
 ### Rename Headers copyCompletionTime -> copyCompletedTime
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $["x-ms-paths"]["/{containerName}/{blob}"]..responses..headers["x-ms-copy-completion-time"]
-  transform: >
-     $["x-ms-client-name"] = "copyCompletedOn";
-     
+  - from: swagger-document
+    where: $["x-ms-paths"]["/{containerName}/{blob}"]..responses..headers["x-ms-copy-completion-time"]
+    transform: >
+      $["x-ms-client-name"] = "copyCompletedOn";
 ```
 
 ### Rename Properties copyCompletionTime -> copyCompletedTime
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions..properties.CopyCompletionTime
-  transform: >
-     $["x-ms-client-name"] = "copyCompletedOn";
-     
+  - from: swagger-document
+    where: $.definitions..properties.CopyCompletionTime
+    transform: >
+      $["x-ms-client-name"] = "copyCompletedOn";
 ```
 
 ### Rename Headers CreationTime -> CreatedOn
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $["x-ms-paths"]["/{containerName}/{blob}"]..responses..headers["x-ms-creation-time"]
-  transform: >
-     $["x-ms-client-name"] = "createdOn";
+  - from: swagger-document
+    where: $["x-ms-paths"]["/{containerName}/{blob}"]..responses..headers["x-ms-creation-time"]
+    transform: >
+      $["x-ms-client-name"] = "createdOn";
 ```
 
 ### Rename Properties CreationTime -> CreatedOn
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions..properties["Creation-Time"]
-  transform: >
-     $["x-ms-client-name"] = "createdOn";
-     
+  - from: swagger-document
+    where: $.definitions..properties["Creation-Time"]
+    transform: >
+      $["x-ms-client-name"] = "createdOn";
 ```
 
 ### Rename Headers AccessTierChangeTime -> AccessTierChangedOn
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $["x-ms-paths"]["/{containerName}/{blob}"]..responses..headers["x-ms-access-tier-change-time"]
-  transform: >
-     $["x-ms-client-name"] = "accessTierChangedOn";
+  - from: swagger-document
+    where: $["x-ms-paths"]["/{containerName}/{blob}"]..responses..headers["x-ms-access-tier-change-time"]
+    transform: >
+      $["x-ms-client-name"] = "accessTierChangedOn";
 ```
 
 ### Rename Properties AccessTierChangeTime -> AccessTierChangedOn
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions..properties.AccessTierChangeTime
-  transform: >
-     $["x-ms-client-name"] = "accessTierChangedOn";
-     
+  - from: swagger-document
+    where: $.definitions..properties.AccessTierChangeTime
+    transform: >
+      $["x-ms-client-name"] = "accessTierChangedOn";
 ```
 
 ### Rename Properties DeletedTime -> DeletedOn
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions..properties.DeletedTime
-  transform: >
-     $["x-ms-client-name"] = "deletedOn";
-     
+  - from: swagger-document
+    where: $.definitions..properties.DeletedTime
+    transform: >
+      $["x-ms-client-name"] = "deletedOn";
 ```
-<!-- 
-### Unify PageRange and ClearRange by using only PageRange type in PageList
-``` yaml
+
+### Remove Encrypted property from BlobMetadata
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions.PageList.properties.ClearRange
-  transform: >
-     $.items["$ref"] = "#/definitions/PageRange";
-     $.xml = {"elementName": "ClearRange"}     
-``` -->
-     
+  - from: swagger-document
+    where: $.definitions.BlobMetadata.properties
+    transform: >
+      if ($.Encrypted) {
+        delete $.Encrypted;
+      }
+```
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions..properties.DeletedTime
+    transform: >
+      $["x-ms-client-name"] = "deletedOn";
+```
 
 ### UserDelegationKey properties
-``` yaml
+
+```yaml
 directive:
-- from: swagger-document
-  where: $.definitions.UserDelegationKey
-  transform: >
-    $.properties.SignedTid["x-ms-client-name"] = "signedTenantId";
-    $.properties.SignedOid["x-ms-client-name"] = "signedObjectId";
+  - from: swagger-document
+    where: $.definitions.UserDelegationKey
+    transform: >
+      $.properties.SignedTid["x-ms-client-name"] = "signedTenantId";
+      $.properties.SignedOid["x-ms-client-name"] = "signedObjectId";
 ```

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -4,7 +4,6 @@ import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 import { bodyToString, getBSU, getSASConnectionStringFromEnvironment, isSuperSet } from "./utils";
 import { record } from "./utils/recorder";
 import { ContainerClient, BlockBlobTier } from "../src";
-import { BlobMetadata } from "../src/generated/src/models";
 import { Test_CPK_INFO } from "./utils/constants";
 dotenv.config({ path: "../.env" });
 
@@ -130,9 +129,7 @@ describe("ContainerClient", () => {
     assert.ok(containerClient.url.indexOf(result.containerName));
     assert.deepStrictEqual(result.segment.blobItems!.length, 1);
     assert.ok(blobClients[0].url.indexOf(result.segment.blobItems![0].name));
-    assert.ok(
-      isSuperSet(result.segment.blobItems![0].metadata as BlobMetadata, metadata as BlobMetadata)
-    );
+    assert.ok(isSuperSet(result.segment.blobItems![0].metadata, metadata));
     assert.equal(result.segment.blobItems![0].properties.accessTier, BlockBlobTier.Cool);
 
     const result2 = (await containerClient
@@ -151,9 +148,7 @@ describe("ContainerClient", () => {
     assert.ok(containerClient.url.indexOf(result2.containerName));
     assert.deepStrictEqual(result2.segment.blobItems!.length, 1);
     assert.ok(blobClients[0].url.indexOf(result2.segment.blobItems![0].name));
-    assert.ok(
-      isSuperSet(result2.segment.blobItems![0].metadata as BlobMetadata, metadata as BlobMetadata)
-    );
+    assert.ok(isSuperSet(result2.segment.blobItems![0].metadata, metadata));
     assert.equal(result2.segment.blobItems![0].properties.accessTier, BlockBlobTier.Cool);
 
     for (const blob of blobClients) {
@@ -194,7 +189,6 @@ describe("ContainerClient", () => {
     assert.ok(containerClient.url.indexOf(result.containerName));
     assert.deepStrictEqual(result.segment.blobItems!.length, 1);
     assert.ok(blobURLs[0].url.indexOf(result.segment.blobItems![0].name));
-    assert.equal(result.segment.blobItems![0].metadata!.encrypted, "true");
   });
 
   it("Verify PagedAsyncIterableIterator for listBlobsFlat", async () => {
@@ -223,7 +217,7 @@ describe("ContainerClient", () => {
       prefix
     })) {
       assert.ok(blobClients[i].url.indexOf(blob.name));
-      assert.ok(isSuperSet(blob.metadata as BlobMetadata, metadata as BlobMetadata));
+      assert.ok(isSuperSet(blob.metadata, metadata));
       i++;
     }
 
@@ -259,11 +253,11 @@ describe("ContainerClient", () => {
 
     let blobItem = await iterator.next();
     assert.ok(blobClients[0].url.indexOf(blobItem.value.name));
-    assert.ok(isSuperSet(blobItem.value.metadata as BlobMetadata, metadata as BlobMetadata));
+    assert.ok(isSuperSet(blobItem.value.metadata, metadata));
 
     blobItem = await iterator.next();
     assert.ok(blobClients[1].url.indexOf(blobItem.value.name));
-    assert.ok(isSuperSet(blobItem.value.metadata as BlobMetadata, metadata as BlobMetadata));
+    assert.ok(isSuperSet(blobItem.value.metadata, metadata));
 
     for (const blob of blobClients) {
       await blob.delete();
@@ -299,7 +293,7 @@ describe("ContainerClient", () => {
       .byPage({ maxPageSize: 2 })) {
       for (const blob of response.segment.blobItems) {
         assert.ok(blobClients[i].url.indexOf(blob.name));
-        assert.ok(isSuperSet(blob.metadata as BlobMetadata, metadata as BlobMetadata));
+        assert.ok(isSuperSet(blob.metadata, metadata));
         i++;
       }
     }
@@ -339,7 +333,7 @@ describe("ContainerClient", () => {
     let response = (await iter.next()).value;
     for (const blob of response.segment.blobItems) {
       assert.ok(blobClients[i].url.indexOf(blob.name));
-      assert.ok(isSuperSet(blob.metadata as BlobMetadata, metadata as BlobMetadata));
+      assert.ok(isSuperSet(blob.metadata, metadata));
       i++;
     }
     // Gets next marker
@@ -359,7 +353,7 @@ describe("ContainerClient", () => {
     // Gets 2 blobs
     for (const blob of response.segment.blobItems) {
       assert.ok(blobClients[i].url.indexOf(blob.name));
-      assert.ok(isSuperSet(blob.metadata as BlobMetadata, metadata as BlobMetadata));
+      assert.ok(isSuperSet(blob.metadata, metadata));
       i++;
     }
 
@@ -470,9 +464,7 @@ describe("ContainerClient", () => {
     assert.deepStrictEqual(result3.continuationToken, "");
     assert.deepStrictEqual(result3.delimiter, delimiter);
     assert.deepStrictEqual(result3.segment.blobItems!.length, 1);
-    assert.ok(
-      isSuperSet(result3.segment.blobItems![0].metadata as BlobMetadata, metadata as BlobMetadata)
-    );
+    assert.ok(isSuperSet(result3.segment.blobItems![0].metadata, metadata));
     assert.ok(blobClients[0].url.indexOf(result3.segment.blobItems![0].name));
 
     for (const blob of blobClients) {

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -1,7 +1,6 @@
 import { HttpPipelineLogLevel, IHttpPipelineLogger } from "../../src/Pipeline";
 import { padStart } from "../../src/utils/utils.common";
 import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
-import { BlobMetadata } from "../../src/generated/src/models";
 
 export const env = isBrowser() ? (window as any).__env__ : process.env;
 
@@ -89,13 +88,15 @@ export class ConsoleHttpPipelineLogger implements IHttpPipelineLogger {
   }
 }
 
+type BlobMetadata = { [propertyName: string]: string };
+
 /**
  * Validate if m1 is super set of m2.
  *
  * @param m1 BlobMetadata
  * @param m2 BlobMetadata
  */
-export function isSuperSet(m1: BlobMetadata, m2: BlobMetadata): boolean {
+export function isSuperSet(m1?: BlobMetadata, m2?: BlobMetadata): boolean {
   if (!m1 || !m2) {
     throw new RangeError("m1 or m2 is invalid");
   }


### PR DESCRIPTION
Addressing #5521 

By removing the `encrypted` property through autorest `BlobMetadata` becomes a simple dictionary

Note: Files under the `generated` folder were generated with autorest