### PR TITLE
[Identity] Change base type of IdentityClientOptions to PipelineOptions

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -6,7 +6,7 @@
 
 import { AccessToken } from '@azure/core-http';
 import { GetTokenOptions } from '@azure/core-http';
-import { ServiceClientOptions } from '@azure/core-http';
+import { PipelineOptions } from '@azure/core-http';
 import { TokenCredential } from '@azure/core-http';
 
 export { AccessToken }
@@ -101,7 +101,7 @@ export function getDefaultAzureCredential(): TokenCredential;
 export { GetTokenOptions }
 
 // @public
-export interface IdentityClientOptions extends ServiceClientOptions {
+export interface IdentityClientOptions extends PipelineOptions {
     authorityHost?: string;
 }
 

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -39,17 +39,7 @@ export class IdentityClient extends ServiceClient {
 
   constructor(options?: IdentityClientOptions) {
     options = options || IdentityClient.getDefaultOptions();
-
-    const internalPipelineOptions = {
-      ...options,
-      ...{
-        loggingOptions: {
-          logger: logger.info,
-        }
-      }
-    };
-
-    super(undefined, createPipelineFromOptions(internalPipelineOptions));
+    super(undefined, createPipelineFromOptions(options));
 
     this.baseUri = this.authorityHost = options.authorityHost || DefaultAuthorityHost;
 

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -5,18 +5,16 @@ import qs from "qs";
 import {
   AccessToken,
   ServiceClient,
-  ServiceClientOptions,
+  PipelineOptions,
   WebResource,
   RequestPrepareOptions,
   GetTokenOptions,
-  tracingPolicy,
-  RequestPolicyFactory
+  createPipelineFromOptions
 } from "@azure/core-http";
 import { CanonicalCode } from "@azure/core-tracing";
 import { AuthenticationError, AuthenticationErrorName } from "./errors";
 import { createSpan } from "../util/tracing";
 import { logger } from '../util/logging';
-
 
 const DefaultAuthorityHost = "https://login.microsoftonline.com";
 
@@ -41,7 +39,17 @@ export class IdentityClient extends ServiceClient {
 
   constructor(options?: IdentityClientOptions) {
     options = options || IdentityClient.getDefaultOptions();
-    super(undefined, options);
+
+    const internalPipelineOptions = {
+      ...options,
+      ...{
+        loggingOptions: {
+          logger: logger.info,
+        }
+      }
+    };
+
+    super(undefined, createPipelineFromOptions(internalPipelineOptions));
 
     this.baseUri = this.authorityHost = options.authorityHost || DefaultAuthorityHost;
 
@@ -162,10 +170,7 @@ export class IdentityClient extends ServiceClient {
 
   static getDefaultOptions(): IdentityClientOptions {
     return {
-      authorityHost: DefaultAuthorityHost,
-      requestPolicyFactories: (factories: RequestPolicyFactory[]) => {
-        return [tracingPolicy(), ...factories];
-      }
+      authorityHost: DefaultAuthorityHost
     };
   }
 }
@@ -174,7 +179,7 @@ export class IdentityClient extends ServiceClient {
  * Provides options to configure how the Identity library makes authentication
  * requests to Azure Active Directory.
  */
-export interface IdentityClientOptions extends ServiceClientOptions {
+export interface IdentityClientOptions extends PipelineOptions {
   /**
    * The authority host to use for authentication requests.  The default is
    * "https://login.microsoftonline.com".

--- a/sdk/identity/identity/test/authTestUtils.ts
+++ b/sdk/identity/identity/test/authTestUtils.ts
@@ -58,7 +58,9 @@ export class MockAuthHttpClient implements HttpClient {
     this.identityClientOptions = {
       authorityHost: "https://authority",
       httpClient: this,
-      noRetryPolicy: true
+      retryOptions: {
+        maxRetries: 0
+      }
     };
   }
 

--- a/sdk/identity/identity/test/identityClient.spec.ts
+++ b/sdk/identity/identity/test/identityClient.spec.ts
@@ -92,6 +92,7 @@ describe("IdentityClient", function () {
       "secret",
       mockHttp.identityClientOptions
     );
+
     await assertRejects(
       credential.getToken("https://test/.default"),
       isExpectedError("unknown_error")

--- a/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
@@ -86,7 +86,7 @@ describe("AuthorizationCodeCredential", function() {
 
     const rootSpan = tracer.startSpan("root");
 
-    const credential = new AuthorizationCodeCredential(      
+    const credential = new AuthorizationCodeCredential(
       "tenant",
       "client",
       "secret",
@@ -116,7 +116,12 @@ describe("AuthorizationCodeCredential", function() {
           children: [
             {
               name: "Azure.Identity.AuthorizationCodeCredential-getToken",
-              children: []
+              children: [
+                {
+                  children: [],
+                  name: "core-http"
+                }
+              ]
             }
           ]
         }

--- a/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
@@ -113,7 +113,12 @@ describe("ClientCertificateCredential", function() {
           children: [
             {
               name: "Azure.Identity.ClientCertificateCredential-getToken",
-              children: []
+              children: [
+                {
+                  children: [],
+                  name: "core-http"
+                }
+              ]
             }
           ]
         }

--- a/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
@@ -356,6 +356,8 @@ describe("DeviceCodeCredential", function() {
                 {
                   name: "Azure.Identity.DeviceCodeCredential-pollForToken",
                   children: [
+                    // We see 4 traces from core-http here because the client in
+                    // this test polls 4 times for the authorization code.
                     {
                       children: [],
                       name: "core-http"

--- a/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
@@ -346,11 +346,33 @@ describe("DeviceCodeCredential", function() {
               children: [
                 {
                   name: "Azure.Identity.DeviceCodeCredential-sendDeviceCodeRequest",
-                  children: []
+                  children: [
+                    {
+                      children: [],
+                      name: "core-http"
+                    }
+                  ]
                 },
                 {
                   name: "Azure.Identity.DeviceCodeCredential-pollForToken",
-                  children: []
+                  children: [
+                    {
+                      children: [],
+                      name: "core-http"
+                    },
+                    {
+                      children: [],
+                      name: "core-http"
+                    },
+                    {
+                      children: [],
+                      name: "core-http"
+                    },
+                    {
+                      children: [],
+                      name: "core-http"
+                    }
+                  ]
                 }
               ]
             }

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -61,7 +61,12 @@ describe("EnvironmentCredential", function() {
               children: [
                 {
                   name: "Azure.Identity.ClientSecretCredential-getToken",
-                  children: []
+                  children: [
+                    {
+                      children: [],
+                      name: "core-http"
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
This change updates `IdentityClientOptions` to be based on `PipelineOptions` instead of `ServiceClientOptions`.  The change went very smoothly; the majority of changes were adding expected trace spans for `core-http` since the `tracingPolicy` wasn't being added to the pipeline in tests before this commit.