### PR TITLE
Remove in-box browser bundles for keyvault-* and identity

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -13,8 +13,7 @@
     "./dist-esm/src/credentials/clientCertificateCredential.js": "./dist-esm/src/credentials/clientCertificateCredential.browser.js",
     "./dist-esm/src/credentials/deviceCodeCredential.js": "./dist-esm/src/credentials/deviceCodeCredential.browser.js",
     "./dist-esm/src/credentials/authorizationCodeCredential.js": "./dist-esm/src/credentials/authorizationCodeCredential.browser.js",
-    "./dist-esm/src/credentials/interactiveBrowserCredential.js": "./dist-esm/src/credentials/interactiveBrowserCredential.browser.js",
-    "./dist/index.js": "./browser/index.js"
+    "./dist-esm/src/credentials/interactiveBrowserCredential.js": "./dist-esm/src/credentials/interactiveBrowserCredential.browser.js"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
@@ -44,7 +43,6 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "files": [
-    "browser/*.js*",
     "dist/",
     "dist-esm/src/",
     "src/",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -26,7 +26,6 @@
   },
   "files": [
     "LICENSE.txt",
-    "ThirdPartyNotices.txt",
     "README.md",
     "types/keyvault-certificates.d.ts",
     "lib/",
@@ -36,7 +35,6 @@
     "tsconfig.json"
   ],
   "browser": {
-    "./dist/index.js": "./browser/azure-keyvault-certificates.min.js",
     "os": false,
     "process": false
   },

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -27,16 +27,13 @@
   "files": [
     "LICENSE.txt",
     "README.md",
-    "ThirdPartyNotices.txt",
     "types/keyvault-keys.d.ts",
-    "browser/",
     "dist/",
     "dist-esm/",
     "src/",
     "tsconfig.json"
   ],
   "browser": {
-    "./dist/index.js": "./browser/azure-keyvault-keys.min.js",
     "os": false,
     "process": false
   },

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -27,16 +27,13 @@
   "files": [
     "LICENSE.txt",
     "README.md",
-    "ThirdPartyNotices.txt",
     "types/keyvault-secrets.d.ts",
-    "browser/",
     "dist/",
     "dist-esm/",
     "src/",
     "tsconfig.json"
   ],
   "browser": {
-    "./dist/index.js": "./browser/azure-keyvault-secrets.min.js",
     "os": false,
     "process": false
   },
@@ -76,7 +73,8 @@
     "@azure/core-paging": "1.0.0-preview.2",
     "@azure/core-tracing": "1.0.0-preview.5",
     "@azure/logger": "1.0.0-preview.1",
-    "tslib": "^1.9.3"
+    "tslib": "^1.9.3",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
@@ -133,7 +131,6 @@
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "^3.2.2",
-    "uglify-js": "^3.4.9",
-    "url": "^0.11.0"
+    "uglify-js": "^3.4.9"
   }
 }

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -73,8 +73,7 @@
     "@azure/core-paging": "1.0.0-preview.2",
     "@azure/core-tracing": "1.0.0-preview.5",
     "@azure/logger": "1.0.0-preview.1",
-    "tslib": "^1.9.3",
-    "url": "^0.11.0"
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
@@ -131,6 +130,7 @@
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "^3.2.2",
-    "uglify-js": "^3.4.9"
+    "uglify-js": "^3.4.9",
+    "url": "^0.11.0"
   }
 }


### PR DESCRIPTION
After talking though the changes in https://github.com/Azure/azure-sdk-for-js/pull/5860 with @Petermarcu, we became uncomfortable shipping browser bundles for any package for GA. We will be bringing them back when we have better plans in place for the following issues:

1. Keeping ThirdPartyNotices.txt up-to-date without requiring manually combing through bundles every time we ship a package.
2. An explicit servicing plan should a security issue arise anywhere in the bundled dependency graph
3. A strategy for ensuring users don't consider using these bundles a good idea short of quick-n-dirty/getting started scenarios.
4. Test collateral that runs against the actual browser artifact