### PR TITLE
README samples and standards for app-configuration, event-hubs, and keyvault-certificates

### DIFF
--- a/sdk/appconfiguration/app-configuration/README.md
+++ b/sdk/appconfiguration/app-configuration/README.md
@@ -3,13 +3,18 @@
 Azure App Configuration is a managed service that helps developers
 centralize their application configurations, simply and securely.
 
-This client library lets you create, retrieve, update, and delete 
-settings within Azure App Configuration.
+Use the App Configuration client library to:
 
-* [Azure App Configuration documentation](https://docs.microsoft.com/en-us/azure/azure-app-configuration/)
-* [NPM](https://www.npmjs.com/package/@azure/app-configuration)
-* [Source](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/appconfiguration/app-configuration/)
-* [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples)
+* create App Configuration settings
+* retrieve the value of a setting for a given key
+* update the value of a setting for a given key
+* delete settings within an App Configuration
+
+[Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/appconfiguration/app-configuration/) |
+[Package (NPM)](https://www.npmjs.com/package/@azure/app-configuration) |
+[API reference documentation](https://docs.microsoft.com/en-us/azure/azure-app-configuration/) |
+[Product documentation](https://docs.microsoft.com/en-us/azure/azure-app-configuration/) |
+[Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples)
 
 ## Getting started
 
@@ -17,7 +22,10 @@ settings within Azure App Configuration.
 
 - Node.js version 8.x.x or higher
 
-### How to Install
+### Install the Package
+
+**Prerequisites**: You must have an [Azure Subscription](https://azure.microsoft.com) and an [App Configuration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/) to use this package. This package currently
+only supports NodeJS versions higher than 8.0.0.
 
 ```bash
 npm install @azure/app-configuration
@@ -25,9 +33,7 @@ npm install @azure/app-configuration
 
 ## Examples
 
-#### nodejs - Create and get a setting in JavaScript
-
-##### Sample code
+#### Create and get a setting
 
 ```javascript
 const appConfig = require("@azure/app-configuration");
@@ -52,8 +58,6 @@ async function run() {
 run().catch(err => console.log("ERROR:", err));
 ```
 
-More in-depth examples can be found in the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples) folder on GitHub.
-
 ## Next steps
 
 Use these samples for a more in-depth demonstration of Azure App Configuration.
@@ -64,17 +68,21 @@ Use these samples for a more in-depth demonstration of Azure App Configuration.
 * [`setReadOnlySample.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts) - marking settings as read-only to prevent modification
 * [`getSettingOnlyIfChanged.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts) - get a setting only if it changed from the last time you got it
 
-View more samples on [GitHub](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples)
+View all samples in [the samples folder](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples)
 
 ## Contributing
 
-This project welcomes contributions and suggestions. Most contributions require you to agree to a
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
-the rights to use your contribution. For details, visit <https://cla.microsoft.com.>
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code.
 

--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -4,11 +4,17 @@ Azure Event Hubs is a highly scalable publish-subscribe service that can ingest 
 
 The Azure Event Hubs client library allows you to send and receive events in your Node.js application.
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs) | [Package (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/next) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/event-hubs/index.html) | [Product documentation](https://azure.microsoft.com/en-us/services/event-hubs/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs) |
+[Package (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/next) |
+[API Reference Documentation](https://azure.github.io/azure-sdk-for-js/event-hubs/index.html) |
+[Product documentation](https://azure.microsoft.com/en-us/services/event-hubs/) |
+[Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/samples)
 
 **NOTE**: If you are using version 2.1.0 or lower, then please use the below links instead
 
-[Source code for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs) | [Package for v2.1.0 (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.0) | [Samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples)
+[Source code for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs) |
+[Package for v2.1.0 (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.0) |
+[Samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples)
 
 ## Getting Started
 
@@ -52,12 +58,16 @@ Interaction with Event Hubs starts with an instance of the [EventHubClient](http
 this class using one of the below
 
 ```javascript
+const { EventHubClient } = require("@azure/event-hubs");
+
 const client = new EventHubClient("my-connection-string", "my-event-hub");
 ```
 
 - This constructor takes the connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;' and entity name to your Event Hub instance. You can get the connection string from the [Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string#get-connection-string-from-the-portal).
 
 ```javascript
+const { EventHubClient } = require("@azure/event-hubs");
+
 const client = new EventHubClient("my-connection-string-with-entity-path");
 ```
 
@@ -66,6 +76,8 @@ const client = new EventHubClient("my-connection-string-with-entity-path");
 If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that Event Hub will result in a connection string that contains the path.
 
 ```javascript
+const { EventHubClient } = require("@azure/event-hubs");
+
 const { DefaultAzureCredential } = require("@azure/identity");
 const credential = new DefaultAzureCredential();
 const client = new EventHubClient("my-host-name", "my-event-hub", credential);
@@ -90,6 +102,8 @@ Because partitions are owned by the Event Hub, their names are assigned at the t
 To understand what partitions are available, you query the Event Hub using the client.
 
 ```javascript
+const { EventHubClient } = require("@azure/event-hubs");
+
 const client = new EventHubCLient("connectionString", "eventHubName");
 const partitionIds = await client.getPartitionIds();
 ```
@@ -103,6 +117,8 @@ In order to publish events, you'll need to create an `EventHubProducer`. Produce
 Use the [send](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubproducer.html#send) method to send a single event or multiple events using a single call.
 
 ```javascript
+const { EventHubClient } = require("@azure/event-hubs");
+
 const client = new EventHubClient("connectionString", "eventHubName");
 const producer = client.createProducer();
 await producer.send({ body: "my-event-body" });
@@ -117,6 +133,8 @@ Events may be added to the `EventDataBatch` using the [tryAdd](https://azure.git
 method until the maximum batch size limit in bytes has been reached.
 
 ```javascript
+const { EventHubClient } = require("@azure/event-hubs");
+
 const client = new EventHubClient("connectionString", "eventHubName");
 const producer = client.createProducer();
 const eventDataBatch = await producer.createBatch();
@@ -142,6 +160,7 @@ To consume events from a single Event Hub partition in a consumer group, create 
 
 ```javascript
 const client = new EventHubClient("connectionString", "eventHubName");
+
 const consumer = client.createConsumer(
   EventHubClient.defaultConsumerGroupName,
   partitionIds[0],
@@ -347,12 +366,26 @@ export DEBUG=azure:event-hubs:error,azure-amqp-common:error,rhea-promise:error,r
 
 ## Next Steps
 
+### More sample code
+
 Please take a look at the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/samples)
-directory for detailed examples on how to use this library to send and receive events to/from
+directory for detailed examples of how to use this library to send and receive events to/from
 [Event Hubs](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-about).
 
 ## Contributing
 
-If you'd like to contribute to this library, please read the [contributing guide](../../../CONTRIBUTING.md) to learn more about how to build and test the code.
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code.
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/eventhub/event-hubs/README.png)

--- a/sdk/keyvault/keyvault-certificates/README.md
+++ b/sdk/keyvault/keyvault-certificates/README.md
@@ -115,18 +115,18 @@ Use the [Azure Cloud Shell](https://shell.azure.com/bash) snippet below to creat
 
 ## Authenticating the client
 
-To use the key vault from TypeScript/JavaScript, you need to first authenticate with the key vault service. To authenticate, first we import the identity and CertificatesClient, which will connect to the key vault.
+To use the key vault from TypeScript/JavaScript, you need to first authenticate with the key vault service. To authenticate, first we import the identity and CertificateClient, which will connect to the key vault.
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 ```
 
 Once these are imported, we can next connect to the key vault service. To do this, we'll need to copy some settings from the key vault we are connecting to into our environment variables. Once they are in our environment, we can access them with the following code:
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 // DefaultAzureCredential expects the following three environment variables:
 // * AZURE_TENANT_ID: The tenant ID in Azure Active Directory
@@ -139,7 +139,7 @@ const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
 // Lastly, create our certificates client and connect to the service
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 ```
 
 ## Examples
@@ -162,14 +162,14 @@ certificate is created.
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 
@@ -189,14 +189,14 @@ Besides the name of the certificate, you can also pass the following attributes:
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 const certificatePolicy = {
@@ -236,14 +236,14 @@ the certificate's policy.
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 
@@ -263,14 +263,14 @@ main();
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 
@@ -289,14 +289,14 @@ main();
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 async function main() {
   for await (let listedCertificate of client.listCertificates()) {
@@ -314,14 +314,14 @@ The certificate attributes can be updated to an existing certificate version wit
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 
@@ -347,14 +347,14 @@ The certificate's policy can also be updated individually with `updateCertificat
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 
@@ -380,14 +380,14 @@ read, recovered or purged.
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 
@@ -411,7 +411,7 @@ available to be read, recovered or purged.
 
 ### Iterating lists of certificates
 
-Using the CertificatesClient, you can retrieve and iterate through all of the
+Using the CertificateClient, you can retrieve and iterate through all of the
 certificates in a Certificate Vault, as well as through all of the deleted certificates and the
 versions of a specific certificate. The following API methods are available:
 
@@ -426,14 +426,14 @@ Which can be used as follows:
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 
@@ -458,14 +458,14 @@ want to use, as follows:
 
 ```javascript
 const { DefaultAzureCredential } = require("@azure/identity");
-const { CertificatesClient } = require("@azure/keyvault-certificates");
+const { CertificateClient } = require("@azure/keyvault-certificates");
 
 const credential = new DefaultAzureCredential();
 
 const vaultName = "<YOUR KEYVAULT NAME>";
 const url = `https://${vaultName}.vault.azure.net`;
 
-const client = new CertificatesClient(url, credential);
+const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
 

--- a/sdk/keyvault/keyvault-certificates/README.md
+++ b/sdk/keyvault/keyvault-certificates/README.md
@@ -25,12 +25,6 @@ Use the client library for Azure Key Vault Certificates in your Node.js applicat
 
 ## Getting started
 
-### Install the package
-
-Install the Azure Key Vault Certificates client library using npm
-
-`npm install @azure/keyvault-certificates`
-
 **Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a
 [Key Vault resource](https://docs.microsoft.com/en-us/azure/key-vault/quick-create-portal) to use this package.
 If you are using this package in a Node.js application, then use Node.js 6.x or higher.
@@ -38,6 +32,18 @@ If you are using this package in a Node.js application, then use Node.js 6.x or 
 To quickly create the needed Key Vault resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:
 
 [![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-js%2Fmaster%2Fsdk%2Fkeyvault%2Fkeyvault-certificates%2Ftests-resources.json)
+
+### Install the package
+
+Install the Azure Key Vault Certificates client library using npm
+
+`npm install @azure/keyvault-certificates`
+
+### Install the identity library
+
+Key Vault clients authenticate using the Azure Identity Library. Install it as well using npm
+
+`npm install @azure/identity`
 
 ### Configure TypeScript
 
@@ -111,14 +117,17 @@ Use the [Azure Cloud Shell](https://shell.azure.com/bash) snippet below to creat
 
 To use the key vault from TypeScript/JavaScript, you need to first authenticate with the key vault service. To authenticate, first we import the identity and CertificatesClient, which will connect to the key vault.
 
-```typescript
-import { DefaultAzureCredential } from "@azure/identity";
-import { CertificatesClient } from "@azure/keyvault-certificates";
+```javascript
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
 ```
 
 Once these are imported, we can next connect to the key vault service. To do this, we'll need to copy some settings from the key vault we are connecting to into our environment variables. Once they are in our environment, we can access them with the following code:
 
-```typescript
+```javascript
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
 // DefaultAzureCredential expects the following three environment variables:
 // * AZURE_TENANT_ID: The tenant ID in Azure Active Directory
 // * AZURE_CLIENT_ID: The application (client) ID registered in the AAD tenant
@@ -152,10 +161,24 @@ a certificate with the same name already exists, a new version of the
 certificate is created.
 
 ```javascript
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
 const certificateName = "MyCertificateName";
-const result = await client.createCertificate(certificateName, {
-  issuerName: "Self"
-});
+
+async function main() {
+  const result = await client.createCertificate(certificateName, {
+    issuerName: "Self"
+  });
+  console.log("result: ", result);
+}
 ```
 
 Besides the name of the certificate, you can also pass the following attributes:
@@ -165,6 +188,16 @@ Besides the name of the certificate, you can also pass the following attributes:
 - `tags`: Any set of key-values that can be used to search and filter certificates.
 
 ```javascript
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
 const certificateName = "MyCertificateName";
 const certificatePolicy = {
   issuerName: "Self"
@@ -173,14 +206,20 @@ const enabled = true;
 const tags = {
   myCustomTag: "myCustomTagsValue"
 };
-const result = await client.createCertificate(
-  certificateName,
-  certificatePolicy,
-  {
-    enabled,
-    tags
-  }
-);
+
+async function main() {
+  const result = await client.createCertificate(
+    certificateName,
+    certificatePolicy,
+    {
+      enabled,
+      tags
+    }
+  );
+  console.log("result: ", result);
+}
+
+main();
 ```
 
 Calling to `createCertificate` with the same name will create a new version of
@@ -196,10 +235,26 @@ optionally get a different version of the certificate by calling
 the certificate's policy.
 
 ```javascript
-const latestCertificate = await client.getCertificateWithPolicy(certificateName);
-console.log(`Latest version of the certificate ${certificateName}: `, latestCertificate);
-const specificCertificate = await client.getCertificate(certificateName, latestCertificate.properties.version!);
-console.log(`The certificate ${certificateName} at the version ${latestCertificate.properties.version!}: `, specificCertificate);
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+const certificateName = "MyCertificateName";
+
+async function main() {
+  const latestCertificate = await client.getCertificateWithPolicy(certificateName);
+  console.log(`Latest version of the certificate ${certificateName}: `, latestCertificate);
+  const specificCertificate = await client.getCertificate(certificateName, latestCertificate.properties.version!);
+  console.log(`The certificate ${certificateName} at the version ${latestCertificate.properties.version!}: `, specificCertificate);
+}
+
+main();
 ```
 
 ### List all versions of a certificate
@@ -207,9 +262,25 @@ console.log(`The certificate ${certificateName} at the version ${latestCertifica
 `listCertificateVersions` will list versions of the given certificate.
 
 ```javascript
-for await (let certificate of client.listCertificateVersions(certificateName)) {
-  console.log("version: ", certificate.properties.version);
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+const certificateName = "MyCertificateName";
+
+async function main() {
+  for await (let certificate of client.listCertificateVersions(certificateName)) {
+    console.log("version: ", certificate.properties.version);
+  }
 }
+
+main();
 ```
 
 ### List all certificates
@@ -217,9 +288,23 @@ for await (let certificate of client.listCertificateVersions(certificateName)) {
 `listCertificates` will list all certificates in the Key Vault.
 
 ```javascript
-for await (let listedCertificate of client.listCertificates()) {
-  console.log("certificate: ", listedCertificate);
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+async function main() {
+  for await (let listedCertificate of client.listCertificates()) {
+    console.log("certificate: ", listedCertificate);
+  }
 }
+
+main();
 ```
 
 ### Updating a certificate
@@ -228,27 +313,59 @@ The certificate attributes can be updated to an existing certificate version wit
 `updateCertificate`, as follows:
 
 ```javascript
-const result = client.getCertificateWithPolicy(certificateName);
-await client.updateCertificate(certificateName, result.properties.version, {
-  certificatePolicy: {
-    issuerName: "Self"
-  },
-  certificateAttributes: {
-    enabled: false
-  },
-  tags: {
-    myCustomTag: "myCustomTagsValue"
-  }
-});
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+const certificateName = "MyCertificateName";
+
+async function main() {
+  const result = client.getCertificateWithPolicy(certificateName);
+  await client.updateCertificate(certificateName, result.properties.version, {
+    certificatePolicy: {
+      issuerName: "Self"
+    },
+    certificateAttributes: {
+      enabled: false
+    },
+    tags: {
+      myCustomTag: "myCustomTagsValue"
+    }
+  });
+}
+
+main();
 ```
 
 The certificate's policy can also be updated individually with `updateCertificatePolicy`, as follows:
 
 ```javascript
-const result = client.getCertificateWithPolicy(certificateName);
-await client.updateCertificatePolicy(certificateName, {
-  issuerName: "Self"
-});
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+const certificateName = "MyCertificateName";
+
+async function main() {
+  const result = client.getCertificateWithPolicy(certificateName);
+  await client.updateCertificatePolicy(certificateName, {
+    issuerName: "Self"
+  });
+}
+
+main();
 ```
 
 ### Deleting a certificate
@@ -256,23 +373,36 @@ await client.updateCertificatePolicy(certificateName, {
 The `deleteCertificate` method sets a certificate up for deletion. This process will
 happen in the background as soon as the necessary resources are available.
 
-```javascript
-await client.deleteCertificate(certificateName);
-```
-
 If [soft-delete](https://docs.microsoft.com/en-us/azure/key-vault/key-vault-ovw-soft-delete)
 is enabled for the Key Vault, this operation will only label the certificate as a
 _deleted_ certificate. A deleted certificate can't be updated. They can only be either
 read, recovered or purged.
 
 ```javascript
-await client.deleteCertificate(certificateName);
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
 
-// If soft-delete is enabled, we can eventually do:
-await client.getDeletedCertificate(certificateName);
-// Deleted certificates can also be recovered or purged:
-await client.recoverDeletedCertificate(certificateName);
-// await client.purgeDeletedCertificate(certificateName);
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+const certificateName = "MyCertificateName";
+
+async function main() {
+  await client.deleteCertificate(certificateName);
+
+  // If soft-delete is enabled, we can eventually do:
+  await client.getDeletedCertificate(certificateName);
+  // Deleted certificates can also be recovered or purged:
+  await client.recoverDeletedCertificate(certificateName);
+  // or
+  await client.purgeDeletedCertificate(certificateName);
+}
+
+main();
 ```
 
 Since the deletion of a certificate won't happen instantly, some time is needed
@@ -295,15 +425,31 @@ versions of a specific certificate. The following API methods are available:
 Which can be used as follows:
 
 ```javascript
-for await (let certificate of client.listCertificates()) {
-  console.log("Certificate: ", certificate);
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+const certificateName = "MyCertificateName";
+
+async function main() {
+  for await (let certificate of client.listCertificates()) {
+    console.log("Certificate: ", certificate);
+  }
+  for await (let deletedCertificate of client.listDeletedCertificates()) {
+    console.log("Deleted certificate: ", deletedCertificate);
+  }
+  for await (let version of client.listCertificateVersions(certificateName)) {
+    console.log("Version: ", version);
+  }
 }
-for await (let deletedCertificate of client.listDeletedCertificates()) {
-  console.log("Deleted certificate: ", deletedCertificate);
-}
-for await (let version of client.listCertificateVersions(certificateName)) {
-  console.log("Version: ", version);
-}
+
+main();
 ```
 
 All of these methods will return **all of the available results** at once. To
@@ -311,21 +457,37 @@ retrieve them by pages, add `.byPage()` right after invoking the API method you
 want to use, as follows:
 
 ```javascript
-for await (let page of client.listCertificates().byPage()) {
-  for (let certificate of page) {
-    console.log("Certificate: ", certificate);
+const { DefaultAzureCredential } = require("@azure/identity");
+const { CertificatesClient } = require("@azure/keyvault-certificates");
+
+const credential = new DefaultAzureCredential();
+
+const vaultName = "<YOUR KEYVAULT NAME>";
+const url = `https://${vaultName}.vault.azure.net`;
+
+const client = new CertificatesClient(url, credential);
+
+const certificateName = "MyCertificateName";
+
+async function main() {
+  for await (let page of client.listCertificates().byPage()) {
+    for (let certificate of page) {
+      console.log("Certificate: ", certificate);
+    }
   }
-}
-for await (let page of client.listDeletedCertificates().byPage()) {
-  for (let deletedCertificate of page) {
-    console.log("Deleted certificate: ", deletedCertificate);
+  for await (let page of client.listDeletedCertificates().byPage()) {
+    for (let deletedCertificate of page) {
+      console.log("Deleted certificate: ", deletedCertificate);
+    }
   }
-}
-for await (let page of client.listCertificateVersions(certificateName).byPage()) {
-  for (let version of page) {
+  for await (let page of client.listCertificateVersions(certificateName).byPage()) {
+    for (let version of page) {
     console.log("Version: ", version);
+    }
   }
 }
+
+main();
 ```
 
 ## Troubleshooting
@@ -348,9 +510,19 @@ directory for detailed examples on how to use this library.
 
 ## Contributing
 
-This project welcomes contributions and suggestions. Please read the
-[contributing guidelines](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md)
-for detailed information about how to contribute and what to expect while contributing.
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
+the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide
+a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions
+provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code
 
 ### Testing
 
@@ -372,9 +544,5 @@ environment variables:
 
 **WARNING:**
 Integration tests will wipe all of the existing records in the targeted Key Vault.
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js/sdk/keyvault/keyvault-certificates/README.png)


### PR DESCRIPTION
Partially addresses #5823

Changes to READMEs for app-configuration, event-hubs, and keyvault-certificates:

- Changed ES6-style import statements to CommonJS require statements with object destructuring in inline samples.
- Re-ordered some sections to be consistent across packages (especially "Contributing" and "Getting Started"
- Added code to inline samples to make them theoretically runnable (though I haven't tested them all as there are too many and they require resources in Azure to test)
  - Wrapped `await` statements in an async function so that they can run
  - added module imports and relevant declarations to the top of inline samples

#5823 also suggests to make "Deploy in Azure" buttons open their pages in a new tab, but this isn't possible on GitHub.