### PR TITLE
update versions in constants files from set-version tool

### DIFF
--- a/sdk/core/core-arm/lib/util/constants.ts
+++ b/sdk/core/core-arm/lib/util/constants.ts
@@ -27,4 +27,4 @@ export const DEFAULT_LANGUAGE = "en-us";
  * @const
  * @type {string}
  */
-export const coreArmVersion = "1.0.0-preview.6";
+export const coreArmVersion = "1.0.0-preview.7";

--- a/sdk/core/core-http/lib/util/constants.ts
+++ b/sdk/core/core-http/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  coreHttpVersion: "1.0.0-preview.6",
+  coreHttpVersion: "1.0.0",
 
   /**
    * Specifies HTTP.


### PR DESCRIPTION
Tool found a brace of versions buried in the code beyond the package.json files. This sets the versions in those files to the release versions. 