### PR TITLE
[storage-blob][keyvault] fixes record & playback issues with some pollers

### DIFF
--- a/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
@@ -22,5 +22,5 @@ export function uniqueString(): string {
 }
 
 export const testPollerProperties = {
-  intervalInMs: isPlayingBack ? 0 : 2000
+  intervalInMs: isPlayingBack ? 0 : undefined
 };

--- a/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
@@ -22,5 +22,5 @@ export function uniqueString(): string {
 }
 
 export const testPollerProperties = {
-  intervalInMs: isRecording ? 2000 : 0
+  intervalInMs: isPlayback ? 0 : 2000
 };

--- a/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-keys/test/utils/recorderUtils.ts
@@ -22,5 +22,5 @@ export function uniqueString(): string {
 }
 
 export const testPollerProperties = {
-  intervalInMs: isPlayback ? 0 : 2000
+  intervalInMs: isPlayingBack ? 0 : 2000
 };

--- a/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
@@ -22,5 +22,5 @@ export function uniqueString(): string {
 }
 
 export const testPollerProperties = {
-  intervalInMs: isPlayingBack ? 0 : 2000
+  intervalInMs: isPlayingBack ? 0 : undefined
 };

--- a/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
+++ b/sdk/keyvault/keyvault-secrets/test/utils/recorderUtils.ts
@@ -22,5 +22,5 @@ export function uniqueString(): string {
 }
 
 export const testPollerProperties = {
-  intervalInMs: isRecording ? 2000 : 0
+  intervalInMs: isPlayingBack ? 0 : 2000
 };

--- a/sdk/storage/storage-blob/test/utils/recorder.ts
+++ b/sdk/storage/storage-blob/test/utils/recorder.ts
@@ -571,5 +571,5 @@ export function record(testContext: any) {
 }
 
 export const testPollerProperties = {
-  intervalInMs: isRecording ? 2000 : 0
+  intervalInMs: isPlayingBack ? 0 : 2000
 }

--- a/sdk/storage/storage-blob/test/utils/recorder.ts
+++ b/sdk/storage/storage-blob/test/utils/recorder.ts
@@ -571,5 +571,5 @@ export function record(testContext: any) {
 }
 
 export const testPollerProperties = {
-  intervalInMs: isPlayingBack ? 0 : 2000
+  intervalInMs: isPlayingBack ? 0 : undefined
 }


### PR DESCRIPTION
2 of the storage blob tests were failing _most_ of the time when running live against the service.
Both were related to the `beginCopyFromURL` poller.
1 failure occurred when trying to abort a copy, and the other when trying to listen to copy progress events.
In both cases, if the initial `startCopyFromURL` request returned with a success copy status, then the tests would fail. This is because
1. A copy can't be aborted once it has been completed.
2. There are no progress events if the copy completes 'immediately'.

Because we can't determine how long it will take the service to perform the copy, both tests have been updated to only run in `playback` mode using recorded service responses. This allows us to test that the poller behavior is correct, without having to rely on the speed of the copy.

This also improves the record & playback story for pollers. Previously, live tests would poll continuously with no minimum delay. This changes the behavior so live tests have a 2 second interval while polling, and playback tests have no interval.