### PR TITLE
[core-http] fixes abortSignal memory leak

### DIFF
--- a/sdk/core/core-http/Changelog.md
+++ b/sdk/core/core-http/Changelog.md
@@ -5,6 +5,7 @@
 - Removed error type `ResponseBodyNotFoundError` that was introduced in the previous preview. Use cases for it were removed.
 - Placeholder for New logging support via the new logger package
 - Placeholder for the fix that parses error responses using default mappers
+- Fixes a memory leak issue resulting from event listeners not being removed from abortSignals.
 - More
 
 ## 1.0.0-preview.4 - 2019-10-07


### PR DESCRIPTION
Fixes #5631 

The root cause of the issue is that core-http was not removing abort event listeners from the user's abortSignal after requests completed. If a user uses the same abortSignal for multiple operations, memory use will gradually increase. An event listener is added because core-http creates its own abortController that gets passed to the http client (to implement timeouts) and it needs to be triggered if the user's abortSignal is triggered.

Since the listener is only meant to trigger the AbortController that's created for the actual http request, it's safe to remove once the response is completed.

I tested against the code provided in the linked issue. Prior to this change, I could see linear growth in memory usage. After this change memory usage stabilizes and the garbage collector can be seen reclaiming memory.