### PR TITLE
[app-configuration] Fixing inconsistencies found during peer review

### DIFF
--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -44,7 +44,7 @@ export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHe
 // @public
 export interface ConfigurationSetting extends ConfigurationSettingParam {
     lastModified?: Date;
-    locked?: boolean;
+    readOnly: boolean;
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -34,7 +34,7 @@ export class AppConfigurationClient {
     }
 
 // @public
-export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {
+export interface ClearReadOnlyOptions extends HttpOnlyIfUnchangedField, RequestOptionsBase {
 }
 
 // @public
@@ -67,7 +67,7 @@ export interface ConfigurationSettingParam extends ConfigurationSettingId {
 export type ConfigurationSettingResponse<HeadersT> = ConfigurationSetting & HttpResponseField<HeadersT> & Pick<HeadersT, Exclude<keyof HeadersT, "eTag">>;
 
 // @public
-export interface DeleteConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {
+export interface DeleteConfigurationSettingOptions extends HttpOnlyIfUnchangedField, RequestOptionsBase {
 }
 
 // @public
@@ -80,7 +80,7 @@ export interface GetConfigurationHeaders extends SyncTokenHeaderField {
 }
 
 // @public
-export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpConditionalFields, OptionalFields {
+export interface GetConfigurationSettingOptions extends RequestOptionsBase, HttpOnlyIfChangedField, OptionalFields {
     acceptDatetime?: string;
 }
 
@@ -89,8 +89,12 @@ export interface GetConfigurationSettingResponse extends ConfigurationSetting, G
 }
 
 // @public
-export interface HttpConditionalFields {
+export interface HttpOnlyIfChangedField {
     onlyIfChanged?: boolean;
+}
+
+// @public
+export interface HttpOnlyIfUnchangedField {
     onlyIfUnchanged?: boolean;
 }
 
@@ -138,7 +142,7 @@ export interface OptionalFields {
 }
 
 // @public
-export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {
+export interface SetConfigurationSettingOptions extends HttpOnlyIfUnchangedField, RequestOptionsBase {
 }
 
 // @public
@@ -150,7 +154,7 @@ export interface SetConfigurationSettingResponse extends ConfigurationSetting, S
 }
 
 // @public
-export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {
+export interface SetReadOnlyOptions extends HttpOnlyIfUnchangedField, RequestOptionsBase {
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -8,7 +8,6 @@
 // NOTE: replace with import { AppConfigurationClient } from "@azure/app-configuration"
 // in a standalone project
 import { AppConfigurationClient } from "../src";
-import { assertEqualSettings } from '../test/testHelpers';
 
 export async function run() {
   console.log("Running get setting only if changed sample");

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -372,7 +372,8 @@ export class AppConfigurationClient {
     return this.spanner.trace("setReadOnly", options, async (newOptions) => {
       const response = await this.client.putLock(id.key, {
         ...newOptions,
-        label: id.label
+        label: id.label,
+        ...checkAndFormatIfAndIfNoneMatch(id, options)
       });
 
       return transformKeyValueResponse(response);
@@ -390,7 +391,8 @@ export class AppConfigurationClient {
     return await this.spanner.trace("clearReadOnly", options, async (newOptions) => {
       const response = await this.client.deleteLock(id.key, {
         ...newOptions,
-        label: id.label
+        label: id.label,
+        ...checkAndFormatIfAndIfNoneMatch(id, options)
       });
 
       return transformKeyValueResponse(response);

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -94,20 +94,20 @@ export class AppConfigurationClient {
    * @param configurationSetting A configuration setting.
    * @param options Optional parameters for the request.
    */
-  async addConfigurationSetting(
+  addConfigurationSetting(
     configurationSetting: AddConfigurationSettingParam,
     options: AddConfigurationSettingOptions = {}
   ): Promise<AddConfigurationSettingResponse> {
-    const result = await this.spanner.trace("addConfigurationSetting", options, (_, newOptions) => {
-      return this.client.putKeyValue(configurationSetting.key, {
+    return this.spanner.trace("addConfigurationSetting", options, async (_, newOptions) => {
+      const originalResponse = await this.client.putKeyValue(configurationSetting.key, {
         ifNoneMatch: "*",
         label: configurationSetting.label,
         entity: configurationSetting,
         ...newOptions
       });
-    });
 
-    return transformKeyValueResponse(result);
+      return transformKeyValueResponse(originalResponse);
+    });    
   }
 
   /**
@@ -120,19 +120,19 @@ export class AppConfigurationClient {
    * @param id The id of the configuration setting to delete.
    * @param options Optional parameters for the request (ex: etag, label)
    */
-  async deleteConfigurationSetting(
+  deleteConfigurationSetting(
     id: ConfigurationSettingId,
     options: DeleteConfigurationSettingOptions = {}
   ): Promise<DeleteConfigurationSettingResponse> {
-    const originalResponse = await this.spanner.trace("deleteConfigurationSetting", options, (newOptions) => {
-      return this.client.deleteKeyValue(id.key, {
+    return this.spanner.trace("deleteConfigurationSetting", options, async (newOptions) => {
+      const originalResponse = await this.client.deleteKeyValue(id.key, {
         label: id.label,
         ...newOptions,
         ...checkAndFormatIfAndIfNoneMatch(id, newOptions)
       });
-    });
 
-    return transformKeyValueResponseWithStatusCode(originalResponse);
+      return transformKeyValueResponseWithStatusCode(originalResponse);
+    });
   }
 
   /**

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -35,7 +35,10 @@ import {
   checkAndFormatIfAndIfNoneMatch,
   extractAfterTokenFromNextLink,
   formatWildcards,
-  makeConfigurationSettingEmpty
+  makeConfigurationSettingEmpty,
+  transformKeyValueResponse,
+  transformKeyValueResponseWithStatusCode,
+  transformKeyValue
 } from "./internal/helpers";
 import { tracingPolicy } from "@azure/core-http";
 import { Spanner } from "./internal/tracingHelpers";
@@ -104,10 +107,7 @@ export class AppConfigurationClient {
       });
     });
 
-    return {
-      ...result,
-      readOnly: !!result.locked
-    };
+    return transformKeyValueResponse(result);
   }
 
   /**
@@ -132,13 +132,7 @@ export class AppConfigurationClient {
       });
     });
 
-    const response: DeleteConfigurationSettingResponse = {
-      ...originalResponse,
-      _response: originalResponse._response,
-      statusCode: originalResponse._response.status
-    };
-
-    return response;
+    return transformKeyValueResponseWithStatusCode(originalResponse);
   }
 
   /**
@@ -163,12 +157,7 @@ export class AppConfigurationClient {
         ...checkAndFormatIfAndIfNoneMatch(id, newOptions)
       });
 
-      const response: GetConfigurationSettingResponse = {
-        ...originalResponse,
-        _response: originalResponse._response,
-        statusCode: originalResponse._response.status,
-        readOnly: !!originalResponse.locked
-      };      
+      const response: GetConfigurationSettingResponse = transformKeyValueResponseWithStatusCode(originalResponse);
 
       // 304 only comes back if the user has passed a conditional option in their
       // request _and_ the remote object has the same etag as what the user passed.
@@ -265,12 +254,7 @@ export class AppConfigurationClient {
   private *createListConfigurationPageFromResponse(currentResponse: GetKeyValuesResponse) {
     yield {
       ...currentResponse,
-      items: currentResponse.items != null ? currentResponse.items.map(item => {
-        return {
-          ...item,
-          readOnly: !!item.locked
-        }
-      }) : []
+      items: currentResponse.items != null ? currentResponse.items.map(transformKeyValue) : []
     };
   }
 
@@ -326,11 +310,7 @@ export class AppConfigurationClient {
 
     yield {
       ...currentResponse,
-      items: currentResponse.items != null ? currentResponse.items.map(item => {
-        return {
-          ...item,
-          readOnly: !!item.locked
-      }}) : []
+      items: currentResponse.items != null ? currentResponse.items.map(transformKeyValue) : []
     };
 
     while (currentResponse.nextLink) {
@@ -349,11 +329,7 @@ export class AppConfigurationClient {
 
       yield {
         ...currentResponse,
-        items: currentResponse.items != null ? currentResponse.items.map(item => {
-          return {
-            ...item,
-            readOnly: !!item.locked
-        }}) : []
+        items: currentResponse.items != null ? currentResponse.items.map(transformKeyValue) : []
       };
     }
   }
@@ -381,10 +357,7 @@ export class AppConfigurationClient {
         ...checkAndFormatIfAndIfNoneMatch(configurationSetting, newOptions)
       });
       
-      return {
-        ...response,
-        readOnly: !!response.locked
-      };
+      return transformKeyValueResponse(response);
     });
   }
 
@@ -402,10 +375,7 @@ export class AppConfigurationClient {
         label: id.label
       });
 
-      return {
-        ...response,
-        readOnly: !!response.locked
-      };
+      return transformKeyValueResponse(response);
     });
   }
 
@@ -423,10 +393,7 @@ export class AppConfigurationClient {
         label: id.label
       });
 
-      return {
-        ...response,
-        readOnly: !!response.locked
-      };
+      return transformKeyValueResponse(response);
     });
   }
 }

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -234,8 +234,7 @@ export class AppConfigurationClient {
       (newOptions) => {
         return this.client.getKeyValues({
           ...newOptions,
-          ...formatWildcards(newOptions),
-          select: newOptions.fields
+          ...formatWildcards(newOptions)
         });
       }
     );
@@ -250,7 +249,6 @@ export class AppConfigurationClient {
           return this.client.getKeyValues({
             ...newOptions,
             ...formatWildcards(newOptions),
-            select: newOptions.fields,
             after: extractAfterTokenFromNextLink(currentResponse.nextLink!)
           });
         }

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -67,7 +67,7 @@ export function checkAndFormatIfAndIfNoneMatch(configurationSetting: Configurati
  */
 export function formatWildcards(
   listConfigOptions: ListConfigurationSettingsOptions | ListRevisionsOptions
-): Pick<AppConfigurationGetKeyValuesOptionalParams, "key" | "label"> {
+): Pick<AppConfigurationGetKeyValuesOptionalParams, "key" | "label" | "select"> {
   let key;
 
   if (listConfigOptions.keys) {
@@ -81,9 +81,16 @@ export function formatWildcards(
     label = listConfigOptions.labels.join(",");
   }
 
+  let fields;
+
+  if (listConfigOptions.fields) {
+    fields = listConfigOptions.fields.map(opt => opt === "readOnly" ? "locked" : opt);
+  }
+
   return {
     key,
-    label
+    label,
+    select: fields
   };
 }
 
@@ -117,7 +124,7 @@ export function makeConfigurationSettingEmpty(configurationSetting: Partial<Reco
     "etag",
     "label",
     "lastModified",
-    "locked",
+    "readOnly",
     "tags",
     "value"
   ];

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -152,8 +152,8 @@ export function transformKeyValue(kvp: KeyValue) : ConfigurationSetting {
  * @ignore
  * @internal
  */
-export function transformKeyValueResponseWithStatusCode<T extends KeyValue & HttpResponseField<any>>(kvp: T) : ConfigurationSetting & HttpResponseField<any> & HttpResponseFields {
-  return addResponseField(kvp, <ConfigurationSetting & HttpResponseField<any> & HttpResponseFields>{
+export function transformKeyValueResponseWithStatusCode<T extends KeyValue & HttpResponseField<any>>(kvp: T) : ConfigurationSetting & { eTag?: string; } & HttpResponseField<any> & HttpResponseFields {
+  return normalizeResponse(kvp, <ConfigurationSetting & HttpResponseField<any> & HttpResponseFields>{
     ...transformKeyValue(kvp),
     statusCode: kvp._response.status,
   });
@@ -163,17 +163,21 @@ export function transformKeyValueResponseWithStatusCode<T extends KeyValue & Htt
  * @ignore
  * @internal
  */
-export function transformKeyValueResponse<T extends KeyValue & HttpResponseField<any>>(kvp: T) : ConfigurationSetting & HttpResponseField<any> {
-  return addResponseField(kvp, <ConfigurationSetting & HttpResponseField<any>>{
+export function transformKeyValueResponse<T extends KeyValue & { eTag?: string; } & HttpResponseField<any>>(kvp: T) : ConfigurationSetting & HttpResponseField<any> {
+  return normalizeResponse(kvp, <ConfigurationSetting & HttpResponseField<any>>{
     ...transformKeyValue(kvp)
   });
 }
 
-function addResponseField<T extends HttpResponseField<any>>(originalResponse: HttpResponseField<any>, newResponse: T) : T {
+function normalizeResponse<T extends HttpResponseField<any> & { eTag?: string; } >(originalResponse: HttpResponseField<any>, newResponse: T) : T {
   Object.defineProperty(newResponse, '_response', {
     enumerable: false,
     value: originalResponse._response
   });
+
+  // this field comes from the header but it's redundant with 
+  // the one serialized in the model itself
+  delete newResponse.eTag;
 
   return newResponse;
 }

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -81,7 +81,7 @@ export function formatWildcards(
     label = listConfigOptions.labels.join(",");
   }
 
-  let fields;
+  let fields: (keyof KeyValue)[]|undefined;
 
   if (listConfigOptions.fields) {
     fields = listConfigOptions.fields.map(opt => opt === "readOnly" ? "locked" : opt);

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -4,7 +4,7 @@
 import { ListConfigurationSettingsOptions } from '..';
 import { URLBuilder } from '@azure/core-http';
 import { isArray } from 'util';
-import { ListRevisionsOptions, ConfigurationSettingId, ConfigurationSetting, HttpConditionalFields, HttpResponseField, HttpResponseFields } from '../models';
+import { ListRevisionsOptions, ConfigurationSettingId, ConfigurationSetting, HttpResponseField, HttpResponseFields, HttpOnlyIfChangedField, HttpOnlyIfUnchangedField } from '../models';
 import { AppConfigurationGetKeyValuesOptionalParams, KeyValue } from '../generated/src/models';
 
 /**
@@ -36,7 +36,7 @@ export function quoteETag(etag: string | undefined): string | undefined {
  * @internal
  * @ignore
  */
-export function checkAndFormatIfAndIfNoneMatch(configurationSetting: ConfigurationSettingId, options: HttpConditionalFields): { ifMatch: string | undefined, ifNoneMatch: string | undefined } {
+export function checkAndFormatIfAndIfNoneMatch(configurationSetting: ConfigurationSettingId, options: HttpOnlyIfChangedField & HttpOnlyIfUnchangedField): { ifMatch: string | undefined, ifNoneMatch: string | undefined } {
   if (options.onlyIfChanged && options.onlyIfUnchanged) {
     throw new Error("onlyIfChanged and onlyIfUnchanged are mutually-exclusive");
   }

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -187,7 +187,6 @@ export interface SetConfigurationSettingOptions extends HttpOnlyIfUnchangedField
 /**
  * Response from setting a ConfigurationSetting.
  */
-// onlyIfUnchanged
 export interface SetConfigurationSettingResponse
   extends ConfigurationSetting,
     SyncTokenHeaderField,

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -110,19 +110,24 @@ export interface HttpResponseField<HeadersT> {
 }
 
 /**
- * Options used to provide if-match or if-none-match headers for an HTTP request
+ * Options used to provide if-none-match for an HTTP request
  */
-export interface HttpConditionalFields {
-  /**
-   * Used to perform an operation only if the targeted resource's etag matches the value provided.
-   */
-  onlyIfUnchanged?: boolean;
-
+export interface HttpOnlyIfChangedField {
   /**
    * Used to perform an operation only if the targeted resource's etag does not match the value
    * provided.
    */
   onlyIfChanged?: boolean;
+}
+
+/**
+ * Options used to provide if-match for an HTTP request
+ */
+export interface HttpOnlyIfUnchangedField {
+  /**
+   * Used to perform an operation only if the targeted resource's etag matches the value provided.
+   */
+  onlyIfUnchanged?: boolean;
 }
 
 /**
@@ -171,13 +176,13 @@ export interface DeleteConfigurationSettingResponse
  * Options for deleting a ConfigurationSetting.
  */
 export interface DeleteConfigurationSettingOptions
-  extends HttpConditionalFields,
+  extends HttpOnlyIfUnchangedField,
     RequestOptionsBase {}
 
 /**
  * Options used when saving a ConfigurationSetting.
  */
-export interface SetConfigurationSettingOptions extends HttpConditionalFields, RequestOptionsBase {}
+export interface SetConfigurationSettingOptions extends HttpOnlyIfUnchangedField, RequestOptionsBase {}
 
 /**
  * Response from setting a ConfigurationSetting.
@@ -211,11 +216,9 @@ export interface GetConfigurationSettingResponse
 /**
  * Options for getting a ConfigurationSetting.
  */
-
- // onlyIfChanged
 export interface GetConfigurationSettingOptions
   extends RequestOptionsBase,
-    HttpConditionalFields,
+    HttpOnlyIfChangedField,
     OptionalFields {
   /**
    * Requests the server to respond with the state of the resource at the specified time.
@@ -281,7 +284,7 @@ export interface ListRevisionsPage extends HttpResponseField<SyncTokenHeaderFiel
 /**
  * Options for clearReadOnly
  */
-export interface ClearReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
+export interface ClearReadOnlyOptions extends HttpOnlyIfUnchangedField, RequestOptionsBase {}
 
 /**
  * Response when clearing the read-only status from a value
@@ -294,7 +297,7 @@ export interface ClearReadOnlyResponse
 /**
  * Options for setReadOnly
  */
-export interface SetReadOnlyOptions extends HttpConditionalFields, RequestOptionsBase {}
+export interface SetReadOnlyOptions extends HttpOnlyIfUnchangedField, RequestOptionsBase {}
 
 /**
  * Response when setting a value to read-only.

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -46,13 +46,13 @@ export interface ConfigurationSettingParam extends ConfigurationSettingId {
 
 /**
  * Configuration setting with extra metadata from the server, indicating
- * its etag, whether it is currently readonly and when it was last modified.
+ * its etag, whether it is currently readOnly and when it was last modified.
  */
 export interface ConfigurationSetting extends ConfigurationSettingParam {
   /**
    * Whether or not the setting is read-only
    */
-  locked?: boolean;
+  readOnly: boolean;
 
   /**
    * The date when this setting was last modified
@@ -182,6 +182,7 @@ export interface SetConfigurationSettingOptions extends HttpConditionalFields, R
 /**
  * Response from setting a ConfigurationSetting.
  */
+// onlyIfUnchanged
 export interface SetConfigurationSettingResponse
   extends ConfigurationSetting,
     SyncTokenHeaderField,
@@ -210,6 +211,8 @@ export interface GetConfigurationSettingResponse
 /**
  * Options for getting a ConfigurationSetting.
  */
+
+ // onlyIfChanged
 export interface GetConfigurationSettingOptions
   extends RequestOptionsBase,
     HttpConditionalFields,

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -41,8 +41,18 @@ describe("etags", () => {
 
     addedSetting.value = "some new value!";
 
+    // etag of the remote setting matches what we have so we're okay to update
     const newlyUpdatedSetting = await client.setConfigurationSetting(addedSetting, { onlyIfUnchanged: true });
     assert.equal(newlyUpdatedSetting.value, addedSetting.value);
+
+    const badEtagSetting = {
+      ...addedSetting,
+      etag: "bogus"
+    };
+
+    // trying to save with a non-matching etag (when we specifically said to only save if
+    // nothing has changed) will result in a 412 (precondition failed)
+    await assertThrowsRestError(() => client.setConfigurationSetting(badEtagSetting, { onlyIfUnchanged: true }), 412);
   });
 
   it("set with an old etag will throw RestError", async () => {
@@ -114,5 +124,67 @@ describe("etags", () => {
     // now our retrieved setting matches what's on the server
     assert.equal("new world", configurationSetting.value);
     assert.equal(updatedSetting.etag, configurationSetting.etag);
+  });
+
+  it("(set|clear)readonly using etags", async () => {
+    const addedSetting = await client.getConfigurationSetting({ key });
+
+    const badEtagSetting = {
+      ...addedSetting,
+      etag: "bogus"
+    };
+
+    // etag won't match so we get a precondition failed
+    await assertThrowsRestError(() => client.setReadOnly(badEtagSetting, {
+      onlyIfUnchanged: true
+    }), 412);
+
+    let actualSetting = await client.getConfigurationSetting(badEtagSetting);
+    // should not be read-only since it didn't match
+    assert.ok(!actualSetting.readOnly);
+
+    // and now that the etag matches we should be able to set the 
+    // key's value to read-onlly
+    await client.setReadOnly(addedSetting, { onlyIfUnchanged: true });
+    actualSetting = await client.getConfigurationSetting(addedSetting);
+    assert.ok(actualSetting.readOnly);
+
+    // now let's try to clear it (using a bogus etag so it won't match)
+    await assertThrowsRestError(() => client.clearReadOnly(badEtagSetting, {
+      onlyIfUnchanged: true
+    }), 412);
+
+    // ...still readOnly
+    actualSetting = await client.getConfigurationSetting(addedSetting);
+    assert.ok(actualSetting.readOnly);
+
+    // now we'll use the right etag (from the setting we just retrieved)
+    await client.clearReadOnly(actualSetting, {
+      onlyIfUnchanged: true
+    });
+
+    // and now it's no longer readOnly
+    actualSetting = await client.getConfigurationSetting(addedSetting);
+    assert.ok(!actualSetting.readOnly);
+  });
+
+  it("delete using etags", async () => {
+    const addedSetting = await client.getConfigurationSetting({ key });
+
+    const badEtagSetting = {
+      ...addedSetting,
+      etag: "bogus"
+    };
+
+    await assertThrowsRestError(() => client.deleteConfigurationSetting(badEtagSetting, { onlyIfUnchanged: true }), 412);    
+    
+    // obviously the setting is still there (or else this would throw)
+    await client.getConfigurationSetting({ key });
+
+    // this time we'll pass in the proper setting with the right etag
+    await client.deleteConfigurationSetting(addedSetting, { onlyIfUnchanged: true })
+
+    // and now the setting isn't found
+    await assertThrowsRestError(() => client.getConfigurationSetting({ key }), 404);
   });
 });

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -89,7 +89,7 @@ describe("etags", () => {
     assert.ok(!response.etag);    
     assert.ok(!response.label);
     assert.ok(!response.lastModified);
-    assert.ok(!response.locked);
+    assert.ok(!response.readOnly);
     assert.ok(!response.tags);
     assert.ok(!response.value);
 

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -93,6 +93,14 @@ describe("helper methods", () => {
       assert.equal("key1,key2", result.key);
       assert.equal("label1,label2", result.label);
     });
+
+    it("fields map properly", () => {
+      const result = formatWildcards({
+        fields: [ "readOnly", "value" ]
+      });
+      
+      assert.deepEqual([ "locked", "value" ], result.select);
+    });
   });
   
   describe("extractAfterTokenFromNextLink", () => {

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -128,7 +128,8 @@ describe("helper methods", () => {
         bodyAsText: "",
         parsedHeaders: {}
       },
-      statusCode: 204
+      statusCode: 204,
+      readOnly: false
     };
 
     makeConfigurationSettingEmpty(response);
@@ -154,7 +155,7 @@ describe("helper methods", () => {
       key: "",
       label: "",
       lastModified: new Date(),
-      locked: true,
+      readOnly: true,
       tags: {},
       value: ""
     };

--- a/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
@@ -32,7 +32,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
       key: testConfigSetting.key,
       label: testConfigSetting.label
     });
-    assert.ok(!storedSetting.locked);
+    assert.ok(!storedSetting.readOnly);
 
     await client.setReadOnly(testConfigSetting);
 
@@ -40,7 +40,7 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
       key: testConfigSetting.key,
       label: testConfigSetting.label
     });
-    assert.ok(storedSetting.locked);
+    assert.ok(storedSetting.readOnly);
 
     // any modification related methods throw exceptions
     await assertThrowsRestError(

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -480,27 +480,30 @@ describe("AppConfigurationClient", () => {
       );
     });
 
-    it("filter on fields", async () => {
+    it.only("filter on fields", async () => {
       // only fill in the 'readOnly' field (which is really the locked field in the REST model)
-      let byKeyIterator = client.listConfigurationSettings({ keys: [`listConfigSettingA-${now}`], fields: ["readOnly"] });
+      let byKeyIterator = client.listConfigurationSettings({ keys: [`listConfigSettingA-${now}`], fields: ["key", "label", "readOnly"] });
       let settings = await toSortedArray(byKeyIterator);
 
-      // the one field we retrieved
+      // the fields we retrieved
+      assert.equal(productionASettingId.key, settings[0].key);
       assert.ok(settings[0].readOnly);
+      assert.equal(uniqueLabel, settings[0].label);
 
       assert.ok(!settings[0].contentType);
-      assert.ok(!settings[0].label);
       assert.ok(!settings[0].value); 
       assert.ok(!settings[0].contentType);
       assert.ok(!settings[0].etag);
 
 
       // only fill in the 'readOnly' field (which is really the locked field in the REST model)
-      byKeyIterator = client.listConfigurationSettings({ keys: [`listConfigSettingA-${now}`], fields: ["value"] });
+      byKeyIterator = client.listConfigurationSettings({ keys: [`listConfigSettingA-${now}`], fields: ["key", "label", "value"] });
       settings = await toSortedArray(byKeyIterator);
 
-      // the one field we retrieved
+      // the fields we retrieved
+      assert.equal(productionASettingId.key, settings[0].key);
       assert.equal("[A] production value", settings[0].value);
+      assert.equal(uniqueLabel, settings[0].label);
 
       assert.ok(!settings[0].readOnly);
       assert.ok(!settings[0].contentType);

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -480,7 +480,7 @@ describe("AppConfigurationClient", () => {
       );
     });
 
-    it.only("filter on fields", async () => {
+    it("filter on fields", async () => {
       // only fill in the 'readOnly' field (which is really the locked field in the REST model)
       let byKeyIterator = client.listConfigurationSettings({ keys: [`listConfigSettingA-${now}`], fields: ["key", "label", "readOnly"] });
       let settings = await toSortedArray(byKeyIterator);
@@ -492,9 +492,7 @@ describe("AppConfigurationClient", () => {
 
       assert.ok(!settings[0].contentType);
       assert.ok(!settings[0].value); 
-      assert.ok(!settings[0].contentType);
       assert.ok(!settings[0].etag);
-
 
       // only fill in the 'readOnly' field (which is really the locked field in the REST model)
       byKeyIterator = client.listConfigurationSettings({ keys: [`listConfigSettingA-${now}`], fields: ["key", "label", "value"] });
@@ -506,9 +504,6 @@ describe("AppConfigurationClient", () => {
       assert.equal(uniqueLabel, settings[0].label);
 
       assert.ok(!settings[0].readOnly);
-      assert.ok(!settings[0].contentType);
-      assert.ok(!settings[0].label);
-      assert.ok(!settings[0].value); 
       assert.ok(!settings[0].contentType);
       assert.ok(!settings[0].etag);
     });

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -100,6 +100,11 @@ describe("AppConfigurationClient", () => {
         value,
         "Unexpected value in result from addConfigurationSetting()."
       );
+
+      // just a sanity check - the 'eTag' field that gets added by the response headers
+      // is removed (and is replaced by the 'etag' field in the model)
+      assert.ok(!(result as any).eTag);
+      assert.ok(result.etag);
     });
 
     it("throws an error if the configuration setting already exists", async () => {

--- a/sdk/appconfiguration/app-configuration/test/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/testHelpers.ts
@@ -38,7 +38,7 @@ export async function deleteKeyCompletely(keys: string[], client: AppConfigurati
   });
 
   for await (const setting of settingsIterator) {
-    if (setting.locked) {
+    if (setting.readOnly) {
       await client.clearReadOnly(setting);
     }
 
@@ -75,11 +75,11 @@ export async function toSortedArray(
 }
 
 export function assertEqualSettings(
-  expected: Pick<ConfigurationSetting, "key" | "value" | "label">[],
+  expected: Pick<ConfigurationSetting, "key" | "value" | "label" | "readOnly">[],
   actual: ConfigurationSetting[]
 ) {
   actual = actual.map((setting) => {
-    return { key: setting.key, label: setting.label, value: setting.value };
+    return { key: setting.key, label: setting.label, value: setting.value, readOnly: setting.readOnly };
   });
 
   assert.deepEqual(expected, actual);

--- a/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
@@ -58,6 +58,12 @@ describe("Various error cases", () => {
 
       await assertThrowsRestError(() => client.setConfigurationSetting(addedSetting), 409);
     });
+
+    it("delete: key that is set to read-only throws 409", async () => {
+      await client.setReadOnly(addedSetting);
+      await assertThrowsRestError(async () => client.deleteConfigurationSetting(addedSetting), 409);
+      await client.clearReadOnly(addedSetting);
+    });
   });
 
   describe("doesn't throw", () => {


### PR DESCRIPTION
As part of the initial design review we renamed the methods that lock and unlock a value to setReadOnly/clearReadOnly. 

This PR goes through and also renames the locked field anywhere else it could show up - the ConfigurationSetting model (and all the derivatives that are used for responses) and when specifying filters for list(Revisions|ConfigurationSettings).