### PR TITLE
[core-http] Normalize casing of allowed headers and query params

### DIFF
--- a/sdk/core/core-http/lib/policies/logPolicy.ts
+++ b/sdk/core/core-http/lib/policies/logPolicy.ts
@@ -98,8 +98,8 @@ export class LogPolicy extends BaseRequestPolicy {
       ? defaultAllowedQueryParameters.concat(allowedQueryParameters)
       : defaultAllowedQueryParameters;
 
-    this.allowedHeaderNames = new Set(allowedHeaderNames);
-    this.allowedQueryParameters = new Set(allowedQueryParameters);
+    this.allowedHeaderNames = new Set(allowedHeaderNames.map(n => n.toLowerCase()));
+    this.allowedQueryParameters = new Set(allowedQueryParameters.map(p => p.toLowerCase()));
   }
 
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
@@ -155,7 +155,7 @@ export class LogPolicy extends BaseRequestPolicy {
     const sanitized: { [s: string]: string } = {};
 
     for (const k of Object.keys(value)) {
-      if (allowedKeys.has(k)) {
+      if (allowedKeys.has(k.toLowerCase())) {
         sanitized[k] = accessor(value, k);
       } else {
         sanitized[k] = RedactedString;
@@ -179,7 +179,7 @@ export class LogPolicy extends BaseRequestPolicy {
 
     const query = URLQuery.parse(queryString);
     for (const k of query.keys()) {
-      if (!this.allowedQueryParameters.has(k)) {
+      if (!this.allowedQueryParameters.has(k.toLowerCase())) {
         query.set(k, RedactedString);
       }
     }

--- a/sdk/core/core-http/test/logFilterTests.ts
+++ b/sdk/core/core-http/test/logFilterTests.ts
@@ -45,7 +45,7 @@ function assertLog(
 
   const options: LogPolicyOptions = {
     logger,
-    allowedHeaderNames: ["x-ms-safe-header"],
+    allowedHeaderNames: ["Capitalized-Header", "x-ms-safe-header"],
     allowedQueryParameters: ["api-version"]
   };
 
@@ -124,6 +124,33 @@ Headers: {
       "x-ms-oh-noes": ":-p"
     });
   });
+
+  it("redacts request headers with different casing", (done) => {
+    const expected = `Request: {
+  "url": "https://foo.com",
+  "method": "PUT",
+  "headers": {
+    "_headersMap": {
+      "capitalized-header": "Don't redact me, bro",
+      "x-ms-safe-header": "It me"
+    }
+  },
+  "withCredentials": false,
+  "timeout": 0
+}
+Response status code: 200
+Headers: {
+  "_headersMap": {}
+}
+`;
+
+    const request = new WebResource("https://foo.com", "PUT", { a: 1 }, undefined, {
+      "Capitalized-Header": "Don't redact me, bro",
+      "x-ms-safe-header": "It me",
+    });
+    assertLog(request, expected, done);
+  });
+
 
   it("redacts query parameters in the query field", (done) => {
     const expected = `Request: {


### PR DESCRIPTION
This change fixes an issue I found while working on PR https://github.com/Azure/azure-sdk-for-js/pull/5636 where the casing of allowed header names and query parameters affected whether `logPolicy` actually allowed them through in the sanitization phase.  In other words, a header name cased as `Accept` would not be considered the same as the `accept` that shows up in the actual headers object in the `WebResource`.

For example, here's a snippet from `@azure/storage-file` logs before this change (pay attention to `date` and `etag` headers):

```
azure:storage-file:info Headers: {
  "_headersMap": {
    "content-length": "REDACTED",
    "date": "REDACTED",
    "etag": "REDACTED",
    "last-modified": "REDACTED",
    "server": "REDACTED",
    "x-ms-client-request-id": "7ae3e068-1c2f-42da-8196-90e51755a5a2",
    "x-ms-file-attributes": "Directory",
    "x-ms-file-change-time": "2019-10-23T21:43:36.0934402Z",
    "x-ms-file-creation-time": "2019-10-23T21:43:36.0934402Z",
    "x-ms-file-id": "13835128424026341376",
    "x-ms-file-last-write-time": "2019-10-23T21:43:36.0934402Z",
    "x-ms-file-parent-id": "0",
    "x-ms-file-permission-key": "REDACTED",
    "x-ms-request-id": "1617afd8-701a-0002-17ea-893a93000000",
    "x-ms-request-server-encrypted": "true",
    "x-ms-version": "2019-02-02"
  }
}
```

Here's an equivalent log after this change:

```
azure:storage-file:info Headers: {
  "_headersMap": {
    "content-length": "0",
    "date": "Wed, 23 Oct 2019 21:57:26 GMT",
    "etag": "\"0x8D75803FE20F0D4\"",
    "last-modified": "Wed, 23 Oct 2019 21:57:26 GMT",
    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
    "x-ms-client-request-id": "2948e28f-ed20-4a77-9de4-2c66c4c56f93",
    "x-ms-file-attributes": "Directory",
    "x-ms-file-change-time": "2019-10-23T21:57:26.7932372Z",
    "x-ms-file-creation-time": "2019-10-23T21:57:26.7932372Z",
    "x-ms-file-id": "13835128424026341376",
    "x-ms-file-last-write-time": "2019-10-23T21:57:26.7932372Z",
    "x-ms-file-parent-id": "0",
    "x-ms-file-permission-key": "REDACTED",
    "x-ms-request-id": "548990d0-f01a-00f6-49ec-891f7f000000",
    "x-ms-request-server-encrypted": "true",
    "x-ms-version": "2019-02-02"
  }
}
```