### PR TITLE
[Storage][File] use sourceConditions field name in public API

### DIFF
--- a/sdk/storage/storage-file/src/FileClient.ts
+++ b/sdk/storage/storage-file/src/FileClient.ts
@@ -19,7 +19,7 @@ import {
   FileSetHTTPHeadersResponse,
   FileSetMetadataResponse,
   FileStartCopyResponse,
-  FileUploadRangeFromURLOptionalParams,
+  SourceModifiedAccessConditions,
   FileUploadRangeFromURLResponse,
   FileUploadRangeResponse,
   HandleItem,
@@ -220,9 +220,7 @@ export interface FileUploadRangeOptions extends CommonOptions {
  * @export
  * @interface FileUploadRangeFromURLOptions
  */
-export interface FileUploadRangeFromURLOptions
-  extends FileUploadRangeFromURLOptionalParams,
-    CommonOptions {
+export interface FileUploadRangeFromURLOptions extends CommonOptions {
   /**
    * An implementation of the `AbortSignalLike` interface to signal the request to cancel the operation.
    * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
@@ -231,6 +229,20 @@ export interface FileUploadRangeFromURLOptions
    * @memberof FileUploadRangeFromURLOptions
    */
   abortSignal?: AbortSignalLike;
+  /**
+   * The timeout parameter is expressed in seconds. For more information, see <a
+   * href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting
+   * Timeouts for File Service Operations.</a>
+   */
+  timeoutInSeconds?: number;
+  /**
+   * Specify the crc64 calculated for the range of bytes that must be read from the copy source.
+   */
+  sourceContentCrc64?: Uint8Array;
+  /**
+   * Additional parameters for the operation
+   */
+  sourceConditions?: SourceModifiedAccessConditions;
 }
 
 /**
@@ -1200,6 +1212,7 @@ export class FileClient extends StorageClient {
         0,
         {
           abortSignal: options.abortSignal,
+          sourceModifiedAccessConditions: options.sourceConditions,
           ...options,
           spanOptions
         }

--- a/sdk/storage/storage-file/src/generatedModels.ts
+++ b/sdk/storage/storage-file/src/generatedModels.ts
@@ -51,5 +51,6 @@ export {
   ShareSetAccessPolicyResponse,
   ShareSetMetadataResponse,
   ShareSetQuotaResponse,
-  SignedIdentifier as SignedIdentifierModel
+  SignedIdentifier as SignedIdentifierModel,
+  SourceModifiedAccessConditions
 } from "./generated/src/models";


### PR DESCRIPTION
for consistency with Blob.

In PR #5672 we adopted the field names `conditions` and `sourceConditions`.
This change fixes the only place in File where `SourceModifiedAccessConditions`
is used in public API to be consistent.