### PR TITLE
Poller implementations: Instant playback

### DIFF
--- a/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { KeyClient, CreateEcKeyOptions, UpdateKeyPropertiesOptions, GetKeyOptions } from "../src";
 import { RestError, isNode } from "@azure/core-http";
-import { isPlayingBack } from "./utils/recorderUtils";
+import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -58,7 +58,8 @@ describe("Keys client - create, read, update and delete operations", () => {
   });
 
   it("can create a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -106,7 +107,8 @@ describe("Keys client - create, read, update and delete operations", () => {
   });
 
   it("can create a RSA key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -138,7 +140,8 @@ describe("Keys client - create, read, update and delete operations", () => {
   });
 
   it("can create an EC key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -226,7 +229,8 @@ describe("Keys client - create, read, update and delete operations", () => {
   });
 
   it("can update key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -241,7 +245,7 @@ describe("Keys client - create, read, update and delete operations", () => {
   it("can delete a key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
-    const poller = await client.beginDeleteKey(keyName);
+    const poller = await client.beginDeleteKey(keyName, testPollerProperties);
     await poller.pollUntilDone();
 
     try {
@@ -258,13 +262,15 @@ describe("Keys client - create, read, update and delete operations", () => {
   });
 
   it("can delete a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
     await assertThrowsAbortError(async () => {
       await client.beginDeleteKey(keyName, {
+        ...testPollerProperties,
         requestOptions: {
           timeout: 1
         }
@@ -295,7 +301,8 @@ describe("Keys client - create, read, update and delete operations", () => {
   });
 
   it("can get a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -321,7 +328,7 @@ describe("Keys client - create, read, update and delete operations", () => {
   it("can get a deleted key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
-    const poller = await client.beginDeleteKey(keyName);
+    const poller = await client.beginDeleteKey(keyName, testPollerProperties);
     assert.equal(poller.getResult()!.name, keyName, "Unexpected key name in result from getKey().");
     await poller.pollUntilDone();
     const getResult = await poller.getResult();
@@ -333,7 +340,7 @@ describe("Keys client - create, read, update and delete operations", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     let error;
     try {
-      const poller = await client.beginDeleteKey(keyName);
+      const poller = await client.beginDeleteKey(keyName, testPollerProperties);
       await poller.pollUntilDone();
       throw Error("Expecting an error but not catching one.");
     } catch (e) {

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { KeyClient } from "../src";
 import { isNode } from "@azure/core-http";
-import { isPlayingBack } from "./utils/recorderUtils";
+import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { retry } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
@@ -63,7 +63,8 @@ describe("Keys client - list keys in various ways", () => {
   });
 
   it("can get the versions of a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const iter = client.listPropertiesOfKeyVersions("doesntmatter", {
@@ -144,7 +145,8 @@ describe("Keys client - list keys in various ways", () => {
   });
 
   it("can get several inserted keys with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const iter = client.listPropertiesOfKeys({ requestOptions: { timeout: 1 } });
@@ -184,7 +186,7 @@ describe("Keys client - list keys in various ways", () => {
       await client.createKey(name, "RSA");
     }
     for (const name of keyNames) {
-      const poller = await client.beginDeleteKey(name);
+      const poller = await client.beginDeleteKey(name, testPollerProperties);
       await poller.pollUntilDone();
     }
 
@@ -208,7 +210,8 @@ describe("Keys client - list keys in various ways", () => {
   });
 
   it("list deleted keys with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const iter = client.listDeletedKeys({ requestOptions: { timeout: 1 } });
@@ -224,7 +227,7 @@ describe("Keys client - list keys in various ways", () => {
       await client.createKey(name, "RSA");
     }
     for (const name of keyNames) {
-      const poller = await client.beginDeleteKey(name);
+      const poller = await client.beginDeleteKey(name, testPollerProperties);
       await poller.pollUntilDone();
     }
 

--- a/sdk/keyvault/keyvault-keys/test/lro.delete.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/lro.delete.test.ts
@@ -3,6 +3,7 @@
 
 import * as assert from "assert";
 import { KeyClient, DeletedKey } from "../src";
+import { testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -32,7 +33,7 @@ describe("Keys client - Long Running Operations - delete", () => {
   it("can wait until a key is deleted", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
-    const poller = await client.beginDeleteKey(keyName);
+    const poller = await client.beginDeleteKey(keyName, testPollerProperties);
     assert.ok(poller.getOperationState().isStarted);
 
     // The pending deleted can be obtained this way:
@@ -51,7 +52,7 @@ describe("Keys client - Long Running Operations - delete", () => {
   it("can resume from a stopped poller", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
-    const poller = await client.beginDeleteKey(keyName);
+    const poller = await client.beginDeleteKey(keyName, testPollerProperties);
     assert.ok(poller.getOperationState().isStarted);
 
     poller.pollUntilDone().catch((e) => {
@@ -69,7 +70,8 @@ describe("Keys client - Long Running Operations - delete", () => {
     const serialized = poller.toString();
 
     const resumePoller = await client.beginDeleteKey(keyName, {
-      resumeFrom: serialized
+      resumeFrom: serialized,
+      ...testPollerProperties
     });
 
     assert.ok(resumePoller.getOperationState().isStarted);

--- a/sdk/keyvault/keyvault-keys/test/lro.recoverDelete.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/lro.recoverDelete.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { KeyClient, DeletedKey } from "../src";
 import { isNode } from "@azure/core-http";
-import { isPlayingBack } from "./utils/recorderUtils";
+import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -36,10 +36,10 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
 
-    const deletePoller = await client.beginDeleteKey(keyName);
+    const deletePoller = await client.beginDeleteKey(keyName, testPollerProperties);
     await deletePoller.pollUntilDone();
 
-    const poller = await client.beginRecoverDeletedKey(keyName);
+    const poller = await client.beginRecoverDeletedKey(keyName, testPollerProperties);
     assert.ok(poller.getOperationState().isStarted);
 
     // The pending key can be obtained this way:
@@ -58,10 +58,10 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
   it("can resume from a stopped poller", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
-    const deletePoller = await client.beginDeleteKey(keyName);
+    const deletePoller = await client.beginDeleteKey(keyName, testPollerProperties);
     await deletePoller.pollUntilDone();
 
-    const poller = await client.beginRecoverDeletedKey(keyName);
+    const poller = await client.beginRecoverDeletedKey(keyName, testPollerProperties);
     assert.ok(poller.getOperationState().isStarted);
 
     poller.pollUntilDone().catch((e) => {
@@ -79,7 +79,8 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
     const serialized = poller.toString();
 
     const resumePoller = await client.beginRecoverDeletedKey(keyName, {
-      resumeFrom: serialized
+      resumeFrom: serialized,
+      ...testPollerProperties
     });
 
     assert.ok(poller.getOperationState().isStarted);
@@ -91,15 +92,19 @@ describe("Keys client - Long Running Operations - recoverDelete", () => {
   });
 
   it("can recover a deleted key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
-    const deletePoller = await client.beginDeleteKey(keyName);
+    const deletePoller = await client.beginDeleteKey(keyName, testPollerProperties);
     await deletePoller.pollUntilDone();
     await assertThrowsAbortError(async () => {
-      await client.beginRecoverDeletedKey(keyName, { requestOptions: { timeout: 1 } });
+      await client.beginRecoverDeletedKey(keyName, {
+        requestOptions: { timeout: 1 },
+        ...testPollerProperties
+      });
     });
   });
 });

--- a/sdk/keyvault/keyvault-keys/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/recoverBackupRestore.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { KeyClient } from "../src";
 import { isNode } from "@azure/core-http";
-import { isPlayingBack } from "./utils/recorderUtils";
+import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { retry } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
@@ -35,7 +35,7 @@ describe("Keys client - restore keys and recover backups", () => {
   it("can recover a deleted key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     await client.createKey(keyName, "RSA");
-    const deletePoller = await client.beginDeleteKey(keyName);
+    const deletePoller = await client.beginDeleteKey(keyName, testPollerProperties);
     assert.equal(
       deletePoller.getResult()!.name,
       keyName,
@@ -46,7 +46,7 @@ describe("Keys client - restore keys and recover backups", () => {
     const getDeletedResult = await deletePoller.getResult();
     assert.equal(getDeletedResult!.name, keyName, "Unexpected key name in result from getKey().");
 
-    const recoverPoller = await client.beginRecoverDeletedKey(keyName);
+    const recoverPoller = await client.beginRecoverDeletedKey(keyName, testPollerProperties);
     await recoverPoller.pollUntilDone();
     const getResult = await client.getKey(keyName);
     assert.equal(getResult.name, keyName, "Unexpected key name in result from getKey().");
@@ -57,7 +57,7 @@ describe("Keys client - restore keys and recover backups", () => {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
     let error;
     try {
-      const recoverPoller = await client.beginRecoverDeletedKey(keyName);
+      const recoverPoller = await client.beginRecoverDeletedKey(keyName, testPollerProperties);
       await recoverPoller.pollUntilDone();
       throw Error("Expecting an error but not catching one.");
     } catch (e) {
@@ -80,7 +80,8 @@ describe("Keys client - restore keys and recover backups", () => {
   });
 
   it("can generate a backup of a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     await assertThrowsAbortError(async () => {
@@ -112,7 +113,8 @@ describe("Keys client - restore keys and recover backups", () => {
   });
 
   it("can restore a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    if (!isNode || isPlayingBack) {
+      // On playback mode, the tests happen too fast for the timeout to work
       recorder.skip();
     }
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);

--- a/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
@@ -20,3 +20,7 @@ export function uniqueString(): string {
         .toString()
         .slice(2);
 }
+
+export const testPollerProperties = {
+  intervalInMs: isRecording ? 2000 : 0
+};

--- a/sdk/keyvault/keyvault-keys/test/utils/testClient.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/testClient.ts
@@ -1,4 +1,4 @@
-import { retry } from "./recorderUtils";
+import { retry, testPollerProperties } from "./recorderUtils";
 import { KeyClient } from "../../src";
 
 export default class TestClient {
@@ -22,7 +22,7 @@ export default class TestClient {
   }
   public async flushKey(keyName: string): Promise<void> {
     const that = this;
-    const poller = await that.client.beginDeleteKey(keyName);
+    const poller = await that.client.beginDeleteKey(keyName, testPollerProperties);
     await poller.pollUntilDone();
     await this.purgeKey(keyName);
   }

--- a/sdk/keyvault/keyvault-secrets/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/CRUD.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { SecretClient } from "../src";
 import { isNode } from "@azure/core-http";
-import { isPlayingBack } from "./utils/recorderUtils";
+import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -272,7 +272,7 @@ describe("Secret client - create, read, update and delete operations", () => {
       `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
     );
     await client.setSecret(secretName, secretValue);
-    const deletePoller = await client.beginDeleteSecret(secretName);
+    const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
 
     let deletedSecret = deletePoller.getResult();
     assert.equal(typeof deletedSecret!.properties.recoveryId, "string");
@@ -309,7 +309,8 @@ describe("Secret client - create, read, update and delete operations", () => {
       await client.beginDeleteSecret(secretName, {
         requestOptions: {
           timeout: 1
-        }
+        },
+        ...testPollerProperties
       });
     });
   });
@@ -320,7 +321,7 @@ describe("Secret client - create, read, update and delete operations", () => {
     );
     let error;
     try {
-      await client.beginDeleteSecret(secretName);
+      await client.beginDeleteSecret(secretName, testPollerProperties);
       throw Error("Expecting an error but not catching one.");
     } catch (e) {
       error = e;
@@ -337,7 +338,7 @@ describe("Secret client - create, read, update and delete operations", () => {
       `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
     );
     await client.setSecret(secretName, "RSA");
-    const deletePoller = await client.beginDeleteSecret(secretName);
+    const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
 
     let deletedSecret = deletePoller.getResult();
     assert.equal(
@@ -365,7 +366,7 @@ describe("Secret client - create, read, update and delete operations", () => {
     );
     let error;
     try {
-      const deletePoller = await client.beginDeleteSecret(secretName);
+      const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
       await deletePoller.pollUntilDone();
       throw Error("Expecting an error but not catching one.");
     } catch (e) {

--- a/sdk/keyvault/keyvault-secrets/test/list.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/list.test.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import chai from "chai";
 import { SecretClient } from "../src";
 import { isNode } from "@azure/core-http";
-import { isPlayingBack } from "./utils/recorderUtils";
+import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -92,7 +92,7 @@ describe("Secret client - list secrets in various ways", () => {
       await client.setSecret(name, "RSA");
     }
     for (const name of secretNames) {
-      const deletePoller = await client.beginDeleteSecret(name);
+      const deletePoller = await client.beginDeleteSecret(name, testPollerProperties);
       await deletePoller.pollUntilDone();
     }
 
@@ -212,7 +212,7 @@ describe("Secret client - list secrets in various ways", () => {
       await client.setSecret(name, "RSA");
     }
     for (const name of secretNames) {
-      const deletePoller = await client.beginDeleteSecret(name);
+      const deletePoller = await client.beginDeleteSecret(name, testPollerProperties);
       await deletePoller.pollUntilDone();
     }
 

--- a/sdk/keyvault/keyvault-secrets/test/lro.delete.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/lro.delete.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { SecretClient, DeletedSecret } from "../src";
 import { isNode } from "@azure/core-http";
-import { isPlayingBack } from "./utils/recorderUtils";
+import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -37,7 +37,7 @@ describe("Secrets client - Long Running Operations - delete", () => {
       `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
     );
     await client.setSecret(secretName, "value");
-    const poller = await client.beginDeleteSecret(secretName);
+    const poller = await client.beginDeleteSecret(secretName, testPollerProperties);
     assert.ok(poller.getOperationState().isStarted);
 
     // The pending deleted secret can be obtained this way:
@@ -58,7 +58,7 @@ describe("Secrets client - Long Running Operations - delete", () => {
       `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
     );
     await client.setSecret(secretName, "value");
-    const poller = await client.beginDeleteSecret(secretName);
+    const poller = await client.beginDeleteSecret(secretName, testPollerProperties);
     assert.ok(poller.getOperationState().isStarted);
 
     poller.pollUntilDone().catch((e) => {
@@ -74,7 +74,8 @@ describe("Secrets client - Long Running Operations - delete", () => {
     const serialized = poller.toString();
 
     const resumePoller = await client.beginDeleteSecret(secretName, {
-      resumeFrom: serialized
+      resumeFrom: serialized,
+      ...testPollerProperties
     });
 
     assert.ok(resumePoller.getOperationState().isStarted);

--- a/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
@@ -20,3 +20,7 @@ export function uniqueString(): string {
         .toString()
         .slice(2);
 }
+
+export const testPollerProperties = {
+  intervalInMs: isRecording ? 2000 : 0
+};

--- a/sdk/keyvault/keyvault-secrets/test/utils/testClient.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/testClient.ts
@@ -1,4 +1,4 @@
-import { retry } from "./recorderUtils";
+import { retry, testPollerProperties } from "./recorderUtils";
 import { SecretClient } from "../../src";
 
 export default class TestClient {
@@ -22,7 +22,7 @@ export default class TestClient {
   }
   public async flushSecret(secretName: string): Promise<void> {
     const that = this;
-    const deletePoller = await that.client.beginDeleteSecret(secretName);
+    const deletePoller = await that.client.beginDeleteSecret(secretName, testPollerProperties);
     await deletePoller.pollUntilDone();
     await this.purgeSecret(secretName);
   }

--- a/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import * as dotenv from "dotenv";
 
 import { getBSU } from "./utils";
-import { record } from "./utils/recorder";
+import { record, testPollerProperties } from "./utils/recorder";
 import {
   BlobClient,
   BlockBlobClient,
@@ -58,7 +58,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     const poller: PollerLike<
       PollOperationState<BlobBeginCopyFromURLResponse>,
       BlobBeginCopyFromURLResponse
-    > = await newBlobClient.beginCopyFromURL(blobClient.url);
+    > = await newBlobClient.beginCopyFromURL(blobClient.url, testPollerProperties);
 
     const result = await poller.pollUntilDone();
     assert.ok(result.copyId);
@@ -74,7 +74,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     const newBlobClient = destinationContainerClient.getBlobClient(
       recorder.getUniqueName("copiedblob")
     );
-    const poller = await newBlobClient.beginCopyFromURL(blobClient.url);
+    const poller = await newBlobClient.beginCopyFromURL(blobClient.url, testPollerProperties);
     let result: BlobBeginCopyFromURLResponse;
     do {
       await poller.poll();
@@ -98,7 +98,8 @@ describe("BlobClient beginCopyFromURL Poller", () => {
       recorder.getUniqueName("copiedblob")
     );
     const poller = await newBlobClient.beginCopyFromURL(
-      "https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/README.md"
+      "https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/README.md",
+      testPollerProperties
     );
     await poller.cancelOperation();
     try {
@@ -119,7 +120,8 @@ describe("BlobClient beginCopyFromURL Poller", () => {
       {
         onProgress(_) {
           onProgressCalled = true;
-        }
+        },
+        ...testPollerProperties
       }
     );
 
@@ -133,7 +135,8 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     );
 
     const poller1 = await newBlobClient.beginCopyFromURL(
-      "https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/README.md"
+      "https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/README.md",
+      testPollerProperties
     );
 
     poller1.stopPolling();
@@ -143,7 +146,8 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     const poller2 = await newBlobClient.beginCopyFromURL(
       "https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/README.md",
       {
-        resumeFrom: state
+        resumeFrom: state,
+        ...testPollerProperties
       }
     );
     const result = await poller2.pollUntilDone();

--- a/sdk/storage/storage-blob/test/utils/recorder.ts
+++ b/sdk/storage/storage-blob/test/utils/recorder.ts
@@ -569,3 +569,7 @@ export function record(testContext: any) {
     }
   };
 }
+
+export const testPollerProperties = {
+  intervalInMs: isRecording ? 2000 : 0
+}


### PR DESCRIPTION
The fix is to pass this in each test call: https://github.com/Azure/azure-sdk-for-js/pull/5836/files#diff-b3ce67ba95f6d817b36c629e38d5f3b5R25

Not sure how I forgot to add this from the beginning!
Is there an issue for this?