### PR TITLE
[Storage][File] Fix a regression where file http headers are not set

### DIFF
--- a/sdk/storage/storage-file/src/FileClient.ts
+++ b/sdk/storage/storage-file/src/FileClient.ts
@@ -750,7 +750,7 @@ export class FileClient extends StorageClient {
         fileLastWriteTimeToString(options.lastWriteTime!),
         {
           abortSignal: options.abortSignal,
-          fileHttpHeaders: options.fileHttpHeaders,
+          fileHTTPHeaders: options.fileHttpHeaders,
           metadata: options.metadata,
           filePermission: options.filePermission,
           filePermissionKey: options.filePermissionKey,


### PR DESCRIPTION
when creating file.

The issue is we only renamed public api surface while the generated code still
expect the a field of `fileHTTPHeaders`.  Fixing by passing the correct field to
the generated code.