### PR TITLE
[Storage][Blob] Remove HttpPipelineLogger and logging options

### DIFF
--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -40,7 +40,7 @@ describe("EnvironmentCredential", function() {
 
     const mockHttpClient = new MockAuthHttpClient();
 
-    const credential = new EnvironmentCredential(mockHttpClient.identityClientOptions);
+    const credential = new EnvironmentCredential(mockHttpClient.tokenCredentialOptions);
     await credential.getToken("scope");
 
     delete process.env.AZURE_TENANT_ID;
@@ -66,7 +66,7 @@ describe("EnvironmentCredential", function() {
 
     const mockHttpClient = new MockAuthHttpClient();
 
-    const credential = new EnvironmentCredential(mockHttpClient.identityClientOptions);
+    const credential = new EnvironmentCredential(mockHttpClient.tokenCredentialOptions);
     await credential.getToken("scope");
 
     delete process.env.AZURE_TENANT_ID;

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -319,6 +319,16 @@ export async function blobToString(blob: Blob): Promise<string> {
 
 A complete example of basic scenarios is at [samples/basic.ts](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob/samples/typescript/basic.ts).
 
+## Troubleshooting
+
+Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
+
+```javascript
+import { setLogLevel } from "@azure/logger";
+
+setLogLevel("info");
+```
+
 ## Authenticating with Azure Active Directory
 
 If you have [registered an application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) with an Azure Active Directory tenant, you can [assign it to an RBAC role](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad) in your Azure Storage account. This enables you to use the Azure.Identity library to authenticate with Azure Storage as shown in the [azureAdAuth.ts sample](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts).

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -319,44 +319,6 @@ export async function blobToString(blob: Blob): Promise<string> {
 
 A complete example of basic scenarios is at [samples/basic.ts](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob/samples/typescript/basic.ts).
 
-## Troubleshooting
-
-It could help diagnozing issues by turning on the console logging. Here's an example logger implementation. First, add a custom logger:
-
-```javascript
-class ConsoleHttpPipelineLogger {
-  constructor(minimumLogLevel) {
-    this.minimumLogLevel = minimumLogLevel;
-  }
-  log(logLevel, message) {
-    const logMessage = `${new Date().toISOString()} ${HttpPipelineLogLevel[logLevel]}: ${message}`;
-    switch (logLevel) {
-      case HttpPipelineLogLevel.ERROR:
-        console.error(logMessage);
-        break;
-      case HttpPipelineLogLevel.WARNING:
-        console.warn(logMessage);
-        break;
-      case HttpPipelineLogLevel.INFO:
-        console.log(logMessage);
-        break;
-    }
-  }
-}
-```
-
-Then when creating the `BlobServiceClient` instance, pass the logger in the options
-
-```javascript
-const blobServiceClient = new BlobServiceClient(
-  `https://${account}.blob.core.windows.net`,
-  sharedKeyCredential,
-  {
-    logger: new ConsoleHttpPipelineLogger(HttpPipelineLogLevel.INFO)
-  }
-);
-```
-
 ## Authenticating with Azure Active Directory
 
 If you have [registered an application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) with an Azure Active Directory tenant, you can [assign it to an RBAC role](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad) in your Azure Storage account. This enables you to use the Azure.Identity library to authenticate with Azure Storage as shown in the [azureAdAuth.ts sample](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts).

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -7,8 +7,6 @@ import {
   HttpClient as IHttpClient,
   HttpHeaders,
   HttpOperationResponse,
-  HttpPipelineLogger as IHttpPipelineLogger,
-  HttpPipelineLogLevel,
   HttpRequestBody,
   RequestPolicy,
   RequestPolicyFactory,
@@ -47,9 +45,7 @@ export {
   StorageOAuthScopes,
   deserializationPolicy,
   IHttpClient,
-  IHttpPipelineLogger,
   HttpHeaders,
-  HttpPipelineLogLevel,
   HttpRequestBody,
   HttpOperationResponse,
   WebResource,
@@ -65,13 +61,6 @@ export {
  * @interface PipelineOptions
  */
 export interface PipelineOptions {
-  /**
-   * Optional. Configures the HTTP pipeline logger.
-   *
-   * @type {IHttpPipelineLogger}
-   * @memberof PipelineOptions
-   */
-  logger?: IHttpPipelineLogger;
   /**
    * Optional. Configures the HTTP client to send requests and receive responses.
    *
@@ -129,7 +118,6 @@ export class Pipeline {
   public toServiceClientOptions(): ServiceClientOptions {
     return {
       httpClient: this.options.HTTPClient,
-      httpPipelineLogger: this.options.logger,
       requestPolicyFactories: this.factories
     };
   }
@@ -165,13 +153,6 @@ export interface StoragePipelineOptions {
    */
   keepAliveOptions?: KeepAliveOptions;
 
-  /**
-   * Configures the HTTP pipeline logger.
-   *
-   * @type {IHttpPipelineLogger}
-   * @memberof StoragePipelineOptions
-   */
-  logger?: IHttpPipelineLogger;
   /**
    * Configures the HTTP client to send requests and receive responses.
    *
@@ -229,7 +210,6 @@ export function newPipeline(
   );
 
   return new Pipeline(factories, {
-    HTTPClient: pipelineOptions.httpClient,
-    logger: pipelineOptions.logger
+    HTTPClient: pipelineOptions.httpClient
   });
 }

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -1,4 +1,3 @@
-import { HttpPipelineLogLevel, IHttpPipelineLogger } from "../../src/Pipeline";
 import { padStart } from "../../src/utils/utils.common";
 import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 
@@ -65,27 +64,6 @@ export function base64encode(content: string): string {
 
 export function base64decode(encodedString: string): string {
   return isBrowser() ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
-}
-
-export class ConsoleHttpPipelineLogger implements IHttpPipelineLogger {
-  constructor(public minimumLogLevel: HttpPipelineLogLevel) {}
-  public log(logLevel: HttpPipelineLogLevel, message: string): void {
-    const logMessage = `${new Date().toISOString()} ${HttpPipelineLogLevel[logLevel]}: ${message}`;
-    switch (logLevel) {
-      case HttpPipelineLogLevel.ERROR:
-        // tslint:disable-next-line:no-console
-        console.error(logMessage);
-        break;
-      case HttpPipelineLogLevel.WARNING:
-        // tslint:disable-next-line:no-console
-        console.warn(logMessage);
-        break;
-      case HttpPipelineLogLevel.INFO:
-        // tslint:disable-next-line:no-console
-        console.log(logMessage);
-        break;
-    }
-  }
 }
 
 type BlobMetadata = { [propertyName: string]: string };


### PR DESCRIPTION
`core-http` has new logging capabilities. Enable request/response logging by setting the AZURE_LOG_LEVEL environment variable or dynamically by importing `setLogLevel` from `@azure/logger` and calling it with a log level. Given this works across libraries, it seems like the preferable solution for customers.

TODO:
* [x] Add troubleshooting steps in the README.