### PR TITLE
[Cosmos] Respect preferredLocations

### DIFF
--- a/sdk/cosmosdb/cosmos/changelog.md
+++ b/sdk/cosmosdb/cosmos/changelog.md
@@ -1,6 +1,7 @@
 ## 3.4.1
 
 - Fix region drop failover scenario and add test (#5892)
+- Fix bug where preferredLocations was not respected (#6026)
 
 ## 3.4.0
 

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -77,9 +77,6 @@ export class ClientContext {
 
       request.headers = await this.buildHeaders(request);
       this.applySessionToken(request);
-
-      // read will use ReadEndpoint since it uses GET operation
-      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Read, response.headers);
       return response;
@@ -131,7 +128,6 @@ export class ClientContext {
     if (query !== undefined) {
       request.method = HTTPMethod.post;
     }
-    request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
     request.headers = await this.buildHeaders(request);
     if (query !== undefined) {
       request.headers[Constants.HttpHeaders.IsQuery] = "true";
@@ -177,7 +173,6 @@ export class ClientContext {
       plugins: this.cosmosClientOptions.plugins
     };
 
-    request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
     request.headers = await this.buildHeaders(request);
     request.headers[Constants.HttpHeaders.IsQueryPlan] = "True";
     request.headers[Constants.HttpHeaders.QueryVersion] = "1.4";
@@ -245,8 +240,6 @@ export class ClientContext {
 
       request.headers = await this.buildHeaders(request);
       this.applySessionToken(request);
-      // deleteResource will use WriteEndpoint since it uses DELETE operation
-      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       if (parseLink(path).type !== "colls") {
         this.captureSessionToken(undefined, path, OperationType.Delete, response.headers);
@@ -296,7 +289,6 @@ export class ClientContext {
       // create will use WriteEndpoint since it uses POST operation
       this.applySessionToken(request);
 
-      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Create, response.headers);
       return response;
@@ -379,9 +371,6 @@ export class ClientContext {
 
       request.headers = await this.buildHeaders(request);
       this.applySessionToken(request);
-
-      // replace will use WriteEndpoint since it uses PUT operation
-      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Replace, response.headers);
       return response;
@@ -427,8 +416,6 @@ export class ClientContext {
       request.headers[Constants.HttpHeaders.IsUpsert] = true;
       this.applySessionToken(request);
 
-      // upsert will use WriteEndpoint since it uses POST operation
-      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Upsert, response.headers);
       return response;
@@ -474,8 +461,6 @@ export class ClientContext {
     };
 
     request.headers = await this.buildHeaders(request);
-    // executeStoredProcedure will use WriteEndpoint since it uses POST operation
-    request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
     return executePlugins(request, executeRequest, PluginOn.operation);
   }
 

--- a/sdk/cosmosdb/cosmos/src/ClientContext.ts
+++ b/sdk/cosmosdb/cosmos/src/ClientContext.ts
@@ -77,6 +77,9 @@ export class ClientContext {
 
       request.headers = await this.buildHeaders(request);
       this.applySessionToken(request);
+
+      // read will use ReadEndpoint since it uses GET operation
+      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Read, response.headers);
       return response;
@@ -128,6 +131,7 @@ export class ClientContext {
     if (query !== undefined) {
       request.method = HTTPMethod.post;
     }
+    request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
     request.headers = await this.buildHeaders(request);
     if (query !== undefined) {
       request.headers[Constants.HttpHeaders.IsQuery] = "true";
@@ -173,6 +177,7 @@ export class ClientContext {
       plugins: this.cosmosClientOptions.plugins
     };
 
+    request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
     request.headers = await this.buildHeaders(request);
     request.headers[Constants.HttpHeaders.IsQueryPlan] = "True";
     request.headers[Constants.HttpHeaders.QueryVersion] = "1.4";
@@ -240,6 +245,8 @@ export class ClientContext {
 
       request.headers = await this.buildHeaders(request);
       this.applySessionToken(request);
+      // deleteResource will use WriteEndpoint since it uses DELETE operation
+      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       if (parseLink(path).type !== "colls") {
         this.captureSessionToken(undefined, path, OperationType.Delete, response.headers);
@@ -289,6 +296,7 @@ export class ClientContext {
       // create will use WriteEndpoint since it uses POST operation
       this.applySessionToken(request);
 
+      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Create, response.headers);
       return response;
@@ -371,6 +379,9 @@ export class ClientContext {
 
       request.headers = await this.buildHeaders(request);
       this.applySessionToken(request);
+
+      // replace will use WriteEndpoint since it uses PUT operation
+      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Replace, response.headers);
       return response;
@@ -416,6 +427,8 @@ export class ClientContext {
       request.headers[Constants.HttpHeaders.IsUpsert] = true;
       this.applySessionToken(request);
 
+      // upsert will use WriteEndpoint since it uses POST operation
+      request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
       const response = await executePlugins(request, executeRequest, PluginOn.operation);
       this.captureSessionToken(undefined, path, OperationType.Upsert, response.headers);
       return response;
@@ -461,6 +474,8 @@ export class ClientContext {
     };
 
     request.headers = await this.buildHeaders(request);
+    // executeStoredProcedure will use WriteEndpoint since it uses POST operation
+    request.endpoint = await this.globalEndpointManager.resolveServiceEndpoint(request);
     return executePlugins(request, executeRequest, PluginOn.operation);
   }
 

--- a/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
+++ b/sdk/cosmosdb/cosmos/src/request/RequestHandler.ts
@@ -80,7 +80,6 @@ async function httpRequest(requestContext: RequestContext) {
   clearTimeout(timeout);
 
   const result = response.status === 204 || response.status === 304 ? null : await response.json();
-  // console.log(JSON.stringify(result, null, 2));
   const headers = {} as any;
   response.headers.forEach((value: string, key: string) => {
     headers[key] = value;

--- a/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
+++ b/sdk/cosmosdb/cosmos/src/retry/retryUtility.ts
@@ -69,7 +69,7 @@ export async function execute({
     requestContext.locationRouting = new LocationRouting();
   }
   requestContext.locationRouting.clearRouteToLocation();
-  if (retryContext) {
+  if (retryContext && Object.keys(retryContext).length > 0) {
     requestContext.locationRouting.routeToLocation(
       retryContext.retryCount || 0,
       !retryContext.retryRequestOnPreferredLocations
@@ -110,7 +110,7 @@ export async function execute({
     } else {
       retryPolicy = retryPolicies.defaultRetryPolicy;
     }
-    const results = await retryPolicy.shouldRetry(err, retryContext, locationEndpoint);
+    const results = await retryPolicy.shouldRetry(err, retryContext, requestContext.endpoint);
     if (!results) {
       headers[Constants.ThrottleRetryCount] =
         retryPolicies.resourceThrottleRetryPolicy.currentRetryAttemptCount;

--- a/sdk/cosmosdb/cosmos/test/integration/aggregateQuery.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/integration/aggregateQuery.spec.ts
@@ -60,7 +60,6 @@ describe("Aggregate Query", function() {
 
   const validateFetchAll = async function(queryIterator: QueryIterator<any>, expectedResults: any) {
     const { resources: results, requestCharge } = await queryIterator.fetchAll();
-    console.log(results);
     assert(requestCharge > 0, "request charge was not greater than zero");
     assert.equal(results.length, expectedResults.length, "invalid number of results");
     assert.equal(queryIterator.hasMoreResults(), false, "hasMoreResults: no more results is left");

--- a/sdk/cosmosdb/cosmos/test/integration/multiregion.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/integration/multiregion.spec.ts
@@ -6,9 +6,108 @@ import { CosmosClient } from "../../dist-esm/CosmosClient";
 import { DatabaseAccount } from "../../dist-esm/documents";
 
 import { endpoint, masterKey } from "../common/_testConfig";
+import { PluginOn, PluginConfig, CosmosClientOptions } from "../../dist-esm";
+
+const databaseAccountResponse = {
+  headers: {
+    "content-location": "https://failovertest.documents.azure.com/",
+    "content-type": "application/json"
+  },
+  result: {
+    _self: "",
+    id: "failovertest",
+    _rid: "failovertest.documents.azure.com",
+    media: "//media/",
+    addresses: "//addresses/",
+    _dbs: "//dbs/",
+    writableLocations: [
+      {
+        name: "East US",
+        databaseAccountEndpoint: "https://failovertest-eastus.documents.azure.com:443/"
+      },
+      {
+        name: "Australia East",
+        databaseAccountEndpoint: "https://failovertest-australiaeast.documents.azure.com:443/"
+      }
+    ],
+    readableLocations: [
+      {
+        name: "East US",
+        databaseAccountEndpoint: "https://failovertest-eastus.documents.azure.com:443/"
+      },
+      {
+        name: "Australia East",
+        databaseAccountEndpoint: "https://failovertest-australiaeast.documents.azure.com:443/"
+      }
+    ],
+    enableMultipleWriteLocations: true,
+    userReplicationPolicy: {
+      asyncReplication: false,
+      minReplicaSetSize: 3,
+      maxReplicasetSize: 4
+    },
+    userConsistencyPolicy: {
+      defaultConsistencyLevel: "Session"
+    },
+    systemReplicationPolicy: {
+      minReplicaSetSize: 3,
+      maxReplicasetSize: 4
+    },
+    readPolicy: {
+      primaryReadCoefficient: 1,
+      secondaryReadCoefficient: 1
+    },
+    queryEngineConfiguration:
+      '{"maxSqlQueryInputLength":262144,"maxJoinsPerSqlQuery":5,"maxLogicalAndPerSqlQuery":500,"maxLogicalOrPerSqlQuery":500,"maxUdfRefPerSqlQuery":10,"maxInExpressionItemsCount":16000,"queryMaxInMemorySortDocumentCount":500,"maxQueryRequestTimeoutFraction":0.9,"sqlAllowNonFiniteNumbers":false,"sqlAllowAggregateFunctions":true,"sqlAllowSubQuery":true,"sqlAllowScalarSubQuery":true,"allowNewKeywords":true,"sqlAllowLike":false,"sqlAllowGroupByClause":true,"maxSpatialQueryCells":12,"spatialMaxGeometryPointCount":256,"sqlAllowTop":true,"enableSpatialIndexing":true}'
+  },
+  code: 200
+};
+
+const collectionResponse = {
+  headers: {},
+  result: {
+    id: "RegionalFailover6198",
+    indexingPolicy: {
+      indexingMode: "consistent",
+      automatic: true,
+      includedPaths: [
+        {
+          path: "/*"
+        }
+      ],
+      excludedPaths: [
+        {
+          path: '/"_etag"/?'
+        }
+      ]
+    },
+    partitionKey: {
+      paths: ["/_partitionKey"],
+      kind: "Hash"
+    },
+    conflictResolutionPolicy: {
+      mode: "LastWriterWins",
+      conflictResolutionPath: "/_ts",
+      conflictResolutionProcedure: ""
+    },
+    geospatialConfig: {
+      type: "Geography"
+    },
+    _rid: "kdY4AIn8g54=",
+    _ts: 1572274839,
+    _self: "dbs/kdY4AA==/colls/kdY4AIn8g54=/",
+    _etag: '"00007500-0000-0100-0000-5db702970000"',
+    _docs: "docs/",
+    _sprocs: "sprocs/",
+    _triggers: "triggers/",
+    _udfs: "udfs/",
+    _conflicts: "conflicts/"
+  },
+  code: 200
+};
 
 // This test requires a multi-region write enabled account with at least two regions.
-(process.env.TESTS_MULTIREGION ? describe : describe.skip)("Multi-region tests", function() {
+describe("Multi-region tests", function() {
   this.timeout(process.env.MOCHA_TIMEOUT || "30000");
   let PreferredLocations: string[] = [];
   let dbAccount: DatabaseAccount;
@@ -26,35 +125,88 @@ import { endpoint, masterKey } from "../common/_testConfig";
   });
 
   it("Preferred locations should be honored for readEndpoint", async function() {
-    const client = new CosmosClient({
+    let requestIndex = 0;
+    let lastEndpointCalled = "";
+    const responses = [
+      databaseAccountResponse,
+      collectionResponse,
+      { code: 200, result: {}, headers: {} }
+    ];
+    const options: CosmosClientOptions = {
       endpoint,
       key: masterKey,
-      connectionPolicy: { preferredLocations: PreferredLocations }
-    });
+      connectionPolicy: { preferredLocations: ["Australia East"] }
+    };
+    const plugins: PluginConfig[] = [
+      {
+        on: PluginOn.request,
+        plugin: async (context, next) => {
+          const response = responses[requestIndex];
+          lastEndpointCalled = context.endpoint;
+          requestIndex++;
+          if (response.code > 400) {
+            throw response;
+          }
+          return response;
+        }
+      }
+    ];
+    const client = new CosmosClient({
+      ...options,
+      plugins
+    } as any);
     const currentReadEndpoint = await client.getReadEndpoint();
-    assert(
-      currentReadEndpoint.includes(PreferredLocations[0].toLowerCase().replace(/ /g, "")),
-      "The readendpoint should be the first preferred location"
+    console.log(currentReadEndpoint);
+    assert.equal(
+      currentReadEndpoint,
+      "https://failovertest-australiaeast.documents.azure.com:443/"
     );
+    await client
+      .database("foo")
+      .container("foo")
+      .item("foo", undefined)
+      .read();
+    assert.equal(lastEndpointCalled, "https://failovertest-australiaeast.documents.azure.com:443/");
   });
 
   it("Preferred locations should be honored for writeEndpoint", async function() {
-    assert(
-      dbAccount.enableMultipleWritableLocations,
-      "MultipleWriteableLocations must be set on your database account for this test to work"
-    );
-    const client = new CosmosClient({
+    let requestIndex = 0;
+    let lastEndpointCalled = "";
+    const responses = [
+      databaseAccountResponse,
+      collectionResponse,
+      { code: 201, result: {}, headers: {} }
+    ];
+    const options: CosmosClientOptions = {
       endpoint,
       key: masterKey,
-      connectionPolicy: {
-        preferredLocations: PreferredLocations,
-        useMultipleWriteLocations: true
+      connectionPolicy: { preferredLocations: ["Australia East"] }
+    };
+    const plugins: PluginConfig[] = [
+      {
+        on: PluginOn.request,
+        plugin: async (context, next) => {
+          const response = responses[requestIndex];
+          lastEndpointCalled = context.endpoint;
+          requestIndex++;
+          if (response.code > 400) {
+            throw response;
+          }
+          return response;
+        }
       }
-    });
-    const currentWriteEndpoint = await client.getWriteEndpoint();
-    assert(
-      currentWriteEndpoint.includes(PreferredLocations[0].toLowerCase().replace(/ /g, "")),
-      "The writeendpoint should be the first preferred location"
-    );
+    ];
+    const client = new CosmosClient({
+      ...options,
+      plugins
+    } as any);
+    const writeEndpoint = await client.getWriteEndpoint();
+    console.log(writeEndpoint);
+    assert.equal(writeEndpoint, "https://failovertest-australiaeast.documents.azure.com:443/");
+    await client
+      .database("foo")
+      .container("foo")
+      .items.upsert({ id: "foo", _partitionKey: "bar" });
+    assert.equal(lastEndpointCalled, "https://failovertest-australiaeast.documents.azure.com:443/");
   });
 });


### PR DESCRIPTION
There is a bug in the retry code where we end up calling the routing code with a parameter that ignores preferred locations passed to the client