### PR TITLE
[keyvault-keys] API changes

### DIFF
--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `deleteKey` and `recoverDeletedKey` are now out of the public API.
   Use `beginDeleteKey` and `beginRecoverDeletedKey` instead.
   They both return a Poller (from our package `@azure/core-lro`) that manages the long running operation.
+- Renamed `Key` to `KeyVaultKey`.
 
 ## 4.0.0-preview.8 (2019-10-09)
 

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -10,6 +10,9 @@
 - All options should match the method's name.
 - All methods that return keyProperties (like the ones that iterate) should contain "propertiesOf" in their names.
 - Flattened all the options bag to extend the `RequestOptionsBase` interface.
+- Renamed the `vautlUrl` parameters into `vaultEndpoint`.
+- Renamed the Wrap/UnwrapOptions into Wrap/UnwrapKeyProperties.
+- Renamed `UpdatedKey` to `UpdatedKeyProperties`.
 
 ## 4.0.0-preview.8 (2019-10-09)
 

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -5,6 +5,11 @@
   Use `beginDeleteKey` and `beginRecoverDeletedKey` instead.
   They both return a Poller (from our package `@azure/core-lro`) that manages the long running operation.
 - Renamed `Key` to `KeyVaultKey`.
+- Renamed `Key.KeyMaterial` to `KeyVaultKey.Key`.
+- All dates should end in "On", except for `notBefore` and `scheduledPurgedDate`.
+- All options should match the method's name.
+- All methods that return keyProperties (like the ones that iterate) should contain "propertiesOf" in their names.
+- Flattened all the options bag to extend the `RequestOptionsBase` interface.
 
 ## 4.0.0-preview.8 (2019-10-09)
 

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -291,23 +291,23 @@ Using the KeysClient, you can retrieve and iterate through all of the
 keys in a Key Vault, as well as through all of the deleted keys and the
 versions of a specific key. The following API methods are available:
 
-- `listKeys` will list all of your non-deleted keys by their names, only
+- `listPropertiesOfKeys` will list all of your non-deleted keys by their names, only
   at their latest versions.
 - `listDeletedKeys` will list all of your deleted keys by their names,
   only at their latest versions.
-- `listKeyVersions` will list all the versions of a key based on a key
+- `listPropertiesOfKeyVersions` will list all the versions of a key based on a key
   name.
 
 Which can be used as follows:
 
 ```javascript
-for await (let key of client.listKeys()) {
+for await (let key of client.listPropertiesOfKeys()) {
   console.log("Key: ", key);
 }
 for await (let deletedKey of client.listDeletedKeys()) {
   console.log("Deleted key: ", deletedKey);
 }
-for await (let version of client.listKeyVersions(keyName)) {
+for await (let version of client.listPropertiesOfKeyVersions(keyName)) {
   console.log("Version: ", version);
 }
 ```
@@ -317,7 +317,7 @@ retrieve them by pages, add `.byPage()` right after invoking the API method you
 want to use, as follows:
 
 ```javascript
-for await (let page of client.listKeys().byPage()) {
+for await (let page of client.listPropertiesOfKeys().byPage()) {
   for (let key of page) {
     console.log("Key: ", key);
   }
@@ -327,7 +327,7 @@ for await (let page of client.listDeletedKeys().byPage()) {
     console.log("Deleted key: ", deletedKey);
   }
 }
-for await (let page of client.listKeyVersions(keyName).byPage()) {
+for await (let page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
   for (let version of page) {
     console.log("Version: ", version);
   }

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -293,7 +293,7 @@ versions of a specific key. The following API methods are available:
 
 - `listPropertiesOfKeys` will list all of your non-deleted keys by their names, only
   at their latest versions.
-- `listDeletedKeys` will list all of your deleted keys by their names,
+- `listPropertiesOfDeletedKeys` will list all of your deleted keys by their names,
   only at their latest versions.
 - `listPropertiesOfKeyVersions` will list all the versions of a key based on a key
   name.
@@ -301,14 +301,14 @@ versions of a specific key. The following API methods are available:
 Which can be used as follows:
 
 ```javascript
-for await (let key of client.listPropertiesOfKeys()) {
-  console.log("Key: ", key);
+for await (let keyProperties of client.listPropertiesOfKeys()) {
+  console.log("Key properties: ", keyProperties);
 }
-for await (let deletedKey of client.listDeletedKeys()) {
-  console.log("Deleted key: ", deletedKey);
+for await (let deletedKeyProperties of client.listPropertiesOfDeletedKeys()) {
+  console.log("Deleted key properties: ", deletedKeyProperties);
 }
-for await (let version of client.listPropertiesOfKeyVersions(keyName)) {
-  console.log("Version: ", version);
+for await (let versionProperties of client.listPropertiesOfKeyVersions(keyName)) {
+  console.log("Version properties: ", versionProperties);
 }
 ```
 
@@ -318,18 +318,18 @@ want to use, as follows:
 
 ```javascript
 for await (let page of client.listPropertiesOfKeys().byPage()) {
-  for (let key of page) {
-    console.log("Key: ", key);
+  for (let keyProperties of page) {
+    console.log("Key properties: ", keyProperties);
   }
 }
-for await (let page of client.listDeletedKeys().byPage()) {
+for await (let page of client.listPropertiesOfDeletedKeys().byPage()) {
   for (let deletedKey of page) {
-    console.log("Deleted key: ", deletedKey);
+    console.log("Deleted key: ", deletedKeyProperties);
   }
 }
 for await (let page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
-  for (let version of page) {
-    console.log("Version: ", version);
+  for (let versionProperties of page) {
+    console.log("Version: ", versionProperties);
   }
 }
 ```

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -293,7 +293,7 @@ versions of a specific key. The following API methods are available:
 
 - `listPropertiesOfKeys` will list all of your non-deleted keys by their names, only
   at their latest versions.
-- `listPropertiesOfDeletedKeys` will list all of your deleted keys by their names,
+- `listDeletedKeys` will list all of your deleted keys by their names,
   only at their latest versions.
 - `listPropertiesOfKeyVersions` will list all the versions of a key based on a key
   name.
@@ -304,8 +304,8 @@ Which can be used as follows:
 for await (let keyProperties of client.listPropertiesOfKeys()) {
   console.log("Key properties: ", keyProperties);
 }
-for await (let deletedKeyProperties of client.listPropertiesOfDeletedKeys()) {
-  console.log("Deleted key properties: ", deletedKeyProperties);
+for await (let deletedKey of client.listDeletedKeys()) {
+  console.log("Deleted: ", deletedKey);
 }
 for await (let versionProperties of client.listPropertiesOfKeyVersions(keyName)) {
   console.log("Version properties: ", versionProperties);
@@ -322,9 +322,9 @@ for await (let page of client.listPropertiesOfKeys().byPage()) {
     console.log("Key properties: ", keyProperties);
   }
 }
-for await (let page of client.listPropertiesOfDeletedKeys().byPage()) {
+for await (let page of client.listDeletedKeys().byPage()) {
   for (let deletedKey of page) {
-    console.log("Deleted key: ", deletedKeyProperties);
+    console.log("Deleted key: ", deletedKey);
   }
 }
 for await (let page of client.listPropertiesOfKeyVersions(keyName).byPage()) {

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -215,11 +215,11 @@ This will create a new version of the same key, which will have the latest
 provided attributes.
 
 Attributes can also be updated to an existing key version with
-`updateKey`, as follows:
+`updateKeyProperties`, as follows:
 
 ```javascript
 const result = await client.createKey(keyName, "RSA");
-await client.updateKey(keyName, result.properties.version, {
+await client.updateKeyProperties(keyName, result.properties.version, {
   enabled: false
 });
 ```

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -24,7 +24,7 @@ export interface CreateEcKeyOptions extends CreateKeyOptions {
 // @public
 export interface CreateKeyOptions {
     enabled?: boolean;
-    expiresOn?: Date;
+    expires?: Date;
     keyOps?: JsonWebKeyOperation[];
     // (undocumented)
     keySize?: number;
@@ -78,11 +78,11 @@ export interface DecryptResult {
 
 // @public
 export interface DeletedKey {
-    key?: JsonWebKey;
+    keyMaterial?: JsonWebKey;
     properties: KeyProperties & {
         readonly recoveryId?: string;
         readonly scheduledPurgeDate?: Date;
-        deletedOn?: Date;
+        readonly deletedDate?: Date;
     };
 }
 
@@ -126,7 +126,7 @@ export interface GetKeysOptions {
 // @public
 export interface ImportKeyOptions {
     enabled?: boolean;
-    expiresOn?: Date;
+    expires?: Date;
     hardwareProtected?: boolean;
     notBefore?: Date;
     requestOptions?: coreHttp.RequestOptionsBase;
@@ -169,25 +169,33 @@ export type JsonWebKeyOperation = "encrypt" | "decrypt" | "sign" | "verify" | "w
 export type JsonWebKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM" | "oct";
 
 // @public
+export interface Key {
+    keyMaterial?: JsonWebKey;
+    keyOperations?: JsonWebKeyOperation[];
+    keyType?: JsonWebKeyType;
+    properties: KeyProperties;
+}
+
+// @public
 export class KeyClient {
     constructor(endPoint: string, credential: TokenCredential, pipelineOptions?: PipelineOptions);
     backupKey(name: string, options?: RequestOptions): Promise<Uint8Array | undefined>;
     beginDeleteKey(name: string, options?: KeyPollerOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
     beginRecoverDeletedKey(name: string, options?: KeyPollerOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
-    createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey>;
-    createKey(name: string, keyType: JsonWebKeyType, options?: CreateKeyOptions): Promise<KeyVaultKey>;
-    createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey>;
+    createEcKey(name: string, options?: CreateEcKeyOptions): Promise<Key>;
+    createKey(name: string, keyType: JsonWebKeyType, options?: CreateKeyOptions): Promise<Key>;
+    createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<Key>;
     protected readonly credential: TokenCredential;
     getDeletedKey(name: string, options?: RequestOptions): Promise<DeletedKey>;
-    getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
-    importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<KeyVaultKey>;
+    getKey(name: string, options?: GetKeyOptions): Promise<Key>;
+    importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<Key>;
     listDeletedKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
     listKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
     listKeyVersions(name: string, options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
     readonly pipeline: ServiceClientOptions;
     purgeDeletedKey(name: string, options?: RequestOptions): Promise<void>;
-    restoreKeyBackup(backup: Uint8Array, options?: RequestOptions): Promise<KeyVaultKey>;
-    updateKey(name: string, keyVersion: string, options?: UpdateKeyOptions): Promise<KeyVaultKey>;
+    restoreKeyBackup(backup: Uint8Array, options?: RequestOptions): Promise<Key>;
+    updateKey(name: string, keyVersion: string, options?: UpdateKeyOptions): Promise<Key>;
     readonly vaultEndpoint: string;
 }
 
@@ -200,24 +208,16 @@ export interface KeyPollerOptions {
 
 // @public
 export interface KeyProperties extends ParsedKeyVaultEntityIdentifier {
-    createdOn?: Date;
+    readonly created?: Date;
     enabled?: boolean;
-    expiresOn?: Date;
+    expires?: Date;
     id?: string;
     notBefore?: Date;
     readonly recoveryLevel?: DeletionRecoveryLevel;
     tags?: {
         [propertyName: string]: string;
     };
-    updatedOn?: Date;
-}
-
-// @public
-export interface KeyVaultKey {
-    key?: JsonWebKey;
-    keyOperations?: JsonWebKeyOperation[];
-    keyType?: JsonWebKeyType;
-    properties: KeyProperties;
+    readonly updated?: Date;
 }
 
 // @public
@@ -250,7 +250,7 @@ export interface ProxyOptions {
 }
 
 // @public
-export interface RecoverDeletedKeyPollOperationState extends PollOperationState<KeyVaultKey> {
+export interface RecoverDeletedKeyPollOperationState extends PollOperationState<Key> {
     // (undocumented)
     client: KeyClientInterface;
     // (undocumented)
@@ -293,7 +293,7 @@ export interface UnwrapResult {
 // @public
 export interface UpdateKeyOptions {
     enabled?: boolean;
-    expiresOn?: Date;
+    expires?: Date;
     keyOps?: JsonWebKeyOperation[];
     notBefore?: Date;
     requestOptions?: coreHttp.RequestOptionsBase;

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -57,14 +57,14 @@ export class CryptographyClient {
     // Warning: (ae-forgotten-export) The symbol "SignOptions" needs to be exported by the entry point index.d.ts
     sign(algorithm: KeySignatureAlgorithm, digest: Uint8Array, options?: SignOptions): Promise<SignResult>;
     signData(algorithm: KeySignatureAlgorithm, data: Uint8Array, options?: SignOptions): Promise<SignResult>;
-    // Warning: (ae-forgotten-export) The symbol "UnwrapOptions" needs to be exported by the entry point index.d.ts
-    unwrapKey(algorithm: KeyWrapAlgorithm, encryptedKey: Uint8Array, options?: UnwrapOptions): Promise<UnwrapResult>;
+    // Warning: (ae-forgotten-export) The symbol "UnwrapKeyOptions" needs to be exported by the entry point index.d.ts
+    unwrapKey(algorithm: KeyWrapAlgorithm, encryptedKey: Uint8Array, options?: UnwrapKeyOptions): Promise<UnwrapResult>;
     readonly vaultBaseUrl: string;
     // Warning: (ae-forgotten-export) The symbol "VerifyOptions" needs to be exported by the entry point index.d.ts
     verify(algorithm: KeySignatureAlgorithm, digest: Uint8Array, signature: Uint8Array, options?: VerifyOptions): Promise<VerifyResult>;
     verifyData(algorithm: KeySignatureAlgorithm, data: Uint8Array, signature: Uint8Array, options?: VerifyOptions): Promise<VerifyResult>;
-    // Warning: (ae-forgotten-export) The symbol "WrapOptions" needs to be exported by the entry point index.d.ts
-    wrapKey(algorithm: KeyWrapAlgorithm, key: Uint8Array, options?: WrapOptions): Promise<WrapResult>;
+    // Warning: (ae-forgotten-export) The symbol "WrapKeyOptions" needs to be exported by the entry point index.d.ts
+    wrapKey(algorithm: KeyWrapAlgorithm, key: Uint8Array, options?: WrapKeyOptions): Promise<WrapResult>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "CryptographyOptions" needs to be exported by the entry point index.d.ts
@@ -196,7 +196,7 @@ export class KeyClient {
     readonly pipeline: ServiceClientOptions;
     purgeDeletedKey(name: string, options?: PurgeDeletedKeyOptions): Promise<void>;
     restoreKeyBackup(backup: Uint8Array, options?: RestoreKeyBackupOptions): Promise<KeyVaultKey>;
-    updateKey(name: string, keyVersion: string, options?: UpdateKeyOptions): Promise<KeyVaultKey>;
+    updateKeyProperties(name: string, keyVersion: string, options?: UpdateKeyPropertiesOptions): Promise<KeyVaultKey>;
     readonly vaultEndpoint: string;
 }
 
@@ -311,7 +311,7 @@ export interface UnwrapResult {
 }
 
 // @public
-export interface UpdateKeyOptions extends coreHttp.RequestOptionsBase {
+export interface UpdateKeyPropertiesOptions extends coreHttp.RequestOptionsBase {
     enabled?: boolean;
     expiresOn?: Date;
     keyOps?: JsonWebKeyOperation[];

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -16,20 +16,22 @@ import { ServiceClientOptions } from '@azure/core-http';
 import { TokenCredential } from '@azure/core-http';
 
 // @public
+export interface BackupKeyOptions extends coreHttp.RequestOptionsBase {
+}
+
+// @public
 export interface CreateEcKeyOptions extends CreateKeyOptions {
     curve?: JsonWebKeyCurveName;
     hsm?: boolean;
 }
 
 // @public
-export interface CreateKeyOptions {
+export interface CreateKeyOptions extends coreHttp.RequestOptionsBase {
     enabled?: boolean;
-    expires?: Date;
+    readonly expiresOn?: Date;
     keyOps?: JsonWebKeyOperation[];
-    // (undocumented)
     keySize?: number;
     notBefore?: Date;
-    requestOptions?: coreHttp.RequestOptionsBase;
     tags?: {
         [propertyName: string]: string;
     };
@@ -65,8 +67,10 @@ export class CryptographyClient {
     wrapKey(algorithm: KeyWrapAlgorithm, key: Uint8Array, options?: WrapOptions): Promise<WrapResult>;
 }
 
+// Warning: (ae-forgotten-export) The symbol "CryptographyOptions" needs to be exported by the entry point index.d.ts
+// 
 // @public
-export interface DecryptOptions extends RequestOptions {
+export interface DecryptOptions extends CryptographyOptions {
 }
 
 // @public
@@ -78,11 +82,15 @@ export interface DecryptResult {
 
 // @public
 export interface DeletedKey {
-    keyMaterial?: JsonWebKey;
+    id?: string;
+    key?: JsonWebKey;
+    keyOperations?: JsonWebKeyOperation[];
+    keyType?: JsonWebKeyType;
+    name: string;
     properties: KeyProperties & {
         readonly recoveryId?: string;
         readonly scheduledPurgeDate?: Date;
-        readonly deletedDate?: Date;
+        deletedOn?: Date;
     };
 }
 
@@ -102,7 +110,7 @@ export interface DeleteKeyPollOperationState extends PollOperationState<DeletedK
 export type DeletionRecoveryLevel = "Purgeable" | "Recoverable+Purgeable" | "Recoverable" | "Recoverable+ProtectedSubscription";
 
 // @public
-export interface EncryptOptions extends RequestOptions {
+export interface EncryptOptions extends CryptographyOptions {
 }
 
 // @public
@@ -113,23 +121,24 @@ export interface EncryptResult {
 }
 
 // @public
-export interface GetKeyOptions {
-    requestOptions?: coreHttp.RequestOptionsBase;
+export interface GetDeletedKeyOptions extends coreHttp.RequestOptionsBase {
+}
+
+// @public
+export interface GetKeyOptions extends coreHttp.RequestOptionsBase {
     version?: string;
 }
 
 // @public
-export interface GetKeysOptions {
-    requestOptions?: coreHttp.RequestOptionsBase;
+export interface GetKeysOptions extends coreHttp.RequestOptionsBase {
 }
 
 // @public
-export interface ImportKeyOptions {
+export interface ImportKeyOptions extends coreHttp.RequestOptionsBase {
     enabled?: boolean;
-    expires?: Date;
+    expiresOn?: Date;
     hardwareProtected?: boolean;
     notBefore?: Date;
-    requestOptions?: coreHttp.RequestOptionsBase;
     tags?: {
         [propertyName: string]: string;
     };
@@ -169,55 +178,59 @@ export type JsonWebKeyOperation = "encrypt" | "decrypt" | "sign" | "verify" | "w
 export type JsonWebKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM" | "oct";
 
 // @public
-export interface Key {
-    keyMaterial?: JsonWebKey;
-    keyOperations?: JsonWebKeyOperation[];
-    keyType?: JsonWebKeyType;
-    properties: KeyProperties;
-}
-
-// @public
 export class KeyClient {
-    constructor(endPoint: string, credential: TokenCredential, pipelineOptions?: PipelineOptions);
-    backupKey(name: string, options?: RequestOptions): Promise<Uint8Array | undefined>;
+    constructor(endpoint: string, credential: TokenCredential, pipelineOptions?: PipelineOptions);
+    backupKey(name: string, options?: BackupKeyOptions): Promise<Uint8Array | undefined>;
     beginDeleteKey(name: string, options?: KeyPollerOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
     beginRecoverDeletedKey(name: string, options?: KeyPollerOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
-    createEcKey(name: string, options?: CreateEcKeyOptions): Promise<Key>;
-    createKey(name: string, keyType: JsonWebKeyType, options?: CreateKeyOptions): Promise<Key>;
-    createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<Key>;
+    createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey>;
+    createKey(name: string, keyType: JsonWebKeyType, options?: CreateKeyOptions): Promise<KeyVaultKey>;
+    createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey>;
     protected readonly credential: TokenCredential;
-    getDeletedKey(name: string, options?: RequestOptions): Promise<DeletedKey>;
-    getKey(name: string, options?: GetKeyOptions): Promise<Key>;
-    importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<Key>;
-    listDeletedKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
-    listKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
-    listKeyVersions(name: string, options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
+    getDeletedKey(name: string, options?: GetDeletedKeyOptions): Promise<DeletedKey>;
+    getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
+    importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<KeyVaultKey>;
+    listDeletedKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<DeletedKey, DeletedKey[]>;
+    listPropertiesOfKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
+    listPropertiesOfKeyVersions(name: string, options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
     readonly pipeline: ServiceClientOptions;
-    purgeDeletedKey(name: string, options?: RequestOptions): Promise<void>;
-    restoreKeyBackup(backup: Uint8Array, options?: RequestOptions): Promise<Key>;
-    updateKey(name: string, keyVersion: string, options?: UpdateKeyOptions): Promise<Key>;
+    purgeDeletedKey(name: string, options?: PurgeDeletedKeyOptions): Promise<void>;
+    restoreKeyBackup(backup: Uint8Array, options?: RestoreKeyBackupOptions): Promise<KeyVaultKey>;
+    updateKey(name: string, keyVersion: string, options?: UpdateKeyOptions): Promise<KeyVaultKey>;
     readonly vaultEndpoint: string;
 }
 
 // @public
-export interface KeyPollerOptions {
+export interface KeyPollerOptions extends coreHttp.RequestOptionsBase {
     intervalInMs?: number;
-    requestOptions?: coreHttp.RequestOptionsBase;
     resumeFrom?: string;
 }
 
 // @public
-export interface KeyProperties extends ParsedKeyVaultEntityIdentifier {
-    readonly created?: Date;
+export interface KeyProperties {
+    readonly createdOn?: Date;
     enabled?: boolean;
-    expires?: Date;
+    expiresOn?: Date;
     id?: string;
+    name: string;
     notBefore?: Date;
     readonly recoveryLevel?: DeletionRecoveryLevel;
     tags?: {
         [propertyName: string]: string;
     };
-    readonly updated?: Date;
+    readonly updatedOn?: Date;
+    vaultEndpoint: string;
+    version?: string;
+}
+
+// @public
+export interface KeyVaultKey {
+    id?: string;
+    key?: JsonWebKey;
+    keyOperations?: JsonWebKeyOperation[];
+    keyType?: JsonWebKeyType;
+    name: string;
+    properties: KeyProperties;
 }
 
 // @public
@@ -250,7 +263,15 @@ export interface ProxyOptions {
 }
 
 // @public
-export interface RecoverDeletedKeyPollOperationState extends PollOperationState<Key> {
+export interface PurgeDeletedKeyOptions extends coreHttp.RequestOptionsBase {
+}
+
+// @public
+export interface RecoverDeletedKeyOptions extends coreHttp.RequestOptionsBase {
+}
+
+// @public
+export interface RecoverDeletedKeyPollOperationState extends PollOperationState<KeyVaultKey> {
     // (undocumented)
     client: KeyClientInterface;
     // (undocumented)
@@ -260,8 +281,7 @@ export interface RecoverDeletedKeyPollOperationState extends PollOperationState<
 }
 
 // @public
-export interface RequestOptions {
-    requestOptions?: coreHttp.RequestOptionsBase;
+export interface RestoreKeyBackupOptions extends coreHttp.RequestOptionsBase {
 }
 
 // @public
@@ -291,12 +311,11 @@ export interface UnwrapResult {
 }
 
 // @public
-export interface UpdateKeyOptions {
+export interface UpdateKeyOptions extends coreHttp.RequestOptionsBase {
     enabled?: boolean;
-    expires?: Date;
+    expiresOn?: Date;
     keyOps?: JsonWebKeyOperation[];
     notBefore?: Date;
-    requestOptions?: coreHttp.RequestOptionsBase;
     tags?: {
         [propertyName: string]: string;
     };

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -24,7 +24,7 @@ export interface CreateEcKeyOptions extends CreateKeyOptions {
 // @public
 export interface CreateKeyOptions {
     enabled?: boolean;
-    expires?: Date;
+    expiresOn?: Date;
     keyOps?: JsonWebKeyOperation[];
     // (undocumented)
     keySize?: number;
@@ -78,11 +78,11 @@ export interface DecryptResult {
 
 // @public
 export interface DeletedKey {
-    keyMaterial?: JsonWebKey;
+    key?: JsonWebKey;
     properties: KeyProperties & {
         readonly recoveryId?: string;
         readonly scheduledPurgeDate?: Date;
-        readonly deletedDate?: Date;
+        deletedOn?: Date;
     };
 }
 
@@ -126,7 +126,7 @@ export interface GetKeysOptions {
 // @public
 export interface ImportKeyOptions {
     enabled?: boolean;
-    expires?: Date;
+    expiresOn?: Date;
     hardwareProtected?: boolean;
     notBefore?: Date;
     requestOptions?: coreHttp.RequestOptionsBase;
@@ -169,33 +169,25 @@ export type JsonWebKeyOperation = "encrypt" | "decrypt" | "sign" | "verify" | "w
 export type JsonWebKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM" | "oct";
 
 // @public
-export interface Key {
-    keyMaterial?: JsonWebKey;
-    keyOperations?: JsonWebKeyOperation[];
-    keyType?: JsonWebKeyType;
-    properties: KeyProperties;
-}
-
-// @public
 export class KeyClient {
     constructor(endPoint: string, credential: TokenCredential, pipelineOptions?: PipelineOptions);
     backupKey(name: string, options?: RequestOptions): Promise<Uint8Array | undefined>;
     beginDeleteKey(name: string, options?: KeyPollerOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
     beginRecoverDeletedKey(name: string, options?: KeyPollerOptions): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>>;
-    createEcKey(name: string, options?: CreateEcKeyOptions): Promise<Key>;
-    createKey(name: string, keyType: JsonWebKeyType, options?: CreateKeyOptions): Promise<Key>;
-    createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<Key>;
+    createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey>;
+    createKey(name: string, keyType: JsonWebKeyType, options?: CreateKeyOptions): Promise<KeyVaultKey>;
+    createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey>;
     protected readonly credential: TokenCredential;
     getDeletedKey(name: string, options?: RequestOptions): Promise<DeletedKey>;
-    getKey(name: string, options?: GetKeyOptions): Promise<Key>;
-    importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<Key>;
+    getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
+    importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<KeyVaultKey>;
     listDeletedKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
     listKeys(options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
     listKeyVersions(name: string, options?: GetKeysOptions): PagedAsyncIterableIterator<KeyProperties, KeyProperties[]>;
     readonly pipeline: ServiceClientOptions;
     purgeDeletedKey(name: string, options?: RequestOptions): Promise<void>;
-    restoreKeyBackup(backup: Uint8Array, options?: RequestOptions): Promise<Key>;
-    updateKey(name: string, keyVersion: string, options?: UpdateKeyOptions): Promise<Key>;
+    restoreKeyBackup(backup: Uint8Array, options?: RequestOptions): Promise<KeyVaultKey>;
+    updateKey(name: string, keyVersion: string, options?: UpdateKeyOptions): Promise<KeyVaultKey>;
     readonly vaultEndpoint: string;
 }
 
@@ -208,16 +200,24 @@ export interface KeyPollerOptions {
 
 // @public
 export interface KeyProperties extends ParsedKeyVaultEntityIdentifier {
-    readonly created?: Date;
+    createdOn?: Date;
     enabled?: boolean;
-    expires?: Date;
+    expiresOn?: Date;
     id?: string;
     notBefore?: Date;
     readonly recoveryLevel?: DeletionRecoveryLevel;
     tags?: {
         [propertyName: string]: string;
     };
-    readonly updated?: Date;
+    updatedOn?: Date;
+}
+
+// @public
+export interface KeyVaultKey {
+    key?: JsonWebKey;
+    keyOperations?: JsonWebKeyOperation[];
+    keyType?: JsonWebKeyType;
+    properties: KeyProperties;
 }
 
 // @public
@@ -250,7 +250,7 @@ export interface ProxyOptions {
 }
 
 // @public
-export interface RecoverDeletedKeyPollOperationState extends PollOperationState<Key> {
+export interface RecoverDeletedKeyPollOperationState extends PollOperationState<KeyVaultKey> {
     // (undocumented)
     client: KeyClientInterface;
     // (undocumented)
@@ -293,7 +293,7 @@ export interface UnwrapResult {
 // @public
 export interface UpdateKeyOptions {
     enabled?: boolean;
-    expires?: Date;
+    expiresOn?: Date;
     keyOps?: JsonWebKeyOperation[];
     notBefore?: Date;
     requestOptions?: coreHttp.RequestOptionsBase;

--- a/sdk/keyvault/keyvault-keys/samples/javascript/cryptography.js
+++ b/sdk/keyvault/keyvault-keys/samples/javascript/cryptography.js
@@ -20,7 +20,7 @@ async function main() {
   // Connection to Azure Key Vault Cryptography functionality
   let myWorkKey = await client.createKey(keyName, "RSA");
 
-  const cryptoClient = new CryptographyClient(url, myWorkKey.keyMaterial.kid, credential);
+  const cryptoClient = new CryptographyClient(url, myWorkKey.key.kid, credential);
 
   // Sign and Verify
   const signatureValue = "MySignature";

--- a/sdk/keyvault/keyvault-keys/samples/javascript/helloWorld.js
+++ b/sdk/keyvault/keyvault-keys/samples/javascript/helloWorld.js
@@ -31,9 +31,9 @@ async function main() {
   console.log("key: ", key);
 
   // Or list the keys we have
-  let listKeys = client.listKeys();
+  let listPropertiesOfKeys = client.listPropertiesOfKeys();
   while (true) {
-    let { done, value } = await listKeys.next();
+    let { done, value } = await listPropertiesOfKeys.next();
     if (done) {
       break;
     }

--- a/sdk/keyvault/keyvault-keys/samples/javascript/helloWorld.js
+++ b/sdk/keyvault/keyvault-keys/samples/javascript/helloWorld.js
@@ -43,7 +43,7 @@ async function main() {
   }
 
   // Update the key
-  const updatedKey = await client.updateKey(keyName, result.properties.version, { enabled: false });
+  const updatedKey = await client.updateKeyProperties(keyName, result.properties.version, { enabled: false });
   console.log("updated key: ", updatedKey);
 
   await client.beginDeleteKey(keyName);

--- a/sdk/keyvault/keyvault-keys/samples/typescript/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/cryptography.ts
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
   // Connection to Azure Key Vault Cryptography functionality
   let myWorkKey = await client.createKey(keyName, "RSA");
 
-  const cryptoClient = new CryptographyClient(url, myWorkKey.keyMaterial!.kid!, credential);
+  const cryptoClient = new CryptographyClient(url, myWorkKey.key!.kid!, credential);
 
   // Sign and Verify
   const signatureValue = "MySignature";

--- a/sdk/keyvault/keyvault-keys/samples/typescript/helloWorld.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/helloWorld.ts
@@ -31,8 +31,8 @@ async function main(): Promise<void> {
   console.log("key: ", key);
 
   // Or list the keys we have
-  for await (const keyAttributes of client.listKeys()) {
-    const key = await client.getKey(keyAttributes.name);
+  for await (const keyProperties of client.listPropertiesOfKeys()) {
+    const key = await client.getKey(keyProperties.name);
     console.log("key: ", key);
   }
 

--- a/sdk/keyvault/keyvault-keys/samples/typescript/helloWorld.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/helloWorld.ts
@@ -37,7 +37,7 @@ async function main(): Promise<void> {
   }
 
   // Update the key
-  const updatedKey = await client.updateKey(keyName, result.properties.version!, {
+  const updatedKey = await client.updateKeyProperties(keyName, result.properties.version!, {
     enabled: false
   });
   console.log("updated key: ", updatedKey);

--- a/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { TokenCredential } from "@azure/core-http";
-import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions, RequestPolicyFactory } from "@azure/core-http";
+import {
+  BaseRequestPolicy,
+  RequestPolicy,
+  RequestPolicyOptions,
+  RequestPolicyFactory
+} from "@azure/core-http";
 import { Constants } from "@azure/core-http";
 import { HttpOperationResponse } from "@azure/core-http";
 import { HttpHeaders } from "@azure/core-http";
@@ -14,7 +19,9 @@ import { AccessTokenCache, ExpiringAccessTokenCache } from "@azure/core-http";
  *
  * @param credential The TokenCredential implementation that can supply the challenge token.
  */
-export function challengeBasedAuthenticationPolicy(credential: TokenCredential): RequestPolicyFactory {
+export function challengeBasedAuthenticationPolicy(
+  credential: TokenCredential
+): RequestPolicyFactory {
   const tokenCache: AccessTokenCache = new ExpiringAccessTokenCache();
   return {
     create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
@@ -24,7 +31,7 @@ export function challengeBasedAuthenticationPolicy(credential: TokenCredential):
 }
 
 export class AuthenticationChallenge {
-  constructor(public scopes: string[] | string) { }
+  constructor(public scopes: string[] | string) {}
 }
 
 /**
@@ -71,7 +78,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       let kv = item.split("=");
       if (kv[0].trim() == "resource") {
         // Remove the quotations around the string
-        let resource = kv[1].trim().replace(/['"]+/g, '');
+        let resource = kv[1].trim().replace(/['"]+/g, "");
         return resource;
       }
     }
@@ -82,9 +89,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
    * Applies the Bearer token to the request through the Authorization header.
    * @param webResource
    */
-  public async sendRequest(
-    webResource: WebResource
-  ): Promise<HttpOperationResponse> {
+  public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
 
     let originalBody = webResource.body;
@@ -106,7 +111,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
 
       if (www_authenticate) {
         let resource = this.parseWWWAuthenticate(www_authenticate);
-        let challenge = new AuthenticationChallenge(resource + "/.default")
+        let challenge = new AuthenticationChallenge(resource + "/.default");
 
         if (this.challenge != challenge) {
           this.challenge = challenge;

--- a/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
@@ -2,12 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 import { TokenCredential } from "@azure/core-http";
-import {
-  BaseRequestPolicy,
-  RequestPolicy,
-  RequestPolicyOptions,
-  RequestPolicyFactory
-} from "@azure/core-http";
+import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions, RequestPolicyFactory } from "@azure/core-http";
 import { Constants } from "@azure/core-http";
 import { HttpOperationResponse } from "@azure/core-http";
 import { HttpHeaders } from "@azure/core-http";
@@ -19,9 +14,7 @@ import { AccessTokenCache, ExpiringAccessTokenCache } from "@azure/core-http";
  *
  * @param credential The TokenCredential implementation that can supply the challenge token.
  */
-export function challengeBasedAuthenticationPolicy(
-  credential: TokenCredential
-): RequestPolicyFactory {
+export function challengeBasedAuthenticationPolicy(credential: TokenCredential): RequestPolicyFactory {
   const tokenCache: AccessTokenCache = new ExpiringAccessTokenCache();
   return {
     create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
@@ -31,7 +24,7 @@ export function challengeBasedAuthenticationPolicy(
 }
 
 export class AuthenticationChallenge {
-  constructor(public scopes: string[] | string) {}
+  constructor(public scopes: string[] | string) { }
 }
 
 /**
@@ -78,7 +71,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       let kv = item.split("=");
       if (kv[0].trim() == "resource") {
         // Remove the quotations around the string
-        let resource = kv[1].trim().replace(/['"]+/g, "");
+        let resource = kv[1].trim().replace(/['"]+/g, '');
         return resource;
       }
     }
@@ -89,7 +82,9 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
    * Applies the Bearer token to the request through the Authorization header.
    * @param webResource
    */
-  public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(
+    webResource: WebResource
+  ): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
 
     let originalBody = webResource.body;
@@ -111,7 +106,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
 
       if (www_authenticate) {
         let resource = this.parseWWWAuthenticate(www_authenticate);
-        let challenge = new AuthenticationChallenge(resource + "/.default");
+        let challenge = new AuthenticationChallenge(resource + "/.default")
 
         if (this.challenge != challenge) {
           this.challenge = challenge;

--- a/sdk/keyvault/keyvault-keys/src/core/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/keyVaultClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "@azure/keyvault-keys";
-const packageVersion = "4.0.0-preview.8";
+const packageVersion = "4.0.0-preview.9";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: string;

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -167,7 +167,7 @@ export class CryptographyClient {
   public async wrapKey(
     algorithm: KeyWrapAlgorithm,
     key: Uint8Array,
-    options?: WrapOptions
+    options?: WrapKeyOptions
   ): Promise<WrapResult> {
     if (isNode) {
       await this.fetchFullKeyIfPossible();
@@ -234,7 +234,7 @@ export class CryptographyClient {
   public async unwrapKey(
     algorithm: KeyWrapAlgorithm,
     encryptedKey: Uint8Array,
-    options?: UnwrapOptions
+    options?: UnwrapKeyOptions
   ): Promise<UnwrapResult> {
     let result = await this.client.unwrapKey(
       this.vaultBaseUrl,
@@ -805,12 +805,12 @@ export interface VerifyOptions extends CryptographyOptions {}
 /**
  * Options for the wrapKey call to the CryptographyClient
  */
-export interface WrapOptions extends CryptographyOptions {}
+export interface WrapKeyOptions extends CryptographyOptions {}
 
 /**
  * Options for the unwrap call to the CryptographyClient
  */
-export interface UnwrapOptions extends CryptographyOptions {}
+export interface UnwrapKeyOptions extends CryptographyOptions {}
 
 /**
  * Result of a decrypt operation

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -588,13 +588,12 @@ export class CryptographyClient {
     } else {
       pipelineOptions.userAgentOptions = {
         userAgentPrefix: libInfo
-      }
+      };
     }
 
-    const authPolicy =
-      isTokenCredential(credential)
-        ? challengeBasedAuthenticationPolicy(credential)
-        : signingPolicy(credential)
+    const authPolicy = isTokenCredential(credential)
+      ? challengeBasedAuthenticationPolicy(credential)
+      : signingPolicy(credential);
 
     const internalPipelineOptions = {
       ...pipelineOptions,
@@ -610,7 +609,7 @@ export class CryptographyClient {
           }
         }
       }
-    }
+    };
 
     this.pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
     this.client = new KeyVaultClient(credential, SERVICE_API_VERSION, this.pipeline);

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -1,4 +1,4 @@
-import { GetKeyOptions, RequestOptions } from "./keysModels";
+import { GetKeyOptions, CryptographyOptions } from "./keysModels";
 import { JsonWebKey, JsonWebKeyEncryptionAlgorithm } from "./core/models";
 import {
   ServiceClientCredentials,
@@ -785,32 +785,32 @@ export type KeySignatureAlgorithm =
 /**
  * Options for the encrypt call to the CryptographyClient
  */
-export interface EncryptOptions extends RequestOptions {}
+export interface EncryptOptions extends CryptographyOptions {}
 
 /**
  * Options for the decrypt call to the CryptographyClient
  */
-export interface DecryptOptions extends RequestOptions {}
+export interface DecryptOptions extends CryptographyOptions {}
 
 /**
  * Options for the sign call to the CryptographyClient
  */
-export interface SignOptions extends RequestOptions {}
+export interface SignOptions extends CryptographyOptions {}
 
 /**
  * Options for the verify call to the CryptographyClient
  */
-export interface VerifyOptions extends RequestOptions {}
+export interface VerifyOptions extends CryptographyOptions {}
 
 /**
  * Options for the wrapKey call to the CryptographyClient
  */
-export interface WrapOptions extends RequestOptions {}
+export interface WrapOptions extends CryptographyOptions {}
 
 /**
  * Options for the unwrap call to the CryptographyClient
  */
-export interface UnwrapOptions extends RequestOptions {}
+export interface UnwrapOptions extends CryptographyOptions {}
 
 /**
  * Result of a decrypt operation

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -297,8 +297,7 @@ export class KeyClient {
       const unflattenedProperties = {
         enabled: options.enabled,
         notBefore: options.notBefore,
-        expires: options.expiresOn,
-        vaultUrl: options.vaultEndpoint
+        expires: options.expiresOn
       };
       const unflattenedOptions = {
         ...options,
@@ -1072,14 +1071,14 @@ export class KeyClient {
     let resultObject: KeyVaultKey & DeletedKey = {
       key: keyBundle.key,
       id: keyBundle.key ? keyBundle.key.kid : undefined,
-      name: keyBundle.attributes ? (keyBundle as any).attributes.name : undefined,
+      name: parsedId.name,
       keyOperations: keyBundle.key ? keyBundle.key.keyOps : undefined,
       keyType: keyBundle.key ? keyBundle.key.kty : undefined,
       properties: {
         expiresOn: attributes.expires,
         createdOn: attributes.created,
         updatedOn: attributes.updated,
-        vaultEndpoint: (attributes as any)!.vaultUrl,
+        vaultEndpoint: parsedId.vaultUrl,
         ...keyBundle,
         ...parsedId,
         ...attributes
@@ -1161,7 +1160,7 @@ export class KeyClient {
       expiresOn: attributes.expires,
       createdOn: attributes.created,
       updatedOn: attributes.updated,
-      vaultEndpoint: (attributes as any)!.vaultUrl,
+      vaultEndpoint: parsedId.vaultUrl,
       ...keyItem,
       ...parsedId,
       ...keyItem.attributes

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -53,7 +53,7 @@ import {
   ParsedKeyVaultEntityIdentifier
 } from "./core/keyVaultBase";
 import {
-  Key,
+  KeyVaultKey,
   KeyClientInterface,
   KeyPollerOptions,
   DeletedKey,
@@ -103,7 +103,7 @@ export {
   JsonWebKeyEncryptionAlgorithm,
   JsonWebKeyOperation,
   JsonWebKeyType,
-  Key,
+  KeyVaultKey,
   KeyProperties,
   KeyPollerOptions,
   PollerLike,
@@ -239,7 +239,7 @@ export class KeyClient {
     return this.getKeyFromKeyBundle(response);
   }
 
-  private async recoverDeletedKey(name: string, options?: RequestOptions): Promise<Key> {
+  private async recoverDeletedKey(name: string, options?: RequestOptions): Promise<KeyVaultKey> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("recoverDeletedKey", requestOptions);
 
@@ -279,7 +279,7 @@ export class KeyClient {
     name: string,
     keyType: JsonWebKeyType,
     options?: CreateKeyOptions
-  ): Promise<Key> {
+  ): Promise<KeyVaultKey> {
     if (options) {
       const unflattenedProperties = {
         enabled: options.enabled,
@@ -333,7 +333,7 @@ export class KeyClient {
    * @param keyType The type of the key.
    * @param [options] The optional parameters
    */
-  public async createEcKey(name: string, options?: CreateEcKeyOptions): Promise<Key> {
+  public async createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey> {
     if (options) {
       const unflattenedProperties = {
         enabled: options.enabled,
@@ -387,7 +387,7 @@ export class KeyClient {
    * @param keyType The type of the key.
    * @param [options] The optional parameters
    */
-  public async createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<Key> {
+  public async createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey> {
     if (options) {
       const unflattenedProperties = {
         enabled: options.enabled,
@@ -443,7 +443,7 @@ export class KeyClient {
    * @param key The Json web key
    * @param [options] The optional parameters
    */
-  public async importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<Key> {
+  public async importKey(name: string, key: JsonWebKey, options: ImportKeyOptions): Promise<KeyVaultKey> {
     if (options) {
       const unflattenedProperties = {
         enabled: options.enabled,
@@ -548,7 +548,7 @@ export class KeyClient {
     name: string,
     keyVersion: string,
     options?: UpdateKeyOptions
-  ): Promise<Key> {
+  ): Promise<KeyVaultKey> {
     if (options) {
       const unflattenedProperties = {
         enabled: options.enabled,
@@ -600,7 +600,7 @@ export class KeyClient {
    * @param name The name of the key.
    * @param [options] The optional parameters
    */
-  public async getKey(name: string, options?: GetKeyOptions): Promise<Key> {
+  public async getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("getKey", requestOptions);
 
@@ -770,7 +770,7 @@ export class KeyClient {
    * @param backup The backup blob associated with a key bundle.
    * @param [options] The optional parameters
    */
-  public async restoreKeyBackup(backup: Uint8Array, options?: RequestOptions): Promise<Key> {
+  public async restoreKeyBackup(backup: Uint8Array, options?: RequestOptions): Promise<KeyVaultKey> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("restoreKeyBackup", requestOptions);
 
@@ -1036,7 +1036,7 @@ export class KeyClient {
     };
   }
 
-  private getKeyFromKeyBundle(keyBundle: KeyBundle): Key {
+  private getKeyFromKeyBundle(keyBundle: KeyBundle): KeyVaultKey {
     const parsedId = parseKeyvaultEntityIdentifier(
       "keys",
       keyBundle.key ? keyBundle.key.kid : undefined

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -249,7 +249,10 @@ export class KeyClient {
     return this.getKeyFromKeyBundle(response);
   }
 
-  private async recoverDeletedKey(name: string, options?: RecoverDeletedKeyOptions): Promise<KeyVaultKey> {
+  private async recoverDeletedKey(
+    name: string,
+    options?: RecoverDeletedKeyOptions
+  ): Promise<KeyVaultKey> {
     const requestOptions = (options && options.requestOptions) || {};
     const span = this.createSpan("recoverDeletedKey", requestOptions);
 
@@ -519,7 +522,7 @@ export class KeyClient {
    */
   public async beginDeleteKey(
     name: string,
-		options: KeyPollerOptions = {}
+    options: KeyPollerOptions = {}
   ): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>> {
     const poller = new DeleteKeyPoller({
       name,
@@ -718,7 +721,7 @@ export class KeyClient {
    */
   public async beginRecoverDeletedKey(
     name: string,
-		options: KeyPollerOptions = {}
+    options: KeyPollerOptions = {}
   ): Promise<PollerLike<PollOperationState<DeletedKey>, DeletedKey>> {
     const poller = new RecoverDeletedKeyPoller({
       name,
@@ -810,7 +813,7 @@ export class KeyClient {
     if (continuationState.continuationToken == null) {
       const optionsComplete: KeyVaultClientGetKeysOptionalParams = {
         maxresults: continuationState.maxPageSize,
-        ...options,
+        ...options
       };
       const currentSetResponse = await this.client.getKeyVersions(
         this.vaultEndpoint,
@@ -898,7 +901,7 @@ export class KeyClient {
     if (continuationState.continuationToken == null) {
       const optionsComplete: KeyVaultClientGetKeysOptionalParams = {
         maxresults: continuationState.maxPageSize,
-        ...options,
+        ...options
       };
       const currentSetResponse = await this.client.getKeys(this.vaultEndpoint, optionsComplete);
       continuationState.continuationToken = currentSetResponse.nextLink;
@@ -978,7 +981,7 @@ export class KeyClient {
     if (continuationState.continuationToken == null) {
       const optionsComplete: KeyVaultClientGetKeysOptionalParams = {
         maxresults: continuationState.maxPageSize,
-        ...options,
+        ...options
       };
       const currentSetResponse = await this.client.getDeletedKeys(
         this.vaultEndpoint,
@@ -1003,7 +1006,9 @@ export class KeyClient {
     }
   }
 
-  private async *listPropertiesOfDeletedKeysAll(options?: ListKeysOptions): AsyncIterableIterator<KeyProperties> {
+  private async *listPropertiesOfDeletedKeysAll(
+    options?: ListKeysOptions
+  ): AsyncIterableIterator<KeyProperties> {
     const f = {};
 
     for await (const page of this.listPropertiesOfDeletedKeysPage(f, options)) {
@@ -1049,7 +1054,8 @@ export class KeyClient {
       [Symbol.asyncIterator]() {
         return this;
       },
-      byPage: (settings: PageSettings = {}) => this.listPropertiesOfDeletedKeysPage(settings, updatedOptions)
+      byPage: (settings: PageSettings = {}) =>
+        this.listPropertiesOfDeletedKeysPage(settings, updatedOptions)
     };
   }
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -298,7 +298,7 @@ export class KeyClient {
         enabled: options.enabled,
         notBefore: options.notBefore,
         expires: options.expiresOn,
-        vaultUrl: options.vaultEndpoint,
+        vaultUrl: options.vaultEndpoint
       };
       const unflattenedOptions = {
         ...options,
@@ -1066,7 +1066,7 @@ export class KeyClient {
       keyBundle.key ? keyBundle.key.kid : undefined
     );
 
-		const attributes: any = keyBundle.attributes || {};
+    const attributes: any = keyBundle.attributes || {};
     delete keyBundle.attributes;
 
     let resultObject: KeyVaultKey & DeletedKey = {
@@ -1155,7 +1155,7 @@ export class KeyClient {
   private getKeyPropertiesFromKeyItem(keyItem: KeyItem): KeyProperties {
     const parsedId = parseKeyvaultEntityIdentifier("keys", keyItem.kid);
 
-		const attributes = keyItem.attributes || {};
+    const attributes = keyItem.attributes || {};
 
     let resultObject = {
       expiresOn: attributes.expires,

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -181,18 +181,18 @@ export class KeyClient {
    *
    * let client = new KeyClient(url, credentials);
    * ```
-   * @param {string} endPoint the base url to the key vault.
+   * @param {string} endpoint the base url to the key vault.
    * @param {TokenCredential} The credential to use for API requests.
    * @param {PipelineOptions} [pipelineOptions={}] Optional. Pipeline options used to configure Key Vault API requests.
    *                                                         Omit this parameter to use the default pipeline configuration.
    * @memberof KeyClient
    */
   constructor(
-    endPoint: string,
+    endpoint: string,
     credential: TokenCredential,
     pipelineOptions: PipelineOptions = {}
   ) {
-    this.vaultEndpoint = endPoint;
+    this.vaultEndpoint = endpoint;
     this.credential = credential;
 
     const libInfo = `azsdk-js-keyvault-keys/${SDK_VERSION}`;
@@ -1070,6 +1070,8 @@ export class KeyClient {
 
     let resultObject: KeyVaultKey & DeletedKey = {
       key: keyBundle.key,
+      id: keyBundle.key ? keyBundle.key.kid : undefined,
+      name: keyBundle.attributes ? (keyBundle as any).attributes.name : undefined,
       keyOperations: keyBundle.key ? keyBundle.key.keyOps : undefined,
       keyType: keyBundle.key ? keyBundle.key.kty : undefined,
       properties: {
@@ -1141,6 +1143,8 @@ export class KeyClient {
 
     return {
       key: keyItem,
+      id: keyItem.kid,
+      name: abstractProperties.name,
       properties: abstractProperties
     };
   }

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -1075,6 +1075,9 @@ export class KeyClient {
       keyOperations: keyBundle.key ? keyBundle.key.keyOps : undefined,
       keyType: keyBundle.key ? keyBundle.key.kty : undefined,
       properties: {
+        expiresOn: attributes!.expires,
+        createdOn: attributes!.created,
+        updatedOn: attributes!.updated,
         ...keyBundle,
         ...parsedId,
         ...attributes
@@ -1088,15 +1091,12 @@ export class KeyClient {
 
     if (attributes) {
       if (attributes.expires) {
-        resultObject.properties.expiresOn = attributes.expires;
         delete (resultObject.properties as any).expires;
       }
       if (attributes.created) {
-        resultObject.properties.createdOn = attributes.created;
         delete (resultObject.properties as any).created;
       }
       if (attributes.updated) {
-        resultObject.properties.updatedOn = attributes.updated;
         delete (resultObject.properties as any).updated;
       }
     }

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -535,7 +535,7 @@ export class KeyClient {
   }
 
   /**
-   * The updateKey method changes specified properties of an existing stored key. Properties that
+   * The updateKeyProperties method changes specified properties of an existing stored key. Properties that
    * are not specified in the request are left unchanged. The value of a key itself cannot be
    * changed. This operation requires the keys/set permission.
    *
@@ -544,7 +544,7 @@ export class KeyClient {
    * let keyName = "MyKey";
    * let client = new KeyClient(url, credentials);
    * let key = await client.getKey(keyName);
-   * let result = await client.updateKey(keyName, key.version, { enabled: false });
+   * let result = await client.updateKeyProperties(keyName, key.version, { enabled: false });
    * ```
    * @summary Updates the properties associated with a specified key in a given key vault.
    * @param name The name of the key.

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -284,7 +284,7 @@ export class KeyClient {
       const unflattenedProperties = {
         enabled: options.enabled,
         notBefore: options.notBefore,
-        expires: options.expires
+        expires: options.expiresOn
       };
       const unflattenedOptions = {
         ...options,
@@ -294,7 +294,7 @@ export class KeyClient {
 
       delete unflattenedOptions.enabled;
       delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expires;
+      delete unflattenedOptions.expiresOn;
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("createKey", unflattenedOptions);
@@ -338,7 +338,7 @@ export class KeyClient {
       const unflattenedProperties = {
         enabled: options.enabled,
         notBefore: options.notBefore,
-        expires: options.expires
+        expires: options.expiresOn
       };
       const unflattenedOptions = {
         ...options,
@@ -348,7 +348,7 @@ export class KeyClient {
 
       delete unflattenedOptions.enabled;
       delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expires;
+      delete unflattenedOptions.expiresOn;
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("createEcKey", unflattenedOptions);
@@ -392,7 +392,7 @@ export class KeyClient {
       const unflattenedProperties = {
         enabled: options.enabled,
         notBefore: options.notBefore,
-        expires: options.expires
+        expires: options.expiresOn
       };
       const unflattenedOptions = {
         ...options,
@@ -402,7 +402,7 @@ export class KeyClient {
 
       delete unflattenedOptions.enabled;
       delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expires;
+      delete unflattenedOptions.expiresOn;
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("createRsaKey", unflattenedOptions);
@@ -448,7 +448,7 @@ export class KeyClient {
       const unflattenedProperties = {
         enabled: options.enabled,
         notBefore: options.notBefore,
-        expires: options.expires,
+        expires: options.expiresOn,
         hsm: options.hardwareProtected
       };
 
@@ -459,7 +459,7 @@ export class KeyClient {
       };
       delete unflattenedOptions.enabled;
       delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expires;
+      delete unflattenedOptions.expiresOn;
       delete unflattenedOptions.requestOptions;
       delete unflattenedOptions.hardwareProtected;
 
@@ -553,7 +553,7 @@ export class KeyClient {
       const unflattenedProperties = {
         enabled: options.enabled,
         notBefore: options.notBefore,
-        expires: options.expires
+        expires: options.expiresOn
       };
       const unflattenedOptions = {
         ...options,
@@ -562,7 +562,7 @@ export class KeyClient {
       };
       delete unflattenedOptions.enabled;
       delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expires;
+      delete unflattenedOptions.expiresOn;
       delete unflattenedOptions.requestOptions;
 
       const span = this.createSpan("updateKey", unflattenedOptions);
@@ -1042,10 +1042,13 @@ export class KeyClient {
       keyBundle.key ? keyBundle.key.kid : undefined
     );
 
+    //.....
+    //.....
+
     let resultObject;
     if (keyBundle.attributes) {
       resultObject = {
-        keyMaterial: keyBundle.key,
+        key: keyBundle.key,
         keyOperations: keyBundle.key ? keyBundle.key.keyOps : undefined,
         keyType: keyBundle.key ? keyBundle.key.kty : undefined,
         properties: {
@@ -1057,7 +1060,7 @@ export class KeyClient {
       delete resultObject.properties.attributes;
     } else {
       resultObject = {
-        keyMaterial: keyBundle.key,
+        key: keyBundle.key,
         keyOperations: keyBundle.key ? keyBundle.key.keyOps : undefined,
         keyType: keyBundle.key ? keyBundle.key.kty : undefined,
         properties: {
@@ -1086,6 +1089,10 @@ export class KeyClient {
         ...keyItem,
         ...parsedId
       };
+    }
+
+		if (resultObject.properties.expires) {
+      delete (resultObject.properties as any).expires;
     }
 
     return resultObject;

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -50,9 +50,7 @@ import { RecoverDeletedKeyPoller } from "./lro/recover/poller";
 import { DeleteKeyPollOperationState } from "./lro/delete/operation";
 import { RecoverDeletedKeyPollOperationState } from "./lro/recover/operation";
 
-import {
-  ParsedKeyVaultEntityIdentifier,
-} from "./core/keyVaultBase";
+import { ParsedKeyVaultEntityIdentifier } from "./core/keyVaultBase";
 import {
   BackupKeyOptions,
   CreateEcKeyOptions,
@@ -70,7 +68,7 @@ import {
   KeyProperties,
   KeyVaultKey,
   ListKeysOptions,
-  UpdateKeyOptions
+  UpdateKeyPropertiesOptions
 } from "./keysModels";
 import { parseKeyvaultIdentifier as parseKeyvaultEntityIdentifier } from "./core/utils";
 
@@ -125,7 +123,7 @@ export {
   RecoverDeletedKeyPollOperationState,
   SignResult,
   UnwrapResult,
-  UpdateKeyOptions,
+  UpdateKeyPropertiesOptions,
   VerifyResult,
   WrapResult,
   logger
@@ -202,13 +200,12 @@ export class KeyClient {
     } else {
       pipelineOptions.userAgentOptions = {
         userAgentPrefix: libInfo
-      }
+      };
     }
 
-    const authPolicy =
-      isTokenCredential(credential)
-        ? challengeBasedAuthenticationPolicy(credential)
-        : signingPolicy(credential)
+    const authPolicy = isTokenCredential(credential)
+      ? challengeBasedAuthenticationPolicy(credential)
+      : signingPolicy(credential);
 
     const internalPipelineOptions = {
       ...pipelineOptions,
@@ -224,7 +221,7 @@ export class KeyClient {
           }
         }
       }
-    }
+    };
 
     this.pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
     this.client = new KeyVaultClient(credential, SERVICE_API_VERSION, this.pipeline);
@@ -554,10 +551,10 @@ export class KeyClient {
    * @param keyVersion The version of the key.
    * @param [options] The optional parameters
    */
-  public async updateKey(
+  public async updateKeyProperties(
     name: string,
     keyVersion: string,
-    options?: UpdateKeyOptions
+    options?: UpdateKeyPropertiesOptions
   ): Promise<KeyVaultKey> {
     if (options) {
       const unflattenedProperties = {
@@ -1162,7 +1159,7 @@ export class KeyClient {
 
     delete resultObject.attributes;
 
-		if (keyItem.attributes!.expires) {
+    if (keyItem.attributes!.expires) {
       resultObject.expiresOn = keyItem.attributes!.expires;
       delete resultObject.expires;
     }

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -1075,6 +1075,8 @@ export class KeyClient {
       keyOperations: keyBundle.key ? keyBundle.key.keyOps : undefined,
       keyType: keyBundle.key ? keyBundle.key.kty : undefined,
       properties: {
+        id: keyBundle.key ? keyBundle.key.kid : undefined,
+        name: parsedId.name,
         expiresOn: attributes.expires,
         createdOn: attributes.created,
         updatedOn: attributes.updated,
@@ -1109,37 +1111,31 @@ export class KeyClient {
   private getDeletedKeyFromKeyItem(keyItem: KeyItem): DeletedKey {
     const parsedId = parseKeyvaultEntityIdentifier("keys", keyItem.kid);
 
-    let abstractProperties: any;
+    const attributes = keyItem.attributes || {};
 
-    if (keyItem.attributes) {
-      abstractProperties = {
-        ...keyItem,
-        ...parsedId,
-        ...keyItem.attributes
-      };
-      delete abstractProperties.attributes;
-    } else {
-      abstractProperties = {
-        ...keyItem,
-        ...parsedId
-      };
-    }
+    let abstractProperties: any = {
+      id: keyItem.kid,
+      name: parsedId.name,
+      deletedOn: (attributes as any).deletedDate,
+      expiresOn: attributes.expires,
+      createdOn: attributes.created,
+      updatedOn: attributes.updated,
+      ...keyItem,
+      ...parsedId,
+      ...keyItem.attributes
+    };
 
     if (abstractProperties.deletedDate) {
-      abstractProperties.deletedOn = abstractProperties.deletedDate;
       delete abstractProperties.deletedDate;
     }
 
     if (abstractProperties.expires) {
-      abstractProperties.expiresOn = abstractProperties.expires;
       delete abstractProperties.expires;
     }
     if (abstractProperties.created) {
-      abstractProperties.createdOn = abstractProperties.created;
       delete abstractProperties.created;
     }
     if (abstractProperties.updated) {
-      abstractProperties.updatedOn = abstractProperties.updated;
       delete abstractProperties.updated;
     }
 

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -52,7 +52,6 @@ import { RecoverDeletedKeyPollOperationState } from "./lro/recover/operation";
 
 import {
   ParsedKeyVaultEntityIdentifier,
-  Pipeline,
 } from "./core/keyVaultBase";
 import {
   BackupKeyOptions,
@@ -1152,8 +1151,7 @@ export class KeyClient {
 
     const attributes = keyItem.attributes || {};
 
-    let resultObject = {
-      expiresOn: attributes.expires,
+    let resultObject: any = {
       createdOn: attributes.created,
       updatedOn: attributes.updated,
       vaultEndpoint: parsedId.vaultUrl,
@@ -1164,8 +1162,9 @@ export class KeyClient {
 
     delete resultObject.attributes;
 
-		if (resultObject.properties.expires) {
-      delete (resultObject.properties as any).expires;
+		if (keyItem.attributes!.expires) {
+      resultObject.expiresOn = keyItem.attributes!.expires;
+      delete resultObject.expires;
     }
 
     return resultObject;

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -16,8 +16,8 @@ import { DeletionRecoveryLevel } from "./core/models";
  * An interface representing the key client. For internal use.
  */
 export interface KeyClientInterface {
-  recoverDeletedKey(name: string, options?: RequestOptions): Promise<Key>;
-  getKey(name: string, options?: GetKeyOptions): Promise<Key>;
+  recoverDeletedKey(name: string, options?: RequestOptions): Promise<KeyVaultKey>;
+  getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
   deleteKey(name: string, options?: coreHttp.RequestOptionsBase): Promise<DeletedKey>;
   getDeletedKey(name: string, options?: RequestOptions): Promise<DeletedKey>;
 }
@@ -26,7 +26,7 @@ export interface KeyClientInterface {
  * @interface
  * An interface representing the complete key with value
  */
-export interface Key {
+export interface KeyVaultKey {
   /**
    * @member {KeyProperties} [properties] The properties of the key.
    */

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -78,13 +78,13 @@ export interface KeyProperties extends ParsedKeyVaultEntityIdentifier {
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  readonly createdOn?: Date;
+  createdOn?: Date;
   /**
    * @member {Date} [updatedOn] Last updated time in UTC.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  readonly updatedOn?: Date;
+  updatedOn?: Date;
   /**
    * @member {DeletionRecoveryLevel} [recoveryLevel] Reflects the deletion
    * recovery level currently in effect for keys in the current vault. If it
@@ -129,7 +129,7 @@ export interface DeletedKey {
      * **NOTE: This property will not be serialized. It can only be populated by
      * the server.**
      */
-    readonly deletedOn?: Date;
+    deletedOn?: Date;
   };
 }
 

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -16,10 +16,10 @@ import { DeletionRecoveryLevel } from "./core/models";
  * An interface representing the key client. For internal use.
  */
 export interface KeyClientInterface {
-  recoverDeletedKey(name: string, options?: RequestOptions): Promise<KeyVaultKey>;
+  recoverDeletedKey(name: string, options?: DeletedKeyOptions): Promise<KeyVaultKey>;
   getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
   deleteKey(name: string, options?: coreHttp.RequestOptionsBase): Promise<DeletedKey>;
-  getDeletedKey(name: string, options?: RequestOptions): Promise<DeletedKey>;
+  getDeletedKey(name: string, options?: DeletedKeyOptions): Promise<DeletedKey>;
 }
 
 /**
@@ -320,9 +320,31 @@ export interface ListKeysOptions {
 
 /**
  * @interface
- * An interface representing the most general set of request options.
+ * An interface representing the options of the deleted key API methods
  */
-export interface RequestOptions {
+export interface DeletedKeyOptions {
+  /**
+   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
+   */
+  requestOptions?: coreHttp.RequestOptionsBase;
+}
+
+/**
+ * @interface
+ * An interface representing the options of the backup key API methods
+ */
+export interface BackupKeyOptions {
+  /**
+   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
+   */
+  requestOptions?: coreHttp.RequestOptionsBase;
+}
+
+/**
+ * @interface
+ * An interface representing the options of the cryptography API methods
+ */
+export interface CryptographyOptions {
   /**
    * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
    */

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -34,7 +34,7 @@ export interface KeyVaultKey {
   /**
    * @member {string} [value] The key value.
    */
-  keyMaterial?: JsonWebKey;
+  key?: JsonWebKey;
   /**
    * JsonWebKey Key Type (kty), as defined in
    * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40. Possible values include:
@@ -65,26 +65,26 @@ export interface KeyProperties extends ParsedKeyVaultEntityIdentifier {
    */
   notBefore?: Date;
   /**
-   * @member {Date} [expires] Expiry date in UTC.
+   * @member {Date} [expiresOn] Expiry date in UTC.
    */
-  expires?: Date;
+  expiresOn?: Date;
   /**
    * @member {{ [propertyName: string]: string }} [tags] Application specific
    * metadata in the form of key-value pairs.
    */
   tags?: { [propertyName: string]: string };
   /**
-   * @member {Date} [created] Creation time in UTC.
+   * @member {Date} [createdOn] Creation time in UTC.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  readonly created?: Date;
+  readonly createdOn?: Date;
   /**
-   * @member {Date} [updated] Last updated time in UTC.
+   * @member {Date} [updatedOn] Last updated time in UTC.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  readonly updated?: Date;
+  readonly updatedOn?: Date;
   /**
    * @member {DeletionRecoveryLevel} [recoveryLevel] Reflects the deletion
    * recovery level currently in effect for keys in the current vault. If it
@@ -107,7 +107,7 @@ export interface DeletedKey {
   /**
    * @member {string} [value] The key value.
    */
-  keyMaterial?: JsonWebKey;
+  key?: JsonWebKey;
   /**
    * @member {KeyProperties} [properties] The properties of the key.
    */
@@ -125,11 +125,11 @@ export interface DeletedKey {
      */
     readonly scheduledPurgeDate?: Date;
     /**
-     * @member {Date} [deletedDate] The time when the key was deleted, in UTC
+     * @member {Date} [deletedOn] The time when the key was deleted, in UTC
      * **NOTE: This property will not be serialized. It can only be populated by
      * the server.**
      */
-    readonly deletedDate?: Date;
+    readonly deletedOn?: Date;
   };
 }
 
@@ -157,9 +157,9 @@ export interface CreateKeyOptions {
    */
   notBefore?: Date;
   /**
-   * @member {Date} [expires] Expiry date in UTC.
+   * @member {Date} [expiresOn] Expiry date in UTC.
    */
-  expires?: Date;
+  expiresOn?: Date;
   /**
    * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
    */
@@ -249,9 +249,9 @@ export interface ImportKeyOptions {
    */
   notBefore?: Date;
   /**
-   * @member {Date} [expires] Expiry date in UTC.
+   * @member {Date} [expiresOn] Expiry date in UTC.
    */
-  expires?: Date;
+  expiresOn?: Date;
   /**
    * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
    */
@@ -277,9 +277,9 @@ export interface UpdateKeyOptions {
    */
   notBefore?: Date;
   /**
-   * @member {Date} [expires] Expiry date in UTC.
+   * @member {Date} [expiresOn] Expiry date in UTC.
    */
-  expires?: Date;
+  expiresOn?: Date;
   /**
    * @member {{ [propertyName: string]: string }} [tags] Application specific
    * metadata in the form of key-value pairs.

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -16,10 +16,10 @@ import { DeletionRecoveryLevel } from "./core/models";
  * An interface representing the key client. For internal use.
  */
 export interface KeyClientInterface {
-  recoverDeletedKey(name: string, options?: DeletedKeyOptions): Promise<KeyVaultKey>;
+  recoverDeletedKey(name: string, options?: GetDeletedKeyOptions): Promise<KeyVaultKey>;
   getKey(name: string, options?: GetKeyOptions): Promise<KeyVaultKey>;
   deleteKey(name: string, options?: coreHttp.RequestOptionsBase): Promise<DeletedKey>;
-  getDeletedKey(name: string, options?: DeletedKeyOptions): Promise<DeletedKey>;
+  getDeletedKey(name: string, options?: GetDeletedKeyOptions): Promise<DeletedKey>;
 }
 
 /**
@@ -138,7 +138,7 @@ export interface DeletedKey {
  * An interface representing the optional parameters that can be
  * passed to createKey
  */
-export interface CreateKeyOptions {
+export interface CreateKeyOptions extends coreHttp.RequestOptionsBase {
   /**
    * @member {{ [propertyName: string]: string }} [tags] Application specific
    * metadata in the form of key-value pairs.
@@ -161,9 +161,8 @@ export interface CreateKeyOptions {
    */
   expiresOn?: Date;
   /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
+   * @member {number} [keySize] Size of the key
    */
-  requestOptions?: coreHttp.RequestOptionsBase;
   keySize?: number;
 }
 
@@ -172,11 +171,7 @@ export interface CreateKeyOptions {
  * An interface representing the optional parameters that can be
  * passed to beginDeleteKey
  */
-export interface KeyPollerOptions {
-  /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
-   */
-  requestOptions?: coreHttp.RequestOptionsBase;
+export interface KeyPollerOptions extends coreHttp.RequestOptionsBase {
   /**
    * @member {number} [intervalInMs] Time between each polling
    */
@@ -229,7 +224,7 @@ export interface CreateRsaKeyOptions extends CreateKeyOptions {
  * An interface representing the optional parameters that can be
  * passed to importKey
  */
-export interface ImportKeyOptions {
+export interface ImportKeyOptions extends coreHttp.RequestOptionsBase {
   /**
    * @member {{ [propertyName: string]: string }} [tags] Application specific
    * metadata in the form of key-value pairs.
@@ -252,17 +247,13 @@ export interface ImportKeyOptions {
    * @member {Date} [expiresOn] Expiry date in UTC.
    */
   expiresOn?: Date;
-  /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
-   */
-  requestOptions?: coreHttp.RequestOptionsBase;
 }
 
 /**
  * @interface
  * An interface representing optional parameters that can be passed to updateKey.
  */
-export interface UpdateKeyOptions {
+export interface UpdateKeyOptions extends coreHttp.RequestOptionsBase {
   /**
    * @member {JsonWebKeyOperation[]} [keyOps] Json web key operations. For more
    * information on possible key operations, see JsonWebKeyOperation.
@@ -285,61 +276,56 @@ export interface UpdateKeyOptions {
    * metadata in the form of key-value pairs.
    */
   tags?: { [propertyName: string]: string };
-  /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
-   */
-  requestOptions?: coreHttp.RequestOptionsBase;
 }
 
 /**
  * @interface
  * An interface representing optional parameters that can be passed to getKey.
  */
-export interface GetKeyOptions {
+export interface GetKeyOptions extends coreHttp.RequestOptionsBase {
   /**
    * @member {string} [version] The version of the secret to retrieve.  If not
    * specified the latest version of the secret will be retrieved.
    */
   version?: string;
-  /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
-   */
-  requestOptions?: coreHttp.RequestOptionsBase;
 }
 
 /**
  * @interface
  * An interface representing optional parameters for KeyClient paged operations.
  */
-export interface ListKeysOptions {
-  /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
-   */
-  requestOptions?: coreHttp.RequestOptionsBase;
-}
+export interface ListKeysOptions extends coreHttp.RequestOptionsBase {}
 
 /**
  * @interface
- * An interface representing the options of the deleted key API methods
+ * An interface representing the options of the getDeletedKey method
  */
-export interface DeletedKeyOptions {
-  /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
-   */
-  requestOptions?: coreHttp.RequestOptionsBase;
-}
+export interface GetDeletedKeyOptions extends coreHttp.RequestOptionsBase {}
 
 /**
  * @interface
- * An interface representing the options of the backup key API methods
+ * An interface representing the options of the purgeDeletedKey method
  */
-export interface BackupKeyOptions {
-  /**
-   * @member {coreHttp.RequestOptionsBase} [requestOptions] Options for this request
-   */
-  requestOptions?: coreHttp.RequestOptionsBase;
-}
+export interface PurgeDeletedKeyOptions extends coreHttp.RequestOptionsBase {}
+ 
+/**
+ * @interface
+ * An interface representing the options of the recoverDeletedKey method
+ */
+export interface RecoverDeletedKeyOptions extends coreHttp.RequestOptionsBase {}
+ 
+/**
+ * @interface
+ * An interface representing the options of the backupKey method
+ */
+export interface BackupKeyOptions extends coreHttp.RequestOptionsBase {}
 
+/**
+ * @interface
+ * An interface representing the options of the restoreKeyBackup method
+ */
+export interface RestoreKeyBackupOptions extends coreHttp.RequestOptionsBase {}
+ 
 /**
  * @interface
  * An interface representing the options of the cryptography API methods

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import * as coreHttp from "@azure/core-http";
-import { ParsedKeyVaultEntityIdentifier } from "./core/keyVaultBase";
 import {
   JsonWebKey,
   JsonWebKeyOperation,
@@ -28,13 +27,17 @@ export interface KeyClientInterface {
  */
 export interface KeyVaultKey {
   /**
-   * @member {KeyProperties} [properties] The properties of the key.
-   */
-  properties: KeyProperties;
-  /**
    * @member {string} [value] The key value.
    */
   key?: JsonWebKey;
+  /**
+   * @member {string} [name] The name of key/secret/certificate.
+   */
+  name: string;
+  /**
+   * Key identifier.
+   */
+  id?: string;
   /**
    * JsonWebKey Key Type (kty), as defined in
    * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40. Possible values include:
@@ -45,17 +48,29 @@ export interface KeyVaultKey {
    * Operations allowed on this key
    */
   keyOperations?: JsonWebKeyOperation[];
+  /**
+   * @member {KeyProperties} [properties] The properties of the key.
+   */
+  properties: KeyProperties;
 }
 
 /**
  * @interface
  * An interface representing the Properties of a key
  */
-export interface KeyProperties extends ParsedKeyVaultEntityIdentifier {
+export interface KeyProperties {
   /**
-   * @member {string} [id] The key id.
+   * @member {string} [name] The name of key/secret/certificate.
    */
-  id?: string;
+  name: string;
+  /**
+   * @member {string} [vaultUrl] The vault URI.
+   */
+  vaultUrl: string;
+  /**
+   * @member {string} [version] The version of key/secret/certificate. May be undefined.
+   */
+  version?: string;
   /**
    * @member {boolean} [enabled] Determines whether the object is enabled.
    */
@@ -108,6 +123,24 @@ export interface DeletedKey {
    * @member {string} [value] The key value.
    */
   key?: JsonWebKey;
+  /**
+   * @member {string} [name] The name of key/secret/certificate.
+   */
+  name: string;
+  /**
+   * Key identifier.
+   */
+  id?: string;
+  /**
+   * JsonWebKey Key Type (kty), as defined in
+   * https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40. Possible values include:
+   * 'EC', 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
+   */
+  keyType?: JsonWebKeyType;
+  /**
+   * Operations allowed on this key
+   */
+  keyOperations?: JsonWebKeyOperation[];
   /**
    * @member {KeyProperties} [properties] The properties of the key.
    */

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -64,9 +64,9 @@ export interface KeyProperties {
    */
   name: string;
   /**
-   * @member {string} [vaultUrl] The vault URI.
+   * @member {string} [vaultEndpoint] The vault URI.
    */
-  vaultUrl: string;
+  vaultEndpoint: string;
   /**
    * @member {string} [version] The version of key/secret/certificate. May be undefined.
    */

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -93,13 +93,13 @@ export interface KeyProperties {
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  createdOn?: Date;
+  readonly createdOn?: Date;
   /**
    * @member {Date} [updatedOn] Last updated time in UTC.
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  updatedOn?: Date;
+  readonly updatedOn?: Date;
   /**
    * @member {DeletionRecoveryLevel} [recoveryLevel] Reflects the deletion
    * recovery level currently in effect for keys in the current vault. If it
@@ -192,7 +192,7 @@ export interface CreateKeyOptions extends coreHttp.RequestOptionsBase {
   /**
    * @member {Date} [expiresOn] Expiry date in UTC.
    */
-  expiresOn?: Date;
+  readonly expiresOn?: Date;
   /**
    * @member {number} [keySize] Size of the key
    */

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -307,13 +307,13 @@ export interface GetDeletedKeyOptions extends coreHttp.RequestOptionsBase {}
  * An interface representing the options of the purgeDeletedKey method
  */
 export interface PurgeDeletedKeyOptions extends coreHttp.RequestOptionsBase {}
- 
+
 /**
  * @interface
  * An interface representing the options of the recoverDeletedKey method
  */
 export interface RecoverDeletedKeyOptions extends coreHttp.RequestOptionsBase {}
- 
+
 /**
  * @interface
  * An interface representing the options of the backupKey method
@@ -325,7 +325,7 @@ export interface BackupKeyOptions extends coreHttp.RequestOptionsBase {}
  * An interface representing the options of the restoreKeyBackup method
  */
 export interface RestoreKeyBackupOptions extends coreHttp.RequestOptionsBase {}
- 
+
 /**
  * @interface
  * An interface representing the options of the cryptography API methods

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -60,6 +60,10 @@ export interface KeyVaultKey {
  */
 export interface KeyProperties {
   /**
+   * Key identifier.
+   */
+  id?: string;
+  /**
    * @member {string} [name] The name of key/secret/certificate.
    */
   name: string;

--- a/sdk/keyvault/keyvault-keys/src/keysModels.ts
+++ b/sdk/keyvault/keyvault-keys/src/keysModels.ts
@@ -290,7 +290,7 @@ export interface ImportKeyOptions extends coreHttp.RequestOptionsBase {
  * @interface
  * An interface representing optional parameters that can be passed to updateKey.
  */
-export interface UpdateKeyOptions extends coreHttp.RequestOptionsBase {
+export interface UpdateKeyPropertiesOptions extends coreHttp.RequestOptionsBase {
   /**
    * @member {JsonWebKeyOperation[]} [keyOps] Json web key operations. For more
    * information on possible key operations, see JsonWebKeyOperation.

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
@@ -4,13 +4,13 @@
 import { AbortSignalLike } from "@azure/abort-controller";
 import { PollOperationState, PollOperation } from "@azure/core-lro";
 import { RequestOptionsBase } from "@azure/core-http";
-import { Key, KeyClientInterface } from "../../keysModels";
+import { KeyVaultKey, KeyClientInterface } from "../../keysModels";
 
 /**
  * @interface
  * An interface representing the state of a delete key's poll operation
  */
-export interface RecoverDeletedKeyPollOperationState extends PollOperationState<Key> {
+export interface RecoverDeletedKeyPollOperationState extends PollOperationState<KeyVaultKey> {
   name: string;
   requestOptions?: RequestOptionsBase;
   client: KeyClientInterface;
@@ -21,7 +21,7 @@ export interface RecoverDeletedKeyPollOperationState extends PollOperationState<
  * An interface representing a delete key's poll operation
  */
 export interface RecoverDeletedKeyPollOperation
-  extends PollOperation<RecoverDeletedKeyPollOperationState, Key> {}
+  extends PollOperation<RecoverDeletedKeyPollOperationState, KeyVaultKey> {}
 
 /**
  * @summary Reaches to the service and updates the delete key's poll operation.

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
@@ -20,7 +20,10 @@ export interface RecoverDeletedKeyPollerOptions {
 /**
  * Class that deletes a poller that waits until a key finishes being deleted
  */
-export class RecoverDeletedKeyPoller extends Poller<RecoverDeletedKeyPollOperationState, KeyVaultKey> {
+export class RecoverDeletedKeyPoller extends Poller<
+  RecoverDeletedKeyPollOperationState,
+  KeyVaultKey
+> {
   /**
    * Defines how much time the poller is going to wait before making a new request to the service.
    * @memberof RecoverDeletedKeyPoller

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/poller.ts
@@ -7,7 +7,7 @@ import {
   RecoverDeletedKeyPollOperationState,
   makeRecoverDeletedKeyPollOperation
 } from "./operation";
-import { Key, KeyClientInterface } from "../../keysModels";
+import { KeyVaultKey, KeyClientInterface } from "../../keysModels";
 
 export interface RecoverDeletedKeyPollerOptions {
   client: KeyClientInterface;
@@ -20,7 +20,7 @@ export interface RecoverDeletedKeyPollerOptions {
 /**
  * Class that deletes a poller that waits until a key finishes being deleted
  */
-export class RecoverDeletedKeyPoller extends Poller<RecoverDeletedKeyPollOperationState, Key> {
+export class RecoverDeletedKeyPoller extends Poller<RecoverDeletedKeyPollOperationState, KeyVaultKey> {
   /**
    * Defines how much time the poller is going to wait before making a new request to the service.
    * @memberof RecoverDeletedKeyPoller

--- a/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
@@ -164,15 +164,15 @@ describe("Keys client - create, read, update and delete operations", () => {
   it("can create a key with expires", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const date = new Date("2019-01-01");
-    const expires = new Date(date.getTime() + 5000); // 5 seconds later
-    expires.setMilliseconds(0);
+    const expiresOn = new Date(date.getTime() + 5000); // 5 seconds later
+    expiresOn.setMilliseconds(0);
 
-    const options = { expires };
+    const options = { expiresOn };
     const result = await client.createRsaKey(keyName, options);
 
     assert.equal(
-      result!.properties.expires!.getTime(),
-      expires.getTime(),
+      result!.properties.expiresOn!.getTime(),
+      expiresOn.getTime(),
       "Unexpected expires value from createKey()."
     );
     assert.equal(
@@ -198,13 +198,13 @@ describe("Keys client - create, read, update and delete operations", () => {
       enabled: false
     };
     const { version } = (await client.createRsaKey(keyName, createOptions)).properties;
-    const expires = new Date("2019-01-01");
-    expires.setMilliseconds(0);
-    const updateOptions: UpdateKeyOptions = { expires };
+    const expiresOn = new Date("2019-01-01");
+    expiresOn.setMilliseconds(0);
+    const updateOptions: UpdateKeyOptions = { expiresOn };
     const result = await client.updateKey(keyName, version || "", updateOptions);
     assert.equal(
-      result!.properties.expires!.getTime(),
-      expires.getTime(),
+      result!.properties.expiresOn!.getTime(),
+      expiresOn.getTime(),
       "Unexpected expires value after attempting to update a disabled key"
     );
     await testClient.flushKey(keyName);

--- a/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
@@ -49,9 +49,7 @@ describe("Keys client - create, read, update and delete operations", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const controller = new AbortController();
     const resultPromise = client.createKey(keyName, "RSA", {
-      requestOptions: {
-        abortSignal: controller.signal
-      }
+      abortSignal: controller.signal
     });
     controller.abort();
     let error;

--- a/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import { KeyClient, CreateEcKeyOptions, UpdateKeyOptions, GetKeyOptions } from "../src";
+import { KeyClient, CreateEcKeyOptions, UpdateKeyPropertiesOptions, GetKeyOptions } from "../src";
 import { RestError, isNode } from "@azure/core-http";
 import { isPlayingBack } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
@@ -31,7 +31,7 @@ describe("Keys client - create, read, update and delete operations", () => {
 
   // The tests follow
 
-  it("can create a key while giving a manual type", async function() {
+  it("can create a key while giving a manual type", async () {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const result = await client.createKey(keyName, "RSA");
     assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
@@ -156,8 +156,8 @@ describe("Keys client - create, read, update and delete operations", () => {
   it("can update key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const { version } = (await client.createRsaKey(keyName)).properties;
-    const options: UpdateKeyOptions = { enabled: false };
-    const result = await client.updateKey(keyName, version || "", options);
+    const options: UpdateKeyPropertiesOptions = { enabled: false };
+    const result = await client.updateKeyProperties(keyName, version || "", options);
     assert.equal(result.properties.enabled, false, "Unexpected enabled value from updateKey().");
     await testClient.flushKey(keyName);
   });
@@ -170,8 +170,8 @@ describe("Keys client - create, read, update and delete operations", () => {
     const { version } = (await client.createRsaKey(keyName, createOptions)).properties;
     const expiresOn = new Date("2019-01-01");
     expiresOn.setMilliseconds(0);
-    const updateOptions: UpdateKeyOptions = { expiresOn };
-    const result = await client.updateKey(keyName, version || "", updateOptions);
+    const updateOptions: UpdateKeyPropertiesOptions = { expiresOn };
+    const result = await client.updateKeyProperties(keyName, version || "", updateOptions);
     assert.equal(
       result!.properties.expiresOn!.getTime(),
       expiresOn.getTime(),
@@ -199,7 +199,7 @@ describe("Keys client - create, read, update and delete operations", () => {
     await testClient.purgeKey(keyName);
   });
 
-  it("delete nonexisting key", async function() {
+  it("delete nonexisting key", async () {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     try {
       await client.getKey(keyName);

--- a/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
@@ -31,7 +31,7 @@ describe("Keys client - create, read, update and delete operations", () => {
 
   // The tests follow
 
-  it("can create a key while giving a manual type", async () {
+  it("can create a key while giving a manual type", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const result = await client.createKey(keyName, "RSA");
     assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
@@ -199,7 +199,7 @@ describe("Keys client - create, read, update and delete operations", () => {
     await testClient.purgeKey(keyName);
   });
 
-  it("delete nonexisting key", async () {
+  it("delete nonexisting key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     try {
       await client.getKey(keyName);

--- a/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
@@ -34,11 +34,7 @@ describe("Keys client - create, read, update and delete operations", () => {
   it("can create a key while giving a manual type", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const result = await client.createKey(keyName, "RSA");
-    assert.equal(
-      result.properties.name,
-      keyName,
-      "Unexpected key name in result from createKey()."
-    );
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -80,11 +76,7 @@ describe("Keys client - create, read, update and delete operations", () => {
   it("can create a RSA key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const result = await client.createRsaKey(keyName);
-    assert.equal(
-      result.properties.name,
-      keyName,
-      "Unexpected key name in result from createKey()."
-    );
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -94,22 +86,14 @@ describe("Keys client - create, read, update and delete operations", () => {
       keySize: 2048
     };
     const result = await client.createRsaKey(keyName, options);
-    assert.equal(
-      result.properties.name,
-      keyName,
-      "Unexpected key name in result from createKey()."
-    );
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     await testClient.flushKey(keyName);
   });
 
   it("can create an EC key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     const result = await client.createEcKey(keyName);
-    assert.equal(
-      result.properties.name,
-      keyName,
-      "Unexpected key name in result from createKey()."
-    );
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -119,11 +103,7 @@ describe("Keys client - create, read, update and delete operations", () => {
       curve: "P-256"
     };
     const result = await client.createEcKey(keyName, options);
-    assert.equal(
-      result.properties.name,
-      keyName,
-      "Unexpected key name in result from createKey()."
-    );
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -151,11 +131,7 @@ describe("Keys client - create, read, update and delete operations", () => {
       notBefore.getTime(),
       "Unexpected notBefore value from createKey()."
     );
-    assert.equal(
-      result.properties.name,
-      keyName,
-      "Unexpected key name in result from createKey()."
-    );
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -173,11 +149,7 @@ describe("Keys client - create, read, update and delete operations", () => {
       expiresOn.getTime(),
       "Unexpected expires value from createKey()."
     );
-    assert.equal(
-      result.properties.name,
-      keyName,
-      "Unexpected key name in result from createKey()."
-    );
+    assert.equal(result.name, keyName, "Unexpected key name in result from createKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -245,11 +217,7 @@ describe("Keys client - create, read, update and delete operations", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
     const getResult = await client.getKey(keyName);
-    assert.equal(
-      getResult.properties.name,
-      keyName,
-      "Unexpected key name in result from getKey()."
-    );
+    assert.equal(getResult.name, keyName, "Unexpected key name in result from getKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -270,18 +238,10 @@ describe("Keys client - create, read, update and delete operations", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
     const poller = await client.beginDeleteKey(keyName);
-    assert.equal(
-      poller.getResult()!.properties.name,
-      keyName,
-      "Unexpected key name in result from getKey()."
-    );
+    assert.equal(poller.getResult()!.name, keyName, "Unexpected key name in result from getKey().");
     await poller.pollUntilDone();
     const getResult = await poller.getResult();
-    assert.equal(
-      getResult!.properties.name,
-      keyName,
-      "Unexpected key name in result from getKey()."
-    );
+    assert.equal(getResult!.name, keyName, "Unexpected key name in result from getKey().");
     await testClient.purgeKey(keyName);
   });
 

--- a/sdk/keyvault/keyvault-keys/test/crypto.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/crypto.test.ts
@@ -6,7 +6,7 @@ import * as crypto from "crypto";
 import * as constants from "constants";
 import { isNode } from "@azure/core-http";
 import { ClientSecretCredential } from "@azure/identity";
-import { CryptographyClient, Key, KeyClient } from "../src";
+import { CryptographyClient, KeyVaultKey, KeyClient } from "../src";
 import { convertJWKtoPEM } from "../src/cryptographyClient";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -20,7 +20,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
   let recorder: any;
   let credential: ClientSecretCredential;
   let keyName: string;
-  let key: Key;
+  let key: KeyVaultKey;
   let keyVaultUrl: string;
   let keyUrl: string;
   let keySuffix: string;

--- a/sdk/keyvault/keyvault-keys/test/crypto.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/crypto.test.ts
@@ -35,8 +35,8 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
     keyName = testClient.formatName("cryptography-client-test" + keySuffix);
     key = await client.createKey(keyName, "RSA");
     keyVaultUrl = key.properties.vaultUrl;
-    keyUrl = key.keyMaterial!.kid as string;
-    cryptoClient = new CryptographyClient(keyVaultUrl, key.keyMaterial!.kid!, credential);
+    keyUrl = key.key!.kid as string;
+    cryptoClient = new CryptographyClient(keyVaultUrl, key.key!.kid!, credential);
   });
 
   after(async function() {
@@ -52,9 +52,9 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
   });
 
   it("getKey from client initialized with a JWK key", async function() {
-    const jwtKeyClient = new CryptographyClient(keyVaultUrl, key.keyMaterial!, credential);
+    const jwtKeyClient = new CryptographyClient(keyVaultUrl, key.key!, credential);
     const getKeyResult = await jwtKeyClient.getKey();
-    assert.equal(getKeyResult.kid, key.keyMaterial!.kid);
+    assert.equal(getKeyResult.kid, key.key!.kid);
   });
 
   if (isRecording) {

--- a/sdk/keyvault/keyvault-keys/test/crypto.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/crypto.test.ts
@@ -34,7 +34,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
     keySuffix = authentication.keySuffix;
     keyName = testClient.formatName("cryptography-client-test" + keySuffix);
     key = await client.createKey(keyName, "RSA");
-    keyVaultUrl = key.properties.vaultUrl;
+    keyVaultUrl = key.properties.vaultEndpoint;
     keyUrl = key.key!.kid as string;
     cryptoClient = new CryptographyClient(keyVaultUrl, key.key!.kid!, credential);
   });

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -31,14 +31,14 @@ describe("Keys client - list keys in various ways", () => {
 
   it("can purge all keys", async function() {
     // WARNING: When running integration-tests, or having TEST_MODE="record", all of the keys in the indicated KEYVAULT_NAME will be deleted as part of this test.
-    for await (const key of client.listKeys()) {
+    for await (const key of client.listPropertiesOfKeys()) {
       try {
         await testClient.flushKey(key.name);
       } catch (e) {}
     }
-    for await (const key of client.listDeletedKeys()) {
+    for await (const deletedKey of client.listDeletedKeys()) {
       try {
-        await testClient.purgeKey(key.name);
+        await testClient.purgeKey(deletedKey.properties.name);
       } catch (e) {}
     }
   });
@@ -47,8 +47,12 @@ describe("Keys client - list keys in various ways", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
     let totalVersions = 0;
-    for await (const version of client.listKeyVersions(keyName)) {
-      assert.equal(version.name, keyName, "Unexpected key name in result from listKeyVersions().");
+    for await (const version of client.listPropertiesOfKeyVersions(keyName)) {
+      assert.equal(
+        version.name,
+        keyName,
+        "Unexpected key name in result from listPropertiesOfKeyVersions()."
+      );
       totalVersions += 1;
     }
     assert.equal(totalVersions, 1, `Unexpected total versions for key ${keyName}`);
@@ -59,12 +63,12 @@ describe("Keys client - list keys in various ways", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
     let totalVersions = 0;
-    for await (const page of client.listKeyVersions(keyName).byPage()) {
+    for await (const page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
       for (const version of page) {
         assert.equal(
           version.name,
           keyName,
-          "Unexpected key name in result from listKeyVersions()."
+          "Unexpected key name in result from listPropertiesOfKeyVersions()."
         );
         totalVersions += 1;
       }
@@ -76,8 +80,12 @@ describe("Keys client - list keys in various ways", () => {
   it("list 0 versions of a non-existing key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     let totalVersions = 0;
-    for await (const version of client.listKeyVersions(keyName)) {
-      assert.equal(version.name, keyName, "Unexpected key name in result from listKeyVersions().");
+    for await (const version of client.listPropertiesOfKeyVersions(keyName)) {
+      assert.equal(
+        version.name,
+        keyName,
+        "Unexpected key name in result from listPropertiesOfKeyVersions()."
+      );
       totalVersions += 1;
     }
     assert.equal(totalVersions, 0, `Unexpected total versions for key ${keyName}`);
@@ -86,12 +94,12 @@ describe("Keys client - list keys in various ways", () => {
   it("list 0 versions of a non-existing key (paged)", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     let totalVersions = 0;
-    for await (const page of client.listKeyVersions(keyName).byPage()) {
+    for await (const page of client.listPropertiesOfKeyVersions(keyName).byPage()) {
       for (const version of page) {
         assert.equal(
           version.name,
           keyName,
-          "Unexpected key name in result from listKeyVersions()."
+          "Unexpected key name in result from listPropertiesOfKeyVersions()."
         );
         totalVersions += 1;
       }
@@ -107,7 +115,7 @@ describe("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const key of client.listKeys()) {
+    for await (const key of client.listPropertiesOfKeys()) {
       // The vault might contain more keys than the ones we inserted.
       if (!keyNames.includes(key.name)) continue;
       found += 1;
@@ -128,7 +136,7 @@ describe("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const page of client.listKeys().byPage()) {
+    for await (const page of client.listPropertiesOfKeys().byPage()) {
       for (const key of page) {
         // The vault might contain more keys than the ones we inserted.
         if (!keyNames.includes(key.name)) continue;
@@ -160,9 +168,9 @@ describe("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const key of client.listDeletedKeys()) {
+    for await (const deletedKey of client.listDeletedKeys()) {
       // The vault might contain more keys than the ones we inserted.
-      if (!keyNames.includes(key.name)) continue;
+      if (!keyNames.includes(deletedKey.properties.name)) continue;
       found += 1;
     }
 
@@ -191,9 +199,9 @@ describe("Keys client - list keys in various ways", () => {
 
     let found = 0;
     for await (const page of client.listDeletedKeys().byPage()) {
-      for (const key of page) {
+      for (const deletedKey of page) {
         // The vault might contain more keys than the ones we inserted.
-        if (!keyNames.includes(key.name)) continue;
+        if (!keyNames.includes(deletedKey.properties.name)) continue;
         found += 1;
       }
     }

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -31,14 +31,14 @@ describe.only("Keys client - list keys in various ways", () => {
 
   it("can purge all keys", async function() {
     // WARNING: When running integration-tests, or having TEST_MODE="record", all of the keys in the indicated KEYVAULT_NAME will be deleted as part of this test.
-    for await (const key of client.listPropertiesOfKeys()) {
+    for await (const properties of client.listPropertiesOfKeys()) {
       try {
-        await testClient.flushKey(key.name);
+        await testClient.flushKey(properties.name);
       } catch (e) {}
     }
     for await (const deletedKey of client.listDeletedKeys()) {
       try {
-        await testClient.purgeKey(deletedKey.properties.name);
+        await testClient.purgeKey(deletedKey.name);
       } catch (e) {}
     }
   });
@@ -115,9 +115,9 @@ describe.only("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const key of client.listPropertiesOfKeys()) {
+    for await (const properties of client.listPropertiesOfKeys()) {
       // The vault might contain more keys than the ones we inserted.
-      if (!keyNames.includes(key.name)) continue;
+      if (!keyNames.includes(properties.name)) continue;
       found += 1;
     }
 
@@ -137,9 +137,9 @@ describe.only("Keys client - list keys in various ways", () => {
 
     let found = 0;
     for await (const page of client.listPropertiesOfKeys().byPage()) {
-      for (const key of page) {
+      for (const properties of page) {
         // The vault might contain more keys than the ones we inserted.
-        if (!keyNames.includes(key.name)) continue;
+        if (!keyNames.includes(properties.name)) continue;
         found += 1;
       }
     }
@@ -170,7 +170,7 @@ describe.only("Keys client - list keys in various ways", () => {
     let found = 0;
     for await (const deletedKey of client.listDeletedKeys()) {
       // The vault might contain more keys than the ones we inserted.
-      if (!keyNames.includes(deletedKey.properties.name)) continue;
+      if (!keyNames.includes(deletedKey.name)) continue;
       found += 1;
     }
 
@@ -201,7 +201,7 @@ describe.only("Keys client - list keys in various ways", () => {
     for await (const page of client.listDeletedKeys().byPage()) {
       for (const deletedKey of page) {
         // The vault might contain more keys than the ones we inserted.
-        if (!keyNames.includes(deletedKey.properties.name)) continue;
+        if (!keyNames.includes(deletedKey.name)) continue;
         found += 1;
       }
     }

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -36,9 +36,9 @@ describe("Keys client - list keys in various ways", () => {
         await testClient.flushKey(key.name);
       } catch (e) {}
     }
-    for await (const deletedKey of client.listDeletedKeys()) {
+    for await (const deletedKeyProperties of client.listPropertiesOfDeletedKeys()) {
       try {
-        await testClient.purgeKey(deletedKey.properties.name);
+        await testClient.purgeKey(deletedKeyProperties.name);
       } catch (e) {}
     }
   });
@@ -168,13 +168,13 @@ describe("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const deletedKey of client.listDeletedKeys()) {
+    for await (const deletedKeyProperties of client.listPropertiesOfDeletedKeys()) {
       // The vault might contain more keys than the ones we inserted.
-      if (!keyNames.includes(deletedKey.properties.name)) continue;
+      if (!keyNames.includes(deletedKeyProperties.name)) continue;
       found += 1;
     }
 
-    assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
+    assert.equal(found, 2, "Unexpected number of keys found by listPropertiesOfDeletedKeys.");
 
     for (const name of keyNames) {
       await testClient.purgeKey(name);
@@ -198,15 +198,15 @@ describe("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const page of client.listDeletedKeys().byPage()) {
-      for (const deletedKey of page) {
+    for await (const page of client.listPropertiesOfDeletedKeys().byPage()) {
+      for (const deletedKeyProperties of page) {
         // The vault might contain more keys than the ones we inserted.
-        if (!keyNames.includes(deletedKey.properties.name)) continue;
+        if (!keyNames.includes(deletedKeyProperties.name)) continue;
         found += 1;
       }
     }
 
-    assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
+    assert.equal(found, 2, "Unexpected number of keys found by listPropertiesOfDeletedKeys.");
 
     for (const name of keyNames) {
       await testClient.purgeKey(name);

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -8,7 +8,7 @@ import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
 
-describe.only("Keys client - list keys in various ways", () => {
+describe("Keys client - list keys in various ways", () => {
   const keyPrefix = `recover${env.KEY_NAME || "KeyName"}`;
   let keySuffix: string;
   let client: KeyClient;

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -8,7 +8,7 @@ import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
 
-describe("Keys client - list keys in various ways", () => {
+describe.only("Keys client - list keys in various ways", () => {
   const keyPrefix = `recover${env.KEY_NAME || "KeyName"}`;
   let keySuffix: string;
   let client: KeyClient;
@@ -36,9 +36,9 @@ describe("Keys client - list keys in various ways", () => {
         await testClient.flushKey(key.name);
       } catch (e) {}
     }
-    for await (const deletedKeyProperties of client.listPropertiesOfDeletedKeys()) {
+    for await (const deletedKey of client.listDeletedKeys()) {
       try {
-        await testClient.purgeKey(deletedKeyProperties.name);
+        await testClient.purgeKey(deletedKey.properties.name);
       } catch (e) {}
     }
   });
@@ -168,13 +168,13 @@ describe("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const deletedKeyProperties of client.listPropertiesOfDeletedKeys()) {
+    for await (const deletedKey of client.listDeletedKeys()) {
       // The vault might contain more keys than the ones we inserted.
-      if (!keyNames.includes(deletedKeyProperties.name)) continue;
+      if (!keyNames.includes(deletedKey.properties.name)) continue;
       found += 1;
     }
 
-    assert.equal(found, 2, "Unexpected number of keys found by listPropertiesOfDeletedKeys.");
+    assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
 
     for (const name of keyNames) {
       await testClient.purgeKey(name);
@@ -198,15 +198,15 @@ describe("Keys client - list keys in various ways", () => {
     }
 
     let found = 0;
-    for await (const page of client.listPropertiesOfDeletedKeys().byPage()) {
-      for (const deletedKeyProperties of page) {
+    for await (const page of client.listDeletedKeys().byPage()) {
+      for (const deletedKey of page) {
         // The vault might contain more keys than the ones we inserted.
-        if (!keyNames.includes(deletedKeyProperties.name)) continue;
+        if (!keyNames.includes(deletedKey.properties.name)) continue;
         found += 1;
       }
     }
 
-    assert.equal(found, 2, "Unexpected number of keys found by listPropertiesOfDeletedKeys.");
+    assert.equal(found, 2, "Unexpected number of keys found by listDeletedKeys.");
 
     for (const name of keyNames) {
       await testClient.purgeKey(name);

--- a/sdk/keyvault/keyvault-keys/test/lro.delete.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/lro.delete.test.ts
@@ -36,14 +36,14 @@ describe("Keys client - Long Running Operations - delete", () => {
     assert.ok(poller.getOperationState().isStarted);
 
     // The pending deleted can be obtained this way:
-    assert.equal(poller.getOperationState().result!.properties.name, keyName);
+    assert.equal(poller.getOperationState().result!.name, keyName);
 
     const deletedKey: DeletedKey = await poller.pollUntilDone();
-    assert.equal(deletedKey.properties.name, keyName);
+    assert.equal(deletedKey.name, keyName);
     assert.ok(poller.getOperationState().isCompleted);
 
     // The final key can also be obtained this way:
-    assert.equal(poller.getOperationState().result!.properties.name, keyName);
+    assert.equal(poller.getOperationState().result!.name, keyName);
 
     await testClient.purgeKey(keyName);
   });
@@ -74,7 +74,7 @@ describe("Keys client - Long Running Operations - delete", () => {
 
     assert.ok(resumePoller.getOperationState().isStarted);
     const deletedKey: DeletedKey = await resumePoller.pollUntilDone();
-    assert.equal(deletedKey.properties.name, keyName);
+    assert.equal(deletedKey.name, keyName);
     assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.purgeKey(keyName);

--- a/sdk/keyvault/keyvault-keys/test/lro.recoverDelete.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/lro.recoverDelete.test.ts
@@ -40,14 +40,14 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
     assert.ok(poller.getOperationState().isStarted);
 
     // The pending key can be obtained this way:
-    assert.equal(poller.getOperationState().result!.properties.name, keyName);
+    assert.equal(poller.getOperationState().result!.name, keyName);
 
     const deletedKey: DeletedKey = await poller.pollUntilDone();
-    assert.equal(deletedKey.properties.name, keyName);
+    assert.equal(deletedKey.name, keyName);
     assert.ok(poller.getOperationState().isCompleted);
 
     // The final key can also be obtained this way:
-    assert.equal(poller.getOperationState().result!.properties.name, keyName);
+    assert.equal(poller.getOperationState().result!.name, keyName);
 
     await testClient.flushKey(keyName);
   });
@@ -81,7 +81,7 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
 
     assert.ok(poller.getOperationState().isStarted);
     const deletedKey: DeletedKey = await resumePoller.pollUntilDone();
-    assert.equal(deletedKey.properties.name, keyName);
+    assert.equal(deletedKey.name, keyName);
     assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.flushKey(keyName);

--- a/sdk/keyvault/keyvault-keys/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/recoverBackupRestore.test.ts
@@ -35,27 +35,19 @@ describe("Keys client - restore keys and recover backups", () => {
     await client.createKey(keyName, "RSA");
     const deletePoller = await client.beginDeleteKey(keyName);
     assert.equal(
-      deletePoller.getResult()!.properties.name,
+      deletePoller.getResult()!.name,
       keyName,
       "Unexpected key name in result from deletePoller.getResult()."
     );
     await deletePoller.pollUntilDone();
 
     const getDeletedResult = await deletePoller.getResult();
-    assert.equal(
-      getDeletedResult!.properties.name,
-      keyName,
-      "Unexpected key name in result from getKey()."
-    );
+    assert.equal(getDeletedResult!.name, keyName, "Unexpected key name in result from getKey().");
 
     const recoverPoller = await client.beginRecoverDeletedKey(keyName);
     await recoverPoller.pollUntilDone();
     const getResult = await client.getKey(keyName);
-    assert.equal(
-      getResult.properties.name,
-      keyName,
-      "Unexpected key name in result from getKey()."
-    );
+    assert.equal(getResult.name, keyName, "Unexpected key name in result from getKey().");
     await testClient.flushKey(keyName);
   });
 
@@ -104,11 +96,7 @@ describe("Keys client - restore keys and recover backups", () => {
     await testClient.flushKey(keyName);
     await retry(async () => client.restoreKeyBackup(backup as Uint8Array));
     const getResult = await client.getKey(keyName);
-    assert.equal(
-      getResult.properties.name,
-      keyName,
-      "Unexpected key name in result from getKey()."
-    );
+    assert.equal(getResult.name, keyName, "Unexpected key name in result from getKey().");
     await testClient.flushKey(keyName);
   });
 


### PR DESCRIPTION
For #5577

Fixes:
- Key to KeyVaultKey
- Key.KeyMaterial to KeyVaultKey.Key
- Core version to preview.9
- All dates should end in "On", except for "notBefore" and "scheduledPurgedDate".
- All options should match the method's name.
- All methods that return keyProperties (like the ones that iterate) should contain "propertiesOf" in their names.
- Flattened all the options bag to extend the RequestOptionsBase interface.

Note:
- ~.Net API apparently doesn't have a method that list the "properties of" the deleted keys. They have "GetDeletedKeys", however, I couldn't use the result of the underlying operation to reconstruct the key. Seems like the underlying operation is returning key properties, not keys. If so, we might need to change that on the .Net API.~ "GetDeletedKeys" should iterate over "DeletedKeys", not properties. According to Heath Stewart.