### PR TITLE
[Storage] Rename options types to be consistent

### DIFF
--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -619,7 +619,7 @@ export interface BlobSetTierOptions extends CommonOptions {
  * Option interface for BlobClient.downloadToBuffer().
  *
  * @export
- * @interface BlobDownloadToBufferOptionsOptions
+ * @interface BlobDownloadToBufferOptions
  */
 export interface BlobDownloadToBufferOptions extends CommonOptions {
   /**
@@ -627,7 +627,7 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @type {AbortSignalLike}
-   * @memberof BlobDownloadToBufferOptionsOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   abortSignal?: AbortSignalLike;
 
@@ -637,7 +637,7 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
    * to the blob size.
    *
    * @type {number}
-   * @memberof BlobDownloadToBufferOptionsOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   blockSize?: number;
 
@@ -662,7 +662,7 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
   /**
    * Progress updater.
    *
-   * @memberof BlobDownloadToBufferOptionsOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 
@@ -670,7 +670,7 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
    * Access conditions headers.
    *
    * @type {BlobAccessConditions}
-   * @memberof BlobDownloadToBufferOptionsOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   blobAccessConditions?: BlobAccessConditions;
 
@@ -678,7 +678,7 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
    * Concurrency of parallel download.
    *
    * @type {number}
-   * @memberof BlobDownloadToBufferOptionsOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   concurrency?: number;
 }
@@ -1457,7 +1457,7 @@ export class BlobClient extends StorageClient {
    * @param {Buffer} buffer Buffer to be fill, must have length larger than count
    * @param {number} offset From which position of the block blob to download(in bytes)
    * @param {number} [count] How much data(in bytes) to be downloaded. Will download to the end when passing undefined
-   * @param {BlobDownloadToBufferOptions} [options] BlobDownloadToBufferOptionsOptions
+   * @param {BlobDownloadToBufferOptions} [options] BlobDownloadToBufferOptions
    * @returns {Promise<Buffer>}
    */
   public async downloadToBuffer(

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -619,15 +619,15 @@ export interface BlobSetTierOptions extends CommonOptions {
  * Option interface for BlobClient.downloadToBuffer().
  *
  * @export
- * @interface DownloadFromBlobOptions
+ * @interface BlobDownloadToBufferOptionsOptions
  */
-export interface DownloadFromBlobOptions extends CommonOptions {
+export interface BlobDownloadToBufferOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @type {AbortSignalLike}
-   * @memberof DownloadFromBlobOptions
+   * @memberof BlobDownloadToBufferOptionsOptions
    */
   abortSignal?: AbortSignalLike;
 
@@ -637,7 +637,7 @@ export interface DownloadFromBlobOptions extends CommonOptions {
    * to the blob size.
    *
    * @type {number}
-   * @memberof DownloadFromBlobOptions
+   * @memberof BlobDownloadToBufferOptionsOptions
    */
   blockSize?: number;
 
@@ -662,7 +662,7 @@ export interface DownloadFromBlobOptions extends CommonOptions {
   /**
    * Progress updater.
    *
-   * @memberof DownloadFromBlobOptions
+   * @memberof BlobDownloadToBufferOptionsOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 
@@ -670,7 +670,7 @@ export interface DownloadFromBlobOptions extends CommonOptions {
    * Access conditions headers.
    *
    * @type {BlobAccessConditions}
-   * @memberof DownloadFromBlobOptions
+   * @memberof BlobDownloadToBufferOptionsOptions
    */
   blobAccessConditions?: BlobAccessConditions;
 
@@ -678,7 +678,7 @@ export interface DownloadFromBlobOptions extends CommonOptions {
    * Concurrency of parallel download.
    *
    * @type {number}
-   * @memberof DownloadFromBlobOptions
+   * @memberof BlobDownloadToBufferOptionsOptions
    */
   concurrency?: number;
 }
@@ -1457,14 +1457,14 @@ export class BlobClient extends StorageClient {
    * @param {Buffer} buffer Buffer to be fill, must have length larger than count
    * @param {number} offset From which position of the block blob to download(in bytes)
    * @param {number} [count] How much data(in bytes) to be downloaded. Will download to the end when passing undefined
-   * @param {DownloadFromBlobOptions} [options] DownloadFromBlobOptions
+   * @param {BlobDownloadToBufferOptions} [options] BlobDownloadToBufferOptionsOptions
    * @returns {Promise<Buffer>}
    */
   public async downloadToBuffer(
     buffer: Buffer,
     offset: number,
     count?: number,
-    options: DownloadFromBlobOptions = {}
+    options: BlobDownloadToBufferOptions = {}
   ): Promise<Buffer> {
     const { span, spanOptions } = createSpan("BlobClient-downloadToBuffer", options.spanOptions);
 

--- a/sdk/storage/storage-blob/src/BlockBlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlockBlobClient.ts
@@ -315,15 +315,15 @@ export interface BlockBlobGetBlockListOptions extends CommonOptions {
  * Option interface for uploadStream().
  *
  * @export
- * @interface UploadStreamToBlockBlobOptions
+ * @interface BlockBlobUploadStreamOptions
  */
-export interface UploadStreamToBlockBlobOptions extends CommonOptions {
+export interface BlockBlobUploadStreamOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @type {AbortSignalLike}
-   * @memberof IUploadToBlockBlobOptions
+   * @memberof BlockBlobUploadStreamOptions
    */
   abortSignal?: AbortSignalLike;
 
@@ -331,7 +331,7 @@ export interface UploadStreamToBlockBlobOptions extends CommonOptions {
    * Blob HTTP Headers.
    *
    * @type {BlobHTTPHeaders}
-   * @memberof UploadStreamToBlockBlobOptions
+   * @memberof BlockBlobUploadStreamOptions
    */
   blobHTTPHeaders?: BlobHTTPHeaders;
 
@@ -339,7 +339,7 @@ export interface UploadStreamToBlockBlobOptions extends CommonOptions {
    * Metadata of block blob.
    *
    * @type {{ [propertyName: string]: string }}
-   * @memberof UploadStreamToBlockBlobOptions
+   * @memberof BlockBlobUploadStreamOptions
    */
   metadata?: { [propertyName: string]: string };
 
@@ -347,14 +347,14 @@ export interface UploadStreamToBlockBlobOptions extends CommonOptions {
    * Access conditions headers.
    *
    * @type {BlobAccessConditions}
-   * @memberof UploadStreamToBlockBlobOptions
+   * @memberof BlockBlobUploadStreamOptions
    */
   accessConditions?: BlobAccessConditions;
 
   /**
    * Progress updater.
    *
-   * @memberof UploadStreamToBlockBlobOptions
+   * @memberof BlockBlobUploadStreamOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 }
@@ -362,15 +362,15 @@ export interface UploadStreamToBlockBlobOptions extends CommonOptions {
  * Option interface for BlockBlobClient.uploadFile() and BlockBlobClient.uploadSeekableStream().
  *
  * @export
- * @interface UploadToBlockBlobOptions
+ * @interface BlobDownloadToBufferOptions
  */
-export interface UploadToBlockBlobOptions extends CommonOptions {
+export interface BlockBlobParallelUploadOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @type {AbortSignalLike}
-   * @memberof IUploadToBlockBlobOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   abortSignal?: AbortSignalLike;
 
@@ -378,7 +378,7 @@ export interface UploadToBlockBlobOptions extends CommonOptions {
    * Destination block blob size in bytes.
    *
    * @type {number}
-   * @memberof UploadToBlockBlobOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   blockSize?: number;
 
@@ -389,14 +389,14 @@ export interface UploadToBlockBlobOptions extends CommonOptions {
    * You can customize a value less equal than the default value.
    *
    * @type {number}
-   * @memberof UploadToBlockBlobOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   maxSingleShotSize?: number;
 
   /**
    * Progress updater.
    *
-   * @memberof UploadToBlockBlobOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 
@@ -404,7 +404,7 @@ export interface UploadToBlockBlobOptions extends CommonOptions {
    * Blob HTTP Headers.
    *
    * @type {BlobHTTPHeaders}
-   * @memberof UploadToBlockBlobOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   blobHTTPHeaders?: Models.BlobHTTPHeaders;
 
@@ -412,7 +412,7 @@ export interface UploadToBlockBlobOptions extends CommonOptions {
    * Metadata of block blob.
    *
    * @type {{ [propertyName: string]: string }}
-   * @memberof UploadToBlockBlobOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   metadata?: { [propertyName: string]: string };
 
@@ -420,7 +420,7 @@ export interface UploadToBlockBlobOptions extends CommonOptions {
    * Access conditions headers.
    *
    * @type {BlobAccessConditions}
-   * @memberof UploadToBlockBlobOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   blobAccessConditions?: BlobAccessConditions;
 
@@ -428,7 +428,7 @@ export interface UploadToBlockBlobOptions extends CommonOptions {
    * Concurrency of parallel uploading. Must be >= 0.
    *
    * @type {number}
-   * @memberof UploadToBlockBlobOptions
+   * @memberof BlobDownloadToBufferOptions
    */
   concurrency?: number;
 }
@@ -443,7 +443,7 @@ export type BlobUploadCommonResponse = Models.BlockBlobUploadHeaders & {
    * The underlying HTTP response.
    *
    * @type {HttpResponse}
-   * @memberof IBlobUploadCommonResponse
+   * @memberof BlobUploadCommonResponse
    */
   _response: HttpResponse;
 };
@@ -884,12 +884,12 @@ export class BlockBlobClient extends BlobClient {
    *
    * @export
    * @param {Blob | ArrayBuffer | ArrayBufferView} browserData Blob, File, ArrayBuffer or ArrayBufferView
-   * @param {UploadToBlockBlobOptions} [options] Options to upload browser data.
+   * @param {BlockBlobParallelUploadOptions} [options] Options to upload browser data.
    * @returns {Promise<BlobUploadCommonResponse>} Response data for the Blob Upload operation.
    */
   public async uploadBrowserData(
     browserData: Blob | ArrayBuffer | ArrayBufferView,
-    options: UploadToBlockBlobOptions = {}
+    options: BlockBlobParallelUploadOptions = {}
   ): Promise<BlobUploadCommonResponse> {
     const { span, spanOptions } = createSpan(
       "BlockBlobClient-uploadBrowserData",
@@ -927,13 +927,13 @@ export class BlockBlobClient extends BlobClient {
    *
    * @param {(offset: number, size: number) => Blob} blobFactory
    * @param {number} size size of the data to upload.
-   * @param {UploadToBlockBlobOptions} [options] Options to Upload to Block Blob operation.
+   * @param {BlockBlobParallelUploadOptions} [options] Options to Upload to Block Blob operation.
    * @returns {Promise<BlobUploadCommonResponse>} Response data for the Blob Upload operation.
    */
   private async uploadSeekableBlob(
     blobFactory: (offset: number, size: number) => Blob,
     size: number,
-    options: UploadToBlockBlobOptions = {}
+    options: BlockBlobParallelUploadOptions = {}
   ): Promise<BlobUploadCommonResponse> {
     if (!options.blockSize) {
       options.blockSize = 0;
@@ -1045,12 +1045,12 @@ export class BlockBlobClient extends BlobClient {
    * to commit the block list.
    *
    * @param {string} filePath Full path of local file
-   * @param {UploadToBlockBlobOptions} [options] Options to Upload to Block Blob operation.
+   * @param {BlockBlobParallelUploadOptions} [options] Options to Upload to Block Blob operation.
    * @returns {(Promise<BlobUploadCommonResponse>)}  Response data for the Blob Upload operation.
    */
   public async uploadFile(
     filePath: string,
-    options: UploadToBlockBlobOptions = {}
+    options: BlockBlobParallelUploadOptions = {}
   ): Promise<BlobUploadCommonResponse> {
     const { span, spanOptions } = createSpan("BlockBlobClient-uploadFile", options.spanOptions);
     try {
@@ -1090,14 +1090,14 @@ export class BlockBlobClient extends BlobClient {
    * @param {number} bufferSize Size of every buffer allocated, also the block size in the uploaded block blob
    * @param {number} maxBuffers Max buffers will allocate during uploading, positive correlation
    *                            with max uploading concurrency
-   * @param {UploadStreamToBlockBlobOptions} [options] Options to Upload Stream to Block Blob operation.
+   * @param {BlockBlobUploadStreamOptions} [options] Options to Upload Stream to Block Blob operation.
    * @returns {Promise<BlobUploadCommonResponse>} Response data for the Blob Upload operation.
    */
   public async uploadStream(
     stream: Readable,
     bufferSize: number,
     maxBuffers: number,
-    options: UploadStreamToBlockBlobOptions = {}
+    options: BlockBlobUploadStreamOptions = {}
   ): Promise<BlobUploadCommonResponse> {
     if (!options.blobHTTPHeaders) {
       options.blobHTTPHeaders = {};
@@ -1169,13 +1169,13 @@ export class BlockBlobClient extends BlobClient {
    * @param {(offset: number) => NodeJS.ReadableStream} streamFactory Returns a Node.js Readable stream starting
    *                                                                  from the offset defined
    * @param {number} size Size of the block blob
-   * @param {UploadToBlockBlobOptions} [options] Options to Upload to Block Blob operation.
+   * @param {BlockBlobParallelUploadOptions} [options] Options to Upload to Block Blob operation.
    * @returns {(Promise<BlobUploadCommonResponse>)}  Response data for the Blob Upload operation.
    */
   private async uploadResetableStream(
     streamFactory: (offset: number, count?: number) => NodeJS.ReadableStream,
     size: number,
-    options: UploadToBlockBlobOptions = {}
+    options: BlockBlobParallelUploadOptions = {}
   ): Promise<BlobUploadCommonResponse> {
     if (!options.blockSize) {
       options.blockSize = 0;

--- a/sdk/storage/storage-blob/src/BlockBlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlockBlobClient.ts
@@ -362,7 +362,7 @@ export interface BlockBlobUploadStreamOptions extends CommonOptions {
  * Option interface for BlockBlobClient.uploadFile() and BlockBlobClient.uploadSeekableStream().
  *
  * @export
- * @interface BlobDownloadToBufferOptions
+ * @interface BlockBlobParallelUploadOptions
  */
 export interface BlockBlobParallelUploadOptions extends CommonOptions {
   /**
@@ -378,7 +378,7 @@ export interface BlockBlobParallelUploadOptions extends CommonOptions {
    * Destination block blob size in bytes.
    *
    * @type {number}
-   * @memberof BlobDownloadToBufferOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   blockSize?: number;
 
@@ -389,14 +389,14 @@ export interface BlockBlobParallelUploadOptions extends CommonOptions {
    * You can customize a value less equal than the default value.
    *
    * @type {number}
-   * @memberof BlobDownloadToBufferOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   maxSingleShotSize?: number;
 
   /**
    * Progress updater.
    *
-   * @memberof BlobDownloadToBufferOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 
@@ -404,7 +404,7 @@ export interface BlockBlobParallelUploadOptions extends CommonOptions {
    * Blob HTTP Headers.
    *
    * @type {BlobHTTPHeaders}
-   * @memberof BlobDownloadToBufferOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   blobHTTPHeaders?: Models.BlobHTTPHeaders;
 
@@ -412,7 +412,7 @@ export interface BlockBlobParallelUploadOptions extends CommonOptions {
    * Metadata of block blob.
    *
    * @type {{ [propertyName: string]: string }}
-   * @memberof BlobDownloadToBufferOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   metadata?: { [propertyName: string]: string };
 
@@ -420,7 +420,7 @@ export interface BlockBlobParallelUploadOptions extends CommonOptions {
    * Access conditions headers.
    *
    * @type {BlobAccessConditions}
-   * @memberof BlobDownloadToBufferOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   blobAccessConditions?: BlobAccessConditions;
 
@@ -428,7 +428,7 @@ export interface BlockBlobParallelUploadOptions extends CommonOptions {
    * Concurrency of parallel uploading. Must be >= 0.
    *
    * @type {number}
-   * @memberof BlobDownloadToBufferOptions
+   * @memberof BlockBlobParallelUploadOptions
    */
   concurrency?: number;
 }

--- a/sdk/storage/storage-file/src/FileClient.ts
+++ b/sdk/storage/storage-file/src/FileClient.ts
@@ -479,22 +479,22 @@ export interface FileForceCloseHandlesOptions extends CommonOptions {
  * Option interface for FileClient.uploadStream().
  *
  * @export
- * @interface UploadStreamToAzureFileOptions
+ * @interface FileUploadStreamOptions
  */
-export interface UploadStreamToAzureFileOptions extends CommonOptions {
+export interface FileUploadStreamOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @type {AbortSignalLike}
-   * @memberof UploadStreamToAzureFileOptions
+   * @memberof FileUploadStreamOptions
    */
   abortSignal?: AbortSignalLike;
   /**
    * Azure File HTTP Headers.
    *
    * @type {FileHttpHeaders}
-   * @memberof UploadStreamToAzureFileOptions
+   * @memberof FileUploadStreamOptions
    */
   fileHttpHeaders?: FileHttpHeaders;
 
@@ -502,14 +502,14 @@ export interface UploadStreamToAzureFileOptions extends CommonOptions {
    * Metadata of the Azure file.
    *
    * @type {Metadata}
-   * @memberof UploadStreamToAzureFileOptions
+   * @memberof FileUploadStreamOptions
    */
   metadata?: Metadata;
 
   /**
    * Progress updater.
    *
-   * @memberof UploadStreamToAzureFileOptions
+   * @memberof FileUploadStreamOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 }
@@ -518,15 +518,15 @@ export interface UploadStreamToAzureFileOptions extends CommonOptions {
  * Option interface for FileClient.uploadFile() and FileClient.uploadSeekableStream().
  *
  * @export
- * @interface UploadToAzureFileOptions
+ * @interface FileParallelUploadOptions
  */
-export interface UploadToAzureFileOptions extends CommonOptions {
+export interface FileParallelUploadOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @type {AbortSignalLike}
-   * @memberof UploadToAzureFileOptions
+   * @memberof FileParallelUploadOptions
    */
   abortSignal?: AbortSignalLike;
   /**
@@ -534,14 +534,14 @@ export interface UploadToAzureFileOptions extends CommonOptions {
    * the default (and maximum size) is FILE_RANGE_MAX_SIZE_BYTES.
    *
    * @type {number}
-   * @memberof UploadToAzureFileOptions
+   * @memberof FileParallelUploadOptions
    */
   rangeSize?: number;
 
   /**
    * Progress updater.
    *
-   * @memberof UploadToAzureFileOptions
+   * @memberof FileParallelUploadOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 
@@ -549,7 +549,7 @@ export interface UploadToAzureFileOptions extends CommonOptions {
    * File HTTP Headers.
    *
    * @type {FileHttpHeaders}
-   * @memberof UploadToAzureFileOptions
+   * @memberof FileParallelUploadOptions
    */
   fileHttpHeaders?: FileHttpHeaders;
 
@@ -557,7 +557,7 @@ export interface UploadToAzureFileOptions extends CommonOptions {
    * Metadata of an Azure file.
    *
    * @type {Metadata}
-   * @memberof UploadToAzureFileOptions
+   * @memberof FileParallelUploadOptions
    */
   metadata?: Metadata;
 
@@ -566,7 +566,7 @@ export interface UploadToAzureFileOptions extends CommonOptions {
    * If not provided, 5 concurrency will be used by default.
    *
    * @type {number}
-   * @memberof UploadToAzureFileOptions
+   * @memberof FileParallelUploadOptions
    */
   concurrency?: number;
 }
@@ -575,15 +575,15 @@ export interface UploadToAzureFileOptions extends CommonOptions {
  * Option interface for DownloadAzurefileToBuffer.
  *
  * @export
- * @interface DownloadFromAzureFileOptions
+ * @interface FileDownloadToBufferOptions
  */
-export interface DownloadFromAzureFileOptions extends CommonOptions {
+export interface FileDownloadToBufferOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
    *
    * @type {AbortSignalLike}
-   * @memberof DownloadFromAzureFileOptions
+   * @memberof FileDownloadToBufferOptions
    */
   abortSignal?: AbortSignalLike;
   /**
@@ -593,7 +593,7 @@ export interface DownloadFromAzureFileOptions extends CommonOptions {
    * Must be > 0, will use the default value if undefined,
    *
    * @type {number}
-   * @memberof DownloadFromAzureFileOptions
+   * @memberof FileDownloadToBufferOptions
    */
   rangeSize?: number;
 
@@ -611,14 +611,14 @@ export interface DownloadFromAzureFileOptions extends CommonOptions {
    * Default value is 5, please set a larger value when in poor network.
    *
    * @type {number}
-   * @memberof DownloadFromAzureFileOptions
+   * @memberof FileDownloadToBufferOptions
    */
   maxRetryRequestsPerRange?: number;
 
   /**
    * Progress updater.
    *
-   * @memberof DownloadFromAzureFileOptions
+   * @memberof FileDownloadToBufferOptions
    */
   progress?: (progress: TransferProgressEvent) => void;
 
@@ -627,7 +627,7 @@ export interface DownloadFromAzureFileOptions extends CommonOptions {
    * If not provided, 5 concurrency will be used by default.
    *
    * @type {number}
-   * @memberof DownloadFromAzureFileOptions
+   * @memberof FileDownloadToBufferOptions
    */
   concurrency?: number;
 }
@@ -1352,12 +1352,12 @@ export class FileClient extends StorageClient {
    * Uploads a browser Blob/File/ArrayBuffer/ArrayBufferView object to an Azure File.
    *
    * @param {Blob | ArrayBuffer | ArrayBufferView} browserData Blob, File, ArrayBuffer or ArrayBufferView
-   * @param {UploadToAzureFileOptions} [options]
+   * @param {FileParallelUploadOptions} [options]
    * @returns {Promise<void>}
    */
   public async uploadBrowserData(
     browserData: Blob | ArrayBuffer | ArrayBufferView,
-    options: UploadToAzureFileOptions = {}
+    options: FileParallelUploadOptions = {}
   ): Promise<void> {
     const { span, spanOptions } = createSpan("FileClient-uploadBrowserData", options.spanOptions);
     try {
@@ -1388,13 +1388,13 @@ export class FileClient extends StorageClient {
    *
    * @param {(offset: number, size: number) => Blob} blobFactory
    * @param {number} size
-   * @param {UploadToAzureFileOptions} [options]
+   * @param {FileParallelUploadOptions} [options]
    * @returns {Promise<void>}
    */
   async uploadSeekableBlob(
     blobFactory: (offset: number, size: number) => Blob,
     size: number,
-    options: UploadToAzureFileOptions = {}
+    options: FileParallelUploadOptions = {}
   ): Promise<void> {
     const { span, spanOptions } = createSpan("FileClient-UploadSeekableBlob", options.spanOptions);
     try {
@@ -1466,10 +1466,10 @@ export class FileClient extends StorageClient {
    *
    * @param {string} filePath Full path of local file
    * @param {FileClient} fileClient FileClient
-   * @param {UploadToAzureFileOptions} [options]
+   * @param {FileParallelUploadOptions} [options]
    * @returns {(Promise<void>)}
    */
-  public async uploadFile(filePath: string, options: UploadToAzureFileOptions = {}): Promise<void> {
+  public async uploadFile(filePath: string, options: FileParallelUploadOptions = {}): Promise<void> {
     const { span, spanOptions } = createSpan("FileClient-uploadFile", options.spanOptions);
     try {
       const size = (await fsStat(filePath)).size;
@@ -1506,13 +1506,13 @@ export class FileClient extends StorageClient {
    *                                                                  from the offset defined
    * @param {number} size Size of the Azure file
    * @param {FileClient} fileClient FileClient
-   * @param {UploadToAzureFileOptions} [options]
+   * @param {FileParallelUploadOptions} [options]
    * @returns {(Promise<void>)}
    */
   async uploadResetableStream(
     streamFactory: (offset: number, count?: number) => NodeJS.ReadableStream,
     size: number,
-    options: UploadToAzureFileOptions = {}
+    options: FileParallelUploadOptions = {}
   ): Promise<void> {
     const { span, spanOptions } = createSpan(
       "FileClient-uploadResetableStream",
@@ -1593,14 +1593,14 @@ export class FileClient extends StorageClient {
    * @param {Buffer} buffer Buffer to be fill, must have length larger than count
    * @param {number} offset From which position of the Azure File to download
    * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined
-   * @param {DownloadFromAzureFileOptions} [options]
+   * @param {FileDownloadToBufferOptions} [options]
    * @returns {Promise<void>}
    */
   public async downloadToBuffer(
     buffer: Buffer,
     offset: number = 0,
     count?: number,
-    options: DownloadFromAzureFileOptions = {}
+    options: FileDownloadToBufferOptions = {}
   ): Promise<void> {
     const { span, spanOptions } = createSpan("FileClient-downloadToBuffer", options.spanOptions);
     try {
@@ -1702,7 +1702,7 @@ export class FileClient extends StorageClient {
    *                            the uploaded file. Size must be > 0 and <= 4 * 1024 * 1024 (4MB)
    * @param {number} maxBuffers Max buffers will allocate during uploading, positive correlation
    *                            with max uploading concurrency
-   * @param {UploadStreamToAzureFileOptions} [options]
+   * @param {FileUploadStreamOptions} [options]
    * @returns {Promise<void>}
    */
   public async uploadStream(
@@ -1710,7 +1710,7 @@ export class FileClient extends StorageClient {
     size: number,
     bufferSize: number,
     maxBuffers: number,
-    options: UploadStreamToAzureFileOptions = {}
+    options: FileUploadStreamOptions = {}
   ): Promise<void> {
     const { span, spanOptions } = createSpan("FileClient-uploadStream", options.spanOptions);
     try {


### PR DESCRIPTION
When the high-level functions were moved into clients, their options type name
were not updated. This change renames them to be consistent with other options
types.

Resolves #5648