### PR TITLE
Attempt a full reference to allow docs.ms documentation to properly render

### DIFF
--- a/sdk/storage/storage-file/src/AccountSASPermissions.ts
+++ b/sdk/storage/storage-file/src/AccountSASPermissions.ts
@@ -7,7 +7,7 @@
  * This is a helper class to construct a string representing the permissions granted by an AccountSAS. Setting a value
  * to true means that any SAS which uses these permissions will grant permissions for that operation. Once all the
  * values are set, this should be serialized with toString and set as the permissions field on an
- * {@link AccountSASSignatureValues} object. It is possible to construct the permissions string without this class, but
+ * {@link @azure/storage-file.AccountSASSignatureValues} object. It is possible to construct the permissions string without this class, but
  * the order of the permissions is particular and this class guarantees correctness.
  *
  * @export


### PR DESCRIPTION
See title! Going to grab the adjusted artifact, check to see if _our_ docs render, then ship it to the docs team to see if _they_ can render the `@{link` syntax properly.

