### PR TITLE
[core-lro] Change PollerOperationState to prefix boolean states with `is`

### DIFF
--- a/sdk/core/core-lro/src/pollOperation.ts
+++ b/sdk/core/core-lro/src/pollOperation.ts
@@ -1,9 +1,9 @@
 import { AbortSignalLike } from "@azure/abort-controller";
 
 export interface PollOperationState<TResult> {
-  started?: boolean;
-  completed?: boolean;
-  cancelled?: boolean;
+  isStarted?: boolean;
+  isCompleted?: boolean;
+  isCancelled?: boolean;
   error?: Error;
   result?: TResult;
 }

--- a/sdk/core/core-lro/src/poller.ts
+++ b/sdk/core/core-lro/src/poller.ts
@@ -134,7 +134,7 @@ export abstract class Poller<TState, TResult> implements PollerLike<TState, TRes
 
   public isDone(): boolean {
     const state = this.getOperationState();
-    return Boolean(state.completed || state.cancelled || state.error);
+    return Boolean(state.isCompleted || state.isCancelled || state.error);
   }
 
   public stopPolling(): void {

--- a/sdk/core/core-lro/test/testClient.test.ts
+++ b/sdk/core/core-lro/test/testClient.test.ts
@@ -53,7 +53,7 @@ describe("Long Running Operations - custom client", function() {
 
     assert.ok(poller.initialResponse!.parsedBody.started);
     assert.ok(poller.previousResponse!.parsedBody.finished);
-    assert.ok(poller.getOperationState().completed);
+    assert.ok(poller.getOperationState().isCompleted);
     assert.equal(result, "Done");
   });
 
@@ -93,7 +93,7 @@ describe("Long Running Operations - custom client", function() {
 
     await poller.pollUntilDone();
     assert.ok(poller.previousResponse!.parsedBody.finished);
-    assert.ok(poller.getOperationState().completed);
+    assert.ok(poller.getOperationState().isCompleted);
 
     result = await poller.getResult();
     assert.equal(result, "Done");
@@ -124,7 +124,7 @@ describe("Long Running Operations - custom client", function() {
     assert.equal(client.totalSentRequests, 11);
 
     await poller.cancelOperation();
-    assert.ok(poller.getOperationState().cancelled);
+    assert.ok(poller.getOperationState().isCancelled);
 
     // Cancelling a poller stops it
     assert.ok(poller.isStopped());

--- a/sdk/core/core-lro/test/testClient.test.ts
+++ b/sdk/core/core-lro/test/testClient.test.ts
@@ -6,6 +6,7 @@ import { delay, WebResource, HttpHeaders, isNode } from "@azure/core-http";
 import { TestClient } from "./utils/testClient";
 import { PollerStoppedError, PollerCancelledError } from "../src";
 import { TestTokenCredential } from "./utils/testTokenCredential";
+import { TestOperationState } from "./utils/testOperation";
 
 const testHttpHeaders: HttpHeaders = new HttpHeaders();
 const testHttpRequest: WebResource = new WebResource();
@@ -48,8 +49,8 @@ describe("Long Running Operations - custom client", function() {
     const result = await poller.pollUntilDone();
 
     // Checking the serialized version of the operation
-    let serializedOperation = JSON.parse(poller.toString());
-    assert.ok(serializedOperation.state.started);
+    let serializedOperation: { state: TestOperationState } = JSON.parse(poller.toString());
+    assert.ok(serializedOperation.state.isStarted);
 
     assert.ok(poller.initialResponse!.parsedBody.started);
     assert.ok(poller.previousResponse!.parsedBody.finished);

--- a/sdk/core/core-lro/test/utils/testOperation.ts
+++ b/sdk/core/core-lro/test/utils/testOperation.ts
@@ -30,10 +30,10 @@ async function update(
   if (!initialResponse) {
     response = await client.sendInitialRequest(new TestWebResource(abortSignal));
     this.state.initialResponse = response;
-    this.state.started = true;
+    this.state.isStarted = true;
   } else if (doFinalResponse) {
     response = await client.sendFinalRequest(new TestWebResource(abortSignal));
-    this.state.completed = true;
+    this.state.isCompleted = true;
     this.state.result = "Done";
     this.state.previousResponse = response;
   } else {
@@ -78,7 +78,7 @@ async function cancel(
 
   return makeOperation({
     ...this.state,
-    cancelled: true,
+    isCancelled: true,
     previousResponse: response
   });
 }

--- a/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/delete/operation.ts
@@ -42,26 +42,26 @@ async function update(
     requestOptions.abortSignal = options.abortSignal;
   }
 
-  if (!state.started) {
+  if (!state.isStarted) {
     const deletedKey = await client.deleteKey(name, requestOptions);
-    state.started = true;
+    state.isStarted = true;
     state.result = deletedKey;
     if (!deletedKey.properties.recoveryId) {
-      state.completed = true;
+      state.isCompleted = true;
     }
   }
 
-  if (!state.completed) {
+  if (!state.isCompleted) {
     try {
       state.result = await client.getDeletedKey(name, { requestOptions });
-      state.completed = true;
+      state.isCompleted = true;
     } catch (error) {
       if (error.statusCode === 403) {
         // At this point, the resource exists but the user doesn't have access to it.
-        state.completed = true;
+        state.isCompleted = true;
       } else if (error.statusCode !== 404) {
         state.error = error;
-        state.completed = true;
+        state.isCompleted = true;
       }
     }
   }

--- a/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-keys/src/lro/recover/operation.ts
@@ -42,28 +42,28 @@ async function update(
     requestOptions.abortSignal = options.abortSignal;
   }
 
-  if (!state.started) {
+  if (!state.isStarted) {
     try {
       state.result = await client.getKey(name, { requestOptions });
-      state.completed = true;
+      state.isCompleted = true;
     } catch (_) {}
-    if (!state.completed) {
+    if (!state.isCompleted) {
       state.result = await client.recoverDeletedKey(name, { requestOptions });
-      state.started = true;
+      state.isStarted = true;
     }
   }
 
-  if (!state.completed) {
+  if (!state.isCompleted) {
     try {
       state.result = await client.getKey(name, { requestOptions });
-      state.completed = true;
+      state.isCompleted = true;
     } catch (error) {
       if (error.statusCode === 403) {
         // At this point, the resource exists but the user doesn't have access to it.
-        state.completed = true;
+        state.isCompleted = true;
       } else if (error.statusCode !== 404) {
         state.error = error;
-        state.completed = true;
+        state.isCompleted = true;
       }
     }
   }

--- a/sdk/keyvault/keyvault-keys/test/lro.delete.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/lro.delete.test.ts
@@ -33,14 +33,14 @@ describe("Keys client - Long Running Operations - delete", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
     const poller = await client.beginDeleteKey(keyName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     // The pending deleted can be obtained this way:
     assert.equal(poller.getOperationState().result!.properties.name, keyName);
 
     const deletedKey: DeletedKey = await poller.pollUntilDone();
     assert.equal(deletedKey.properties.name, keyName);
-    assert.ok(poller.getOperationState().completed);
+    assert.ok(poller.getOperationState().isCompleted);
 
     // The final key can also be obtained this way:
     assert.equal(poller.getOperationState().result!.properties.name, keyName);
@@ -52,7 +52,7 @@ describe("Keys client - Long Running Operations - delete", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
     const poller = await client.beginDeleteKey(keyName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     poller.pollUntilDone().catch((e) => {
       assert.ok(e instanceof PollerStoppedError);
@@ -64,7 +64,7 @@ describe("Keys client - Long Running Operations - delete", () => {
 
     poller.stopPolling();
     assert.ok(poller.isStopped());
-    assert.ok(!poller.getOperationState().completed);
+    assert.ok(!poller.getOperationState().isCompleted);
 
     const serialized = poller.toString();
 
@@ -72,10 +72,10 @@ describe("Keys client - Long Running Operations - delete", () => {
       resumeFrom: serialized
     });
 
-    assert.ok(resumePoller.getOperationState().started);
+    assert.ok(resumePoller.getOperationState().isStarted);
     const deletedKey: DeletedKey = await resumePoller.pollUntilDone();
     assert.equal(deletedKey.properties.name, keyName);
-    assert.ok(resumePoller.getOperationState().completed);
+    assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.purgeKey(keyName);
   });

--- a/sdk/keyvault/keyvault-keys/test/lro.recoverDelete.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/lro.recoverDelete.test.ts
@@ -37,14 +37,14 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
     await deletePoller.pollUntilDone();
 
     const poller = await client.beginRecoverDeletedKey(keyName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     // The pending key can be obtained this way:
     assert.equal(poller.getOperationState().result!.properties.name, keyName);
 
     const deletedKey: DeletedKey = await poller.pollUntilDone();
     assert.equal(deletedKey.properties.name, keyName);
-    assert.ok(poller.getOperationState().completed);
+    assert.ok(poller.getOperationState().isCompleted);
 
     // The final key can also be obtained this way:
     assert.equal(poller.getOperationState().result!.properties.name, keyName);
@@ -59,7 +59,7 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
     await deletePoller.pollUntilDone();
 
     const poller = await client.beginRecoverDeletedKey(keyName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     poller.pollUntilDone().catch((e) => {
       assert.ok(e instanceof PollerStoppedError);
@@ -71,7 +71,7 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
 
     poller.stopPolling();
     assert.ok(poller.isStopped());
-    assert.ok(!poller.getOperationState().completed);
+    assert.ok(!poller.getOperationState().isCompleted);
 
     const serialized = poller.toString();
 
@@ -79,10 +79,10 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
       resumeFrom: serialized
     });
 
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
     const deletedKey: DeletedKey = await resumePoller.pollUntilDone();
     assert.equal(deletedKey.properties.name, keyName);
-    assert.ok(resumePoller.getOperationState().completed);
+    assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.flushKey(keyName);
   });

--- a/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/delete/operation.ts
@@ -42,26 +42,26 @@ async function update(
     requestOptions.abortSignal = options.abortSignal;
   }
 
-  if (!state.started) {
+  if (!state.isStarted) {
     const deletedSecret = await client.deleteSecret(name, requestOptions);
-    state.started = true;
+    state.isStarted = true;
     state.result = deletedSecret;
     if (!deletedSecret.properties.recoveryId) {
-      state.completed = true;
+      state.isCompleted = true;
     }
   }
 
-  if (!state.completed) {
+  if (!state.isCompleted) {
     try {
       state.result = await client.getDeletedSecret(name, { requestOptions });
-      state.completed = true;
+      state.isCompleted = true;
     } catch (error) {
       if (error.statusCode === 403) {
         // At this point, the resource exists but the user doesn't have access to it.
-        state.completed = true;
+        state.isCompleted = true;
       } else if (error.statusCode !== 404) {
         state.error = error;
-        state.completed = true;
+        state.isCompleted = true;
       }
     }
   }

--- a/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
+++ b/sdk/keyvault/keyvault-secrets/src/lro/recover/operation.ts
@@ -43,28 +43,28 @@ async function update(
     requestOptions.abortSignal = options.abortSignal;
   }
 
-  if (!state.started) {
+  if (!state.isStarted) {
     try {
       state.result = (await client.getSecret(name, { requestOptions })).properties;
-      state.completed = true;
+      state.isCompleted = true;
     } catch (_) {}
-    if (!state.completed) {
+    if (!state.isCompleted) {
       state.result = await client.recoverDeletedSecret(name, { requestOptions });
-      state.started = true;
+      state.isStarted = true;
     }
   }
 
-  if (!state.completed) {
+  if (!state.isCompleted) {
     try {
       state.result = (await client.getSecret(name, { requestOptions })).properties;
-      state.completed = true;
+      state.isCompleted = true;
     } catch (error) {
       if (error.statusCode === 403) {
         // At this point, the resource exists but the user doesn't have access to it.
-        state.completed = true;
+        state.isCompleted = true;
       } else if (error.statusCode !== 404) {
         state.error = error;
-        state.completed = true;
+        state.isCompleted = true;
       }
     }
   }

--- a/sdk/keyvault/keyvault-secrets/test/lro.delete.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/lro.delete.test.ts
@@ -35,14 +35,14 @@ describe("Secrets client - Long Running Operations - delete", () => {
     );
     await client.setSecret(secretName, "value");
     const poller = await client.beginDeleteSecret(secretName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     // The pending deleted secret can be obtained this way:
     assert.equal(poller.getOperationState().result!.properties.name, secretName);
 
     const deletedSecret: DeletedSecret = await poller.pollUntilDone();
     assert.equal(deletedSecret.properties.name, secretName);
-    assert.ok(poller.getOperationState().completed);
+    assert.ok(poller.getOperationState().isCompleted);
 
     // The final secret can also be obtained this way:
     assert.equal(poller.getOperationState().result!.properties.name, secretName);
@@ -56,7 +56,7 @@ describe("Secrets client - Long Running Operations - delete", () => {
     );
     await client.setSecret(secretName, "value");
     const poller = await client.beginDeleteSecret(secretName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     poller.pollUntilDone().catch((e) => {
       assert.ok(e instanceof PollerStoppedError);
@@ -66,7 +66,7 @@ describe("Secrets client - Long Running Operations - delete", () => {
 
     poller.stopPolling();
     assert.ok(poller.isStopped());
-    assert.ok(!poller.getOperationState().completed);
+    assert.ok(!poller.getOperationState().isCompleted);
 
     const serialized = poller.toString();
 
@@ -74,10 +74,10 @@ describe("Secrets client - Long Running Operations - delete", () => {
       resumeFrom: serialized
     });
 
-    assert.ok(resumePoller.getOperationState().started);
+    assert.ok(resumePoller.getOperationState().isStarted);
     const deletedSecret: DeletedSecret = await resumePoller.pollUntilDone();
     assert.equal(deletedSecret.properties.name, secretName);
-    assert.ok(resumePoller.getOperationState().completed);
+    assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.purgeSecret(secretName);
   });

--- a/sdk/keyvault/keyvault-secrets/test/lro.recover.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/lro.recover.test.ts
@@ -39,14 +39,14 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
     await deletePoller.pollUntilDone();
 
     const poller = await client.beginRecoverDeletedSecret(secretName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     // The pending secret properties can be obtained this way:
     assert.equal(poller.getOperationState().result!.name, secretName);
 
     const secretProperties: SecretProperties = await poller.pollUntilDone();
     assert.equal(secretProperties.name, secretName);
-    assert.ok(poller.getOperationState().completed);
+    assert.ok(poller.getOperationState().isCompleted);
 
     // The final secret can also be obtained this way:
     assert.equal(poller.getOperationState().result!.name, secretName);
@@ -63,7 +63,7 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
     await deletePoller.pollUntilDone();
 
     const poller = await client.beginRecoverDeletedSecret(secretName);
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
 
     poller.pollUntilDone().catch((e: PollerStoppedError | Error) => {
       assert.ok(e instanceof PollerStoppedError);
@@ -75,7 +75,7 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
 
     poller.stopPolling();
     assert.ok(poller.isStopped());
-    assert.ok(!poller.getOperationState().completed);
+    assert.ok(!poller.getOperationState().isCompleted);
 
     const serialized = poller.toString();
 
@@ -83,10 +83,10 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
       resumeFrom: serialized
     });
 
-    assert.ok(poller.getOperationState().started);
+    assert.ok(poller.getOperationState().isStarted);
     const secretProperties: SecretProperties = await resumePoller.pollUntilDone();
     assert.equal(secretProperties.name, secretName);
-    assert.ok(resumePoller.getOperationState().completed);
+    assert.ok(resumePoller.getOperationState().isCompleted);
 
     await testClient.flushSecret(secretName);
   });


### PR DESCRIPTION
Based on feedback from @bterlson, this minor rename PR prefixes a few boolean properties of `PollerOperationState` with `is`.

This aligns them with `isStopped` and `isDone` on the poller itself.