### PR TITLE
[Storage][Blob] Add missing x-ms-parameter-location for PathRenameMode

### DIFF
--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -6,7 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { ServiceClientOptions } from "@azure/core-http";
+
 import * as coreHttp from "@azure/core-http";
 
 /**
@@ -690,16 +690,6 @@ export interface AppendPositionAccessConditions {
 }
 
 /**
- * An interface representing StorageClientOptions.
- */
-export interface StorageClientOptions extends ServiceClientOptions {
-  /**
-   * Determines the behavior of the rename operation. Possible values include: 'legacy', 'posix'
-   */
-  pathRenameMode?: PathRenameMode;
-}
-
-/**
  * Optional Parameters.
  */
 export interface ServiceSetPropertiesOptionalParams extends coreHttp.RequestOptionsBase {
@@ -1279,6 +1269,10 @@ export interface DirectoryRenameOptionalParams extends coreHttp.RequestOptionsBa
    */
   marker?: string;
   /**
+   * Determines the behavior of the rename operation. Possible values include: 'legacy', 'posix'
+   */
+  pathRenameMode?: PathRenameMode;
+  /**
    * Optional.  User-defined properties to be stored with the file or directory, in the format of a
    * comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is base64
    * encoded.
@@ -1651,6 +1645,10 @@ export interface BlobRenameOptionalParams extends coreHttp.RequestOptionsBase {
    * Timeouts for Blob Service Operations.</a>
    */
   timeoutInSeconds?: number;
+  /**
+   * Determines the behavior of the rename operation. Possible values include: 'legacy', 'posix'
+   */
+  pathRenameMode?: PathRenameMode;
   /**
    * Optional.  User-defined properties to be stored with the file or directory, in the format of a
    * comma-separated list of name and value pairs "n1=v1, n2=v2, ...", where each value is base64

--- a/sdk/storage/storage-blob/src/generated/src/models/parameters.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/parameters.ts
@@ -992,7 +992,10 @@ export const pageWrite1: coreHttp.OperationParameter = {
   }
 };
 export const pathRenameMode: coreHttp.OperationQueryParameter = {
-  parameterPath: "pathRenameMode",
+  parameterPath: [
+    "options",
+    "pathRenameMode"
+  ],
   mapper: {
     serializedName: "mode",
     type: {

--- a/sdk/storage/storage-blob/src/generated/src/storageClient.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClient.ts
@@ -8,6 +8,7 @@
  * regenerated.
  */
 
+import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as operations from "./operations";
@@ -29,7 +30,7 @@ class StorageClient extends StorageClientContext {
    * operation.
    * @param [options] The parameter options
    */
-  constructor(url: string, options?: Models.StorageClientOptions) {
+  constructor(url: string, options?: coreHttp.ServiceClientOptions) {
     super(url, options);
     this.service = new operations.Service(this);
     this.container = new operations.Container(this);

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -9,7 +9,6 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
 
 const packageName = "azure-storage-blob";
 const packageVersion = "1.0.0";
@@ -17,7 +16,6 @@ const packageVersion = "1.0.0";
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;
   version: string;
-  pathRenameMode?: Models.PathRenameMode;
 
   /**
    * Initializes a new instance of the StorageClientContext class.
@@ -25,7 +23,7 @@ export class StorageClientContext extends coreHttp.ServiceClient {
    * operation.
    * @param [options] The parameter options
    */
-  constructor(url: string, options?: Models.StorageClientOptions) {
+  constructor(url: string, options?: coreHttp.ServiceClientOptions) {
     if (url == undefined) {
       throw new Error("'url' cannot be null.");
     }
@@ -45,8 +43,5 @@ export class StorageClientContext extends coreHttp.ServiceClient {
     this.baseUri = "{url}";
     this.requestContentType = "application/json; charset=utf-8";
     this.url = url;
-    if (options.pathRenameMode !== null && options.pathRenameMode !== undefined) {
-      this.pathRenameMode = options.pathRenameMode;
-    }
   }
 }

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -233,3 +233,13 @@ directive:
       $.properties.SignedTid["x-ms-client-name"] = "signedTenantId";
       $.properties.SignedOid["x-ms-client-name"] = "signedObjectId";
 ```
+
+### Add missing x-ms-parameter-location for PathRenameMode
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.parameters.PathRenameMode
+    transform: >
+      $["x-ms-parameter-location"] = "method";
+```


### PR DESCRIPTION
The parameter was missing the x-ms-parameter-location properties, which leads to
incorrect code generated in our storageClientContext.ts. Among them `import * as
Models ...` which blocks our api review report generation.

This change adds the missing "x-ms-parameter-location": "method".