### PR TITLE
Respect env certificate and user/pw

### DIFF
--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -7,7 +7,9 @@ import { ClientSecretCredential } from "./clientSecretCredential";
 import { createSpan } from "../util/tracing";
 import { AuthenticationErrorName } from "../client/errors";
 import { CanonicalCode } from "@azure/core-tracing";
-import { logger } from '../util/logging';
+import { logger } from "../util/logging";
+import { ClientCertificateCredential } from "./clientCertificateCredential";
+import { UsernamePasswordCredential } from "./usernamePasswordCredential";
 
 /**
  * Enables authentication to Azure Active Directory using client secret
@@ -37,8 +39,40 @@ export class EnvironmentCredential implements TokenCredential {
       clientSecret = process.env.AZURE_CLIENT_SECRET;
 
     if (tenantId && clientId && clientSecret) {
-      logger.info(`EnvironmentCredential: loaded with tenant ID: ${tenantId}, clientId: ${clientId}`);
+      logger.info(
+        `EnvironmentCredential: loaded with tenant ID: ${tenantId}, clientId: ${clientId}`
+      );
       this._credential = new ClientSecretCredential(tenantId, clientId, clientSecret, options);
+      return;
+    }
+
+    const certificatePath = process.env.AZURE_CLIENT_CERTIFICATE_PATH;
+    if (tenantId && clientId && certificatePath) {
+      logger.info(
+        `EnvironmentCredential: loaded with tenant ID: ${tenantId}, clientId: ${clientId}, certificatePath: ${certificatePath}`
+      );
+      this._credential = new ClientCertificateCredential(
+        tenantId,
+        clientId,
+        certificatePath,
+        options
+      );
+      return;
+    }
+
+    const username = process.env.AZURE_USERNAME;
+    const password = process.env.AZURE_PASSWORD;
+    if (tenantId && clientId && username && password) {
+      logger.info(
+        `EnvironmentCredential: loaded with tenant ID: ${tenantId}, clientId: ${clientId}, username: ${username}`
+      );
+      this._credential = new UsernamePasswordCredential(
+        tenantId,
+        clientId,
+        username,
+        password,
+        options
+      );
     }
   }
 

--- a/sdk/identity/identity/test/authTestUtils.ts
+++ b/sdk/identity/identity/test/authTestUtils.ts
@@ -98,11 +98,13 @@ export function assertClientCredentials(
       true,
       "Request body doesn't contain expected tenantId"
     );
+
     assert.strictEqual(
       authRequest.body.indexOf(`client_id=${expectedClientId}`) > -1,
       true,
       "Request body doesn't contain expected clientId"
     );
+
     assert.strictEqual(
       authRequest.body.indexOf(`client_secret=${expectedClientSecret}`) > -1,
       true,

--- a/sdk/identity/identity/test/authTestUtils.ts
+++ b/sdk/identity/identity/test/authTestUtils.ts
@@ -111,6 +111,39 @@ export function assertClientCredentials(
   }
 }
 
+export function assertClientUsernamePassword(
+  authRequest: WebResource,
+  expectedTenantId: string,
+  expectedClientId: string,
+  expectedUsername: string,
+  expectedPassword: string
+): void {
+  if (!authRequest) {
+    assert.fail("No authentication request was intercepted");
+  } else {
+    assert.strictEqual(
+      authRequest.url.startsWith(`https://authority/${expectedTenantId}`),
+      true,
+      "Request body doesn't contain expected tenantId"
+    );
+    assert.strictEqual(
+      authRequest.body.indexOf(`client_id=${expectedClientId}`) > -1,
+      true,
+      "Request body doesn't contain expected clientId"
+    );
+    assert.strictEqual(
+      authRequest.body.indexOf(`username=${expectedUsername}`) > -1,
+      true,
+      "Request body doesn't contain expected username"
+    );
+    assert.strictEqual(
+      authRequest.body.indexOf(`password=${expectedPassword}`) > -1,
+      true,
+      "Request body doesn't contain expected password"
+    );
+  }
+}
+
 // Node's `assert.rejects` doesn't appear until 8.13.0 so we'll
 // use our own simple implementation here
 export async function assertRejects(

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -2,8 +2,13 @@
 // Licensed under the MIT License.
 
 import assert from "assert";
+import path from "path";
 import { EnvironmentCredential } from "../../src";
-import { MockAuthHttpClient, assertClientCredentials } from "../authTestUtils";
+import {
+  MockAuthHttpClient,
+  assertClientCredentials,
+  assertClientUsernamePassword
+} from "../authTestUtils";
 import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 
 describe("EnvironmentCredential", function() {
@@ -23,6 +28,54 @@ describe("EnvironmentCredential", function() {
 
     const authRequest = mockHttpClient.requests[0];
     assertClientCredentials(authRequest, "tenant", "client", "secret");
+  });
+
+  it("finds and uses client certificate path environment variables", async () => {
+    process.env.AZURE_TENANT_ID = "tenant";
+    process.env.AZURE_CLIENT_ID = "client";
+    process.env.AZURE_CLIENT_CERTIFICATE_PATH = path.resolve(
+      __dirname,
+      "../test/azure-identity-test.crt"
+    );
+
+    const mockHttpClient = new MockAuthHttpClient();
+
+    const credential = new EnvironmentCredential(mockHttpClient.identityClientOptions);
+    await credential.getToken("scope");
+
+    delete process.env.AZURE_TENANT_ID;
+    delete process.env.AZURE_CLIENT_ID;
+    delete process.env.AZURE_CLIENT_CERTIFICATE_PATH;
+
+    assert.strictEqual(
+      (credential as any)._credential.certificateThumbprint,
+      "47080F3BAA6BF8DF068531106FBCF2DC6E5F6919"
+    );
+
+    assert.strictEqual(
+      (credential as any)._credential.certificateX5t,
+      "RwgPO6pr+N8GhTEQb7zy3G5faRk="
+    );
+  });
+
+  it("finds and uses client username/password environment variables", async () => {
+    process.env.AZURE_TENANT_ID = "tenant";
+    process.env.AZURE_CLIENT_ID = "client";
+    process.env.AZURE_USERNAME = "user";
+    process.env.AZURE_PASSWORD = "password";
+
+    const mockHttpClient = new MockAuthHttpClient();
+
+    const credential = new EnvironmentCredential(mockHttpClient.identityClientOptions);
+    await credential.getToken("scope");
+
+    delete process.env.AZURE_TENANT_ID;
+    delete process.env.AZURE_CLIENT_ID;
+    delete process.env.AZURE_USERNAME;
+    delete process.env.AZURE_PASSWORD;
+
+    const authRequest = mockHttpClient.requests[0];
+    assertClientUsernamePassword(authRequest, "tenant", "client", "user", "password");
   });
 
   it("finds and uses client credential environment variables with tracing", async () => {


### PR DESCRIPTION
This adds support for loading the client certificate credential from a path given in the environment (AZURE_CLIENT_CERTIFICATE_PATH) as well as using the username/password given in the environment (AZURE_USERNAME / AZURE_PASSWORD).

Part of the implementation for https://github.com/Azure/azure-sdk-for-js/issues/5696.