### PR TITLE
Move SpanOptions inside OperationOptions

### DIFF
--- a/sdk/core/core-http/lib/operationOptions.ts
+++ b/sdk/core/core-http/lib/operationOptions.ts
@@ -17,7 +17,7 @@ export interface OperationOptions {
   /**
    * Options used when tracing is enabled.
    */
-  tracing?: OperationTracingOptions;
+  tracingOptions?: OperationTracingOptions;
 }
 
 export interface OperationTracingOptions {
@@ -58,7 +58,7 @@ export interface OperationRequestOptions {
 export function operationOptionsToRequestOptionsBase<T extends OperationOptions>(
   opts: T
 ): RequestOptionsBase {
-  const { requestOptions, tracing, ...additionalOptions } = opts;
+  const { requestOptions, tracingOptions, ...additionalOptions } = opts;
 
   let result: RequestOptionsBase = additionalOptions;
 
@@ -66,8 +66,8 @@ export function operationOptionsToRequestOptionsBase<T extends OperationOptions>
     result = { ...result, ...requestOptions };
   }
 
-  if (tracing) {
-    result.spanOptions = tracing.spanOptions;
+  if (tracingOptions) {
+    result.spanOptions = tracingOptions.spanOptions;
   }
 
   return result;

--- a/sdk/core/core-http/lib/operationOptions.ts
+++ b/sdk/core/core-http/lib/operationOptions.ts
@@ -15,7 +15,14 @@ export interface OperationOptions {
    */
   requestOptions?: OperationRequestOptions;
   /**
-   * Options used to create a span when tracing is enabled.
+   * Options used when tracing is enabled.
+   */
+  tracing?: OperationTracingOptions;
+}
+
+export interface OperationTracingOptions {
+  /**
+   * OpenTelemetry SpanOptions used to create a span when tracing is enabled.
    */
   spanOptions?: SpanOptions;
 }
@@ -48,17 +55,20 @@ export interface OperationRequestOptions {
  *
  * @param opts OperationOptions object to convert to RequestOptionsBase
  */
-export function operationOptionsToRequestOptionsBase<T extends OperationOptions> (
+export function operationOptionsToRequestOptionsBase<T extends OperationOptions>(
   opts: T
-): Omit<T, "requestOptions"> &
-  OperationOptions["requestOptions"] &
-  RequestOptionsBase {
-  if (opts.requestOptions) {
-    const newOpts = { ...opts, ...opts.requestOptions };
-    delete newOpts.requestOptions;
+): RequestOptionsBase {
+  const { requestOptions, tracing, ...additionalOptions } = opts;
 
-    return newOpts;
+  let result: RequestOptionsBase = additionalOptions;
+
+  if (requestOptions) {
+    result = { ...result, ...requestOptions };
   }
 
-  return opts;
+  if (tracing) {
+    result.spanOptions = tracing.spanOptions;
+  }
+
+  return result;
 }

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -63,8 +63,7 @@ export class CryptographyClient {
 }
 
 // @public
-export interface CryptographyOptions {
-    requestOptions?: coreHttp.RequestOptionsBase;
+export interface CryptographyOptions extends coreHttp.OperationOptions {
 }
 
 // @public

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -303,19 +303,15 @@ export class KeyClient {
   ): Promise<KeyVaultKey> {
     if (options) {
       const requestOptions = operationOptionsToRequestOptionsBase(options);
-      const unflattenedProperties = {
-        enabled: options.enabled,
-        notBefore: options.notBefore,
-        expires: options.expiresOn
-      };
+      const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
-        ...requestOptions,
-        keyAttributes: unflattenedProperties
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires
+        }
       };
-
-      delete unflattenedOptions.enabled;
-      delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expiresOn;
 
       const span = this.createSpan("createKey", unflattenedOptions);
 
@@ -356,19 +352,15 @@ export class KeyClient {
   public async createEcKey(name: string, options?: CreateEcKeyOptions): Promise<KeyVaultKey> {
     if (options) {
       const requestOptions = operationOptionsToRequestOptionsBase(options);
-      const unflattenedProperties = {
-        enabled: options.enabled,
-        notBefore: options.notBefore,
-        expires: options.expiresOn
-      };
+      const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
-        ...requestOptions,
-        keyAttributes: unflattenedProperties
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires
+        }
       };
-
-      delete unflattenedOptions.enabled;
-      delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expiresOn;
 
       const span = this.createSpan("createEcKey", unflattenedOptions);
 
@@ -409,19 +401,15 @@ export class KeyClient {
   public async createRsaKey(name: string, options?: CreateRsaKeyOptions): Promise<KeyVaultKey> {
     if (options) {
       const requestOptions = operationOptionsToRequestOptionsBase(options);
-      const unflattenedProperties = {
-        enabled: options.enabled,
-        notBefore: options.notBefore,
-        expires: options.expiresOn
-      };
+      const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
-        ...requestOptions,
-        keyAttributes: unflattenedProperties
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires
+        }
       };
-
-      delete unflattenedOptions.enabled;
-      delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expiresOn;
 
       const span = this.createSpan("createRsaKey", unflattenedOptions);
 
@@ -468,21 +456,22 @@ export class KeyClient {
   ): Promise<KeyVaultKey> {
     if (options) {
       const requestOptions = operationOptionsToRequestOptionsBase(options);
-      const unflattenedProperties = {
-        enabled: options.enabled,
-        notBefore: options.notBefore,
-        expires: options.expiresOn,
-        hsm: options.hardwareProtected
-      };
-
+      const {
+        enabled,
+        notBefore,
+        expiresOn: expires,
+        hardwareProtected: hsm,
+        ...remainingOptions
+      } = requestOptions;
       const unflattenedOptions = {
-        ...requestOptions,
-        keyAttributes: unflattenedProperties
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires,
+          hsm
+        }
       };
-      delete unflattenedOptions.enabled;
-      delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expiresOn;
-      delete unflattenedOptions.hardwareProtected;
 
       const span = this.createSpan("importKey", unflattenedOptions);
 
@@ -575,18 +564,15 @@ export class KeyClient {
   ): Promise<KeyVaultKey> {
     if (options) {
       const requestOptions = operationOptionsToRequestOptionsBase(options);
-      const unflattenedProperties = {
-        enabled: options.enabled,
-        notBefore: options.notBefore,
-        expires: options.expiresOn
-      };
+      const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
-        ...requestOptions,
-        keyAttributes: unflattenedProperties
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires
+        }
       };
-      delete unflattenedOptions.enabled;
-      delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expiresOn;
 
       const span = this.createSpan("updateKey", unflattenedOptions);
 

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -214,7 +214,7 @@ export class SecretClient {
       const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
         ...remainingOptions,
-        keyAttributes: {
+        secretAttributes: {
           enabled,
           notBefore,
           expires
@@ -318,7 +318,7 @@ export class SecretClient {
       const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
         ...remainingOptions,
-        keyAttributes: {
+        secretAttributes: {
           enabled,
           notBefore,
           expires

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -211,18 +211,15 @@ export class SecretClient {
     const requestOptions = operationOptionsToRequestOptionsBase(options);
 
     if (requestOptions) {
-      const unflattenedProperties = {
-        enabled: requestOptions.enabled,
-        notBefore: requestOptions.notBefore,
-        expires: requestOptions.expiresOn
-      };
+      const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
-        ...requestOptions,
-        secretAttributes: unflattenedProperties
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires
+        }
       };
-      delete unflattenedOptions.enabled;
-      delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expiresOn;
 
       const span = this.createSpan("setSecret", unflattenedOptions);
 
@@ -318,18 +315,15 @@ export class SecretClient {
     const requestOptions = operationOptionsToRequestOptionsBase(options);
 
     if (requestOptions) {
-      const unflattenedProperties = {
-        enabled: requestOptions.enabled,
-        notBefore: requestOptions.notBefore,
-        expires: requestOptions.expiresOn
-      };
+      const { enabled, notBefore, expiresOn: expires, ...remainingOptions } = requestOptions;
       const unflattenedOptions = {
-        ...requestOptions,
-        secretAttributes: unflattenedProperties
+        ...remainingOptions,
+        keyAttributes: {
+          enabled,
+          notBefore,
+          expires
+        }
       };
-      delete unflattenedOptions.enabled;
-      delete unflattenedOptions.notBefore;
-      delete unflattenedOptions.expiresOn;
 
       const span = this.createSpan("updateSecretProperties", unflattenedOptions);
 
@@ -628,7 +622,6 @@ export class SecretClient {
     continuationState: PageSettings,
     options: RequestOptionsBase = {}
   ): AsyncIterableIterator<SecretProperties[]> {
-
     if (continuationState.continuationToken == null) {
       const optionsComplete: KeyVaultClientGetSecretsOptionalParams = {
         maxresults: continuationState.maxPageSize,
@@ -669,11 +662,7 @@ export class SecretClient {
   ): AsyncIterableIterator<SecretProperties> {
     const f = {};
 
-    for await (const page of this.listPropertiesOfSecretVersionsPage(
-      secretName,
-      f,
-      options
-    )) {
+    for await (const page of this.listPropertiesOfSecretVersionsPage(secretName, f, options)) {
       for (const item of page) {
         yield item;
       }


### PR DESCRIPTION
 In order to make it more obvious that `SpanOptions` is about tracing, this change moves it under a new `tracing` property bag inside `OperationOptions`. This will also allow us to add additional tracing-related properties in the future that are not part of `SpanOptions`, which is defined by OpenTelemetry.

Fixes #5755 