### PR TITLE
[Storage] Standardize name and path usage in clients

### DIFF
--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -697,11 +697,11 @@ export class BlobClient extends StorageClient {
    * @memberof BlobClient
    */
   private blobContext: Blob;
-  private _blobName: string;
+  private _name: string;
   private _containerName: string;
 
-  public get blobName(): string {
-    return this._blobName;
+  public get name(): string {
+    return this._name;
   }
 
   public get containerName(): string {
@@ -849,7 +849,7 @@ export class BlobClient extends StorageClient {
 
     super(url, pipeline);
     ({
-      blobName: this._blobName,
+      blobName: this._name,
       containerName: this._containerName
     } = this.getBlobAndContainerNamesFromUrl());
     this.blobContext = new Blob(this.storageClientContext);

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -536,7 +536,7 @@ describe("BlobClient", () => {
       containerName,
       "Container name is not the same as the one provided."
     );
-    assert.equal(newClient.blobName, blobName, "Blob name is not the same as the one provided.");
+    assert.equal(newClient.name, blobName, "Blob name is not the same as the one provided.");
     assert.equal(
       newClient.accountName,
       accountName,

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -236,7 +236,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const blobSAS = generateBlobSASQueryParameters(
       {
-        blobName: blobClient.blobName,
+        blobName: blobClient.name,
         cacheControl: "cache-control-override",
         containerName: blobClient.containerName,
         contentDisposition: "content-disposition-override",
@@ -291,7 +291,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const blobSAS = generateBlobSASQueryParameters(
       {
-        blobName: blobClient.blobName,
+        blobName: blobClient.name,
         cacheControl: "cache-control-override",
         containerName: blobClient.containerName,
         contentDisposition: "content-disposition-override",
@@ -347,7 +347,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const blobSAS = generateBlobSASQueryParameters(
       {
-        blobName: blobClient.blobName,
+        blobName: blobClient.name,
         cacheControl: "cache-control-override",
         containerName: blobClient.containerName,
         contentDisposition: "content-disposition-override",
@@ -404,7 +404,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     });
     const blobSAS = generateBlobSASQueryParameters(
       {
-        blobName: blobClient.blobName,
+        blobName: blobClient.name,
         cacheControl: "cache-control-override",
         containerName: blobClient.containerName,
         contentDisposition: "content-disposition-override",
@@ -627,7 +627,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const blobSAS = generateBlobSASQueryParameters(
       {
-        blobName: blobClient.blobName,
+        blobName: blobClient.name,
         cacheControl: "cache-control-override",
         containerName: blobClient.containerName,
         contentDisposition: "content-disposition-override",
@@ -698,7 +698,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const blobSAS = generateBlobSASQueryParameters(
       {
-        blobName: blobClient.blobName,
+        blobName: blobClient.name,
         cacheControl: "cache-control-override",
         containerName: blobClient.containerName,
         contentDisposition: "content-disposition-override",

--- a/sdk/storage/storage-file/src/DirectoryClient.ts
+++ b/sdk/storage/storage-file/src/DirectoryClient.ts
@@ -289,14 +289,14 @@ export class DirectoryClient extends StorageClient {
    */
   private context: Directory;
   private _shareName: string;
-  private _dirPath: string;
+  private _name: string;
 
   public get shareName(): string {
     return this._shareName;
   }
 
-  public get dirPath(): string {
-    return this._dirPath;
+  public get name(): string {
+    return this._name;
   }
 
   /**
@@ -350,7 +350,7 @@ export class DirectoryClient extends StorageClient {
     super(url, pipeline);
     ({
       shareName: this._shareName,
-      filePathOrDirectoryPath: this._dirPath
+      filePathOrDirectoryPath: this._name
     } = getShareNameAndPathFromUrl(this.url));
     this.context = new Directory(this.storageClientContext);
   }

--- a/sdk/storage/storage-file/src/DirectoryClient.ts
+++ b/sdk/storage/storage-file/src/DirectoryClient.ts
@@ -289,14 +289,14 @@ export class DirectoryClient extends StorageClient {
    */
   private context: Directory;
   private _shareName: string;
-  private _name: string;
+  private _path: string;
 
   public get shareName(): string {
     return this._shareName;
   }
 
-  public get name(): string {
-    return this._name;
+  public get path(): string {
+    return this._path;
   }
 
   /**
@@ -350,7 +350,7 @@ export class DirectoryClient extends StorageClient {
     super(url, pipeline);
     ({
       shareName: this._shareName,
-      filePathOrDirectoryPath: this._name
+      filePathOrDirectoryPath: this._path
     } = getShareNameAndPathFromUrl(this.url));
     this.context = new Directory(this.storageClientContext);
   }

--- a/sdk/storage/storage-file/src/FileClient.ts
+++ b/sdk/storage/storage-file/src/FileClient.ts
@@ -647,14 +647,14 @@ export class FileClient extends StorageClient {
    */
   private context: File;
   private _shareName: string;
-  private _filePath: string;
+  private _path: string;
 
   public get shareName(): string {
     return this._shareName;
   }
 
-  public get filePath(): string {
-    return this._filePath;
+  public get path(): string {
+    return this._path;
   }
 
   /**
@@ -708,7 +708,7 @@ export class FileClient extends StorageClient {
     super(url, pipeline);
     ({
       shareName: this._shareName,
-      filePathOrDirectoryPath: this._filePath
+      filePathOrDirectoryPath: this._path
     } = getShareNameAndPathFromUrl(this.url));
     this.context = new File(this.storageClientContext);
   }

--- a/sdk/storage/storage-file/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/directoryclient.spec.ts
@@ -745,7 +745,7 @@ describe("DirectoryClient", () => {
       `https://${accountName}.file.core.windows.net/` + shareName + "/" + dirName
     );
     assert.equal(newClient.shareName, shareName, "Share name is not the same as the one provided.");
-    assert.equal(newClient.dirPath, dirName, "DirPath is not the same as the one provided.");
+    assert.equal(newClient.name, dirName, "DirPath is not the same as the one provided.");
     assert.equal(
       newClient.accountName,
       accountName,

--- a/sdk/storage/storage-file/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file/test/directoryclient.spec.ts
@@ -745,7 +745,7 @@ describe("DirectoryClient", () => {
       `https://${accountName}.file.core.windows.net/` + shareName + "/" + dirName
     );
     assert.equal(newClient.shareName, shareName, "Share name is not the same as the one provided.");
-    assert.equal(newClient.name, dirName, "DirPath is not the same as the one provided.");
+    assert.equal(newClient.path, dirName, "DirPath is not the same as the one provided.");
     assert.equal(
       newClient.accountName,
       accountName,

--- a/sdk/storage/storage-file/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file/test/fileclient.spec.ts
@@ -513,7 +513,7 @@ describe("FileClient", () => {
     );
     assert.equal(newClient.shareName, shareName, "Share name is not the same as the one provided.");
     assert.equal(
-      newClient.filePath,
+      newClient.path,
       dirName + "/" + fileName,
       "FilePath is not the same as the one provided."
     );

--- a/sdk/storage/storage-file/test/node/sas.spec.ts
+++ b/sdk/storage/storage-file/test/node/sas.spec.ts
@@ -243,7 +243,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         contentLanguage: "content-language-override",
         contentType: "content-type-override",
         expiryTime: tmr,
-        filePath: fileClient.filePath,
+        filePath: fileClient.path,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: FileSASPermissions.parse("rcwd").toString(),
         protocol: SASProtocol.HTTPSandHTTP,

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -377,10 +377,10 @@ export class QueueClient extends StorageClient {
    * @memberof QueueClient
    */
   private queueContext: Queue;
-  private _queueName: string;
+  private _name: string;
   private _messagesUrl: string;
-  public get queueName(): string {
-    return this._queueName;
+  public get name(): string {
+    return this._name;
   }
 
   /**
@@ -492,7 +492,7 @@ export class QueueClient extends StorageClient {
       throw new Error("Expecting non-empty strings for queueName parameter");
     }
     super(url, pipeline);
-    this._queueName = this.getQueueNameFromUrl();
+    this._name = this.getQueueNameFromUrl();
     this.queueContext = new Queue(this.storageClientContext);
 
     // MessagesContext

--- a/sdk/storage/storage-queue/test/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/messageidclient.spec.ts
@@ -203,6 +203,6 @@ describe("MessageIdClient", () => {
     const newClient = new QueueClient(
       extractConnectionStringParts(getSASConnectionStringFromEnvironment()).url + "/" + queueName
     );
-    assert.equal(newClient.queueName, queueName, "Queue name is not the same as the one provided.");
+    assert.equal(newClient.name, queueName, "Queue name is not the same as the one provided.");
   });
 });

--- a/sdk/storage/storage-queue/test/messagesclient.spec.ts
+++ b/sdk/storage/storage-queue/test/messagesclient.spec.ts
@@ -384,6 +384,6 @@ describe("MessagesClient", () => {
         queueName +
         "/messages/"
     );
-    assert.equal(newClient.queueName, queueName, "Queue name is not the same as the one provided.");
+    assert.equal(newClient.name, queueName, "Queue name is not the same as the one provided.");
   });
 });

--- a/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/messageidclient.spec.ts
@@ -165,7 +165,7 @@ describe("MessageIdClient Node.js only", () => {
     assert.ok(eResult.messageId);
     assert.ok(eResult.popReceipt);
 
-    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueClient.queueName);
+    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueClient.name);
     await newClient.updateMessage(
       eResult.messageId,
       eResult.popReceipt,
@@ -183,7 +183,7 @@ describe("MessageIdClient Node.js only", () => {
     assert.ok(eResult.messageId);
     assert.ok(eResult.popReceipt);
 
-    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueClient.queueName, {
+    const newClient = new QueueClient(getConnectionStringFromEnvironment(), queueClient.name, {
       retryOptions: {
         maxTries: 5
       }

--- a/sdk/storage/storage-queue/test/node/sas.spec.ts
+++ b/sdk/storage/storage-queue/test/node/sas.spec.ts
@@ -186,7 +186,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const queueSAS = generateQueueSASQueryParameters(
       {
-        queueName: queueClient.queueName,
+        queueName: queueClient.name,
         expiryTime: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: QueueSASPermissions.parse("raup").toString(),
@@ -221,7 +221,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const queueSAS = generateQueueSASQueryParameters(
       {
-        queueName: queueClient.queueName,
+        queueName: queueClient.name,
         expiryTime: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: QueueSASPermissions.parse("raup").toString(),
@@ -284,7 +284,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const queueSAS = generateQueueSASQueryParameters(
       {
-        queueName: queueClient.queueName,
+        queueName: queueClient.name,
         identifier: id
       },
       sharedKeyCredential as SharedKeyCredential

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -161,7 +161,7 @@ describe("QueueClient", () => {
   it("verify accountName and queueName passed to the client", async () => {
     const accountName = "myaccount";
     const newClient = new QueueClient(`https://${accountName}.queue.core.windows.net/` + queueName);
-    assert.equal(newClient.queueName, queueName, "Queue name is not the same as the one provided.");
+    assert.equal(newClient.name, queueName, "Queue name is not the same as the one provided.");
     assert.equal(
       newClient.accountName,
       accountName,


### PR DESCRIPTION
This PR renames the properties on the DirectoryClient, FileClient and QueueClient  as per #5568