### PR TITLE
Remove body field from RestError Object in core-http Library

### DIFF
--- a/sdk/core/core-arm/lib/lroPollStrategy.ts
+++ b/sdk/core/core-arm/lib/lroPollStrategy.ts
@@ -99,9 +99,9 @@ export abstract class LROPollStrategy {
     error.request = stripRequest(this._pollState.mostRecentRequest);
     error.response = this._pollState.mostRecentResponse;
     error.message = `Long running operation failed with status: "${this._pollState.state}".`;
-    error.body = this._pollState.resource;
-    if (error.body) {
-      const innerError: any = error.body.error;
+    error.response.parsedBody = this._pollState.resource;
+    if (error.response.parsedBody) {
+      const innerError: any = error.response.parsedBody.error;
       if (innerError) {
         if (innerError.message) {
           error.message = `Long running operation failed with error: "${innerError.message}".`;
@@ -407,7 +407,7 @@ class LocationLROPollStrategy extends LROPollStrategy {
           // Ignore the exception, use resultBody as the error message
         }
 
-        throw new RestError(errorMessage, undefined, statusCode, stripRequest(result.request), result, resultBody);
+        throw new RestError(errorMessage, undefined, statusCode, stripRequest(result.request), result);
       } else {
         throw new Error(`The response with status code ${statusCode} from polling for long running operation url "${lroPollState.locationHeaderValue}" is not valid.`);
       }
@@ -484,7 +484,7 @@ class AzureAsyncOperationLROPollStrategy extends LROPollStrategy {
         error.statusCode = statusCode;
         error.request = stripRequest(response.request);
         error.response = response;
-        error.body = parsedResponse;
+        error.response.parsedBody = parsedResponse;
         throw error;
       }
 
@@ -567,7 +567,7 @@ class GetResourceLROPollStrategy extends LROPollStrategy {
         error.statusCode = statusCode;
         error.request = stripRequest(result.request);
         error.response = result;
-        error.body = responseBody;
+        error.response.parsedBody = responseBody;
         throw error;
       }
 

--- a/sdk/core/core-http/lib/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/deserializationPolicy.ts
@@ -193,13 +193,11 @@ export function deserializeResponseBody(
                         ? parsedErrorResponse[defaultResponseBodyMapper.xmlElementName!]
                         : [];
                   }
-                  error.body = operationSpec.serializer.deserialize(
+                  error.response!.parsedBody = operationSpec.serializer.deserialize(
                     defaultResponseBodyMapper,
                     valueToDeserialize,
-                    "error.body"
+                    "error.response.parsedBody"
                   );
-                  // Setting the parsedBody on response to enable flattening as per operationSpec
-                  error.response!.parsedBody = error.body;
                 }
               }
 
@@ -270,8 +268,7 @@ function parse(
       errCode,
       operationResponse.status,
       operationResponse.request,
-      operationResponse,
-      operationResponse.bodyAsText
+      operationResponse
     );
     return Promise.reject(e);
   };

--- a/sdk/core/core-http/lib/restError.ts
+++ b/sdk/core/core-http/lib/restError.ts
@@ -13,22 +13,19 @@ export class RestError extends Error {
   statusCode?: number;
   request?: WebResource;
   response?: HttpOperationResponse;
-  body?: any;
   details?: unknown;
   constructor(
     message: string,
     code?: string,
     statusCode?: number,
     request?: WebResource,
-    response?: HttpOperationResponse,
-    body?: any
+    response?: HttpOperationResponse
   ) {
     super(message);
     this.code = code;
     this.statusCode = statusCode;
     this.request = request;
     this.response = response;
-    this.body = body;
 
     Object.setPrototypeOf(this, RestError.prototype);
   }

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -257,7 +257,7 @@ describe("BlobClient", () => {
         "AbortCopyFromClient should be failed and throw exception for an completed copy operation."
       );
     } catch (err) {
-      assert.ok((err as any).body.Code === "InvalidHeaderValue");
+      assert.ok((err as any).response.parsedBody.Code === "InvalidHeaderValue");
     }
   });
 

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -264,7 +264,7 @@ describe("BlobClient Node.js only", () => {
         "AbortCopyFromClient should be failed and throw exception for an completed copy operation."
       );
     } catch (err) {
-      assert.ok((err as any).body.Code === "InvalidHeaderValue");
+      assert.ok((err as any).parsedBody.Code === "InvalidHeaderValue");
     }
   });
 

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -264,7 +264,7 @@ describe("BlobClient Node.js only", () => {
         "AbortCopyFromClient should be failed and throw exception for an completed copy operation."
       );
     } catch (err) {
-      assert.ok((err as any).parsedBody.Code === "InvalidHeaderValue");
+      assert.ok((err as any).response.parsedBody.Code === "InvalidHeaderValue");
     }
   });
 


### PR DESCRIPTION
Per recent conversation with @ramya-rao-a I am removing the body field from RestError Object in core-http Library. If required, this can be read from the response object. 

Additional details:
With https://github.com/Azure/azure-sdk-for-js/pull/5437, 
- the `response` property on the error will now have the parsed body & headers along with raw body & headers that it already had. 
- the `details` property on the error will have the shape/data model as defined in swagger for errors

With these changes, the `body` property on the `RestError` itself becomes redundant. 

