### PR TITLE
[Storage] [Queue & Blob] Consistency on startsOn and expiresOn

### DIFF
--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -78,13 +78,13 @@ export class AccountSASServices {
 
 // @public
 export interface AccountSASSignatureValues {
-    expiryTime: Date;
+    expiresOn: Date;
     ipRange?: SasIPRange;
     permissions: AccountSASPermissions;
     protocol?: SASProtocol;
     resourceTypes: string;
     services: string;
-    startTime?: Date;
+    startsOn?: Date;
     version?: string;
 }
 
@@ -750,13 +750,13 @@ export interface BlobSASSignatureValues {
     contentEncoding?: string;
     contentLanguage?: string;
     contentType?: string;
-    expiryTime?: Date;
+    expiresOn?: Date;
     identifier?: string;
     ipRange?: SasIPRange;
     permissions?: BlobSASPermissions;
     protocol?: SASProtocol;
     snapshotTime?: string;
-    startTime?: Date;
+    startsOn?: Date;
     version?: string;
 }
 
@@ -775,7 +775,7 @@ export class BlobServiceClient extends StorageClient {
     getContainerClient(containerName: string): ContainerClient;
     getProperties(options?: ServiceGetPropertiesOptions): Promise<ServiceGetPropertiesResponse>;
     getStatistics(options?: ServiceGetStatisticsOptions): Promise<ServiceGetStatisticsResponse>;
-    getUserDelegationKey(start: Date, expiry: Date, options?: ServiceGetUserDelegationKeyOptions): Promise<ServiceGetUserDelegationKeyResponse>;
+    getUserDelegationKey(startsOn: Date, expiresOn: Date, options?: ServiceGetUserDelegationKeyOptions): Promise<ServiceGetUserDelegationKeyResponse>;
     listContainers(options?: ServiceListContainersOptions): PagedAsyncIterableIterator<ContainerItem, ServiceListContainersSegmentResponse>;
     setProperties(properties: BlobServiceProperties, options?: ServiceSetPropertiesOptions): Promise<ServiceSetPropertiesResponse>;
 }
@@ -2089,13 +2089,13 @@ export enum SASProtocol {
 
 // @public
 export class SASQueryParameters {
-    constructor(version: string, signature: string, permissions?: string, services?: string, resourceTypes?: string, protocol?: SASProtocol, startTime?: Date, expiryTime?: Date, ipRange?: SasIPRange, identifier?: string, resource?: string, cacheControl?: string, contentDisposition?: string, contentEncoding?: string, contentLanguage?: string, contentType?: string, userDelegationKey?: UserDelegationKey);
+    constructor(version: string, signature: string, permissions?: string, services?: string, resourceTypes?: string, protocol?: SASProtocol, startsOn?: Date, expiresOn?: Date, ipRange?: SasIPRange, identifier?: string, resource?: string, cacheControl?: string, contentDisposition?: string, contentEncoding?: string, contentLanguage?: string, contentType?: string, userDelegationKey?: UserDelegationKey);
     readonly cacheControl?: string;
     readonly contentDisposition?: string;
     readonly contentEncoding?: string;
     readonly contentLanguage?: string;
     readonly contentType?: string;
-    readonly expiryTime?: Date;
+    readonly expiresOn?: Date;
     readonly identifier?: string;
     readonly ipRange: SasIPRange | undefined;
     readonly permissions?: string;
@@ -2104,7 +2104,7 @@ export class SASQueryParameters {
     readonly resourceTypes?: string;
     readonly services?: string;
     readonly signature: string;
-    readonly startTime?: Date;
+    readonly startsOn?: Date;
     toString(): string;
     readonly version: string;
 }
@@ -2288,8 +2288,8 @@ export type ServiceSubmitBatchResponseModel = ServiceSubmitBatchHeaders & {
 // @public
 export interface SignedIdentifier {
     accessPolicy: {
-        start?: Date;
-        expiry?: Date;
+        startsOn?: Date;
+        expiresOn?: Date;
         permissions: string;
     };
     id: string;
@@ -2384,10 +2384,10 @@ export type SyncCopyStatusType = 'success';
 
 // @public
 export interface UserDelegationKey {
-    signedExpiry: Date;
+    signedExpiresOn: Date;
     signedObjectId: string;
     signedService: string;
-    signedStart: Date;
+    signedStartsOn: Date;
     signedTenantId: string;
     signedVersion: string;
     value: string;
@@ -2395,10 +2395,10 @@ export interface UserDelegationKey {
 
 // @public
 export interface UserDelegationKeyModel {
-    signedExpiry: string;
+    signedExpiresOn: string;
     signedObjectId: string;
     signedService: string;
-    signedStart: string;
+    signedStartsOn: string;
     signedTenantId: string;
     signedVersion: string;
     value: string;

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -32,9 +32,9 @@ import { WebResource } from '@azure/core-http';
 
 // @public
 export interface AccessPolicy {
-    expiry: string;
+    expiresOn: string;
     permissions: string;
-    start: string;
+    startsOn: string;
 }
 
 // @public

--- a/sdk/storage/storage-blob/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/AccountSASSignatureValues.ts
@@ -51,7 +51,7 @@ export interface AccountSASSignatureValues {
    * @type {Date}
    * @memberof AccountSASSignatureValues
    */
-  startTime?: Date;
+  startsOn?: Date;
 
   /**
    * The time after which the SAS will no longer work.
@@ -59,7 +59,7 @@ export interface AccountSASSignatureValues {
    * @type {Date}
    * @memberof AccountSASSignatureValues
    */
-  expiryTime: Date;
+  expiresOn: Date;
 
   /**
    * Specifies which operations the SAS user may perform. Please refer to {@link AccountSASPermissions} for help
@@ -131,10 +131,10 @@ export function generateAccountSASQueryParameters(
     parsedPermissions,
     parsedServices,
     parsedResourceTypes,
-    accountSASSignatureValues.startTime
-      ? truncatedISO8061Date(accountSASSignatureValues.startTime, false)
+    accountSASSignatureValues.startsOn
+      ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
       : "",
-    truncatedISO8061Date(accountSASSignatureValues.expiryTime, false),
+    truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
     accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
     accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
     version,
@@ -150,8 +150,8 @@ export function generateAccountSASQueryParameters(
     parsedServices,
     parsedResourceTypes,
     accountSASSignatureValues.protocol,
-    accountSASSignatureValues.startTime,
-    accountSASSignatureValues.expiryTime,
+    accountSASSignatureValues.startsOn,
+    accountSASSignatureValues.expiresOn,
     accountSASSignatureValues.ipRange
   );
 }

--- a/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
@@ -44,7 +44,7 @@ export interface BlobSASSignatureValues {
    * @type {Date}
    * @memberof BlobSASSignatureValues
    */
-  startTime?: Date;
+  startsOn?: Date;
 
   /**
    * Optional only when identifier is provided. The time after which the SAS will no longer work.
@@ -52,7 +52,7 @@ export interface BlobSASSignatureValues {
    * @type {Date}
    * @memberof BlobSASSignatureValues
    */
-  expiryTime?: Date;
+  expiresOn?: Date;
 
   /**
    * Optional only when identifier is provided.
@@ -153,10 +153,10 @@ export interface BlobSASSignatureValues {
  * Creates an instance of SASQueryParameters.
  *
  * Only accepts required settings needed to create a SAS. For optional settings please
- * set corresponding properties directly, such as permissions, startTime and identifier.
+ * set corresponding properties directly, such as permissions, startsOn and identifier.
  *
- * WARNING: When identifier is not provided, permissions and expiryTime are required.
- * You MUST assign value to identifier or expiryTime & permissions manually if you initial with
+ * WARNING: When identifier is not provided, permissions and expiresOn are required.
+ * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
  * @example
@@ -165,8 +165,8 @@ export interface BlobSASSignatureValues {
  * const containerSAS = generateBlobSASQueryParameters({
  *     containerName, // Required
  *     permissions: ContainerSASPermissions.parse("racwdl").toString(), // Required
- *     startTime: new Date(), // Required
- *     expiryTime: tmr, // Optional. Date type
+ *     startsOn: new Date(), // Required
+ *     expiresOn: tmr, // Optional. Date type
  *     ipRange: { start: "0.0.0.0", end: "255.255.255.255" }, // Optional
  *     protocol: SASProtocol.HTTPSandHTTP, // Optional
  *     version: "2016-05-31" // Optional
@@ -178,12 +178,12 @@ export interface BlobSASSignatureValues {
  * @example
  * ```js
  * // Generate service level SAS for a container with identifier
- * // startTime & permissions are optional when identifier is provided
+ * // startsOn & permissions are optional when identifier is provided
  * const identifier = "unique-id";
  * await containerClient.setAccessPolicy(undefined, [
  *   {
  *     accessPolicy: {
- *       expiry: tmr, // Date type
+ *       expiresOn: tmr, // Date type
  *       permissions: ContainerSASPermissions.parse("racwdl").toString(),
  *       start: now // Date type
  *     },
@@ -207,8 +207,8 @@ export interface BlobSASSignatureValues {
  *     containerName, // Required
  *     blobName, // Required
  *     permissions: BlobSASPermissions.parse("racwd").toString(), // Required
- *     startTime: new Date(), // Required
- *     expiryTime: tmr, // Optional. Date type
+ *     startsOn: new Date(), // Required
+ *     expiresOn: tmr, // Optional. Date type
  *     cacheControl: "cache-control-override", // Optional
  *     contentDisposition: "content-disposition-override", // Optional
  *     contentEncoding: "content-encoding-override", // Optional
@@ -236,17 +236,17 @@ export function generateBlobSASQueryParameters(
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
  * Creates an instance of SASQueryParameters.
- * WARNING: identifier will be ignored when generating user delegation SAS, permissions and expiryTime are required.
+ * WARNING: identifier will be ignored when generating user delegation SAS, permissions and expiresOn are required.
  *
  * @example
  * ```js
  * // Generate user delegation SAS for a container
- * const userDelegationKey = await blobServiceClient.getUserDelegationKey(aborter, startTime, expiryTime);
+ * const userDelegationKey = await blobServiceClient.getUserDelegationKey(aborter, startsOn, expiresOn);
  * const containerSAS = generateBlobSASQueryParameters({
  *     containerName, // Required
  *     permissions: ContainerSASPermissions.parse("racwdl").toString(), // Required
- *     startTime, // Required. Date type
- *     expiryTime, // Optional. Date type
+ *     startsOn, // Required. Date type
+ *     expiresOn, // Optional. Date type
  *     ipRange: { start: "0.0.0.0", end: "255.255.255.255" }, // Optional
  *     protocol: SASProtocol.HTTPSandHTTP, // Optional
  *     version: "2018-11-09" // Must >= 2018-11-09 to generate user delegation SAS
@@ -325,10 +325,10 @@ export function generateBlobSASQueryParameters(
  * Creates an instance of SASQueryParameters.
  *
  * Only accepts required settings needed to create a SAS. For optional settings please
- * set corresponding properties directly, such as permissions, startTime and identifier.
+ * set corresponding properties directly, such as permissions, startsOn and identifier.
  *
- * WARNING: When identifier is not provided, permissions and expiryTime are required.
- * You MUST assign value to identifier or expiryTime & permissions manually if you initial with
+ * WARNING: When identifier is not provided, permissions and expiresOn are required.
+ * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
  * @param {BlobSASSignatureValues} blobSASSignatureValues
@@ -341,10 +341,10 @@ function generateBlobSASQueryParameters20150405(
 ): SASQueryParameters {
   if (
     !blobSASSignatureValues.identifier &&
-    (!blobSASSignatureValues.permissions && !blobSASSignatureValues.expiryTime)
+    (!blobSASSignatureValues.permissions && !blobSASSignatureValues.expiresOn)
   ) {
     throw new RangeError(
-      "Must provide 'permissions' and 'expiryTime' for Blob SAS generation when 'identifier' is not provided."
+      "Must provide 'permissions' and 'expiresOn' for Blob SAS generation when 'identifier' is not provided."
     );
   }
 
@@ -373,11 +373,11 @@ function generateBlobSASQueryParameters20150405(
   // Signature is generated on the un-url-encoded values.
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
-    blobSASSignatureValues.startTime
-      ? truncatedISO8061Date(blobSASSignatureValues.startTime, false)
+    blobSASSignatureValues.startsOn
+      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
       : "",
-    blobSASSignatureValues.expiryTime
-      ? truncatedISO8061Date(blobSASSignatureValues.expiryTime, false)
+    blobSASSignatureValues.expiresOn
+      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -404,8 +404,8 @@ function generateBlobSASQueryParameters20150405(
     undefined,
     undefined,
     blobSASSignatureValues.protocol,
-    blobSASSignatureValues.startTime,
-    blobSASSignatureValues.expiryTime,
+    blobSASSignatureValues.startsOn,
+    blobSASSignatureValues.expiresOn,
     blobSASSignatureValues.ipRange,
     blobSASSignatureValues.identifier,
     resource,
@@ -424,10 +424,10 @@ function generateBlobSASQueryParameters20150405(
  * Creates an instance of SASQueryParameters.
  *
  * Only accepts required settings needed to create a SAS. For optional settings please
- * set corresponding properties directly, such as permissions, startTime and identifier.
+ * set corresponding properties directly, such as permissions, startsOn and identifier.
  *
- * WARNING: When identifier is not provided, permissions and expiryTime are required.
- * You MUST assign value to identifier or expiryTime & permissions manually if you initial with
+ * WARNING: When identifier is not provided, permissions and expiresOn are required.
+ * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
  * @param {BlobSASSignatureValues} blobSASSignatureValues
@@ -440,10 +440,10 @@ function generateBlobSASQueryParameters20181109(
 ): SASQueryParameters {
   if (
     !blobSASSignatureValues.identifier &&
-    (!blobSASSignatureValues.permissions && !blobSASSignatureValues.expiryTime)
+    (!blobSASSignatureValues.permissions && !blobSASSignatureValues.expiresOn)
   ) {
     throw new RangeError(
-      "Must provide 'permissions' and 'expiryTime' for Blob SAS generation when 'identifier' is not provided."
+      "Must provide 'permissions' and 'expiresOn' for Blob SAS generation when 'identifier' is not provided."
     );
   }
 
@@ -475,11 +475,11 @@ function generateBlobSASQueryParameters20181109(
   // Signature is generated on the un-url-encoded values.
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
-    blobSASSignatureValues.startTime
-      ? truncatedISO8061Date(blobSASSignatureValues.startTime, false)
+    blobSASSignatureValues.startsOn
+      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
       : "",
-    blobSASSignatureValues.expiryTime
-      ? truncatedISO8061Date(blobSASSignatureValues.expiryTime, false)
+    blobSASSignatureValues.expiresOn
+      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       sharedKeyCredential.accountName,
@@ -508,8 +508,8 @@ function generateBlobSASQueryParameters20181109(
     undefined,
     undefined,
     blobSASSignatureValues.protocol,
-    blobSASSignatureValues.startTime,
-    blobSASSignatureValues.expiryTime,
+    blobSASSignatureValues.startsOn,
+    blobSASSignatureValues.expiresOn,
     blobSASSignatureValues.ipRange,
     blobSASSignatureValues.identifier,
     resource,
@@ -528,9 +528,9 @@ function generateBlobSASQueryParameters20181109(
  * Creates an instance of SASQueryParameters.
  *
  * Only accepts required settings needed to create a SAS. For optional settings please
- * set corresponding properties directly, such as permissions, startTime and identifier.
+ * set corresponding properties directly, such as permissions, startsOn and identifier.
  *
- * WARNING: identifier will be ignored, permissions and expiryTime are required.
+ * WARNING: identifier will be ignored, permissions and expiresOn are required.
  *
  * @param {BlobSASSignatureValues} blobSASSignatureValues
  * @param {UserDelegationKeyCredential} userDelegationKeyCredential
@@ -540,9 +540,9 @@ function generateBlobSASQueryParametersUDK20181109(
   blobSASSignatureValues: BlobSASSignatureValues,
   userDelegationKeyCredential: UserDelegationKeyCredential
 ): SASQueryParameters {
-  if (!blobSASSignatureValues.permissions || !blobSASSignatureValues.expiryTime) {
+  if (!blobSASSignatureValues.permissions || !blobSASSignatureValues.expiresOn) {
     throw new RangeError(
-      "Must provide 'permissions' and 'expiryTime' for Blob SAS generation when generating user delegation SAS."
+      "Must provide 'permissions' and 'expiresOn' for Blob SAS generation when generating user delegation SAS."
     );
   }
 
@@ -574,11 +574,11 @@ function generateBlobSASQueryParametersUDK20181109(
   // Signature is generated on the un-url-encoded values.
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
-    blobSASSignatureValues.startTime
-      ? truncatedISO8061Date(blobSASSignatureValues.startTime, false)
+    blobSASSignatureValues.startsOn
+      ? truncatedISO8061Date(blobSASSignatureValues.startsOn, false)
       : "",
-    blobSASSignatureValues.expiryTime
-      ? truncatedISO8061Date(blobSASSignatureValues.expiryTime, false)
+    blobSASSignatureValues.expiresOn
+      ? truncatedISO8061Date(blobSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(
       userDelegationKeyCredential.accountName,
@@ -587,11 +587,11 @@ function generateBlobSASQueryParametersUDK20181109(
     ),
     userDelegationKeyCredential.userDelegationKey.signedObjectId,
     userDelegationKeyCredential.userDelegationKey.signedTenantId,
-    userDelegationKeyCredential.userDelegationKey.signedStart
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStart, false)
+    userDelegationKeyCredential.userDelegationKey.signedStartsOn
+      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedStartsOn, false)
       : "",
-    userDelegationKeyCredential.userDelegationKey.signedExpiry
-      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiry, false)
+    userDelegationKeyCredential.userDelegationKey.signedExpiresOn
+      ? truncatedISO8061Date(userDelegationKeyCredential.userDelegationKey.signedExpiresOn, false)
       : "",
     userDelegationKeyCredential.userDelegationKey.signedService,
     userDelegationKeyCredential.userDelegationKey.signedVersion,
@@ -616,8 +616,8 @@ function generateBlobSASQueryParametersUDK20181109(
     undefined,
     undefined,
     blobSASSignatureValues.protocol,
-    blobSASSignatureValues.startTime,
-    blobSASSignatureValues.expiryTime,
+    blobSASSignatureValues.startsOn,
+    blobSASSignatureValues.expiresOn,
     blobSASSignatureValues.ipRange,
     blobSASSignatureValues.identifier,
     resource,

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -213,14 +213,14 @@ export interface UserDelegationKey {
    * @type {Date}
    * @memberof UserDelegationKey
    */
-  signedStart: Date;
+  signedStartsOn: Date;
   /**
    * The date-time the key expires.
    *
    * @type {Date}
    * @memberof UserDelegationKey
    */
-  signedExpiry: Date;
+  signedExpiresOn: Date;
   /**
    * Abbreviation of the Azure Storage service that accepts the key.
    *
@@ -355,7 +355,11 @@ export class BlobServiceClient extends StorageClient {
   constructor(url: string, pipeline: Pipeline);
   constructor(
     url: string,
-    credentialOrPipeline?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential | Pipeline,
+    credentialOrPipeline?:
+      | StorageSharedKeyCredential
+      | AnonymousCredential
+      | TokenCredential
+      | Pipeline,
     options?: StoragePipelineOptions
   ) {
     let pipeline: Pipeline;
@@ -798,14 +802,14 @@ export class BlobServiceClient extends StorageClient {
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key
    *
-   * @param {Date} start      The start time for the user delegation SAS. Must be within 7 days of the current time
-   * @param {Date} expiry     The end time for the user delegation SAS. Must be within 7 days of the current time
+   * @param {Date} startsOn      The start time for the user delegation SAS. Must be within 7 days of the current time
+   * @param {Date} expiresOn     The end time for the user delegation SAS. Must be within 7 days of the current time
    * @returns {Promise<ServiceGetUserDelegationKeyResponse>}
    * @memberof BlobServiceClient
    */
   public async getUserDelegationKey(
-    start: Date,
-    expiry: Date,
+    startsOn: Date,
+    expiresOn: Date,
     options: ServiceGetUserDelegationKeyOptions = {}
   ): Promise<ServiceGetUserDelegationKeyResponse> {
     const { span, spanOptions } = createSpan(
@@ -815,8 +819,8 @@ export class BlobServiceClient extends StorageClient {
     try {
       const response = await this.serviceContext.getUserDelegationKey(
         {
-          start: truncatedISO8061Date(start, false),
-          expiry: truncatedISO8061Date(expiry, false)
+          startsOn: truncatedISO8061Date(startsOn, false),
+          expiresOn: truncatedISO8061Date(expiresOn, false)
         },
         {
           abortSignal: options.abortSignal,
@@ -827,8 +831,8 @@ export class BlobServiceClient extends StorageClient {
       const userDelegationKey = {
         signedObjectId: response.signedObjectId,
         signedTenantId: response.signedTenantId,
-        signedStart: new Date(response.signedStart),
-        signedExpiry: new Date(response.signedExpiry),
+        signedStartsOn: new Date(response.signedStartsOn),
+        signedExpiresOn: new Date(response.signedExpiresOn),
         signedService: response.signedService,
         signedVersion: response.signedVersion,
         value: response.value

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -48,7 +48,14 @@ import "@azure/core-paging";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
 import { createSpan } from "./utils/tracing";
 import { CommonOptions, StorageClient } from "./StorageClient";
-import { BlobClient, AppendBlobClient, BlockBlobClient, PageBlobClient, BlockBlobUploadOptions, BlobDeleteOptions } from "./BlobClient";
+import {
+  BlobClient,
+  AppendBlobClient,
+  BlockBlobClient,
+  PageBlobClient,
+  BlockBlobUploadOptions,
+  BlobDeleteOptions
+} from "./BlobClient";
 
 /**
  * Options to configure Container - Create operation.
@@ -215,13 +222,13 @@ export interface SignedIdentifier {
    */
   accessPolicy: {
     /**
-     * @member {Date} start Optional. The date-time the policy is active
+     * @member {Date} startsOn Optional. The date-time the policy is active
      */
-    start?: Date;
+    startsOn?: Date;
     /**
-     * @member {Date} expiry Optional. The date-time the policy expires
+     * @member {Date} expiresOn Optional. The date-time the policy expires
      */
-    expiry?: Date;
+    expiresOn?: Date;
     /**
      * @member {string} permissions The permissions for the acl policy
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-container-acl
@@ -894,7 +901,7 @@ export class ContainerClient extends StorageClient {
    * Gets the permissions for the specified container. The permissions indicate
    * whether container data may be accessed publicly.
    *
-   * WARNING: JavaScript Date will potential lost precision when parsing start and expiry string.
+   * WARNING: JavaScript Date will potential lost precision when parsing startsOn and expiresOn string.
    * For example, new Date("2018-12-31T03:44:23.8827891Z").toISOString() will get "2018-12-31T03:44:23.882Z".
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl
@@ -940,12 +947,12 @@ export class ContainerClient extends StorageClient {
           permissions: identifier.accessPolicy.permissions
         };
 
-        if (identifier.accessPolicy.expiry) {
-          accessPolicy.expiry = new Date(identifier.accessPolicy.expiry);
+        if (identifier.accessPolicy.expiresOn) {
+          accessPolicy.expiresOn = new Date(identifier.accessPolicy.expiresOn);
         }
 
-        if (identifier.accessPolicy.start) {
-          accessPolicy.start = new Date(identifier.accessPolicy.start);
+        if (identifier.accessPolicy.startsOn) {
+          accessPolicy.startsOn = new Date(identifier.accessPolicy.startsOn);
         }
 
         res.signedIdentifiers.push({
@@ -996,12 +1003,12 @@ export class ContainerClient extends StorageClient {
       for (const identifier of containerAcl || []) {
         acl.push({
           accessPolicy: {
-            expiry: identifier.accessPolicy.expiry
-              ? truncatedISO8061Date(identifier.accessPolicy.expiry)
+            expiresOn: identifier.accessPolicy.expiresOn
+              ? truncatedISO8061Date(identifier.accessPolicy.expiresOn)
               : "",
             permissions: identifier.accessPolicy.permissions,
-            start: identifier.accessPolicy.start
-              ? truncatedISO8061Date(identifier.accessPolicy.start)
+            startsOn: identifier.accessPolicy.startsOn
+              ? truncatedISO8061Date(identifier.accessPolicy.startsOn)
               : ""
           },
           id: identifier.id

--- a/sdk/storage/storage-blob/src/SASQueryParameters.ts
+++ b/sdk/storage/storage-blob/src/SASQueryParameters.ts
@@ -58,7 +58,7 @@ export class SASQueryParameters {
    * @type {Date}
    * @memberof SASQueryParameters
    */
-  public readonly startTime?: Date;
+  public readonly startsOn?: Date;
 
   /**
    * Optional only when identifier is provided. The expiry time for this SAS token.
@@ -66,7 +66,7 @@ export class SASQueryParameters {
    * @type {Date}
    * @memberof SASQueryParameters
    */
-  public readonly expiryTime?: Date;
+  public readonly expiresOn?: Date;
 
   /**
    * Optional only when identifier is provided.
@@ -199,7 +199,7 @@ export class SASQueryParameters {
    * @type {Date}
    * @memberof SASQueryParameters
    */
-  private readonly signedStart?: Date;
+  private readonly signedStartsOn?: Date;
 
   /**
    * The date-time the key expires.
@@ -209,7 +209,7 @@ export class SASQueryParameters {
    * @type {Date}
    * @memberof SASQueryParameters
    */
-  private readonly signedExpiry?: Date;
+  private readonly signedExpiresOn?: Date;
 
   /**
    * Abbreviation of the Azure Storage service that accepts the user delegation key.
@@ -257,8 +257,8 @@ export class SASQueryParameters {
    * @param {string} [services] Representing the storage services being accessed (only for Account SAS)
    * @param {string} [resourceTypes] Representing the storage resource types being accessed (only for Account SAS)
    * @param {SASProtocol} [protocol] Representing the allowed HTTP protocol(s)
-   * @param {Date} [startTime] Representing the start time for this SAS token
-   * @param {Date} [expiryTime] Representing the expiry time for this SAS token
+   * @param {Date} [startsOn] Representing the start time for this SAS token
+   * @param {Date} [expiresOn] Representing the expiry time for this SAS token
    * @param {SasIPRange} [ipRange] Representing the range of valid IP addresses for this SAS token
    * @param {string} [identifier] Representing the signed identifier (only for Service SAS)
    * @param {string} [resource] Representing the storage container or blob (only for Service SAS)
@@ -277,8 +277,8 @@ export class SASQueryParameters {
     services?: string,
     resourceTypes?: string,
     protocol?: SASProtocol,
-    startTime?: Date,
-    expiryTime?: Date,
+    startsOn?: Date,
+    expiresOn?: Date,
     ipRange?: SasIPRange,
     identifier?: string,
     resource?: string,
@@ -292,10 +292,10 @@ export class SASQueryParameters {
     this.version = version;
     this.services = services;
     this.resourceTypes = resourceTypes;
-    this.expiryTime = expiryTime;
+    this.expiresOn = expiresOn;
     this.permissions = permissions;
     this.protocol = protocol;
-    this.startTime = startTime;
+    this.startsOn = startsOn;
     this.ipRangeInner = ipRange;
     this.identifier = identifier;
     this.resource = resource;
@@ -309,8 +309,8 @@ export class SASQueryParameters {
     if (userDelegationKey) {
       this.signedOid = userDelegationKey.signedObjectId;
       this.signedTenentId = userDelegationKey.signedTenantId;
-      this.signedStart = userDelegationKey.signedStart;
-      this.signedExpiry = userDelegationKey.signedExpiry;
+      this.signedStartsOn = userDelegationKey.signedStartsOn;
+      this.signedExpiresOn = userDelegationKey.signedExpiresOn;
       this.signedService = userDelegationKey.signedService;
       this.signedVersion = userDelegationKey.signedVersion;
     }
@@ -367,14 +367,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.startTime ? truncatedISO8061Date(this.startTime, false) : undefined
+            this.startsOn ? truncatedISO8061Date(this.startsOn, false) : undefined
           );
           break;
         case "se":
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.expiryTime ? truncatedISO8061Date(this.expiryTime, false) : undefined
+            this.expiresOn ? truncatedISO8061Date(this.expiresOn, false) : undefined
           );
           break;
         case "sip":
@@ -397,14 +397,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedStart ? truncatedISO8061Date(this.signedStart, false) : undefined
+            this.signedStartsOn ? truncatedISO8061Date(this.signedStartsOn, false) : undefined
           );
           break;
         case "ske": // Signed key expiry time
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.signedExpiry ? truncatedISO8061Date(this.signedExpiry, false) : undefined
+            this.signedExpiresOn ? truncatedISO8061Date(this.signedExpiresOn, false) : undefined
           );
           break;
         case "sks": // Signed key service

--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -16,11 +16,11 @@ export interface KeyInfo {
   /**
    * The date-time the key is active in ISO 8601 UTC time
    */
-  start: string;
+  startsOn: string;
   /**
    * The date-time the key expires in ISO 8601 UTC time
    */
-  expiry: string;
+  expiresOn: string;
 }
 
 /**
@@ -40,13 +40,13 @@ export interface UserDelegationKey {
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    */
-  signedStart: string;
+  signedStartsOn: string;
   /**
    * The date-time the key expires
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    */
-  signedExpiry: string;
+  signedExpiresOn: string;
   /**
    * Abbreviation of the Azure Storage service that accepts the key
    */
@@ -101,13 +101,13 @@ export interface AccessPolicy {
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    */
-  start: string;
+  startsOn: string;
   /**
    * the date-time the policy expires
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    */
-  expiry: string;
+  expiresOn: string;
   /**
    * the permissions for the acl policy
    */

--- a/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
@@ -15,7 +15,7 @@ export const KeyInfo: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "KeyInfo",
     modelProperties: {
-      start: {
+      startsOn: {
         xmlName: "Start",
         required: true,
         serializedName: "Start",
@@ -23,7 +23,7 @@ export const KeyInfo: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      expiry: {
+      expiresOn: {
         xmlName: "Expiry",
         required: true,
         serializedName: "Expiry",
@@ -57,7 +57,7 @@ export const UserDelegationKey: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      signedStart: {
+      signedStartsOn: {
         xmlName: "SignedStart",
         required: true,
         serializedName: "SignedStart",
@@ -65,7 +65,7 @@ export const UserDelegationKey: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      signedExpiry: {
+      signedExpiresOn: {
         xmlName: "SignedExpiry",
         required: true,
         serializedName: "SignedExpiry",
@@ -166,7 +166,7 @@ export const AccessPolicy: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "AccessPolicy",
     modelProperties: {
-      start: {
+      startsOn: {
         xmlName: "Start",
         required: true,
         serializedName: "Start",
@@ -174,7 +174,7 @@ export const AccessPolicy: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      expiry: {
+      expiresOn: {
         xmlName: "Expiry",
         required: true,
         serializedName: "Expiry",

--- a/sdk/storage/storage-blob/swagger/README.md
+++ b/sdk/storage/storage-blob/swagger/README.md
@@ -228,6 +228,8 @@ directive:
     transform: >
       $.properties.SignedTid["x-ms-client-name"] = "signedTenantId";
       $.properties.SignedOid["x-ms-client-name"] = "signedObjectId";
+      $.properties.SignedStart["x-ms-client-name"] = "signedStartsOn";
+      $.properties.SignedExpiry["x-ms-client-name"] = "signedExpiresOn";
 ```
 
 ### Add missing x-ms-parameter-location for PathRenameMode
@@ -266,4 +268,28 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}"].head.responses["200"].headers["Content-Length"]
   transform: >
     $.description = "The size of the blob in bytes. For a page blob, this header returns the value of the x-ms-blob-content-length header that is stored with the blob.";
+```
+
+### Rename AccessPolicy start -> startsOn and expiry to expiresOn
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.AccessPolicy.properties
+    transform: >
+      $.Start["x-ms-client-name"] = "startsOn";
+      $.Expiry["x-ms-client-name"] = "expiresOn";
+
+```
+
+### Rename KeyInfo start -> startsOn
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.KeyInfo.properties
+    transform: >
+      $.Start["x-ms-client-name"] = "startsOn";
+      $.Expiry["x-ms-client-name"] = "expiresOn";
+
 ```

--- a/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
@@ -435,9 +435,9 @@ describe("BlobServiceClient", () => {
     assert.notDeepStrictEqual(response.value, undefined);
     assert.notDeepStrictEqual(response.signedVersion, undefined);
     assert.notDeepStrictEqual(response.signedTenantId, undefined);
-    assert.notDeepStrictEqual(response.signedStart, undefined);
+    assert.notDeepStrictEqual(response.signedStartsOn, undefined);
     assert.notDeepStrictEqual(response.signedService, undefined);
     assert.notDeepStrictEqual(response.signedObjectId, undefined);
-    assert.notDeepStrictEqual(response.signedExpiry, undefined);
+    assert.notDeepStrictEqual(response.signedExpiresOn, undefined);
   });
 });

--- a/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/appendblobclient.spec.ts
@@ -125,7 +125,7 @@ describe("AppendBlobClient Node.js only", () => {
 
     const sas = generateBlobSASQueryParameters(
       {
-        expiryTime,
+        expiresOn: expiryTime,
         containerName,
         blobName: blockBlobName,
         permissions: BlobSASPermissions.parse("r")
@@ -159,7 +159,7 @@ describe("AppendBlobClient Node.js only", () => {
     expiryTime.setDate(expiryTime.getDate() + 1);
     const sas = generateBlobSASQueryParameters(
       {
-        expiryTime,
+        expiresOn: expiryTime,
         containerName,
         blobName: blockBlobName,
         permissions: BlobSASPermissions.parse("r")

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -223,7 +223,7 @@ describe("BlobClient Node.js only", () => {
 
     const sas = generateBlobSASQueryParameters(
       {
-        expiryTime,
+        expiresOn: expiryTime,
         permissions: BlobSASPermissions.parse("racwd"),
         containerName,
         blobName

--- a/sdk/storage/storage-blob/test/node/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/containerclient.spec.ts
@@ -45,9 +45,9 @@ describe("ContainerClient Node.js only", () => {
     const containerAcl = [
       {
         accessPolicy: {
-          expiry: new Date("2018-12-31T11:22:33.4567890Z"),
+          expiresOn: new Date("2018-12-31T11:22:33.4567890Z"),
           permissions: ContainerSASPermissions.parse("rwd").toString(),
-          start: new Date("2017-12-31T11:22:33.4567890Z")
+          startsOn: new Date("2017-12-31T11:22:33.4567890Z")
         },
         id: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="
       }

--- a/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/pageblobclient.spec.ts
@@ -135,7 +135,7 @@ describe("PageBlobClient Node.js only", () => {
     expiryTime.setDate(expiryTime.getDate() + 1);
     const sas = generateBlobSASQueryParameters(
       {
-        expiryTime,
+        expiresOn: expiryTime,
         containerName,
         blobName: blockBlobName,
         permissions: BlobSASPermissions.parse("r")
@@ -256,7 +256,7 @@ describe("PageBlobClient Node.js only", () => {
     expiryTime.setDate(expiryTime.getDate() + 1);
     const sas = generateBlobSASQueryParameters(
       {
-        expiryTime,
+        expiresOn: expiryTime,
         containerName,
         blobName: blockBlobName,
         permissions: BlobSASPermissions.parse("r")

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -45,13 +45,13 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: AccountSASPermissions.parse("rwdlacup"),
         protocol: SASProtocol.HttpsAndHttp,
         resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
         services: AccountSASServices.parse("btqf").toString(),
-        startTime: now,
+        startsOn: now,
         version: "2016-05-31"
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -76,7 +76,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         permissions: AccountSASPermissions.parse("wdlcup"),
         resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
         services: AccountSASServices.parse("btqf").toString()
@@ -110,7 +110,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         permissions: AccountSASPermissions.parse("rwdlacup"),
         resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
         services: AccountSASServices.parse("tqf").toString()
@@ -144,7 +144,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: AccountSASPermissions.parse("rwdlacup"),
         protocol: SASProtocol.HttpsAndHttp,
@@ -189,11 +189,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const containerSAS = generateBlobSASQueryParameters(
       {
         containerName: containerClient.containerName,
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: ContainerSASPermissions.parse("racwdl"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         version: "2016-05-31"
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -243,11 +243,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         contentEncoding: "content-encoding-override",
         contentLanguage: "content-language-override",
         contentType: "content-type-override",
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: BlobSASPermissions.parse("racwd"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         version: "2016-05-31"
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -298,11 +298,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         contentEncoding: "content-encoding-override",
         contentLanguage: "content-language-override",
         contentType: "content-type-override",
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: BlobSASPermissions.parse("racwd"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now
+        startsOn: now
       },
       sharedKeyCredential as StorageSharedKeyCredential
     );
@@ -354,11 +354,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         contentEncoding: "content-encoding-override",
         contentLanguage: "content-language-override",
         contentType: "content-type-override",
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: BlobSASPermissions.parse("racwd"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         snapshotTime: response.snapshot
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -411,11 +411,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         contentEncoding: "content-encoding-override",
         contentLanguage: "content-language-override",
         contentType: "content-type-override",
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: BlobSASPermissions.parse("racwd"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         version: "2016-05-31"
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -457,9 +457,9 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await containerClient.setAccessPolicy(undefined, [
       {
         accessPolicy: {
-          expiry: tmr,
+          expiresOn: tmr,
           permissions: ContainerSASPermissions.parse("racwdl").toString(),
-          start: now
+          startsOn: now
         },
         id
       }
@@ -512,11 +512,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const containerSAS = generateBlobSASQueryParameters(
       {
         containerName: containerClient.containerName,
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: ContainerSASPermissions.parse("racwdl"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         version: "2019-02-02"
       },
       userDelegationKey,
@@ -568,7 +568,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const containerSAS = generateBlobSASQueryParameters(
       {
         containerName: containerClient.containerName,
-        expiryTime: tmr,
+        expiresOn: tmr,
         permissions: ContainerSASPermissions.parse("racwdl")
       },
       userDelegationKey,
@@ -634,11 +634,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         contentEncoding: "content-encoding-override",
         contentLanguage: "content-language-override",
         contentType: "content-type-override",
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: BlobSASPermissions.parse("racwd"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now
+        startsOn: now
       },
       userDelegationKey,
       accountName
@@ -705,11 +705,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         contentEncoding: "content-encoding-override",
         contentLanguage: "content-language-override",
         contentType: "content-type-override",
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: BlobSASPermissions.parse("racwd"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         snapshotTime: response.snapshot
       },
       userDelegationKey,

--- a/sdk/storage/storage-blob/test/utils/index.ts
+++ b/sdk/storage/storage-blob/test/utils/index.ts
@@ -187,13 +187,13 @@ export function getSASConnectionStringFromEnvironment(): string {
 
   const sas = generateAccountSASQueryParameters(
     {
-      expiryTime: tmr,
+      expiresOn: tmr,
       ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
       permissions: AccountSASPermissions.parse("rwdlacup"),
       protocol: SASProtocol.HttpsAndHttp,
       resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
       services: AccountSASServices.parse("btqf").toString(),
-      startTime: now,
+      startsOn: now,
       version: "2016-05-31"
     },
     sharedKeyCredential as StorageSharedKeyCredential

--- a/sdk/storage/storage-queue/review/storage-queue.api.md
+++ b/sdk/storage/storage-queue/review/storage-queue.api.md
@@ -68,13 +68,13 @@ export class AccountSASServices {
 
 // @public
 export interface AccountSASSignatureValues {
-    expiryTime: Date;
+    expiresOn: Date;
     ipRange?: SasIPRange;
     permissions: AccountSASPermissions;
     protocol?: SASProtocol;
     resourceTypes: string;
     services: string;
-    startTime?: Date;
+    startsOn?: Date;
     version?: string;
 }
 
@@ -528,13 +528,13 @@ export class QueueSASPermissions {
 
 // @public
 export interface QueueSASSignatureValues {
-    expiryTime?: Date;
+    expiresOn?: Date;
     identifier?: string;
     ipRange?: SasIPRange;
     permissions?: QueueSASPermissions;
     protocol?: SASProtocol;
     queueName: string;
-    startTime?: Date;
+    startsOn?: Date;
     version?: string;
 }
 
@@ -667,8 +667,8 @@ export enum SASProtocol {
 
 // @public
 export class SASQueryParameters {
-    constructor(version: string, signature: string, permissions?: string, services?: string, resourceTypes?: string, protocol?: SASProtocol, startTime?: Date, expiryTime?: Date, ipRange?: SasIPRange, identifier?: string, resource?: string);
-    readonly expiryTime?: Date;
+    constructor(version: string, signature: string, permissions?: string, services?: string, resourceTypes?: string, protocol?: SASProtocol, startsOn?: Date, expiresOn?: Date, ipRange?: SasIPRange, identifier?: string, resource?: string);
+    readonly expiresOn?: Date;
     readonly identifier?: string;
     readonly ipRange: SasIPRange | undefined;
     readonly permissions?: string;
@@ -677,7 +677,7 @@ export class SASQueryParameters {
     readonly resourceTypes?: string;
     readonly services?: string;
     readonly signature: string;
-    readonly startTime?: Date;
+    readonly startsOn?: Date;
     toString(): string;
     readonly version: string;
 }
@@ -779,8 +779,8 @@ export type ServiceSetPropertiesResponse = ServiceSetPropertiesHeaders & {
 // @public
 export interface SignedIdentifier {
     accessPolicy: {
-        start: Date;
-        expiry: Date;
+        startsOn: Date;
+        expiresOn: Date;
         permissions: string;
     };
     id: string;

--- a/sdk/storage/storage-queue/review/storage-queue.api.md
+++ b/sdk/storage/storage-queue/review/storage-queue.api.md
@@ -28,9 +28,9 @@ import { WebResource } from '@azure/core-http';
 
 // @public
 export interface AccessPolicy {
-    expiry: string;
+    expiresOn: string;
     permissions: string;
-    start: string;
+    startsOn: string;
 }
 
 // @public

--- a/sdk/storage/storage-queue/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-queue/src/AccountSASSignatureValues.ts
@@ -51,7 +51,7 @@ export interface AccountSASSignatureValues {
    * @type {Date}
    * @memberof AccountSASSignatureValues
    */
-  startTime?: Date;
+  startsOn?: Date;
 
   /**
    * The time after which the SAS will no longer work.
@@ -59,7 +59,7 @@ export interface AccountSASSignatureValues {
    * @type {Date}
    * @memberof AccountSASSignatureValues
    */
-  expiryTime: Date;
+  expiresOn: Date;
 
   /**
    * Specifies which operations the SAS user may perform. Please refer to {@link AccountSASPermissions} for help
@@ -131,10 +131,10 @@ export function generateAccountSASQueryParameters(
     parsedPermissions,
     parsedServices,
     parsedResourceTypes,
-    accountSASSignatureValues.startTime
-      ? truncatedISO8061Date(accountSASSignatureValues.startTime, false)
+    accountSASSignatureValues.startsOn
+      ? truncatedISO8061Date(accountSASSignatureValues.startsOn, false)
       : "",
-    truncatedISO8061Date(accountSASSignatureValues.expiryTime, false),
+    truncatedISO8061Date(accountSASSignatureValues.expiresOn, false),
     accountSASSignatureValues.ipRange ? ipRangeToString(accountSASSignatureValues.ipRange) : "",
     accountSASSignatureValues.protocol ? accountSASSignatureValues.protocol : "",
     version,
@@ -150,8 +150,8 @@ export function generateAccountSASQueryParameters(
     parsedServices,
     parsedResourceTypes,
     accountSASSignatureValues.protocol,
-    accountSASSignatureValues.startTime,
-    accountSASSignatureValues.expiryTime,
+    accountSASSignatureValues.startsOn,
+    accountSASSignatureValues.expiresOn,
     accountSASSignatureValues.ipRange
   );
 }

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -173,13 +173,13 @@ export interface SignedIdentifier {
    */
   accessPolicy: {
     /**
-     * @member {Date} start the date-time the policy is active.
+     * @member {Date} startsOn the date-time the policy is active.
      */
-    start: Date;
+    startsOn: Date;
     /**
-     * @member {string} expiry the date-time the policy expires.
+     * @member {string} expiresOn the date-time the policy expires.
      */
-    expiry: Date;
+    expiresOn: Date;
     /**
      * @member {string} permission the permissions for the acl policy
      * @see https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-acl
@@ -726,9 +726,9 @@ export class QueueClient extends StorageClient {
       for (const identifier of response) {
         res.signedIdentifiers.push({
           accessPolicy: {
-            expiry: new Date(identifier.accessPolicy.expiry),
+            expiresOn: new Date(identifier.accessPolicy.expiresOn),
             permissions: identifier.accessPolicy.permissions,
-            start: new Date(identifier.accessPolicy.start)
+            startsOn: new Date(identifier.accessPolicy.startsOn)
           },
           id: identifier.id
         });
@@ -765,9 +765,9 @@ export class QueueClient extends StorageClient {
       for (const identifier of queueAcl || []) {
         acl.push({
           accessPolicy: {
-            expiry: truncatedISO8061Date(identifier.accessPolicy.expiry),
+            expiresOn: truncatedISO8061Date(identifier.accessPolicy.expiresOn),
             permissions: identifier.accessPolicy.permissions,
-            start: truncatedISO8061Date(identifier.accessPolicy.start)
+            startsOn: truncatedISO8061Date(identifier.accessPolicy.startsOn)
           },
           id: identifier.id
         });

--- a/sdk/storage/storage-queue/src/QueueSASSignatureValues.ts
+++ b/sdk/storage/storage-queue/src/QueueSASSignatureValues.ts
@@ -41,7 +41,7 @@ export interface QueueSASSignatureValues {
    * @type {Date}
    * @memberof QueueSASSignatureValues
    */
-  startTime?: Date;
+  startsOn?: Date;
 
   /**
    * Optional only when identifier is provided. The time after which the SAS will no longer work.
@@ -49,7 +49,7 @@ export interface QueueSASSignatureValues {
    * @type {Date}
    * @memberof QueueSASSignatureValues
    */
-  expiryTime?: Date;
+  expiresOn?: Date;
 
   /**
    * Optional only when identifier is provided.
@@ -94,10 +94,10 @@ export interface QueueSASSignatureValues {
  * Creates an instance of SASQueryParameters.
  *
  * Only accepts required settings needed to create a SAS. For optional settings please
- * set corresponding properties directly, such as permissions, startTime and identifier.
+ * set corresponding properties directly, such as permissions, startsOn and identifier.
  *
- * WARNING: When identifier is not provided, permissions and expiryTime are required.
- * You MUST assign value to identifier or expiryTime & permissions manually if you initial with
+ * WARNING: When identifier is not provided, permissions and expiresOn are required.
+ * You MUST assign value to identifier or expiresOn & permissions manually if you initial with
  * this constructor.
  *
  * @export
@@ -111,10 +111,10 @@ export function generateQueueSASQueryParameters(
 ): SASQueryParameters {
   if (
     !queueSASSignatureValues.identifier &&
-    (!queueSASSignatureValues.permissions && !queueSASSignatureValues.expiryTime)
+    (!queueSASSignatureValues.permissions && !queueSASSignatureValues.expiresOn)
   ) {
     throw new RangeError(
-      "Must provide 'permissions' and 'expiryTime' for Queue SAS generation when 'identifier' is not provided."
+      "Must provide 'permissions' and 'expiresOn' for Queue SAS generation when 'identifier' is not provided."
     );
   }
 
@@ -133,11 +133,11 @@ export function generateQueueSASQueryParameters(
   // Signature is generated on the un-url-encoded values.
   const stringToSign = [
     verifiedPermissions ? verifiedPermissions : "",
-    queueSASSignatureValues.startTime
-      ? truncatedISO8061Date(queueSASSignatureValues.startTime, false)
+    queueSASSignatureValues.startsOn
+      ? truncatedISO8061Date(queueSASSignatureValues.startsOn, false)
       : "",
-    queueSASSignatureValues.expiryTime
-      ? truncatedISO8061Date(queueSASSignatureValues.expiryTime, false)
+    queueSASSignatureValues.expiresOn
+      ? truncatedISO8061Date(queueSASSignatureValues.expiresOn, false)
       : "",
     getCanonicalName(sharedKeyCredential.accountName, queueSASSignatureValues.queueName),
     queueSASSignatureValues.identifier,
@@ -155,8 +155,8 @@ export function generateQueueSASQueryParameters(
     undefined,
     undefined,
     queueSASSignatureValues.protocol,
-    queueSASSignatureValues.startTime,
-    queueSASSignatureValues.expiryTime,
+    queueSASSignatureValues.startsOn,
+    queueSASSignatureValues.expiresOn,
     queueSASSignatureValues.ipRange,
     queueSASSignatureValues.identifier
   );

--- a/sdk/storage/storage-queue/src/SASQueryParameters.ts
+++ b/sdk/storage/storage-queue/src/SASQueryParameters.ts
@@ -57,7 +57,7 @@ export class SASQueryParameters {
    * @type {Date}
    * @memberof SASQueryParameters
    */
-  public readonly startTime?: Date;
+  public readonly startsOn?: Date;
 
   /**
    * Optional only when identifier is provided. The expiry time for this SAS token.
@@ -65,7 +65,7 @@ export class SASQueryParameters {
    * @type {Date}
    * @memberof SASQueryParameters
    */
-  public readonly expiryTime?: Date;
+  public readonly expiresOn?: Date;
 
   /**
    * Optional only when identifier is provided.
@@ -155,8 +155,8 @@ export class SASQueryParameters {
    * @param {string} [services] Representing the storage services being accessed (only for Account SAS)
    * @param {string} [resourceTypes] Representing the storage resource types being accessed (only for Account SAS)
    * @param {SASProtocol} [protocol] Representing the allowed HTTP protocol(s)
-   * @param {Date} [startTime] Representing the start time for this SAS token
-   * @param {Date} [expiryTime] Representing the expiry time for this SAS token
+   * @param {Date} [startsOn] Representing the start time for this SAS token
+   * @param {Date} [expiresOn] Representing the expiry time for this SAS token
    * @param {SasIPRange} [ipRange] Representing the range of valid IP addresses for this SAS token
    * @param {string} [identifier] Representing the signed identifier (only for Service SAS)
    * @param {string} [resource] Representing the storage queue (only for Service SAS)
@@ -168,8 +168,8 @@ export class SASQueryParameters {
     services?: string,
     resourceTypes?: string,
     protocol?: SASProtocol,
-    startTime?: Date,
-    expiryTime?: Date,
+    startsOn?: Date,
+    expiresOn?: Date,
     ipRange?: SasIPRange,
     identifier?: string,
     resource?: string
@@ -177,10 +177,10 @@ export class SASQueryParameters {
     this.version = version;
     this.services = services;
     this.resourceTypes = resourceTypes;
-    this.expiryTime = expiryTime;
+    this.expiresOn = expiresOn;
     this.permissions = permissions;
     this.protocol = protocol;
-    this.startTime = startTime;
+    this.startsOn = startsOn;
     this.ipRangeInner = ipRange;
     this.identifier = identifier;
     this.resource = resource;
@@ -215,14 +215,14 @@ export class SASQueryParameters {
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.startTime ? truncatedISO8061Date(this.startTime, false) : undefined
+            this.startsOn ? truncatedISO8061Date(this.startsOn, false) : undefined
           );
           break;
         case "se":
           this.tryAppendQueryParameter(
             queries,
             param,
-            this.expiryTime ? truncatedISO8061Date(this.expiryTime, false) : undefined
+            this.expiresOn ? truncatedISO8061Date(this.expiresOn, false) : undefined
           );
           break;
         case "sip":

--- a/sdk/storage/storage-queue/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-queue/src/generated/src/models/index.ts
@@ -18,13 +18,13 @@ export interface AccessPolicy {
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    */
-  start: string;
+  startsOn: string;
   /**
    * the date-time the policy expires
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    */
-  expiry: string;
+  expiresOn: string;
   /**
    * the permissions for the acl policy
    */

--- a/sdk/storage/storage-queue/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-queue/src/generated/src/models/mappers.ts
@@ -15,7 +15,7 @@ export const AccessPolicy: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "AccessPolicy",
     modelProperties: {
-      start: {
+      startsOn: {
         xmlName: "Start",
         required: true,
         serializedName: "Start",
@@ -23,7 +23,7 @@ export const AccessPolicy: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      expiry: {
+      expiresOn: {
         xmlName: "Expiry",
         required: true,
         serializedName: "Expiry",

--- a/sdk/storage/storage-queue/swagger/README.md
+++ b/sdk/storage/storage-queue/swagger/README.md
@@ -191,3 +191,16 @@ directive:
     transform: >
       $["x-ms-client-name"] = "queueAnalyticsLogging"
 ```
+
+
+### Rename AccessPolicy start -> startsOn
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.AccessPolicy.properties
+    transform: >
+      $.Start["x-ms-client-name"] = "startsOn";
+      $.Expiry["x-ms-client-name"] = "expiresOn";
+
+```

--- a/sdk/storage/storage-queue/test/node/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/node/queueclient.spec.ts
@@ -36,9 +36,9 @@ describe("QueueClient Node.js only", () => {
     const queueAcl = [
       {
         accessPolicy: {
-          expiry: new Date("2018-12-31T11:22:33.4567890Z"),
+          expiresOn: new Date("2018-12-31T11:22:33.4567890Z"),
           permissions: "raup",
-          start: new Date("2017-12-31T11:22:33.4567890Z")
+          startsOn: new Date("2017-12-31T11:22:33.4567890Z")
         },
         id: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="
       }

--- a/sdk/storage/storage-queue/test/node/sas.spec.ts
+++ b/sdk/storage/storage-queue/test/node/sas.spec.ts
@@ -43,13 +43,13 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: AccountSASPermissions.parse("rwdlacup"),
         protocol: SASProtocol.HttpsAndHttp,
         resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
         services: AccountSASServices.parse("btqf").toString(),
-        startTime: now,
+        startsOn: now,
         version: "2016-05-31"
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -74,7 +74,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         permissions: AccountSASPermissions.parse("wdlcup"),
         resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
         services: AccountSASServices.parse("btqf").toString()
@@ -108,7 +108,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         permissions: AccountSASPermissions.parse("rwdlacup"),
         resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
         services: AccountSASServices.parse("b").toString()
@@ -142,7 +142,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
 
     const sas = generateAccountSASQueryParameters(
       {
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: AccountSASPermissions.parse("rwdlacup"),
         protocol: SASProtocol.HttpsAndHttp,
@@ -187,11 +187,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const queueSAS = generateQueueSASQueryParameters(
       {
         queueName: queueClient.name,
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: QueueSASPermissions.parse("raup"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         version: "2016-05-31"
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -222,11 +222,11 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     const queueSAS = generateQueueSASQueryParameters(
       {
         queueName: queueClient.name,
-        expiryTime: tmr,
+        expiresOn: tmr,
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: QueueSASPermissions.parse("raup"),
         protocol: SASProtocol.HttpsAndHttp,
-        startTime: now,
+        startsOn: now,
         version: "2016-05-31"
       },
       sharedKeyCredential as StorageSharedKeyCredential
@@ -274,9 +274,9 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await queueClient.setAccessPolicy([
       {
         accessPolicy: {
-          expiry: tmr,
+          expiresOn: tmr,
           permissions: QueueSASPermissions.parse("raup").toString(),
-          start: now
+          startsOn: now
         },
         id
       }

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -103,9 +103,9 @@ describe("QueueClient", () => {
     const queueAcl = [
       {
         accessPolicy: {
-          expiry: new Date("2018-12-31T11:22:33.4567890Z"),
+          expiresOn: new Date("2018-12-31T11:22:33.4567890Z"),
           permissions: "rwdl",
-          start: new Date("2017-12-31T11:22:33.4567890Z")
+          startsOn: new Date("2017-12-31T11:22:33.4567890Z")
         },
         id: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="
       }

--- a/sdk/storage/storage-queue/test/utils/index.ts
+++ b/sdk/storage/storage-queue/test/utils/index.ts
@@ -82,13 +82,13 @@ export function getSASConnectionStringFromEnvironment(): string {
 
   const sas = generateAccountSASQueryParameters(
     {
-      expiryTime: tmr,
+      expiresOn: tmr,
       ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
       permissions: AccountSASPermissions.parse("rwdlacup"),
       protocol: SASProtocol.HttpsAndHttp,
       resourceTypes: AccountSASResourceTypes.parse("sco").toString(),
       services: AccountSASServices.parse("btqf").toString(),
-      startTime: now,
+      startsOn: now,
       version: "2016-05-31"
     },
     sharedKeyCredential as StorageSharedKeyCredential


### PR DESCRIPTION
There are a few places where start and expiry are used inconsistently. For consistency throughout the library and with other languages the following renames are needed:

start. startTime => startsOn
expiry, expiryTime => expiresOn

Fixes #5894
