### PR TITLE
[core-lro] fixes UnhandledPromiseRejectionWarning 

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -50,6 +50,8 @@ stages:
           safeName: azurecoreauth
         - name: azure-core-http
           safeName: azurecorehttp
+        - name: azure-core-lro
+          safeName: azurecorelro
         - name: azure-core-paging
           safeName: azurecorepaging
         - name: azure-core-tracing

--- a/sdk/core/core-lro/src/poller.ts
+++ b/sdk/core/core-lro/src/poller.ts
@@ -42,6 +42,10 @@ export abstract class Poller<TState, TResult> {
         this.reject = reject;
       }
     );
+    // This prevents the UnhandledPromiseRejectionWarning in node.js from being thrown.
+    // The above warning would get thrown if `poller.poll` is called, it returns an error,
+    // and pullUntilDone did not have a .catch or await try/catch on it's return value.
+    this.promise.catch(() => {});
   }
 
   protected abstract async delay(): Promise<void>;

--- a/sdk/core/core-lro/test/testClient.test.ts
+++ b/sdk/core/core-lro/test/testClient.test.ts
@@ -62,13 +62,8 @@ describe("Long Running Operations - custom client", function() {
       // NOTE: Don't set any responses so that poller.poll throws an error
       const client = new TestClient(new TestTokenCredential("my-test-token"));
       let foundUnhandled = false;
-      let checkerResolve: () => void;
-      const checkerPromise = new Promise((resolve) => {
-        checkerResolve = resolve;
-      });
       const checker = () => {
         foundUnhandled = true;
-        checkerResolve();
       };
 
       process.once("unhandledRejection", checker);
@@ -78,7 +73,7 @@ describe("Long Running Operations - custom client", function() {
       } catch (err) {
         assert.notEqual(err.message, "Test failure", "client.startLRO did not throw an error.");
         // delay(0) gives the event loop a chance emit the UnhandledPromiseRejectionWarning so we can catch it.
-        await Promise.race([checkerPromise, delay(0)]);
+        await delay(0);
         assert.equal(foundUnhandled, false, "An UnhandledPromiseRejectionWarning was thrown.");
       }
     });

--- a/sdk/core/core-lro/test/testClient.test.ts
+++ b/sdk/core/core-lro/test/testClient.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import assert from "assert";
-import { delay, WebResource, HttpHeaders } from "@azure/core-http";
+import { delay, WebResource, HttpHeaders, isNode } from "@azure/core-http";
 import { TestClient } from "./utils/testClient";
 import { PollerStoppedError, PollerCancelledError } from "../src";
 import { TestTokenCredential } from "./utils/testTokenCredential";
@@ -56,6 +56,33 @@ describe("Long Running Operations - custom client", function() {
     assert.ok(poller.getOperationState().completed);
     assert.equal(result, "Done");
   });
+
+  if (isNode) {
+    it("won't throw UnhandledPromiseRejectionWarnings when poll called without pollUntilDone", async function() {
+      // NOTE: Don't set any responses so that poller.poll throws an error
+      const client = new TestClient(new TestTokenCredential("my-test-token"));
+      let foundUnhandled = false;
+      let checkerResolve: () => void;
+      const checkerPromise = new Promise((resolve) => {
+        checkerResolve = resolve;
+      });
+      const checker = () => {
+        foundUnhandled = true;
+        checkerResolve();
+      };
+
+      process.once("unhandledRejection", checker);
+      try {
+        await client.startLRO();
+        throw new Error("Test failure");
+      } catch (err) {
+        assert.notEqual(err.message, "Test failure", "client.startLRO did not throw an error.");
+        // delay(0) gives the event loop a chance emit the UnhandledPromiseRejectionWarning so we can catch it.
+        await Promise.race([checkerPromise, delay(0)]);
+        assert.equal(foundUnhandled, false, "An UnhandledPromiseRejectionWarning was thrown.");
+      }
+    });
+  }
 
   it("can poll a long running operation with more than one promise", async function() {
     const client = new TestClient(new TestTokenCredential("my-test-token"));


### PR DESCRIPTION
This fixes an issue that can occur where:
1. poller.poll is called and throws an error
2. poller.pollUntilDone is not called, or does not have a .catch handler attached

In this scenario, an UnhandledPromiseRejectionWarning was being thrown. This happened because poller.poll would call `this.reject` which rejected the promise returned by `poller.pollUntilDone`. This was being done to essentially cache the rejected promise in case `pollUntilDone` was called, but no error handler was being attached to that promise otherwise.
