### PR TITLE
[Storage] Update polyfill to fix the failed browser tests in IE

### DIFF
--- a/sdk/storage/README.md
+++ b/sdk/storage/README.md
@@ -55,6 +55,7 @@ This library depends on following ES features which need external polyfills load
 - `String.prototype.repeat`
 - `String.prototype.includes`
 - `Array.prototype.includes`
+- `Object.assign`
 - `Object.keys` (Override IE11's `Object.keys` with ES6 polyfill forcely to enable [ES6 behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
 - `Symbol`
 

--- a/sdk/storage/storage-blob/ChangeLog.md
+++ b/sdk/storage/storage-blob/ChangeLog.md
@@ -58,6 +58,7 @@
     - (with proxyURI) `UseDevelopmentStorage=true;DevelopmentStorageProxyUri=proxyURI`
 - [Breaking] `encrypted` attribute is removed from `BlobMetadata` interface. [PR #5612](https://github.com/Azure/azure-sdk-for-js/pull/5612)
 - [Breaking] Return type of `downloadToBuffer` helper method on `BlobClient` is changed to `Promise<Buffer>` from `Promise<void>` [PR #5624](https://github.com/Azure/azure-sdk-for-js/pull/5624)
+- [Breaking] IE11 needs `Object.assign` polyfill loaded.
 
 ## 2019.10 12.0.0-preview.4
 

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -45,6 +45,7 @@ This library depends on following ES features which need external polyfills load
 - `String.prototype.repeat`
 - `String.prototype.includes`
 - `Array.prototype.includes`
+- `Object.assign`
 - `Object.keys` (Override IE11's `Object.keys` with ES6 polyfill forcely to enable [ES6 behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
 - `Symbol`
 

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -129,7 +129,7 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["IE"],
+    browsers: ["ChromeHeadless"],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -29,8 +29,8 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
+      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
+      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
       "recordings/browsers/**/*.json"
     ],
@@ -129,7 +129,7 @@ module.exports = function(config) {
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     // 'ChromeHeadless', 'Chrome', 'Firefox', 'Edge', 'IE'
-    browsers: ["ChromeHeadless"],
+    browsers: ["IE"],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits

--- a/sdk/storage/storage-blob/samples/browserSamples/basic.html
+++ b/sdk/storage/storage-blob/samples/browserSamples/basic.html
@@ -9,7 +9,7 @@ and replace code in the below script tag to try them out.
 
 <!-- Uncomment the following script tag to include polyfill to run the sample in IE11 -->
 <!-- 
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always"></script>
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always"></script>
 -->
 <!-- Import browser bundle `azure-storage-blob.js` or `azure-storage-blob.min.js`-->
 <script src="./azure-storage-blob.js"></script>

--- a/sdk/storage/storage-file/ChangeLog.md
+++ b/sdk/storage/storage-file/ChangeLog.md
@@ -24,6 +24,7 @@
 - [Breaking] Appropriate attribute renames in all the interfaces [PR #5610](https://github.com/Azure/azure-sdk-for-js/pull/5610)
   - Example - `nextMarker` -> `continuationToken`, `HTTPClient` -> `HttpClient`, `permission` -> `permissions`, `parallelism` -> `concurrency`
 - [Breaking] `forceCloseHandlesSegment` is not exposed from the library in favour of the new method `forceCloseAllHandles` on `FileClient` and `DirectoryClient`. [PR #5620](https://github.com/Azure/azure-sdk-for-js/pull/5620)
+- [Breaking] IE11 needs `Object.assign` polyfill loaded.
 
 ## 2019.10 12.0.0-preview.4
 

--- a/sdk/storage/storage-file/README.md
+++ b/sdk/storage/storage-file/README.md
@@ -44,6 +44,7 @@ This library depends on following ES features which need external polyfills load
 - `String.prototype.repeat`
 - `String.prototype.includes`
 - `Array.prototype.includes`
+- `Object.assign`
 - `Object.keys` (Override IE11's `Object.keys` with ES6 polyfill forcely to enable [ES6 behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
 - `Symbol`
 

--- a/sdk/storage/storage-file/karma.conf.js
+++ b/sdk/storage/storage-file/karma.conf.js
@@ -29,8 +29,8 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
+      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
+      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
       "recordings/browsers/**/*.json"
     ],

--- a/sdk/storage/storage-file/samples/browserSample.html
+++ b/sdk/storage/storage-file/samples/browserSample.html
@@ -9,7 +9,7 @@ and replace code in the below script tag to try them out.
 
 <!-- Uncomment the following script tag to include polyfill to run the sample in IE11 -->
 <!-- 
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always"></script>
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always"></script>
 -->
 <!-- Import browser bundle `azure-storage-file.js` or `azure-storage-file.min.js`-->
 <script src="./azure-storage-file.js"></script>

--- a/sdk/storage/storage-queue/ChangeLog.md
+++ b/sdk/storage/storage-queue/ChangeLog.md
@@ -28,6 +28,7 @@
   - emulator connection string shorthands are supported
     - `UseDevelopmentStorage=true`
     - (with proxyURI) `UseDevelopmentStorage=true;DevelopmentStorageProxyUri=proxyURI`
+- [Breaking] IE11 needs `Object.assign` polyfill loaded.
 
 ## 2019.10 12.0.0-preview.4
 

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -43,6 +43,7 @@ This library depends on following ES features which need external polyfills load
 - `String.prototype.repeat`
 - `String.prototype.includes`
 - `Array.prototype.includes`
+- `Object.assign`
 - `Object.keys` (Override IE11's `Object.keys` with ES6 polyfill forcely to enable [ES6 behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Notes))
 - `Symbol`
 

--- a/sdk/storage/storage-queue/karma.conf.js
+++ b/sdk/storage/storage-queue/karma.conf.js
@@ -29,8 +29,8 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       // polyfill service supporting IE11 missing features
-      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
-      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
+      // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
+      "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
       "recordings/browsers/**/*.json"
     ],

--- a/sdk/storage/storage-queue/samples/browserSample.html
+++ b/sdk/storage/storage-queue/samples/browserSample.html
@@ -9,7 +9,7 @@ and replace code in the below script tag to try them out.
 
 <!-- Uncomment the following script tag to include polyfill to run the sample in IE11 -->
 <!-- 
-  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always"></script>
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always"></script>
 -->
 <!-- Import browser bundle `azure-storage-queue.js` or `azure-storage-queue.min.js`-->
 <script src="./azure-storage-queue.js"></script>


### PR DESCRIPTION
### **Why are we updating polyfill?**
In the core-logger package, debug shim uses `Object.assign` which is incompatible with IE11
![image](https://user-images.githubusercontent.com/10452642/67337931-e5638d80-f4dc-11e9-93b4-daa8c0613949.png)
Introduced here - https://github.com/Azure/azure-sdk-for-js/blob/5297357da043fd539b5053c99ddc49e18394ae5e/sdk/core/logger/src/debug.ts#L133

Updating the polyfill wiith `Object.assign` fixes the issue. Thanks to @chradek, for suggesting the fix.


### Browser Tests
**BLOB - IE** 
![image](https://user-images.githubusercontent.com/10452642/67335966-6c166b80-f4d9-11e9-822e-0826ca5f45b5.png)

**FILE - IE**
![image](https://user-images.githubusercontent.com/10452642/67336428-3625b700-f4da-11e9-8332-d403b5e9cb5d.png)
(Failed test - Known Issue - IE behavior)

**QUEUE - IE**
![image](https://user-images.githubusercontent.com/10452642/67336803-d11e9100-f4da-11e9-99c3-068abbd39e06.png)

