### PR TITLE
[Storage] Rename NewPipelineOptions to StoragePipelineOptions

### DIFF
--- a/sdk/storage/storage-queue/review/storage-queue.api.md
+++ b/sdk/storage/storage-queue/review/storage-queue.api.md
@@ -252,19 +252,7 @@ export interface Metadata {
 }
 
 // @public
-export function newPipeline(credential: SharedKeyCredential | AnonymousCredential | TokenCredential, pipelineOptions?: NewPipelineOptions): Pipeline;
-
-// @public
-export interface NewPipelineOptions {
-    httpClient?: IHttpClient;
-    // Warning: (ae-forgotten-export) The symbol "KeepAliveOptions" needs to be exported by the entry point index.d.ts
-    keepAliveOptions?: KeepAliveOptions;
-    logger?: IHttpPipelineLogger;
-    // (undocumented)
-    proxy?: ProxySettings | string;
-    retryOptions?: RetryOptions;
-    telemetry?: TelemetryOptions;
-}
+export function newPipeline(credential: SharedKeyCredential | AnonymousCredential | TokenCredential, pipelineOptions?: StoragePipelineOptions): Pipeline;
 
 // @public
 export interface PeekedMessageItem {
@@ -301,8 +289,8 @@ export type QueueClearMessagesResponse = MessagesClearResponse;
 // 
 // @public
 export class QueueClient extends StorageClient {
-    constructor(connectionString: string, queueName: string, options?: NewPipelineOptions);
-    constructor(url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: NewPipelineOptions);
+    constructor(connectionString: string, queueName: string, options?: StoragePipelineOptions);
+    constructor(url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
     clearMessages(options?: QueueClearMessagesOptions): Promise<QueueClearMessagesResponse>;
     create(options?: QueueCreateOptions): Promise<QueueCreateResponse>;
@@ -479,11 +467,11 @@ export type QueueSendMessageResponse = {
 
 // @public
 export class QueueServiceClient extends StorageClient {
-    constructor(url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: NewPipelineOptions);
+    constructor(url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
     createQueue(queueName: string, options?: QueueCreateOptions): Promise<QueueCreateResponse>;
     deleteQueue(queueName: string, options?: QueueDeleteOptions): Promise<QueueDeleteResponse>;
-    static fromConnectionString(connectionString: string, options?: NewPipelineOptions): QueueServiceClient;
+    static fromConnectionString(connectionString: string, options?: StoragePipelineOptions): QueueServiceClient;
     getProperties(options?: ServiceGetPropertiesOptions): Promise<ServiceGetPropertiesResponse>;
     getQueueClient(queueName: string): QueueClient;
     getStatistics(options?: ServiceGetStatisticsOptions): Promise<ServiceGetStatisticsResponse>;
@@ -699,6 +687,18 @@ export interface SignedIdentifierModel {
 
 // @public (undocumented)
 export const StorageOAuthScopes: string | string[];
+
+// @public
+export interface StoragePipelineOptions {
+    httpClient?: IHttpClient;
+    // Warning: (ae-forgotten-export) The symbol "KeepAliveOptions" needs to be exported by the entry point index.d.ts
+    keepAliveOptions?: KeepAliveOptions;
+    logger?: IHttpPipelineLogger;
+    // (undocumented)
+    proxy?: ProxySettings | string;
+    retryOptions?: RetryOptions;
+    telemetry?: TelemetryOptions;
+}
 
 // @public
 export interface TelemetryOptions {

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -139,22 +139,22 @@ export class Pipeline {
  * Option interface for newPipeline() method.
  *
  * @export
- * @interface NewPipelineOptions
+ * @interface StoragePipelineOptions
  */
-export interface NewPipelineOptions {
+export interface StoragePipelineOptions {
   proxy?: ProxySettings | string;
   /**
    * Telemetry configures the built-in telemetry policy behavior.
    *
    * @type {TelemetryOptions}
-   * @memberof NewPipelineOptions
+   * @memberof StoragePipelineOptions
    */
   telemetry?: TelemetryOptions;
   /**
    * Configures the built-in retry policy behavior.
    *
    * @type {RetryOptions}
-   * @memberof NewPipelineOptions
+   * @memberof StoragePipelineOptions
    */
   retryOptions?: RetryOptions;
 
@@ -162,7 +162,7 @@ export interface NewPipelineOptions {
    * Keep alive configurations. Default keep-alive is enabled.
    *
    * @type {KeepAliveOptions}
-   * @memberof NewPipelineOptions
+   * @memberof StoragePipelineOptions
    */
   keepAliveOptions?: KeepAliveOptions;
 
@@ -170,14 +170,14 @@ export interface NewPipelineOptions {
    * Configures the HTTP pipeline logger.
    *
    * @type {IHttpPipelineLogger}
-   * @memberof NewPipelineOptions
+   * @memberof StoragePipelineOptions
    */
   logger?: IHttpPipelineLogger;
   /**
    * Configures the HTTP client to send requests and receive responses.
    *
    * @type {IHttpClient}
-   * @memberof NewPipelineOptions
+   * @memberof StoragePipelineOptions
    */
   httpClient?: IHttpClient;
 }
@@ -189,13 +189,13 @@ export interface NewPipelineOptions {
  * @param {SharedKeyCredential | AnonymousCredential | TokenCredential} credential Such as AnonymousCredential, SharedKeyCredential
  *                                                  or a TokenCredential from @azure/identity. If not specified,
  *                                                  AnonymousCredential is used.
- * @param {NewPipelineOptions} [pipelineOptions] Options.
+ * @param {StoragePipelineOptions} [pipelineOptions] Options.
  * @returns {Pipeline} A new Pipeline object.
  * @memberof Pipeline
  */
 export function newPipeline(
   credential: SharedKeyCredential | AnonymousCredential | TokenCredential,
-  pipelineOptions: NewPipelineOptions = {}
+  pipelineOptions: StoragePipelineOptions = {}
 ): Pipeline {
   // Order is important. Closer to the API at the top & closer to the network at the bottom.
   // The credential's policy factory must appear close to the wire so it can sign any

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -26,7 +26,7 @@ import {
 } from "./generatedModels";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { Messages, MessageId, Queue } from "./generated/src/operations";
-import { newPipeline, NewPipelineOptions, Pipeline } from "./Pipeline";
+import { newPipeline, StoragePipelineOptions, Pipeline } from "./Pipeline";
 import { StorageClient, CommonOptions } from "./StorageClient";
 import {
   appendToURLPath,
@@ -417,10 +417,10 @@ export class QueueClient extends StorageClient {
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
    * @param {string} queueName Queue name.
-   * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueClient
    */
-  constructor(connectionString: string, queueName: string, options?: NewPipelineOptions);
+  constructor(connectionString: string, queueName: string, options?: StoragePipelineOptions);
   /**
    * Creates an instance of QueueClient.
    *
@@ -431,13 +431,13 @@ export class QueueClient extends StorageClient {
    * @param {SharedKeyCredential | AnonymousCredential | TokenCredential} credential Such as AnonymousCredential, SharedKeyCredential
    *                                                  or a TokenCredential from @azure/identity. If not specified,
    *                                                  AnonymousCredential is used.
-   * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueClient
    */
   constructor(
     url: string,
     credential?: SharedKeyCredential | AnonymousCredential | TokenCredential,
-    options?: NewPipelineOptions
+    options?: StoragePipelineOptions
   );
   /**
    * Creates an instance of QueueClient.
@@ -459,7 +459,7 @@ export class QueueClient extends StorageClient {
       | TokenCredential
       | Pipeline
       | string,
-    options?: NewPipelineOptions
+    options?: StoragePipelineOptions
   ) {
     options = options || {};
     let pipeline: Pipeline;
@@ -473,14 +473,14 @@ export class QueueClient extends StorageClient {
       credentialOrPipelineOrQueueName instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipelineOrQueueName)
     ) {
-      // (url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: NewPipelineOptions)
+      // (url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
       url = urlOrConnectionString;
       pipeline = newPipeline(credentialOrPipelineOrQueueName, options);
     } else if (
       !credentialOrPipelineOrQueueName &&
       typeof credentialOrPipelineOrQueueName !== "string"
     ) {
-      // (url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: NewPipelineOptions)
+      // (url: string, credential?: SharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
       // The second paramter is undefined. Use anonymous credential.
       url = urlOrConnectionString;
       pipeline = newPipeline(new AnonymousCredential(), options);
@@ -488,7 +488,7 @@ export class QueueClient extends StorageClient {
       credentialOrPipelineOrQueueName &&
       typeof credentialOrPipelineOrQueueName === "string"
     ) {
-      // (connectionString: string, containerName: string, queueName: string, options?: NewPipelineOptions)
+      // (connectionString: string, containerName: string, queueName: string, options?: StoragePipelineOptions)
       const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
       if (extractedCreds.kind === "AccountConnString") {
         if (isNode) {

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -16,7 +16,7 @@ import {
 } from "./generatedModels";
 import { AbortSignalLike } from "@azure/abort-controller";
 import { Service } from "./generated/src/operations";
-import { newPipeline, NewPipelineOptions, Pipeline } from "./Pipeline";
+import { newPipeline, StoragePipelineOptions, Pipeline } from "./Pipeline";
 import { StorageClient, CommonOptions } from "./StorageClient";
 import "@azure/core-paging";
 import { PageSettings, PagedAsyncIterableIterator } from "@azure/core-paging";
@@ -158,13 +158,13 @@ export class QueueServiceClient extends StorageClient {
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
    * @returns {QueueServiceClient} A new QueueServiceClient object from the given connection string.
    * @memberof QueueServiceClient
    */
   public static fromConnectionString(
     connectionString: string,
-    options?: NewPipelineOptions
+    options?: StoragePipelineOptions
   ): QueueServiceClient {
     options = options || {};
     const extractedCreds = extractConnectionStringParts(connectionString);
@@ -208,13 +208,13 @@ export class QueueServiceClient extends StorageClient {
    * @param {SharedKeyCredential | AnonymousCredential | TokenCredential} credential Such as AnonymousCredential, SharedKeyCredential
    *                                                  or a TokenCredential from @azure/identity. If not specified,
    *                                                  AnonymousCredential is used.
-   * @param {NewPipelineOptions} [options] Options to configure the HTTP pipeline.
+   * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueServiceClient
    */
   constructor(
     url: string,
     credential?: SharedKeyCredential | AnonymousCredential | TokenCredential,
-    options?: NewPipelineOptions
+    options?: StoragePipelineOptions
   );
   /**
    * Creates an instance of QueueServiceClient.
@@ -230,7 +230,7 @@ export class QueueServiceClient extends StorageClient {
   constructor(
     url: string,
     credentialOrPipeline?: SharedKeyCredential | AnonymousCredential | TokenCredential | Pipeline,
-    options?: NewPipelineOptions
+    options?: StoragePipelineOptions
   ) {
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {


### PR DESCRIPTION
For consistency with Blob. This rename was missed from previous renames in Blob and File