### PR TITLE
[Storage Queues] Rename options & responses as per method names

### DIFF
--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -341,6 +341,10 @@ export interface QueueDeleteMessageOptions extends CommonOptions {
   abortSignal?: AbortSignalLike;
 }
 
+export declare type QueueUpdateMessageResponse = Models.MessageIdUpdateResponse;
+export declare type QueueDeleteMessageResponse = Models.MessageIdDeleteResponse;
+export declare type QueueClearMessagesResponse = Models.MessagesClearResponse;
+
 /**
  * Options to configure MessageId - Update operation
  *
@@ -739,12 +743,12 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages
    *
    * @param {QueueClearMessagesOptions} [options] Options to clear messages operation.
-   * @returns {Promise<Models.MessageClearResponse>} Response data for the clear messages operation.
+   * @returns {Promise<QueueClearMessagesResponse>} Response data for the clear messages operation.
    * @memberof QueueClient
    */
   public async clearMessages(
     options: QueueClearMessagesOptions = {}
-  ): Promise<Models.MessagesClearResponse> {
+  ): Promise<QueueClearMessagesResponse> {
     const { span, spanOptions } = createSpan("QueueClient-clearMessages", options.spanOptions);
     try {
       return this.messagesContext.clear({
@@ -911,14 +915,14 @@ export class QueueClient extends StorageClient {
    *
    * @param {string} popReceipt A valid pop receipt value returned from an earlier call to the dequeue messages or update message operation.
    * @param {QueueDeleteMessageOptions} [options] Options to delete message operation.
-   * @returns {Promise<Models.MessageIdDeleteResponse>} Response data for the delete message operation.
+   * @returns {Promise<QueueDeleteMessageResponse>} Response data for the delete message operation.
    * @memberof QueueClient
    */
   public async deleteMessage(
     messageId: string,
     popReceipt: string,
     options: QueueDeleteMessageOptions = {}
-  ): Promise<Models.MessageIdDeleteResponse> {
+  ): Promise<QueueDeleteMessageResponse> {
     const { span, spanOptions } = createSpan("QueueClient-deleteMessage", options.spanOptions);
     try {
       return this.getMessageIdContext(messageId).deleteMethod(popReceipt, {
@@ -950,7 +954,7 @@ export class QueueClient extends StorageClient {
    *                                   be set to a value later than the expiry time.
    *                                   A message can be updated until it has been deleted or has expired.
    * @param {QueueUpdateMessageOptions} [options] Options to update message operation.
-   * @returns {Promise<Models.MessageIdUpdateResponse>} Response data for the update message operation.
+   * @returns {Promise<QueueUpdateMessageResponse>} Response data for the update message operation.
    * @memberof QueueClient
    */
   public async updateMessage(
@@ -959,7 +963,7 @@ export class QueueClient extends StorageClient {
     message: string,
     visibilityTimeout?: number,
     options: QueueUpdateMessageOptions = {}
-  ): Promise<Models.MessageIdUpdateResponse> {
+  ): Promise<QueueUpdateMessageResponse> {
     const { span, spanOptions } = createSpan("QueueClient-updateMessage", options.spanOptions);
     try {
       return this.getMessageIdContext(messageId).update(

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -188,9 +188,9 @@ export declare type QueueGetAccessPolicyResponse = {
  * Options to configure Messages - Clear operation
  *
  * @export
- * @interface MessagesClearOptions
+ * @interface QueueClearMessagesOptions
  */
-export interface MessagesClearOptions extends CommonOptions {
+export interface QueueClearMessagesOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -205,10 +205,10 @@ export interface MessagesClearOptions extends CommonOptions {
  * Options to configure Messages - Enqueue operation
  *
  * @export
- * @interface MessagesEnqueueOptions
+ * @interface QueueSendMessageOptions
  * @extends {Models.MessagesEnqueueOptionalParams}
  */
-export interface MessagesEnqueueOptions
+export interface QueueSendMessageOptions
   extends Models.MessagesEnqueueOptionalParams,
     CommonOptions {}
 
@@ -216,10 +216,10 @@ export interface MessagesEnqueueOptions
  * Options to configure Messages - Dequeue operation
  *
  * @export
- * @interface MessagesDequeueOptions
+ * @interface QueueReceiveMessageOptions
  * @extends {Models.MessagesDequeueOptionalParams}
  */
-export interface MessagesDequeueOptions
+export interface QueueReceiveMessageOptions
   extends Models.MessagesDequeueOptionalParams,
     CommonOptions {}
 
@@ -227,12 +227,14 @@ export interface MessagesDequeueOptions
  * Options to configure Messages - Peek operation
  *
  * @export
- * @interface MessagesPeekOptions
+ * @interface QueuePeekMessagesOptions
  * @extends {Models.MessagesPeekOptionalParams}
  */
-export interface MessagesPeekOptions extends Models.MessagesPeekOptionalParams, CommonOptions {}
+export interface QueuePeekMessagesOptions
+  extends Models.MessagesPeekOptionalParams,
+    CommonOptions {}
 
-export declare type MessagesEnqueueResponse = {
+export declare type QueueSendMessageResponse = {
   /**
    * @member {string} messageId The ID of the enqueued Message.
    */
@@ -278,7 +280,7 @@ export declare type MessagesEnqueueResponse = {
     };
   };
 
-export declare type MessagesDequeueResponse = {
+export declare type QueueReceiveMessageResponse = {
   dequeuedMessageItems: Models.DequeuedMessageItem[];
 } & Models.MessagesDequeueHeaders & {
     /**
@@ -300,7 +302,7 @@ export declare type MessagesDequeueResponse = {
     };
   };
 
-export declare type MessagesPeekResponse = {
+export declare type QueuePeekMessagesResponse = {
   peekedMessageItems: Models.PeekedMessageItem[];
 } & Models.MessagesPeekHeaders & {
     /**
@@ -326,9 +328,9 @@ export declare type MessagesPeekResponse = {
  * Options to configure MessageId - Delete operation
  *
  * @export
- * @interface MessageIdDeleteOptions
+ * @interface QueueDeleteMessageOptions
  */
-export interface MessageIdDeleteOptions extends CommonOptions {
+export interface QueueDeleteMessageOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -343,9 +345,9 @@ export interface MessageIdDeleteOptions extends CommonOptions {
  * Options to configure MessageId - Update operation
  *
  * @export
- * @interface MessageIdUpdateOptions
+ * @interface QueueUpdateMessageOptions
  */
-export interface MessageIdUpdateOptions extends CommonOptions {
+export interface QueueUpdateMessageOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -736,12 +738,12 @@ export class QueueClient extends StorageClient {
    * Clear deletes all messages from a queue.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages
    *
-   * @param {MessagesClearOptions} [options] Options to Messages clear operation.
-   * @returns {Promise<Models.MessageClearResponse>} Response data for the Messages clear operation.
+   * @param {QueueClearMessagesOptions} [options] Options to clear messages operation.
+   * @returns {Promise<Models.MessageClearResponse>} Response data for the clear messages operation.
    * @memberof QueueClient
    */
   public async clearMessages(
-    options: MessagesClearOptions = {}
+    options: QueueClearMessagesOptions = {}
   ): Promise<Models.MessagesClearResponse> {
     const { span, spanOptions } = createSpan("QueueClient-clearMessages", options.spanOptions);
     try {
@@ -767,15 +769,15 @@ export class QueueClient extends StorageClient {
    * To include markup in the message, the contents of the message must either be XML-escaped or Base64-encode.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/put-message
    *
-   * @param {string} messageText Text of the message to enqueue
-   * @param {MessagesEnqueueOptionas} [options] Options to Messages enqueue operation.
-   * @returns {Promise<Models.MessagesEnqueueResponse>} Response data for the Messages enqueue operation.
+   * @param {string} messageText Text of the message to send
+   * @param {QueueSendMessageOptions} [options] Options to send messages operation.
+   * @returns {Promise<QueueSendMessageResponse>} Response data for the send messages operation.
    * @memberof QueueClient
    */
   public async sendMessage(
     messageText: string,
-    options: MessagesEnqueueOptions = {}
-  ): Promise<MessagesEnqueueResponse> {
+    options: QueueSendMessageOptions = {}
+  ): Promise<QueueSendMessageResponse> {
     const { span, spanOptions } = createSpan("QueueClient-sendMessage", options.spanOptions);
     try {
       const response = await this.messagesContext.enqueue(
@@ -817,13 +819,13 @@ export class QueueClient extends StorageClient {
    * Dequeue retrieves one or more messages from the front of the queue.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages
    *
-   * @param {MessagesDequeueOptionals} [options] Options to Messages dequeue operation.
-   * @returns {Promise<Models.MessagesDequeueResponse>} Response data for the Messages dequeue operation.
+   * @param {QueueReceiveMessageOptions} [options] Options to receive messages operation.
+   * @returns {Promise<QueueReceiveMessageResponse>} Response data for the receive messages operation.
    * @memberof QueueClient
    */
   public async receiveMessages(
-    options: MessagesDequeueOptions = {}
-  ): Promise<MessagesDequeueResponse> {
+    options: QueueReceiveMessageOptions = {}
+  ): Promise<QueueReceiveMessageResponse> {
     const { span, spanOptions } = createSpan("QueueClient-receiveMessages", options.spanOptions);
     try {
       const response = await this.messagesContext.dequeue({
@@ -832,7 +834,7 @@ export class QueueClient extends StorageClient {
         spanOptions
       });
 
-      const res: MessagesDequeueResponse = {
+      const res: QueueReceiveMessageResponse = {
         _response: response._response,
         date: response.date,
         requestId: response.requestId,
@@ -862,11 +864,13 @@ export class QueueClient extends StorageClient {
    * Peek retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/peek-messages
    *
-   * @param {MessagesPeekOptions} [options] Options to Messages peek operation.
-   * @returns {Promise<Models.MessagesPeekResponse>} Response data for the Messages peek operation.
+   * @param {QueuePeekMessagesOptions} [options] Options to peek messages operation.
+   * @returns {QueuePeekMessagesResponse>} Response data for the peek messages operation.
    * @memberof QueueClient
    */
-  public async peekMessages(options: MessagesPeekOptions = {}): Promise<MessagesPeekResponse> {
+  public async peekMessages(
+    options: QueuePeekMessagesOptions = {}
+  ): Promise<QueuePeekMessagesResponse> {
     const { span, spanOptions } = createSpan("QueueClient-peekMessages", options.spanOptions);
     try {
       const response = await this.messagesContext.peek({
@@ -875,7 +879,7 @@ export class QueueClient extends StorageClient {
         spanOptions
       });
 
-      const res: MessagesPeekResponse = {
+      const res: QueuePeekMessagesResponse = {
         _response: response._response,
         date: response.date,
         requestId: response.requestId,
@@ -906,14 +910,14 @@ export class QueueClient extends StorageClient {
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2
    *
    * @param {string} popReceipt A valid pop receipt value returned from an earlier call to the dequeue messages or update message operation.
-   * @param {MessageIdDeleteOptions} [options] Options to MessageId Delete operation.
-   * @returns {Promise<Models.MessageIdDeleteResponse>} Response data for the MessageId delete operation.
+   * @param {QueueDeleteMessageOptions} [options] Options to delete message operation.
+   * @returns {Promise<Models.MessageIdDeleteResponse>} Response data for the delete message operation.
    * @memberof QueueClient
    */
   public async deleteMessage(
     messageId: string,
     popReceipt: string,
-    options: MessageIdDeleteOptions = {}
+    options: QueueDeleteMessageOptions = {}
   ): Promise<Models.MessageIdDeleteResponse> {
     const { span, spanOptions } = createSpan("QueueClient-deleteMessage", options.spanOptions);
     try {
@@ -945,8 +949,8 @@ export class QueueClient extends StorageClient {
    *                                   and cannot be larger than 7 days. The visibility timeout of a message cannot
    *                                   be set to a value later than the expiry time.
    *                                   A message can be updated until it has been deleted or has expired.
-   * @param {MessageIdUpdateOptions} [options] Options to MessageId Update operation.
-   * @returns {Promise<Models.MessageIdUpdateResponse>} Response data for the MessageId update operation.
+   * @param {QueueUpdateMessageOptions} [options] Options to update message operation.
+   * @returns {Promise<Models.MessageIdUpdateResponse>} Response data for the update message operation.
    * @memberof QueueClient
    */
   public async updateMessage(
@@ -954,7 +958,7 @@ export class QueueClient extends StorageClient {
     popReceipt: string,
     message: string,
     visibilityTimeout?: number,
-    options: MessageIdUpdateOptions = {}
+    options: QueueUpdateMessageOptions = {}
   ): Promise<Models.MessageIdUpdateResponse> {
     const { span, spanOptions } = createSpan("QueueClient-updateMessage", options.spanOptions);
     try {


### PR DESCRIPTION
This PR attempts to rename options & responses as per https://github.com/Azure/azure-sdk-for-js/issues/5590#issuecomment-542985484

