### PR TITLE
Fix broken reference links to gitHub.io in readme

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -6,7 +6,7 @@ The Azure Event Hubs client library allows you to send and receive events in you
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs) |
 [Package (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/next) |
-[API Reference Documentation](https://azure.github.io/azure-sdk-for-js/event-hubs/index.html) |
+[API Reference Documentation](https://azure.github.io/azure-sdk-for-js/eventhub.html#azure-event-hubs) |
 [Product documentation](https://azure.microsoft.com/en-us/services/event-hubs/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/samples)
 
@@ -54,7 +54,7 @@ For more concepts and deeper discussion, see: [Event Hubs Features](https://docs
 
 ### Authenticate the client
 
-Interaction with Event Hubs starts with an instance of the [EventHubClient](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubclient.html#constructor) class. You can instantiate
+Interaction with Event Hubs starts with an instance of the [EventHubClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubclient.html#constructor) class. You can instantiate
 this class using one of the below
 
 ```javascript
@@ -121,7 +121,7 @@ In order to publish events, you'll need to create an `EventHubProducer`. Produce
 
 #### Send a single event or an array of events
 
-Use the [send](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubproducer.html#send) method to send a single event or multiple events using a single call.
+Use the [send](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducer.html#send) method to send a single event or multiple events using a single call.
 
 ```javascript
 const { EventHubClient } = require("@azure/event-hubs");
@@ -142,9 +142,9 @@ main();
 
 #### Send a batch of events
 
-Use the [createBatch](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubproducer.html#createbatch) method to create
-an `EventDataBatch` object which can then be sent using the [send](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubproducer.html#send) method.
-Events may be added to the `EventDataBatch` using the [tryAdd](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventdatabatch.html#tryadd)
+Use the [createBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducer.html#createbatch) method to create
+an `EventDataBatch` object which can then be sent using the [send](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducer.html#send) method.
+Events may be added to the `EventDataBatch` using the [tryAdd](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventdatabatch.html#tryadd)
 method until the maximum batch size limit in bytes has been reached.
 
 ```javascript
@@ -205,7 +205,7 @@ You can use this consumer in one of 3 ways to receive events:
 
 #### Get an array of events
 
-Use the [receiveBatch](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubconsumer.html#receivebatch) function which returns a promise that resolves to an array of events.
+Use the [receiveBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumer.html#receivebatch) function which returns a promise that resolves to an array of events.
 
 This function takes an optional parameter called `abortSignal` to cancel current operation.
 
@@ -234,12 +234,12 @@ main();
 
 #### Register event handler
 
-Use the [receive](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubconsumer.html#receive) to set up event handlers and have it running as long as you need.
+Use the [receive](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumer.html#receive) to set up event handlers and have it running as long as you need.
 
 This function takes an optional parameter called `abortSignal` to cancel current operation.
 
 ```javascript
-const { delay, EventHubClient} = require("@azure/event-hubs");
+const { delay, EventHubClient } = require("@azure/event-hubs");
 
 async function main() {
   const client = new EventHubClient("connectionString", "eventHubName");
@@ -272,9 +272,9 @@ main();
 
 #### Use async iterator
 
-Use the [getMessageIterator](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventhubconsumer.html#geteventiterator) to get an async iterator over events.
+Use the [getMessageIterator](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumer.html#geteventiterator) to get an async iterator over events.
 
-This function takes an optional [EventIteratorOptions](https://azure.github.io/azure-sdk-for-js/event-hubs/interfaces/eventiteratoroptions.html) parameter that includes `abortSignal` to cancel the current operation.
+This function takes an optional [EventIteratorOptions](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/interfaces/eventiteratoroptions.html) parameter that includes `abortSignal` to cancel the current operation.
 
 ```javascript
 const { EventHubClient } = require("@azure/event-hubs");
@@ -288,7 +288,7 @@ async function main() {
     EventPosition.latest()
   );
 
-  for await (const events of consumer.getEventIterator()){
+  for await (const events of consumer.getEventIterator()) {
     // your code here
   }
 
@@ -301,7 +301,7 @@ main();
 
 ### Consume events using an Event Processor
 
-[EventProcessor](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventprocessor.html) is a high level construct which internally uses the `EventHubConsumer` which is mentioned in previous examples
+[EventProcessor](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventprocessor.html) is a high level construct which internally uses the `EventHubConsumer` which is mentioned in previous examples
 to receive events from multiple partitions at once.
 
 Typically, Event Processor based applications consist of one or more instances of EventProcessor instances which have been
@@ -309,14 +309,14 @@ configured to consume events from the same Event Hub and consumer group. They ba
 workload across different instances by distributing the partitions to be processed among themselves.
 They also allow the user to track progress when events are processed using checkpoints.
 
-The `EventProcessor` will delegate the processing of events to a [PartitionProcessor](https://azure.github.io/azure-sdk-for-js/event-hubs/interfaces/partitionprocessor.html)
+The `EventProcessor` will delegate the processing of events to a [PartitionProcessor](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/interfaces/partitionprocessor.html)
 that you provide, allowing you to focus on business logic while the `EventProcessor` holds responsibility for managing the underlying consumer
 operations including checkpointing and load balancing.
 
 A checkpoint is meant to represent the last successfully processed event by the user from a particular
 partition of a consumer group in an Event Hub instance. The `EventProcessor` uses an instance of `PartitionManager`
 to update checkpoints and to store the relevant information required by the load balancing algorithm.
-While for the purposes of getting started you can use the [InMemoryPartitionManager](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/inmemorypartitionmanager.html) that is shipped out of the box from this library,
+While for the purposes of getting started you can use the [InMemoryPartitionManager](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/inmemorypartitionmanager.html) that is shipped out of the box from this library,
 it is recommended to use a peristent store when running in production.
 Search npm with the prefix `@azure/eventhubs-checkpointstore-` to find packages that support this and use the `PartitionManager` implementation from one such package.
 
@@ -377,7 +377,7 @@ async function main() {
   await client.close();
 }
 
-main()
+main();
 ```
 
 To control the number of events passed to processEvents, use the options argument in the EventProcessor constructor.
@@ -414,7 +414,7 @@ async function main() {
 main();
 ```
 
-**Notes:** For scalable and efficient receiving, please take a look at [EventProcessor](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/eventprocessor.html). The EventProcessor, internally uses the batched receiver to receive events.
+**Notes:** For scalable and efficient receiving, please take a look at [EventProcessor](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventprocessor.html). The EventProcessor, internally uses the batched receiver to receive events.
 
 ## Troubleshooting
 
@@ -478,7 +478,7 @@ directory for detailed examples of how to use this library to send and receive e
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.microsoft.com.
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/README.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/README.md
@@ -2,7 +2,7 @@
 
 An Azure Blob storage based solution to store checkpoints and to aid in load balancing when using `EventProcessor` from the [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs) library
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/eventhubs-checkpointstore-blob) | [Package (npm)](https://www.npmjs.com/package/@azure/eventhubs-checkpointstore-blob) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/eventhubs-checkpointstore-blob/index.html) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/eventhubs-checkpointstore-blob/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/eventhubs-checkpointstore-blob) | [Package (npm)](https://www.npmjs.com/package/@azure/eventhubs-checkpointstore-blob) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/eventhub.html#azure-eventhubs-checkpointstore-blob) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/eventhubs-checkpointstore-blob/samples)
 
 ## Getting started
 
@@ -44,7 +44,7 @@ You also need to enable `compilerOptions.allowSyntheticDefaultImports` in your t
   and to provide resiliency if a failover between readers running on different machines occurs. It is possible to return to older data by specifying a lower offset from this checkpointing process.
   Through this mechanism, checkpointing enables both failover resiliency and event stream replay.
 
-  A [BlobPartitionManager](https://azure.github.io/azure-sdk-for-js/eventhubs-checkpointstore-blob/classes/blobpartitionmanager.html) is a class that implements key methods required by the Event Processor to balance load and update checkpoints.
+  A [BlobPartitionManager](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-eventhubs-checkpointstore-blob/1.0.0-preview.4/classes/blobpartitionmanager.html) is a class that implements key methods required by the Event Processor to balance load and update checkpoints.
 
 ## Examples
 
@@ -69,7 +69,7 @@ const partitionManager =  new BlobPartitionManager(containerClient);
 
 To checkpoint events received using an EventProcessor to Azure Blob Storage, you will need to pass an instance of the Partition Manager to the Event Processor along with the code to call the `updateCheckpoint()` method.
 
-In this example, we will use a `SamplePartitionProcessor` that extends the [PartitionProcessor](https://azure.github.io/azure-sdk-for-js/event-hubs/classes/partitionprocessor.html) class in order to checkpoint the last event in the batch.
+In this example, we will use a `SamplePartitionProcessor` that extends the [PartitionProcessor](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-eventhubs-checkpointstore-blob/1.0.0-preview.4/classes/partitionprocessor.html) class in order to checkpoint the last event in the batch.
 
 ```javascript
 import { ContainerClient } from "@azure/storage-blob",

--- a/sdk/keyvault/keyvault-certificates/README.md
+++ b/sdk/keyvault/keyvault-certificates/README.md
@@ -21,7 +21,7 @@ Use the client library for Azure Key Vault Certificates in your Node.js applicat
 
 **Please Note:** This is a preview version of the Key Vault Certificates library.
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-certificates) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/keyvault-certificates) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-certificates) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/keyvault.html#azure-keyvault-certificates) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples)
 
 ## Getting started
 

--- a/sdk/keyvault/keyvault-keys/README.md
+++ b/sdk/keyvault/keyvault-keys/README.md
@@ -33,7 +33,7 @@ Using the cryptography client available in this library you also have access to
 
 **Please Note:** This is a preview version of the Key Vault Keys library
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-keys) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/keyvault-keys) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-keys) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/keyvault.html#azure-keyvault-keys) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples)
 
 ## Getting started
 

--- a/sdk/keyvault/keyvault-secrets/README.md
+++ b/sdk/keyvault/keyvault-secrets/README.md
@@ -22,7 +22,7 @@ Use the client library for Azure Key Vault Secrets in your Node.js application t
 
 **Please Note:** This is a preview version of the Key Vault Secrets library
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-secrets) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/keyvault-secrets) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-secrets) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/keyvault.html#azure-keyvault-secrets) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets/samples)
 
 ## Getting started
 

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -8,7 +8,7 @@ Version: 12.0.0-preview.5
 
 - [Package (npm)](https://www.npmjs.com/package/@azure/storage-blob/v/12.0.0-preview.5)
 - [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples)
-- [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage-blob/index.html)
+- [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-blob)
 - [Product documentation](https://docs.microsoft.com/azure/storage/blobs/storage-blobs-overview)
 - [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob)
 - [Azure Storage Blob REST APIs](https://docs.microsoft.com/rest/api/storageservices/blob-service-rest-api)

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -12,7 +12,7 @@ Version: 12.0.0-preview.5
 
 - [Package (npm)](https://www.npmjs.com/package/@azure/storage-file-share/v/12.0.0-preview.5)
 - [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples)
-- [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage-file-share/index.html)
+- [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share)
 - [Product documentation](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction)
 - [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share)
 - [Azure Storage File REST APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/file-service-rest-api)

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -8,7 +8,7 @@ Version: 12.0.0-preview.5
 
 - [Package (npm)](https://www.npmjs.com/package/@azure/storage-queue/v/12.0.0-preview.5)
 - [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-queue/samples)
-- [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage-queue/index.html)
+- [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-queue)
 - [Product documentation](https://docs.microsoft.com/azure/storage/queues/storage-queues-introduction)
 - [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-queue)
 - [Azure Storage Queue REST APIs](https://docs.microsoft.com/rest/api/storageservices/queue-service-rest-api)


### PR DESCRIPTION
For readmes of following services: 
- storage
- keyvault
- eventhub