### PR TITLE
[core-http] Remove PipelineOptions.updatePipelinePolicies

### DIFF
--- a/sdk/core/core-http/lib/pipelineOptions.ts
+++ b/sdk/core/core-http/lib/pipelineOptions.ts
@@ -9,7 +9,6 @@ import { ProxyOptions } from "./serviceClient";
 import { UserAgentOptions } from "./policies/userAgentPolicy";
 import { DeserializationOptions } from "./policies/deserializationPolicy";
 import { LogPolicyOptions } from "./policies/logPolicy";
-import { RequestPolicyFactory } from "./policies/requestPolicy";
 
 /**
  * Defines options that are used to configure the HTTP pipeline for
@@ -47,17 +46,6 @@ export interface PipelineOptions {
    * Options for adding user agent details to outgoing requests.
    */
   userAgentOptions?: UserAgentOptions;
-
-  /**
-   * A function that accepts the array of RequestPolicyFactory created for
-   * this PipelineOptions instance and can return modified list of policies.
-   * This is useful for adding, inserting, or removing policies in special
-   * case scenarios. If the function does not modify the array of
-   * RequestPolicyFactory, it must return the original array it was given.
-   */
-  updatePipelinePolicies?: (
-    requestPolicyFactories: RequestPolicyFactory[]
-  ) => RequestPolicyFactory[];
 }
 
 /**

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -703,11 +703,6 @@ export function createPipelineFromOptions(
 
   requestPolicyFactories.push(logPolicy(loggingOptions));
 
-  if (pipelineOptions.updatePipelinePolicies) {
-    // If the update function throws an exception, let it bubble up.
-    requestPolicyFactories = pipelineOptions.updatePipelinePolicies(requestPolicyFactories);
-  }
-
   return {
     httpClient: pipelineOptions.httpClient,
     requestPolicyFactories


### PR DESCRIPTION
This change removes `updatePipelinePolicies` from `PipelineOptions` as it is no longer needed since the Storage libraries will not adopt `PipelineOptions` verbatim before GA.  Removing it now gives us more time to design a better pipeline customization API for `PipelineOptions`.