### PR TITLE
[Storage][Blob] Storage PipelineOptions alignment

### DIFF
--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -319,44 +319,6 @@ export async function blobToString(blob: Blob): Promise<string> {
 
 A complete example of basic scenarios is at [samples/basic.ts](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob/samples/typescript/basic.ts).
 
-## Troubleshooting
-
-It could help diagnozing issues by turning on the console logging. Here's an example logger implementation. First, add a custom logger:
-
-```javascript
-class ConsoleHttpPipelineLogger {
-  constructor(minimumLogLevel) {
-    this.minimumLogLevel = minimumLogLevel;
-  }
-  log(logLevel, message) {
-    const logMessage = `${new Date().toISOString()} ${HttpPipelineLogLevel[logLevel]}: ${message}`;
-    switch (logLevel) {
-      case HttpPipelineLogLevel.ERROR:
-        console.error(logMessage);
-        break;
-      case HttpPipelineLogLevel.WARNING:
-        console.warn(logMessage);
-        break;
-      case HttpPipelineLogLevel.INFO:
-        console.log(logMessage);
-        break;
-    }
-  }
-}
-```
-
-Then when creating the `BlobServiceClient` instance, pass the logger in the options
-
-```javascript
-const blobServiceClient = new BlobServiceClient(
-  `https://${account}.blob.core.windows.net`,
-  sharedKeyCredential,
-  {
-    logger: new ConsoleHttpPipelineLogger(HttpPipelineLogLevel.INFO)
-  }
-);
-```
-
 ## Authenticating with Azure Active Directory
 
 If you have [registered an application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) with an Azure Active Directory tenant, you can [assign it to an RBAC role](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth-aad) in your Azure Storage account. This enables you to use the Azure.Identity library to authenticate with Azure Storage as shown in the [azureAdAuth.ts sample](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-blob/samples/typescript/azureAdAuth.ts).

--- a/sdk/storage/storage-blob/src/AppendBlobClient.ts
+++ b/sdk/storage/storage-blob/src/AppendBlobClient.ts
@@ -6,7 +6,8 @@ import {
   TransferProgressEvent,
   TokenCredential,
   isTokenCredential,
-  isNode
+  isNode,
+  getDefaultProxySettings
 } from "@azure/core-http";
 import { CanonicalCode } from "@azure/core-tracing";
 import {
@@ -335,7 +336,7 @@ export class AppendBlobClient extends BlobClient {
             appendToURLPath(extractedCreds.url, encodeURIComponent(containerName)),
             encodeURIComponent(blobName)
           );
-          options.proxy = extractedCreds.proxyUri;
+          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -5,7 +5,8 @@ import {
   isNode,
   TransferProgressEvent,
   TokenCredential,
-  isTokenCredential
+  isTokenCredential,
+  getDefaultProxySettings
 } from "@azure/core-http";
 import { CanonicalCode } from "@azure/core-tracing";
 import {
@@ -894,7 +895,8 @@ export class BlobClient extends StorageClient {
             appendToURLPath(extractedCreds.url, encodeURIComponent(containerName)),
             encodeURIComponent(blobName)
           );
-          options.proxy = extractedCreds.proxyUri;
+
+          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TokenCredential, isTokenCredential, isNode, HttpResponse } from "@azure/core-http";
+import { TokenCredential, isTokenCredential, isNode, HttpResponse, getDefaultProxySettings } from "@azure/core-http";
 import { CanonicalCode } from "@azure/core-tracing";
 import { AbortSignalLike } from "@azure/abort-controller";
 import {
@@ -298,7 +298,7 @@ export class BlobServiceClient extends StorageClient {
           extractedCreds.accountName!,
           extractedCreds.accountKey
         );
-        options.proxy = extractedCreds.proxyUri;
+        options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
         const pipeline = newPipeline(sharedKeyCredential, options);
         return new BlobServiceClient(extractedCreds.url, pipeline);
       } else {

--- a/sdk/storage/storage-blob/src/BlockBlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlockBlobClient.ts
@@ -10,7 +10,8 @@ import {
   TransferProgressEvent,
   TokenCredential,
   isTokenCredential,
-  isNode
+  isNode,
+  getDefaultProxySettings
 } from "@azure/core-http";
 import { CanonicalCode } from "@azure/core-tracing";
 import {
@@ -597,7 +598,7 @@ export class BlockBlobClient extends BlobClient {
             appendToURLPath(extractedCreds.url, encodeURIComponent(containerName)),
             encodeURIComponent(blobName)
           );
-          options.proxy = extractedCreds.proxyUri;
+          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -6,7 +6,8 @@ import {
   HttpResponse,
   TokenCredential,
   isTokenCredential,
-  isNode
+  isNode,
+  getDefaultProxySettings
 } from "@azure/core-http";
 import { CanonicalCode } from "@azure/core-tracing";
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -610,7 +611,7 @@ export class ContainerClient extends StorageClient {
             extractedCreds.accountKey
           );
           url = appendToURLPath(extractedCreds.url, encodeURIComponent(containerName));
-          options.proxy = extractedCreds.proxyUri;
+          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/PageBlobClient.ts
+++ b/sdk/storage/storage-blob/src/PageBlobClient.ts
@@ -6,7 +6,8 @@ import {
   TransferProgressEvent,
   TokenCredential,
   isTokenCredential,
-  isNode
+  isNode,
+  getDefaultProxySettings
 } from "@azure/core-http";
 import { CanonicalCode } from "@azure/core-tracing";
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -511,7 +512,7 @@ export class PageBlobClient extends BlobClient {
             appendToURLPath(extractedCreds.url, encodeURIComponent(containerName)),
             encodeURIComponent(blobName)
           );
-          options.proxy = extractedCreds.proxyUri;
+          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -7,8 +7,6 @@ import {
   HttpClient as IHttpClient,
   HttpHeaders,
   HttpOperationResponse,
-  HttpPipelineLogger as IHttpPipelineLogger,
-  HttpPipelineLogLevel,
   HttpRequestBody,
   RequestPolicy,
   RequestPolicyFactory,
@@ -47,9 +45,7 @@ export {
   StorageOAuthScopes,
   deserializationPolicy,
   IHttpClient,
-  IHttpPipelineLogger,
   HttpHeaders,
-  HttpPipelineLogLevel,
   HttpRequestBody,
   HttpOperationResponse,
   WebResource,
@@ -65,13 +61,6 @@ export {
  * @interface PipelineOptions
  */
 export interface PipelineOptions {
-  /**
-   * Optional. Configures the HTTP pipeline logger.
-   *
-   * @type {IHttpPipelineLogger}
-   * @memberof PipelineOptions
-   */
-  logger?: IHttpPipelineLogger;
   /**
    * Optional. Configures the HTTP client to send requests and receive responses.
    *
@@ -129,7 +118,6 @@ export class Pipeline {
   public toServiceClientOptions(): ServiceClientOptions {
     return {
       httpClient: this.options.HTTPClient,
-      httpPipelineLogger: this.options.logger,
       requestPolicyFactories: this.factories
     };
   }
@@ -165,13 +153,6 @@ export interface StoragePipelineOptions {
    */
   keepAliveOptions?: KeepAliveOptions;
 
-  /**
-   * Configures the HTTP pipeline logger.
-   *
-   * @type {IHttpPipelineLogger}
-   * @memberof StoragePipelineOptions
-   */
-  logger?: IHttpPipelineLogger;
   /**
    * Configures the HTTP client to send requests and receive responses.
    *
@@ -229,7 +210,6 @@ export function newPipeline(
   );
 
   return new Pipeline(factories, {
-    HTTPClient: pipelineOptions.httpClient,
-    logger: pipelineOptions.logger
+    HTTPClient: pipelineOptions.httpClient
   });
 }

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -66,7 +66,7 @@ export interface PipelineOptions {
    * @type {IHttpClient}
    * @memberof PipelineOptions
    */
-  HTTPClient?: IHttpClient;
+  httpClient?: IHttpClient;
 }
 
 /**
@@ -116,7 +116,7 @@ export class Pipeline {
    */
   public toServiceClientOptions(): ServiceClientOptions {
     return {
-      httpClient: this.options.HTTPClient,
+      httpClient: this.options.httpClient,
       requestPolicyFactories: this.factories
     };
   }
@@ -203,6 +203,6 @@ export function newPipeline(
   );
 
   return new Pipeline(factories, {
-    HTTPClient: pipelineOptions.httpClient
+    httpClient: pipelineOptions.httpClient
   });
 }

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -18,9 +18,9 @@ import {
   TokenCredential,
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
-  ProxySettings,
   tracingPolicy,
-  logPolicy
+  logPolicy,
+  ProxyOptions
 } from "@azure/core-http";
 
 import { logger } from "./log";
@@ -129,7 +129,7 @@ export class Pipeline {
  * @interface StoragePipelineOptions
  */
 export interface StoragePipelineOptions {
-  proxyOptions?: ProxySettings;
+  proxyOptions?: ProxyOptions;
   /**
    * Telemetry configures the built-in telemetry policy behavior.
    *

--- a/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
@@ -25,7 +25,7 @@ export interface UserAgentOptions {
    * @type {string}
    * @memberof TelemetryOptions
    */
-  userAgentPrefix: string;
+  userAgentPrefix?: string;
 }
 
 /**

--- a/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
@@ -18,14 +18,14 @@ import { SDK_VERSION } from "./utils/constants";
  * @export
  * @interface TelemetryOptions
  */
-export interface TelemetryOptions {
+export interface UserAgentOptions {
   /**
-   * Configues the costom string that is pre-pended to the user agent string.
+   * Configues the custom string that is pre-pended to the user agent string.
    *
    * @type {string}
    * @memberof TelemetryOptions
    */
-  value: string;
+  userAgentPrefix: string;
 }
 
 /**
@@ -40,15 +40,15 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
 
   /**
    * Creates an instance of TelemetryPolicyFactory.
-   * @param {TelemetryOptions} [telemetry]
+   * @param {UserAgentOptions} [telemetry]
    * @memberof TelemetryPolicyFactory
    */
-  constructor(telemetry?: TelemetryOptions) {
+  constructor(telemetry?: UserAgentOptions) {
     const userAgentInfo: string[] = [];
 
     if (isNode) {
       if (telemetry) {
-        const telemetryString = telemetry.value.replace(" ", "");
+        const telemetryString = telemetry.userAgentPrefix.replace(" ", "");
         if (telemetryString.length > 0 && userAgentInfo.indexOf(telemetryString) === -1) {
           userAgentInfo.push(telemetryString);
         }

--- a/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
@@ -48,7 +48,7 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
 
     if (isNode) {
       if (telemetry) {
-        const telemetryString = telemetry.userAgentPrefix.replace(" ", "");
+        const telemetryString = (telemetry.userAgentPrefix || "").replace(" ", "");
         if (telemetryString.length > 0 && userAgentInfo.indexOf(telemetryString) === -1) {
           userAgentInfo.push(telemetryString);
         }

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -52,7 +52,7 @@ describe("AppendBlobClient Node.js only", () => {
     const factories = (appendBlobClient as any).pipeline.factories;
     const credential = factories[factories.length - 1] as SharedKeyCredential;
     const newClient = new AppendBlobClient(appendBlobClient.url, credential, {
-      telemetry: { value: "test/1.0" }
+      userAgentOptions: { userAgentPrefix: "test/1.0" }
     });
 
     await newClient.create();

--- a/sdk/storage/storage-blob/test/utils/testutils.common.ts
+++ b/sdk/storage/storage-blob/test/utils/testutils.common.ts
@@ -1,4 +1,3 @@
-import { HttpPipelineLogLevel, IHttpPipelineLogger } from "../../src/Pipeline";
 import { padStart } from "../../src/utils/utils.common";
 import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
 
@@ -65,27 +64,6 @@ export function base64encode(content: string): string {
 
 export function base64decode(encodedString: string): string {
   return isBrowser() ? atob(encodedString) : Buffer.from(encodedString, "base64").toString();
-}
-
-export class ConsoleHttpPipelineLogger implements IHttpPipelineLogger {
-  constructor(public minimumLogLevel: HttpPipelineLogLevel) {}
-  public log(logLevel: HttpPipelineLogLevel, message: string): void {
-    const logMessage = `${new Date().toISOString()} ${HttpPipelineLogLevel[logLevel]}: ${message}`;
-    switch (logLevel) {
-      case HttpPipelineLogLevel.ERROR:
-        // tslint:disable-next-line:no-console
-        console.error(logMessage);
-        break;
-      case HttpPipelineLogLevel.WARNING:
-        // tslint:disable-next-line:no-console
-        console.warn(logMessage);
-        break;
-      case HttpPipelineLogLevel.INFO:
-        // tslint:disable-next-line:no-console
-        console.log(logMessage);
-        break;
-    }
-  }
 }
 
 type BlobMetadata = { [propertyName: string]: string };


### PR DESCRIPTION
This PR, in addition to #5807, brings StoragePipelineOptions in line with core-http's version. This will allow adopting core-http's PipelineOptions and default pipeline in the future.

The changes are primarily to the PipelineOptions and StoragePipelineOptions interfaces.

Aside from renaming properties, this also drops support in StorageOptions for passing in a proxy as a string, instead user should use ProxySettings object. Passing a complete URL seems like a reasonable thing to add to core in the future.