### PR TITLE
[core-lro] Browser build path fixes

### DIFF
--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -38,7 +38,7 @@
     "README.md"
   ],
   "browser": {
-    "./dist/index.js": "./browser/azure-core-lro.js",
+    "./dist/index.js": "./browser/azure-core-lro.min.js",
     "os": false,
     "process": false
   },
@@ -96,6 +96,7 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
     "@azure/core-http": "1.0.0-preview.6",
+    "events": "^3.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -38,7 +38,7 @@
     "README.md"
   ],
   "browser": {
-    "./dist/index.js": "./browser/azure-core-lro.min.js",
+    "./dist/index.js": "./browser/azure-core-lro.js",
     "os": false,
     "process": false
   },
@@ -96,7 +96,6 @@
   "dependencies": {
     "@azure/abort-controller": "1.0.0-preview.2",
     "@azure/core-http": "1.0.0-preview.6",
-    "events": "^3.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/sdk/core/core-lro/rollup.base.config.js
+++ b/sdk/core/core-lro/rollup.base.config.js
@@ -21,7 +21,7 @@ const banner = [
   " * Licensed under the MIT License. See License.txt in the project root for",
   " * license information.",
   " * ",
-  ` * Azure KeyVault Keys SDK for JavaScript - ${version}`,
+  ` * Azure Core Lro SDK for JavaScript - ${version}`,
   " */"
 ].join("\n");
 
@@ -36,7 +36,7 @@ export function nodeConfig(test = false) {
     output: {
       file: "dist/index.js",
       format: "cjs",
-      name: "azurekeyvaultkeys",
+      name: "azurecorelro",
       sourcemap: true,
       banner: banner
     },
@@ -82,10 +82,10 @@ export function browserConfig(test = false) {
   const baseConfig = {
     input: "dist-esm/src/index.js",
     output: {
-      file: "browser/azure-keyvault-keys.js",
+      file: "browser/azure-core-lro.js",
       banner: banner,
       format: "umd",
-      name: "azurekeyvaultkeys",
+      name: "azurecorelro",
       globals: {
         "@azure/core-http": "Azure.Core.HTTP",
         "@azure/core-arm": "Azure.Core.ARM"
@@ -137,7 +137,7 @@ export function browserConfig(test = false) {
     // applies to test code, which causes all tests to be removed by tree-shaking.
     baseConfig.treeshake = false;
   } else if (production) {
-    baseConfig.output.file = "browser/azure-keyvault-keys.min.js";
+    baseConfig.output.file = "browser/azure-core-lro.min.js";
     baseConfig.plugins.push(
       terser({
         output: {

--- a/sdk/core/core-lro/rollup.base.config.js
+++ b/sdk/core/core-lro/rollup.base.config.js
@@ -21,7 +21,7 @@ const banner = [
   " * Licensed under the MIT License. See License.txt in the project root for",
   " * license information.",
   " * ",
-  ` * Azure Core Lro SDK for JavaScript - ${version}`,
+  ` * Azure Core LRO SDK for JavaScript - ${version}`,
   " */"
 ].join("\n");
 


### PR DESCRIPTION
Some remaining KeyVault-Keys traces have been addressed.

**NOTE:** The production minified path is correct, so the bug I'm fixing doesn't affect the actual released bundle nor tests from packages using this library.