### PR TITLE
[core-auth] Change GetTokenOptions to be based on OperationOptions

### DIFF
--- a/sdk/core/core-auth/review/core-auth.api.md
+++ b/sdk/core/core-auth/review/core-auth.api.md
@@ -16,14 +16,28 @@ export interface AccessToken {
 }
 
 // @public
-export interface GetTokenOptions {
-    abortSignal?: AbortSignalLike;
-    spanOptions?: SpanOptions;
-    timeout?: number;
+export interface GetTokenOptions extends OperationOptions {
 }
 
 // @public
 export function isTokenCredential(credential: any): credential is TokenCredential;
+
+// @public
+export interface OperationOptions {
+    abortSignal?: AbortSignalLike;
+    requestOptions?: OperationRequestOptions;
+    tracingOptions?: OperationTracingOptions;
+}
+
+// @public (undocumented)
+export interface OperationRequestOptions {
+    timeout?: number;
+}
+
+// @public (undocumented)
+export interface OperationTracingOptions {
+    spanOptions?: SpanOptions;
+}
 
 // @public
 export interface TokenCredential {

--- a/sdk/core/core-auth/src/index.ts
+++ b/sdk/core/core-auth/src/index.ts
@@ -8,4 +8,10 @@ export {
   isTokenCredential
 } from "./tokenCredential";
 
+export {
+  OperationOptions,
+  OperationTracingOptions,
+  OperationRequestOptions
+} from "./operationOptions";
+
 export { AbortSignalLike } from '@azure/abort-controller';

--- a/sdk/core/core-auth/src/operationOptions.ts
+++ b/sdk/core/core-auth/src/operationOptions.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AbortSignalLike } from "@azure/abort-controller";
+import { SpanOptions } from "@azure/core-tracing";
+
+/**
+ * The base options type for all operations.
+ */
+export interface OperationOptions {
+  /**
+   * The signal which can be used to abort requests.
+   */
+  abortSignal?: AbortSignalLike;
+  /**
+   * Options used when creating and sending HTTP requests for this operation.
+   */
+  requestOptions?: OperationRequestOptions;
+  /**
+   * Options used when tracing is enabled.
+   */
+  tracingOptions?: OperationTracingOptions;
+}
+
+export interface OperationTracingOptions {
+  /**
+   * OpenTelemetry SpanOptions used to create a span when tracing is enabled.
+   */
+  spanOptions?: SpanOptions;
+}
+
+export interface OperationRequestOptions {
+  /**
+   * The number of milliseconds a request can take before automatically being terminated.
+   */
+  timeout?: number;
+}

--- a/sdk/core/core-auth/src/tokenCredential.ts
+++ b/sdk/core/core-auth/src/tokenCredential.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { AbortSignalLike } from "@azure/abort-controller";
-import { SpanOptions } from "@azure/core-tracing";
+import { OperationOptions } from "./operationOptions";
 
 /**
  * Represents a credential capable of providing an authentication token.
@@ -21,24 +21,7 @@ export interface TokenCredential {
 /**
  * Defines options for TokenCredential.getToken.
  */
-export interface GetTokenOptions {
-
-  /**
-   * An AbortSignalLike implementation that can be used to cancel
-   * the token request.
-   */
-  abortSignal?: AbortSignalLike;
-
-  /**
-   * The amount of time in milliseconds that the credential will poll
-   * for authentication endpoints (e.g. managed service identity).
-   */
-  timeout?: number;
-
-  /**
-   * Options to create a span using the tracer if any was set.
-   */
-  spanOptions?: SpanOptions;
+export interface GetTokenOptions extends OperationOptions {
 }
 
 /**

--- a/sdk/core/core-http/lib/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/bearerTokenAuthenticationPolicy.ts
@@ -73,7 +73,9 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
     const token = await this.getToken({
       abortSignal: webResource.abortSignal,
-      spanOptions: webResource.spanOptions
+      tracingOptions: {
+        spanOptions: webResource.spanOptions
+      }
     });
     webResource.headers.set(Constants.HeaderConstants.AUTHORIZATION, `Bearer ${token}`);
     return this._nextPolicy.sendRequest(webResource);

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -40,7 +40,7 @@ describe("BearerTokenAuthenticationPolicy", function() {
     await bearerTokenAuthPolicy.sendRequest(request);
 
     assert(
-      fakeGetToken.calledWith(tokenScopes, { abortSignal: undefined, spanOptions: undefined }),
+      fakeGetToken.calledWith(tokenScopes, { abortSignal: undefined, tracingOptions: { spanOptions: undefined } }),
       "fakeGetToken called incorrectly."
     );
     assert.strictEqual(

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -123,7 +123,7 @@ export class IdentityClient extends ServiceClient {
           Accept: "application/json",
           "Content-Type": "application/x-www-form-urlencoded"
         },
-        spanOptions: newOptions.spanOptions,
+        spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions,
         abortSignal: options && options.abortSignal
       });
 

--- a/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
@@ -82,7 +82,7 @@ export class AuthorizationCodeCredential implements TokenCredential {
     authorizationCode: string,
     redirectUri: string,
     options?: TokenCredentialOptions
-  ); 
+  );
   /**
    * @ignore
    * @internal
@@ -97,7 +97,7 @@ export class AuthorizationCodeCredential implements TokenCredential {
   ) {
     this.clientId = clientId;
     this.tenantId = tenantId;
-    
+
     if (typeof redirectUriOrOptions === "string") {
       // the clientId+clientSecret constructor
       this.clientSecret = clientSecretOrAuthorizationCode;
@@ -108,11 +108,11 @@ export class AuthorizationCodeCredential implements TokenCredential {
       // clientId only
       this.clientSecret = undefined;
       this.authorizationCode = clientSecretOrAuthorizationCode;
-      this.redirectUri = authorizationCodeOrRedirectUri as string;      
+      this.redirectUri = authorizationCodeOrRedirectUri as string;
       options = redirectUriOrOptions as TokenCredentialOptions;
     }
 
-    this.identityClient = new IdentityClient(options);    
+    this.identityClient = new IdentityClient(options);
   }
 
   /**
@@ -172,7 +172,7 @@ export class AuthorizationCodeCredential implements TokenCredential {
             "Content-Type": "application/x-www-form-urlencoded"
           },
           abortSignal: options && options.abortSignal,
-          spanOptions: newOptions.spanOptions
+          spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions
         });
 
         tokenResponse = await this.identityClient.sendTokenRequest(webResource);

--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
@@ -135,7 +135,7 @@ export class ClientCertificateCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         abortSignal: options && options.abortSignal,
-        spanOptions: newOptions.spanOptions
+        spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(webResource);

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.ts
@@ -77,7 +77,7 @@ export class ClientSecretCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         abortSignal: options && options.abortSignal,
-        spanOptions: newOptions.spanOptions
+        spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(webResource);

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -71,7 +71,7 @@ export class DeviceCodeCredential implements TokenCredential {
    * to initiate the device code authorization flow with Azure Active Directory.
    *
    * @param The Azure Active Directory tenant (directory) ID or name.
-   * @param tenantId The Azure Active Directory tenant (directory) ID or name. 
+   * @param tenantId The Azure Active Directory tenant (directory) ID or name.
    *                 'organizations' may be used when dealing with multi-tenant scenarios.
    * @param clientId The client (application) ID of an App Registration in the tenant.
    * @param userPromptCallback A callback function that will be invoked to show
@@ -113,7 +113,7 @@ export class DeviceCodeCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         abortSignal: options && options.abortSignal,
-        spanOptions: newOptions.spanOptions
+        spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions
       });
 
       logger.info("DeviceCodeCredential: sending devicecode request");
@@ -129,13 +129,13 @@ export class DeviceCodeCredential implements TokenCredential {
         err.name === AuthenticationErrorName
           ? CanonicalCode.UNAUTHENTICATED
           : CanonicalCode.UNKNOWN;
-      
+
       if (err.name === AuthenticationErrorName) {
         logger.warning(`DeviceCodeCredential: failed to authenticate ${(err as AuthenticationError).errorResponse.errorDescription}`);
       } else {
         logger.warning(`DeviceCodeCredential: failed to authenticate ${err}`);
       }
-      
+
       span.setStatus({
         code,
         message: err.message
@@ -169,7 +169,7 @@ export class DeviceCodeCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         abortSignal: options && options.abortSignal,
-        spanOptions: newOptions.spanOptions
+        spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions
       });
 
       while (tokenResponse === null) {

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -36,30 +36,30 @@ export class ManagedIdentityCredential implements TokenCredential {
 
   /**
    * Creates an instance of ManagedIdentityCredential with a client ID
-   * 
+   *
    * @param clientId The client (application) ID of an App Registration in the tenant.
    * @param options Options for configuring the client which makes the access token request.
    */
   constructor(clientId: string, options?: TokenCredentialOptions);
   /**
    * Creates an instance of ManagedIdentityCredential
-   * 
+   *
    * @param options Options for configuring the client which makes the access token request.
    */
   constructor(options?: TokenCredentialOptions);
   /**
    * @internal
-   * @ignore   
+   * @ignore
    */
   constructor(clientIdOrOptions: string | TokenCredentialOptions | undefined, options?: TokenCredentialOptions) {
 
     if (typeof clientIdOrOptions === "string") {
       // clientId, options constructor
       this.clientId = clientIdOrOptions;
-      this.identityClient = new IdentityClient(options); 
+      this.identityClient = new IdentityClient(options);
     } else {
       // options only constructor
-      this.identityClient = new IdentityClient(clientIdOrOptions); 
+      this.identityClient = new IdentityClient(clientIdOrOptions);
     }
   }
 
@@ -169,14 +169,14 @@ export class ManagedIdentityCredential implements TokenCredential {
       delete request.headers.Metadata;
     }
 
-    request.spanOptions = options.spanOptions;
+    request.spanOptions = options.tracingOptions && options.tracingOptions.spanOptions;
 
     try {
       // Create a request with a timeout since we expect that
       // not having a "Metadata" header should cause an error to be
       // returned quickly from the endpoint, proving its availability.
       const webResource = this.identityClient.createWebResource(request);
-      webResource.timeout = options.timeout || 500;
+      webResource.timeout = options.requestOptions && options.requestOptions.timeout || 500;
 
       try {
         logger.info(`ManagedIdentityCredential: pinging IMDS endpoint`);
@@ -260,7 +260,7 @@ export class ManagedIdentityCredential implements TokenCredential {
         disableJsonStringifyOnBody: true,
         deserializationMapper: undefined,
         abortSignal: options.abortSignal,
-        spanOptions: options.spanOptions,
+        spanOptions: options.tracingOptions && options.tracingOptions.spanOptions,
         ...authRequestOptions
       });
 

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -83,7 +83,7 @@ export class UsernamePasswordCredential implements TokenCredential {
           "Content-Type": "application/x-www-form-urlencoded"
         },
         abortSignal: options && options.abortSignal,
-        spanOptions: newOptions.spanOptions
+        spanOptions: newOptions.tracingOptions && newOptions.tracingOptions.spanOptions
       });
 
       const tokenResponse = await this.identityClient.sendTokenRequest(webResource);

--- a/sdk/identity/identity/src/util/tracing.ts
+++ b/sdk/identity/identity/src/util/tracing.ts
@@ -14,21 +14,30 @@ export function createSpan(
   options: GetTokenOptions = {}
 ): { span: Span; options: GetTokenOptions } {
   const tracer = getTracer();
-  const spanOptions: SpanOptions = {
-    ...options.spanOptions,
+
+  const tracingOptions = {
+    spanOptions: {},
+    ...options.tracingOptions
+  };
+
+  tracingOptions.spanOptions = {
+    ...tracingOptions.spanOptions,
     kind: SpanKind.CLIENT
   };
 
-  const span = tracer.startSpan(`Azure.Identity.${operationName}`, spanOptions);
+  const span = tracer.startSpan(`Azure.Identity.${operationName}`, tracingOptions.spanOptions);
   span.setAttribute("component", "identity");
 
   let newOptions = options;
   if (span.isRecordingEvents()) {
     newOptions = {
       ...options,
-      spanOptions: {
-        ...options.spanOptions,
-        parent: span
+      tracingOptions: {
+        ...tracingOptions,
+        spanOptions: {
+          ...tracingOptions.spanOptions,
+          parent: span
+        }
       }
     };
   }

--- a/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
@@ -98,8 +98,10 @@ describe("AuthorizationCodeCredential", function() {
     );
 
     await credential.getToken("scope", {
-      spanOptions: {
-        parent: rootSpan
+      tracingOptions: {
+        spanOptions: {
+          parent: rootSpan
+        }
       }
     });
 

--- a/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
@@ -95,8 +95,10 @@ describe("ClientCertificateCredential", function() {
     );
 
     await credential.getToken("scope", {
-      spanOptions: {
-        parent: rootSpan
+      tracingOptions: {
+        spanOptions: {
+          parent: rootSpan
+        }
       }
     });
 

--- a/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
@@ -325,8 +325,10 @@ describe("DeviceCodeCredential", function() {
     );
 
     await credential.getToken("scope", {
-      spanOptions: {
-        parent: rootSpan
+      tracingOptions: {
+        spanOptions: {
+          parent: rootSpan
+        }
       }
     });
 

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -90,8 +90,10 @@ describe("EnvironmentCredential", function() {
     const credential = new EnvironmentCredential(mockHttpClient.tokenCredentialOptions);
     const rootSpan = tracer.startSpan("root");
     await credential.getToken("scope", {
-      spanOptions: {
-        parent: rootSpan
+      tracingOptions: {
+        spanOptions: {
+          parent: rootSpan
+        }
       }
     });
     rootSpan.end();

--- a/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
@@ -187,7 +187,7 @@ describe("ManagedIdentityCredential", function() {
       ? new ManagedIdentityCredential(clientId, { ...mockHttpClient.tokenCredentialOptions })
       : new ManagedIdentityCredential({ ...mockHttpClient.tokenCredentialOptions });
 
-    const token = await credential.getToken(scopes, { timeout });
+    const token = await credential.getToken(scopes, { requestOptions: { timeout } });
     return {
       token,
       requests: mockHttpClient.requests


### PR DESCRIPTION
This PR changes `GetTokenOptions` to be solely based on the new `OperationOptions` to achieve better consistency with the API signatures in other Track 2 client libraries.  For now I'm duplicating the shapes of `OperationOptions` and its constituent types because `core-auth` shouldn't take a circular dependency on `core-http`.  We will reorganize things in the future so that this won't be necessary.

Fixes #5900