### PR TITLE
[Storage] Update downloadToBuffer to return buffer

### DIFF
--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -1446,7 +1446,7 @@ export class BlobClient extends StorageClient {
   }
 
   // High level function
-  
+
   /**
    * ONLY AVAILABLE IN NODE.JS RUNTIME.
    *
@@ -1458,7 +1458,7 @@ export class BlobClient extends StorageClient {
    * @param {number} offset From which position of the block blob to download(in bytes)
    * @param {number} [count] How much data(in bytes) to be downloaded. Will download to the end when passing undefined
    * @param {DownloadFromBlobOptions} [options] DownloadFromBlobOptions
-   * @returns {Promise<void>}
+   * @returns {Promise<Buffer>}
    */
   public async downloadToBuffer(
     buffer: Buffer,

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -1446,7 +1446,7 @@ export class BlobClient extends StorageClient {
   }
 
   // High level function
-
+  
   /**
    * ONLY AVAILABLE IN NODE.JS RUNTIME.
    *
@@ -1465,7 +1465,7 @@ export class BlobClient extends StorageClient {
     offset: number,
     count?: number,
     options: DownloadFromBlobOptions = {}
-  ): Promise<void> {
+  ): Promise<Buffer> {
     const { span, spanOptions } = createSpan("BlobClient-downloadToBuffer", options.spanOptions);
 
     try {
@@ -1538,6 +1538,7 @@ export class BlobClient extends StorageClient {
         });
       }
       await batch.do();
+      return buffer;
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,


### PR DESCRIPTION
This PR updates the downloadToBuffer() method to return buffer instead of void as per #5463