### PR TITLE
[Storage] [Blob] add fs: false to storage-blob package.json browser mapping

### DIFF
--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -12,6 +12,7 @@
     "./dist-esm/test/utils/index.js": "./dist-esm/test/utils/index.browser.js",
     "./dist-esm/src/BatchUtils.js": "./dist-esm/src/BatchUtils.browser.js",
     "./dist-esm/src/BlobDownloadResponse.js": "./dist-esm/src/BlobDownloadResponse.browser.js",
+    "fs": false,
     "os": false,
     "process": false
   },


### PR DESCRIPTION
`fs` isn't required in the browser, but webpack will complain about the missing export. This change ensures webpack will not complain and bundle without error out-of-the-box.