### PR TITLE
[storage-blob] Links, examples, and some doc fixes

### DIFF
--- a/sdk/storage/storage-blob/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/AccountSASSignatureValues.ts
@@ -14,10 +14,10 @@ import { truncatedISO8061Date } from "./utils/utils.common";
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
  * AccountSASSignatureValues is used to generate a Shared Access Signature (SAS) for an Azure Storage account. Once
- * all the values here are set appropriately, call generateSASQueryParameters() to obtain a representation of the SAS
- * which can actually be applied to blob urls. Note: that both this class and {@link SASQueryParameters} exist because
- * the former is mutable and a logical representation while the latter is immutable and used to generate actual REST
- * requests.
+ * all the values here are set appropriately, call {@link generateAccountSASQueryParameters} to obtain a representation
+ * of the SAS which can actually be applied to blob urls. Note: that both this class and {@link SASQueryParameters}
+ * exist because the former is mutable and a logical representation while the latter is immutable and used to generate
+ * actual REST requests.
  *
  * @see https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1
  * for more conceptual information on SAS

--- a/sdk/storage/storage-blob/src/BlobBatch.ts
+++ b/sdk/storage/storage-blob/src/BlobBatch.ts
@@ -53,7 +53,7 @@ export interface BatchSubRequest {
 
 /**
  * A BlobBatch represents an aggregated set of operations on blobs.
- * Currently, only delete and setAccessTier are supported.
+ * Currently, only `delete` and `setAccessTier` are supported.
  *
  * @export
  * @class BlobBatch
@@ -274,7 +274,11 @@ export class BlobBatch {
 
   public async setBlobAccessTier(
     urlOrBlobClient: string | BlobClient,
-    credentialOrTier: StorageSharedKeyCredential | AnonymousCredential | TokenCredential | AccessTier,
+    credentialOrTier:
+      | StorageSharedKeyCredential
+      | AnonymousCredential
+      | TokenCredential
+      | AccessTier,
     tierOrOptions?: AccessTier | BlobSetTierOptions,
     options?: BlobSetTierOptions
   ): Promise<void> {
@@ -290,7 +294,10 @@ export class BlobBatch {
     ) {
       // First overload
       url = urlOrBlobClient;
-      credential = credentialOrTier as StorageSharedKeyCredential | AnonymousCredential | TokenCredential;
+      credential = credentialOrTier as
+        | StorageSharedKeyCredential
+        | AnonymousCredential
+        | TokenCredential;
       tier = tierOrOptions as AccessTier;
     } else if (urlOrBlobClient instanceof BlobClient) {
       // Second overload
@@ -341,7 +348,7 @@ export class BlobBatch {
 
 /**
  * Inner batch request class which is responsible for assembling and serializing sub requests.
- * See https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#request-body for how request get assembled.
+ * See https://docs.microsoft.com/en-us/rest/api/storageservices/blob-batch#request-body for how requests are assembled.
  */
 class InnerBatchRequest {
   private operationCount: number;

--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -130,7 +130,7 @@ export class BlobBatchClient {
 
   /**
    * Creates a {@link BlobBatch}.
-   * A {@link BlobBatch} represents an aggregated set of operations on blobs.
+   * A BlobBatch represents an aggregated set of operations on blobs.
    */
   public createBatch(): BlobBatch {
     return new BlobBatch();

--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -59,12 +59,12 @@ export declare type BlobBatchSubmitBatchResponse = ParsedBatchResponse &
   };
 
 /**
- * Contains response data for the deleteBlobs operation.
+ * Contains response data for the {@link deleteBlobs} operation.
  */
 export declare type BlobBatchDeleteBlobsResponse = BlobBatchSubmitBatchResponse;
 
 /**
- * Contains response data for the setBlobsAccessTier operation.
+ * Contains response data for the {@link setBlobsAccessTier} operation.
  */
 export declare type BlobBatchSetBlobsAccessTierResponse = BlobBatchSubmitBatchResponse;
 
@@ -106,7 +106,11 @@ export class BlobBatchClient {
   constructor(url: string, pipeline: Pipeline);
   constructor(
     url: string,
-    credentialOrPipeline?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential | Pipeline,
+    credentialOrPipeline?:
+      | StorageSharedKeyCredential
+      | AnonymousCredential
+      | TokenCredential
+      | Pipeline,
     options?: StoragePipelineOptions
   ) {
     let pipeline: Pipeline;
@@ -125,8 +129,8 @@ export class BlobBatchClient {
   }
 
   /**
-   * Creates a BlobBatch.
-   * A BlobBatch represents an aggregated set of operations on blobs.
+   * Creates a {@link BlobBatch}.
+   * A {@link BlobBatch} represents an aggregated set of operations on blobs.
    */
   public createBatch(): BlobBatch {
     return new BlobBatch();
@@ -239,7 +243,11 @@ export class BlobBatchClient {
 
   public async setBlobsAccessTier(
     urlsOrBlobClients: string[] | BlobClient[],
-    credentialOrTier: StorageSharedKeyCredential | AnonymousCredential | TokenCredential | AccessTier,
+    credentialOrTier:
+      | StorageSharedKeyCredential
+      | AnonymousCredential
+      | TokenCredential
+      | AccessTier,
     tierOrOptions?: AccessTier | BlobSetTierOptions,
     options?: BlobSetTierOptions
   ): Promise<BlobBatchSetBlobsAccessTierResponse> {

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -3062,10 +3062,7 @@ export class BlockBlobClient extends BlobClient {
    *
    * @example
    * ```js
-   * const content = "hello";
-   * const blobName = "newblob" + new Date().getTime();
-   * const blobClient = containerClient.getBlobClient(blobName);
-   * const blockBlobClient = blobClient.getBlockBlobClient();
+   * const content = "Hello world!";
    * const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
    * ```
    */

--- a/sdk/storage/storage-blob/src/BlobClient.ts
+++ b/sdk/storage/storage-blob/src/BlobClient.ts
@@ -118,7 +118,7 @@ import {
 import { PollerLike, PollOperationState } from "@azure/core-lro";
 
 /**
- * Options to configure Blob - Begin Copy from URL operation.
+ * Options to configure the {@link BlobClient.beginCopyFromURL} operation.
  *
  * @export
  * @interface BlobBeginCopyFromURLOptions
@@ -153,7 +153,7 @@ export interface BlobBeginCopyFromURLOptions extends BlobStartCopyFromURLOptions
 }
 
 /**
- * Contains response data for the beginCopyFromURL operation.
+ * Contains response data for the {@link BlobClient.beginCopyFromURL} operation.
  *
  * @export
  * @interface BlobBeginCopyFromURLResponse
@@ -161,7 +161,7 @@ export interface BlobBeginCopyFromURLOptions extends BlobStartCopyFromURLOptions
 export interface BlobBeginCopyFromURLResponse extends BlobStartCopyFromURLResponse {}
 
 /**
- * Options to configure Blob - Download operation.
+ * Options to configure the {@link BlobClient.download} operation.
  *
  * @export
  * @interface BlobDownloadOptions
@@ -224,7 +224,7 @@ export interface BlobDownloadOptions extends CommonOptions {
    * Above kind of ends will not trigger retry policy defined in a pipeline,
    * because they doesn't emit network errors.
    *
-   * With this option, every additional retry means an additional FileClient.download() request will be made
+   * With this option, every additional retry means an additional `FileClient.download()` request will be made
    * from the broken point, until the requested range has been successfully downloaded or maxRetryRequests is reached.
    *
    * Default value is 5, please set a larger value when loading large files in poor network.
@@ -243,7 +243,7 @@ export interface BlobDownloadOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Exists operation.
+ * Options to configure the {@link BlobClient.exists} operation.
  *
  * @export
  * @interface BlobExistsOptions
@@ -267,7 +267,7 @@ export interface BlobExistsOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Get Properties operation.
+ * Options to configure the {@link BlobClient.getProperties} operation.
  *
  * @export
  * @interface BlobGetPropertiesOptions
@@ -298,7 +298,7 @@ export interface BlobGetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Blob - Delete operation.
+ * Options to configure the {@link BlobClient.delete} operation.
  *
  * @export
  * @interface BlobDeleteOptions
@@ -338,7 +338,7 @@ export interface BlobDeleteOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Undelete operation.
+ * Options to configure the {@link BlobClient.undelete} operation.
  *
  * @export
  * @interface BlobUndeleteOptions
@@ -362,7 +362,7 @@ export interface BlobUndeleteOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Set Http Headers operation.
+ * Options to configure the {@link BlobClient.setHTTPHeaders} operation.
  *
  * @export
  * @interface BlobSetHTTPHeadersOptions
@@ -393,7 +393,7 @@ export interface BlobSetHTTPHeadersOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Set Metadata operation.
+ * Options to configure the {@link BlobClient.setMetadata} operation.
  *
  * @export
  * @interface BlobSetMetadataOptions
@@ -544,7 +544,7 @@ export interface BlobBreakLeaseOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Create Snapshot operation.
+ * Options to configure the {@link BlobClient.createSnapshot} operation.
  *
  * @export
  * @interface BlobCreateSnapshotOptions
@@ -582,7 +582,7 @@ export interface BlobCreateSnapshotOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Start Copy from URL operation.
+ * Options to configure the {@link BlobClient.beginCopyFromURL} operation.
  *
  * @export
  * @interface BlobStartCopyFromURLOptions
@@ -636,7 +636,7 @@ export interface BlobStartCopyFromURLOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Abort Copy from URL operation.
+ * Options to configure the {@link BlobClient.abortCopyFromURL} operation.
  *
  * @export
  * @interface BlobAbortCopyFromURLOptions
@@ -661,7 +661,7 @@ export interface BlobAbortCopyFromURLOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - synchronous Copy From URL operation.
+ * Options to configure the {@link BlobClient.syncCopyFromURL} operation.
  *
  * @export
  * @interface BlobSyncCopyFromURLOptions
@@ -699,7 +699,7 @@ export interface BlobSyncCopyFromURLOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Blob - Set Tier operation.
+ * Options to configure the {@link BlobClient.setAccessTier} operation.
  *
  * @export
  * @interface BlobSetTierOptions
@@ -732,7 +732,7 @@ export interface BlobSetTierOptions extends CommonOptions {
 }
 
 /**
- * Option interface for BlobClient.downloadToBuffer().
+ * Option interface for the {@link BlobClient.downloadToBuffer} operation.
  *
  * @export
  * @interface BlobDownloadToBufferOptions
@@ -1044,6 +1044,49 @@ export class BlobClient extends StorageClient {
    * @param {BlobDownloadOptions} [options] Optional options to Blob Download operation.
    * @returns {Promise<BlobDownloadResponseModel>}
    * @memberof BlobClient
+   *
+   * @example
+   * ```js
+   * // Download and convert a blob to a string (Node.js only)
+   * const downloadBlockBlobResponse = await blobClient.download();
+   * const downloaded = await streamToString(downloadBlockBlobResponse.readableStreamBody);
+   * console.log("Downloaded blob content:", downloaded);
+   *
+   * async function streamToString(readableStream) {
+   *   return new Promise((resolve, reject) => {
+   *     const chunks = [];
+   *     readableStream.on("data", (data) => {
+   *       chunks.push(data.toString());
+   *     });
+   *     readableStream.on("end", () => {
+   *       resolve(chunks.join(""));
+   *     });
+   *     readableStream.on("error", reject);
+   *   });
+   * }
+   * ```
+   *
+   * @example
+   * ```js
+   * // Download and convert a blob to a string (Browser only)
+   * const downloadBlockBlobResponse = await blobClient.download();
+   * const downloaded = await blobToString(await downloadBlockBlobResponse.blobBody);
+   * console.log(
+   *   "Downloaded blob content",
+   *   downloaded
+   * );
+   *
+   * async function blobToString(blob: Blob): Promise<string> {
+   *   const fileReader = new FileReader();
+   *   return new Promise<string>((resolve, reject) => {
+   *     fileReader.onloadend = (ev: any) => {
+   *       resolve(ev.target!.result);
+   *     };
+   *     fileReader.onerror = reject;
+   *     fileReader.readAsText(blob);
+   *   });
+   * }
+   * ```
    */
   public async download(
     offset: number = 0,
@@ -1364,7 +1407,7 @@ export class BlobClient extends StorageClient {
   }
 
   /**
-   * Get a BlobLeaseClient that manages leases on the blob.
+   * Get a {@link BlobLeaseClient} that manages leases on the blob.
    *
    * @param {string} [proposeLeaseId] Initial proposed lease Id.
    * @returns {BlobLeaseClient} A new BlobLeaseClient object for managing leases on the blob.
@@ -1925,7 +1968,7 @@ export class BlobClient extends StorageClient {
 }
 
 /**
- * Options to configure Append Blob - Create operation.
+ * Options to configure {@link AppendBlobClient.create} operation.
  *
  * @export
  * @interface AppendBlobCreateOptions
@@ -1971,7 +2014,7 @@ export interface AppendBlobCreateOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Append Blob - Append Block operation.
+ * Options to configure the {@link AppendBlobClient.appendBlock} operation.
  *
  * @export
  * @interface AppendBlobAppendBlockOptions
@@ -1994,7 +2037,7 @@ export interface AppendBlobAppendBlockOptions extends CommonOptions {
   conditions?: AppendBlobRequestConditions;
   /**
    * Callback to receive events on the progress of append block operation.
-   * 
+   *
    * @type {(progress: TransferProgressEvent) => void}
    * @memberof AppendBlobAppendBlockOptions
    */
@@ -2029,8 +2072,8 @@ export interface AppendBlobAppendBlockOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Append Blob - Append Block From URL operation.
- * 
+ * Options to configure the {@link AppendBlobClient.appendBlockFromURL} operation.
+ *
  * @export
  * @interface AppendBlobAppendBlockFromURLOptions
  */
@@ -2414,7 +2457,7 @@ export class AppendBlobClient extends BlobClient {
 }
 
 /**
- * Options to configure Block Blob - Upload operation.
+ * Options to configure {@link BlockBlobClient.upload} operation.
  *
  * @export
  * @interface BlockBlobUploadOptions
@@ -2474,7 +2517,7 @@ export interface BlockBlobUploadOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Block Blob - Stage Block operation.
+ * Options to configure {@link BlockBlobClient.stageBlock} operation.
  *
  * @export
  * @interface BlockBlobStageBlockOptions
@@ -2534,7 +2577,7 @@ export interface BlockBlobStageBlockOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Block Blob - Stage Block from URL operation.
+ * Options to configure {@link BlockBlobClient.stageBlockFromURL} operation.
  *
  * @export
  * @interface BlockBlobStageBlockFromURLOptions
@@ -2595,7 +2638,7 @@ export interface BlockBlobStageBlockFromURLOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Block Blob - Commit Block List operation.
+ * Options to configure {@link BlockBlobClient.commitBlockList} operation.
  *
  * @export
  * @interface BlockBlobCommitBlockListOptions
@@ -2648,7 +2691,7 @@ export interface BlockBlobCommitBlockListOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Block Blob - Get Block List operation.
+ * Options to configure {@link BlockBlobClient.getBlockList} operation.
  *
  * @export
  * @interface BlockBlobGetBlockListOptions
@@ -2673,7 +2716,7 @@ export interface BlockBlobGetBlockListOptions extends CommonOptions {
 }
 
 /**
- * Option interface for uploadStream().
+ * Option interface for the {@link BlockBlobClient.uploadStream} operation.
  *
  * @export
  * @interface BlockBlobUploadStreamOptions
@@ -2721,7 +2764,7 @@ export interface BlockBlobUploadStreamOptions extends CommonOptions {
   onProgress?: (progress: TransferProgressEvent) => void;
 }
 /**
- * Option interface for BlockBlobClient.uploadFile() and BlockBlobClient.uploadSeekableStream().
+ * Option interface for {@link BlockBlobClient.uploadFile} and {@link BlockBlobClient.uploadSeekableStream}.
  *
  * @export
  * @interface BlockBlobParallelUploadOptions
@@ -2797,7 +2840,8 @@ export interface BlockBlobParallelUploadOptions extends CommonOptions {
 }
 
 /**
- * Type for BlockBlobClient.uploadFile(), BlockBlobClient.uploadStream() and BlockBlobClient.uploadBrowserDate().
+ * Response type for {@link BlockBlobClient.uploadFile}, {@link BlockBlobClient.uploadStream}, and
+ * {@link BlockBlobClient.uploadBrowserDate}.
  *
  * @export
  */
@@ -3000,10 +3044,10 @@ export class BlockBlobClient extends BlobClient {
    * Updating an existing block blob overwrites any existing metadata on the blob.
    * Partial updates are not supported; the content of the existing blob is
    * overwritten with the new content. To perform a partial update of a block blob's,
-   * use stageBlock and commitBlockList.
+   * use {@link stageBlock} and {@link commitBlockList}.
    *
-   * This is a non-parallel uploading method, please use uploadFile(),
-   * uploadStream() or uploadBrowserData() for better performance
+   * This is a non-parallel uploading method, please use {@link uploadFile},
+   * {@link uploadStream} or {@link uploadBrowserData} for better performance
    * with concurrency uploading.
    *
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
@@ -3015,6 +3059,15 @@ export class BlockBlobClient extends BlobClient {
    * @param {BlockBlobUploadOptions} [options] Options to the Block Blob Upload operation.
    * @returns {Promise<BlockBlobUploadResponse>} Response data for the Block Blob Upload operation.
    * @memberof BlockBlobClient
+   *
+   * @example
+   * ```js
+   * const content = "hello";
+   * const blobName = "newblob" + new Date().getTime();
+   * const blobClient = containerClient.getBlobClient(blobName);
+   * const blockBlobClient = blobClient.getBlockBlobClient();
+   * const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
+   * ```
    */
   public async upload(
     body: HttpRequestBody,
@@ -3146,8 +3199,8 @@ export class BlockBlobClient extends BlobClient {
   /**
    * Writes a blob by specifying the list of block IDs that make up the blob.
    * In order to be written as part of a blob, a block must have been successfully written
-   * to the server in a prior stageBlock operation. You can call commitBlockList to update a blob
-   * by uploading only those blocks that have changed, then committing the new and existing
+   * to the server in a prior {@link stageBlock} operation. You can call {@link commitBlockList} to
+   * update a blob by uploading only those blocks that have changed, then committing the new and existing
    * blocks together. Any blocks not specified in the block list and permanently deleted.
    * @see https://docs.microsoft.com/rest/api/storageservices/put-block-list
    *
@@ -3245,8 +3298,8 @@ export class BlockBlobClient extends BlobClient {
    * Uploads a browser Blob/File/ArrayBuffer/ArrayBufferView object to block blob.
    *
    * When buffer length <= 256MB, this method will use 1 upload call to finish the upload.
-   * Otherwise, this method will call stageBlock to upload blocks, and finally call commitBlockList
-   * to commit the block list.
+   * Otherwise, this method will call {@link stageBlock} to upload blocks, and finally call
+   * {@link commitBlockList} to commit the block list.
    *
    * @export
    * @param {Blob | ArrayBuffer | ArrayBufferView} browserData Blob, File, ArrayBuffer or ArrayBufferView
@@ -3285,8 +3338,8 @@ export class BlockBlobClient extends BlobClient {
   /**
    * ONLY AVAILABLE IN BROWSERS.
    *
-   * Uploads a browser Blob object to block blob. Requires a blobFactory as the data source,
-   * which need to return a Blob object with the offset and size provided.
+   * Uploads a browser {@link Blob} object to block blob. Requires a blobFactory as the data source,
+   * which need to return a {@link Blob} object with the offset and size provided.
    *
    * When buffer length <= 256MB, this method will use 1 upload call to finish the upload.
    * Otherwise, this method will call stageBlock to upload blocks, and finally call commitBlockList
@@ -3543,7 +3596,7 @@ export class BlockBlobClient extends BlobClient {
    * is the offset in the block blob to be uploaded.
    *
    * When buffer length <= 256MB, this method will use 1 upload call to finish the upload.
-   * Otherwise, this method will call stageBlock to upload blocks, and finally call commitBlockList
+   * Otherwise, this method will call {@link stageBlock} to upload blocks, and finally call {@link commitBlockList}
    * to commit the block list.
    *
    * @export
@@ -3669,7 +3722,7 @@ export class BlockBlobClient extends BlobClient {
 }
 
 /**
- * Options to configure Page Blob - Create operation.
+ * Options to configure the {@link PageBlobClient.create} operation.
  *
  * @export
  * @interface PageBlobCreateOptions
@@ -3730,7 +3783,7 @@ export interface PageBlobCreateOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Upload Pages operation.
+ * Options to configure the {@link PageBlobClient.uploadPages} operation.
  *
  * @export
  * @interface PageBlobUploadPagesOptions
@@ -3788,7 +3841,7 @@ export interface PageBlobUploadPagesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Clear Pages operation.
+ * Options to configure the {@link PageBlobClient.clearPages} operation.
  *
  * @export
  * @interface PageBlobClearPagesOptions
@@ -3819,7 +3872,7 @@ export interface PageBlobClearPagesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Get Page Ranges operation.
+ * Options to configure the {@link PageBlobClient.getPageRanges} operation.
  *
  * @export
  * @interface PageBlobGetPageRangesOptions
@@ -3843,7 +3896,7 @@ export interface PageBlobGetPageRangesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Get Ranges Diff operation.
+ * Options to configure the {@link PageBlobClient.getRangesDiff} operation.
  *
  * @export
  * @interface PageBlobGetPageRangesDiffOptions
@@ -3874,7 +3927,7 @@ export interface PageBlobGetPageRangesDiffOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Resize operation.
+ * Options to configure {@link PageBlobClient.resize} operation.
  *
  * @export
  * @interface PageBlobResizeOptions
@@ -3898,7 +3951,7 @@ export interface PageBlobResizeOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Update Sequence Number operation.
+ * Options to configure {@link PageBlobClient.updateSequenceNumber} operation.
  *
  * @export
  * @interface PageBlobUpdateSequenceNumberOptions
@@ -3922,7 +3975,7 @@ export interface PageBlobUpdateSequenceNumberOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Start Copy Incremental operation.
+ * Options to configure {@link PageBlobClient.startCopyIncremental} operation.
  *
  * @export
  * @interface PageBlobStartCopyIncrementalOptions
@@ -3946,8 +3999,8 @@ export interface PageBlobStartCopyIncrementalOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Page Blob - Upload Pages From URL operation.
- * 
+ * Options to configure {@link PageBlobClient.uploadPagesFromURL} operation.
+ *
  * @export
  * @interface PageBlobUploadPagesFromURLOptions
  */

--- a/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
+++ b/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
@@ -23,7 +23,7 @@ import { ReadableStreamGetter, RetriableReadableStream } from "./utils/Retriable
  * automatically retry when internal read stream unexpected ends. (This kind of unexpected ends cannot
  * trigger retries defined in pipeline retry policy.)
  *
- * The readableStreamBody stream will retry underlayer, you can just use it as a normal Node.js
+ * The {@link readableStreamBody} stream will retry underlayer, you can just use it as a normal Node.js
  * Readable stream.
  *
  * @export

--- a/sdk/storage/storage-blob/src/BlobLeaseClient.ts
+++ b/sdk/storage/storage-blob/src/BlobLeaseClient.ts
@@ -62,6 +62,8 @@ export interface Lease {
 
 /**
  * Contains the response data for operations that create, modify, or delete a lease.
+ *
+ * See {@link BlobLeaseClient}.
  */
 export type LeaseOperationResponse = Lease & {
   /**
@@ -100,7 +102,7 @@ export interface LeaseOperationOptions extends CommonOptions {
 }
 
 /**
- * A client that manages leases for a ContainerClient or a BlobClient.
+ * A client that manages leases for a {@link ContainerClient} or a {@link BlobClient}.
  *
  * @export
  * @class BlobLeaseClient
@@ -174,7 +176,10 @@ export class BlobLeaseClient {
     duration: number,
     options: LeaseOperationOptions = {}
   ): Promise<LeaseOperationResponse> {
-    const { span, spanOptions } = createSpan("BlobLeaseClient-acquireLease", options.tracingOptions);
+    const { span, spanOptions } = createSpan(
+      "BlobLeaseClient-acquireLease",
+      options.tracingOptions
+    );
     try {
       return await this._containerOrBlobOperation.acquireLease({
         abortSignal: options.abortSignal,
@@ -245,7 +250,10 @@ export class BlobLeaseClient {
    * @memberof BlobLeaseClient
    */
   public async releaseLease(options: LeaseOperationOptions = {}): Promise<LeaseOperationResponse> {
-    const { span, spanOptions } = createSpan("BlobLeaseClient-releaseLease", options.tracingOptions);
+    const { span, spanOptions } = createSpan(
+      "BlobLeaseClient-releaseLease",
+      options.tracingOptions
+    );
     try {
       return await this._containerOrBlobOperation.releaseLease(this._leaseId, {
         abortSignal: options.abortSignal,

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -351,7 +351,7 @@ export class BlobServiceClient extends StorageClient {
    * @example
    * ```js
    * const account = "<storage account name>"
-   * const sharedKeyCredential = new SharedKeyCredential(account, "<account key>");
+   * const sharedKeyCredential = new StorageSharedKeyCredential(account, "<account key>");
    *
    * const blobServiceClient = new BlobServiceClient(
    *   `https://${account}.blob.core.windows.net`,

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -339,7 +339,10 @@ export class BlobServiceClient extends StorageClient {
    *
    * @example
    * ```js
-   * const account = "<storage account name>"
+   * const account = "<storage account name>";
+   *
+   * // Use a TokenCredential implementation from the @azure/identity package.
+   * // In this case, a DefaultAzureCredential (recommended for most users)
    * const defaultAzureCredential = new DefaultAzureCredential();
    *
    * const blobServiceClient = new BlobServiceClient(

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -413,7 +413,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * @example
    * ```js
-   * const containerClient = blobServiceClient.getContainerClient("<container name>);
+   * const containerClient = blobServiceClient.getContainerClient("<container name>");
    * ```
    */
   public getContainerClient(containerName: string): ContainerClient {

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -339,11 +339,23 @@ export class BlobServiceClient extends StorageClient {
    *
    * @example
    * ```js
+   * const account = "<storage account name>"
    * const defaultAzureCredential = new DefaultAzureCredential();
    *
    * const blobServiceClient = new BlobServiceClient(
-   *   `https://<Storage Account Name>.blob.core.windows.net`,
+   *   `https://${account}.blob.core.windows.net`,
    *   defaultAzureCredential
+   * );
+   * ```
+   *
+   * @example
+   * ```js
+   * const account = "<storage account name>"
+   * const sharedKeyCredential = new SharedKeyCredential(account, "<account key>");
+   *
+   * const blobServiceClient = new BlobServiceClient(
+   *   `https://${account}.blob.core.windows.net`,
+   *   sharedKeyCredential
    * );
    * ```
    */
@@ -398,8 +410,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * @example
    * ```js
-   * const containerName = "ExampleContainer";
-   * const containerClient = blobServiceClient.getContainerClient(containerName);
+   * const containerClient = blobServiceClient.getContainerClient("<container name>);
    * ```
    */
   public getContainerClient(containerName: string): ContainerClient {

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -41,7 +41,7 @@ import { BlobBatchClient } from "./BlobBatchClient";
 import { CommonOptions, StorageClient } from "./StorageClient";
 
 /**
- * Options to configure the Service - Get Properties operation.
+ * Options to configure the {@link BlobServiceClient.getProperties} operation.
  *
  * @export
  * @interface ServiceGetPropertiesOptions
@@ -58,7 +58,7 @@ export interface ServiceGetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Service - Set Properties operation.
+ * Options to configure the {@link BlobServiceClient.setProperties} operation.
  *
  * @export
  * @interface ServiceSetPropertiesOptions
@@ -75,7 +75,7 @@ export interface ServiceSetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Service - Get Account Info operation.
+ * Options to configure the {@link BlobServiceClient.getAccountInfo} operation.
  *
  * @export
  * @interface ServiceGetAccountInfoOptions
@@ -92,7 +92,7 @@ export interface ServiceGetAccountInfoOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Service - Get Statistics operation.
+ * Options to configure the {@link BlobServiceClient.getStatistics} operation.
  *
  * @export
  * @interface ServiceGetStatisticsOptions
@@ -126,7 +126,7 @@ export interface ServiceGetUserDelegationKeyOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Service - List Container Segment operation.
+ * Options to configure the {@link BlobServiceClient.listContainerSegment} operation.
  *
  * @interface ServiceListContainersSegmentOptions
  */
@@ -163,7 +163,7 @@ interface ServiceListContainersSegmentOptions extends CommonOptions {
 }
 
 /**
- * Options to configure the Service - List Containers operation.
+ * Options to configure the {@link BlobServiceClient.listContainers} operation.
  *
  * @export
  * @interface ServiceListContainersOptions
@@ -245,7 +245,7 @@ export interface UserDelegationKey {
 }
 
 /**
- * Contains response data for the getUserDelegationKey operation.
+ * Contains response data for the {@link getUserDelegationKey} operation.
  */
 export declare type ServiceGetUserDelegationKeyResponse = UserDelegationKey &
   ServiceGetUserDelegationKeyHeaders & {
@@ -336,6 +336,16 @@ export class BlobServiceClient extends StorageClient {
    *                                                  AnonymousCredential is used.
    * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
    * @memberof BlobServiceClient
+   *
+   * @example
+   * ```js
+   * const defaultAzureCredential = new DefaultAzureCredential();
+   *
+   * const blobServiceClient = new BlobServiceClient(
+   *   `https://<Storage Account Name>.blob.core.windows.net`,
+   *   defaultAzureCredential
+   * );
+   * ```
    */
   constructor(
     url: string,
@@ -380,11 +390,17 @@ export class BlobServiceClient extends StorageClient {
   }
 
   /**
-   * Creates a ContainerClient object
+   * Creates a {@link ContainerClient} object
    *
    * @param {string} containerName A container name
    * @returns {ContainerClient} A new ContainerClient object for the given container name.
    * @memberof BlobServiceClient
+   *
+   * @example
+   * ```js
+   * const containerName = "ExampleContainer";
+   * const containerClient = blobServiceClient.getContainerClient(containerName);
+   * ```
    */
   public getContainerClient(containerName: string): ContainerClient {
     return new ContainerClient(

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -761,8 +761,7 @@ export class ContainerClient extends StorageClient {
    * ```js
    * const content = "Hello world!";
    *
-   * const blobClient = containerClient.getBlobClient("<blob name>");
-   * const blockBlobClient = blobClient.getBlockBlobClient();
+   * const blockBlobClient = containerClient.getBlockBlobClient("<blob name>");
    * const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
    * ```
    */

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -58,7 +58,7 @@ import {
 } from "./BlobClient";
 
 /**
- * Options to configure Container - Create operation.
+ * Options to configure {@link ContainerClient.create} operation.
  *
  * @export
  * @interface ContainerCreateOptions
@@ -91,7 +91,7 @@ export interface ContainerCreateOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Container - Get Properties operation.
+ * Options to configure {@link ContainerClient.getProperties} operation.
  *
  * @export
  * @interface ContainerGetPropertiesOptions
@@ -116,7 +116,7 @@ export interface ContainerGetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Container - Delete operation.
+ * Options to configure {@link ContainerClient.delete} operation.
  *
  * @export
  * @interface ContainerDeleteMethodOptions
@@ -140,7 +140,7 @@ export interface ContainerDeleteMethodOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Container - Exists operation.
+ * Options to configure {@link ContainerClient.exists} operation.
  *
  * @export
  * @interface ContainerExistsOptions
@@ -157,7 +157,7 @@ export interface ContainerExistsOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Container - Set Metadata operation.
+ * Options to configure {@link ContainerClient.setMetadata} operation.
  *
  * @export
  * @interface ContainerSetMetadataOptions
@@ -182,7 +182,7 @@ export interface ContainerSetMetadataOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Container - Get Access Policy operation.
+ * Options to configure {@link ContainerClient.getAccessPolicy} operation.
  *
  * @export
  * @interface ContainerGetAccessPolicyOptions
@@ -238,7 +238,7 @@ export interface SignedIdentifier {
 }
 
 /**
- * Contains response data for the getAccessPolicy operation.
+ * Contains response data for the {@link ContainerClient.getAccessPolicy} operation.
  */
 export declare type ContainerGetAccessPolicyResponse = {
   signedIdentifiers: SignedIdentifierModel[];
@@ -263,7 +263,7 @@ export declare type ContainerGetAccessPolicyResponse = {
   };
 
 /**
- * Options to configure Container - Set Access Policy operation.
+ * Options to configure {@link ContainerClient.setAccessPolicy} operation.
  *
  * @export
  * @interface ContainerSetAccessPolicyOptions
@@ -407,7 +407,14 @@ export interface ContainerChangeLeaseOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Container - List Blobs Segment operation.
+ * Options to configure Container - List Segment operations.
+ *
+ * See:
+ * - {@link ContainerClient.listSegments}
+ * - {@link ContainerClient.listBlobFlatSegment}
+ * - {@link ContainerClient.listBlobHierarchySegment}
+ * - {@link ContainerClient.listHierarchySegments}
+ * - {@link ContainerClient.listItemsByHierarchy}
  *
  * @interface ContainerListBlobsSegmentOptions
  */
@@ -443,7 +450,11 @@ interface ContainerListBlobsSegmentOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Container - List Blobs operation.
+ * Options to configure Container - List Blobs operations.
+ *
+ * See:
+ * - {@link ContainerClient.listBlobsFlat}
+ * - {@link ContainerClient.listBlobsByHierarchy}
  *
  * @export
  * @interface ContainerListBlobsOptions
@@ -525,7 +536,7 @@ export class ContainerClient extends StorageClient {
    */
   constructor(connectionString: string, containerName: string, options?: StoragePipelineOptions);
   /**
-   * Creates an instance of PageBlobClient.
+   * Creates an instance of ContainerClient.
    * This method accepts an encoded URL or non-encoded URL pointing to a page blob.
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
@@ -550,7 +561,7 @@ export class ContainerClient extends StorageClient {
     options?: StoragePipelineOptions
   );
   /**
-   * Creates an instance of PageBlobClient.
+   * Creates an instance of ContainerClient.
    * This method accepts an encoded URL or non-encoded URL pointing to a page blob.
    * Encoded URL string will NOT be escaped twice, only special characters in URL path will be escaped.
    * If a blob name includes ? or %, blob name must be encoded in the URL.
@@ -649,6 +660,14 @@ export class ContainerClient extends StorageClient {
    * @param {ContainerCreateOptions} [options] Options to Container Create operation.
    * @returns {Promise<ContainerCreateResponse>}
    * @memberof ContainerClient
+   *
+   * @example
+   * ```js
+   * const containerName = "myNewContainer";
+   * const containerClient = blobServiceClient.getContainerClient(containerName);
+   * const createContainerResponse = await containerClient.create();
+   * console.log("Container was created successfully", createContainerResponse.requestId);
+   * ```
    */
   public async create(options: ContainerCreateOptions = {}): Promise<ContainerCreateResponse> {
     const { span, spanOptions } = createSpan("ContainerClient-create", options.tracingOptions);
@@ -708,7 +727,7 @@ export class ContainerClient extends StorageClient {
   }
 
   /**
-   * Creates a BlobClient object.
+   * Creates a {@link BlobClient}
    *
    * @param {string} blobName A blob name
    * @returns {BlobClient} A new BlobClient object for the given blob name.
@@ -719,7 +738,7 @@ export class ContainerClient extends StorageClient {
   }
 
   /**
-   * Creates a AppendBlobClient object.
+   * Creates an {@link AppendBlobClient}
    *
    * @param {string} blobName An append blob name
    * @returns {AppendBlobClient}
@@ -733,11 +752,20 @@ export class ContainerClient extends StorageClient {
   }
 
   /**
-   * Creates a BlockBlobClient object.
+   * Creates a {@link BlockBlobClient}
    *
    * @param {string} blobName A block blob name
    * @returns {BlockBlobClient}
    * @memberof ContainerClient
+   *
+   * @example
+   * ```js
+   * const content = "hello";
+   * const blobName = "newblob" + new Date().getTime();
+   * const blobClient = containerClient.getBlobClient(blobName);
+   * const blockBlobClient = blobClient.getBlockBlobClient();
+   * const uploadBlobResponse = await blockBlobClient.upload(content, content.length)
+   * ```
    */
   public getBlockBlobClient(blobName: string): BlockBlobClient {
     return new BlockBlobClient(
@@ -747,7 +775,7 @@ export class ContainerClient extends StorageClient {
   }
 
   /**
-   * Creates a PageBlobClient object.
+   * Creates a {@link PageBlobClient}
    *
    * @param {string} blobName A page blob name
    * @returns {PageBlobClient}
@@ -901,7 +929,7 @@ export class ContainerClient extends StorageClient {
    * Gets the permissions for the specified container. The permissions indicate
    * whether container data may be accessed publicly.
    *
-   * WARNING: JavaScript Date will potential lost precision when parsing startsOn and expiresOn string.
+   * WARNING: JavaScript Date will potentially lose precision when parsing startsOn and expiresOn strings.
    * For example, new Date("2018-12-31T03:44:23.8827891Z").toISOString() will get "2018-12-31T03:44:23.882Z".
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-acl
@@ -1035,7 +1063,7 @@ export class ContainerClient extends StorageClient {
   }
 
   /**
-   * Get a BlobLeaseClient that manages leases on the container.
+   * Get a {@link BlobLeaseClient} that manages leases on the container.
    *
    * @param {string} [proposeLeaseId] Initial proposed lease Id.
    * @returns {BlobLeaseClient} A new BlobLeaseClient object for managing leases on the container.
@@ -1051,11 +1079,11 @@ export class ContainerClient extends StorageClient {
    * Updating an existing block blob overwrites any existing metadata on the blob.
    * Partial updates are not supported; the content of the existing blob is
    * overwritten with the new content. To perform a partial update of a block blob's,
-   * use stageBlock and commitBlockList.
+   * use {@link BlockBlobClient.stageBlock} and {@link BlockBlobClient.commitBlockList}.
    *
-   * This is a non-parallel uploading method, please use BlockBlobClient.uploadFile(),
-   * BlockBlobClient.uploadStream() or BlockBlobClient.uploadBrowserData() for better performance
-   * with concurrency uploading.
+   * This is a non-parallel uploading method, please use {@link BlockBlobClient.uploadFile},
+   * {@link BlockBlobClient.uploadStream} or {@link BlockBlobClient.uploadBrowserData} for better
+   * performance with concurrency uploading.
    *
    * @see https://docs.microsoft.com/rest/api/storageservices/put-blob
    *
@@ -1136,7 +1164,7 @@ export class ContainerClient extends StorageClient {
   /**
    * listBlobFlatSegment returns a single segment of blobs starting from the
    * specified Marker. Use an empty Marker to start enumeration from the beginning.
-   * After getting a segment, process it, and then call ListBlobsFlatSegment again
+   * After getting a segment, process it, and then call listBlobsFlatSegment again
    * (passing the the previously-returned Marker) to get the next segment.
    * @see https://docs.microsoft.com/rest/api/storageservices/list-blobs
    *
@@ -1173,7 +1201,7 @@ export class ContainerClient extends StorageClient {
   /**
    * listBlobHierarchySegment returns a single segment of blobs starting from
    * the specified Marker. Use an empty Marker to start enumeration from the
-   * beginning. After getting a segment, process it, and then call ListBlobsHierarchicalSegment
+   * beginning. After getting a segment, process it, and then call listBlobsHierarchicalSegment
    * again (passing the the previously-returned Marker) to get the next segment.
    * @see https://docs.microsoft.com/rest/api/storageservices/list-blobs
    *
@@ -1239,7 +1267,7 @@ export class ContainerClient extends StorageClient {
   }
 
   /**
-   * Returns an AsyncIterableIterator for Blob Items
+   * Returns an AsyncIterableIterator of {@link BlobItem} objects
    *
    * @private
    * @param {ContainerListBlobsSegmentOptions} [options] Options to list blobs operation.
@@ -1405,7 +1433,7 @@ export class ContainerClient extends StorageClient {
   }
 
   /**
-   * Returns an AsyncIterableIterator for BlobPrefixes and BlobItems
+   * Returns an AsyncIterableIterator for {@link BlobPrefix} and {@link BlobItem} objects.
    *
    * @private
    * @param {string} delimiter The charactor or string used to define the virtual hierarchy

--- a/sdk/storage/storage-blob/src/ContainerClient.ts
+++ b/sdk/storage/storage-blob/src/ContainerClient.ts
@@ -663,8 +663,7 @@ export class ContainerClient extends StorageClient {
    *
    * @example
    * ```js
-   * const containerName = "myNewContainer";
-   * const containerClient = blobServiceClient.getContainerClient(containerName);
+   * const containerClient = blobServiceClient.getContainerClient("<container name>");
    * const createContainerResponse = await containerClient.create();
    * console.log("Container was created successfully", createContainerResponse.requestId);
    * ```
@@ -760,11 +759,11 @@ export class ContainerClient extends StorageClient {
    *
    * @example
    * ```js
-   * const content = "hello";
-   * const blobName = "newblob" + new Date().getTime();
-   * const blobClient = containerClient.getBlobClient(blobName);
+   * const content = "Hello world!";
+   *
+   * const blobClient = containerClient.getBlobClient("<blob name>");
    * const blockBlobClient = blobClient.getBlockBlobClient();
-   * const uploadBlobResponse = await blockBlobClient.upload(content, content.length)
+   * const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
    * ```
    */
   public getBlockBlobClient(blobName: string): BlockBlobClient {

--- a/sdk/storage/storage-blob/src/PageBlobRangeResponse.ts
+++ b/sdk/storage/storage-blob/src/PageBlobRangeResponse.ts
@@ -23,7 +23,7 @@ export interface PageList {
 }
 
 /**
- * Contains response data for the getPageRanges operation.
+ * Contains response data for the {@link BlobClient.getPageRanges} operation.
  */
 export interface PageBlobGetPageRangesResponse extends PageList, PageBlobGetPageRangesHeaders {
   /**
@@ -48,7 +48,7 @@ export interface PageBlobGetPageRangesResponse extends PageList, PageBlobGetPage
 }
 
 /**
- * Contains response data for the getPageRangesDiff operation.
+ * Contains response data for the {@link BlobClient.getPageRangesDiff} operation.
  */
 export interface PageBlobGetPageRangesDiffResponse
   extends PageList,

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -73,10 +73,11 @@ export interface PipelineOptions {
 
 /**
  * A Pipeline class containing HTTP request policies.
- * You can create a default Pipeline by calling newPipeline().
+ * You can create a default Pipeline by calling {@link newPipeline}.
  * Or you can create a Pipeline with your own policies by the constructor of Pipeline.
- * Refer to newPipeline() and provided policies as reference before
- * implementing your customized Pipeline.
+ *
+ * Refer to {@link newPipeline} and provided policies before implementing your
+ * customized Pipeline.
  *
  * @export
  * @class Pipeline
@@ -110,7 +111,7 @@ export class Pipeline {
   }
 
   /**
-   * Transfer Pipeline object to ServiceClientOptions object which required by
+   * Transfer Pipeline object to ServiceClientOptions object which is required by
    * ServiceClient constructor.
    *
    * @returns {ServiceClientOptions} The ServiceClientOptions object from this Pipeline.
@@ -125,7 +126,7 @@ export class Pipeline {
 }
 
 /**
- * Option interface for newPipeline() method.
+ * Options interface for the {@link newPipeline} function.
  *
  * @export
  * @interface StoragePipelineOptions

--- a/sdk/storage/storage-blob/src/StorageClient.ts
+++ b/sdk/storage/storage-blob/src/StorageClient.ts
@@ -27,7 +27,8 @@ export interface OperationTracingOptions {
 }
 
 /**
- * A StorageClient represents a based URL class for BlobServiceClient, ContainerClient and etc.
+ * A StorageClient represents a based URL class for {@link BlobServiceClient}, {@link ContainerClient}
+ * and etc.
  *
  * @export
  * @class StorageClient

--- a/sdk/storage/storage-blob/src/StorageRetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/StorageRetryPolicyFactory.ts
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 
 import { RequestPolicy, RequestPolicyFactory, RequestPolicyOptions } from "@azure/core-http";
-import {
-  StorageRetryPolicy,
-  StorageRetryPolicyType
-} from "./policies/StorageRetryPolicy";
+import { StorageRetryPolicy, StorageRetryPolicyType } from "./policies/StorageRetryPolicy";
 
 export { StorageRetryPolicyType, StorageRetryPolicy };
 
@@ -80,7 +77,7 @@ export interface StorageRetryOptions {
 }
 
 /**
- * StorageRetryPolicyFactory is a factory class helping generating StorageRetryPolicy objects.
+ * StorageRetryPolicyFactory is a factory class helping generating {@link StorageRetryPolicy} objects.
  *
  * @export
  * @class StorageRetryPolicyFactory

--- a/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
@@ -14,7 +14,7 @@ import { TelemetryPolicy } from "./policies/TelemetryPolicy";
 import { SDK_VERSION } from "./utils/constants";
 
 /**
- * TelemetryPolicyFactory is a factory class helping generating TelemetryPolicy objects.
+ * TelemetryPolicyFactory is a factory class helping generating {@link TelemetryPolicy} objects.
  *
  * @export
  * @class TelemetryPolicyFactory

--- a/sdk/storage/storage-blob/src/credentials/AnonymousCredential.ts
+++ b/sdk/storage/storage-blob/src/credentials/AnonymousCredential.ts
@@ -18,7 +18,7 @@ import { Credential } from "./Credential";
  */
 export class AnonymousCredential extends Credential {
   /**
-   * Creates an AnonymousCredentialPolicy object.
+   * Creates an {@link AnonymousCredentialPolicy} object.
    *
    * @param {RequestPolicy} nextPolicy
    * @param {RequestPolicyOptions} options

--- a/sdk/storage/storage-blob/src/policies/CredentialPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/CredentialPolicy.ts
@@ -26,7 +26,7 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
 
   /**
    * Child classes must implement this method with request signing. This method
-   * will be executed in sendRequest().
+   * will be executed in {@link sendRequest}.
    *
    * @protected
    * @abstract

--- a/sdk/storage/storage-blob/src/pollers/BlobStartCopyFromUrlPoller.ts
+++ b/sdk/storage/storage-blob/src/pollers/BlobStartCopyFromUrlPoller.ts
@@ -10,8 +10,8 @@ import {
 } from "../BlobClient";
 
 /**
- * Defines the operations from a `BlobClient` that are needed for the poller
- * returned by `beginCopyFromURL` to work.
+ * Defines the operations from a {@link BlobClient} that are needed for the poller
+ * returned by {@link BlobClient.beginCopyFromURL} to work.
  */
 export type CopyPollerBlobClient = Pick<BlobClient, "abortCopyFromURL" | "getProperties"> & {
   startCopyFromURL(
@@ -21,7 +21,7 @@ export type CopyPollerBlobClient = Pick<BlobClient, "abortCopyFromURL" | "getPro
 };
 
 /**
- * The state used by the poller returned from `beginCopyFromURL`.
+ * The state used by the poller returned from {@link BlobClient.beginCopyFromURL}.
  *
  * This state is passed into the user-specified `onProgress` callback
  * whenever copy progress is detected.
@@ -29,7 +29,7 @@ export type CopyPollerBlobClient = Pick<BlobClient, "abortCopyFromURL" | "getPro
 export interface BlobBeginCopyFromUrlPollState
   extends PollOperationState<BlobBeginCopyFromURLResponse> {
   /**
-   * The instance of `BlobClient` that was used when calling `beginCopyFromURL`.
+   * The instance of {@link BlobClient} that was used when calling {@link BlobClient.beginCopyFromURL}.
    */
   readonly blobClient: CopyPollerBlobClient;
   /**
@@ -41,11 +41,11 @@ export interface BlobBeginCopyFromUrlPollState
    */
   copyProgress?: string;
   /**
-   * The source URL provided in `beginCopyFromURL`.
+   * The source URL provided in {@link BlobClient.beginCopyFromURL}.
    */
   copySource: string;
   /**
-   * The options that were passed to the initial `beginCopyFromURL` call.
+   * The options that were passed to the initial {@link BlobClient.beginCopyFromURL} call.
    * This is exposed for the poller and should not be modified directly.
    */
   readonly startCopyFromURLOptions?: BlobStartCopyFromURLOptions;
@@ -63,7 +63,8 @@ export interface BlobBeginCopyFromURLPollOperation
 
 /**
  * The set of options used to configure the poller.
- * This is an internal interface populated by `blobClient.beginCopyFromURL`.
+ * This is an internal interface populated by {@link BlobClient.beginCopyFromURL}.
+ *
  * @ignore
  */
 export interface BlobBeginCopyFromUrlPollerOptions {
@@ -76,7 +77,7 @@ export interface BlobBeginCopyFromUrlPollerOptions {
 }
 
 /**
- * This is the poller returned by `beginCopyFromURL`.
+ * This is the poller returned by {@link BlobClient.beginCopyFromURL}.
  * This can not be instantiated directly outside of this package.
  *
  * @ignore


### PR DESCRIPTION
GA doc check for storage-blob

Changes:
- Added a few more samples to inline doc comments in storage-blob (if an example was in the README, I added it to the inline samples for related methods)
- Added intra-package links to related types using `@link` syntax for everything I could catch. This should help make the docs a lot more navigable, as now most options types (which have their own HTML pages) link to their consumer methods as well as vice-versa.
- Fixed occasional typos as I noticed them

CC @ramya-rao-a 