### PR TITLE
Fix log issue in core-http

### DIFF
--- a/sdk/core/core-http/lib/coreHttp.ts
+++ b/sdk/core/core-http/lib/coreHttp.ts
@@ -40,7 +40,7 @@ export {
   BearerTokenAuthenticationPolicy,
   bearerTokenAuthenticationPolicy
 } from "./policies/bearerTokenAuthenticationPolicy";
-export { LogPolicyOptions, LoggingOptions, logPolicy } from "./policies/logPolicy";
+export { LogPolicyOptions, logPolicy } from "./policies/logPolicy";
 export {
   BaseRequestPolicy,
   RequestPolicy,
@@ -55,7 +55,11 @@ export { getDefaultProxySettings, proxyPolicy } from "./policies/proxyPolicy";
 export { redirectPolicy, RedirectOptions } from "./policies/redirectPolicy";
 export { keepAlivePolicy, KeepAliveOptions } from "./policies/keepAlivePolicy";
 export { signingPolicy } from "./policies/signingPolicy";
-export { userAgentPolicy, getDefaultUserAgentValue, UserAgentOptions } from "./policies/userAgentPolicy";
+export {
+  userAgentPolicy,
+  getDefaultUserAgentValue,
+  UserAgentOptions
+} from "./policies/userAgentPolicy";
 export { deserializationPolicy, deserializeResponseBody } from "./policies/deserializationPolicy";
 export { tracingPolicy } from "./policies/tracingPolicy";
 export {

--- a/sdk/core/core-http/lib/pipelineOptions.ts
+++ b/sdk/core/core-http/lib/pipelineOptions.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 
 import { HttpClient } from "./httpClient";
-import { RetryOptions } from './policies/exponentialRetryPolicy';
-import { KeepAliveOptions } from './policies/keepAlivePolicy';
-import { RedirectOptions } from './policies/redirectPolicy';
-import { ProxyOptions } from './serviceClient';
-import { UserAgentOptions } from './policies/userAgentPolicy';
-import { DeserializationOptions } from './policies/deserializationPolicy';
-import { LoggingOptions } from './policies/logPolicy';
-import { RequestPolicyFactory } from './policies/requestPolicy';
+import { RetryOptions } from "./policies/exponentialRetryPolicy";
+import { KeepAliveOptions } from "./policies/keepAlivePolicy";
+import { RedirectOptions } from "./policies/redirectPolicy";
+import { ProxyOptions } from "./serviceClient";
+import { UserAgentOptions } from "./policies/userAgentPolicy";
+import { DeserializationOptions } from "./policies/deserializationPolicy";
+import { LogPolicyOptions } from "./policies/logPolicy";
+import { RequestPolicyFactory } from "./policies/requestPolicy";
 
 /**
  * Defines options that are used to configure the HTTP pipeline for
@@ -55,7 +55,9 @@ export interface PipelineOptions {
    * case scenarios. If the function does not modify the array of
    * RequestPolicyFactory, it must return the original array it was given.
    */
-  updatePipelinePolicies?: (requestPolicyFactories: RequestPolicyFactory[]) => RequestPolicyFactory[];
+  updatePipelinePolicies?: (
+    requestPolicyFactories: RequestPolicyFactory[]
+  ) => RequestPolicyFactory[];
 }
 
 /**
@@ -71,5 +73,5 @@ export interface InternalPipelineOptions extends PipelineOptions {
   /**
    * Options to configure request/response logging.
    */
-  loggingOptions?: LoggingOptions;
+  loggingOptions?: LogPolicyOptions;
 }

--- a/sdk/core/core-http/lib/policies/logPolicy.ts
+++ b/sdk/core/core-http/lib/policies/logPolicy.ts
@@ -11,7 +11,7 @@ import {
   RequestPolicyOptions
 } from "./requestPolicy";
 import { Debugger } from "@azure/logger";
-import { logger as coreLogger, logger } from "../log";
+import { logger as coreLogger } from "../log";
 
 export interface LogPolicyOptions {
   /**
@@ -36,12 +36,12 @@ export interface LoggingOptions {
   /**
    * The Debugger (logger) instance to use for writing pipeline logs.
    */
-  logger?: Debugger,
+  logger?: Debugger;
 
   /**
    * Options to pass to the logPolicy factory.
    */
-  logPolicyOptions?: LogPolicyOptions
+  logPolicyOptions?: LogPolicyOptions;
 }
 
 const RedactedString = "REDACTED";
@@ -72,31 +72,33 @@ const defaultAllowedHeaderNames = [
   "User-Agent"
 ];
 
-const defaultAllowedQueryParameters: string[] = [
-  "api-version"
-];
+const defaultAllowedQueryParameters: string[] = ["api-version"];
 
 export const DefaultLoggingOptions: LoggingOptions = {
   logger: undefined,
   logPolicyOptions: {
-    allowedHeaderNames: [],      // These are empty lists because they are additive to
-    allowedQueryParameters: []   // the real defaultAllowed[HeaderNames|QueryParameters].
+    allowedHeaderNames: [], // These are empty lists because they are additive to
+    allowedQueryParameters: [] // the real defaultAllowed[HeaderNames|QueryParameters].
   }
-}
+};
 
 export function logPolicy(
-  logger: any = coreLogger.info.bind(coreLogger),
-  logOptions: LogPolicyOptions = {}
+  loggingOptions: LoggingOptions = DefaultLoggingOptions
 ): RequestPolicyFactory {
   return {
     create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
-      return new LogPolicy(nextPolicy, options, logger, logOptions);
+      return new LogPolicy(
+        nextPolicy,
+        options,
+        loggingOptions.logger,
+        loggingOptions.logPolicyOptions
+      );
     }
   };
 }
 
 export class LogPolicy extends BaseRequestPolicy {
-  logger?: any;
+  logger: Debugger;
 
   public allowedHeaderNames: Set<string>;
   public allowedQueryParameters: Set<string>;
@@ -104,7 +106,7 @@ export class LogPolicy extends BaseRequestPolicy {
   constructor(
     nextPolicy: RequestPolicy,
     options: RequestPolicyOptions,
-    logger: any = console.log,
+    logger: Debugger = coreLogger.info,
     { allowedHeaderNames = [], allowedQueryParameters = [] }: LogPolicyOptions = {}
   ) {
     super(nextPolicy, options);
@@ -125,7 +127,7 @@ export class LogPolicy extends BaseRequestPolicy {
   }
 
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
-    if (!logger.info.enabled) return this._nextPolicy.sendRequest(request);
+    if (!this.logger.enabled) return this._nextPolicy.sendRequest(request);
 
     this.logRequest(request);
     return this._nextPolicy.sendRequest(request).then((response) => this.logResponse(response));

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -6,7 +6,7 @@ import { DefaultHttpClient } from "./defaultHttpClient";
 import { HttpClient } from "./httpClient";
 import { HttpOperationResponse, RestResponse } from "./httpOperationResponse";
 import { HttpPipelineLogger } from "./httpPipelineLogger";
-import { logPolicy, DefaultLoggingOptions, LoggingOptions } from "./policies/logPolicy";
+import { logPolicy, LogPolicyOptions } from "./policies/logPolicy";
 import { OperationArguments } from "./operationArguments";
 import {
   getPathStringFromParameter,
@@ -674,8 +674,7 @@ export function createPipelineFromOptions(
     ...pipelineOptions.deserializationOptions
   };
 
-  const loggingOptions: LoggingOptions = {
-    ...DefaultLoggingOptions,
+  const loggingOptions: LogPolicyOptions = {
     ...pipelineOptions.loggingOptions
   };
 

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -6,7 +6,7 @@ import { DefaultHttpClient } from "./defaultHttpClient";
 import { HttpClient } from "./httpClient";
 import { HttpOperationResponse, RestResponse } from "./httpOperationResponse";
 import { HttpPipelineLogger } from "./httpPipelineLogger";
-import { logPolicy, DefaultLoggingOptions } from "./policies/logPolicy";
+import { logPolicy, DefaultLoggingOptions, LoggingOptions } from "./policies/logPolicy";
 import { OperationArguments } from "./operationArguments";
 import {
   getPathStringFromParameter,
@@ -25,7 +25,7 @@ import { generateClientRequestIdPolicy } from "./policies/generateClientRequestI
 import {
   userAgentPolicy,
   getDefaultUserAgentHeaderName,
-  getDefaultUserAgentValue,
+  getDefaultUserAgentValue
 } from "./policies/userAgentPolicy";
 import { redirectPolicy, DefaultRedirectOptions } from "./policies/redirectPolicy";
 import {
@@ -49,9 +49,9 @@ import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
 import { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 import { signingPolicy } from "./policies/signingPolicy";
 import { logger } from "./log";
-import { InternalPipelineOptions } from './pipelineOptions';
-import { DefaultKeepAliveOptions, keepAlivePolicy } from './policies/keepAlivePolicy';
-import { tracingPolicy } from './policies/tracingPolicy';
+import { InternalPipelineOptions } from "./pipelineOptions";
+import { DefaultKeepAliveOptions, keepAlivePolicy } from "./policies/keepAlivePolicy";
+import { tracingPolicy } from "./policies/tracingPolicy";
 
 /**
  * Options to configure a proxy for outgoing requests (Node.js only).
@@ -460,16 +460,14 @@ export class ServiceClient {
         sendRequestError = error;
       }
       if (sendRequestError) {
-        if (sendRequestError.response){
+        if (sendRequestError.response) {
           sendRequestError.details = flattenResponse(
             sendRequestError.response,
             operationSpec.responses[sendRequestError.statusCode] ||
               operationSpec.responses["default"]
           );
         }
-        result = Promise.reject(
-          sendRequestError
-        );
+        result = Promise.reject(sendRequestError);
       } else {
         result = Promise.resolve(
           flattenResponse(rawResponse!, operationSpec.responses[rawResponse!.status])
@@ -625,7 +623,7 @@ function createDefaultRequestPolicyFactories(
     factories.push(proxyPolicy(proxySettings));
   }
 
-  factories.push(logPolicy(logger.info, {}));
+  factories.push(logPolicy({ logger: logger.info }));
 
   return factories;
 }
@@ -633,7 +631,7 @@ function createDefaultRequestPolicyFactories(
 export function createPipelineFromOptions(
   pipelineOptions: InternalPipelineOptions,
   authPolicyFactory?: RequestPolicyFactory
-) : ServiceClientOptions {
+): ServiceClientOptions {
   let requestPolicyFactories: RequestPolicyFactory[] = [];
 
   let userAgentValue = undefined;
@@ -668,9 +666,7 @@ export function createPipelineFromOptions(
 
   const proxySettings = pipelineOptions.proxyOptions || getDefaultProxySettings();
   if (isNode && proxySettings) {
-    requestPolicyFactories.push(
-      proxyPolicy(proxySettings)
-    )
+    requestPolicyFactories.push(proxyPolicy(proxySettings));
   }
 
   const deserializationOptions = {
@@ -678,7 +674,7 @@ export function createPipelineFromOptions(
     ...pipelineOptions.deserializationOptions
   };
 
-  const loggingOptions = {
+  const loggingOptions: LoggingOptions = {
     ...DefaultLoggingOptions,
     ...pipelineOptions.loggingOptions
   };
@@ -696,24 +692,17 @@ export function createPipelineFromOptions(
       retryOptions.retryDelayInMs,
       retryOptions.maxRetryDelayInMs
     )
-  )
+  );
 
   if (redirectOptions.handleRedirects) {
-    requestPolicyFactories.push(
-      redirectPolicy(redirectOptions.maxRetries)
-    );
+    requestPolicyFactories.push(redirectPolicy(redirectOptions.maxRetries));
   }
 
   if (authPolicyFactory) {
     requestPolicyFactories.push(authPolicyFactory);
   }
 
-  requestPolicyFactories.push(
-    logPolicy(
-      loggingOptions.logger,
-      loggingOptions.logPolicyOptions
-    )
-  );
+  requestPolicyFactories.push(logPolicy(loggingOptions));
 
   if (pipelineOptions.updatePipelinePolicies) {
     // If the update function throws an exception, let it bubble up.
@@ -725,7 +714,6 @@ export function createPipelineFromOptions(
     requestPolicyFactories
   };
 }
-
 
 export type PropertyParent = { [propertyName: string]: any };
 

--- a/sdk/core/core-http/test/logFilterTests.ts
+++ b/sdk/core/core-http/test/logFilterTests.ts
@@ -7,7 +7,7 @@ import { HttpOperationResponse } from "../lib/httpOperationResponse";
 import { LogPolicy } from "../lib/policies/logPolicy";
 import { RequestPolicy, RequestPolicyOptions } from "../lib/policies/requestPolicy";
 import { WebResource } from "../lib/webResource";
-import { getLogLevel, setLogLevel, AzureLogLevel } from "@azure/logger";
+import { getLogLevel, setLogLevel, AzureLogLevel, Debugger } from "@azure/logger";
 
 function getNextPolicy(responseHeaders?: RawHttpHeaders): RequestPolicy {
   return {
@@ -31,9 +31,17 @@ function assertLog(
 ): void {
   let output = "";
 
-  const logger = (message: string): void => {
+  const loggerFn = (message: string): void => {
     output += message + "\n";
   };
+
+  const logger: Debugger = Object.assign(loggerFn, {
+    enabled: true,
+    destroy: () => true,
+    namespace: "test",
+    extend: () => logger,
+    log: () => {}
+  });
 
   const options = {
     allowedHeaderNames: ["x-ms-safe-header"],

--- a/sdk/core/core-http/test/logFilterTests.ts
+++ b/sdk/core/core-http/test/logFilterTests.ts
@@ -4,7 +4,7 @@
 import { assert } from "chai";
 import { HttpHeaders, RawHttpHeaders } from "../lib/httpHeaders";
 import { HttpOperationResponse } from "../lib/httpOperationResponse";
-import { LogPolicy } from "../lib/policies/logPolicy";
+import { LogPolicy, LogPolicyOptions } from "../lib/policies/logPolicy";
 import { RequestPolicy, RequestPolicyOptions } from "../lib/policies/requestPolicy";
 import { WebResource } from "../lib/webResource";
 import { getLogLevel, setLogLevel, AzureLogLevel, Debugger } from "@azure/logger";
@@ -43,17 +43,13 @@ function assertLog(
     log: () => {}
   });
 
-  const options = {
+  const options: LogPolicyOptions = {
+    logger,
     allowedHeaderNames: ["x-ms-safe-header"],
     allowedQueryParameters: ["api-version"]
   };
 
-  const lf = new LogPolicy(
-    getNextPolicy(responseHeaders),
-    new RequestPolicyOptions(),
-    logger,
-    options
-  );
+  const lf = new LogPolicy(getNextPolicy(responseHeaders), new RequestPolicyOptions(), options);
 
   lf.sendRequest(request)
     .then(() => {


### PR DESCRIPTION
* Don't clone the log function with .bind(), since we later check `logger.enabled`
* Minor refactor to have `logPolicy` take `LoggingOptions` directly.
* Tighten some typings.
* Prettier did some minor formatting cleanup

Fixes #5744