### PR TITLE
[core-tracing] Allow tracing to be disabled by environment

### DIFF
--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -14,6 +14,11 @@ export function setTracer(tracer: Tracer) {
   cache.tracer = tracer;
 }
 
+function isBrowser() {
+  return typeof window !== "undefined";
+}
+const env = isBrowser() ? (window as any).__env__ : process.env;
+
 /**
  * Retrieves the active tracer, or returns a
  * no-op implementation if one is not set.
@@ -23,7 +28,7 @@ export function getTracer() {
   if (!cache.tracer) {
     cache.tracer = new NoOpTracer();
   }
-  if (process && process.env && process.env.AZURE_TRACING_DISABLED) {
+  if (env.AZURE_TRACING_DISABLED) {
     cache.tracer = new NoOpTracer();
   }
   return cache.tracer;

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -23,5 +23,8 @@ export function getTracer() {
   if (!cache.tracer) {
     cache.tracer = new NoOpTracer();
   }
+  if (process.env.AZURE_TRACING_DISABLED) {
+    cache.tracer = new NoOpTracer();
+  }
   return cache.tracer;
 }

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -23,7 +23,7 @@ export function getTracer() {
   if (!cache.tracer) {
     cache.tracer = new NoOpTracer();
   }
-  if (process.env.AZURE_TRACING_DISABLED) {
+  if (process && process.env && process.env.AZURE_TRACING_DISABLED) {
     cache.tracer = new NoOpTracer();
   }
   return cache.tracer;


### PR DESCRIPTION
This allows tracing to be disabled via the AZURE_TRACING_DISABLED environment variable.

Part of the implementation for #5696.