### PR TITLE
[Storage] Update global variables used in browser mode to include the word "storage"

### DIFF
--- a/sdk/storage/README.md
+++ b/sdk/storage/README.md
@@ -124,9 +124,9 @@ To use the client libraries with JS bundle in the browsers, simply add a script 
 
 The JS bundled file is compatible with [UMD](https://github.com/umdjs/umd) standard, if no module system found, following global variable(s) will be exported:
 
-- `azblob`
-- `azfileshare`
-- `azqueue`
+- `azstorageblob`
+- `azstoragefileshare`
+- `azstoragequeue`
 
 #### Download
 

--- a/sdk/storage/storage-blob/BreakingChanges.md
+++ b/sdk/storage/storage-blob/BreakingChanges.md
@@ -1,5 +1,9 @@
 # Breaking Changes
 
+## 2019.11 12.0.0-preview.6
+
+- JS bundle in the browsers - Global variable for the package has been renamed from `azblob` to `azstorageblob`.
+
 ## 2019.11 12.0.0-preview.5
 
 - [Breaking] `IPRange` is renamed to `SasIPRange`. [PR #5551](https://github.com/Azure/azure-sdk-for-js/pull/5551)

--- a/sdk/storage/storage-blob/ChangeLog.md
+++ b/sdk/storage/storage-blob/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019.11 12.0.0-preview.6
+
+- [Breaking] JS bundle in the browsers - Global variable for the package has been renamed from `azblob` to `azstorageblob`.
+
 ## 2019.11 12.0.0-preview.5
 
 - [Breaking] `IPRange` is renamed to `SasIPRange`. [PR #5551](https://github.com/Azure/azure-sdk-for-js/pull/5551)

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -103,7 +103,7 @@ To use the library with JS bundle in the browsers, simply add a script tag to yo
 
 The JS bundled file is compatible with [UMD](https://github.com/umdjs/umd) standard, if no module system found, following global variable(s) will be exported:
 
-- `azblob`
+- `azstorageblob`
 
 #### Download
 

--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -87,7 +87,7 @@ export function browserConfig(test = false, production = false) {
       file: "browser/azure-storage-blob.js",
       banner: banner,
       format: "umd",
-      name: "azblob",
+      name: "azstorageblob",
       sourcemap: true
     },
     preserveSymlinks: false,

--- a/sdk/storage/storage-blob/samples/browserSamples/basic.html
+++ b/sdk/storage/storage-blob/samples/browserSamples/basic.html
@@ -17,7 +17,7 @@ and replace code in the below script tag to try them out.
 <script>
   const account = "";
   const accountSas = "";
-  const blobServiceClient = new azblob.BlobServiceClient(
+  const blobServiceClient = new azstorageblob.BlobServiceClient(
     "https://" + account + ".blob.core.windows.net" + accountSas
   );
 

--- a/sdk/storage/storage-blob/samples/browserSamples/largeFileUploads.html
+++ b/sdk/storage/storage-blob/samples/browserSamples/largeFileUploads.html
@@ -27,7 +27,7 @@
     <script src="./azure-storage-blob.js"></script>
 
     <script>
-      // azblob is default exported entry when importing Azure Storage Blob SDK by <script src="azure-storage.blob.js">
+      // azstorageblob is default exported entry when importing Azure Storage Blob SDK by <script src="azure-storage.blob.js">
 
       // SasStore is a class to cache SAS for blobs
       class SasStore {
@@ -66,7 +66,7 @@
         }
       }
 
-      class SasUpdatePolicy extends azblob.BaseRequestPolicy {
+      class SasUpdatePolicy extends azstorageblob.BaseRequestPolicy {
         constructor(nextPolicy, options, sasStore) {
           super(nextPolicy, options);
           this.sasStore = sasStore;
@@ -89,12 +89,12 @@
       async function upload() {
         const sasStore = new SasStore();
 
-        const pipeline = azblob.newPipeline(new azblob.AnonymousCredential());
+        const pipeline = azstorageblob.newPipeline(new azstorageblob.AnonymousCredential());
         // Inject SAS update policy factory into current pipeline
         pipeline.factories.unshift(new SasUpdatePolicyFactory(sasStore));
 
         const url = "https://jsv10.blob.core.windows.net/mycontainer/myblob";
-        const blockBlobClient = new azblob.BlockBlobClient(
+        const blockBlobClient = new azstorageblob.BlockBlobClient(
           `${url}${await sasStore.getValidSASForBlob(url)}`, // A SAS should start with "?"
           pipeline
         );

--- a/sdk/storage/storage-file-share/BreakingChanges.md
+++ b/sdk/storage/storage-file-share/BreakingChanges.md
@@ -1,5 +1,9 @@
 # Breaking Changes
 
+## 2019.11 12.0.0-preview.6
+
+- JS bundle in the browsers - Global variable for the package has been renamed from `azfile` to `azstoragefileshare`.
+
 ## 2019.10 12.0.0-preview.5
 
 - [Breaking] `IPRange` is renamed to `SasIPRange`. [PR #5551](https://github.com/Azure/azure-sdk-for-js/pull/5551)

--- a/sdk/storage/storage-file-share/ChangeLog.md
+++ b/sdk/storage/storage-file-share/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 2019.11 12.0.0-preview.6
 
 - Bug Fix - Previous versions of `@azure/storage-file` library failed for the react-apps because of the usage of `fs.stat` method which is not available in browsers. The issue is fixed in this new release.
+- [Breaking] JS bundle in the browsers - Global variable for the package has been renamed from `azfile` to `azstoragefileshare`.
 
 ## 2019.10 12.0.0-preview.5
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -102,7 +102,7 @@ To use the library with JS bundle in the browsers, simply add a script tag to yo
 
 The JS bundled file is compatible with [UMD](https://github.com/umdjs/umd) standard, if no module system found, following global variable(s) will be exported:
 
-- `azfileshare`
+- `azstoragefileshare`
 
 #### Download
 

--- a/sdk/storage/storage-file-share/rollup.base.config.js
+++ b/sdk/storage/storage-file-share/rollup.base.config.js
@@ -87,7 +87,7 @@ export function browserConfig(test = false, production = false) {
       file: "browser/azure-storage-file-share.js",
       banner: banner,
       format: "umd",
-      name: "azfileshare",
+      name: "azstoragefileshare",
       sourcemap: true
     },
     preserveSymlinks: false,

--- a/sdk/storage/storage-file-share/samples/browserSample.html
+++ b/sdk/storage/storage-file-share/samples/browserSample.html
@@ -17,7 +17,7 @@ and replace code in the below script tag to try them out.
 <script>
   const account = "";
   const accountSas = "";
-  const serviceClient = new azfileshare.ShareServiceClient(
+  const serviceClient = new azstoragefileshare.ShareServiceClient(
     "https://" + account + ".file.core.windows.net" + accountSas
   );
 

--- a/sdk/storage/storage-queue/BreakingChanges.md
+++ b/sdk/storage/storage-queue/BreakingChanges.md
@@ -1,5 +1,9 @@
 # Breaking Changes
 
+## 2019.11 12.0.0-preview.6
+
+- JS bundle in the browsers - Global variable for the package has been renamed from `azqueue` to `azstoragequeue`.
+
 ## 2019.11 12.0.0-preview.5
 
 - [Breaking] Major API changes for the `@azure/storage-queue` package.

--- a/sdk/storage/storage-queue/ChangeLog.md
+++ b/sdk/storage/storage-queue/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019.11 12.0.0-preview.6
+
+- [Breaking] JS bundle in the browsers - Global variable for the package has been renamed from `azqueue` to `azstoragequeue`.
+
 ## 2019.11 12.0.0-preview.5
 
 - [Breaking] Major API changes for the `@azure/storage-queue` package.

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -91,7 +91,7 @@ To use the library with JS bundle in the browsers, simply add a script tag to yo
 
 The JS bundled file is compatible with [UMD](https://github.com/umdjs/umd) standard, if no module system found, following global variable(s) will be exported:
 
-- `azqueue`
+- `azstoragequeue`
 
 #### Download
 

--- a/sdk/storage/storage-queue/rollup.base.config.js
+++ b/sdk/storage/storage-queue/rollup.base.config.js
@@ -79,7 +79,7 @@ export function browserConfig(test = false, production = false) {
       file: "browser/azure-storage-queue.js",
       banner: banner,
       format: "umd",
-      name: "azqueue",
+      name: "azstoragequeue",
       sourcemap: true
     },
     preserveSymlinks: false,

--- a/sdk/storage/storage-queue/samples/browserSample.html
+++ b/sdk/storage/storage-queue/samples/browserSample.html
@@ -17,7 +17,7 @@ and replace code in the below script tag to try them out.
 <script>
   const account = "";
   const accountSas = "";
-  const queueServiceClient = new azqueue.QueueServiceClient(
+  const queueServiceClient = new azstoragequeue.QueueServiceClient(
     "https://" + account + ".queue.core.windows.net" + accountSas
   );
 


### PR DESCRIPTION
This PR updates the name of the global variables used in browser mode to include the word "storage".
This helps in differentiating between other possible "queue", "file" or "blob" entities in Azure