### PR TITLE
Revert amqp-common update

### DIFF
--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -60,7 +60,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/amqp-common": "^1.0.0-preview.6",
+    "@azure/amqp-common": "^1.0.0-preview.5",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "async-lock": "^1.1.3",
     "debug": "^3.1.0",


### PR DESCRIPTION
In #5520, we made an update to amqp-common which was not required to fix the bug at hand.
This PR reverts that change to keep the next changes minimal and to keep rush happy as it cannot handle version mismatches (service bus uses version 5 of amqp-common in that branch) 