### PR TITLE
[Identity] Add code snippet for ChainedTokenCredential, remove cross package links

### DIFF
--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -20,7 +20,7 @@ const DefaultAuthorityHost = "https://login.microsoftonline.com";
 
 /**
  * An internal type used to communicate details of a token request's
- * response that should not be sent back as part of the AccessToken.
+ * response that should not be sent back as part of the access token.
  */
 export interface TokenResponse {
   /**

--- a/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/authorizationCodeCredential.ts
@@ -116,7 +116,7 @@ export class AuthorizationCodeCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -15,9 +15,9 @@ export class ChainedTokenCredential implements TokenCredential {
 
   /**
    * Create a ChainedTokenCredential with the given TokenCredential sources
-   * 
+   *
    * @param sources {@link TokenCredential} implementations to be tried in order
-   * 
+   *
    * Example usage:
    * ```javascript
    * const firstCredential = new ClientSecretCredential(tenantId, clientId, clientSecret);

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -13,6 +13,18 @@ import { CanonicalCode } from "@azure/core-tracing";
 export class ChainedTokenCredential implements TokenCredential {
   private _sources: TokenCredential[] = [];
 
+  /**
+   * Create a ChainedTokenCredential with the given TokenCredential sources
+   * 
+   * @param sources {@link TokenCredential} implementations to be tried in order
+   * 
+   * Example usage:
+   * ```javascript
+   * const firstCredential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+   * const secondCredential = new ClientSecretCredential(tenantId, anotherClientId, anotherSecret);
+   * const credentialChain = new ChainedTokenCredential(firstCredential, secondCredential);
+   * ```
+   */
   constructor(...sources: TokenCredential[]) {
     this._sources = sources;
   }

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -7,8 +7,8 @@ import { createSpan } from "../util/tracing";
 import { CanonicalCode } from "@azure/core-tracing";
 
 /**
- * Enables multiple {@link TokenCredential} implementations to be tried in order
- * until one of the getToken methods returns an {@link AccessToken}.
+ * Enables multiple TokenCredential implementations to be tried in order
+ * until one of the getToken methods returns an access token.
  */
 export class ChainedTokenCredential implements TokenCredential {
   private _sources: TokenCredential[] = [];
@@ -16,7 +16,7 @@ export class ChainedTokenCredential implements TokenCredential {
   /**
    * Create a ChainedTokenCredential with the given TokenCredential sources
    *
-   * @param sources {@link TokenCredential} implementations to be tried in order
+   * @param sources TokenCredential implementations to be tried in order
    *
    * Example usage:
    * ```javascript
@@ -30,10 +30,10 @@ export class ChainedTokenCredential implements TokenCredential {
   }
 
   /**
-   * Returns the first {@link AccessToken} returned by one of the chained
-   * {@link TokenCredential} implementations.  Throws an {@link AggregateAuthenticationError}
+   * Returns the first access token returned by one of the chained
+   * TokenCredential implementations.  Throws an {@link AggregateAuthenticationError}
    * when one or more credentials throws an {@link AuthenticationError} and
-   * no credentials have returned an {@link AccessToken}.
+   * no credentials have returned an access token.
    *
    * @param scopes The list of scopes for which the token will have access.
    * @param options The options used to configure any requests this

--- a/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
+++ b/sdk/identity/identity/src/credentials/chainedTokenCredential.ts
@@ -7,16 +7,16 @@ import { createSpan } from "../util/tracing";
 import { CanonicalCode } from "@azure/core-tracing";
 
 /**
- * Enables multiple TokenCredential implementations to be tried in order
+ * Enables multiple `TokenCredential` implementations to be tried in order
  * until one of the getToken methods returns an access token.
  */
 export class ChainedTokenCredential implements TokenCredential {
   private _sources: TokenCredential[] = [];
 
   /**
-   * Create a ChainedTokenCredential with the given TokenCredential sources
+   * Creates an instance of ChainedTokenCredential using the given credentials.
    *
-   * @param sources TokenCredential implementations to be tried in order
+   * @param sources `TokenCredential` implementations to be tried in order.
    *
    * Example usage:
    * ```javascript
@@ -31,13 +31,13 @@ export class ChainedTokenCredential implements TokenCredential {
 
   /**
    * Returns the first access token returned by one of the chained
-   * TokenCredential implementations.  Throws an {@link AggregateAuthenticationError}
+   * `TokenCredential` implementations.  Throws an {@link AggregateAuthenticationError}
    * when one or more credentials throws an {@link AuthenticationError} and
    * no credentials have returned an access token.
    *
    * @param scopes The list of scopes for which the token will have access.
    * @param options The options used to configure any requests this
-   *                TokenCredential implementation might make.
+   *                `TokenCredential` implementation might make.
    */
   async getToken(
     scopes: string | string[],

--- a/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientCertificateCredential.ts
@@ -76,7 +76,7 @@ export class ClientCertificateCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/clientSecretCredential.ts
+++ b/sdk/identity/identity/src/credentials/clientSecretCredential.ts
@@ -45,7 +45,7 @@ export class ClientSecretCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -219,7 +219,7 @@ export class DeviceCodeCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/deviceCodeCredential.ts
@@ -70,8 +70,7 @@ export class DeviceCodeCredential implements TokenCredential {
    * Creates an instance of DeviceCodeCredential with the details needed
    * to initiate the device code authorization flow with Azure Active Directory.
    *
-   * @param The Azure Active Directory tenant (directory) ID or name.
-   * @param tenantId The Azure Active Directory tenant (directory) ID or name.
+   * @param tenantId The Azure Active Directory tenant (directory) ID or name. 
    *                 'organizations' may be used when dealing with multi-tenant scenarios.
    * @param clientId The client (application) ID of an App Registration in the tenant.
    * @param userPromptCallback A callback function that will be invoked to show

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -77,7 +77,7 @@ export class EnvironmentCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.browser.ts
@@ -126,7 +126,7 @@ export class InteractiveBrowserCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
+++ b/sdk/identity/identity/src/credentials/interactiveBrowserCredential.ts
@@ -21,7 +21,7 @@ export class InteractiveBrowserCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -285,7 +285,7 @@ export class ManagedIdentityCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.

--- a/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
+++ b/sdk/identity/identity/src/credentials/usernamePasswordCredential.ts
@@ -47,7 +47,7 @@ export class UsernamePasswordCredential implements TokenCredential {
   }
 
   /**
-   * Authenticates with Azure Active Directory and returns an {@link AccessToken} if
+   * Authenticates with Azure Active Directory and returns an access token if
    * successful.  If authentication cannot be performed at this time, this method may
    * return null.  If an error occurs during authentication, an {@link AuthenticationError}
    * containing failure details will be thrown.


### PR DESCRIPTION
- Added a code snippet to the documentation for `ChainedTokenCredential`
- removed an errant line from `DeviceCodeCredential` docs
- remove cross package links to `TokenCredential` and `AccessToken` from `core-auth` as they dont render well at the moment

_From @ramya-rao-a:_

From our github.io pages:

![image](https://user-images.githubusercontent.com/16890566/67730538-8c02cf00-f9b2-11e9-91cc-7149071d3d3d.png)

From our official docs:

![image](https://user-images.githubusercontent.com/16890566/67730559-9a50eb00-f9b2-11e9-8859-98fa59874d4e.png)
