### PR TITLE
[Storage][Blob] Fix comment on BlobGetPropertiesHeaders.contentLength

### DIFF
--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -3975,7 +3975,8 @@ export interface BlobGetPropertiesHeaders {
    */
   leaseStatus?: LeaseStatusType;
   /**
-   * The number of bytes present in the response body.
+   * The size of the blob in bytes. For a page blob, this header returns the value of the
+   * x-ms-blob-content-length header that is stored with the blob.
    */
   contentLength?: number;
   /**

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -258,3 +258,12 @@ directive:
   transform: >
     $["x-ms-client-name"] = "etag";
 ```
+
+### Fix comment for BlobGetPropertiesHeaders Content-Length
+``` yaml
+directive:
+- from: swagger-document
+  where: $["x-ms-paths"]["/{containerName}/{blob}"].head.responses["200"].headers["Content-Length"]
+  transform: >
+    $.description = "The size of the blob in bytes. For a page blob, this header returns the value of the x-ms-blob-content-length header that is stored with the blob.";
+```


### PR DESCRIPTION
Fixes #5177

Update comment for Content-Type through autorest to align with [documentation](https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob)