### PR TITLE
[Storage] `fs.stat` works only in node environment

### DIFF
--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -3,6 +3,7 @@
 
 import * as fs from "fs";
 import * as util from "util";
+import { isNode } from "@azure/core-http";
 
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
@@ -181,4 +182,4 @@ export async function readStreamToLocalFile(
  *
  * Promisified version of fs.stat().
  */
-export const fsStat = util.promisify(fs.stat);
+export const fsStat = util.promisify(isNode ? fs.stat : function stat() {});

--- a/sdk/storage/storage-file/ChangeLog.md
+++ b/sdk/storage/storage-file/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019.11 12.0.0-preview.6
+
+- Bug Fix - Previous versions of `@azure/storage-file` library failed for the react-apps because of the usage of `fs.stat` method which is not available in browsers. The issue is fixed in this new release.
+
 ## 2019.10 12.0.0-preview.5
 
 - [Breaking] `IPRange` is renamed to `SasIPRange`. [PR #5551](https://github.com/Azure/azure-sdk-for-js/pull/5551)

--- a/sdk/storage/storage-file/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file/src/utils/utils.node.ts
@@ -3,6 +3,7 @@
 
 import * as fs from "fs";
 import * as util from "util";
+import { isNode } from "@azure/core-http";
 
 /**
  * Reads a readable stream into buffer. Fill the buffer from offset to end.
@@ -130,4 +131,4 @@ export async function readStreamToLocalFile(rs: NodeJS.ReadableStream, file: str
  *
  * Promisified version of fs.stat().
  */
-export const fsStat = util.promisify(fs.stat);
+export const fsStat = util.promisify(isNode ? fs.stat : function stat() {});


### PR DESCRIPTION
## Description
- shimming in browsers in rollup config wasn't enough for fs.stat 
- utils.node.js file is being loaded in the browser for react apps (dist-esm folder is getting loaded for the react-app as opposed to the browser bundle)
### Error
- **utils.node.js** file is being loaded in the browser for react apps
![image](https://user-images.githubusercontent.com/10452642/67443956-e0294000-f5bb-11e9-87ed-261e36f2fee0.png)

- Error -  `fs.stat` is not allowed in the browser
![image](https://user-images.githubusercontent.com/10452642/67443465-da325f80-f5b9-11e9-864a-869bbf60a009.png)
- Usage of `fs.stat` in **utils.node.js** file
![image](https://user-images.githubusercontent.com/10452642/67443944-d0a9f700-f5bb-11e9-8982-afc22f84f90f.png)

## Fix
This PR comes up with a simple fix to leverage `fs.stat` only in the node environment.
```typescript
util.promisify(isNode ? fs.stat : function stat() {})
```

After this fix, 
- `@azure/storage-file` library works fine in the react-app.
- `@azure/storage-blob` library has circular dependencies which break the react-app(fixing that in a separate PR),
- `@azure/storage-queue` library doesn't have this issue.

## References
Fixes #5621, partially fixes #4890 