### PR TITLE
[KeyVault] Fix failures for live tests around timeout when run in browser mode

### DIFF
--- a/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/CRUD.test.ts
@@ -41,37 +41,34 @@ describe("Keys client - create, read, update and delete operations", () => {
 
   // If this test is not skipped in the browser's playback, no other test will be played back.
   // This is a bug related to the browser features of the recorder.
-  it("can abort creating a key", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    const controller = new AbortController();
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can abort creating a key", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+      const controller = new AbortController();
 
-    await assertThrowsAbortError(async () => {
-      const resultPromise = client.createKey(keyName, "RSA", {
-        abortSignal: controller.signal
-      });
-      controller.abort();
-      await resultPromise;
-    });
-  });
-
-  it("can create a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-
-    await assertThrowsAbortError(async () => {
-      await client.createKey(keyName, "RSA", {
-        requestOptions: {
-          timeout: 1
-        }
+      await assertThrowsAbortError(async () => {
+        const resultPromise = client.createKey(keyName, "RSA", {
+          abortSignal: controller.signal
+        });
+        controller.abort();
+        await resultPromise;
       });
     });
-  });
+  }
+
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can create a key with requestOptions timeout", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+
+      await assertThrowsAbortError(async () => {
+        await client.createKey(keyName, "RSA", {
+          requestOptions: {
+            timeout: 1
+          }
+        });
+      });
+    });
+  }
 
   it("cannot create a key with an empty name", async function() {
     const keyName = "";
@@ -106,21 +103,19 @@ describe("Keys client - create, read, update and delete operations", () => {
     await testClient.flushKey(keyName);
   });
 
-  it("can create a RSA key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can create a RSA key with requestOptions timeout", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
 
-    await assertThrowsAbortError(async () => {
-      await client.createRsaKey(keyName, {
-        requestOptions: {
-          timeout: 1
-        }
+      await assertThrowsAbortError(async () => {
+        await client.createRsaKey(keyName, {
+          requestOptions: {
+            timeout: 1
+          }
+        });
       });
     });
-  });
+  }
 
   it("can create an EC key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -139,21 +134,19 @@ describe("Keys client - create, read, update and delete operations", () => {
     await testClient.flushKey(keyName);
   });
 
-  it("can create an EC key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can create an EC key with requestOptions timeout", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
 
-    await assertThrowsAbortError(async () => {
-      await client.createEcKey(keyName, {
-        requestOptions: {
-          timeout: 1
-        }
+      await assertThrowsAbortError(async () => {
+        await client.createEcKey(keyName, {
+          requestOptions: {
+            timeout: 1
+          }
+        });
       });
     });
-  });
+  }
 
   it("can create a disabled key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -228,19 +221,17 @@ describe("Keys client - create, read, update and delete operations", () => {
     await testClient.flushKey(keyName);
   });
 
-  it("can update key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    const { version } = (await client.createRsaKey(keyName)).properties;
-    const options: UpdateKeyPropertiesOptions = { enabled: false, requestOptions: { timeout: 1 } };
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can update key with requestOptions timeout", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+      const { version } = (await client.createRsaKey(keyName)).properties;
+      const options: UpdateKeyPropertiesOptions = { enabled: false, requestOptions: { timeout: 1 } };
 
-    await assertThrowsAbortError(async () => {
-      await client.updateKeyProperties(keyName, version || "", options);
+      await assertThrowsAbortError(async () => {
+        await client.updateKeyProperties(keyName, version || "", options);
+      });
     });
-  });
+  }
 
   it("can delete a key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -261,22 +252,20 @@ describe("Keys client - create, read, update and delete operations", () => {
     await testClient.purgeKey(keyName);
   });
 
-  it("can delete a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    await client.createKey(keyName, "RSA");
-    await assertThrowsAbortError(async () => {
-      await client.beginDeleteKey(keyName, {
-        ...testPollerProperties,
-        requestOptions: {
-          timeout: 1
-        }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can delete a key with requestOptions timeout", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+      await client.createKey(keyName, "RSA");
+      await assertThrowsAbortError(async () => {
+        await client.beginDeleteKey(keyName, {
+          ...testPollerProperties,
+          requestOptions: {
+            timeout: 1
+          }
+        });
       });
     });
-  });
+  }
 
   it("delete nonexisting key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -300,17 +289,15 @@ describe("Keys client - create, read, update and delete operations", () => {
     await testClient.flushKey(keyName);
   });
 
-  it("can get a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    await client.createKey(keyName, "RSA");
-    await assertThrowsAbortError(async () => {
-      await client.getKey(keyName, { requestOptions: { timeout: 1 } });
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can get a key with requestOptions timeout", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+      await client.createKey(keyName, "RSA");
+      await assertThrowsAbortError(async () => {
+        await client.getKey(keyName, { requestOptions: { timeout: 1 } });
+      });
     });
-  });
+  }
 
   it("can get a specific version of a key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -62,18 +62,16 @@ describe("Keys client - list keys in various ways", () => {
     await testClient.flushKey(keyName);
   });
 
-  it("can get the versions of a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const iter = client.listPropertiesOfKeyVersions("doesntmatter", {
-      requestOptions: { timeout: 1 }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can get the versions of a key with requestOptions timeout", async function() {
+      const iter = client.listPropertiesOfKeyVersions("doesntmatter", {
+        requestOptions: { timeout: 1 }
+      });
+      await assertThrowsAbortError(async () => {
+        await iter.next();
+      });
     });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
+  }
 
   it("can get the versions of a key (paged)", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -144,17 +142,15 @@ describe("Keys client - list keys in various ways", () => {
     }
   });
 
-  it("can get several inserted keys with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const iter = client.listPropertiesOfKeys({ requestOptions: { timeout: 1 } });
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can get several inserted keys with requestOptions timeout", async function() {
+      const iter = client.listPropertiesOfKeys({ requestOptions: { timeout: 1 } });
 
-    await assertThrowsAbortError(async () => {
-      await iter.next();
+      await assertThrowsAbortError(async () => {
+        await iter.next();
+      });
     });
-  });
+  }
 
   it("can get several inserted keys (paged)", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -209,16 +205,14 @@ describe("Keys client - list keys in various ways", () => {
     }
   });
 
-  it("list deleted keys with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const iter = client.listDeletedKeys({ requestOptions: { timeout: 1 } });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("list deleted keys with requestOptions timeout", async function() {
+      const iter = client.listDeletedKeys({ requestOptions: { timeout: 1 } });
+      await assertThrowsAbortError(async () => {
+        await iter.next();
+      });
     });
-  });
+  }
 
   it("list deleted keys (paged)", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);

--- a/sdk/keyvault/keyvault-keys/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/recoverBackupRestore.test.ts
@@ -79,15 +79,13 @@ describe("Keys client - restore keys and recover backups", () => {
     await testClient.flushKey(keyName);
   });
 
-  it("can generate a backup of a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    await assertThrowsAbortError(async () => {
-      await client.backupKey("doesntmatter", { requestOptions: { timeout: 1 } });
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can generate a backup of a key with requestOptions timeout", async function() {
+      await assertThrowsAbortError(async () => {
+        await client.backupKey("doesntmatter", { requestOptions: { timeout: 1 } });
+      });
     });
-  });
+  }
 
   it("fails to generate a backup of a non-existing key", async function() {
     const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
@@ -112,20 +110,18 @@ describe("Keys client - restore keys and recover backups", () => {
     await testClient.flushKey(keyName);
   });
 
-  it("can restore a key with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      // On playback mode, the tests happen too fast for the timeout to work
-      recorder.skip();
-    }
-    const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
-    await client.createKey(keyName, "RSA");
-    const backup = await client.backupKey(keyName);
-    await testClient.flushKey(keyName);
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can restore a key with requestOptions timeout", async function() {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+      await client.createKey(keyName, "RSA");
+      const backup = await client.backupKey(keyName);
+      await testClient.flushKey(keyName);
 
-    await assertThrowsAbortError(async () => {
-      await client.restoreKeyBackup(backup!, { requestOptions: { timeout: 1 } });
+      await assertThrowsAbortError(async () => {
+        await client.restoreKeyBackup(backup!, { requestOptions: { timeout: 1 } });
+      });
     });
-  });
+  }
 
   it("fails to restore a key with a malformed backup", async function() {
     const backup = new Uint8Array(8693);

--- a/sdk/keyvault/keyvault-secrets/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/CRUD.test.ts
@@ -61,21 +61,20 @@ describe("Secret client - create, read, update and delete operations", () => {
     });
   });
 
-  it("can timeout adding a secret", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await assertThrowsAbortError(async () => {
-      await client.setSecret(secretName, secretValue, {
-        requestOptions: {
-          timeout: 1
-        }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can timeout adding a secret", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await assertThrowsAbortError(async () => {
+        await client.setSecret(secretName, secretValue, {
+          requestOptions: {
+            timeout: 1
+          }
+        });
       });
     });
-  });
+  }
 
   it("cannot create a secret with an empty name", async function() {
     const secretName = "";
@@ -141,26 +140,25 @@ describe("Secret client - create, read, update and delete operations", () => {
     await testClient.flushSecret(secretName);
   });
 
-  it("can timeout updating a secret", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    const expiryDate = new Date("3000-01-01");
-    expiryDate.setMilliseconds(0);
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can timeout updating a secret", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      const expiryDate = new Date("3000-01-01");
+      expiryDate.setMilliseconds(0);
 
-    await client.setSecret(secretName, secretValue);
-    await assertThrowsAbortError(async () => {
-      await client.updateSecretProperties(secretName, "", {
-        expiresOn: expiryDate,
-        requestOptions: {
-          timeout: 1
-        }
+      await client.setSecret(secretName, secretValue);
+      await assertThrowsAbortError(async () => {
+        await client.updateSecretProperties(secretName, "", {
+          expiresOn: expiryDate,
+          requestOptions: {
+            timeout: 1
+          }
+        });
       });
     });
-  });
+  }
 
   it("can update a disabled secret", async function() {
     const secretName = testClient.formatName(
@@ -194,22 +192,21 @@ describe("Secret client - create, read, update and delete operations", () => {
     await testClient.flushSecret(secretName);
   });
 
-  it("can timeout getting a secret", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, secretValue);
-    await assertThrowsAbortError(async () => {
-      await client.getSecret(secretName, {
-        requestOptions: {
-          timeout: 1
-        }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can timeout getting a secret", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await client.setSecret(secretName, secretValue);
+      await assertThrowsAbortError(async () => {
+        await client.getSecret(secretName, {
+          requestOptions: {
+            timeout: 1
+          }
+        });
       });
     });
-  });
+  }
 
   it("can't get a disabled secret", async function() {
     const secretName = testClient.formatName(
@@ -297,23 +294,22 @@ describe("Secret client - create, read, update and delete operations", () => {
     await testClient.purgeSecret(secretName);
   });
 
-  it("can timeout deleting a secret", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, secretValue);
-    await assertThrowsAbortError(async () => {
-      await client.beginDeleteSecret(secretName, {
-        requestOptions: {
-          timeout: 1
-        },
-        ...testPollerProperties
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can timeout deleting a secret", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await client.setSecret(secretName, secretValue);
+      await assertThrowsAbortError(async () => {
+        await client.beginDeleteSecret(secretName, {
+          requestOptions: {
+            timeout: 1
+          },
+          ...testPollerProperties
+        });
       });
     });
-  });
+  }
 
   it("can delete a secret (Non Existing)", async function() {
     const secretName = testClient.formatName(

--- a/sdk/keyvault/keyvault-secrets/test/list.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/list.test.ts
@@ -71,17 +71,16 @@ describe("Secret client - list secrets in various ways", () => {
     }
   });
 
-  it("can get secret properties with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const iter = client.listPropertiesOfSecrets({
-      requestOptions: { timeout: 1 }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can get secret properties with requestOptions timeout", async function() {
+      const iter = client.listPropertiesOfSecrets({
+        requestOptions: { timeout: 1 }
+      });
+      await assertThrowsAbortError(async () => {
+        await iter.next();
+      });
     });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
+  }
 
   it("can list deleted secrets", async function() {
     const secretName = testClient.formatName(
@@ -110,17 +109,16 @@ describe("Secret client - list secrets in various ways", () => {
     }
   });
 
-  it("can get the deleted secrets with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const iter = client.listDeletedSecrets({
-      requestOptions: { timeout: 1 }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can get the deleted secrets with requestOptions timeout", async function() {
+      const iter = client.listDeletedSecrets({
+        requestOptions: { timeout: 1 }
+      });
+      await assertThrowsAbortError(async () => {
+        await iter.next();
+      });
     });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
+  }
 
   it("can retrieve all versions of a secret", async function() {
     const secretName = testClient.formatName(
@@ -153,17 +151,16 @@ describe("Secret client - list secrets in various ways", () => {
     await testClient.flushSecret(secretName);
   });
 
-  it("can get versions of a secret with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const iter = client.listPropertiesOfSecretVersions("doesntmatter", {
-      requestOptions: { timeout: 1 }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can get versions of a secret with requestOptions timeout", async function() {
+      const iter = client.listPropertiesOfSecretVersions("doesntmatter", {
+        requestOptions: { timeout: 1 }
+      });
+      await assertThrowsAbortError(async () => {
+        await iter.next();
+      });
     });
-    await assertThrowsAbortError(async () => {
-      await iter.next();
-    });
-  });
+  }
 
   it("can list secret versions (non existing)", async function() {
     const secretName = testClient.formatName(

--- a/sdk/keyvault/keyvault-secrets/test/lro.delete.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/lro.delete.test.ts
@@ -86,16 +86,15 @@ describe("Secrets client - Long Running Operations - delete", () => {
     await testClient.purgeSecret(secretName);
   });
 
-  it("can attempt to delete a secret with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip();
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, "value");
-    await assertThrowsAbortError(async () => {
-      await client.beginDeleteSecret(secretName, { requestOptions: { timeout: 1 } });
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can attempt to delete a secret with requestOptions timeout", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await client.setSecret(secretName, "value");
+      await assertThrowsAbortError(async () => {
+        await client.beginDeleteSecret(secretName, { requestOptions: { timeout: 1 } });
+      });
     });
-  });
+	}
 });

--- a/sdk/keyvault/keyvault-secrets/test/lro.recover.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/lro.recover.test.ts
@@ -95,21 +95,20 @@ describe("Secrets client - Long Running Operations - recoverDelete", () => {
     await testClient.flushSecret(secretName);
   });
 
-  it("can attempt to recover a deleted secret with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip();
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, "value");
-    const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-    await assertThrowsAbortError(async () => {
-      await client.beginRecoverDeletedSecret(secretName, {
-        requestOptions: { timeout: 1 },
-        ...testPollerProperties
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can attempt to recover a deleted secret with requestOptions timeout", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await client.setSecret(secretName, "value");
+      const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
+      await deletePoller.pollUntilDone();
+      await assertThrowsAbortError(async () => {
+        await client.beginRecoverDeletedSecret(secretName, {
+          requestOptions: { timeout: 1 },
+          ...testPollerProperties
+        });
       });
     });
-  });
+  }
 });

--- a/sdk/keyvault/keyvault-secrets/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/recoverBackupRestore.test.ts
@@ -161,22 +161,21 @@ describe("Secret client - restore secrets and recover backups", () => {
     );
   });
 
-  it("can timeout deleting a secret", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, "RSA");
-    const backup = await client.backupSecret(secretName);
-    await testClient.flushSecret(secretName);
-    await assertThrowsAbortError(async () => {
-      await client.restoreSecretBackup(backup as Uint8Array, {
-        requestOptions: {
-          timeout: 1
-        }
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can timeout deleting a secret", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await client.setSecret(secretName, "RSA");
+      const backup = await client.backupSecret(secretName);
+      await testClient.flushSecret(secretName);
+      await assertThrowsAbortError(async () => {
+        await client.restoreSecretBackup(backup as Uint8Array, {
+          requestOptions: {
+            timeout: 1
+          }
+        });
       });
     });
-  });
+  }
 });

--- a/sdk/keyvault/keyvault-secrets/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/recoverBackupRestore.test.ts
@@ -80,25 +80,24 @@ describe("Secret client - restore secrets and recover backups", () => {
     assert.equal(error.message, `Secret not found: ${secretName}`);
   });
 
-  it("can recover a deleted a secret with requestOptions timeout", async function() {
-    if (!isNode || isPlayingBack) {
-      recorder.skip(); // On playback mode, the tests happen too fast for the timeout to work
-    }
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, "RSA");
-    const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
-    await deletePoller.pollUntilDone();
-    await assertThrowsAbortError(async () => {
-      await client.beginRecoverDeletedSecret(secretName, {
-        requestOptions: {
-          timeout: 1
-        },
-        ...testPollerProperties
+  if (isNode && !isPlayingBack) { // On playback mode, the tests happen too fast for the timeout to work
+    it("can recover a deleted a secret with requestOptions timeout", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await client.setSecret(secretName, "RSA");
+      const deletePoller = await client.beginDeleteSecret(secretName, testPollerProperties);
+      await deletePoller.pollUntilDone();
+      await assertThrowsAbortError(async () => {
+        await client.beginRecoverDeletedSecret(secretName, {
+          requestOptions: {
+            timeout: 1
+          },
+          ...testPollerProperties
+        });
       });
     });
-  });
+  }
 
   it("can backup a secret", async function() {
     const secretName = testClient.formatName(


### PR DESCRIPTION
Fixes #5846
Fixes #5849

recorder.skip doesn't work if TEST_MODE is not set.

The tests being skipped in this PR in browser mode are due to https://github.com/Azure/azure-sdk-for-js/issues/5747

The tests are skipped in playback mode because the http requests take no time to respond, so timeout does not work.