### PR TITLE
Added eng to core ci build for coverage.

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -32,6 +32,7 @@ pr:
   paths:
     include:
       - sdk/core/
+      - eng/
 
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml


### PR DESCRIPTION
This PR adds the ```eng/``` path to the PR path filters. This is because we disabled the ```js - client - ci``` pipeline which shouldn't be needed anymore because of unified pipelines, but we still wanted some coverage for changes to the eng folder.