### PR TITLE
[storage] fix logging policy

### DIFF
--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -205,11 +205,11 @@ export function newPipeline(
     new BrowserPolicyFactory(),
     deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer
     new RetryPolicyFactory(pipelineOptions.retryOptions),
-    logPolicy(
-      logger.info, {
-        allowedHeaderNames: StorageBlobLoggingAllowedHeaderNames,
-        allowedQueryParameters: StorageBlobLoggingAllowedQueryParameters
-      })
+    logPolicy({
+      logger: logger.info,
+      allowedHeaderNames: StorageBlobLoggingAllowedHeaderNames,
+      allowedQueryParameters: StorageBlobLoggingAllowedQueryParameters
+    })
   ];
 
   if (isNode) {

--- a/sdk/storage/storage-file/src/Pipeline.ts
+++ b/sdk/storage/storage-file/src/Pipeline.ts
@@ -198,11 +198,11 @@ export function newPipeline(
     new BrowserPolicyFactory(),
     deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer
     new RetryPolicyFactory(pipelineOptions.retryOptions),
-    logPolicy(
-      logger.info, {
-        allowedHeaderNames: StorageFileLoggingAllowedHeaderNames,
-        allowedQueryParameters: StorageFileLoggingAllowedQueryParameters
-      })
+    logPolicy({
+      logger: logger.info,
+      allowedHeaderNames: StorageFileLoggingAllowedHeaderNames,
+      allowedQueryParameters: StorageFileLoggingAllowedQueryParameters
+    })
   ];
 
   if (isNode) {

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -208,11 +208,11 @@ export function newPipeline(
     new BrowserPolicyFactory(),
     deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer
     new RetryPolicyFactory(pipelineOptions.retryOptions),
-    logPolicy(
-      logger.info, {
-        allowedHeaderNames: StorageQueueLoggingAllowedHeaderNames,
-        allowedQueryParameters: StorageQueueLoggingAllowedQueryParameters
-      })
+    logPolicy({
+      logger: logger.info,
+      allowedHeaderNames: StorageQueueLoggingAllowedHeaderNames,
+      allowedQueryParameters: StorageQueueLoggingAllowedQueryParameters
+    })
   ];
 
   if (isNode) {


### PR DESCRIPTION
#5751 changed the `LogPolicy` to accept a single parameter instead of 2. The logger is now part of the options passed into the policy, rather than a separate param.