### PR TITLE
[core-http] Update default whitelisted headers and query params

### DIFF
--- a/sdk/core/core-http/lib/policies/logPolicy.ts
+++ b/sdk/core/core-http/lib/policies/logPolicy.ts
@@ -31,13 +31,34 @@ export interface LogPolicyOptions {
 const RedactedString = "REDACTED";
 
 const defaultAllowedHeaderNames = [
-  "Date",
-  "traceparent",
   "x-ms-client-request-id",
-  "x-ms-request-id"
+  "x-ms-return-client-request-id",
+  "traceparent",
+
+  "Accept",
+  "Cache-Control",
+  "Connection",
+  "Content-Length",
+  "Content-Type",
+  "Date",
+  "ETag",
+  "Expires",
+  "If-Match",
+  "If-Modified-Since",
+  "If-None-Match",
+  "If-Unmodified-Since",
+  "Last-Modified",
+  "Pragma",
+  "Request-Id",
+  "Retry-After",
+  "Server",
+  "Transfer-Encoding",
+  "User-Agent"
 ];
 
-const defaultAllowedQueryParameters: string[] = [];
+const defaultAllowedQueryParameters: string[] = [
+  "api-version"
+];
 
 export function logPolicy(
   logger: any = coreLogger.info.bind(coreLogger),


### PR DESCRIPTION
Bringing us into alignment with .NET as of PR https://github.com/Azure/azure-sdk-for-net/pull/8166.  I'm also adding `api-version` to whitelisted query params because it seems like we'd care to know that in any case.