### PR TITLE
turn off strictPeerDep

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -41,7 +41,7 @@
      * The default value is false to avoid legacy compatibility issues.
      * It is strongly recommended to set strictPeerDependencies=true.
      */
-    "strictPeerDependencies": true,
+    "strictPeerDependencies": false,
     /**
      * Configures the strategy used to select versions during installation.
      *
@@ -360,7 +360,7 @@
     {
       "packageName": "@azure/core-lro",
       "projectFolder": "sdk/core/core-lro"
-    }, 
+    },
     {
       "packageName": "@azure/core-paging",
       "projectFolder": "sdk/core/core-paging",


### PR DESCRIPTION
Disablingsince this setting should be used only when the mono-repos doesn't have conflicting peer dependencies. We have conflicting peer dependency on rhea-promise - between versions - 1.0.0 and 0.1.15

cc: @mikeharder  @bsiegel  @bterlson 