### PR TITLE
[Storage] Use aka.ms links for bundling documentation

### DIFF
--- a/sdk/storage/storage-blob/BreakingChanges.md
+++ b/sdk/storage/storage-blob/BreakingChanges.md
@@ -25,7 +25,7 @@
 - Updates to `BlockBlobClient.uploadStream`
   - `maxBuffers` attribute of is renamed to `maxConcurrency`
 - Bug Fix - The page object returned from `ContainerClient.listContainers` had its `containerItems` property set to an empty string instead of an empty array if the storage account has no blob containers. The issue is fixed in this new release.
-- The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
+- The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
 ## 2019.10 12.0.0-preview.5
 

--- a/sdk/storage/storage-blob/ChangeLog.md
+++ b/sdk/storage/storage-blob/ChangeLog.md
@@ -30,7 +30,7 @@
   - Added default values for parameters, bufferSize = `8MB` and maxConcurrency = `5`
 - [Breaking] Bug Fix - The page object returned from `ContainerClient.listContainers` had its `containerItems` property set to an empty string instead of an empty array if the storage account has no blob containers. The issue is fixed in this new release.
 - `BlobClient.downloadToBuffer()` helper method has a new overload where it is not required to pass the `Buffer`. Attributes `offset` and `count` are optional, downloads the entire blob if they are not provided.
-- [Breaking] The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
+- [Breaking] The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
 ## 2019.10 12.0.0-preview.5
 

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -93,7 +93,7 @@ const AzureStorageBlob = require("@azure/storage-blob");
 
 ### JavaScript Bundle
 
-To use this client library in the browser, you need to use a bundler. For details on how to do this, please refer to our [bundling documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
+To use this client library in the browser, you need to use a bundler. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
 ### CORS
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -98,7 +98,7 @@ const AzureStorageFileShare = require("@azure/storage-file-share");
 
 ### JavaScript Bundle
 
-To use this client library in the browser, you need to use a bundler. For details on how to do this, please refer to our [bundling documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
+To use this client library in the browser, you need to use a bundler. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
 ### CORS
 

--- a/sdk/storage/storage-queue/BreakingChanges.md
+++ b/sdk/storage/storage-queue/BreakingChanges.md
@@ -20,7 +20,7 @@
 - [Breaking]
   - The `UniqueRequestIdPolicy` and `KeepAlivePolicy` are no longer exported from this library. The
     corresponding policies from the `@azure/core-http` library are meant to be used instead.
-- [Breaking] The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
+- [Breaking] The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
 ## 2019.10 12.0.0-preview.5
 

--- a/sdk/storage/storage-queue/ChangeLog.md
+++ b/sdk/storage/storage-queue/ChangeLog.md
@@ -24,7 +24,7 @@
 - [Breaking]
   - The `UniqueRequestIdPolicy` and `KeepAlivePolicy` are no longer exported from this library. The
     corresponding policies from the `@azure/core-http` library are meant to be used instead.
-- [Breaking] The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
+- [Breaking] The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
 ## 2019.10 12.0.0-preview.5
 

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -81,7 +81,7 @@ const AzureStorageQueue = require("@azure/storage-queue");
 
 ### JavaScript Bundle
 
-To use this client library in the browser, you need to use a bundler. For details on how to do this, please refer to our [bundling documentation](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md).
+To use this client library in the browser, you need to use a bundler. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 
 ### CORS
 


### PR DESCRIPTION
As the bundling documentation may move, aka.ms seems to be the wise choice.