### PR TITLE
[CODEOWNERS] Fix issue where api review file owner rule not mat…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,6 @@
 # Catch all
 /sdk/ @ramya-rao-a
 
-# API review files
-/sdk/**/review/*api.md @bterlson
-
 # Core
 /sdk/core/abort-controller/ @chradek
 /sdk/core/core-amqp/ @ramya-rao-a @chradek
@@ -35,6 +32,9 @@
 /sdk/storage/ @XiaoningLiu @jeremymeng @HarshaNalluru @vinjiang @jiacfan
 
 /sdk/test-utils/ @HarshaNalluru
+
+# API review files
+/sdk/**/review/*api.md @bterlson
 
 # Management Plane
 /**/*Management*.ts @qiaozha


### PR DESCRIPTION
The precedence is that last rule wins, so specific library directory
owners override the api review file owner.  Fixing it by move the api
review rule after sdk rules.