### PR TITLE
[storage-file-share] Doc fixes, links, and README check for file-share

### DIFF
--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -1,35 +1,48 @@
-# Azure Storage client library for JavaScript - File Share
+# Azure Storage File Share client library for JavaScript
 
 Azure Files offers fully managed file shares in the cloud that are accessible via the industry standard Server Message Block (SMB) protocol. Azure file shares can be mounted concurrently by cloud or on-premises deployments of Windows, Linux, and macOS. Additionally, Azure file shares can be cached on Windows Servers with Azure File Sync for fast access near where the data is being used.
 
 This project provides a client library in JavaScript that makes it easy to consume Microsoft Azure File Storage service.
 
+Use the client libraries in this package to:
+
+- Get/Set File Service Properties
+- Create/List/Delete File Shares
+- Create/List/Delete File Directories
+- Create/Read/List/Update/Delete Files
+
 > Note: This package was previously published under the name `@azure/storage-file`.
 > It has been renamed to `@azure/storage-file-share` to better align with the upcoming new package
 > for Azure Storage Files DataLake and provide a consistent set of APIs for working with files on Azure.
 
-Version: 12.0.0-preview.6
-
-- [Package (npm)](https://www.npmjs.com/package/@azure/storage-file-share/v/12.0.0-preview.6)
-- [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples)
-- [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share)
-- [Product documentation](https://docs.microsoft.com/en-us/azure/storage/files/storage-files-introduction)
-- [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share)
-- [Azure Storage File REST APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/file-service-rest-api)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share) |
+[Package (npm)](https://www.npmjs.com/package/@azure/storage-file-share/) |
+[API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share) |
+[Product documentation](https://docs.microsoft.com/azure/storage/files/storage-files-introduction) |
+[Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples) |
+[Azure Storage File REST APIs](https://docs.microsoft.com/rest/api/storageservices/file-service-rest-api)
 
 ## Key concepts
 
-### Features
+The following components and their corresponding client libraries make up the Azure Storage File Share service:
 
-- File Storage
-  - Get/Set File Service Properties
-  - Create/List/Delete File Shares
-  - Create/List/Delete File Directories
-  - Create/Read/List/Update/Delete Files
-- Features new
-  - Asynchronous I/O for all operations using the async methods
-  - HttpPipeline which enables a high degree of per-request configurability
-  - 1-to-1 correlation with the Storage REST API for clarity and simplicity
+- The storage account itself, represented by a `ShareServiceClient`
+- A file share within the storage account, represented by a `ShareClient`
+- An optional hierarchy of directories within the file share, represented by `ShareDirectoryClient` instances
+- A file within the file share, which may be up to 1 TiB in size, represented by a `ShareFileClient`
+
+## Getting started
+
+**Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a [Storage Account](https://docs.microsoft.com/azure/storage/files/storage-how-to-use-files-portal) to use this package. If you are using this package in a Node.js application, then Node.js version 8.0.0 or higher is required.
+
+
+### Install the package
+
+The preferred way to install the Azure File Storage client library for JavaScript is to use the npm package manager. Type the following into a terminal window:
+
+```bash
+npm install @azure/storage-file-share
+```
 
 ### Compatibility
 
@@ -59,7 +72,7 @@ There are differences between Node.js and browsers runtime. When getting started
 ##### Following features, interfaces, classes or functions are only available in Node.js
 
 - Shared Key Authorization based on account name and account key
-  - `SharedKeyCredential`
+  - `StorageSharedKeyCredential`
 - Shared Access Signature(SAS) generation
   - `generateAccountSASQueryParameters()`
   - `generateFileSASQueryParameters()`
@@ -73,28 +86,6 @@ There are differences between Node.js and browsers runtime. When getting started
 
 - Parallel uploading and downloading
   - `ShareFileClient.uploadBrowserData()`
-
-## Getting started
-
-### NPM
-
-The preferred way to install the Azure File Storage client library for JavaScript is to use the npm package manager. Simply type the following into a terminal window:
-
-```bash
-npm install @azure/storage-file-share
-```
-
-In your TypeScript or JavaScript file, import via following:
-
-```javascript
-import * as AzureStorageFileShare from "@azure/storage-file-share";
-```
-
-Or
-
-```javascript
-const AzureStorageFileShare = require("@azure/storage-file-share");
-```
 
 ### JavaScript Bundle
 
@@ -114,31 +105,38 @@ For example, you can create following CORS settings for debugging. But please cu
 
 ## Examples
 
-### Import types
+### Import the package
 
-You can use the `const Azure = require("@azure/storage-file-share");` shown above then use types and functions from `Azure`.
-Or you can selectively import certain types,
+Tu use the clients, import the package into your file:
 
 ```javascript
-const { ShareServiceClient, SharedKeyCredential } = require("@azure/storage-file-share");
+const AzureStorageFileShare = require("@azure/storage-file-share");
 ```
 
-### Create the file service client
-
-Use the constructor to create a instance of `ShareServiceClient`, passing in the credential.
+Alternative, selectively import only the types you need:
 
 ```javascript
-// Enter your storage account name and shared key
-const account = "";
-const accountKey = "";
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+```
 
-// Use SharedKeyCredential with storage account and account key
-// SharedKeyCredential is only avaiable in Node.js runtime, not in browsers
-const sharedKeyCredential = new SharedKeyCredential(account, accountKey);
+### Create the share service client
+
+Use the constructor to create a instance of `ShareServiceClient`. It needs to authenticate with the Azure service, so pass in a `StorageSharedKeyCredential` with your account and key.
+
+```javascript
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+
+// Enter your storage account name and shared key
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+// Use StorageSharedKeyCredential with storage account and account key
+// StorageSharedKeyCredential is only avaiable in Node.js runtime, not in browsers
+const credential = new StorageSharedKeyCredential(account, accountKey);
 const serviceClient = new ShareServiceClient(
   // When using AnonymousCredential, following url should include a valid SAS
   `https://${account}.file.core.windows.net`,
-  sharedKeyCredential
+  credential
 );
 ```
 
@@ -148,52 +146,119 @@ Use `ShareServiceClient.listShares()` to iterator shares in this account,
 with the new `for-await-of` syntax:
 
 ```javascript
-let shareIter1 = serviceClient.listShares();
-let i = 1;
-for await (const share of shareIter1) {
-  console.log(`Share${i}: ${share.name}`);
-  i++;
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new StorageSharedKeyCredential(account, accountKey);
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net`,
+  credential
+);
+
+async function main() {
+  let shareIter1 = serviceClient.listShares();
+  let i = 1;
+  for await (const share of shareIter1) {
+    console.log(`Share${i}: ${share.name}`);
+    i++;
+  }
 }
+
+main();
 ```
 
 Alternatively without `for-await-of`:
 
 ```javascript
-let shareIter2 = await serviceClient.listShares();
-let i = 1;
-let shareItem = await shareIter2.next();
-while (!shareItem.done) {
-  console.log(`Share ${i++}: ${shareItem.value.name}`);
-  shareItem = await shareIter2.next();
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new StorageSharedKeyCredential(account, accountKey);
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net`,
+  credential
+);
+
+async function main() {
+  let shareIter2 = await serviceClient.listShares();
+  let i = 1;
+  let shareItem = await shareIter2.next();
+  while (!shareItem.done) {
+    console.log(`Share ${i++}: ${shareItem.value.name}`);
+    shareItem = await shareIter2.next();
+  }
 }
+
+main();
 ```
 
 ### Create a new share and a directory
 
 ```javascript
-const shareName = `newshare${new Date().getTime()}`;
-const shareClient = serviceClient.getShareClient(shareName);
-await shareClient.create();
-console.log(`Create share ${shareName} successfully`);
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
-const directoryName = `newdirectory${new Date().getTime()}`;
-const directoryClient = shareClient.getDirectoryClient(directoryName);
-await directoryClient.create();
-console.log(`Create directory ${directoryName} successfully`);
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new StorageSharedKeyCredential(account, accountKey);
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net`,
+  credential
+);
+
+async function main() {
+  const shareName = `newshare${new Date().getTime()}`;
+  const shareClient = serviceClient.getShareClient(shareName);
+  await shareClient.create();
+  console.log(`Create share ${shareName} successfully`);
+
+  const directoryName = `newdirectory${new Date().getTime()}`;
+  const directoryClient = shareClient.getDirectoryClient(directoryName);
+  await directoryClient.create();
+  console.log(`Create directory ${directoryName} successfully`);
+}
+
+main()
 ```
 
 ### Create an azure file then upload to it
 
 ```javascript
-const content = "Hello World!";
-const fileName = "newfile" + new Date().getTime();
-const fileClient = directoryClient.getFileClient(fileName);
-await fileClient.create(content.length);
-console.log(`Create file ${fileName} successfully`);
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
-// Upload file range
-await fileClient.uploadRange(content, 0, content.length);
-console.log(`Upload file range "${content}" to ${fileName} successfully`);
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new StorageSharedKeyCredential(account, accountKey);
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net`,
+  credential
+);
+
+const shareName = "<share name>";
+const directoryName = "<directory name>"
+
+async function main() {
+  const directoryClient = serviceClient
+    .getShareClient(shareName)
+    .getDirectoryClient(directoryName);
+
+  const content = "Hello World!";
+  const fileName = "newfile" + new Date().getTime();
+  const fileClient = directoryClient.getFileClient(fileName);
+  await fileClient.create(content.length);
+  console.log(`Create file ${fileName} successfully`);
+
+  // Upload file range
+  await fileClient.uploadRange(content, 0, content.length);
+  console.log(`Upload file range "${content}" to ${fileName} successfully`);
+}
+
+main();
 ```
 
 ### List files and directories under a directory
@@ -203,32 +268,76 @@ with the new `for-await-of` syntax. The `kind` property can be used to identify 
 a iterm is a directory or a file.
 
 ```javascript
-let dirIter1 = directoryClient.listFilesAndDirectories();
-let i = 1;
-for await (const item of dirIter1) {
-  if (item.kind === "directory") {
-    console.log(`${i} - directory\t: ${item.name}`);
-  } else {
-    console.log(`${i} - file\t: ${item.name}`);
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new StorageSharedKeyCredential(account, accountKey);
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net`,
+  credential
+);
+
+const shareName = "<share name>";
+const directoryName = "<directory name>"
+
+async function main() {
+  const directoryClient = serviceClient
+    .getShareClient(shareName)
+    .getDirectoryClient(directoryName);
+
+  let dirIter1 = directoryClient.listFilesAndDirectories();
+  let i = 1;
+  for await (const item of dirIter1) {
+    if (item.kind === "directory") {
+      console.log(`${i} - directory\t: ${item.name}`);
+    } else {
+      console.log(`${i} - file\t: ${item.name}`);
+    }
+    i++;
   }
-  i++;
 }
+
+main();
 ```
 
 Alternatively without using `for-await-of`:
 
 ```javascript
-let dirIter2 = await directoryClient.listFilesAndDirectories();
-let i = 1;
-let item = await dirIter2.next();
-while (!item.done) {
-  if (item.value.kind === "directory") {
-    console.log(`${i} - directory\t: ${item.value.name}`);
-  } else {
-    console.log(`${i} - file\t: ${item.value.name}`);
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new StorageSharedKeyCredential(account, accountKey);
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net`,
+  credential
+);
+
+const shareName = "<share name>";
+const directoryName = "<directory name>"
+
+async function main() {
+  const directoryClient = serviceClient
+    .getShareClient(shareName)
+    .getDirectoryClient(directoryName);
+
+  let dirIter2 = await directoryClient.listFilesAndDirectories();
+  let i = 1;
+  let item = await dirIter2.next();
+  while (!item.done) {
+    if (item.value.kind === "directory") {
+      console.log(`${i} - directory\t: ${item.value.name}`);
+    } else {
+      console.log(`${i} - file\t: ${item.value.name}`);
+    }
+    item = await dirIter2.next();
   }
-  item = await dirIter2.next();
 }
+
+main();
 ```
 
 For a complete sample on iterating please see [samples/iterators-files-and-directories.ts](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-share/samples/typescript/iterators-files-and-directories.ts).
@@ -236,12 +345,19 @@ For a complete sample on iterating please see [samples/iterators-files-and-direc
 ### Download a file and convert it to a string (Node.js)
 
 ```javascript
-// Get file content from position 0 to the end
-// In Node.js, get downloaded data by accessing downloadFileResponse.readableStreamBody
-const downloadFileResponse = await fileClient.download();
-console.log(
-  `Downloaded file content: ${await streamToString(downloadFileResponse.readableStreamBody)}`
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
+
+const account = "<account>";
+const accountKey = "<accountkey>";
+
+const credential = new StorageSharedKeyCredential(account, accountKey);
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net`,
+  credential
 );
+
+const shareName = "<share name>";
+const fileName = "<file name>"
 
 // [Node.js only] A helper method used to read a Node.js readable stream into string
 async function streamToString(readableStream) {
@@ -256,6 +372,22 @@ async function streamToString(readableStream) {
     readableStream.on("error", reject);
   });
 }
+
+async function main() {
+  const fileClient = serviceClient
+    .getShareClient(shareName)
+    .rootDirectoryClient
+    .getFileClient(fileName);
+
+  // Get file content from position 0 to the end
+  // In Node.js, get downloaded data by accessing downloadFileResponse.readableStreamBody
+  const downloadFileResponse = await fileClient.download();
+  console.log(
+    `Downloaded file content: ${await streamToString(downloadFileResponse.readableStreamBody)}`
+  );
+}
+
+main();
 ```
 
 ### Download a file and convert it to a string (Browsers)
@@ -299,8 +431,9 @@ setLogLevel("info");
 
 More code samples
 
-- [File Share Storage Examples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples)
-- [File Share Storage Examples - Test Cases](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/test)
+- [File Share Storage Samples (JavaScript)](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript)
+- [File Share Storage Samples (TypeScript)](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript)
+- [File Share Storage Test Cases](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/test)
 
 ## Contributing
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -107,7 +107,7 @@ For example, you can create following CORS settings for debugging. But please cu
 
 ### Import the package
 
-Tu use the clients, import the package into your file:
+To use the clients, import the package into your file:
 
 ```javascript
 const AzureStorageFileShare = require("@azure/storage-file-share");
@@ -158,9 +158,9 @@ const serviceClient = new ShareServiceClient(
 );
 
 async function main() {
-  let shareIter1 = serviceClient.listShares();
+  let shareIter = serviceClient.listShares();
   let i = 1;
-  for await (const share of shareIter1) {
+  for await (const share of shareIter) {
     console.log(`Share${i}: ${share.name}`);
     i++;
   }
@@ -184,12 +184,12 @@ const serviceClient = new ShareServiceClient(
 );
 
 async function main() {
-  let shareIter2 = await serviceClient.listShares();
+  let shareIter = await serviceClient.listShares();
   let i = 1;
-  let shareItem = await shareIter2.next();
+  let shareItem = await shareIter.next();
   while (!shareItem.done) {
     console.log(`Share ${i++}: ${shareItem.value.name}`);
-    shareItem = await shareIter2.next();
+    shareItem = await shareIter.next();
   }
 }
 
@@ -222,7 +222,7 @@ async function main() {
   console.log(`Create directory ${directoryName} successfully`);
 }
 
-main()
+main();
 ```
 
 ### Create an azure file then upload to it
@@ -240,7 +240,7 @@ const serviceClient = new ShareServiceClient(
 );
 
 const shareName = "<share name>";
-const directoryName = "<directory name>"
+const directoryName = "<directory name>";
 
 async function main() {
   const directoryClient = serviceClient
@@ -280,16 +280,16 @@ const serviceClient = new ShareServiceClient(
 );
 
 const shareName = "<share name>";
-const directoryName = "<directory name>"
+const directoryName = "<directory name>";
 
 async function main() {
   const directoryClient = serviceClient
     .getShareClient(shareName)
     .getDirectoryClient(directoryName);
 
-  let dirIter1 = directoryClient.listFilesAndDirectories();
+  let dirIter = directoryClient.listFilesAndDirectories();
   let i = 1;
-  for await (const item of dirIter1) {
+  for await (const item of dirIter) {
     if (item.kind === "directory") {
       console.log(`${i} - directory\t: ${item.name}`);
     } else {
@@ -317,23 +317,23 @@ const serviceClient = new ShareServiceClient(
 );
 
 const shareName = "<share name>";
-const directoryName = "<directory name>"
+const directoryName = "<directory name>";
 
 async function main() {
   const directoryClient = serviceClient
     .getShareClient(shareName)
     .getDirectoryClient(directoryName);
 
-  let dirIter2 = await directoryClient.listFilesAndDirectories();
+  let dirIter = await directoryClient.listFilesAndDirectories();
   let i = 1;
-  let item = await dirIter2.next();
+  let item = await dirIter.next();
   while (!item.done) {
     if (item.value.kind === "directory") {
       console.log(`${i} - directory\t: ${item.value.name}`);
     } else {
       console.log(`${i} - file\t: ${item.value.name}`);
     }
-    item = await dirIter2.next();
+    item = await dirIter.next();
   }
 }
 
@@ -357,7 +357,7 @@ const serviceClient = new ShareServiceClient(
 );
 
 const shareName = "<share name>";
-const fileName = "<file name>"
+const fileName = "<file name>";
 
 // [Node.js only] A helper method used to read a Node.js readable stream into string
 async function streamToString(readableStream) {

--- a/sdk/storage/storage-file-share/src/AccountSASSignatureValues.ts
+++ b/sdk/storage/storage-file-share/src/AccountSASSignatureValues.ts
@@ -14,7 +14,7 @@ import { truncatedISO8061Date } from "./utils/utils.common";
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
  * AccountSASSignatureValues is used to generate a Shared Access Signature (SAS) for an Azure Storage account. Once
- * all the values here are set appropriately, call generateSASQueryParameters() to obtain a representation of the SAS
+ * all the values here are set appropriately, call {@link generateAccountSASQueryParameters} to obtain a representation of the SAS
  * which can actually be applied to file urls. Note: that both this class and {@link SASQueryParameters} exist because
  * the former is mutable and a logical representation while the latter is immutable and used to generate actual REST
  * requests.

--- a/sdk/storage/storage-file-share/src/FileDownloadResponse.ts
+++ b/sdk/storage/storage-file-share/src/FileDownloadResponse.ts
@@ -13,12 +13,12 @@ import {
 /**
  * ONLY AVAILABLE IN NODE.JS RUNTIME.
  *
- * FileDownloadResponse implements FileDownloadResponseModel interface, and in Node.js runtime it will
- * automatically retry when internal read stream unexpected ends. (This kind of unexpected ends cannot
- * trigger retries defined in pipeline retry policy.)
+ * FileDownloadResponse implements the `FileDownloadResponseModel` interface, and in a Node.js runtime it will
+ * automatically retry when its internal read stream unexpectedly ends. (This kind of unexpected end cannot
+ * trigger retries defined in the pipeline retry policy.)
  *
- * The readableStreamBody stream will retry underlayer, you can just use it as a normal Node.js
- * Readable stream.
+ * The {@link readableStreamBody} stream will retry beneath the `ReadableStream` layer, so you can just use it as
+ * a normal Node.js Readable stream.
  *
  * @export
  * @class FileDownloadResponse

--- a/sdk/storage/storage-file-share/src/Pipeline.ts
+++ b/sdk/storage/storage-file-share/src/Pipeline.ts
@@ -67,9 +67,10 @@ export interface PipelineOptions {
 
 /**
  * A Pipeline class containing HTTP request policies.
- * You can create a default Pipeline by calling newPipeline().
+ * You can create a default Pipeline by calling {@link newPipeline}.
  * Or you can create a Pipeline with your own policies by the constructor of Pipeline.
- * Refer to newPipeline() and provided policies as reference before
+ *
+ * Refer to {@link newPipeline} and provided policies as reference before
  * implementing your customized Pipeline.
  *
  * @export
@@ -119,7 +120,7 @@ export class Pipeline {
 }
 
 /**
- * Option interface for newPipeline() function.
+ * Option interface for {@link newPipeline} function.
  *
  * @export
  * @interface StoragePipelineOptions
@@ -160,7 +161,7 @@ export interface StoragePipelineOptions {
 }
 
 /**
- * Creates a new Pipeline object with Credential provided.
+ * Creates a new {@link Pipeline} object with {@link Credential} provided.
  *
  * @static
  * @param {Credential} credential Such as AnonymousCredential, StorageSharedKeyCredential.

--- a/sdk/storage/storage-file-share/src/ShareClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareClient.ts
@@ -47,7 +47,7 @@ import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import { createSpan } from "./utils/tracing";
 
 /**
- * Options to configure Share - Create operation.
+ * Options to configure the {@link ShareClient.create} operation.
  *
  * @export
  * @interface ShareCreateOptions
@@ -80,7 +80,7 @@ export interface ShareCreateOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Delete operation.
+ * Options to configure the {@link ShareClient.delete} operation.
  *
  * @export
  * @interface ShareDeleteMethodOptions
@@ -106,7 +106,7 @@ export interface ShareDeleteMethodOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Set Metadata operation.
+ * Options to configure the {@link ShareClient.setMetadata} operation.
  *
  * @export
  * @interface ShareSetMetadataOptions
@@ -123,7 +123,7 @@ export interface ShareSetMetadataOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Set Access Policy operation.
+ * Options to configure the {@link ShareClient.setAccessPolicy} operation.
  *
  * @export
  * @interface ShareSetAccessPolicyOptions
@@ -140,7 +140,7 @@ export interface ShareSetAccessPolicyOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Get Access Policy operation.
+ * Options to configure the {@link ShareClient.getAccessPolicy} operation.
  *
  * @export
  * @interface ShareGetAccessPolicyOptions
@@ -157,7 +157,7 @@ export interface ShareGetAccessPolicyOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Get Properties operation.
+ * Options to configure the {@link ShareClient.getProperties} operation.
  *
  * @export
  * @interface ShareGetPropertiesOptions
@@ -174,7 +174,7 @@ export interface ShareGetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Set Quota operation.
+ * Options to configure the {@link ShareClient.setQuota} operation.
  *
  * @export
  * @interface ShareSetQuotaOptions
@@ -191,7 +191,7 @@ export interface ShareSetQuotaOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Get Statistics operation.
+ * Options to configure the {@link ShareClient.getStatistics} operation.
  *
  * @export
  * @interface ShareGetStatisticsOptions
@@ -261,7 +261,7 @@ export declare type ShareGetAccessPolicyResponse = {
   };
 
 /**
- * Options to configure Share - Create Snapshot operation.
+ * Options to configure the {@link ShareClient.createSnapshot} operation.
  *
  * @export
  * @interface ShareCreateSnapshotOptions
@@ -285,7 +285,7 @@ export interface ShareCreateSnapshotOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Share - Create Permission operation.
+ * Options to configure the {@link ShareClient.createPermission} operation.
  *
  * @export
  * @interface ShareCreatePermissionOptions
@@ -301,7 +301,7 @@ export interface ShareCreatePermissionOptions extends CommonOptions {
   abortSignal?: AbortSignalLike;
 }
 /**
- * Options to configure Share - Get Permission operation.
+ * Options to configure the {@link ShareClient.getPermission} operation.
  *
  * @export
  * @interface ShareGetPermissionOptions
@@ -318,7 +318,7 @@ export interface ShareGetPermissionOptions extends CommonOptions {
 }
 
 /**
- * Response - Share Get Statistics Operation.
+ * Response data for the {@link ShareClient.getStatistics} Operation.
  *
  * @export
  * @interface ShareGetStatisticsResponse
@@ -497,7 +497,7 @@ export class ShareClient extends StorageClient {
   }
 
   /**
-   * Creates a ShareDirectoryClient object.
+   * Creates a {@link ShareDirectoryClient} object.
    *
    * @param directoryName A directory name
    * @returns {ShareDirectoryClient} The ShareDirectoryClient object for the given directory name.
@@ -637,11 +637,12 @@ export class ShareClient extends StorageClient {
    * account's index and is no longer accessible to clients. The file's data is later
    * removed from the service during garbage collection.
    *
-   * Delete File will fail with status code 409 (Conflict) and error code SharingViolation
+   * Delete File will fail with status code 409 (Conflict) and error code `SharingViolation`
    * if the file is open on an SMB client.
    *
    * Delete File is not supported on a share snapshot, which is a read-only copy of
-   * a share. An attempt to perform this operation on a share snapshot will fail with 400 (InvalidQueryParameterValue)
+   * a share. An attempt to perform this operation on a share snapshot will fail with 400
+   * (`InvalidQueryParameterValue`)
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2
    *

--- a/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
@@ -41,7 +41,7 @@ import { createSpan } from "./utils/tracing";
 import { CanonicalCode } from "@azure/core-tracing";
 
 /**
- * Options to configure Directory - Create operation.
+ * Options to configure {@link ShareDirectoryClient.create} operation.
  *
  * @export
  * @interface DirectoryCreateOptions
@@ -78,7 +78,12 @@ export interface DirectoryProperties
 }
 
 /**
- * Options to configure Directory - List Files and Directories Segment operation.
+ * Options to configure Directory - List Files and Directories Segment operations.
+ *
+ * See:
+ * - {@link ShareDirectoryClient.iterateFilesAndDirectoriesSegments}
+ * - {@link ShareDirectoryClient.listFilesAndDirectoriesItems}
+ * - {@link ShareDirectoryClient.listFilesAndDirectoriesSegment}
  *
  * @interface DirectoryListFilesAndDirectoriesSegmentOptions
  */
@@ -112,7 +117,7 @@ interface DirectoryListFilesAndDirectoriesSegmentOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Directory - List Files and Directories operation.
+ * Options to configure {@link ShareDirectoryClient.listFilesAndDirectories} operation.
  *
  * @export
  * @interface DirectoryListFilesAndDirectoriesOptions
@@ -137,7 +142,7 @@ export interface DirectoryListFilesAndDirectoriesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Directory - Delete operation.
+ * Options to configure the {@link ShareDirectoryClient.delete} operation.
  *
  * @export
  * @interface DirectoryDeleteOptions
@@ -154,7 +159,7 @@ export interface DirectoryDeleteOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Directory - Get Properties operation.
+ * Options to configure the {@link ShareDirectoryClient.getProperties} operation.
  *
  * @export
  * @interface DirectoryGetPropertiesOptions
@@ -171,7 +176,7 @@ export interface DirectoryGetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Directory - Set Metadata operation.
+ * Options to configure the {@link ShareDirectoryClient.setMetadata} operation.
  *
  * @export
  * @interface DirectorySetMetadataOptions
@@ -188,7 +193,13 @@ export interface DirectorySetMetadataOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Directory - List Handles Segment.
+ * Options to configure Directory - List Handles Segment operations.
+ *
+ * See:
+ * - {@link ShareDirectoryClient.listHandlesSegment}
+ * - {@link ShareDirectoryClient.iterateHandleSegments}
+ * - {@link ShareDirectoryClient.listHandleItems}
+ *
  *
  * @export
  * @interface DirectoryListHandlesSegmentOptions
@@ -221,7 +232,7 @@ export interface DirectoryListHandlesSegmentOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Directory - List Handles.
+ * Options to configure the {@link ShareDirectoryClient.listHandles} operation.
  *
  * @export
  * @interface DirectoryListHandlesOptions
@@ -246,7 +257,11 @@ export interface DirectoryListHandlesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure Directory - Force Close Handles Segment.
+ * Options to configure Directory - Force Close Handles Segment operations.
+ *
+ * See:
+ * - {@link ShareDirectoryClient.forceCloseHandlesSegment}
+ * - {@link ShareDirectoryClient.forceCloseAllHandles}
  *
  * @export
  * @interface DirectoryForceCloseHandlesSegmentOptions
@@ -271,7 +286,7 @@ export interface DirectoryForceCloseHandlesSegmentOptions extends CommonOptions 
 }
 
 /**
- * Options to configure Directory - Force Close Handles.
+ * Options to configure {@link ShareDirectoryClient.forceCloseHandle}.
  *
  * @export
  * @interface DirectoryForceCloseHandlesOptions
@@ -458,6 +473,13 @@ export class ShareDirectoryClient extends StorageClient {
    * @param subDirectoryName A subdirectory name
    * @returns {ShareDirectoryClient} The ShareDirectoryClient object for the given subdirectory name.
    * @memberof ShareDirectoryClient
+   *
+   * @example
+   * ```js
+   * const directoryClient = shareClient.getDirectoryClient("<directory name>");
+   * await directoryClient.create();
+   * console.log("Created directory successfully");
+   * ```
    */
   public getDirectoryClient(subDirectoryName: string): ShareDirectoryClient {
     return new ShareDirectoryClient(
@@ -627,11 +649,24 @@ export class ShareDirectoryClient extends StorageClient {
   }
 
   /**
-   * Creates a ShareFileClient object.
+   * Creates a {@link ShareFileClient} object.
    *
    * @param {string} fileName A file name.
    * @returns {ShareFileClient} A new ShareFileClient object for the given file name.
    * @memberof ShareFileClient
+   *
+   * @example
+   * ```js
+   * const content = "Hello world!"
+   *
+   * const fileClient = directoryClient.getFileClient("<file name>");
+   *
+   * await fileClient.create(content.length);
+   * console.log("Created file successfully!");
+   *
+   * await fileClient.uplaodRange(content, 0, content.length);
+   * console.log("Updated file successfully!")
+   * ```
    */
   public getFileClient(fileName: string): ShareFileClient {
     return new ShareFileClient(
@@ -735,7 +770,7 @@ export class ShareDirectoryClient extends StorageClient {
   }
 
   /**
-   * Returns an AsyncIterableIterator for DirectoryListFilesAndDirectoriesSegmentResponses
+   * Returns an AsyncIterableIterator for {@link DirectoryListFilesAndDirectoriesSegmentResponse} objects
    *
    * @private
    * @param {string} [marker] A string value that identifies the portion of
@@ -940,7 +975,7 @@ export class ShareDirectoryClient extends StorageClient {
   }
 
   /**
-   * Returns an AsyncIterableIterator for DirectoryListHandlesResponse
+   * Returns an AsyncIterableIterator for {@link DirectoryListHandlesResponse}
    *
    * @private
    * @param {string} [marker] A string value that identifies the portion of the list to be

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -60,7 +60,7 @@ import { getShareNameAndPathFromUrl } from "./utils/utils.common";
 import { createSpan } from "./utils/tracing";
 
 /**
- * Options to configure File - Create operation.
+ * Options to configure the {@link ShareFileClient.create} operation.
  *
  * @export
  * @interface FileCreateOptions
@@ -112,7 +112,7 @@ export interface FileProperties extends FileAndDirectorySetPropertiesCommonOptio
 export interface SetPropertiesResponse extends FileSetHTTPHeadersResponse {}
 
 /**
- * Options to configure File - Delete operation.
+ * Options to configure the {@link ShareFileClient.delete} operation.
  *
  * @export
  * @interface FileDeleteOptions
@@ -129,7 +129,11 @@ export interface FileDeleteOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - Download operation.
+ * Options to configure File - Download operations.
+ *
+ * See:
+ * - {@link ShareFileClient.download}
+ * - {@link ShareFileClient.downloadToFile}
  *
  * @export
  * @interface FileDownloadOptions
@@ -179,7 +183,7 @@ export interface FileDownloadOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - Upload Range operation.
+ * Options to configure the {@link ShareFileClient.uploadRange} operation.
  *
  * @export
  * @interface FileUploadRangeOptions
@@ -215,7 +219,7 @@ export interface FileUploadRangeOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - Upload Range from URL operation.
+ * Options to configure the {@link ShareFileClient.uploadRangeFromURL} operation.
  *
  * @export
  * @interface FileUploadRangeFromURLOptions
@@ -269,7 +273,7 @@ export interface FileUploadRangeFromURLOptions extends CommonOptions {
 // }
 
 /**
- * Options to configure File - Get Range List operation.
+ * Options to configure the {@link ShareFileClient.getRangeList} operation.
  *
  * @export
  * @interface FileGetRangeListOptions
@@ -293,7 +297,7 @@ export interface FileGetRangeListOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - Get Properties operation.
+ * Options to configure the {@link ShareFileClient.getProperties} operation.
  *
  * @export
  * @interface FileGetPropertiesOptions
@@ -310,7 +314,7 @@ export interface FileGetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Contains response data for the getRangeList operation.
+ * Contains response data for the {@link ShareFileClient.getRangeList} operation.
  */
 export type FileGetRangeListResponse = FileGetRangeListHeaders & {
   /**
@@ -340,7 +344,7 @@ export type FileGetRangeListResponse = FileGetRangeListHeaders & {
 };
 
 /**
- * Options to configure File - Start Copy operation.
+ * Options to configure the {@link ShareFileClient.startCopyFromURL} operation.
  *
  * @export
  * @interface FileStartCopyOptions
@@ -364,7 +368,7 @@ export interface FileStartCopyOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - Set Metadata operation.
+ * Options to configure the {@link ShareFileClient.setMetadata} operation.
  *
  * @export
  * @interface FileSetMetadataOptions
@@ -381,7 +385,7 @@ export interface FileSetMetadataOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - HTTP Headers operation.
+ * Options to configure the {@link ShareFileClient.setHttpHeaders} operation.
  *
  * @export
  * @interface FileSetHttpHeadersOptions
@@ -400,7 +404,7 @@ export interface FileSetHttpHeadersOptions
 }
 
 /**
- * Options to configure File - Abort Copy From URL operation.
+ * Options to configure the {@link ShareFileClient.abortCopyFromURL} operation.
  *
  * @export
  * @interface FileAbortCopyFromURLOptions
@@ -417,7 +421,7 @@ export interface FileAbortCopyFromURLOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - Resize operation.
+ * Options to configure the {@link ShareFileClient.resize} operation.
  *
  * @export
  * @interface FileResizeOptions
@@ -436,7 +440,7 @@ export interface FileResizeOptions
 }
 
 /**
- * Options to configure File - Clear Range operation.
+ * Options to configure the {@link ShareFileClient.clearRange} operation.
  *
  * @export
  * @interface FileClearRangeOptions
@@ -453,7 +457,12 @@ export interface FileClearRangeOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - File List Handles Segment.
+ * Options to configure File - List Handles Segment operations.
+ *
+ * See:
+ * - {@link ShareFileClient.listHandlesSegment}
+ * - {@link ShareFileClient.iterateHandleSegments}
+ * - {@link ShareFileClient.listHandleItems}
  *
  * @export
  * @interface FileListHandlesSegmentOptions
@@ -489,7 +498,12 @@ export interface FileListHandlesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File - File Force Close Handles Options.
+ * Options to configure File - Force Close Handles operations.
+ *
+ * See:
+ * - {@link ShareFileClient.forceCloseHandlesSegment}
+ * - {@link ShareFileClient.forceCloseAllHandles}
+ * - {@link ShareFileCLient.forceCloseHandle}
  *
  * @export
  * @interface FileForceCloseHandlesOptions
@@ -544,7 +558,11 @@ export interface FileUploadStreamOptions extends CommonOptions {
 }
 
 /**
- * Option interface for ShareFileClient.uploadFile() and ShareFileClient.uploadSeekableStream().
+ * Option interface for File - Upload operations
+ *
+ * See:
+ * - {@link ShareFileClient.uploadFile}
+ * - {@link ShareFileClient.uploadSeekableStream}
  *
  * @export
  * @interface FileParallelUploadOptions
@@ -601,7 +619,7 @@ export interface FileParallelUploadOptions extends CommonOptions {
 }
 
 /**
- * Option interface for DownloadAzurefileToBuffer.
+ * Option interface for the {@link ShareFileClient.downloadToBuffer} operation.
  *
  * @export
  * @interface FileDownloadToBufferOptions
@@ -751,6 +769,19 @@ export class ShareFileClient extends StorageClient {
    * @param {FileCreateOptions} [options] Options to File Create operation.
    * @returns {Promise<FileCreateResponse>} Response data for the File Create  operation.
    * @memberof ShareFileClient
+   *
+   * @example
+   * ```js
+   * const content = "Hello world!";
+   *
+   * // Create the file
+   * await fileClient.create(content.length);
+   * console.log("Created file successfully!");
+   *
+   * // Then upload data to the file
+   * await fileClient.uploadRange(content, 0, content.length);
+   * console.log("Updated file successfully!")
+   * ```
    */
   public async create(size: number, options: FileCreateOptions = {}): Promise<FileCreateResponse> {
     const { span, spanOptions } = createSpan("ShareFileClient-create", options.tracingOptions);
@@ -807,6 +838,52 @@ export class ShareFileClient extends StorageClient {
    * @param {FileDownloadOptions} [options] Options to File Download operation.
    * @returns {Promise<FileDownloadResponse>} Response data for the File Download operation.
    * @memberof ShareFileClient
+   *
+   * @example
+   * ```js
+   * // Download a file to a string (Node.js only)
+   * const downloadFileResponse = await fileClient.download();
+   * console.log(
+   *   "Downloaded file content:",
+   *   await streamToString(downloadFileResponse.readableStreamBody)}
+   * );
+   *
+   * // [Node.js only] A helper method used to read a Node.js readable stream into string
+   * async function streamToString(readableStream) {
+   *   return new Promise((resolve, reject) => {
+   *     const chunks = [];
+   *     readableStream.on("data", (data) => {
+   *       chunks.push(data.toString());
+   *     });
+   *     readableStream.on("end", () => {
+   *       resolve(chunks.join(""));
+   *     });
+   *     readableStream.on("error", reject);
+   *   });
+   * }
+   * ```
+   *
+   * @example
+   * ```js
+   * // Download a file to a string (Browser only)
+   * const downloadFileResponse = await fileClient.download(0);
+   * console.log(
+   *   "Downloaded file content:",
+   *   await streamToString(downloadFileResponse.blobBody)}
+   * );
+   *
+   * // [Browser only] A helper method used to convert a browser Blob into string.
+   * export async function blobToString(blob: Blob): Promise<string> {
+   *   const fileReader = new FileReader();
+   *   return new Promise<string>((resolve, reject) => {
+   *     fileReader.onloadend = (ev: any) => {
+   *       resolve(ev.target!.result);
+   *     };
+   *     fileReader.onerror = reject;
+   *     fileReader.readAsText(blob);
+   *   });
+   * }
+   * ```
    */
   public async download(
     offset: number = 0,
@@ -1141,6 +1218,19 @@ export class ShareFileClient extends StorageClient {
    * @param {FileUploadRangeOptions} [options={}] Options to File Upload Range operation.
    * @returns {Promise<FileUploadRangeResponse>} Response data for the File Upload Range operation.
    * @memberof ShareFileClient
+   *
+   * @example
+   * ```js
+   * const content = "Hello world!";
+   *
+   * // Create the file
+   * await fileClient.create(content.length);
+   * console.log("Created file successfully!");
+   *
+   * // Then upload data to the file
+   * await fileClient.uploadRange(content, 0, content.length);
+   * console.log("Updated file successfully!")
+   * ```
    */
   public async uploadRange(
     body: HttpRequestBody,
@@ -2108,7 +2198,7 @@ export class ShareFileClient extends StorageClient {
    *
    * @param {string} handleId Specific handle ID, cannot be asterisk "*".
    *                          Use forceCloseAllHandles() to close all handles.
-   * @param {FileForceCloseHandlesOptions} [options] Options to force close handles operation.
+   * @param FileForceCloseHandlesOptions} [options] Options to force close handles operation.
    * @returns {Promise<FileForceCloseHandlesResponse>}
    * @memberof ShareFileClient
    */

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -27,7 +27,12 @@ import { CanonicalCode } from "@azure/core-tracing";
 import { createSpan } from "./utils/tracing";
 
 /**
- * Options to configure List Shares Segment operation.
+ * Options to configure Share - List Shares Segment operations.
+ *
+ * See:
+ * - {@link ShareServiceClient.listSegments}
+ * - {@link ShareServiceClient.listItems}
+ * - {@link ShareServiceClient.listSharesSegment}
  *
  * @interface ServiceListSharesSegmentOptions
  */
@@ -69,7 +74,7 @@ interface ServiceListSharesSegmentOptions extends CommonOptions {
 }
 
 /**
- * Options to configure List Shares operation.
+ * Options to configure the {@link ShareServiceClient.listShares} operation.
  *
  * @export
  * @interface ServiceListSharesOptions
@@ -110,7 +115,7 @@ export interface ServiceListSharesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File Service - Get Properties operation.
+ * Options to configure the {@link ShareServiceClient.getProperties} operation.
  *
  * @export
  * @interface ServiceGetPropertiesOptions
@@ -127,7 +132,7 @@ export interface ServiceGetPropertiesOptions extends CommonOptions {
 }
 
 /**
- * Options to configure File Service - Set Properties operation.
+ * Options to configure the {@link ShareServiceClient.setProperties} operation.
  *
  * @export
  * @interface ServiceSetPropertiesOptions
@@ -248,6 +253,13 @@ export class ShareServiceClient extends StorageClient {
    * @param shareName Name of a share.
    * @returns {ShareClient} The ShareClient object for the given share name.
    * @memberof ShareServiceClient
+   *
+   * @example
+   * ```js
+   * const shareClient = serviceClient.getShareClient("<share name>");
+   * await shareClient.create();
+   * console.log("Created share successfully!");
+   * ```
    */
   public getShareClient(shareName: string): ShareClient {
     return new ShareClient(appendToURLPath(this.url, shareName), this.pipeline);
@@ -390,7 +402,7 @@ export class ShareServiceClient extends StorageClient {
   }
 
   /**
-   * Returns an AsyncIterableIterator for ServiceListSharesSegmentResponses
+   * Returns an AsyncIterableIterator for {@link ServiceListSharesSegmentResponse} objects
    *
    * @private
    * @param {string} [marker] A string value that identifies the portion of

--- a/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
@@ -14,7 +14,7 @@ import { TelemetryPolicy } from "./policies/TelemetryPolicy";
 import { SDK_VERSION } from "./utils/constants";
 
 /**
- * TelemetryPolicyFactory is a factory class helping generating TelemetryPolicy objects.
+ * TelemetryPolicyFactory is a factory class helping generating {@link TelemetryPolicy} objects.
  *
  * @export
  * @class TelemetryPolicyFactory
@@ -56,7 +56,7 @@ export class TelemetryPolicyFactory implements RequestPolicyFactory {
   }
 
   /**
-   * Creates a RequestPolicy object.
+   * Creates a {@link RequestPolicy} object.
    *
    * @param {RequestPolicy} nextPolicy
    * @param {RequestPolicyOptions} options

--- a/sdk/storage/storage-file-share/src/credentials/AnonymousCredential.ts
+++ b/sdk/storage/storage-file-share/src/credentials/AnonymousCredential.ts
@@ -8,7 +8,7 @@ import { Credential } from "./Credential";
 
 /**
  * AnonymousCredential provides a credentialPolicyCreator member used to create
- * AnonymousCredentialPolicy objects. AnonymousCredentialPolicy is used with
+ * {@link AnonymousCredentialPolicy} objects. AnonymousCredentialPolicy is used with
  * HTTP(S) requests that read public resources or for use with Shared Access
  * Signatures (SAS).
  *
@@ -18,7 +18,7 @@ import { Credential } from "./Credential";
  */
 export class AnonymousCredential extends Credential {
   /**
-   * Creates an AnonymousCredentialPolicy object.
+   * Creates an {@link AnonymousCredentialPolicy} object.
    *
    * @param {RequestPolicy} nextPolicy
    * @param {RequestPolicyOptions} options

--- a/sdk/storage/storage-file-share/src/credentials/StorageSharedKeyCredential.ts
+++ b/sdk/storage/storage-file-share/src/credentials/StorageSharedKeyCredential.ts
@@ -46,7 +46,7 @@ export class StorageSharedKeyCredential extends Credential {
   }
 
   /**
-   * Creates a StorageSharedKeyCredentialPolicy object.
+   * Creates a {@link StorageSharedKeyCredentialPolicy} object.
    *
    * @param {RequestPolicy} nextPolicy
    * @param {RequestPolicyOptions} options

--- a/sdk/storage/storage-file-share/src/policies/CredentialPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/CredentialPolicy.ts
@@ -26,7 +26,7 @@ export abstract class CredentialPolicy extends BaseRequestPolicy {
 
   /**
    * Child classes must implement this method with request signing. This method
-   * will be executed in sendRequest().
+   * will be executed in {@link sendRequest}.
    *
    * @protected
    * @abstract

--- a/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageSharedKeyCredentialPolicy.ts
@@ -16,7 +16,7 @@ import { CredentialPolicy } from "./CredentialPolicy";
  */
 export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
   /**
-   * Reference to StorageSharedKeyCredential which generates StorageSharedKeyCredentialPolicy
+   * Reference to {@link StorageSharedKeyCredential} which generates StorageSharedKeyCredentialPolicy
    *
    * @type {StorageSharedKeyCredential}
    * @memberof StorageSharedKeyCredentialPolicy
@@ -141,11 +141,9 @@ export class StorageSharedKeyCredentialPolicy extends CredentialPolicy {
       return value.name.toLowerCase().startsWith(HeaderConstants.PREFIX_FOR_STORAGE);
     });
 
-    headersArray.sort(
-      (a, b): number => {
-        return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
-      }
-    );
+    headersArray.sort((a, b): number => {
+      return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    });
 
     // Remove duplicate headers
     headersArray = headersArray.filter((value, index, array) => {


### PR DESCRIPTION
Same treatment as blobs & queues for file shares. See: #5924  #5931 #5936 & #5957 

One PR with both sets of changes rather than two.

Changes:
- README:
  - Reordered sections of the readme
  - removed locales from URLs
  - Made samples runnable
  - Removed version information and changelog-style sections
  - Prefer `require` to es6 for now
- Inline docs:
  - Added samples from readme to inline docs
  - Added link tags where I noticed they could be added
  - Surrounded the names of exteranal types with backticks as appropriate
  - linked options types to their consumer methods