### PR TITLE
[Storage][Blob] Containeritems empty

### DIFF
--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -642,6 +642,8 @@ export class BlobServiceClient extends StorageClient {
     if (!!marker || marker === undefined) {
       do {
         listContainersSegmentResponse = await this.listContainersSegment(marker, options);
+        listContainersSegmentResponse.containerItems =
+          listContainersSegmentResponse.containerItems || [];
         marker = listContainersSegmentResponse.continuationToken;
         yield await listContainersSegmentResponse;
       } while (marker);


### PR DESCRIPTION
Related to #5716

It seems like we are getting containerItems as an empty string rather than as empty array as [defined in the types](https://github.com/Azure/azure-sdk-for-js/blob/0b10e832d87807d7d0a58dcbb1b57b819417a2ea/sdk/storage/storage-blob/src/generated/src/models/index.ts#L314)

We seem to be getting the string from a layer below us, since there is no manipulation on our side. I'm investigating where the empty string is actually coming from and if there is a better way to handle this. Meanwhile this is a potential fix on our side. This fix will probably need to be replicated in queue and add tests to cover this scenario

@HarshaNalluru, @jeremymeng , @ramya-rao-a  any thoughts?