### PR TITLE
[Storage] Fix build failures caused by the left over old references after #5613

### DIFF
--- a/sdk/storage/storage-blob/test/node/emulator-tests.spec.ts
+++ b/sdk/storage/storage-blob/test/node/emulator-tests.spec.ts
@@ -56,7 +56,7 @@ describe("Emulator Tests", () => {
       newClient.containerName,
       "Container name didn't match with the provided one."
     );
-    assert.equal(newClient.blobName, blobName, "Blob name didn't match with the provided one.");
+    assert.equal(newClient.name, blobName, "Blob name didn't match with the provided one.");
     const result = await newClient.getProperties();
     assert.deepStrictEqual(result.metadata, metadata);
   });
@@ -82,7 +82,7 @@ describe("Emulator Tests", () => {
       containerName,
       "Container name didn't match with the provided one."
     );
-    assert.equal(newClient.blobName, blobName, "Blob name didn't match with the provided one.");
+    assert.equal(newClient.name, blobName, "Blob name didn't match with the provided one.");
     const body: string = "randomstring";
     await newClient.upload(body, body.length);
     const result = await newClient.download(0);
@@ -141,7 +141,7 @@ describe("Emulator Tests", () => {
       containerName,
       "Container name didn't match with the provided one."
     );
-    assert.equal(newClient.blobName, blobName, "Blob name didn't match with the provided one.");
+    assert.equal(newClient.name, blobName, "Blob name didn't match with the provided one.");
     await newClient.create(512);
     const result = await newClient.download(0);
     assert.deepStrictEqual(await bodyToString(result, 512), "\u0000".repeat(512));

--- a/sdk/storage/storage-queue/test/node/emulator-tests.spec.ts
+++ b/sdk/storage/storage-queue/test/node/emulator-tests.spec.ts
@@ -62,7 +62,7 @@ describe("Emulator Tests", () => {
 
     const result = await newClient.getProperties();
 
-    assert.equal(newClient.queueName, queueName, "Queue name didn't match with the provided one.");
+    assert.equal(newClient.name, queueName, "Queue name didn't match with the provided one.");
     assert.ok(result.requestId);
     assert.ok(result.version);
     assert.ok(result.date);


### PR DESCRIPTION
Not sure why the build didn't fail at #5613 