### PR TITLE
Update pnpm-lock.yaml

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,14 +1,12 @@
 dependencies:
   '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
   '@azure/arm-servicebus': 3.2.0
-  '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
+  '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
   '@azure/event-hubs': 2.1.1
-  '@azure/keyvault-keys': 4.0.0-preview.9
-  '@azure/keyvault-secrets': 4.0.0-preview.9
   '@azure/logger-js': 1.3.2
   '@azure/ms-rest-nodeauth': 0.9.3
   '@azure/storage-blob': 12.0.0-preview.5
-  '@microsoft/api-extractor': 7.3.8
+  '@microsoft/api-extractor': 7.5.2
   '@opencensus/web-types': 0.0.7
   '@rush-temp/abort-controller': 'file:projects/abort-controller.tgz'
   '@rush-temp/app-configuration': 'file:projects/app-configuration.tgz'
@@ -21,7 +19,7 @@ dependencies:
   '@rush-temp/core-lro': 'file:projects/core-lro.tgz'
   '@rush-temp/core-paging': 'file:projects/core-paging.tgz'
   '@rush-temp/core-tracing': 'file:projects/core-tracing.tgz'
-  '@rush-temp/cosmos': 'file:projects/cosmos.tgz_webpack@4.39.2'
+  '@rush-temp/cosmos': 'file:projects/cosmos.tgz_webpack@4.41.2'
   '@rush-temp/event-hubs': 'file:projects/event-hubs.tgz'
   '@rush-temp/event-processor-host': 'file:projects/event-processor-host.tgz'
   '@rush-temp/eventhubs-checkpointstore-blob': 'file:projects/eventhubs-checkpointstore-blob.tgz'
@@ -38,16 +36,16 @@ dependencies:
   '@rush-temp/test-utils-recorder': 'file:projects/test-utils-recorder.tgz'
   '@rush-temp/testhub': 'file:projects/testhub.tgz'
   '@types/async-lock': 1.1.1
-  '@types/chai': 4.2.0
+  '@types/chai': 4.2.4
   '@types/chai-as-promised': 7.1.2
   '@types/chai-string': 1.4.2
   '@types/debug': 4.1.5
   '@types/dotenv': 6.1.1
   '@types/execa': 0.9.0
-  '@types/express': 4.17.1
+  '@types/express': 4.17.2
   '@types/fast-json-stable-stringify': 2.0.0
   '@types/fetch-mock': 7.3.1
-  '@types/fs-extra': 8.0.0
+  '@types/fs-extra': 8.0.1
   '@types/glob': 7.1.1
   '@types/is-buffer': 2.0.0
   '@types/jssha': 2.0.0
@@ -57,43 +55,43 @@ dependencies:
   '@types/mocha': 5.2.7
   '@types/nise': 1.4.0
   '@types/nock': 10.0.3
-  '@types/node': 8.10.52
-  '@types/node-fetch': 2.5.0
+  '@types/node': 8.10.58
+  '@types/node-fetch': 2.5.3
   '@types/priorityqueuejs': 1.0.1
   '@types/qs': 6.5.3
   '@types/query-string': 6.2.0
   '@types/semaphore': 1.1.0
-  '@types/sinon': 7.0.13
+  '@types/sinon': 7.5.0
   '@types/tough-cookie': 2.3.5
   '@types/tunnel': 0.0.1
-  '@types/underscore': 1.9.2
-  '@types/uuid': 3.4.5
-  '@types/webpack': 4.39.0
+  '@types/underscore': 1.9.3
+  '@types/uuid': 3.4.6
+  '@types/webpack': 4.39.8
   '@types/webpack-dev-middleware': 2.0.3
   '@types/ws': 6.0.3
-  '@types/xml2js': 0.4.4
-  '@types/yargs': 13.0.2
-  '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-  '@typescript-eslint/eslint-plugin-tslint': 2.3.0_b840da7ae58bd563f8e3899e03f6a2da
-  '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+  '@types/xml2js': 0.4.5
+  '@types/yargs': 13.0.3
+  '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+  '@typescript-eslint/eslint-plugin-tslint': 2.3.3_b440fbe82fef3b179d75a1e01e8e53ff
+  '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
   assert: 1.5.0
   async-lock: 1.2.2
   azure-storage: 2.10.3
   babel-runtime: 6.26.0
-  buffer: 5.4.0
+  buffer: 5.4.3
   chai: 4.2.0
   chai-as-promised: 7.1.1_chai@4.2.0
   chai-exclude: 2.0.2_chai@4.2.0
   chai-string: 1.5.0_chai@4.2.0
-  cross-env: 5.2.0
+  cross-env: 5.2.1
   death: 1.1.0
   debug: 4.1.1
   delay: 4.3.0
-  dotenv: 8.1.0
+  dotenv: 8.2.0
   es6-promise: 4.2.8
-  eslint: 6.2.1
-  eslint-config-prettier: 6.1.0_eslint@6.2.1
-  eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+  eslint: 6.6.0
+  eslint-config-prettier: 6.5.0_eslint@6.6.0
+  eslint-plugin-no-null: 1.0.2_eslint@6.6.0
   eslint-plugin-no-only-tests: 2.3.1
   eslint-plugin-promise: 4.2.1
   esm: 3.2.25
@@ -101,47 +99,47 @@ dependencies:
   execa: 1.0.0
   express: 4.17.1
   fast-json-stable-stringify: 2.0.0
-  fetch-mock: 7.3.9
-  form-data: 2.5.0
+  fetch-mock: 7.7.2_node-fetch@2.6.0
+  form-data: 2.5.1
   fs-extra: 8.1.0
-  glob: 7.1.4
+  glob: 7.1.5
   guid-typescript: 1.0.9
   gulp: 4.0.2
-  gulp-zip: 5.0.0_gulp@4.0.2
-  https-proxy-agent: 2.2.2
+  gulp-zip: 5.0.1_gulp@4.0.2
+  https-proxy-agent: 2.2.4
   inherits: 2.0.4
-  is-buffer: 2.0.3
+  is-buffer: 2.0.4
   jssha: 2.3.1
   jws: 3.2.2
-  karma: 4.2.0
-  karma-chai: 0.1.0_chai@4.2.0+karma@4.2.0
+  karma: 4.4.1
+  karma-chai: 0.1.0_chai@4.2.0+karma@4.4.1
   karma-chrome-launcher: 3.1.0
   karma-cli: 2.0.0
   karma-coverage: 2.0.1
-  karma-edge-launcher: 0.4.2_karma@4.2.0
+  karma-edge-launcher: 0.4.2_karma@4.4.1
   karma-env-preprocessor: 0.1.1
   karma-firefox-launcher: 1.2.0
-  karma-ie-launcher: 1.0.0_karma@4.2.0
-  karma-json-preprocessor: 0.3.3_karma@4.2.0
+  karma-ie-launcher: 1.0.0_karma@4.4.1
+  karma-json-preprocessor: 0.3.3_karma@4.4.1
   karma-json-to-file-reporter: 1.0.1
-  karma-junit-reporter: 1.2.0_karma@4.2.0
+  karma-junit-reporter: 1.2.0_karma@4.4.1
   karma-mocha: 1.3.0
-  karma-mocha-reporter: 2.2.5_karma@4.2.0
+  karma-mocha-reporter: 2.2.5_karma@4.4.1
   karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
-  karma-requirejs: 1.1.0_karma@4.2.0+requirejs@2.3.6
-  karma-rollup-preprocessor: 7.0.2_rollup@1.20.1
+  karma-requirejs: 1.1.0_karma@4.4.1+requirejs@2.3.6
+  karma-rollup-preprocessor: 7.0.2_rollup@1.26.3
   karma-sourcemap-loader: 0.3.7
   karma-typescript-es6-transform: 4.1.1
-  karma-webpack: 4.0.2_webpack@4.39.2
+  karma-webpack: 4.0.2_webpack@4.41.2
   long: 4.0.0
   mocha: 6.2.2
-  mocha-chrome: 2.0.0
+  mocha-chrome: 2.2.0
   mocha-junit-reporter: 1.23.1_mocha@6.2.2
   mocha-multi: 1.1.3_mocha@6.2.2
   moment: 2.24.0
   msal: 1.1.3
-  nise: 1.5.1
-  nock: 11.3.2
+  nise: 1.5.2
+  nock: 11.7.0
   node-abort-controller: 1.0.4
   node-fetch: 2.6.0
   npm-run-all: 4.1.5
@@ -154,57 +152,57 @@ dependencies:
   process: 0.11.10
   promise: 8.0.3
   proxy-agent: 3.1.1
-  puppeteer: 1.19.0
-  qs: 6.8.0
+  puppeteer: 1.20.0
+  qs: 6.9.0
   query-string: 5.1.1
   regenerator-runtime: 0.13.3
   requirejs: 2.3.6
-  rhea: 1.0.8
+  rhea: 1.0.11
   rhea-promise: 0.1.15
   rimraf: 3.0.0
-  rollup: 1.20.1
-  rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
-  rollup-plugin-inject: 3.0.1
+  rollup: 1.26.3
+  rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
+  rollup-plugin-inject: 3.0.2
   rollup-plugin-json: 4.0.0
   rollup-plugin-local-resolve: 1.0.7
   rollup-plugin-multi-entry: 2.1.0
   rollup-plugin-node-globals: 1.4.0
-  rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+  rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
   rollup-plugin-replace: 2.2.0
   rollup-plugin-shim: 1.0.0
-  rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-  rollup-plugin-terser: 5.1.1_rollup@1.20.1
-  rollup-plugin-uglify: 6.0.2_rollup@1.20.1
-  rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
+  rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+  rollup-plugin-terser: 5.1.2_rollup@1.26.3
+  rollup-plugin-uglify: 6.0.3_rollup@1.26.3
+  rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
   semaphore: 1.1.0
   shx: 0.3.2
-  sinon: 7.4.1
+  sinon: 7.5.0
   snap-shot-it: 7.9.0
-  source-map-support: 0.5.13
+  source-map-support: 0.5.16
   stream-browserify: 2.0.2
-  terser: 4.2.0
+  terser: 4.3.9
   tough-cookie: 3.0.1
-  ts-loader: 6.0.4_typescript@3.5.3
+  ts-loader: 6.2.1_typescript@3.6.4
   ts-mocha: 6.0.0_mocha@6.2.2
-  ts-node: 8.3.0_typescript@3.5.3
+  ts-node: 8.4.1_typescript@3.6.4
   tslib: 1.10.0
-  tslint: 5.20.0_typescript@3.5.3
+  tslint: 5.20.0_typescript@3.6.4
   tslint-config-prettier: 1.18.0
   tunnel: 0.0.6
   typedoc: 0.15.0
-  typescript: 3.5.3
-  uglify-js: 3.6.0
+  typescript: 3.6.4
+  uglify-js: 3.6.7
   url: 0.11.0
   util: 0.12.1
   uuid: 3.3.3
-  webpack: 4.39.2_webpack@4.39.2
-  webpack-cli: 3.3.7_webpack@4.39.2
-  webpack-dev-middleware: 3.7.0_webpack@4.39.2
-  ws: 7.1.2
+  webpack: 4.41.2_webpack@4.41.2
+  webpack-cli: 3.3.10_webpack@4.41.2
+  webpack-dev-middleware: 3.7.2_webpack@4.41.2
+  ws: 7.2.0
   xhr-mock: 2.5.0
-  xml2js: 0.4.19
-  yargs: 14.0.0
-  yarn: 1.17.3
+  xml2js: 0.4.22
+  yargs: 14.2.0
+  yarn: 1.19.1
 lockfileVersion: 5.1
 packages:
   /@azure/abort-controller/1.0.0-preview.2:
@@ -222,7 +220,7 @@ packages:
       buffer: 5.4.3
       debug: 3.2.6
       events: 3.0.0
-      is-buffer: 2.0.3
+      is-buffer: 2.0.4
       jssha: 2.3.1
       process: 0.11.10
       rhea-promise: 0.1.15
@@ -243,40 +241,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-e0nNyP0O802YMb4jq0nsVduIBHRWtmX/AtiWMCDI1f0KtcEmNRPfbP8DxU6iNgwnV09qy3EfaRfSY0vMsYs5cg==
-  /@azure/core-amqp/1.0.0-preview.4_rhea-promise@1.0.0:
-    dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-auth': 1.0.0-preview.3
-      '@types/async-lock': 1.1.1
-      '@types/is-buffer': 2.0.0
-      async-lock: 1.2.2
-      buffer: 5.4.3
-      debug: 4.1.1
-      events: 3.0.0
-      is-buffer: 2.0.4
-      jssha: 2.3.1
-      process: 0.11.10
-      rhea-promise: 1.0.0
-      stream-browserify: 2.0.2
-      tslib: 1.10.0
-      url: 0.11.0
-      util: 0.12.1
-    dev: false
-    peerDependencies:
-      rhea-promise: ^1.0.0
-    resolution:
-      integrity: sha512-lfdU85JSq2nDbHukoO4bFavAktKjTIJY0ORkmFlxWokkH5o0FuGn619Yyyo8EgttFBn3h7SoeisnHZGP2J+x6g==
   /@azure/core-asynciterator-polyfill/1.0.0-preview.1:
     dev: false
     resolution:
       integrity: sha512-hMp0y+j/odkAyTa5TYewn4hUlFdEe3sR9uTd2Oq+se61RtuDsqM7UWrNNlyylPyjIENSZHJVWN7jte/jvvMN2Q==
-  /@azure/core-auth/1.0.0-preview.3:
-    dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      tslib: 1.10.0
-    dev: false
-    resolution:
-      integrity: sha512-SUG/ccOMGjPVUwKvwAW6r543bd66UOHu66N/jycr0hMVLI/46TuMZJIMjA2AN2+Gc+IrxSXQeJbN2VBFiJBWvA==
   /@azure/core-auth/1.0.0-preview.4:
     dependencies:
       '@azure/abort-controller': 1.0.0-preview.2
@@ -291,7 +259,7 @@ packages:
       '@azure/core-auth': 1.0.0-preview.4
       '@azure/core-tracing': 1.0.0-preview.5
       '@azure/logger': 1.0.0-preview.1
-      '@types/node-fetch': 2.5.2
+      '@types/node-fetch': 2.5.3
       '@types/tunnel': 0.0.1
       form-data: 2.5.1
       node-fetch: 2.6.0
@@ -304,34 +272,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-DoSAphAlzIFRZXvVxNtZYAWPpcT85GmYCKheDgF12cr/EDIlfH6g9+el6b+Knm8Cx4HSNlEbja8dWK1786jFKQ==
-  /@azure/core-lro/1.0.0-preview.1:
-    dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-http': 1.0.0-preview.6
-      events: 3.0.0
-      tslib: 1.10.0
-    dev: false
-    resolution:
-      integrity: sha512-EfiRp1WE1gK/i+iyIHy9Ick8BKrMkQvQRW8Y++vHR8aAG8rAWixmSUgZjJD0SzeL7T+m3BXzMqw1+pPyC2Wmow==
   /@azure/core-paging/1.0.0-preview.2:
     dependencies:
       '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
     dev: false
     resolution:
       integrity: sha512-D0oiOmg82AnhTT3xkIyTpEhCesHtlpV2rTVVlCQmQPbfzAWh8eBZp1QAgNQcBdF6uXZrp69znpXSnICmtfH23Q==
-  /@azure/core-tracing/1.0.0-preview.1:
-    dependencies:
-      tslib: 1.10.0
-    dev: false
-    resolution:
-      integrity: sha512-nDfxQopw7lfJG5N845BOS6Vcl84GcB1Q3BHKJAHghLOmdHQjV9Z92M4ziFAQ60UnOj2zrUefM6yDZcKjANCcyg==
-  /@azure/core-tracing/1.0.0-preview.4:
-    dependencies:
-      '@opencensus/web-types': 0.0.7
-      tslib: 1.10.0
-    dev: false
-    resolution:
-      integrity: sha512-xl6mAe1dqVxD1PH2Qnx/XFlblQcItG/lNUcPa1qp7+MrLKP4Wb7hoOK1mZfCkGKZZW4SGkRxwS9b+dR4R4x8Uw==
   /@azure/core-tracing/1.0.0-preview.5:
     dependencies:
       '@opencensus/web-types': 0.0.7
@@ -339,19 +285,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-i3hF4EQucZmn2l4zXscwG5bilnboKHtnLMFVuzXk55dt487/9EJ5uMOP3eyTFpULGjn6xubgYFAJVpUJGVQv4w==
-  /@azure/cosmos-sign/1.0.2:
+  /@azure/eslint-plugin-azure-sdk/2.0.1_47985cb813de276321a61b23c1c6de5b:
     dependencies:
-      crypto-js: 3.1.9-1
-    dev: false
-    resolution:
-      integrity: sha512-+y3EDcbSFuieOKqw9VyaX7D13LB4LycQIdmLwSqFnSUO0mWl+RBLCKW3RL6XiyWOHRV2sMNT9vwGzwiFZI70vQ==
-  /@azure/eslint-plugin-azure-sdk/2.0.1_9e8391ca70fb0408a9da4393803aa477:
-    dependencies:
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
-      eslint: 6.2.1
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
+      eslint: 6.6.0
       fast-levenshtein: 2.0.6
-      glob: 7.1.4
-      typescript: 3.6.3
+      glob: 7.1.5
+      typescript: 3.6.4
     dev: false
     engines:
       node: '>=8.0.0'
@@ -374,47 +314,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nGnFBPcB/rs+5YWwmHJg+d3Cs7BrjtVfuD1eEv8j+ui2X6uXxB88wom1A2t/7xsSzkunQSrXJ2mCwdHxKI5aHw==
-  /@azure/event-hubs/5.0.0-preview.5:
-    dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-amqp': 1.0.0-preview.4_rhea-promise@1.0.0
-      '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
-      '@azure/core-tracing': 1.0.0-preview.4
-      async-lock: 1.2.2
-      buffer: 5.4.3
-      debug: 4.1.1
-      is-buffer: 2.0.4
-      jssha: 2.3.1
-      process: 0.11.10
-      rhea-promise: 1.0.0
-      tslib: 1.10.0
-      uuid: 3.3.3
-    dev: false
-    resolution:
-      integrity: sha512-Dm9OYrILFisPyurarbKgWRigQ38N9ULaR0jBzjs1a/GfYUcQQbPzkx+RFXGWIdx8RaoEUC3XJ9MnlUYmQU3rZA==
-  /@azure/keyvault-keys/4.0.0-preview.9:
-    dependencies:
-      '@azure/core-http': 1.0.0-preview.6
-      '@azure/core-lro': 1.0.0-preview.1
-      '@azure/core-paging': 1.0.0-preview.2
-      '@azure/core-tracing': 1.0.0-preview.5
-      '@azure/logger': 1.0.0-preview.1
-      tslib: 1.10.0
-    dev: false
-    resolution:
-      integrity: sha512-5t00Ny/mIw5wk/zJWfD62L/9XtXwFlhKa0NvHqyazFCUyA28WJWhtZEXUEYPvi6hnVTRwgev4sLkhQLDp2JfYQ==
-  /@azure/keyvault-secrets/4.0.0-preview.9:
-    dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-http': 1.0.0-preview.6
-      '@azure/core-lro': 1.0.0-preview.1
-      '@azure/core-paging': 1.0.0-preview.2
-      '@azure/core-tracing': 1.0.0-preview.5
-      '@azure/logger': 1.0.0-preview.1
-      tslib: 1.10.0
-    dev: false
-    resolution:
-      integrity: sha512-1edsYF1janNJpetcqBOgkvb12o/tt8RP4sZV14ILfyoFor2I1ez8nH8iG143rT+hchQU5EtyD2Y9dWNu68UajQ==
   /@azure/logger-js/1.3.2:
     dependencies:
       tslib: 1.10.0
@@ -442,30 +341,15 @@ packages:
     dependencies:
       '@types/tunnel': 0.0.0
       axios: 0.19.0
-      form-data: 2.5.0
+      form-data: 2.5.1
       tough-cookie: 2.5.0
       tslib: 1.10.0
       tunnel: 0.0.6
       uuid: 3.3.3
-      xml2js: 0.4.19
+      xml2js: 0.4.22
     dev: false
     resolution:
       integrity: sha512-jAa6Y2XrvwbEqkaEXDHK+ReNo0WnCPS+LgQ1dRAJUUNxK4CghF5u+SXsVtPENritilVE7FVteqsLOtlhTk+haA==
-  /@azure/ms-rest-js/2.0.4:
-    dependencies:
-      '@types/node-fetch': 2.5.0
-      '@types/tunnel': 0.0.1
-      abort-controller: 3.0.0
-      form-data: 2.5.0
-      node-fetch: 2.6.0
-      tough-cookie: 3.0.1
-      tslib: 1.10.0
-      tunnel: 0.0.6
-      uuid: 3.3.3
-      xml2js: 0.4.19
-    dev: false
-    resolution:
-      integrity: sha512-nSOPt6st0RtxclYBQV65qXZpvMDqiDQssktvB/SMTAJ5bIytSPtBmlttTTigO5qHvwQcfzzpQE0sMceK+dJ/IQ==
   /@azure/ms-rest-nodeauth/0.9.3:
     dependencies:
       '@azure/ms-rest-azure-env': 1.1.2
@@ -491,33 +375,32 @@ packages:
     dev: false
     resolution:
       integrity: sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
-  /@babel/generator/7.5.5:
+  /@babel/generator/7.6.4:
     dependencies:
-      '@babel/types': 7.5.5
+      '@babel/types': 7.6.3
       jsesc: 2.5.2
       lodash: 4.17.15
       source-map: 0.5.7
-      trim-right: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==
+      integrity: sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
   /@babel/helper-function-name/7.1.0:
     dependencies:
       '@babel/helper-get-function-arity': 7.0.0
-      '@babel/template': 7.4.4
-      '@babel/types': 7.5.5
+      '@babel/template': 7.6.0
+      '@babel/types': 7.6.3
     dev: false
     resolution:
       integrity: sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
   /@babel/helper-get-function-arity/7.0.0:
     dependencies:
-      '@babel/types': 7.5.5
+      '@babel/types': 7.6.3
     dev: false
     resolution:
       integrity: sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   /@babel/helper-split-export-declaration/7.4.4:
     dependencies:
-      '@babel/types': 7.5.5
+      '@babel/types': 7.6.3
     dev: false
     resolution:
       integrity: sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
@@ -529,43 +412,43 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
-  /@babel/parser/7.5.5:
+  /@babel/parser/7.6.4:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
-  /@babel/template/7.4.4:
+      integrity: sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
+  /@babel/template/7.6.0:
     dependencies:
       '@babel/code-frame': 7.5.5
-      '@babel/parser': 7.5.5
-      '@babel/types': 7.5.5
+      '@babel/parser': 7.6.4
+      '@babel/types': 7.6.3
     dev: false
     resolution:
-      integrity: sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==
-  /@babel/traverse/7.5.5:
+      integrity: sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==
+  /@babel/traverse/7.6.3:
     dependencies:
       '@babel/code-frame': 7.5.5
-      '@babel/generator': 7.5.5
+      '@babel/generator': 7.6.4
       '@babel/helper-function-name': 7.1.0
       '@babel/helper-split-export-declaration': 7.4.4
-      '@babel/parser': 7.5.5
-      '@babel/types': 7.5.5
+      '@babel/parser': 7.6.4
+      '@babel/types': 7.6.3
       debug: 4.1.1
       globals: 11.12.0
       lodash: 4.17.15
     dev: false
     resolution:
-      integrity: sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==
-  /@babel/types/7.5.5:
+      integrity: sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
+  /@babel/types/7.6.3:
     dependencies:
       esutils: 2.0.3
       lodash: 4.17.15
       to-fast-properties: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+      integrity: sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
   /@bahmutov/data-driven/1.0.0:
     dependencies:
       check-more-types: 2.24.0
@@ -575,29 +458,6 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==
-  /@microsoft/api-extractor-model/7.3.2:
-    dependencies:
-      '@microsoft/node-core-library': 3.14.0
-      '@microsoft/tsdoc': 0.12.12
-      '@types/node': 8.5.8
-    dev: false
-    resolution:
-      integrity: sha512-2yNbQsQl5PI36l5WzHQshwjBHPe5IeIcmidWad0E+wjyaAxGMLx5pBp5AgXY2JG9S9VQjFmmGmqJJBXn8tzu+w==
-  /@microsoft/api-extractor-model/7.3.4:
-    dependencies:
-      '@microsoft/node-core-library': 3.14.1
-      '@microsoft/tsdoc': 0.12.14
-      '@types/node': 8.5.8
-    dev: false
-    resolution:
-      integrity: sha512-a9gXhWG7PWcUNpJRtxGZ/Vepq1ke5ES2B6NnBH0M3zT//vGYXymf7aOQepCHfmY4p1cJvvmJoJNGMwtoC0eF5A==
-  /@microsoft/api-extractor-model/7.5.1:
-    dependencies:
-      '@microsoft/node-core-library': 3.15.1
-      '@microsoft/tsdoc': 0.12.14
-    dev: false
-    resolution:
-      integrity: sha512-qzgmJeoqpJqYDS1yj9YTPdd/+9OWGFwfzGFyr6kVarexomdPSltcoQYIS5JnrB/RFNeUgTNUlwn5mYdyp2Xv6A==
   /@microsoft/api-extractor-model/7.5.2:
     dependencies:
       '@microsoft/node-core-library': 3.16.0
@@ -605,51 +465,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-wDXQ6IvrVg7tp3iqA+7f7yrSzjUPQ2kVNKsrxD5AqbGeohsJYePbmWvz6V8yxxO7ZuM9W7V5zLY6pYh4epq8Dg==
-  /@microsoft/api-extractor/7.3.11:
-    dependencies:
-      '@microsoft/api-extractor-model': 7.3.4
-      '@microsoft/node-core-library': 3.14.1
-      '@microsoft/ts-command-line': 4.2.7
-      '@microsoft/tsdoc': 0.12.14
-      colors: 1.2.5
-      lodash: 4.17.15
-      resolve: 1.8.1
-      source-map: 0.6.1
-      typescript: 3.5.3
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-i/hBovsbk1btBIQFWHHbAQdcXxL07+nYwF6wxDabtM+rJgySQ/flsjZJYXJV+ADlP0L3jyKdWZNF03M3zlQUlw==
-  /@microsoft/api-extractor/7.3.8:
-    dependencies:
-      '@microsoft/api-extractor-model': 7.3.2
-      '@microsoft/node-core-library': 3.14.0
-      '@microsoft/ts-command-line': 4.2.7
-      '@microsoft/tsdoc': 0.12.12
-      colors: 1.2.5
-      lodash: 4.17.15
-      resolve: 1.8.1
-      source-map: 0.6.1
-      typescript: 3.5.3
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-zw3HWmPW9vWWIoI3SPb2tuJ2suXVoF9ty37Mww+00I4gKLPPDooVad1kBiNtdjHXBj0QwYAOsGcfoBN9Qgt2bw==
-  /@microsoft/api-extractor/7.5.0:
-    dependencies:
-      '@microsoft/api-extractor-model': 7.5.1
-      '@microsoft/node-core-library': 3.15.1
-      '@microsoft/ts-command-line': 4.3.2
-      '@microsoft/tsdoc': 0.12.14
-      colors: 1.2.5
-      lodash: 4.17.15
-      resolve: 1.8.1
-      source-map: 0.6.1
-      typescript: 3.5.3
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-CxKNZFD9TRo/y8MQzlk4z/Z5jPCaQsDq7ON9baE544CKnmF4sNlmoS9ydkt0As3v6OYKjp50d2N4NAmZoOVXzg==
   /@microsoft/api-extractor/7.5.2:
     dependencies:
       '@microsoft/api-extractor-model': 7.5.2
@@ -665,42 +480,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-IGMpxhiTaUsGGdrGqCwhwGbyJNMwrVe0wi3vYqFL0G93N+DO2uI89/JNGxaiGjgQ8nCem6u8hPd0NhOcGU6DcA==
-  /@microsoft/node-core-library/3.14.0:
-    dependencies:
-      '@types/fs-extra': 5.0.4
-      '@types/jju': 1.4.1
-      '@types/node': 8.5.8
-      '@types/z-schema': 3.16.31
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      jju: 1.4.0
-      z-schema: 3.18.4
-    dev: false
-    resolution:
-      integrity: sha512-+gbTXTRfvR40hTH+C3Vno/RJ51sU/RZAyHb2bo9af8GCdOgxCxCs+qp2KCXklbpuolmIPFfbCmdTwv90yH5tJw==
-  /@microsoft/node-core-library/3.14.1:
-    dependencies:
-      '@types/fs-extra': 5.0.4
-      '@types/jju': 1.4.1
-      '@types/node': 8.5.8
-      '@types/z-schema': 3.16.31
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      jju: 1.4.0
-      z-schema: 3.18.4
-    dev: false
-    resolution:
-      integrity: sha512-KVYef9kjK6lmGOOjYRctYFX3ymZ71xobweBftwP8hQS5JTBX+QqpAOvfiFQmlMgfJ7/TS7u3u3QjVzeztuz5cg==
-  /@microsoft/node-core-library/3.15.1:
-    dependencies:
-      '@types/node': 8.10.54
-      colors: 1.2.5
-      fs-extra: 7.0.1
-      jju: 1.4.0
-      z-schema: 3.18.4
-    dev: false
-    resolution:
-      integrity: sha512-fUrcgu+w40k2GW8fiOUFby7jaKAAuDKaTrQuFQ3j+0Pg3ANnJ2uKtVf3bgFiNu+uVKpwVtLo4CPS8TwFduJRow==
   /@microsoft/node-core-library/3.16.0:
     dependencies:
       '@types/node': 8.10.54
@@ -711,23 +490,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-zjgOAmOhWgE5eX8ofmRagcomeIhs96GizRm7m9UfAuzhEmWtQSOE33/WpZzoyw41S/bjevHi7YbkY+R70mdjFg==
-  /@microsoft/ts-command-line/4.2.7:
-    dependencies:
-      '@types/argparse': 1.0.33
-      '@types/node': 8.5.8
-      argparse: 1.0.10
-      colors: 1.2.5
-    dev: false
-    resolution:
-      integrity: sha512-PwUMIIDl8oWyl64Y5DW5FAuoRk4KWTBZdk4FEh366KEm5xYFBQhCeatHGURIj8nEYm0Xb2coCrXF77dGDlp/Qw==
-  /@microsoft/ts-command-line/4.3.2:
-    dependencies:
-      '@types/argparse': 1.0.33
-      argparse: 1.0.10
-      colors: 1.2.5
-    dev: false
-    resolution:
-      integrity: sha512-2QeyilabCe6IpBylPXuY6dCA1S9ym3Ii0zakXVPpyfjSj1NesnyuUeuh6e8kyIqzqJ+3LYjfPG63XzUBtwGqqw==
   /@microsoft/ts-command-line/4.3.4:
     dependencies:
       '@types/argparse': 1.0.33
@@ -736,10 +498,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-PNqh7tACiOaM3znLX2EjECbabk0PfChEn6lMzrC62+xtV2Xr0N0dj1PtvDX125cxxF4FNcWoZqCODzJI/cB0GA==
-  /@microsoft/tsdoc/0.12.12:
-    dev: false
-    resolution:
-      integrity: sha512-5EzH1gHIonvvgA/xWRmVAJmRkTQj/yayUXyr66hFwNZiFE4j7lP8is9YQeXhwxGZEjO1PVMblAmFF0CyjNtPGw==
   /@microsoft/tsdoc/0.12.14:
     dev: false
     resolution:
@@ -756,13 +514,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
-  /@sinonjs/formatio/3.2.1:
-    dependencies:
-      '@sinonjs/commons': 1.6.0
-      '@sinonjs/samsam': 3.3.3
-    dev: false
-    resolution:
-      integrity: sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==
   /@sinonjs/formatio/3.2.2:
     dependencies:
       '@sinonjs/commons': 1.6.0
@@ -794,44 +545,36 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TU1X8jmAU2BjwKryBFV/GDezz7Ge0xu9ZuYC7dy6wKj4hnL0JcxeseCOr/G2JkGylff6hdUBrR+Ee5ApAQeU5g==
-  /@types/bluebird/3.5.27:
+  /@types/bluebird/3.5.28:
     dev: false
     resolution:
-      integrity: sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==
+      integrity: sha512-0Vk/kqkukxPKSzP9c8WJgisgGDx5oZDbsLLWIP5t70yThO/YleE+GEm2S1GlRALTaack3O7U5OS5qEm7q2kciA==
   /@types/body-parser/1.17.1:
     dependencies:
       '@types/connect': 3.4.32
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==
   /@types/chai-as-promised/7.1.2:
     dependencies:
-      '@types/chai': 4.2.0
+      '@types/chai': 4.2.4
     dev: false
     resolution:
       integrity: sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==
   /@types/chai-string/1.4.2:
     dependencies:
-      '@types/chai': 4.2.0
+      '@types/chai': 4.2.4
     dev: false
     resolution:
       integrity: sha512-ld/1hV5qcPRGuwlPdvRfvM3Ka/iofOk2pH4VkasK4b1JJP1LjNmWWn0LsISf6RRzyhVOvs93rb9tM09e+UuF8Q==
-  /@types/chai/4.2.0:
+  /@types/chai/4.2.4:
     dev: false
     resolution:
-      integrity: sha512-zw8UvoBEImn392tLjxoavuonblX/4Yb9ha4KBU10FirCfwgzhKO0dvyJSF9ByxV1xK1r2AgnAi/tvQaLgxQqxA==
-  /@types/chai/4.2.1:
-    dev: false
-    resolution:
-      integrity: sha512-LDKlQW/V8bQr5p9aoHye9p7x9faxq0GVeWAkn/Zgyyn848LIAzuR1sHQjGmUBFUpINuGWDG2NTM/ofA2aLMIew==
-  /@types/chai/4.2.3:
-    dev: false
-    resolution:
-      integrity: sha512-VRw2xEGbll3ZiTQ4J02/hUjNqZoue1bMhoo2dgM2LXjDdyaq4q80HgBDHwpI0/VKlo4Eg+BavyQMv/NYgTetzA==
+      integrity: sha512-7qvf9F9tMTzo0akeswHPGqgUx/gIaJqrOEET/FCD8CFRkSUHlygQiM5yB6OvjrtdxBVLSyw7COJubsFYs0683g==
   /@types/connect/3.4.32:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
@@ -841,7 +584,7 @@ packages:
       integrity: sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
   /@types/dotenv/6.1.1:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-ftQl3DtBvqHl9L16tpqqzA4YzCSXZfi7g8cQceTz5rOlYtk/IZbFjAv3mLOQlNIgOaylCQWQoBdDQHPgEBJPHg==
@@ -859,25 +602,25 @@ packages:
       integrity: sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
   /@types/execa/0.9.0:
     dependencies:
-      '@types/node': 8.10.55
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==
-  /@types/express-serve-static-core/4.16.9:
+  /@types/express-serve-static-core/4.16.11:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/range-parser': 1.2.3
     dev: false
     resolution:
-      integrity: sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==
-  /@types/express/4.17.1:
+      integrity: sha512-K8d2M5t3tBQimkyaYTXxtHYyoJPUEhy2/omVRnTAKw5FEdT+Ft6lTaTOpoJdHeG+mIwQXXtqiTcYZ6IR8LTzjQ==
+  /@types/express/4.17.2:
     dependencies:
       '@types/body-parser': 1.17.1
-      '@types/express-serve-static-core': 4.16.9
+      '@types/express-serve-static-core': 4.16.11
       '@types/serve-static': 1.13.3
     dev: false
     resolution:
-      integrity: sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==
+      integrity: sha512-5mHFNyavtLoJmnusB8OKJ5bshSzw+qkMIBAobLrIM48HJvunFva9mOa6aBwh64lBFyNwBbs0xiEFuj4eU/NjCA==
   /@types/fast-json-stable-stringify/2.0.0:
     dev: false
     resolution:
@@ -886,21 +629,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2U4vZWHNbsbK7TRmizgr/pbKe0FKopcxu+hNDtIBDiM1wvrKRItybaYj7VQ6w/hZJStU/JxRiNi5ww4YDEvKbA==
-  /@types/fs-extra/5.0.4:
-    dependencies:
-      '@types/node': 8.10.53
-    dev: false
-    resolution:
-      integrity: sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==
-  /@types/fs-extra/8.0.0:
-    dependencies:
-      '@types/node': 8.10.52
-    dev: false
-    resolution:
-      integrity: sha512-bCtL5v9zdbQW86yexOlXWTEGvLNqWxMFyi7gQA7Gcthbezr2cPSOb8SkESVKA937QD5cIwOFLDFt0MQoXOEr9Q==
   /@types/fs-extra/8.0.1:
     dependencies:
-      '@types/node': 8.10.56
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==
@@ -908,20 +639,16 @@ packages:
     dependencies:
       '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
   /@types/is-buffer/2.0.0:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==
-  /@types/jju/1.4.1:
-    dev: false
-    resolution:
-      integrity: sha512-LFt+YA7Lv2IZROMwokZKiPNORAV5N3huMs3IKnzlE430HWhWYZ8b+78HiwJXJJP1V2IEjinyJURuRJfGoaFSIA==
   /@types/json-schema/7.0.3:
     dev: false
     resolution:
@@ -937,14 +664,14 @@ packages:
       integrity: sha512-oBnY3csYnXfqZXDRBJwP1nDDJCW/+VMJ88UHT4DCy0deSXpJIQvMCwYlnmdW4M+u7PiSfQc44LmiFcUbJ8hLEw==
   /@types/jws/3.2.0:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-2s6isKtNTfbfeP/VtvdB9JXE1LkFXndO2AjQ2f+nvTqwL8bxK1s9qxmymwklCpNthJG16dwvpsBjKE14Yc/pbA==
   /@types/karma/3.0.3:
     dependencies:
-      '@types/bluebird': 3.5.27
-      '@types/node': 8.10.52
+      '@types/bluebird': 3.5.28
+      '@types/node': 8.10.58
       log4js: 3.0.6
     dev: false
     resolution:
@@ -955,7 +682,7 @@ packages:
       integrity: sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
   /@types/memory-fs/0.3.2:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-j5AcZo7dbMxHoOimcHEIh0JZe5e1b8q8AqGSpZJrYc7xOgCIP79cIjTdx5jSDLtySnQDwkDTqwlC7Xw7uXw7qg==
@@ -977,58 +704,24 @@ packages:
       integrity: sha512-DPxmjiDwubsNmguG5X4fEJ+XCyzWM3GXWsqQlvUcjJKa91IOoJUy51meDr0GkzK64qqNcq85ymLlyjoct9tInw==
   /@types/nock/10.0.3:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-OthuN+2FuzfZO3yONJ/QVjKmLEuRagS9TV9lEId+WHL9KhftYG+/2z+pxlr0UgVVXSpVD8woie/3fzQn8ft/Ow==
-  /@types/node-fetch/2.5.0:
-    dependencies:
-      '@types/node': 8.10.52
-    dev: false
-    resolution:
-      integrity: sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==
-  /@types/node-fetch/2.5.2:
+  /@types/node-fetch/2.5.3:
     dependencies:
       '@types/node': 8.10.58
     dev: false
     resolution:
-      integrity: sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==
-  /@types/node/12.7.2:
-    dev: false
-    resolution:
-      integrity: sha512-dyYO+f6ihZEtNPDcWNR1fkoTDf3zAK3lAABDze3mz6POyIercH0lEUawUFXlG8xaQZmm1yEBON/4TsYv/laDYg==
-  /@types/node/12.7.4:
-    dev: false
-    resolution:
-      integrity: sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==
-  /@types/node/8.10.52:
-    dev: false
-    resolution:
-      integrity: sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw==
-  /@types/node/8.10.53:
-    dev: false
-    resolution:
-      integrity: sha512-aOmXdv1a1/vYUn1OT1CED8ftbkmmYbKhKGSyMDeJiidLvKRKvZUQOdXwG/wcNY7T1Qb0XTlVdiYjIq00U7pLrQ==
+      integrity: sha512-X3TNlzZ7SuSwZsMkb5fV7GrPbVKvHc2iwHmslb8bIxRKWg2iqkfm3F/Wd79RhDpOXR7wCtKAwc5Y2JE6n/ibyw==
   /@types/node/8.10.54:
     dev: false
     resolution:
       integrity: sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==
-  /@types/node/8.10.55:
-    dev: false
-    resolution:
-      integrity: sha512-iZeh1EgupfmAAOASk580R1SL5lWF3CsBVgVH0395qyNF8fhO16xy1UwAav2PdGxIIsYRn7RzJgMGjdsvam6YYg==
-  /@types/node/8.10.56:
-    dev: false
-    resolution:
-      integrity: sha512-5yWs9hy3UWdandOgvmmPCNJ3jI5/o8syatQWOmiAO/9/PptOQ+0O2ANKHltFhE4MGCt/QiVkoxQFUbeha9Yf4w==
   /@types/node/8.10.58:
     dev: false
     resolution:
       integrity: sha512-NNcUk/rAdR7Pie7WiA5NHp345dTkD62qaxqscQXVIjCjog/ZXsrG8Wo7dZMZAzE7PSpA+qR2S3TYTeFCKuBFxQ==
-  /@types/node/8.5.8:
-    dev: false
-    resolution:
-      integrity: sha512-8KmlRxwbKZfjUHFIt3q8TF5S2B+/E5BaAoo/3mgc5h6FJzqxXkCK/VMetO+IRDtwtU6HUvovHMBn+XRj7SV9Qg==
   /@types/priorityqueuejs/1.0.1:
     dev: false
     resolution:
@@ -1047,7 +740,7 @@ packages:
       integrity: sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
@@ -1055,21 +748,17 @@ packages:
     dev: false
     resolution:
       integrity: sha512-YD+lyrPhrsJdSOaxmA9K1lzsCoN0J29IsQGMKd67SbkPDXxJPdwdqpok1sytD19NEozUaFpjIsKOWnJDOYO/GA==
-  /@types/semver/5.5.0:
-    dev: false
-    resolution:
-      integrity: sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==
   /@types/serve-static/1.13.3:
     dependencies:
-      '@types/express-serve-static-core': 4.16.9
+      '@types/express-serve-static-core': 4.16.11
       '@types/mime': 2.0.1
     dev: false
     resolution:
       integrity: sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==
-  /@types/sinon/7.0.13:
+  /@types/sinon/7.5.0:
     dev: false
     resolution:
-      integrity: sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==
+      integrity: sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==
   /@types/source-list-map/0.1.2:
     dev: false
     resolution:
@@ -1084,13 +773,13 @@ packages:
       integrity: sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==
   /@types/tunnel/0.0.0:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==
   /@types/tunnel/0.0.1:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
@@ -1100,77 +789,73 @@ packages:
     dev: false
     resolution:
       integrity: sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
-  /@types/underscore/1.9.2:
+  /@types/underscore/1.9.3:
     dev: false
     resolution:
-      integrity: sha512-KgOKTAD+9X+qvZnB5S1+onqKc4E+PZ+T6CM/NA5ohRPLHJXb+yCJMVf8pWOnvuBuKFNUAJW8N97IA6lba6mZGg==
-  /@types/uuid/3.4.5:
+      integrity: sha512-SwbHKB2DPIDlvYqtK5O+0LFtZAyrUSw4c0q+HWwmH1Ve3KMQ0/5PlV3RX97+3dP7yMrnNQ8/bCWWvQpPl03Mug==
+  /@types/uuid/3.4.6:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
-      integrity: sha512-MNL15wC3EKyw1VLF+RoVO4hJJdk9t/Hlv3rt1OL65Qvuadm4BYo6g9ZJQqoq7X8NBFSsQXgAujWciovh2lpVjA==
+      integrity: sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==
   /@types/webpack-dev-middleware/2.0.3:
     dependencies:
       '@types/connect': 3.4.32
       '@types/memory-fs': 0.3.2
-      '@types/webpack': 4.39.0
-      loglevel: 1.6.3
+      '@types/webpack': 4.39.8
+      loglevel: 1.6.4
     dev: false
     resolution:
       integrity: sha512-DzNJJ6ah/6t1n8sfAgQyEbZ/OMmFcF9j9P3aesnm7G6/iBFR/qiGin8K89J0RmaWIBzhTMdDg3I5PmKmSv7N9w==
   /@types/webpack-sources/0.1.5:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/source-list-map': 0.1.2
       source-map: 0.6.1
     dev: false
     resolution:
       integrity: sha512-zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==
-  /@types/webpack/4.39.0:
+  /@types/webpack/4.39.8:
     dependencies:
       '@types/anymatch': 1.3.1
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/tapable': 1.0.4
       '@types/uglify-js': 3.0.4
       '@types/webpack-sources': 0.1.5
       source-map: 0.6.1
     dev: false
     resolution:
-      integrity: sha512-8gUiAl6RBI4IoCJVQ9AChp4k2Tcd4ocNei2S83goHKCj8WesBtlqp9/wPd29dArHIGMdHxICwBi8YMm8PD6PEg==
+      integrity: sha512-lkJvwNJQUPW2SbVwAZW9s9whJp02nzLf2yTNwMULa4LloED9MYS1aNnGeoBCifpAI1pEBkTpLhuyRmBnLEOZAA==
   /@types/ws/6.0.3:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
       integrity: sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==
-  /@types/xml2js/0.4.4:
+  /@types/xml2js/0.4.5:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
     dev: false
     resolution:
-      integrity: sha512-O6Xgai01b9PB3IGA0lRIp1Ex3JBcxGDhdO0n3NIIpCyDOAjxcIGQFmkvgJpP8anTrthxOUQjBfLdRRi0Zn/TXA==
-  /@types/yargs-parser/13.0.0:
+      integrity: sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==
+  /@types/yargs-parser/13.1.0:
     dev: false
     resolution:
-      integrity: sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==
-  /@types/yargs/13.0.2:
+      integrity: sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==
+  /@types/yargs/13.0.3:
     dependencies:
-      '@types/yargs-parser': 13.0.0
+      '@types/yargs-parser': 13.1.0
     dev: false
     resolution:
-      integrity: sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
-  /@types/z-schema/3.16.31:
-    dev: false
-    resolution:
-      integrity: sha1-LrHQCl5Ow/pYx2r94S4YK2bcXBw=
-  /@typescript-eslint/eslint-plugin-tslint/2.3.0_b840da7ae58bd563f8e3899e03f6a2da:
+      integrity: sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==
+  /@typescript-eslint/eslint-plugin-tslint/2.3.3_b440fbe82fef3b179d75a1e01e8e53ff:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.3.0_eslint@6.2.1
-      eslint: 6.2.1
+      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.6.0
+      eslint: 6.6.0
       lodash.memoize: 4.1.2
-      tslint: 5.20.0_typescript@3.5.3
-      typescript: 3.5.3
+      tslint: 5.20.0_typescript@3.6.4
+      typescript: 3.6.4
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -1179,83 +864,11 @@ packages:
       tslint: ^5.0.0
       typescript: '*'
     resolution:
-      integrity: sha512-dhkJtS40dkjPcYlTMNWRMsjz6zOTeT8ZTyNeNZqibc3HfD51LoPj6oYVWrngc4aVCzw/FabEZVu+gRKg+lvlDg==
-  /@typescript-eslint/eslint-plugin/2.0.0_3cafee28902d96627d4743e014bc28ff:
+      integrity: sha512-zJCrQLrwakkYyMaCySW8I35gl2StOc3xJ0LqhhHXkRTWsFtMYLD92HhFcJyW2zpOQYi+rJXhTE5rrXXV75Rlew==
+  /@typescript-eslint/eslint-plugin/2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.2.1
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
-      eslint: 6.2.1
-      eslint-utils: 1.4.2
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.5.3
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0-alpha.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-Mo45nxTTELODdl7CgpZKJISvLb+Fu64OOO2ZFc2x8sYSnUpFrBUW3H+H/ZGYmEkfnL6VkdtOSxgdt+Av79j0sA==
-  /@typescript-eslint/eslint-plugin/2.1.0_3a8cea979a77aa77c321dad4153067ce:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.1.0_eslint@6.3.0
-      '@typescript-eslint/parser': 2.1.0_eslint@6.3.0
-      eslint: 6.3.0
-      eslint-utils: 1.4.2
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.6.2
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-3i/dLPwxaVfCsaLu3HkB8CAA1Uw3McAegrTs+VBJ0BrGRKW7nUwSqRfHfCS7sw7zSbf62q3v0v6pOS8MyaYItg==
-  /@typescript-eslint/eslint-plugin/2.3.3_ac2af3c58153fd08c91227fd925d839a:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
-      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
-      eslint: 6.5.1
-      eslint-utils: 1.4.2
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.6.4
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-12cCbwu5PbQudkq2xCIS/QhB7hCMrsNPXK+vJtqy/zFqtzVkPRGy12O5Yy0gUK086f3VHV/P4a4R4CjMW853pA==
-  /@typescript-eslint/eslint-plugin/2.4.0_4828c2c2dec21a69cf7db8f78e46e2d1:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.4.0_eslint@6.5.1
-      '@typescript-eslint/parser': 2.4.0_eslint@6.5.1
-      eslint: 6.5.1
-      eslint-utils: 1.4.2
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.6.4
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    resolution:
-      integrity: sha512-se/YCk7PUoyMwSm/u3Ii9E+BgDUc736uw/lXCDpXEqRgPGsoBTtS8Mntue/vZX8EGyzGplYuePBuVyhZDM9EpQ==
-  /@typescript-eslint/eslint-plugin/2.5.0_0889f7972d3c13f808589e80f38ca335:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.5.0_eslint@6.6.0
-      '@typescript-eslint/parser': 2.5.0_eslint@6.6.0
+      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.6.0+typescript@3.6.4
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       eslint: 6.6.0
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
@@ -1272,73 +885,12 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-ddrJZxp5ns1Lh5ofZQYk3P8RyvKfyz/VcRR4ZiJLHO/ljnQAO8YvTfj268+WJOOadn99mvDiqJA65+HAKoeSPA==
-  /@typescript-eslint/eslint-plugin/2.5.0_9532ddc6a515f233700227c4e2ab0e1c:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 2.5.0_eslint@6.5.1
-      '@typescript-eslint/parser': 2.5.0_eslint@6.5.1
-      eslint: 6.5.1
-      eslint-utils: 1.4.3
-      functional-red-black-tree: 1.0.1
-      regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.6.4
-      typescript: 3.6.4
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      '@typescript-eslint/parser': ^2.0.0
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-ddrJZxp5ns1Lh5ofZQYk3P8RyvKfyz/VcRR4ZiJLHO/ljnQAO8YvTfj268+WJOOadn99mvDiqJA65+HAKoeSPA==
-  /@typescript-eslint/experimental-utils/2.0.0_eslint@6.2.1:
-    dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.0.0
-      eslint: 6.2.1
-      eslint-scope: 4.0.3
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: '*'
-    resolution:
-      integrity: sha512-XGJG6GNBXIEx/mN4eTRypN/EUmsd0VhVGQ1AG+WTgdvjHl0G8vHhVBHrd/5oI6RRYBRnedNymSYWW1HAdivtmg==
-  /@typescript-eslint/experimental-utils/2.1.0_eslint@6.3.0:
-    dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.1.0
-      eslint: 6.3.0
-      eslint-scope: 4.0.3
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: '*'
-    resolution:
-      integrity: sha512-ZJGLYXa4nxjNzomaEk1qts38B/vludg2LOM7dRc7SppEKsMPTS1swaTKS/pom+x4d/luJGoG00BDIss7PR1NQA==
-  /@typescript-eslint/experimental-utils/2.3.0_eslint@6.2.1:
-    dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.3.0
-      eslint: 6.2.1
-      eslint-scope: 5.0.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: '*'
-    resolution:
-      integrity: sha512-ry+fgd0Hh33LyzS30bIhX/a1HJpvtnecjQjWxxsZTavrRa1ymdmX7tz+7lPrPAxB018jnNzwNtog6s3OhxPTAg==
-  /@typescript-eslint/experimental-utils/2.3.3_eslint@6.5.1:
+      integrity: sha512-Z0rddsGqioKbvqfohg7BwkFC3PuNLsB+GE9QkFza7tiDzuHoy0y823Y+oGNDzxNZrYyLjqkZtCTl4vCqOmEN4g==
+  /@typescript-eslint/experimental-utils/2.3.3_eslint@6.6.0:
     dependencies:
       '@types/json-schema': 7.0.3
       '@typescript-eslint/typescript-estree': 2.3.3
-      eslint: 6.5.1
+      eslint: 6.6.0
       eslint-scope: 5.0.0
     dev: false
     engines:
@@ -1347,36 +899,10 @@ packages:
       eslint: '*'
     resolution:
       integrity: sha512-MQ4jKPMTU1ty4TigJCRKFPye2qyQdH8jzIIkceaHgecKFmkNS1hXPqKiZ+mOehkz6+HcN5Nuvwm+frmWZR9tdg==
-  /@typescript-eslint/experimental-utils/2.4.0_eslint@6.5.1:
+  /@typescript-eslint/experimental-utils/2.6.1_eslint@6.6.0+typescript@3.6.4:
     dependencies:
       '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.4.0
-      eslint: 6.5.1
-      eslint-scope: 5.0.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: '*'
-    resolution:
-      integrity: sha512-2cvhNaJoWavgTtnC7e1jUSPZQ7e4U2X9Yoy5sQmkS7lTESuyuZrlRcaoNuFfYEd6hgrmMU7+QoSp8Ad+kT1nfA==
-  /@typescript-eslint/experimental-utils/2.5.0_eslint@6.5.1:
-    dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.5.0
-      eslint: 6.5.1
-      eslint-scope: 5.0.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: '*'
-    resolution:
-      integrity: sha512-UgcQGE0GKJVChyRuN1CWqDW8Pnu7+mVst0aWrhiyuUD1J9c+h8woBdT4XddCvhcXDodTDVIfE3DzGHVjp7tUeQ==
-  /@typescript-eslint/experimental-utils/2.5.0_eslint@6.6.0:
-    dependencies:
-      '@types/json-schema': 7.0.3
-      '@typescript-eslint/typescript-estree': 2.5.0
+      '@typescript-eslint/typescript-estree': 2.6.1_typescript@3.6.4
       eslint: 6.6.0
       eslint-scope: 5.0.0
     dev: false
@@ -1384,83 +910,14 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
       eslint: '*'
+      typescript: '*'
     resolution:
-      integrity: sha512-UgcQGE0GKJVChyRuN1CWqDW8Pnu7+mVst0aWrhiyuUD1J9c+h8woBdT4XddCvhcXDodTDVIfE3DzGHVjp7tUeQ==
-  /@typescript-eslint/parser/2.0.0_eslint@6.2.1:
+      integrity: sha512-EVrrUhl5yBt7fC7c62lWmriq4MIc49zpN3JmrKqfiFXPXCM5ErfEcZYfKOhZXkW6MBjFcJ5kGZqu1b+lyyExUw==
+  /@typescript-eslint/parser/2.6.1_eslint@6.6.0+typescript@3.6.4:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.0.0_eslint@6.2.1
-      '@typescript-eslint/typescript-estree': 2.0.0
-      eslint: 6.2.1
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-    resolution:
-      integrity: sha512-ibyMBMr0383ZKserIsp67+WnNVoM402HKkxqXGlxEZsXtnGGurbnY90pBO3e0nBUM7chEEOcxUhgw9aPq7fEBA==
-  /@typescript-eslint/parser/2.1.0_eslint@6.3.0:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.1.0_eslint@6.3.0
-      '@typescript-eslint/typescript-estree': 2.1.0
-      eslint: 6.3.0
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-    resolution:
-      integrity: sha512-0+hzirRJoqE1T4lSSvCfKD+kWjIpDWfbGBiisK5CENcr+22pPkHB2sfV1giON+UxHV4A08SSrQonZk7X2zIQdw==
-  /@typescript-eslint/parser/2.3.3_eslint@6.5.1:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.3.3_eslint@6.5.1
-      '@typescript-eslint/typescript-estree': 2.3.3
-      eslint: 6.5.1
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-    resolution:
-      integrity: sha512-+cV53HuYFeeyrNW8x/rgPmbVrzzp/rpRmwbJnNtwn4K8mroL1BdjxwQh7X9cUHp9rm4BBiEWmD3cSBjKG7d5mw==
-  /@typescript-eslint/parser/2.4.0_eslint@6.5.1:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.4.0_eslint@6.5.1
-      '@typescript-eslint/typescript-estree': 2.4.0
-      eslint: 6.5.1
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-    resolution:
-      integrity: sha512-IouAKi/grJ4MFrwdXIJ1GHAwbPWYgkT3b/x8Q49F378c9nwgxVkO76e0rZeUVpwHMaUuoKG2sUeK0XGkwdlwkw==
-  /@typescript-eslint/parser/2.5.0_eslint@6.5.1:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.5.0_eslint@6.5.1
-      '@typescript-eslint/typescript-estree': 2.5.0
-      eslint: 6.5.1
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-    resolution:
-      integrity: sha512-9UBMiAwIDWSl79UyogaBdj3hidzv6exjKUx60OuZuFnJf56tq/UMpdPcX09YmGqE8f4AnAueYtBxV8IcAT3jdQ==
-  /@typescript-eslint/parser/2.5.0_eslint@6.6.0:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.5.0_eslint@6.6.0
-      '@typescript-eslint/typescript-estree': 2.5.0
+      '@typescript-eslint/experimental-utils': 2.6.1_eslint@6.6.0+typescript@3.6.4
+      '@typescript-eslint/typescript-estree': 2.6.1_typescript@3.6.4
       eslint: 6.6.0
       eslint-visitor-keys: 1.1.0
     dev: false
@@ -1468,42 +925,12 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     peerDependencies:
       eslint: ^5.0.0 || ^6.0.0
+      typescript: '*'
     resolution:
-      integrity: sha512-9UBMiAwIDWSl79UyogaBdj3hidzv6exjKUx60OuZuFnJf56tq/UMpdPcX09YmGqE8f4AnAueYtBxV8IcAT3jdQ==
-  /@typescript-eslint/typescript-estree/2.0.0:
-    dependencies:
-      lodash.unescape: 4.0.1
-      semver: 6.3.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-NXbmzA3vWrSgavymlzMWNecgNOuiMMp62MO3kI7awZRLRcsA1QrYWo6q08m++uuAGVbXH/prZi2y1AWuhSu63w==
-  /@typescript-eslint/typescript-estree/2.1.0:
-    dependencies:
-      glob: 7.1.4
-      is-glob: 4.0.1
-      lodash.unescape: 4.0.1
-      semver: 6.3.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-482ErJJ7QYghBh+KA9G+Fwcuk/PLTy+9NBMz8S+6UFrUUnVvHRNAL7I70kdws2te0FBYEZW7pkDaXoT+y8UARw==
-  /@typescript-eslint/typescript-estree/2.3.0:
-    dependencies:
-      glob: 7.1.4
-      is-glob: 4.0.1
-      lodash.unescape: 4.0.1
-      semver: 6.3.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-WBxfwsTeCOsmQ7cLjow7lgysviBKUW34npShu7dxJYUQCbSG5nfZWZTgmQPKEc+3flpbSM7tjXjQOgETYp+njQ==
+      integrity: sha512-PDPkUkZ4c7yA+FWqigjwf3ngPUgoLaGjMlFh6TRtbjhqxFBnkElDfckSjm98q9cMr4xRzZ15VrS/xKm6QHYf0w==
   /@typescript-eslint/typescript-estree/2.3.3:
     dependencies:
-      glob: 7.1.4
+      glob: 7.1.5
       is-glob: 4.0.1
       lodash.unescape: 4.0.1
       semver: 6.3.0
@@ -1512,33 +939,24 @@ packages:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
       integrity: sha512-GkACs12Xp8d/STunNv/iSMYJFQrkrax9vuPZySlgSzoJJtw1cp6tbEw4qsLskQv6vloLrkFJHcTJ0a/yCB5cIA==
-  /@typescript-eslint/typescript-estree/2.4.0:
-    dependencies:
-      chokidar: 3.2.1
-      glob: 7.1.4
-      is-glob: 4.0.1
-      lodash.unescape: 4.0.1
-      semver: 6.3.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    resolution:
-      integrity: sha512-/DzDAtMqF5d9IlXrrvu/Id/uoKjnSxf/3FbtKK679a/T7lbDM8qQuirtGvFy6Uh+x0hALuCMwnMfUf0P24/+Iw==
-  /@typescript-eslint/typescript-estree/2.5.0:
+  /@typescript-eslint/typescript-estree/2.6.1_typescript@3.6.4:
     dependencies:
       debug: 4.1.1
       glob: 7.1.5
       is-glob: 4.0.1
       lodash.unescape: 4.0.1
       semver: 6.3.0
+      tsutils: 3.17.1_typescript@3.6.4
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
+    peerDependencies:
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-AXURyF8NcA3IsnbjNX1v9qbwa0dDoY9YPcKYR2utvMHoUcu3636zrz0gRWtVAyxbPCkhyKuGg6WZIyi2Fc79CA==
+      integrity: sha512-+sTnssW6bcbDZKE8Ce7VV6LdzkQz2Bxk7jzk1J8H1rovoTxnm6iXvYIyncvNsaB/kBCOM63j/LNJfm27bNdUoA==
   /@webassemblyjs/ast/1.8.5:
     dependencies:
       '@webassemblyjs/helper-module-context': 1.8.5
@@ -1683,14 +1101,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-  /abort-controller/3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-    dev: false
-    engines:
-      node: '>=6.5'
-    resolution:
-      integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
   /accepts/1.3.7:
     dependencies:
       mime-types: 2.1.24
@@ -1700,14 +1110,6 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
-  /acorn-jsx/5.0.2_acorn@7.0.0:
-    dependencies:
-      acorn: 7.0.0
-    dev: false
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0
-    resolution:
-      integrity: sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==
   /acorn-jsx/5.1.0_acorn@7.1.0:
     dependencies:
       acorn: 7.1.0
@@ -1736,13 +1138,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
-  /acorn/7.0.0:
-    dev: false
-    engines:
-      node: '>=0.4.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==
   /acorn/7.1.0:
     dev: false
     engines:
@@ -1752,7 +1147,7 @@ packages:
       integrity: sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==
   /adal-node/0.1.28:
     dependencies:
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       async: 3.1.0
       date-utils: 1.2.21
       jws: 3.2.2
@@ -1845,12 +1240,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=
-  /ansi-escapes/3.2.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
   /ansi-escapes/4.2.1:
     dependencies:
       type-fest: 0.5.2
@@ -1920,17 +1309,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
-  /anymatch/3.0.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.0.7
-    dev: false
-    resolution:
-      integrity: sha512-c6IvoeBECQlMVuYUjSwimnhmztImpErfxJzWZhIQinIvQWoGOnB0dLIgifbPHQt5heS6mNlaZG16f06H3C8t1g==
   /anymatch/3.1.1:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.0.7
+      picomatch: 2.1.0
     dev: false
     engines:
       node: '>= 8'
@@ -2159,7 +1541,7 @@ packages:
       integrity: sha1-yL4BCitc0A3qlsgRFgNGk9/dgtE=
   /async-done/1.3.2:
     dependencies:
-      end-of-stream: 1.4.1
+      end-of-stream: 1.4.4
       once: 1.4.0
       process-nextick-args: 2.0.1
       stream-exhaust: 1.0.2
@@ -2224,7 +1606,7 @@ packages:
   /axios/0.19.0:
     dependencies:
       follow-redirects: 1.5.10
-      is-buffer: 2.0.3
+      is-buffer: 2.0.4
     dev: false
     resolution:
       integrity: sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
@@ -2616,7 +1998,7 @@ packages:
   /babel-polyfill/6.26.0:
     dependencies:
       babel-runtime: 6.26.0
-      core-js: 2.6.9
+      core-js: 2.6.10
       regenerator-runtime: 0.10.5
     dev: false
     resolution:
@@ -2660,7 +2042,7 @@ packages:
     dependencies:
       babel-core: 6.26.3
       babel-runtime: 6.26.0
-      core-js: 2.6.9
+      core-js: 2.6.10
       home-or-tmp: 2.0.0
       lodash: 4.17.15
       mkdirp: 0.5.1
@@ -2670,7 +2052,7 @@ packages:
       integrity: sha1-btAhFz4vy0htestFxgCahW9kcHE=
   /babel-runtime/6.26.0:
     dependencies:
-      core-js: 2.6.9
+      core-js: 2.6.10
       regenerator-runtime: 0.11.1
     dev: false
     resolution:
@@ -2801,18 +2183,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
-  /binary-search-bounds/2.0.3:
-    dev: false
-    resolution:
-      integrity: sha1-X/hhbW3SylOIvIWy1iZuK52lAtw=
   /blob/0.0.5:
     dev: false
     resolution:
       integrity: sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
-  /bluebird/3.5.5:
-    dev: false
-    resolution:
-      integrity: sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
   /bluebird/3.7.1:
     dev: false
     resolution:
@@ -2923,9 +2297,9 @@ packages:
       browserify-rsa: 4.0.1
       create-hash: 1.2.0
       create-hmac: 1.1.7
-      elliptic: 6.5.0
+      elliptic: 6.5.1
       inherits: 2.0.4
-      parse-asn1: 5.1.4
+      parse-asn1: 5.1.5
     dev: false
     resolution:
       integrity: sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=
@@ -2937,8 +2311,8 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30000989
-      electron-to-chromium: 1.3.237
+      caniuse-lite: 1.0.30001008
+      electron-to-chromium: 1.3.302
     dev: false
     hasBin: true
     resolution:
@@ -2992,13 +2366,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
-  /buffer/5.4.0:
-    dependencies:
-      base64-js: 1.3.1
-      ieee754: 1.1.13
-    dev: false
-    resolution:
-      integrity: sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==
   /buffer/5.4.3:
     dependencies:
       base64-js: 1.3.1
@@ -3030,11 +2397,11 @@ packages:
       integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
   /cacache/12.0.3:
     dependencies:
-      bluebird: 3.5.5
-      chownr: 1.1.2
+      bluebird: 3.7.1
+      chownr: 1.1.3
       figgy-pudding: 3.5.1
-      glob: 7.1.4
-      graceful-fs: 4.2.2
+      glob: 7.1.5
+      graceful-fs: 4.2.3
       infer-owner: 1.0.4
       lru-cache: 5.1.1
       mississippi: 3.0.0
@@ -3128,10 +2495,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /caniuse-lite/1.0.30000989:
+  /caniuse-lite/1.0.30001008:
     dev: false
     resolution:
-      integrity: sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==
+      integrity: sha512-b8DJyb+VVXZGRgJUa30cbk8gKHZ3LOZTBLaUEEVr2P4xpmFigOCc62CO4uzquW641Ouq1Rm9N+rWLWdSYDaDIw==
   /caseless/0.12.0:
     dev: false
     resolution:
@@ -3227,45 +2594,13 @@ packages:
       normalize-path: 3.0.0
       path-is-absolute: 1.0.1
       readdirp: 2.2.1
-      upath: 1.1.2
+      upath: 1.2.0
     dev: false
     optionalDependencies:
       fsevents: 1.2.9
     resolution:
       integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
-  /chokidar/3.0.2:
-    dependencies:
-      anymatch: 3.0.3
-      braces: 3.0.2
-      glob-parent: 5.0.0
-      is-binary-path: 2.1.0
-      is-glob: 4.0.1
-      normalize-path: 3.0.0
-      readdirp: 3.1.2
-    dev: false
-    engines:
-      node: '>= 8'
-    optionalDependencies:
-      fsevents: 2.0.7
-    resolution:
-      integrity: sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==
-  /chokidar/3.2.1:
-    dependencies:
-      anymatch: 3.1.1
-      braces: 3.0.2
-      glob-parent: 5.1.0
-      is-binary-path: 2.1.0
-      is-glob: 4.0.1
-      normalize-path: 3.0.0
-      readdirp: 3.1.3
-    dev: false
-    engines:
-      node: '>= 8'
-    optionalDependencies:
-      fsevents: 2.1.1
-    resolution:
-      integrity: sha512-/j5PPkb5Feyps9e+jo07jUZGvkB5Aj953NrI4s8xSVScrAo/RHeILrtdb4uzR7N6aaFFxxJ+gt8mA8HfNpw76w==
-  /chokidar/3.2.2:
+  /chokidar/3.3.0:
     dependencies:
       anymatch: 3.1.1
       braces: 3.0.2
@@ -3276,33 +2611,33 @@ packages:
       readdirp: 3.2.0
     dev: false
     engines:
-      node: '>= 8'
+      node: '>= 8.10.0'
     optionalDependencies:
       fsevents: 2.1.1
     resolution:
-      integrity: sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==
-  /chownr/1.1.2:
+      integrity: sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==
+  /chownr/1.1.3:
     dev: false
     resolution:
-      integrity: sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==
-  /chrome-launcher/0.10.7:
+      integrity: sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
+  /chrome-launcher/0.11.2:
     dependencies:
-      '@types/node': 8.10.52
-      is-wsl: 1.1.0
+      '@types/node': 8.10.58
+      is-wsl: 2.1.1
       lighthouse-logger: 1.2.0
       mkdirp: 0.5.1
       rimraf: 2.7.1
     dev: false
     resolution:
-      integrity: sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==
-  /chrome-remote-interface/0.27.2:
+      integrity: sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==
+  /chrome-remote-interface/0.28.0:
     dependencies:
       commander: 2.11.0
       ws: 6.2.1
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-pVLljQ29SAx8KIv5tSa9sIf8GrEsAZdPJoeWOmY3/nrIzFmE+EryNNHvDkddGod0cmAFTv+GmPG0uvzxi2NWsA==
+      integrity: sha512-md2qSn6rc/fADlN+Blk2UWNg0SGPYjH2s68piaPN9e62HItKm6uWeXXHh0+28Bq10oaWw8fzNAm1itDFJ+nS4w==
   /chrome-trace-event/1.0.2:
     dependencies:
       tslib: 1.10.0
@@ -3345,14 +2680,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
-  /cli-cursor/2.1.0:
-    dependencies:
-      restore-cursor: 2.0.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
   /cli-cursor/3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -3468,12 +2795,6 @@ packages:
       node: '>=0.1.90'
     resolution:
       integrity: sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==
-  /colors/1.3.3:
-    dev: false
-    engines:
-      node: '>=0.1.90'
-    resolution:
-      integrity: sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
   /colors/1.4.0:
     dev: false
     engines:
@@ -3492,14 +2813,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
-  /commander/2.20.0:
-    dev: false
-    resolution:
-      integrity: sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
-  /commander/2.20.1:
-    dev: false
-    resolution:
-      integrity: sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==
   /commander/2.20.3:
     dev: false
     resolution:
@@ -3556,12 +2869,10 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==
-  /console-browserify/1.1.0:
-    dependencies:
-      date-now: 0.1.4
+  /console-browserify/1.2.0:
     dev: false
     resolution:
-      integrity: sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=
+      integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
   /constants-browserify/1.0.0:
     dev: false
     resolution:
@@ -3626,23 +2937,18 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==
-  /core-js/2.6.9:
+  /core-js/2.6.10:
     dev: false
     requiresBuild: true
     resolution:
-      integrity: sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
-  /core-js/3.2.1:
-    dev: false
-    requiresBuild: true
-    resolution:
-      integrity: sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
+      integrity: sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
   /core-util-is/1.0.2:
     dev: false
     resolution:
       integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
   /cp-file/6.2.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       make-dir: 2.1.0
       nested-error-stacks: 2.1.0
       pify: 4.0.1
@@ -3655,7 +2961,7 @@ packages:
   /create-ecdh/4.0.3:
     dependencies:
       bn.js: 4.11.8
-      elliptic: 6.5.0
+      elliptic: 6.5.1
     dev: false
     resolution:
       integrity: sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
@@ -3680,16 +2986,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
-  /cross-env/5.2.0:
-    dependencies:
-      cross-spawn: 6.0.5
-      is-windows: 1.0.2
-    dev: false
-    engines:
-      node: '>=4.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
   /cross-env/5.2.1:
     dependencies:
       cross-spawn: 6.0.5
@@ -3738,16 +3034,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
-  /crypto-hash/1.1.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-5DWmfCxQZHWocCpkOXVFmfYj7v5vZXF3ZNzMeyyJ6OzGfDTEEOm2CWA8KzZ578eA7j5VPCLOdGjOU8sGgi8BYw==
-  /crypto-js/3.1.9-1:
-    dev: false
-    resolution:
-      integrity: sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
   /currently-unhandled/0.4.1:
     dependencies:
       array-find-index: 1.0.2
@@ -3760,14 +3046,14 @@ packages:
     dev: false
     resolution:
       integrity: sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=
-  /cyclist/0.2.2:
+  /cyclist/1.0.1:
     dev: false
     resolution:
-      integrity: sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
+      integrity: sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
   /d/1.0.1:
     dependencies:
-      es5-ext: 0.10.50
-      type: 1.0.3
+      es5-ext: 0.10.52
+      type: 1.2.0
     dev: false
     resolution:
       integrity: sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
@@ -3795,10 +3081,6 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==
-  /date-now/0.1.4:
-    dev: false
-    resolution:
-      integrity: sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
   /date-utils/1.2.21:
     dev: false
     engines:
@@ -3887,13 +3169,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
-  /deepmerge/2.2.1:
-    dev: false
-    engines:
-      node: '>=0.10.0'
-    optional: true
-    resolution:
-      integrity: sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
   /default-compare/1.0.0:
     dependencies:
       kind-of: 5.1.0
@@ -4066,12 +3341,6 @@ packages:
       npm: '>=1.2'
     resolution:
       integrity: sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==
-  /dotenv/8.1.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
   /dotenv/8.2.0:
     dev: false
     engines:
@@ -4080,7 +3349,7 @@ packages:
       integrity: sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
   /duplexify/3.7.1:
     dependencies:
-      end-of-stream: 1.4.1
+      end-of-stream: 1.4.4
       inherits: 2.0.4
       readable-stream: 2.3.6
       stream-shift: 1.0.0
@@ -4115,11 +3384,11 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.237:
+  /electron-to-chromium/1.3.302:
     dev: false
     resolution:
-      integrity: sha512-SPAFjDr/7iiVK2kgTluwxela6eaWjjFkS9rO/iYpB/KGXgccUom5YC7OIf19c8m8GGptWxLU0Em8xM64A/N7Fg==
-  /elliptic/6.5.0:
+      integrity: sha512-1qConyiVEbj4xZRBXqtGR003+9tV0rJF0PS6aeO0Ln/UL637js9hdwweCl07meh/kJoI2N4W8q3R3g3F5z46ww==
+  /elliptic/6.5.1:
     dependencies:
       bn.js: 4.11.8
       brorand: 1.1.0
@@ -4130,7 +3399,7 @@ packages:
       minimalistic-crypto-utils: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==
+      integrity: sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==
   /emoji-regex/7.0.3:
     dev: false
     resolution:
@@ -4151,12 +3420,12 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
-  /end-of-stream/1.4.1:
+  /end-of-stream/1.4.4:
     dependencies:
       once: 1.4.0
     dev: false
     resolution:
-      integrity: sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==
+      integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   /engine.io-client/3.2.1:
     dependencies:
       component-emitter: 1.2.1
@@ -4196,7 +3465,7 @@ packages:
       integrity: sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==
   /enhanced-resolve/4.1.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       memory-fs: 0.4.1
       tapable: 1.1.3
     dev: false
@@ -4204,6 +3473,16 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==
+  /enhanced-resolve/4.1.1:
+    dependencies:
+      graceful-fs: 4.2.3
+      memory-fs: 0.5.0
+      tapable: 1.1.3
+    dev: false
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==
   /ent/2.2.0:
     dev: false
     resolution:
@@ -4221,19 +3500,23 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.13.0:
+  /es-abstract/1.16.0:
     dependencies:
       es-to-primitive: 1.2.0
       function-bind: 1.1.1
       has: 1.0.3
+      has-symbols: 1.0.0
       is-callable: 1.1.4
       is-regex: 1.0.4
+      object-inspect: 1.6.0
       object-keys: 1.1.1
+      string.prototype.trimleft: 2.1.0
+      string.prototype.trimright: 2.1.0
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==
+      integrity: sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==
   /es-to-primitive/1.2.0:
     dependencies:
       is-callable: 1.1.4
@@ -4244,14 +3527,14 @@ packages:
       node: '>= 0.4'
     resolution:
       integrity: sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==
-  /es5-ext/0.10.50:
+  /es5-ext/0.10.52:
     dependencies:
       es6-iterator: 2.0.3
-      es6-symbol: 3.1.1
+      es6-symbol: 3.1.3
       next-tick: 1.0.0
     dev: false
     resolution:
-      integrity: sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==
+      integrity: sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==
   /es6-error/4.1.1:
     dev: false
     resolution:
@@ -4259,8 +3542,8 @@ packages:
   /es6-iterator/2.0.3:
     dependencies:
       d: 1.0.1
-      es5-ext: 0.10.50
-      es6-symbol: 3.1.1
+      es5-ext: 0.10.52
+      es6-symbol: 3.1.3
     dev: false
     resolution:
       integrity: sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
@@ -4278,28 +3561,28 @@ packages:
     dev: false
     resolution:
       integrity: sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  /es6-symbol/3.1.1:
+  /es6-symbol/3.1.3:
     dependencies:
       d: 1.0.1
-      es5-ext: 0.10.50
+      ext: 1.1.2
     dev: false
     resolution:
-      integrity: sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
+      integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
   /es6-weak-map/2.0.3:
     dependencies:
       d: 1.0.1
-      es5-ext: 0.10.50
+      es5-ext: 0.10.52
       es6-iterator: 2.0.3
-      es6-symbol: 3.1.1
+      es6-symbol: 3.1.3
     dev: false
     resolution:
       integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  /escape-goat/2.1.0:
+  /escape-goat/2.1.1:
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-7fMXQmS/6yjYQT/yydWKCAm5ucuU7QtqP6/CE7BIKk6z3xTP4MLqkdUBwaViQVuTAde8yZgZIjSnEAPRl6u53g==
+      integrity: sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
   /escape-html/1.0.3:
     dev: false
     resolution:
@@ -4344,36 +3627,6 @@ packages:
       source-map: 0.2.0
     resolution:
       integrity: sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=
-  /eslint-config-prettier/6.1.0_eslint@6.2.1:
-    dependencies:
-      eslint: 6.2.1
-      get-stdin: 6.0.0
-    dev: false
-    hasBin: true
-    peerDependencies:
-      eslint: '>=3.14.1'
-    resolution:
-      integrity: sha512-k9fny9sPjIBQ2ftFTesJV21Rg4R/7a7t7LCtZVrYQiHEp8Nnuk3EGaDmsKSAnsPj0BYcgB2zxzHa2NTkIxcOLg==
-  /eslint-config-prettier/6.2.0_eslint@6.3.0:
-    dependencies:
-      eslint: 6.3.0
-      get-stdin: 6.0.0
-    dev: false
-    hasBin: true
-    peerDependencies:
-      eslint: '>=3.14.1'
-    resolution:
-      integrity: sha512-VLsgK/D+S/FEsda7Um1+N8FThec6LqE3vhcMyp8mlmto97y3fGf3DX7byJexGuOb1QY0Z/zz222U5t+xSfcZDQ==
-  /eslint-config-prettier/6.4.0_eslint@6.5.1:
-    dependencies:
-      eslint: 6.5.1
-      get-stdin: 6.0.0
-    dev: false
-    hasBin: true
-    peerDependencies:
-      eslint: '>=3.14.1'
-    resolution:
-      integrity: sha512-YrKucoFdc7SEko5Sxe4r6ixqXPDP1tunGw91POeZTTRKItf/AMFYt/YLEQtZMkR2LVpAVhcAcZgcWpm1oGPW7w==
   /eslint-config-prettier/6.5.0_eslint@6.6.0:
     dependencies:
       eslint: 6.6.0
@@ -4384,36 +3637,6 @@ packages:
       eslint: '>=3.14.1'
     resolution:
       integrity: sha512-cjXp8SbO9VFGW/Z7mbTydqS9to8Z58E5aYhj3e1+Hx7lS9s6gL5ILKNpCqZAFOVYRcSkWPFYljHrEh8QFEK5EQ==
-  /eslint-plugin-no-null/1.0.2_eslint@6.2.1:
-    dependencies:
-      eslint: 6.2.1
-    dev: false
-    engines:
-      node: '>=5.0.0'
-    peerDependencies:
-      eslint: '>=3.0.0'
-    resolution:
-      integrity: sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=
-  /eslint-plugin-no-null/1.0.2_eslint@6.3.0:
-    dependencies:
-      eslint: 6.3.0
-    dev: false
-    engines:
-      node: '>=5.0.0'
-    peerDependencies:
-      eslint: '>=3.0.0'
-    resolution:
-      integrity: sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=
-  /eslint-plugin-no-null/1.0.2_eslint@6.5.1:
-    dependencies:
-      eslint: 6.5.1
-    dev: false
-    engines:
-      node: '>=5.0.0'
-    peerDependencies:
-      eslint: '>=3.0.0'
-    resolution:
-      integrity: sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=
   /eslint-plugin-no-null/1.0.2_eslint@6.6.0:
     dependencies:
       eslint: 6.6.0
@@ -4454,14 +3677,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
-  /eslint-utils/1.4.2:
-    dependencies:
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
   /eslint-utils/1.4.3:
     dependencies:
       eslint-visitor-keys: 1.1.0
@@ -4476,141 +3691,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
-  /eslint/6.2.1:
-    dependencies:
-      '@babel/code-frame': 7.5.5
-      ajv: 6.10.2
-      chalk: 2.4.2
-      cross-spawn: 6.0.5
-      debug: 4.1.1
-      doctrine: 3.0.0
-      eslint-scope: 5.0.0
-      eslint-utils: 1.4.2
-      eslint-visitor-keys: 1.1.0
-      espree: 6.1.0
-      esquery: 1.0.1
-      esutils: 2.0.3
-      file-entry-cache: 5.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.0.0
-      globals: 11.12.0
-      ignore: 4.0.6
-      import-fresh: 3.1.0
-      imurmurhash: 0.1.4
-      inquirer: 6.5.2
-      is-glob: 4.0.1
-      js-yaml: 3.13.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.3.0
-      lodash: 4.17.15
-      minimatch: 3.0.4
-      mkdirp: 0.5.1
-      natural-compare: 1.4.0
-      optionator: 0.8.2
-      progress: 2.0.3
-      regexpp: 2.0.1
-      semver: 6.3.0
-      strip-ansi: 5.2.0
-      strip-json-comments: 3.0.1
-      table: 5.4.6
-      text-table: 0.2.0
-      v8-compile-cache: 2.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    hasBin: true
-    resolution:
-      integrity: sha512-ES7BzEzr0Q6m5TK9i+/iTpKjclXitOdDK4vT07OqbkBT2/VcN/gO9EL1C4HlK3TAOXYv2ItcmbVR9jO1MR0fJg==
-  /eslint/6.3.0:
-    dependencies:
-      '@babel/code-frame': 7.5.5
-      ajv: 6.10.2
-      chalk: 2.4.2
-      cross-spawn: 6.0.5
-      debug: 4.1.1
-      doctrine: 3.0.0
-      eslint-scope: 5.0.0
-      eslint-utils: 1.4.2
-      eslint-visitor-keys: 1.1.0
-      espree: 6.1.1
-      esquery: 1.0.1
-      esutils: 2.0.3
-      file-entry-cache: 5.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.0.0
-      globals: 11.12.0
-      ignore: 4.0.6
-      import-fresh: 3.1.0
-      imurmurhash: 0.1.4
-      inquirer: 6.5.2
-      is-glob: 4.0.1
-      js-yaml: 3.13.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.3.0
-      lodash: 4.17.15
-      minimatch: 3.0.4
-      mkdirp: 0.5.1
-      natural-compare: 1.4.0
-      optionator: 0.8.2
-      progress: 2.0.3
-      regexpp: 2.0.1
-      semver: 6.3.0
-      strip-ansi: 5.2.0
-      strip-json-comments: 3.0.1
-      table: 5.4.6
-      text-table: 0.2.0
-      v8-compile-cache: 2.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    hasBin: true
-    resolution:
-      integrity: sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==
-  /eslint/6.5.1:
-    dependencies:
-      '@babel/code-frame': 7.5.5
-      ajv: 6.10.2
-      chalk: 2.4.2
-      cross-spawn: 6.0.5
-      debug: 4.1.1
-      doctrine: 3.0.0
-      eslint-scope: 5.0.0
-      eslint-utils: 1.4.2
-      eslint-visitor-keys: 1.1.0
-      espree: 6.1.1
-      esquery: 1.0.1
-      esutils: 2.0.3
-      file-entry-cache: 5.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.0
-      globals: 11.12.0
-      ignore: 4.0.6
-      import-fresh: 3.1.0
-      imurmurhash: 0.1.4
-      inquirer: 6.5.2
-      is-glob: 4.0.1
-      js-yaml: 3.13.1
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.3.0
-      lodash: 4.17.15
-      minimatch: 3.0.4
-      mkdirp: 0.5.1
-      natural-compare: 1.4.0
-      optionator: 0.8.2
-      progress: 2.0.3
-      regexpp: 2.0.1
-      semver: 6.3.0
-      strip-ansi: 5.2.0
-      strip-json-comments: 3.0.1
-      table: 5.4.6
-      text-table: 0.2.0
-      v8-compile-cache: 2.1.0
-    dev: false
-    engines:
-      node: ^8.10.0 || ^10.13.0 || >=11.10.1
-    hasBin: true
-    resolution:
-      integrity: sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==
   /eslint/6.6.0:
     dependencies:
       '@babel/code-frame': 7.5.5
@@ -4656,38 +3736,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-PpEBq7b6qY/qrOmpYQ/jTMDYfuQMELR4g4WI1M/NaSDDD/bdcMb+dj4Hgks7p41kW2caXsPsEZAEAyAgjVVC0g==
-  /esm/3.2.18:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-1UENjnnI37UDp7KuOqKYjfqdaMim06eBWnDv37smaxTIzDl0ZWnlgoXwsVwD9+Lidw+q/f1gUf2diVMDCycoVw==
   /esm/3.2.25:
     dev: false
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
-  /espree/6.1.0:
-    dependencies:
-      acorn: 7.0.0
-      acorn-jsx: 5.0.2_acorn@7.0.0
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: '>=6.0.0'
-    resolution:
-      integrity: sha512-boA7CHRLlVWUSg3iL5Kmlt/xT3Q+sXnKoRYYzj1YeM10A76TEJBbotV5pKbnK42hEUIr121zTv+QLRM5LsCPXQ==
-  /espree/6.1.1:
-    dependencies:
-      acorn: 7.0.0
-      acorn-jsx: 5.0.2_acorn@7.0.0
-      eslint-visitor-keys: 1.1.0
-    dev: false
-    engines:
-      node: '>=6.0.0'
-    resolution:
-      integrity: sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==
   /espree/6.1.2:
     dependencies:
       acorn: 7.1.0
@@ -4767,16 +3821,6 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
-  /event-target-shim/5.0.1:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
-  /eventemitter3/3.1.2:
-    dev: false
-    resolution:
-      integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
   /eventemitter3/4.0.0:
     dev: false
     resolution:
@@ -4867,6 +3911,12 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
+  /ext/1.1.2:
+    dependencies:
+      type: 2.0.0
+    dev: false
+    resolution:
+      integrity: sha512-/KLjJdTNyDepCihrk4HQt57nAE1IRCEo5jUt+WgWGCr1oARhibDvmI2DMcSNWood1T9AUWwq+jaV1wvRqaXfnA==
   /extend-shallow/1.1.4:
     dependencies:
       kind-of: 1.1.0
@@ -4976,31 +4026,30 @@ packages:
     dev: false
     resolution:
       integrity: sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
-  /fetch-mock/7.3.9:
+  /fetch-mock/7.7.2_node-fetch@2.6.0:
     dependencies:
       babel-polyfill: 6.26.0
-      core-js: 2.6.9
+      core-js: 2.6.10
       glob-to-regexp: 0.4.1
+      lodash.isequal: 4.5.0
+      node-fetch: 2.6.0
       path-to-regexp: 2.4.0
       whatwg-url: 6.5.0
     dev: false
     engines:
       node: '>=4.0.0'
+    peerDependencies:
+      node-fetch: '*'
+    peerDependenciesMeta:
+      node-fetch:
+        optional: true
     requiresBuild: true
     resolution:
-      integrity: sha512-PgsTbiQBNapFz2P2UwDl3gowK3nZqfV4HdyDZ1dI4eTGGH9MLAeBglIPbyDbbNQoGYBOfla6/9uaiq7az2z4Aw==
+      integrity: sha512-ZlRehtVmXaVhkIrH5fQz12czbowGmWCiGnEbsliHFs5aelzbiBLC2dtuQnvbRJB8krEiY2cgVfspMHu7V4WhnQ==
   /figgy-pudding/3.5.1:
     dev: false
     resolution:
       integrity: sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
-  /figures/2.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   /figures/3.1.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -5212,16 +4261,6 @@ packages:
       node: '>= 0.12'
     resolution:
       integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  /form-data/2.5.0:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.24
-    dev: false
-    engines:
-      node: '>= 0.12'
-    resolution:
-      integrity: sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==
   /form-data/2.5.1:
     dependencies:
       asynckit: 0.4.0
@@ -5261,7 +4300,7 @@ packages:
       integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=
   /fs-extra/7.0.1:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
@@ -5271,7 +4310,7 @@ packages:
       integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
   /fs-extra/8.1.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       jsonfile: 4.0.0
       universalify: 0.1.2
     dev: false
@@ -5281,7 +4320,7 @@ packages:
       integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   /fs-mkdirp-stream/1.0.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       through2: 2.0.5
     dev: false
     engines:
@@ -5290,7 +4329,7 @@ packages:
       integrity: sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=
   /fs-write-stream-atomic/1.0.10:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       iferr: 0.1.5
       imurmurhash: 0.1.4
       readable-stream: 2.3.6
@@ -5313,13 +4352,6 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
-  /fsevents/2.0.7:
-    dev: false
-    engines:
-      node: ^8.16.0 || ^10.6.0 || >=11.0.0
-    optional: true
-    resolution:
-      integrity: sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==
   /fsevents/2.1.1:
     dev: false
     engines:
@@ -5416,14 +4448,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
-  /glob-parent/5.0.0:
-    dependencies:
-      is-glob: 4.0.1
-    dev: false
-    engines:
-      node: '>= 6'
-    resolution:
-      integrity: sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==
   /glob-parent/5.1.0:
     dependencies:
       is-glob: 4.0.1
@@ -5435,7 +4459,7 @@ packages:
   /glob-stream/6.1.0:
     dependencies:
       extend: 3.0.2
-      glob: 7.1.4
+      glob: 7.1.5
       glob-parent: 3.1.0
       is-negated-glob: 1.0.0
       ordered-read-streams: 1.0.1
@@ -5487,17 +4511,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
-  /glob/7.1.4:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.0.4
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: false
-    resolution:
-      integrity: sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   /glob/7.1.5:
     dependencies:
       fs.realpath: 1.0.0
@@ -5576,10 +4589,6 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==
-  /graceful-fs/4.2.2:
-    dev: false
-    resolution:
-      integrity: sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
   /graceful-fs/4.2.3:
     dev: false
     resolution:
@@ -5620,21 +4629,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==
-  /gulp-zip/5.0.0_gulp@4.0.2:
-    dependencies:
-      get-stream: 5.1.0
-      gulp: 4.0.2
-      plugin-error: 1.0.1
-      through2: 3.0.1
-      vinyl: 2.2.0
-      yazl: 2.5.1
-    dev: false
-    engines:
-      node: '>=8'
-    peerDependencies:
-      gulp: '>=4'
-    resolution:
-      integrity: sha512-oR3t8kn+ccHkSyRcBV5kBLPXrhqTh5d6wBAR7r7wqjNQNBhYvOwPedCwlAaGcNl1qSeXNDn6qOk1Qyxvx9Wrow==
   /gulp-zip/5.0.1_gulp@4.0.2:
     dependencies:
       get-stream: 5.1.0
@@ -5648,9 +4642,6 @@ packages:
       node: '>=8'
     peerDependencies:
       gulp: '>=4'
-    peerDependenciesMeta:
-      gulp:
-        optional: true
     resolution:
       integrity: sha512-M/IWLh9RvOpuofDZkgDirtiyz9J3yIqnDOJ3muzk2D/XnZ1ruqPlPLRIpXnl/aZU+xXwKPdOIxjRzkUcVEQyZQ==
   /gulp/4.0.2:
@@ -5673,7 +4664,7 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha1-4oxNRdBey77YGDY86PnFkmIp/+U=
-  /handlebars/4.2.0:
+  /handlebars/4.5.1:
     dependencies:
       neo-async: 2.6.1
       optimist: 0.6.1
@@ -5683,9 +4674,9 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.6.0
+      uglify-js: 3.6.7
     resolution:
-      integrity: sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
+      integrity: sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==
   /har-schema/2.0.0:
     dev: false
     engines:
@@ -5823,10 +4814,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-  /highlight.js/9.15.10:
+  /highlight.js/9.16.2:
     dev: false
     resolution:
-      integrity: sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw==
+      integrity: sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw==
   /hmac-drbg/1.0.1:
     dependencies:
       hash.js: 1.1.7
@@ -5852,10 +4843,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
-  /hosted-git-info/2.8.4:
+  /hosted-git-info/2.8.5:
     dev: false
     resolution:
-      integrity: sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==
+      integrity: sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
   /http-errors/1.7.2:
     dependencies:
       depd: 1.1.2
@@ -5889,16 +4880,6 @@ packages:
       node: '>= 4.5.0'
     resolution:
       integrity: sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
-  /http-proxy/1.17.0:
-    dependencies:
-      eventemitter3: 3.1.2
-      follow-redirects: 1.9.0
-      requires-port: 1.0.0
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==
   /http-proxy/1.18.0:
     dependencies:
       eventemitter3: 4.0.0
@@ -5924,7 +4905,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
-  /https-proxy-agent/2.2.2:
+  /https-proxy-agent/2.2.4:
     dependencies:
       agent-base: 4.3.0
       debug: 3.2.6
@@ -5932,16 +4913,7 @@ packages:
     engines:
       node: '>= 4.5.0'
     resolution:
-      integrity: sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
-  /https-proxy-agent/2.2.3:
-    dependencies:
-      agent-base: 4.3.0
-      debug: 3.2.6
-    dev: false
-    engines:
-      node: '>= 4.5.0'
-    resolution:
-      integrity: sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==
+      integrity: sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
   /https-proxy-agent/3.0.1:
     dependencies:
       agent-base: 4.3.0
@@ -6043,26 +5015,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-  /inquirer/6.5.2:
-    dependencies:
-      ansi-escapes: 3.2.0
-      chalk: 2.4.2
-      cli-cursor: 2.1.0
-      cli-width: 2.2.0
-      external-editor: 3.1.0
-      figures: 2.0.0
-      lodash: 4.17.15
-      mute-stream: 0.0.7
-      run-async: 2.3.0
-      rxjs: 6.5.3
-      string-width: 2.1.1
-      strip-ansi: 5.2.0
-      through: 2.3.8
-    dev: false
-    engines:
-      node: '>=6.0.0'
-    resolution:
-      integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
   /inquirer/7.0.0:
     dependencies:
       ansi-escapes: 4.2.1
@@ -6178,12 +5130,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
-  /is-buffer/2.0.3:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
   /is-buffer/2.0.4:
     dev: false
     engines:
@@ -6369,12 +5315,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
-  /is-reference/1.1.3:
+  /is-reference/1.1.4:
     dependencies:
       '@types/estree': 0.0.39
     dev: false
     resolution:
-      integrity: sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==
+      integrity: sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==
   /is-regex/1.0.4:
     dependencies:
       has: 1.0.3
@@ -6445,12 +5391,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-  /is-wsl/2.1.0:
+  /is-wsl/2.1.1:
     dev: false
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-pFTjpv/x5HRj8kbZ/Msxi9VrvtOMRBqaDi3OIcbwPI3OuH+r3lLxVWukLITBaOGJIbA/w2+M1eVmVa4XNQlAmQ==
+      integrity: sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
   /isarray/0.0.1:
     dev: false
     resolution:
@@ -6509,11 +5455,11 @@ packages:
       integrity: sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.5.5
-      '@babel/parser': 7.5.5
-      '@babel/template': 7.4.4
-      '@babel/traverse': 7.5.5
-      '@babel/types': 7.5.5
+      '@babel/generator': 7.6.4
+      '@babel/parser': 7.6.4
+      '@babel/template': 7.6.0
+      '@babel/traverse': 7.6.3
+      '@babel/types': 7.6.3
       istanbul-lib-coverage: 2.0.5
       semver: 6.3.0
     dev: false
@@ -6545,7 +5491,7 @@ packages:
       integrity: sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
   /istanbul-reports/2.2.6:
     dependencies:
-      handlebars: 4.2.0
+      handlebars: 4.5.1
     dev: false
     engines:
       node: '>=6'
@@ -6558,7 +5504,7 @@ packages:
       escodegen: 1.8.1
       esprima: 2.7.3
       glob: 5.0.15
-      handlebars: 4.2.0
+      handlebars: 4.5.1
       js-yaml: 3.13.1
       mkdirp: 0.5.1
       nopt: 3.0.6
@@ -6673,7 +5619,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  /json5/2.1.0:
+  /json5/2.1.1:
     dependencies:
       minimist: 1.2.0
     dev: false
@@ -6681,11 +5627,11 @@ packages:
       node: '>=6'
     hasBin: true
     resolution:
-      integrity: sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
+      integrity: sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   /jsonfile/4.0.0:
     dev: false
     optionalDependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
     resolution:
       integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
   /jsonparse/1.2.0:
@@ -6732,10 +5678,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
-  /karma-chai/0.1.0_chai@4.2.0+karma@4.2.0:
+  /karma-chai/0.1.0_chai@4.2.0+karma@4.4.1:
     dependencies:
       chai: 4.2.0
-      karma: 4.2.0
+      karma: 4.4.1
     dev: false
     peerDependencies:
       chai: '*'
@@ -6774,28 +5720,6 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-SnFkHsnLsaXfxkey51rRN9JDLAEKYW2Lb0qOEvcruukk0NkSNDkjobNDZPt9Ni3kIhLZkLtpGOz661hN7OaZvQ==
-  /karma-edge-launcher/0.4.2_karma@4.2.0:
-    dependencies:
-      edge-launcher: 1.2.2
-      karma: 4.2.0
-    dev: false
-    engines:
-      node: '>=4'
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==
-  /karma-edge-launcher/0.4.2_karma@4.3.0:
-    dependencies:
-      edge-launcher: 1.2.2
-      karma: 4.3.0
-    dev: false
-    engines:
-      node: '>=4'
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==
   /karma-edge-launcher/0.4.2_karma@4.4.1:
     dependencies:
       edge-launcher: 1.2.2
@@ -6813,28 +5737,10 @@ packages:
       integrity: sha1-u+jIfVnADtt2BwvTwxtLOdXcfhU=
   /karma-firefox-launcher/1.2.0:
     dependencies:
-      is-wsl: 2.1.0
+      is-wsl: 2.1.1
     dev: false
     resolution:
       integrity: sha512-j9Zp8M8+VLq1nI/5xZGfzeaEPtGQ/vk3G+Y8vpmFWLvKLNZ2TDjD6cu2dUu7lDbu1HXNgatsAX4jgCZTkR9qhQ==
-  /karma-ie-launcher/1.0.0_karma@4.2.0:
-    dependencies:
-      karma: 4.2.0
-      lodash: 4.17.15
-    dev: false
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=
-  /karma-ie-launcher/1.0.0_karma@4.3.0:
-    dependencies:
-      karma: 4.3.0
-      lodash: 4.17.15
-    dev: false
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=
   /karma-ie-launcher/1.0.0_karma@4.4.1:
     dependencies:
       karma: 4.4.1
@@ -6844,22 +5750,6 @@ packages:
       karma: '>=0.9'
     resolution:
       integrity: sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=
-  /karma-json-preprocessor/0.3.3_karma@4.2.0:
-    dependencies:
-      karma: 4.2.0
-    dev: false
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha1-X36ZW+uuS06PCiy1IVBVSq8LHi4=
-  /karma-json-preprocessor/0.3.3_karma@4.3.0:
-    dependencies:
-      karma: 4.3.0
-    dev: false
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha1-X36ZW+uuS06PCiy1IVBVSq8LHi4=
   /karma-json-preprocessor/0.3.3_karma@4.4.1:
     dependencies:
       karma: 4.4.1
@@ -6870,30 +5760,10 @@ packages:
       integrity: sha1-X36ZW+uuS06PCiy1IVBVSq8LHi4=
   /karma-json-to-file-reporter/1.0.1:
     dependencies:
-      json5: 2.1.0
+      json5: 2.1.1
     dev: false
     resolution:
       integrity: sha512-kNCi+0UrXAeTJMpMsHkHNbfmlErsYT+/haNakJIhsE/gtj3Jx7zWRg7BTc1HHSbH5KeVXVRJr3/KLB/NHWY7Hg==
-  /karma-junit-reporter/1.2.0_karma@4.2.0:
-    dependencies:
-      karma: 4.2.0
-      path-is-absolute: 1.0.1
-      xmlbuilder: 8.2.2
-    dev: false
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=
-  /karma-junit-reporter/1.2.0_karma@4.3.0:
-    dependencies:
-      karma: 4.3.0
-      path-is-absolute: 1.0.1
-      xmlbuilder: 8.2.2
-    dev: false
-    peerDependencies:
-      karma: '>=0.9'
-    resolution:
-      integrity: sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=
   /karma-junit-reporter/1.2.0_karma@4.4.1:
     dependencies:
       karma: 4.4.1
@@ -6904,28 +5774,6 @@ packages:
       karma: '>=0.9'
     resolution:
       integrity: sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=
-  /karma-mocha-reporter/2.2.5_karma@4.2.0:
-    dependencies:
-      chalk: 2.4.2
-      karma: 4.2.0
-      log-symbols: 2.2.0
-      strip-ansi: 4.0.0
-    dev: false
-    peerDependencies:
-      karma: '>=0.13'
-    resolution:
-      integrity: sha1-FRIAlejtgZGG5HoLAS8810GJVWA=
-  /karma-mocha-reporter/2.2.5_karma@4.3.0:
-    dependencies:
-      chalk: 2.4.2
-      karma: 4.3.0
-      log-symbols: 2.2.0
-      strip-ansi: 4.0.0
-    dev: false
-    peerDependencies:
-      karma: '>=0.13'
-    resolution:
-      integrity: sha1-FRIAlejtgZGG5HoLAS8810GJVWA=
   /karma-mocha-reporter/2.2.5_karma@4.4.1:
     dependencies:
       chalk: 2.4.2
@@ -6954,9 +5802,9 @@ packages:
       karma-coverage: '>=0.5.4'
     resolution:
       integrity: sha512-FM5h8eHcHbMMR+2INBUxD+4+wUbkCnobfn5uWprkLyj6Xcm2MRFQOuAJn9h2H13nNso6rk+QoNpHd5xCevlPOw==
-  /karma-requirejs/1.1.0_karma@4.2.0+requirejs@2.3.6:
+  /karma-requirejs/1.1.0_karma@4.4.1+requirejs@2.3.6:
     dependencies:
-      karma: 4.2.0
+      karma: 4.4.1
       requirejs: 2.3.6
     dev: false
     peerDependencies:
@@ -6964,11 +5812,11 @@ packages:
       requirejs: ^2.1.0
     resolution:
       integrity: sha1-/driy4fX68FvsCIok1ZNf+5Xh5g=
-  /karma-rollup-preprocessor/7.0.2_rollup@1.20.1:
+  /karma-rollup-preprocessor/7.0.2_rollup@1.26.3:
     dependencies:
-      chokidar: 3.0.2
+      chokidar: 3.3.0
       debounce: 1.2.0
-      rollup: 1.20.1
+      rollup: 1.26.3
     dev: false
     engines:
       node: '>= 8.0.0'
@@ -6978,7 +5826,7 @@ packages:
       integrity: sha512-A+kr5FoiMr/S8dIPij/nuzB9PLhkrh3umFowjumAOKBDVQRhPYs3kKmQ82hP3+2MB6CICqeB4MmiIE4iTwUmDQ==
   /karma-sourcemap-loader/0.3.7:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
     dev: false
     resolution:
       integrity: sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=
@@ -6989,19 +5837,19 @@ packages:
       babel-core: 6.26.3
       babel-preset-env: 1.7.0
       log4js: 4.5.1
-      magic-string: 0.25.3
+      magic-string: 0.25.4
     dev: false
     resolution:
       integrity: sha512-WTGGThwufBT73c20q30iTcXq8Jb3Wat/h+JW1lwKgMtymT5rVxLknoaUVNfenaV3+cRMiTEsBT773kz9jWk6IQ==
-  /karma-webpack/4.0.2_webpack@4.39.2:
+  /karma-webpack/4.0.2_webpack@4.41.2:
     dependencies:
       clone-deep: 4.0.1
       loader-utils: 1.2.3
       neo-async: 2.6.1
       schema-utils: 1.0.0
       source-map: 0.7.3
-      webpack: 4.39.2_webpack@4.39.2
-      webpack-dev-middleware: 3.7.0_webpack@4.39.2
+      webpack: 4.41.2_webpack@4.41.2
+      webpack-dev-middleware: 3.7.2_webpack@4.41.2
     dev: false
     engines:
       node: '>= 8.9.0'
@@ -7009,82 +5857,12 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-970/okAsdUOmiMOCY8sb17A2I8neS25Ad9uhyK3GHgmRSIFJbDcNEFE8dqqUhNe9OHiCC9k3DMrSmtd/0ymP1A==
-  /karma/4.2.0:
-    dependencies:
-      bluebird: 3.5.5
-      body-parser: 1.19.0
-      braces: 3.0.2
-      chokidar: 3.0.2
-      colors: 1.3.3
-      connect: 3.7.0
-      core-js: 3.2.1
-      di: 0.0.1
-      dom-serialize: 2.2.1
-      flatted: 2.0.1
-      glob: 7.1.4
-      graceful-fs: 4.2.2
-      http-proxy: 1.17.0
-      isbinaryfile: 3.0.3
-      lodash: 4.17.15
-      log4js: 4.5.1
-      mime: 2.4.4
-      minimatch: 3.0.4
-      optimist: 0.6.1
-      qjobs: 1.2.0
-      range-parser: 1.2.1
-      rimraf: 2.7.1
-      safe-buffer: 5.2.0
-      socket.io: 2.1.1
-      source-map: 0.6.1
-      tmp: 0.0.33
-      useragent: 2.3.0
-    dev: false
-    engines:
-      node: '>= 8'
-    hasBin: true
-    resolution:
-      integrity: sha512-fmCuxN1rwJxTdZfOXK5LjlmS4Ana/OvzNMpkyLL/TLE8hmgSkpVpMYQ7RTVa8TNKRVQDZNl5W1oF5cfKfgIMlA==
-  /karma/4.3.0:
-    dependencies:
-      bluebird: 3.5.5
-      body-parser: 1.19.0
-      braces: 3.0.2
-      chokidar: 3.0.2
-      colors: 1.3.3
-      connect: 3.7.0
-      core-js: 3.2.1
-      di: 0.0.1
-      dom-serialize: 2.2.1
-      flatted: 2.0.1
-      glob: 7.1.4
-      graceful-fs: 4.2.2
-      http-proxy: 1.17.0
-      isbinaryfile: 3.0.3
-      lodash: 4.17.15
-      log4js: 4.5.1
-      mime: 2.4.4
-      minimatch: 3.0.4
-      optimist: 0.6.1
-      qjobs: 1.2.0
-      range-parser: 1.2.1
-      rimraf: 2.7.1
-      safe-buffer: 5.2.0
-      socket.io: 2.1.1
-      source-map: 0.6.1
-      tmp: 0.0.33
-      useragent: 2.3.0
-    dev: false
-    engines:
-      node: '>= 8'
-    hasBin: true
-    resolution:
-      integrity: sha512-NSPViHOt+RW38oJklvYxQC4BSQsv737oQlr/r06pCM+slDOr4myuI1ivkRmp+3dVpJDfZt2DmaPJ2wkx+ZZuMQ==
   /karma/4.4.1:
     dependencies:
       bluebird: 3.7.1
       body-parser: 1.19.0
       braces: 3.0.2
-      chokidar: 3.2.2
+      chokidar: 3.3.0
       colors: 1.4.0
       connect: 3.7.0
       di: 0.0.1
@@ -7227,7 +6005,7 @@ packages:
       integrity: sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==
   /load-json-file/1.1.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       parse-json: 2.2.0
       pify: 2.3.0
       pinkie-promise: 2.0.1
@@ -7239,7 +6017,7 @@ packages:
       integrity: sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=
   /load-json-file/4.0.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       parse-json: 4.0.0
       pify: 3.0.0
       strip-bom: 3.0.0
@@ -7346,12 +6124,12 @@ packages:
       node: '>=6.0'
     resolution:
       integrity: sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==
-  /loglevel/1.6.3:
+  /loglevel/1.6.4:
     dev: false
     engines:
       node: '>= 0.6.0'
     resolution:
-      integrity: sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
+      integrity: sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==
   /lolex/4.2.0:
     dev: false
     resolution:
@@ -7385,14 +6163,14 @@ packages:
       integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   /lru-cache/5.1.1:
     dependencies:
-      yallist: 3.0.3
+      yallist: 3.1.1
     dev: false
     resolution:
       integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
-  /lunr/2.3.6:
+  /lunr/2.3.8:
     dev: false
     resolution:
-      integrity: sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q==
+      integrity: sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==
   /macos-release/2.3.0:
     dev: false
     engines:
@@ -7405,12 +6183,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==
-  /magic-string/0.25.3:
+  /magic-string/0.25.4:
     dependencies:
       sourcemap-codec: 1.4.6
     dev: false
     resolution:
-      integrity: sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==
+      integrity: sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==
   /make-dir/2.1.0:
     dependencies:
       pify: 4.0.1
@@ -7496,7 +6274,7 @@ packages:
     dependencies:
       arr-union: 3.1.0
       async-array-reduce: 0.2.1
-      glob: 7.1.4
+      glob: 7.1.5
       has-glob: 1.0.0
       is-valid-glob: 1.0.0
       resolve-dir: 1.0.1
@@ -7551,6 +6329,15 @@ packages:
     dev: false
     resolution:
       integrity: sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
+  /memory-fs/0.5.0:
+    dependencies:
+      errno: 0.1.7
+      readable-stream: 2.3.6
+    dev: false
+    engines:
+      node: '>=4.3.0 <5.0.0 || >=5.10'
+    resolution:
+      integrity: sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==
   /memorystream/0.3.1:
     dev: false
     engines:
@@ -7633,7 +6420,7 @@ packages:
   /micromatch/4.0.2:
     dependencies:
       braces: 3.0.2
-      picomatch: 2.0.7
+      picomatch: 2.1.0
     dev: false
     engines:
       node: '>=8'
@@ -7675,12 +6462,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
-  /mimic-fn/1.2.0:
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
   /mimic-fn/2.1.0:
     dev: false
     engines:
@@ -7732,10 +6513,10 @@ packages:
     dependencies:
       concat-stream: 1.6.2
       duplexify: 3.7.1
-      end-of-stream: 1.4.1
+      end-of-stream: 1.4.4
       flush-write-stream: 1.1.1
       from2: 2.3.0
-      parallel-transform: 1.1.0
+      parallel-transform: 1.2.0
       pump: 3.0.0
       pumpify: 1.5.1
       stream-each: 1.2.3
@@ -7761,16 +6542,16 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
-  /mocha-chrome/2.0.0:
+  /mocha-chrome/2.2.0:
     dependencies:
       chalk: 2.4.2
-      chrome-launcher: 0.10.7
-      chrome-remote-interface: 0.27.2
+      chrome-launcher: 0.11.2
+      chrome-remote-interface: 0.28.0
       chrome-unmirror: 0.1.0
       debug: 4.1.1
       deep-assign: 3.0.0
       import-local: 2.0.0
-      loglevel: 1.6.3
+      loglevel: 1.6.4
       meow: 5.0.0
       nanobus: 4.4.0
     dev: false
@@ -7778,7 +6559,7 @@ packages:
       node: '>= 8.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-Kq6W9jdXY3C2PhNHtSrk3GnDuoAKN+DbgJKCLfXtc5cql8oHB8+rUYlq9t1c8in6vQ6/X432E/U8h0pV5QlAug==
+      integrity: sha512-RXP6Q2mlM2X+eO2Z8gribmiH4J9x5zu/JcTZ3deQSwiC5260BzizOc0eD1NWP3JuypGCKRwReicv4KCNIFtTZQ==
   /mocha-junit-reporter/1.23.1_mocha@6.2.2:
     dependencies:
       debug: 2.6.9
@@ -7879,10 +6660,6 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==
-  /mute-stream/0.0.7:
-    dev: false
-    resolution:
-      integrity: sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
   /mute-stream/0.0.8:
     dev: false
     resolution:
@@ -7967,16 +6744,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-  /nise/1.5.1:
-    dependencies:
-      '@sinonjs/formatio': 3.2.1
-      '@sinonjs/text-encoding': 0.7.1
-      just-extend: 4.0.2
-      lolex: 4.2.0
-      path-to-regexp: 1.7.0
-    dev: false
-    resolution:
-      integrity: sha512-edFWm0fsFG2n318rfEnKlTZTkjlbVOFF9XIA+fj+Ed+Qz1laYW2lobwavWoMzGrYDHH1EpiNJgDfvGnkZztR/g==
   /nise/1.5.2:
     dependencies:
       '@sinonjs/formatio': 3.2.2
@@ -7987,7 +6754,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
-  /nock/11.3.2:
+  /nock/11.7.0:
     dependencies:
       chai: 4.2.0
       debug: 4.1.1
@@ -7999,20 +6766,7 @@ packages:
     engines:
       node: '>= 8.0'
     resolution:
-      integrity: sha512-Bb00vTmuXyucMT9gcnMSiE2n6P5yrRoAyej0eF6ik6VUxG0FKp4RcSx1TzFusEDtY3hMNpsd7ZYUSIvwtNpTrw==
-  /nock/11.6.0:
-    dependencies:
-      chai: 4.2.0
-      debug: 4.1.1
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.15
-      mkdirp: 0.5.1
-      propagate: 2.0.1
-    dev: false
-    engines:
-      node: '>= 8.0'
-    resolution:
-      integrity: sha512-9ocFR68CxS6nf2XtQNpdSh5n4QQSKl87DhXgLnHO/RD4CsGThFtu8/QG6myHTnrUHRE6JSKpiGjLJdRe2ZSlIA==
+      integrity: sha512-7c1jhHew74C33OBeRYyQENT+YXQiejpwIrEjinh6dRurBae+Ei4QjeUaPlkptIF0ZacEiVCnw8dWaxqepkiihg==
   /node-abort-controller/1.0.4:
     dev: false
     resolution:
@@ -8035,7 +6789,7 @@ packages:
       assert: 1.5.0
       browserify-zlib: 0.2.0
       buffer: 4.9.1
-      console-browserify: 1.1.0
+      console-browserify: 1.2.0
       constants-browserify: 1.0.0
       crypto-browserify: 3.12.0
       domain-browser: 1.2.0
@@ -8054,7 +6808,7 @@ packages:
       tty-browserify: 0.0.0
       url: 0.11.0
       util: 0.11.1
-      vm-browserify: 1.1.0
+      vm-browserify: 1.1.2
     dev: false
     resolution:
       integrity: sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -8067,7 +6821,7 @@ packages:
       integrity: sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
   /normalize-package-data/2.5.0:
     dependencies:
-      hosted-git-info: 2.8.4
+      hosted-git-info: 2.8.5
       resolve: 1.12.0
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
@@ -8105,7 +6859,7 @@ packages:
       minimatch: 3.0.4
       pidtree: 0.3.0
       read-pkg: 3.0.0
-      shell-quote: 1.7.1
+      shell-quote: 1.7.2
       string.prototype.padend: 3.0.0
     dev: false
     engines:
@@ -8136,7 +6890,7 @@ packages:
       find-cache-dir: 2.1.0
       find-up: 3.0.0
       foreground-child: 1.5.6
-      glob: 7.1.4
+      glob: 7.1.5
       istanbul-lib-coverage: 2.0.5
       istanbul-lib-hook: 2.0.7
       istanbul-lib-instrument: 3.3.0
@@ -8149,7 +6903,7 @@ packages:
       resolve-from: 4.0.0
       rimraf: 2.7.1
       signal-exit: 3.0.2
-      spawn-wrap: 1.4.2
+      spawn-wrap: 1.4.3
       test-exclude: 5.2.3
       uuid: 3.3.3
       yargs: 13.3.0
@@ -8184,6 +6938,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+  /object-inspect/1.6.0:
+    dev: false
+    resolution:
+      integrity: sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==
   /object-keys/1.1.1:
     dev: false
     engines:
@@ -8223,7 +6981,7 @@ packages:
   /object.entries/1.1.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.13.0
+      es-abstract: 1.16.0
       function-bind: 1.1.1
       has: 1.0.3
     dev: false
@@ -8234,7 +6992,7 @@ packages:
   /object.getownpropertydescriptors/2.0.3:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.13.0
+      es-abstract: 1.16.0
     dev: false
     engines:
       node: '>= 0.8'
@@ -8280,14 +7038,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
-  /onetime/2.0.1:
-    dependencies:
-      mimic-fn: 1.2.0
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   /onetime/5.1.0:
     dependencies:
       mimic-fn: 2.1.0
@@ -8460,7 +7210,7 @@ packages:
       integrity: sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==
   /package-hash/3.0.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       hasha: 3.0.0
       lodash.flattendeep: 4.4.0
       release-zalgo: 1.0.0
@@ -8473,14 +7223,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
-  /parallel-transform/1.1.0:
+  /parallel-transform/1.2.0:
     dependencies:
-      cyclist: 0.2.2
+      cyclist: 1.0.1
       inherits: 2.0.4
       readable-stream: 2.3.6
     dev: false
     resolution:
-      integrity: sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=
+      integrity: sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==
   /parent-module/1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -8489,7 +7239,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
-  /parse-asn1/5.1.4:
+  /parse-asn1/5.1.5:
     dependencies:
       asn1.js: 4.10.1
       browserify-aes: 1.2.0
@@ -8499,7 +7249,7 @@ packages:
       safe-buffer: 5.2.0
     dev: false
     resolution:
-      integrity: sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==
+      integrity: sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==
   /parse-filepath/1.0.2:
     dependencies:
       is-absolute: 1.0.0
@@ -8635,7 +7385,7 @@ packages:
       integrity: sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
   /path-type/1.1.0:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       pify: 2.3.0
       pinkie-promise: 2.0.1
     dev: false
@@ -8675,12 +7425,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
-  /picomatch/2.0.7:
+  /picomatch/2.1.0:
     dev: false
     engines:
-      node: '>=8'
+      node: '>=8.6'
     resolution:
-      integrity: sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+      integrity: sha512-uhnEDzAbrcJ8R3g2fANnSuXZMBtkpSjxTTgn2LeSiQlfmq72enQJWdQllXW24MBLYnA1SBD2vfvx2o0Zw3Ielw==
   /pidtree/0.3.0:
     dev: false
     engines:
@@ -8868,16 +7618,16 @@ packages:
     dev: false
     resolution:
       integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-  /psl/1.3.0:
+  /psl/1.4.0:
     dev: false
     resolution:
-      integrity: sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==
+      integrity: sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
   /public-encrypt/4.0.3:
     dependencies:
       bn.js: 4.11.8
       browserify-rsa: 4.0.1
       create-hash: 1.2.0
-      parse-asn1: 5.1.4
+      parse-asn1: 5.1.5
       randombytes: 2.1.0
       safe-buffer: 5.2.0
     dev: false
@@ -8885,14 +7635,14 @@ packages:
       integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==
   /pump/2.0.1:
     dependencies:
-      end-of-stream: 1.4.1
+      end-of-stream: 1.4.4
       once: 1.4.0
     dev: false
     resolution:
       integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==
   /pump/3.0.0:
     dependencies:
-      end-of-stream: 1.4.1
+      end-of-stream: 1.4.4
       once: 1.4.0
     dev: false
     resolution:
@@ -8921,33 +7671,17 @@ packages:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
   /pupa/2.0.1:
     dependencies:
-      escape-goat: 2.1.0
+      escape-goat: 2.1.1
     dev: false
     engines:
       node: '>=8'
     resolution:
       integrity: sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==
-  /puppeteer/1.19.0:
-    dependencies:
-      debug: 4.1.1
-      extract-zip: 1.6.7
-      https-proxy-agent: 2.2.2
-      mime: 2.4.4
-      progress: 2.0.3
-      proxy-from-env: 1.0.0
-      rimraf: 2.7.1
-      ws: 6.2.1
-    dev: false
-    engines:
-      node: '>=6.4.0'
-    requiresBuild: true
-    resolution:
-      integrity: sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==
   /puppeteer/1.20.0:
     dependencies:
       debug: 4.1.1
       extract-zip: 1.6.7
-      https-proxy-agent: 2.2.3
+      https-proxy-agent: 2.2.4
       mime: 2.4.4
       progress: 2.0.3
       proxy-from-env: 1.0.0
@@ -8977,12 +7711,12 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
-  /qs/6.8.0:
+  /qs/6.9.0:
     dev: false
     engines:
       node: '>=0.6'
     resolution:
-      integrity: sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w==
+      integrity: sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==
   /query-string/5.1.1:
     dependencies:
       decode-uri-component: 0.2.0
@@ -9151,7 +7885,7 @@ packages:
       integrity: sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
   /readdirp/2.2.1:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       micromatch: 3.1.10
       readable-stream: 2.3.6
     dev: false
@@ -9159,25 +7893,9 @@ packages:
       node: '>=0.10'
     resolution:
       integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
-  /readdirp/3.1.2:
-    dependencies:
-      picomatch: 2.0.7
-    dev: false
-    engines:
-      node: '>= 8'
-    resolution:
-      integrity: sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==
-  /readdirp/3.1.3:
-    dependencies:
-      picomatch: 2.0.7
-    dev: false
-    engines:
-      node: '>= 8'
-    resolution:
-      integrity: sha512-ZOsfTGkjO2kqeR5Mzr5RYDbTGYneSkdNKX2fOX2P5jF7vMrd/GNnIAUtDldeHHumHUCQ3V05YfWUdxMPAsRu9Q==
   /readdirp/3.2.0:
     dependencies:
-      picomatch: 2.0.7
+      picomatch: 2.1.0
     dev: false
     engines:
       node: '>= 8'
@@ -9459,15 +8177,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
-  /restore-cursor/2.0.0:
-    dependencies:
-      onetime: 2.0.1
-      signal-exit: 3.0.2
-    dev: false
-    engines:
-      node: '>=4'
-    resolution:
-      integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
   /restore-cursor/3.1.0:
     dependencies:
       onetime: 5.1.0
@@ -9490,7 +8199,7 @@ packages:
   /rhea-promise/0.1.15:
     dependencies:
       debug: 3.2.6
-      rhea: 1.0.8
+      rhea: 1.0.11
       tslib: 1.10.0
     dev: false
     resolution:
@@ -9498,34 +8207,34 @@ packages:
   /rhea-promise/1.0.0:
     dependencies:
       debug: 3.2.6
-      rhea: 1.0.8
+      rhea: 1.0.11
       tslib: 1.10.0
     dev: false
     resolution:
       integrity: sha512-odAjpbB/IpFFBenPDwPkTWMQldt+DUlMBH9yI48Ct5OgTeDuuQcBnlhB+YCc6g2z8+URiP2ejms88joEanNCaw==
-  /rhea/1.0.8:
+  /rhea/1.0.11:
     dependencies:
       debug: 3.2.6
     dev: false
     resolution:
-      integrity: sha512-TNv6rD/74h2QiXrUpFHw6fzGNuOpVOcjPRGtlKC5eIy5NLfvb2RiZGZs7lpg4al22p5pAAQjLZuPTDipReUzPA==
+      integrity: sha512-gmloHC4fpBzak8DwzVdL+sMmnzFpuOqxCiXFgSk/sTge2ftSXeGIYqemVSEuWBUH6bfS/hx47O/2B71LxM2IQQ==
   /rimraf/2.6.3:
     dependencies:
-      glob: 7.1.4
+      glob: 7.1.5
     dev: false
     hasBin: true
     resolution:
       integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   /rimraf/2.7.1:
     dependencies:
-      glob: 7.1.4
+      glob: 7.1.5
     dev: false
     hasBin: true
     resolution:
       integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   /rimraf/3.0.0:
     dependencies:
-      glob: 7.1.4
+      glob: 7.1.5
     dev: false
     hasBin: true
     resolution:
@@ -9537,75 +8246,30 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  /rollup-plugin-alias/1.5.2:
-    dependencies:
-      slash: 3.0.0
-    dev: false
-    resolution:
-      integrity: sha512-ODeZXhTxpD48sfcYLAFc1BGrsXKDj7o1CSNH3uYbdK3o0NxyMmaQPTNgW+ko+am92DLC8QSTe4kyxTuEkI5S5w==
-  /rollup-plugin-commonjs/10.0.2_rollup@1.20.1:
+  /rollup-plugin-commonjs/10.1.0_rollup@1.26.3:
     dependencies:
       estree-walker: 0.6.1
-      is-reference: 1.1.3
-      magic-string: 0.25.3
+      is-reference: 1.1.4
+      magic-string: 0.25.4
       resolve: 1.12.0
-      rollup: 1.20.1
-      rollup-pluginutils: 2.8.1
-    dev: false
-    peerDependencies:
-      rollup: '>=1.12.0'
-    resolution:
-      integrity: sha512-DxeR4QXTgTOFseYls1V7vgKbrSJmPYNdEMOs0OvH+7+89C3GiIonU9gFrE0u39Vv1KWm3wepq8KAvKugtoM2Zw==
-  /rollup-plugin-commonjs/10.1.0_rollup@1.20.3:
-    dependencies:
-      estree-walker: 0.6.1
-      is-reference: 1.1.3
-      magic-string: 0.25.3
-      resolve: 1.12.0
-      rollup: 1.20.3
-      rollup-pluginutils: 2.8.1
+      rollup: 1.26.3
+      rollup-pluginutils: 2.8.2
     dev: false
     peerDependencies:
       rollup: '>=1.12.0'
     resolution:
       integrity: sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
-  /rollup-plugin-commonjs/10.1.0_rollup@1.23.1:
+  /rollup-plugin-inject/3.0.2:
     dependencies:
       estree-walker: 0.6.1
-      is-reference: 1.1.3
-      magic-string: 0.25.3
-      resolve: 1.12.0
-      rollup: 1.23.1
-      rollup-pluginutils: 2.8.1
-    dev: false
-    peerDependencies:
-      rollup: '>=1.12.0'
-    resolution:
-      integrity: sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
-  /rollup-plugin-commonjs/10.1.0_rollup@1.25.2:
-    dependencies:
-      estree-walker: 0.6.1
-      is-reference: 1.1.3
-      magic-string: 0.25.3
-      resolve: 1.12.0
-      rollup: 1.25.2
-      rollup-pluginutils: 2.8.1
-    dev: false
-    peerDependencies:
-      rollup: '>=1.12.0'
-    resolution:
-      integrity: sha512-jlXbjZSQg8EIeAAvepNwhJj++qJWNJw1Cl0YnOqKtP5Djx+fFGkp3WRh+W0ASCaFG5w1jhmzDxgu3SJuVxPF4Q==
-  /rollup-plugin-inject/3.0.1:
-    dependencies:
-      estree-walker: 0.6.1
-      magic-string: 0.25.3
-      rollup-pluginutils: 2.8.1
+      magic-string: 0.25.4
+      rollup-pluginutils: 2.8.2
     dev: false
     resolution:
-      integrity: sha512-zF0jOuSpBxdLwAeDsS/+zGYgseaoH9LwqRNsByuzmE3bxfQ4Pg2gDoXGGWiia7iFyA8nLT+6iHrAqQYtH3Olow==
+      integrity: sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==
   /rollup-plugin-json/4.0.0:
     dependencies:
-      rollup-pluginutils: 2.8.1
+      rollup-pluginutils: 2.8.2
     dev: false
     resolution:
       integrity: sha512-hgb8N7Cgfw5SZAkb3jf0QXii6QX/FOkiIq2M7BAQIEydjHvTyxXHQiIzZaTFgx1GK0cRCHOCBHIyEkkLdWKxow==
@@ -9626,70 +8290,18 @@ packages:
       estree-walker: 0.5.2
       magic-string: 0.22.5
       process-es6: 0.11.6
-      rollup-pluginutils: 2.8.1
+      rollup-pluginutils: 2.8.2
     dev: false
     resolution:
       integrity: sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==
-  /rollup-plugin-node-resolve/5.2.0_rollup@1.20.1:
+  /rollup-plugin-node-resolve/5.2.0_rollup@1.26.3:
     dependencies:
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
       resolve: 1.12.0
-      rollup: 1.20.1
-      rollup-pluginutils: 2.8.1
-    dev: false
-    peerDependencies:
-      rollup: '>=1.11.0'
-    resolution:
-      integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  /rollup-plugin-node-resolve/5.2.0_rollup@1.20.3:
-    dependencies:
-      '@types/resolve': 0.0.8
-      builtin-modules: 3.1.0
-      is-module: 1.0.0
-      resolve: 1.12.0
-      rollup: 1.20.3
-      rollup-pluginutils: 2.8.1
-    dev: false
-    peerDependencies:
-      rollup: '>=1.11.0'
-    resolution:
-      integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  /rollup-plugin-node-resolve/5.2.0_rollup@1.23.1:
-    dependencies:
-      '@types/resolve': 0.0.8
-      builtin-modules: 3.1.0
-      is-module: 1.0.0
-      resolve: 1.12.0
-      rollup: 1.23.1
-      rollup-pluginutils: 2.8.1
-    dev: false
-    peerDependencies:
-      rollup: '>=1.11.0'
-    resolution:
-      integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  /rollup-plugin-node-resolve/5.2.0_rollup@1.24.0:
-    dependencies:
-      '@types/resolve': 0.0.8
-      builtin-modules: 3.1.0
-      is-module: 1.0.0
-      resolve: 1.12.0
-      rollup: 1.24.0
-      rollup-pluginutils: 2.8.1
-    dev: false
-    peerDependencies:
-      rollup: '>=1.11.0'
-    resolution:
-      integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
-  /rollup-plugin-node-resolve/5.2.0_rollup@1.25.2:
-    dependencies:
-      '@types/resolve': 0.0.8
-      builtin-modules: 3.1.0
-      is-module: 1.0.0
-      resolve: 1.12.0
-      rollup: 1.25.2
-      rollup-pluginutils: 2.8.1
+      rollup: 1.26.3
+      rollup-pluginutils: 2.8.2
     dev: false
     peerDependencies:
       rollup: '>=1.11.0'
@@ -9697,8 +8309,9 @@ packages:
       integrity: sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
   /rollup-plugin-replace/2.2.0:
     dependencies:
-      magic-string: 0.25.3
-      rollup-pluginutils: 2.8.1
+      magic-string: 0.25.4
+      rollup-pluginutils: 2.8.2
+    deprecated: This module has moved and is now available at @rollup/plugin-replace. Please update your dependencies. This version is no longer maintained.
     dev: false
     resolution:
       integrity: sha512-/5bxtUPkDHyBJAKketb4NfaeZjL5yLZdeUihSfbF2PQMz+rSTEb8ARKoOl3UBT4m7/X+QOXJo3sLTcq+yMMYTA==
@@ -9706,9 +8319,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rZqFD43y4U9nSqVq3iyWBiDwmBQJY8Txi04yI9jTKD3xcl7CbFjh1qRpQshUB3sONLubDzm7vJiwB+1MEGv67w==
-  /rollup-plugin-sourcemaps/0.4.2_rollup@1.20.1:
+  /rollup-plugin-sourcemaps/0.4.2_rollup@1.26.3:
     dependencies:
-      rollup: 1.20.1
+      rollup: 1.26.3
       rollup-pluginutils: 2.8.2
       source-map-resolve: 0.5.2
     dev: false
@@ -9719,140 +8332,37 @@ packages:
       rollup: '>=0.31.2'
     resolution:
       integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  /rollup-plugin-sourcemaps/0.4.2_rollup@1.20.3:
-    dependencies:
-      rollup: 1.20.3
-      rollup-pluginutils: 2.8.2
-      source-map-resolve: 0.5.2
-    dev: false
-    engines:
-      node: '>=4.5.0'
-      npm: '>=2.15.9'
-    peerDependencies:
-      rollup: '>=0.31.2'
-    resolution:
-      integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  /rollup-plugin-sourcemaps/0.4.2_rollup@1.23.1:
-    dependencies:
-      rollup: 1.23.1
-      rollup-pluginutils: 2.8.2
-      source-map-resolve: 0.5.2
-    dev: false
-    engines:
-      node: '>=4.5.0'
-      npm: '>=2.15.9'
-    peerDependencies:
-      rollup: '>=0.31.2'
-    resolution:
-      integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  /rollup-plugin-sourcemaps/0.4.2_rollup@1.24.0:
-    dependencies:
-      rollup: 1.24.0
-      rollup-pluginutils: 2.8.2
-      source-map-resolve: 0.5.2
-    dev: false
-    engines:
-      node: '>=4.5.0'
-      npm: '>=2.15.9'
-    peerDependencies:
-      rollup: '>=0.31.2'
-    resolution:
-      integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  /rollup-plugin-sourcemaps/0.4.2_rollup@1.25.2:
-    dependencies:
-      rollup: 1.25.2
-      rollup-pluginutils: 2.8.2
-      source-map-resolve: 0.5.2
-    dev: false
-    engines:
-      node: '>=4.5.0'
-      npm: '>=2.15.9'
-    peerDependencies:
-      rollup: '>=0.31.2'
-    resolution:
-      integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  /rollup-plugin-terser/5.1.1_rollup@1.20.1:
+  /rollup-plugin-terser/5.1.2_rollup@1.26.3:
     dependencies:
       '@babel/code-frame': 7.5.5
       jest-worker: 24.9.0
-      rollup: 1.20.1
-      rollup-pluginutils: 2.8.1
-      serialize-javascript: 1.8.0
-      terser: 4.2.0
-    dev: false
-    peerDependencies:
-      rollup: '>=0.66.0 <2'
-    resolution:
-      integrity: sha512-McIMCDEY8EU6Y839C09UopeRR56wXHGdvKKjlfiZG/GrP6wvZQ62u2ko/Xh1MNH2M9WDL+obAAHySljIZYCuPQ==
-  /rollup-plugin-terser/5.1.1_rollup@1.20.3:
-    dependencies:
-      '@babel/code-frame': 7.5.5
-      jest-worker: 24.9.0
-      rollup: 1.20.3
-      rollup-pluginutils: 2.8.1
-      serialize-javascript: 1.8.0
-      terser: 4.2.0
-    dev: false
-    peerDependencies:
-      rollup: '>=0.66.0 <2'
-    resolution:
-      integrity: sha512-McIMCDEY8EU6Y839C09UopeRR56wXHGdvKKjlfiZG/GrP6wvZQ62u2ko/Xh1MNH2M9WDL+obAAHySljIZYCuPQ==
-  /rollup-plugin-terser/5.1.2_rollup@1.23.1:
-    dependencies:
-      '@babel/code-frame': 7.5.5
-      jest-worker: 24.9.0
-      rollup: 1.23.1
+      rollup: 1.26.3
       rollup-pluginutils: 2.8.2
       serialize-javascript: 1.9.1
-      terser: 4.3.8
+      terser: 4.3.9
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <2'
     resolution:
       integrity: sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==
-  /rollup-plugin-terser/5.1.2_rollup@1.25.2:
+  /rollup-plugin-uglify/6.0.3_rollup@1.26.3:
     dependencies:
       '@babel/code-frame': 7.5.5
       jest-worker: 24.9.0
-      rollup: 1.25.2
-      rollup-pluginutils: 2.8.2
+      rollup: 1.26.3
       serialize-javascript: 1.9.1
-      terser: 4.3.8
-    dev: false
-    peerDependencies:
-      rollup: '>=0.66.0 <2'
-    resolution:
-      integrity: sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==
-  /rollup-plugin-uglify/6.0.2_rollup@1.20.1:
-    dependencies:
-      '@babel/code-frame': 7.5.5
-      jest-worker: 24.9.0
-      rollup: 1.20.1
-      serialize-javascript: 1.8.0
-      uglify-js: 3.6.0
-    dev: false
-    peerDependencies:
-      rollup: '>=0.66.0 <2'
-    resolution:
-      integrity: sha512-qwz2Tryspn5QGtPUowq5oumKSxANKdrnfz7C0jm4lKxvRDsNe/hSGsB9FntUul7UeC4TsZEWKErVgE1qWSO0gw==
-  /rollup-plugin-uglify/6.0.3_rollup@1.25.2:
-    dependencies:
-      '@babel/code-frame': 7.5.5
-      jest-worker: 24.9.0
-      rollup: 1.25.2
-      serialize-javascript: 1.9.1
-      uglify-js: 3.6.4
+      uglify-js: 3.6.7
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <2'
     resolution:
       integrity: sha512-PIv3CfhZJlOG8C85N0GX+uK09TPggmAS6Nk6fpp2ELzDAV5VUhNzOURDU2j7+MwuRr0zq9IZttUTADc/jH8Gkg==
-  /rollup-plugin-visualizer/2.5.4_rollup@1.20.1:
+  /rollup-plugin-visualizer/2.7.2_rollup@1.26.3:
     dependencies:
       mkdirp: 0.5.1
       open: 6.4.0
       pupa: 2.0.1
-      rollup: 1.20.1
+      rollup: 1.26.3
       source-map: 0.7.3
     dev: false
     engines:
@@ -9860,106 +8370,22 @@ packages:
     peerDependencies:
       rollup: '>=0.60.0'
     resolution:
-      integrity: sha512-ehMX8Us4UmHmt9y6uvBdtW3ASAQDqCcmp07Qrm8dBqQMf1eAd89Rc/owGZr0cDp764dvLKQRA03W+nWlRajl4w==
-  /rollup-plugin-visualizer/2.5.4_rollup@1.20.3:
-    dependencies:
-      mkdirp: 0.5.1
-      open: 6.4.0
-      pupa: 2.0.1
-      rollup: 1.20.3
-      source-map: 0.7.3
-    dev: false
-    engines:
-      node: '>=8.10'
-    peerDependencies:
-      rollup: '>=0.60.0'
-    resolution:
-      integrity: sha512-ehMX8Us4UmHmt9y6uvBdtW3ASAQDqCcmp07Qrm8dBqQMf1eAd89Rc/owGZr0cDp764dvLKQRA03W+nWlRajl4w==
-  /rollup-plugin-visualizer/2.6.0_rollup@1.24.0:
-    dependencies:
-      mkdirp: 0.5.1
-      open: 6.4.0
-      pupa: 2.0.1
-      rollup: 1.24.0
-      source-map: 0.7.3
-    dev: false
-    engines:
-      node: '>=8.10'
-    peerDependencies:
-      rollup: '>=0.60.0'
-    resolution:
-      integrity: sha512-9HjvKAKUNqlcpLszA14njiQJgi+5rZSdMJymKXpFncHMBRPPCRh9jmKzZHqhoq5c1K/+Tjo9flMUcgdlPD397Q==
-  /rollup-plugin-visualizer/2.6.0_rollup@1.25.2:
-    dependencies:
-      mkdirp: 0.5.1
-      open: 6.4.0
-      pupa: 2.0.1
-      rollup: 1.25.2
-      source-map: 0.7.3
-    dev: false
-    engines:
-      node: '>=8.10'
-    peerDependencies:
-      rollup: '>=0.60.0'
-    resolution:
-      integrity: sha512-9HjvKAKUNqlcpLszA14njiQJgi+5rZSdMJymKXpFncHMBRPPCRh9jmKzZHqhoq5c1K/+Tjo9flMUcgdlPD397Q==
-  /rollup-pluginutils/2.8.1:
-    dependencies:
-      estree-walker: 0.6.1
-    dev: false
-    resolution:
-      integrity: sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
+      integrity: sha512-aJ9GA2mGblEttMmyA2bO8Ce40/VAH3tFYhiXaEJKuJTY6eaU5q744wgE6H8YzM2mc1uLQeejn6A00ldjUSLhyA==
   /rollup-pluginutils/2.8.2:
     dependencies:
       estree-walker: 0.6.1
     dev: false
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  /rollup/1.20.1:
+  /rollup/1.26.3:
     dependencies:
       '@types/estree': 0.0.39
-      '@types/node': 12.7.2
-      acorn: 7.0.0
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-8DV8eWLq84fbJFRqkjWg8BWX4NTTdHpx9bxjmTl/83z54o6Ygo1OgUDjJGFq/xe5i0kDspnbjzw2V+ZPXD/BrQ==
-  /rollup/1.20.3:
-    dependencies:
-      '@types/estree': 0.0.39
-      '@types/node': 12.7.4
-      acorn: 7.0.0
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-/OMCkY0c6E8tleeVm4vQVDz24CkVgvueK3r8zTYu2AQNpjrcaPwO9hE+pWj5LTFrvvkaxt4MYIp2zha4y0lRvg==
-  /rollup/1.23.1:
-    dependencies:
-      '@types/estree': 0.0.39
-      '@types/node': 8.10.54
+      '@types/node': 8.10.58
       acorn: 7.1.0
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-95C1GZQpr/NIA0kMUQmSjuMDQ45oZfPgDBcN0yZwBG7Kee//m7H68vgIyg+SPuyrTZ5PrXfyLK80OzXeKG5dAA==
-  /rollup/1.24.0:
-    dependencies:
-      '@types/estree': 0.0.39
-      '@types/node': 8.10.54
-      acorn: 7.1.0
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-PiFETY/rPwodQ8TTC52Nz2DSCYUATznGh/ChnxActCr8rV5FIk3afBUb3uxNritQW/Jpbdn3kq1Rwh1HHYMwdQ==
-  /rollup/1.25.2:
-    dependencies:
-      '@types/estree': 0.0.39
-      '@types/node': 8.10.56
-      acorn: 7.1.0
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-+7z6Wab/L45QCPcfpuTZKwKiB0tynj05s/+s2U3F2Bi7rOLPr9UcjUwO7/xpjlPNXA/hwnth6jBExFRGyf3tMg==
+      integrity: sha512-8MhY/M8gnv3Q/pQQSWYWzbeJ5J1C5anCNY5BK1kV8Yzw9RFS0FF4lbLt+uyPO3wLKWXSXrhAL5pWL85TZAh+Sw==
   /run-async/2.3.0:
     dependencies:
       is-promise: 2.1.0
@@ -10018,12 +8444,6 @@ packages:
       node: '>= 4'
     resolution:
       integrity: sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==
-  /semaphore/1.0.5:
-    dev: false
-    engines:
-      node: '>=0.8.0'
-    resolution:
-      integrity: sha1-tJJXbmavGT25XWXiXsU/Xxl5jWA=
   /semaphore/1.1.0:
     dev: false
     engines:
@@ -10068,10 +8488,6 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
-  /serialize-javascript/1.8.0:
-    dev: false
-    resolution:
-      integrity: sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==
   /serialize-javascript/1.9.1:
     dev: false
     resolution:
@@ -10140,13 +8556,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
-  /shell-quote/1.7.1:
+  /shell-quote/1.7.2:
     dev: false
     resolution:
-      integrity: sha512-2kUqeAGnMAu6YrTPX4E3LfxacH9gKljzVjlkUeSqY0soGwK4KLl7TURXCem712tkhBCeeaFP9QK4dKn88s3Icg==
+      integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
   /shelljs/0.8.3:
     dependencies:
-      glob: 7.1.4
+      glob: 7.1.5
       interpret: 1.2.0
       rechoir: 0.6.2
     dev: false
@@ -10170,30 +8586,24 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
-  /sinon/7.4.1:
+  /sinon/7.5.0:
     dependencies:
       '@sinonjs/commons': 1.6.0
-      '@sinonjs/formatio': 3.2.1
+      '@sinonjs/formatio': 3.2.2
       '@sinonjs/samsam': 3.3.3
       diff: 3.5.0
       lolex: 4.2.0
-      nise: 1.5.1
+      nise: 1.5.2
       supports-color: 5.5.0
     dev: false
     resolution:
-      integrity: sha512-7s9buHGHN/jqoy/v4bJgmt0m1XEkCEd/tqdHXumpBp0JSujaT4Ng84JU5wDdK4E85ZMq78NuDe0I3NAqXY8TFg==
+      integrity: sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
   /slash/1.0.0:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
-  /slash/3.0.0:
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
   /slice-ansi/2.1.0:
     dependencies:
       ansi-styles: 3.2.1
@@ -10378,13 +8788,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==
-  /source-map-support/0.5.13:
+  /source-map-support/0.5.16:
     dependencies:
       buffer-from: 1.1.1
       source-map: 0.6.1
     dev: false
     resolution:
-      integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+      integrity: sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
   /source-map-url/0.4.0:
     dev: false
     resolution:
@@ -10426,7 +8836,7 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw==
-  /spawn-wrap/1.4.2:
+  /spawn-wrap/1.4.3:
     dependencies:
       foreground-child: 1.5.6
       mkdirp: 0.5.1
@@ -10436,7 +8846,7 @@ packages:
       which: 1.3.1
     dev: false
     resolution:
-      integrity: sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==
+      integrity: sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==
   /spdx-correct/3.1.0:
     dependencies:
       spdx-expression-parse: 3.0.0
@@ -10522,7 +8932,7 @@ packages:
       integrity: sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==
   /stream-each/1.2.3:
     dependencies:
-      end-of-stream: 1.4.1
+      end-of-stream: 1.4.4
       stream-shift: 1.0.0
     dev: false
     resolution:
@@ -10616,13 +9026,31 @@ packages:
   /string.prototype.padend/3.0.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.13.0
+      es-abstract: 1.16.0
       function-bind: 1.1.1
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
       integrity: sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=
+  /string.prototype.trimleft/2.1.0:
+    dependencies:
+      define-properties: 1.1.3
+      function-bind: 1.1.1
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==
+  /string.prototype.trimright/2.1.0:
+    dependencies:
+      define-properties: 1.1.3
+      function-bind: 1.1.1
+    dev: false
+    engines:
+      node: '>= 0.4'
+    resolution:
+      integrity: sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==
   /string_decoder/0.10.31:
     dev: false
     resolution:
@@ -10751,7 +9179,7 @@ packages:
   /sver-compat/1.5.0:
     dependencies:
       es6-iterator: 2.0.3
-      es6-symbol: 3.1.1
+      es6-symbol: 3.1.3
     dev: false
     resolution:
       integrity: sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=
@@ -10772,16 +9200,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-  /terser-webpack-plugin/1.4.1_webpack@4.39.2:
+  /terser-webpack-plugin/1.4.1_webpack@4.41.2:
     dependencies:
       cacache: 12.0.3
       find-cache-dir: 2.1.0
       is-wsl: 1.1.0
       schema-utils: 1.0.0
-      serialize-javascript: 1.8.0
+      serialize-javascript: 1.9.1
       source-map: 0.6.1
-      terser: 4.2.0
-      webpack: 4.39.2_webpack@4.39.2
+      terser: 4.3.9
+      webpack: 4.41.2_webpack@4.41.2
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -10791,31 +9219,20 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==
-  /terser/4.2.0:
+  /terser/4.3.9:
     dependencies:
-      commander: 2.20.0
+      commander: 2.20.3
       source-map: 0.6.1
-      source-map-support: 0.5.13
+      source-map-support: 0.5.16
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-6lPt7lZdZ/13icQJp8XasFOwZjFJkxFFIb/N1fhYEQNoNI3Ilo3KABZ9OocZvZoB39r6SiIk/0+v/bt8nZoSeA==
-  /terser/4.3.8:
-    dependencies:
-      commander: 2.20.1
-      source-map: 0.6.1
-      source-map-support: 0.5.13
-    dev: false
-    engines:
-      node: '>=6.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-otmIRlRVmLChAWsnSFNO0Bfk6YySuBp6G9qrHiJwlLDd4mxe2ta4sjI7TzIR+W1nBMjilzrMcPOz9pSusgx3hQ==
+      integrity: sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==
   /test-exclude/5.2.3:
     dependencies:
-      glob: 7.1.4
+      glob: 7.1.5
       minimatch: 3.0.4
       read-pkg-up: 4.0.0
       require-main-filename: 2.0.0
@@ -10966,7 +9383,7 @@ packages:
       integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
   /tough-cookie/2.4.3:
     dependencies:
-      psl: 1.3.0
+      psl: 1.4.0
       punycode: 1.4.1
     dev: false
     engines:
@@ -10975,7 +9392,7 @@ packages:
       integrity: sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   /tough-cookie/2.5.0:
     dependencies:
-      psl: 1.3.0
+      psl: 1.4.0
       punycode: 2.1.1
     dev: false
     engines:
@@ -10985,7 +9402,7 @@ packages:
   /tough-cookie/3.0.1:
     dependencies:
       ip-regex: 2.1.0
-      psl: 1.3.0
+      psl: 1.4.0
       punycode: 2.1.1
     dev: false
     engines:
@@ -11016,21 +9433,21 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
-  /ts-loader/6.0.4_typescript@3.5.3:
+  /ts-loader/6.2.1_typescript@3.6.4:
     dependencies:
       chalk: 2.4.2
-      enhanced-resolve: 4.1.0
+      enhanced-resolve: 4.1.1
       loader-utils: 1.2.3
       micromatch: 4.0.2
       semver: 6.3.0
-      typescript: 3.5.3
+      typescript: 3.6.4
     dev: false
     engines:
       node: '>=8.6'
     peerDependencies:
       typescript: '*'
     resolution:
-      integrity: sha512-p2zJYe7OtwR+49kv4gs7v4dMrfYD1IPpOtqiSPCbe8oR+4zEBtdHwzM7A7M91F+suReqgzZrlClk4LRSSp882g==
+      integrity: sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==
   /ts-mocha/6.0.0_mocha@6.2.2:
     dependencies:
       mocha: 6.2.2
@@ -11040,7 +9457,7 @@ packages:
       node: '>= 6.X.X'
     hasBin: true
     optionalDependencies:
-      tsconfig-paths: 3.8.0
+      tsconfig-paths: 3.9.0
     peerDependencies:
       mocha: ^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X
     resolution:
@@ -11053,7 +9470,7 @@ packages:
       make-error: 1.3.5
       minimist: 1.2.0
       mkdirp: 0.5.1
-      source-map-support: 0.5.13
+      source-map-support: 0.5.16
       yn: 2.0.0
     dev: false
     engines:
@@ -11061,44 +9478,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
-  /ts-node/8.3.0_typescript@3.5.3:
-    dependencies:
-      arg: 4.1.1
-      diff: 4.0.1
-      make-error: 1.3.5
-      source-map-support: 0.5.13
-      typescript: 3.5.3
-      yn: 3.1.1
-    dev: false
-    engines:
-      node: '>=4.2.0'
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.0'
-    resolution:
-      integrity: sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
-  /ts-node/8.3.0_typescript@3.6.2:
-    dependencies:
-      arg: 4.1.1
-      diff: 4.0.1
-      make-error: 1.3.5
-      source-map-support: 0.5.13
-      typescript: 3.6.2
-      yn: 3.1.1
-    dev: false
-    engines:
-      node: '>=4.2.0'
-    hasBin: true
-    peerDependencies:
-      typescript: '>=2.0'
-    resolution:
-      integrity: sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
   /ts-node/8.4.1_typescript@3.6.4:
     dependencies:
       arg: 4.1.1
       diff: 4.0.1
       make-error: 1.3.5
-      source-map-support: 0.5.13
+      source-map-support: 0.5.16
       typescript: 3.6.4
       yn: 3.1.1
     dev: false
@@ -11109,17 +9494,16 @@ packages:
       typescript: '>=2.0'
     resolution:
       integrity: sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==
-  /tsconfig-paths/3.8.0:
+  /tsconfig-paths/3.9.0:
     dependencies:
       '@types/json5': 0.0.29
-      deepmerge: 2.2.1
       json5: 1.0.1
       minimist: 1.2.0
       strip-bom: 3.0.0
     dev: false
     optional: true
     resolution:
-      integrity: sha512-zZEYFo4sjORK8W58ENkRn9s+HmQFkkwydDG7My5s/fnfr2YYCaiyXe/HBUcIgU8epEKOXwiahOO+KZYjiXlWyQ==
+      integrity: sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
   /tslib/1.10.0:
     dev: false
     resolution:
@@ -11131,22 +9515,22 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-  /tslint/5.20.0_typescript@3.5.3:
+  /tslint/5.20.0_typescript@3.6.4:
     dependencies:
       '@babel/code-frame': 7.5.5
       builtin-modules: 1.1.1
       chalk: 2.4.2
-      commander: 2.20.0
+      commander: 2.20.3
       diff: 4.0.1
-      glob: 7.1.4
+      glob: 7.1.5
       js-yaml: 3.13.1
       minimatch: 3.0.4
       mkdirp: 0.5.1
       resolve: 1.12.0
       semver: 5.7.1
       tslib: 1.10.0
-      tsutils: 2.29.0_typescript@3.5.3
-      typescript: 3.5.3
+      tsutils: 2.29.0_typescript@3.6.4
+      typescript: 3.6.4
     dev: false
     engines:
       node: '>=4.8.0'
@@ -11155,37 +9539,15 @@ packages:
       typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
     resolution:
       integrity: sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==
-  /tsutils/2.29.0_typescript@3.5.3:
+  /tsutils/2.29.0_typescript@3.6.4:
     dependencies:
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
     dev: false
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
       integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  /tsutils/3.17.1_typescript@3.5.3:
-    dependencies:
-      tslib: 1.10.0
-      typescript: 3.5.3
-    dev: false
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    resolution:
-      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
-  /tsutils/3.17.1_typescript@3.6.2:
-    dependencies:
-      tslib: 1.10.0
-      typescript: 3.6.2
-    dev: false
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    resolution:
-      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /tsutils/3.17.1_typescript@3.6.4:
     dependencies:
       tslib: 1.10.0
@@ -11246,10 +9608,14 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  /type/1.0.3:
+  /type/1.2.0:
     dev: false
     resolution:
-      integrity: sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==
+      integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
+  /type/2.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
   /typedarray/0.0.6:
     dev: false
     resolution:
@@ -11258,7 +9624,7 @@ packages:
     dependencies:
       backbone: 1.4.0
       jquery: 3.4.1
-      lunr: 2.3.6
+      lunr: 2.3.8
       underscore: 1.9.1
     dev: false
     engines:
@@ -11269,8 +9635,8 @@ packages:
     dependencies:
       '@types/minimatch': 3.0.3
       fs-extra: 8.1.0
-      handlebars: 4.2.0
-      highlight.js: 9.15.10
+      handlebars: 4.5.1
+      highlight.js: 9.16.2
       lodash: 4.17.15
       marked: 0.7.0
       minimatch: 3.0.4
@@ -11291,20 +9657,6 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
-  /typescript/3.6.2:
-    dev: false
-    engines:
-      node: '>=4.2.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
-  /typescript/3.6.3:
-    dev: false
-    engines:
-      node: '>=4.2.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
   /typescript/3.6.4:
     dev: false
     engines:
@@ -11312,27 +9664,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
-  /uglify-js/3.6.0:
-    dependencies:
-      commander: 2.20.0
-      source-map: 0.6.1
-    dev: false
-    engines:
-      node: '>=0.8.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
-  /uglify-js/3.6.2:
-    dependencies:
-      commander: 2.20.0
-      source-map: 0.6.1
-    dev: false
-    engines:
-      node: '>=0.8.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-+gh/xFte41GPrgSMJ/oJVq15zYmqr74pY9VoM69UzMzq9NFk4YDylclb1/bhEzZSaUQjbW5RvniHeq1cdtRYjw==
-  /uglify-js/3.6.4:
+  /uglify-js/3.6.7:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -11341,7 +9673,7 @@ packages:
       node: '>=0.8.0'
     hasBin: true
     resolution:
-      integrity: sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==
+      integrity: sha512-4sXQDzmdnoXiO+xvmTzQsfIiwrjUCSA95rSP4SEd8tDb51W2TiDOlL76Hl+Kw0Ie42PSItCW8/t6pBNCF2R48A==
   /ultron/1.1.1:
     dev: false
     resolution:
@@ -11412,12 +9744,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==
-  /universal-user-agent/4.0.0:
-    dependencies:
-      os-name: 3.1.0
-    dev: false
-    resolution:
-      integrity: sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==
   /universalify/0.1.2:
     dev: false
     engines:
@@ -11439,12 +9765,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
-  /upath/1.1.2:
+  /upath/1.2.0:
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==
+      integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
   /uri-js/4.2.2:
     dependencies:
       punycode: 2.1.1
@@ -11587,7 +9913,7 @@ packages:
     dependencies:
       fs-mkdirp-stream: 1.0.0
       glob-stream: 6.1.0
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       is-valid-glob: 1.0.0
       lazystream: 1.0.0
       lead: 1.0.0
@@ -11611,7 +9937,7 @@ packages:
     dependencies:
       append-buffer: 1.0.2
       convert-source-map: 1.6.0
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       normalize-path: 2.1.1
       now-and-later: 2.0.1
       remove-bom-buffer: 3.0.0
@@ -11638,10 +9964,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
-  /vm-browserify/1.1.0:
+  /vm-browserify/1.1.2:
     dev: false
     resolution:
-      integrity: sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
+      integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
   /void-elements/2.0.1:
     dev: false
     engines:
@@ -11651,7 +9977,7 @@ packages:
   /watchpack/1.6.0:
     dependencies:
       chokidar: 2.1.8
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       neo-async: 2.6.1
     dev: false
     resolution:
@@ -11660,7 +9986,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-  /webpack-cli/3.3.7_webpack@4.39.2:
+  /webpack-cli/3.3.10_webpack@4.41.2:
     dependencies:
       chalk: 2.4.2
       cross-spawn: 6.0.5
@@ -11672,7 +9998,7 @@ packages:
       loader-utils: 1.2.3
       supports-color: 6.1.0
       v8-compile-cache: 2.0.3
-      webpack: 4.39.2_webpack@4.39.2
+      webpack: 4.41.2_webpack@4.41.2
       yargs: 13.2.4
     dev: false
     engines:
@@ -11681,13 +10007,14 @@ packages:
     peerDependencies:
       webpack: 4.x.x
     resolution:
-      integrity: sha512-OhTUCttAsr+IZSMVwGROGRHvT+QAs8H6/mHIl4SvhAwYywjiylYjpwybGx7WQ9Hkb45FhjtsymkwiRRbGJ1SZQ==
-  /webpack-dev-middleware/3.7.0_webpack@4.39.2:
+      integrity: sha512-u1dgND9+MXaEt74sJR4PR7qkPxXUSQ0RXYq8x1L6Jg1MYVEmGPrH6Ah6C4arD4r0J1P5HKjRqpab36k0eIzPqg==
+  /webpack-dev-middleware/3.7.2_webpack@4.41.2:
     dependencies:
       memory-fs: 0.4.1
       mime: 2.4.4
+      mkdirp: 0.5.1
       range-parser: 1.2.1
-      webpack: 4.39.2_webpack@4.39.2
+      webpack: 4.41.2_webpack@4.41.2
       webpack-log: 2.0.0
     dev: false
     engines:
@@ -11695,7 +10022,7 @@ packages:
     peerDependencies:
       webpack: ^4.0.0
     resolution:
-      integrity: sha512-qvDesR1QZRIAZHOE3iQ4CXLZZSQ1lAUsSpnQmlB1PBfoN/xdRjmge3Dok0W4IdaVLJOGJy3sGI4sZHwjRU0PCA==
+      integrity: sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==
   /webpack-log/2.0.0:
     dependencies:
       ansi-colors: 3.2.4
@@ -11712,7 +10039,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
-  /webpack/4.39.2_webpack@4.39.2:
+  /webpack/4.41.2_webpack@4.41.2:
     dependencies:
       '@webassemblyjs/ast': 1.8.5
       '@webassemblyjs/helper-module-context': 1.8.5
@@ -11722,7 +10049,7 @@ packages:
       ajv: 6.10.2
       ajv-keywords: 3.4.1_ajv@6.10.2
       chrome-trace-event: 1.0.2
-      enhanced-resolve: 4.1.0
+      enhanced-resolve: 4.1.1
       eslint-scope: 4.0.3
       json-parse-better-errors: 1.0.2
       loader-runner: 2.4.0
@@ -11734,7 +10061,7 @@ packages:
       node-libs-browser: 2.2.1
       schema-utils: 1.0.0
       tapable: 1.1.3
-      terser-webpack-plugin: 1.4.1_webpack@4.39.2
+      terser-webpack-plugin: 1.4.1_webpack@4.41.2
       watchpack: 1.6.0
       webpack-sources: 1.4.3
     dev: false
@@ -11744,7 +10071,7 @@ packages:
     peerDependencies:
       webpack: '*'
     resolution:
-      integrity: sha512-AKgTfz3xPSsEibH00JfZ9sHXGUwIQ6eZ9tLN8+VLzachk1Cw2LVmy+4R7ZiwTa9cZZ15tzySjeMui/UnSCAZhA==
+      integrity: sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==
   /whatwg-url/6.5.0:
     dependencies:
       lodash.sortby: 4.7.0
@@ -11823,7 +10150,7 @@ packages:
       integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
   /write-file-atomic/2.4.3:
     dependencies:
-      graceful-fs: 4.2.2
+      graceful-fs: 4.2.3
       imurmurhash: 0.1.4
       signal-exit: 3.0.2
     dev: false
@@ -11851,12 +10178,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
-  /ws/7.1.2:
+  /ws/7.2.0:
     dependencies:
       async-limiter: 1.0.1
     dev: false
     resolution:
-      integrity: sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==
+      integrity: sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==
   /xhr-mock/2.5.0:
     dependencies:
       global: 4.4.0
@@ -11874,13 +10201,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=
-  /xml2js/0.4.19:
-    dependencies:
-      sax: 1.2.4
-      xmlbuilder: 9.0.7
-    dev: false
-    resolution:
-      integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
   /xml2js/0.4.22:
     dependencies:
       sax: 1.2.4
@@ -11891,12 +10211,6 @@ packages:
       node: '>=4.0.0'
     resolution:
       integrity: sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==
-  /xmlbuilder/0.4.3:
-    dev: false
-    engines:
-      node: '>=0.2.0'
-    resolution:
-      integrity: sha1-xGFLp04K0ZbmCcknLNnh3bKKilg=
   /xmlbuilder/11.0.1:
     dev: false
     engines:
@@ -11955,10 +10269,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-  /yallist/3.0.3:
+  /yallist/3.1.1:
     dev: false
     resolution:
-      integrity: sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
+      integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
   /yargs-parser/10.1.0:
     dependencies:
       camelcase: 4.1.0
@@ -11972,6 +10286,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  /yargs-parser/15.0.0:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: false
+    resolution:
+      integrity: sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
   /yargs-parser/5.0.0:
     dependencies:
       camelcase: 3.0.0
@@ -12019,7 +10340,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
-  /yargs/14.0.0:
+  /yargs/14.2.0:
     dependencies:
       cliui: 5.0.0
       decamelize: 1.2.0
@@ -12031,10 +10352,10 @@ packages:
       string-width: 3.1.0
       which-module: 2.0.0
       y18n: 4.0.0
-      yargs-parser: 13.1.1
+      yargs-parser: 15.0.0
     dev: false
     resolution:
-      integrity: sha512-ssa5JuRjMeZEUjg7bEL99AwpitxU/zWGAGpdj0di41pOEmJti8NR6kyUIJBkR78DTYNPZOU08luUo0GTHuB+ow==
+      integrity: sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==
   /yargs/7.1.0:
     dependencies:
       camelcase: 3.0.0
@@ -12053,13 +10374,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=
-  /yarn/1.17.3:
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-CgA8o7nRZaQvmeF/WBx2FC7f9W/0X59T2IaLYqgMo6637wfp5mMEsM3YXoJtKUspnpmDJKl/gGFhnqS+sON7hA==
   /yarn/1.19.1:
     dev: false
     engines:
@@ -12103,34 +10417,34 @@ packages:
     dev: false
     hasBin: true
     optionalDependencies:
-      commander: 2.20.0
+      commander: 2.20.3
     resolution:
       integrity: sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
   'file:projects/abort-controller.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.3.8
+      '@microsoft/api-extractor': 7.5.2
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.0
+      cross-env: 5.2.1
       delay: 4.3.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
@@ -12138,34 +10452,32 @@ packages:
       nyc: 14.1.1
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      ts-node: 8.3.0_typescript@3.5.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-dcoUe5xRW9aexEjML4qU2tGPASWJbvdi3BkFyJ7kSa+dZw80zqRZJVeYtDmB/axqg2Vvl+VowMcVdSC/Rm7Fyw==
+      integrity: sha512-GRP0FEblaWYehNCxXr7lKsVkWcglIOWkYzCxXfXirEeoRsXCCWNYT24D2n9qovj7YbzdSf6eRWIrq7aY+COP4g==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/app-configuration.tgz':
     dependencies:
-      '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
-      '@azure/core-paging': 1.0.0-preview.2
-      '@microsoft/api-extractor': 7.3.11
+      '@microsoft/api-extractor': 7.5.2
       '@types/dotenv': 6.1.1
       '@types/mocha': 5.2.7
       assert: 1.5.0
-      dotenv: 8.1.0
-      eslint: 6.3.0
-      eslint-config-prettier: 6.2.0_eslint@6.3.0
-      eslint-plugin-no-null: 1.0.2_eslint@6.3.0
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       mocha: 6.2.2
@@ -12174,27 +10486,26 @@ packages:
       nyc: 14.1.1
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.20.3
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.3
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.3
-      ts-node: 8.3.0_typescript@3.6.2
+      rollup: 1.26.3
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.6.2
-      uglify-js: 3.6.0
+      typescript: 3.6.4
+      uglify-js: 3.6.7
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-ODrco+wRfDJrpUxvbT9zsowf/LABtK5Tbi5CVfFy7mkS8Ug4Gb0POSJylD9OAuwJqvDJjq8ii9wQZfzwez5OWg==
+      integrity: sha512-pJNMAf0RMhIDTN+9EuCKjROM9QCNRfLgSDk9tYoC3YaxjA/BeYGo/UFTTS9QOZFJyFmX4zXu6bmQW1Uzzxbkgw==
       tarball: 'file:projects/app-configuration.tgz'
     version: 0.0.0
   'file:projects/cognitiveservices-inkrecognizer.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
       '@microsoft/api-extractor': 7.5.2
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.56
-      '@typescript-eslint/eslint-plugin': 2.5.0_0889f7972d3c13f808589e80f38ca335
-      '@typescript-eslint/parser': 2.5.0_eslint@6.6.0
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       cross-env: 5.2.1
       dotenv: 8.2.0
@@ -12213,58 +10524,56 @@ packages:
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.25.2
-      rollup-plugin-commonjs: 10.1.0_rollup@1.25.2
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.25.2
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.25.2
-      rollup-plugin-uglify: 6.0.3_rollup@1.25.2
-      rollup-plugin-visualizer: 2.6.0_rollup@1.25.2
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-uglify: 6.0.3_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       tslib: 1.10.0
       typescript: 3.6.4
       util: 0.12.1
     dev: false
     name: '@rush-temp/cognitiveservices-inkrecognizer'
     resolution:
-      integrity: sha512-UtGKI+ItjHck+zYIW64yFZbC866azVFmKPx87d/Ft8Lx10DKYShE8ThM2w1Wqlx5aElXJ0GGUKSrVBxIYGi9gw==
+      integrity: sha512-BwQDZ43P77tBMQaxuvYNY5CNqtL996JOteX1IYwWgTG2YLbDu3ODnj5UyL58JBcNR5Jj6jy7lnHKy7XvOTFl3A==
       tarball: 'file:projects/cognitiveservices-inkrecognizer.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-auth': 1.0.0-preview.3
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.0
+      '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 4.1.5
       '@types/dotenv': 6.1.1
       '@types/is-buffer': 2.0.0
       '@types/jssha': 2.0.0
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@types/sinon': 7.0.13
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@types/sinon': 7.5.0
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       async-lock: 1.2.2
-      buffer: 5.4.0
+      buffer: 5.4.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
-      cross-env: 5.2.0
+      cross-env: 5.2.1
       debug: 4.1.1
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
-      is-buffer: 2.0.3
+      is-buffer: 2.0.4
       jssha: 2.3.1
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-mocha: 1.3.0
       mocha: 6.2.2
@@ -12273,46 +10582,46 @@ packages:
       nyc: 14.1.1
       prettier: 1.18.2
       process: 0.11.10
-      puppeteer: 1.19.0
-      rhea: 1.0.8
+      puppeteer: 1.20.0
+      rhea: 1.0.11
       rhea-promise: 1.0.0
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
-      rollup-plugin-inject: 3.0.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
+      rollup-plugin-inject: 3.0.2
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
       rollup-plugin-node-globals: 1.4.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      sinon: 7.4.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      sinon: 7.5.0
       stream-browserify: 2.0.2
-      ts-node: 8.3.0_typescript@3.5.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       url: 0.11.0
       util: 0.12.1
-      ws: 7.1.2
+      ws: 7.2.0
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-CY/MfjXyi8bPqpesqs9pQw35agOiUWqqiZSWsLUcqC9HCF9kJEToZWtmX9iAA1XHzk8bgN2mN/vPOjZ2iYtGTA==
+      integrity: sha512-ZdzRc8R58DStrI3cLWzRtXn4/YHJ9EfRzLGij8Q2stP/wQ6QPR7wp9qqEuXlwDwekubqh5n0Lle62rtm2Q6g8w==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-arm.tgz':
     dependencies:
-      '@types/chai': 4.2.0
+      '@types/chai': 4.2.4
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       chai: 4.2.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       mocha: 6.2.2
@@ -12321,54 +10630,53 @@ packages:
       npm-run-all: 4.1.5
       nyc: 14.1.1
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       shx: 0.3.2
-      ts-node: 8.3.0_typescript@3.5.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.5.3
-      uglify-js: 3.6.0
-      yarn: 1.17.3
+      typescript: 3.6.4
+      uglify-js: 3.6.7
+      yarn: 1.19.1
     dev: false
     name: '@rush-temp/core-arm'
     resolution:
-      integrity: sha512-ZtAnzHeIz298qVBVaR5GBD10xp4o6oVJAx9wX9Rwjp98VEcWJZpwdkbdVAa+5SoiSVgGFxcx7OgvYc28wbV25Q==
+      integrity: sha512-Lz5z7BKnT69nScjnhVRywLOUlNMipvUxjdYhxn9geK/Sjq7Fne1h6wledTsnHkH6LqxadrfblvqNG82PVXi8KA==
       tarball: 'file:projects/core-arm.tgz'
     version: 0.0.0
   'file:projects/core-asynciterator-polyfill.tgz':
     dependencies:
-      '@types/node': 8.10.52
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       prettier: 1.18.2
-      typescript: 3.5.3
+      typescript: 3.6.4
     dev: false
     name: '@rush-temp/core-asynciterator-polyfill'
     resolution:
-      integrity: sha512-hp2FjyoaLo9iJIGV0Aq7UI8oGzIr29OewVSFfuckKI+2aDUrh6Kamlg/hw/HrZ/a3ybccP3oqGjwA2uze4DoAg==
+      integrity: sha512-X2qR67x/Wgwcs8VjH/m3EA7HFB22mL2sf9YJCvpdIUXvz5ENGH54U4TC8IAc2AxcqlKjOi1pwFUAf9yBf4nAJQ==
       tarball: 'file:projects/core-asynciterator-polyfill.tgz'
     version: 0.0.0
   'file:projects/core-auth.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
-      '@microsoft/api-extractor': 7.3.8
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
+      '@microsoft/api-extractor': 7.5.2
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      cross-env: 5.2.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       inherits: 2.0.4
@@ -12377,70 +10685,66 @@ packages:
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       util: 0.12.1
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-w3ovGn0lGP+vE1SawjmVL+Cqy7aOncCPQfvmKhXrCmJyuiGw3naDZFbPi2xid2ljzlTG9TmhIbJzS3nd+AYmBA==
+      integrity: sha512-srhEmghmah8zyVEpORwaqYAgIXLwIZH+9nDCD4+XZafbUSDcChADN+arueSpBeR80mRc5ncO/xAcpMS6e9uyJQ==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-auth': 1.0.0-preview.3
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
       '@azure/logger-js': 1.3.2
-      '@types/chai': 4.2.0
-      '@types/express': 4.17.1
+      '@types/chai': 4.2.4
+      '@types/express': 4.17.2
       '@types/fetch-mock': 7.3.1
       '@types/glob': 7.1.1
       '@types/karma': 3.0.3
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@types/node-fetch': 2.5.0
-      '@types/semver': 5.5.0
-      '@types/sinon': 7.0.13
+      '@types/node': 8.10.58
+      '@types/node-fetch': 2.5.3
+      '@types/sinon': 7.5.0
       '@types/tough-cookie': 2.3.5
       '@types/tunnel': 0.0.1
-      '@types/uuid': 3.4.5
-      '@types/webpack': 4.39.0
+      '@types/uuid': 3.4.6
+      '@types/webpack': 4.39.8
       '@types/webpack-dev-middleware': 2.0.3
-      '@types/xml2js': 0.4.4
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/xml2js': 0.4.5
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       babel-runtime: 6.26.0
-      buffer: 5.4.0
       chai: 4.2.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       express: 4.17.1
-      fetch-mock: 7.3.9
-      form-data: 2.5.0
-      glob: 7.1.4
-      karma: 4.2.0
-      karma-chai: 0.1.0_chai@4.2.0+karma@4.2.0
+      fetch-mock: 7.7.2_node-fetch@2.6.0
+      form-data: 2.5.1
+      glob: 7.1.5
+      karma: 4.4.1
+      karma-chai: 0.1.0_chai@4.2.0+karma@4.4.1
       karma-chrome-launcher: 3.1.0
       karma-mocha: 1.3.0
-      karma-rollup-preprocessor: 7.0.2_rollup@1.20.1
+      karma-rollup-preprocessor: 7.0.2_rollup@1.26.3
       karma-sourcemap-loader: 0.3.7
       karma-typescript-es6-transform: 4.1.1
-      karma-webpack: 4.0.2_webpack@4.39.2
+      karma-webpack: 4.0.2_webpack@4.41.2
       mocha: 6.2.2
-      mocha-chrome: 2.0.0
+      mocha-chrome: 2.2.0
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
       node-fetch: 2.6.0
@@ -12448,71 +10752,67 @@ packages:
       nyc: 14.1.1
       prettier: 1.18.2
       process: 0.11.10
-      puppeteer: 1.19.0
+      puppeteer: 1.20.0
       regenerator-runtime: 0.13.3
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-alias: 1.5.2
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
-      semver: 5.7.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       shx: 0.3.2
-      sinon: 7.4.1
-      terser: 4.2.0
+      sinon: 7.5.0
+      terser: 4.3.9
       tough-cookie: 3.0.1
-      ts-loader: 6.0.4_typescript@3.5.3
-      ts-node: 8.3.0_typescript@3.5.3
+      ts-loader: 6.2.1_typescript@3.6.4
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
       tunnel: 0.0.6
-      typescript: 3.5.3
-      uglify-js: 3.6.0
+      typescript: 3.6.4
+      uglify-js: 3.6.7
       uuid: 3.3.3
-      webpack: 4.39.2_webpack@4.39.2
-      webpack-cli: 3.3.7_webpack@4.39.2
-      webpack-dev-middleware: 3.7.0_webpack@4.39.2
+      webpack: 4.41.2_webpack@4.41.2
+      webpack-cli: 3.3.10_webpack@4.41.2
+      webpack-dev-middleware: 3.7.2_webpack@4.41.2
       xhr-mock: 2.5.0
-      xml2js: 0.4.19
-      xmlbuilder: 0.4.3
-      yarn: 1.17.3
+      xml2js: 0.4.22
+      yarn: 1.19.1
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-2KwRZLaon1Cflqbsvg+GmNy06PkgKfji3jThaE0aphT0D0a/oo9/XW2GTrqYtyADAdXLrCq0KoFGJUDzKuxItA==
+      integrity: sha512-RG094kUcOURoMOR9r6vJV8mwDlZWvTCNHT36y4I/t1SysovH5LEWiGNi4arYRAUmqeGA50318F5OzuWKHD2KOw==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-lro.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@microsoft/api-extractor': 7.5.0
-      '@types/chai': 4.2.3
+      '@microsoft/api-extractor': 7.5.2
+      '@types/chai': 4.2.4
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.54
-      '@typescript-eslint/eslint-plugin': 2.4.0_4828c2c2dec21a69cf7db8f78e46e2d1
-      '@typescript-eslint/parser': 2.4.0_eslint@6.5.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      eslint: 6.5.1
-      eslint-config-prettier: 6.4.0_eslint@6.5.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.5.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
-      karma: 4.3.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.3.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.3.0
-      karma-json-preprocessor: 0.3.3_karma@4.3.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-json-preprocessor: 0.3.3_karma@4.4.1
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 1.2.0_karma@4.3.0
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.3.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
@@ -12521,55 +10821,54 @@ packages:
       nyc: 14.1.1
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.24.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.24.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.24.0
-      rollup-plugin-visualizer: 2.6.0_rollup@1.24.0
+      rollup: 1.26.3
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       shx: 0.3.2
       ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
-      uglify-js: 3.6.2
+      uglify-js: 3.6.7
       yarn: 1.19.1
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
-      integrity: sha512-08hTv8lX5MG5LiW3v7VgjJQiTm8wKzDYU/4vENBIz/JhmKMAzJPVrCUHlXx3o0BxUSVNW9KE2iqokdCzLI72Ew==
+      integrity: sha512-DTIeNPjGqEbzNK+7Req7RxSJtihR1AEnXXopfzFz3QO7Yl9c6b8AHXz43RUd+eop/uSvN8YgjmBtXS3zbGX7dg==
       tarball: 'file:projects/core-lro.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
     dependencies:
-      '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
-      '@types/node': 8.10.52
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       prettier: 1.18.2
-      typescript: 3.5.3
+      typescript: 3.6.4
     dev: false
     name: '@rush-temp/core-paging'
     resolution:
-      integrity: sha512-xOqUN7eqYRxsxYfR88uGVXFkRsKzSO/JD/fjOxl5OpY56DsS1zfdwybNB2uERE/HXcNVwF1fLjK58XJMluWutQ==
+      integrity: sha512-Y71/KYGma55iX5cO3YRZG1drCJ6YV17d+HH2uXz56jOrak7Vidrb8cQbjABjHxx4Awh70wl7JO57Ac8K6/dcCA==
       tarball: 'file:projects/core-paging.tgz'
     version: 0.0.0
   'file:projects/core-tracing.tgz':
     dependencies:
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
-      '@microsoft/api-extractor': 7.3.8
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
+      '@microsoft/api-extractor': 7.5.2
       '@opencensus/web-types': 0.0.7
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      cross-env: 5.2.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       inherits: 2.0.4
@@ -12578,68 +10877,62 @@ packages:
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       util: 0.12.1
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-VJmT0GHarxzJtO23yqQKzOYaa5cHr4sODS7JL2S+rvwANQ/65/4N3P4kTlkw75e3+dBnLGZKxB8ihqQyLUaspw==
+      integrity: sha512-YdS71ViNSfXzoc4YC7cE+fx8UGIfuTZt1GD8YOvXPNs/zU2bJaxvjvHalVwdp04V4bQz2ou/nDOn1iJSGrPT9A==
       tarball: 'file:projects/core-tracing.tgz'
     version: 0.0.0
-  'file:projects/cosmos.tgz_webpack@4.39.2':
+  'file:projects/cosmos.tgz_webpack@4.41.2':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/cosmos-sign': 1.0.2
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
-      '@microsoft/api-extractor': 7.3.8
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
+      '@microsoft/api-extractor': 7.5.2
       '@types/debug': 4.1.5
       '@types/fast-json-stable-stringify': 2.0.0
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@types/node-fetch': 2.5.0
+      '@types/node': 8.10.58
+      '@types/node-fetch': 2.5.3
       '@types/priorityqueuejs': 1.0.1
       '@types/semaphore': 1.1.0
-      '@types/sinon': 7.0.13
+      '@types/sinon': 7.5.0
       '@types/tunnel': 0.0.1
-      '@types/underscore': 1.9.2
-      '@types/uuid': 3.4.5
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/eslint-plugin-tslint': 2.3.0_b840da7ae58bd563f8e3899e03f6a2da
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
-      abort-controller: 3.0.0
-      atob: 2.1.2
-      binary-search-bounds: 2.0.3
-      cross-env: 5.2.0
-      crypto-hash: 1.1.0
+      '@types/underscore': 1.9.3
+      '@types/uuid': 3.4.6
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/eslint-plugin-tslint': 2.3.3_b440fbe82fef3b179d75a1e01e8e53ff
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
+      cross-env: 5.2.1
       debug: 4.1.1
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
-      esm: 3.2.18
+      esm: 3.2.25
       execa: 1.0.0
       fast-json-stable-stringify: 2.0.0
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-cli: 2.0.0
       karma-firefox-launcher: 1.2.0
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
-      karma-requirejs: 1.1.0_karma@4.2.0+requirejs@2.3.6
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
+      karma-requirejs: 1.1.0_karma@4.4.1+requirejs@2.3.6
       karma-sourcemap-loader: 0.3.7
-      karma-webpack: 4.0.2_webpack@4.39.2
+      karma-webpack: 4.0.2_webpack@4.41.2
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
@@ -12651,21 +10944,20 @@ packages:
       proxy-agent: 3.1.1
       requirejs: 2.3.6
       rimraf: 3.0.0
-      rollup: 1.20.1
+      rollup: 1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-local-resolve: 1.0.7
       rollup-plugin-multi-entry: 2.1.0
-      semaphore: 1.0.5
-      sinon: 7.4.1
+      semaphore: 1.1.0
+      sinon: 7.5.0
       snap-shot-it: 7.9.0
-      source-map-support: 0.5.13
-      ts-node: 8.3.0_typescript@3.5.3
+      source-map-support: 0.5.16
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      tslint: 5.20.0_typescript@3.5.3
+      tslint: 5.20.0_typescript@3.6.4
       tslint-config-prettier: 1.18.0
       typedoc: 0.15.0
-      typescript: 3.5.3
-      universal-user-agent: 4.0.0
+      typescript: 3.6.4
       uuid: 3.3.3
     dev: false
     id: 'file:projects/cosmos.tgz'
@@ -12673,55 +10965,53 @@ packages:
     peerDependencies:
       webpack: '*'
     resolution:
-      integrity: sha512-Hk3XL/Z06TvR0SvJZoctyBYN05DCSEGcAq+YlRqPbbNXk/7VXtbrZU7hR5CgDO6DYe7cxFoLoJphfEjECQgcTQ==
+      integrity: sha512-vA0zZ7IgRHanU9mttXqsQrEavnSJjQJa3/GK8EMHQAMmhoY+toRsgym1Eam//OrMrDlYjBh9kQMMwdDN0TK3cg==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/event-hubs.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-asynciterator-polyfill': 1.0.0-preview.1
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
-      '@microsoft/api-extractor': 7.3.8
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
+      '@microsoft/api-extractor': 7.5.2
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.0
+      '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.5
       '@types/dotenv': 6.1.1
       '@types/long': 4.0.0
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@types/uuid': 3.4.5
+      '@types/node': 8.10.58
+      '@types/uuid': 3.4.6
       '@types/ws': 6.0.3
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       async-lock: 1.2.2
-      buffer: 5.4.0
+      buffer: 5.4.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 5.2.0
+      cross-env: 5.2.1
       debug: 4.1.1
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
-      https-proxy-agent: 2.2.2
-      is-buffer: 2.0.3
+      https-proxy-agent: 2.2.4
+      is-buffer: 2.0.4
       jssha: 2.3.1
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
@@ -12729,63 +11019,63 @@ packages:
       nyc: 14.1.1
       prettier: 1.18.2
       process: 0.11.10
-      puppeteer: 1.19.0
+      puppeteer: 1.20.0
       rhea-promise: 1.0.0
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
-      rollup-plugin-inject: 3.0.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
+      rollup-plugin-inject: 3.0.2
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
       ts-mocha: 6.0.0_mocha@6.2.2
-      ts-node: 8.3.0_typescript@3.5.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       uuid: 3.3.3
-      ws: 7.1.2
+      ws: 7.2.0
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-KNftvL3ZWPXhYkmZVVos6rQJxhT4nDqdbHy49hLx/n6RcAyJsAPx6wps9nkvMeJYNzxvGFig7DxFobOv1VRhrg==
+      integrity: sha512-FfwMPIntuJk7r6kI3i6xSad8SB7Vrj7NCHLSZ0b2sqcJVvkABJFHTmMmLpFCIDDHEMsO33UAWnloyp9+ZsFV4w==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
     dependencies:
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
       '@azure/event-hubs': 2.1.1
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@microsoft/api-extractor': 7.3.8
+      '@microsoft/api-extractor': 7.5.2
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.0
+      '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.5
       '@types/dotenv': 6.1.1
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@types/uuid': 3.4.5
+      '@types/node': 8.10.58
+      '@types/uuid': 3.4.6
       '@types/ws': 6.0.3
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       async-lock: 1.2.2
       azure-storage: 2.10.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 5.2.0
+      cross-env: 5.2.1
       debug: 4.1.1
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
-      https-proxy-agent: 2.2.2
+      https-proxy-agent: 2.2.4
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
@@ -12793,117 +11083,115 @@ packages:
       path-browserify: 1.0.0
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-uglify: 6.0.2_rollup@1.20.1
-      ts-node: 8.3.0_typescript@3.5.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-uglify: 6.0.3_rollup@1.26.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       uuid: 3.3.3
-      ws: 7.1.2
+      ws: 7.2.0
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-8dN6fhytbzgZRqnpSy3U5NfEt/yf9rtTeE4JPeCiZnCl2nwF3H/2rtWuCo1dFq7iOSOs5PD18D3ruAcLO+6tEg==
+      integrity: sha512-tyWDvaUzGva2ahhJobs9dwj3imJPSoEr2bDydX/aXPcnXbSQ1CeJx9xizllPYx6BEPv26jQW/94xXErig5QEGw==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
     dependencies:
-      '@azure/event-hubs': 5.0.0-preview.5
       '@azure/storage-blob': 12.0.0-preview.5
-      '@microsoft/api-extractor': 7.3.11
-      '@types/chai': 4.2.1
+      '@microsoft/api-extractor': 7.5.2
+      '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.5
       '@types/dotenv': 6.1.1
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.53
-      '@typescript-eslint/eslint-plugin': 2.1.0_3a8cea979a77aa77c321dad4153067ce
-      '@typescript-eslint/parser': 2.1.0_eslint@6.3.0
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
       cross-env: 5.2.1
       debug: 4.1.1
-      dotenv: 8.1.0
-      eslint: 6.3.0
-      eslint-config-prettier: 6.2.0_eslint@6.3.0
-      eslint-plugin-no-null: 1.0.2_eslint@6.3.0
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
       guid-typescript: 1.0.9
       inherits: 2.0.4
-      karma: 4.3.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.3.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.3.0
-      karma-junit-reporter: 1.2.0_karma@4.3.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.3.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.20.3
-      rollup-plugin-commonjs: 10.1.0_rollup@1.20.3
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.3
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.3
-      rollup-plugin-terser: 5.1.1_rollup@1.20.3
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.3
-      ts-node: 8.3.0_typescript@3.6.2
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.6.2
+      typescript: 3.6.4
       util: 0.12.1
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-S1S37JvBZwNShZm8EJSp8nV4rxjjAn0UOWZq0RW40unBKLvbZTk1JzhtzC528N63txJkwrN0pNCe+9Vf0+GaLg==
+      integrity: sha512-BnJn8JUK5qyQryO8/U8S7TPSYFkW/q1HTYVyYpE3fwFoJ3+4+usDhmt+0tdXwWPx4+wPT8c5G6gO4a6pSGyC5w==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@microsoft/api-extractor': 7.5.0
-      '@types/express': 4.17.1
+      '@microsoft/api-extractor': 7.5.2
+      '@types/express': 4.17.2
       '@types/jws': 3.2.0
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/qs': 6.5.3
-      '@types/uuid': 3.4.5
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/uuid': 3.4.6
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.0
-      eslint: 6.2.1
+      cross-env: 5.2.1
+      eslint: 6.6.0
       events: 3.0.0
       express: 4.17.1
       inherits: 2.0.4
       jws: 3.2.2
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
       karma-env-preprocessor: 0.1.1
-      karma-json-preprocessor: 0.3.3_karma@4.2.0
+      karma-json-preprocessor: 0.3.3_karma@4.4.1
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
@@ -12911,339 +11199,316 @@ packages:
       msal: 1.1.3
       open: 6.4.0
       prettier: 1.18.2
-      puppeteer: 1.19.0
-      qs: 6.8.0
+      puppeteer: 1.20.0
+      qs: 6.9.0
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       util: 0.12.1
       uuid: 3.3.3
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-VTpB41OgRWVk4lhItph6pLRu5sGrTCUXxmp0c10JFCrUSM3heCqnvi15KxW2XThANnkwkUYGWUCqJKFiLcwxEQ==
+      integrity: sha512-3NKsPsFu/mOtZv2GqG2he44KyyRGelHi58SOdEHcznac8S5EIFGL2OqBqiVJGHRAtf7+AaJnGs85vQxOcPXVvg==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
     dependencies:
-      '@azure/core-paging': 1.0.0-preview.2
-      '@azure/core-tracing': 1.0.0-preview.1
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
-      '@azure/keyvault-keys': 4.0.0-preview.9
-      '@azure/keyvault-secrets': 4.0.0-preview.9
-      '@microsoft/api-extractor': 7.3.8
-      '@types/chai': 4.2.0
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
+      '@microsoft/api-extractor': 7.5.2
+      '@types/chai': 4.2.4
       '@types/dotenv': 6.1.1
-      '@types/fs-extra': 8.0.0
+      '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
-      '@types/nise': 1.4.0
-      '@types/nock': 10.0.3
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/query-string': 6.2.0
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 5.2.0
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      cross-env: 5.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.1.0
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-json-preprocessor: 0.3.3_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-json-preprocessor: 0.3.3_karma@4.4.1
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
-      nise: 1.5.1
-      nock: 11.3.2
       nyc: 14.1.1
       prettier: 1.18.2
-      puppeteer: 1.19.0
+      puppeteer: 1.20.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
-      source-map-support: 0.5.13
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
+      source-map-support: 0.5.16
       tslib: 1.10.0
-      typescript: 3.5.3
-      uglify-js: 3.6.0
+      typescript: 3.6.4
+      uglify-js: 3.6.7
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-Higb/DXXoMv81q3IGBXK8g8rtrSuRAcqKx4uQopnx+YzaZILRcA3Xp9Lc3+7sOXOiIYrJGJ5OKKdkpt9gKcKNQ==
+      integrity: sha512-KR/x7n9ahpAotFc67ywF6dmVgMelXDEAhYqruOJShF4t0CspYLnvRFx/nbQDDurn2YJXHaAuqNZp1GB4S6qD9g==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-paging': 1.0.0-preview.2
-      '@azure/core-tracing': 1.0.0-preview.1
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
-      '@microsoft/api-extractor': 7.3.8
-      '@types/chai': 4.2.0
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
+      '@microsoft/api-extractor': 7.5.2
+      '@types/chai': 4.2.4
       '@types/dotenv': 6.1.1
-      '@types/fs-extra': 8.0.0
+      '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
-      '@types/nise': 1.4.0
-      '@types/nock': 10.0.3
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/query-string': 6.2.0
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 5.2.0
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      cross-env: 5.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.1.0
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-json-preprocessor: 0.3.3_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-json-preprocessor: 0.3.3_karma@4.4.1
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
-      nise: 1.5.1
-      nock: 11.3.2
       nyc: 14.1.1
       prettier: 1.18.2
-      puppeteer: 1.19.0
+      puppeteer: 1.20.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
-      source-map-support: 0.5.13
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
+      source-map-support: 0.5.16
       tslib: 1.10.0
-      typescript: 3.5.3
-      uglify-js: 3.6.0
+      typescript: 3.6.4
+      uglify-js: 3.6.7
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-+Jug7jVCeVNKTwqCGt9A95Kpu08hx8OjYiMdC4Ov4M/nLnQjBh1nr2bd9+a2M6j5aViMf4CUlrFV1PGYUdG8Uw==
+      integrity: sha512-c1T6cfy4EEBx+xqYMz4u0x97DDY6dtseegIyrhNjrtSIB/pj2evzP+uXS1vhzvM50/sE3fZHw+Ppn1H1uaYpPQ==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-paging': 1.0.0-preview.2
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
-      '@microsoft/api-extractor': 7.3.8
-      '@types/chai': 4.2.0
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
+      '@microsoft/api-extractor': 7.5.2
+      '@types/chai': 4.2.4
       '@types/dotenv': 6.1.1
-      '@types/fs-extra': 8.0.0
+      '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
-      '@types/nise': 1.4.0
-      '@types/nock': 10.0.3
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/query-string': 6.2.0
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 5.2.0
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      cross-env: 5.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.1.0
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-json-preprocessor: 0.3.3_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-json-preprocessor: 0.3.3_karma@4.4.1
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
-      nise: 1.5.1
-      nock: 11.3.2
       nyc: 14.1.1
       prettier: 1.18.2
-      puppeteer: 1.19.0
+      puppeteer: 1.20.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
-      source-map-support: 0.5.13
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
+      source-map-support: 0.5.16
       tslib: 1.10.0
-      typescript: 3.5.3
-      uglify-js: 3.6.0
+      typescript: 3.6.4
+      uglify-js: 3.6.7
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-VgBi7CYYjmH3TSN8yrx4lKyekJfiDQXrMGB49c6PMV3CLUXmfGIVPlCqO9EvpgJipx1b+B0uRkoXmqGztI0YRw==
+      integrity: sha512-Ovjotq3PpgMTDU3WVikIl5nQn6LuJExNM6fvmKouDQmVG4lwO5V9avjSrMPCPwl62HoZvujIeJbxeKQ80D0aqQ==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/logger.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.0
-      '@types/chai': 4.2.3
-      '@types/debug': 4.1.5
+      '@microsoft/api-extractor': 7.5.2
+      '@types/chai': 4.2.4
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.54
-      '@types/sinon': 7.0.13
-      '@typescript-eslint/eslint-plugin': 2.3.3_ac2af3c58153fd08c91227fd925d839a
-      '@typescript-eslint/parser': 2.3.3_eslint@6.5.1
+      '@types/node': 8.10.58
+      '@types/sinon': 7.5.0
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
       cross-env: 5.2.1
-      debug: 4.1.1
       delay: 4.3.0
-      dotenv: 8.1.0
-      eslint: 6.5.1
-      eslint-config-prettier: 6.4.0_eslint@6.5.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.5.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
-      karma: 4.3.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.3.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.3.0
-      karma-junit-reporter: 1.2.0_karma@4.3.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.3.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
       nyc: 14.1.1
       prettier: 1.18.2
-      puppeteer: 1.19.0
+      puppeteer: 1.20.0
       rimraf: 3.0.0
-      rollup: 1.23.1
-      rollup-plugin-commonjs: 10.1.0_rollup@1.23.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.23.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.23.1
-      rollup-plugin-terser: 5.1.2_rollup@1.23.1
-      sinon: 7.4.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      sinon: 7.5.0
       ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
     dev: false
     name: '@rush-temp/logger'
     resolution:
-      integrity: sha512-8TROTdWpg8LAKw7uOUWRkW0DZ/ZwZASRFtY59rs9fc+pfZb8ZBNgIGM5HNOmYqU2vuSjwFYu3CLKf4c7D9CoAg==
+      integrity: sha512-xgKVrXpxp8rzAbnQAg33MoEvgz/eBb5j/1FJhEz2+BXusX06Fl3hOM+g2I6O8In8qrlBDeERgrEmj0JzyiaEiw==
       tarball: 'file:projects/logger.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
     dependencies:
       '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
       '@azure/arm-servicebus': 3.2.0
-      '@azure/eslint-plugin-azure-sdk': 2.0.1_9e8391ca70fb0408a9da4393803aa477
+      '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@microsoft/api-extractor': 7.3.8
+      '@microsoft/api-extractor': 7.5.2
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.0
+      '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 4.1.5
       '@types/dotenv': 6.1.1
       '@types/is-buffer': 2.0.0
       '@types/long': 4.0.0
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/ws': 6.0.3
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      buffer: 5.4.0
+      buffer: 5.4.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-exclude: 2.0.2_chai@4.2.0
-      cross-env: 5.2.0
+      cross-env: 5.2.1
       debug: 4.1.1
       delay: 4.3.0
-      dotenv: 8.1.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      dotenv: 8.2.0
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
-      https-proxy-agent: 2.2.2
-      is-buffer: 2.0.3
-      karma: 4.2.0
+      https-proxy-agent: 2.2.4
+      is-buffer: 2.0.4
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       long: 4.0.0
       mocha: 6.2.2
@@ -13254,125 +11519,50 @@ packages:
       prettier: 1.18.2
       process: 0.11.10
       promise: 8.0.3
-      puppeteer: 1.19.0
-      rhea: 1.0.8
+      puppeteer: 1.20.0
+      rhea: 1.0.11
       rhea-promise: 0.1.15
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
-      rollup-plugin-inject: 3.0.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
+      rollup-plugin-inject: 3.0.2
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      ts-node: 8.3.0_typescript@3.5.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.5.3
-      ws: 7.1.2
+      typescript: 3.6.4
+      ws: 7.2.0
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-eq8J6VXg5PNWuUXxn+pZt6bMzPRVoA35WqZNA4ZzKkkTco8p67Vr9LTJ2iFMGooG4EaooJNtSoBcnS6E9c8EYQ==
+      integrity: sha512-Art7x4ca+9R3Dtt843VjjfE46bkZoMbSX+35cq//5oqLra+dQLO1zuHYEOIx6olZTPt4PE8lrxf2xS8NE/YTUw==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-paging': 1.0.0-preview.2
-      '@azure/ms-rest-js': 2.0.4
-      '@microsoft/api-extractor': 7.3.8
-      '@types/dotenv': 6.1.1
-      '@types/execa': 0.9.0
-      '@types/fs-extra': 8.0.0
-      '@types/mocha': 5.2.7
-      '@types/nise': 1.4.0
-      '@types/nock': 10.0.3
-      '@types/node': 8.10.52
-      '@types/query-string': 6.2.0
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
-      assert: 1.5.0
-      cross-env: 5.2.0
-      dotenv: 8.1.0
-      es6-promise: 4.2.8
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
-      eslint-plugin-no-only-tests: 2.3.1
-      eslint-plugin-promise: 4.2.1
-      events: 3.0.0
-      execa: 1.0.0
-      fs-extra: 8.1.0
-      gulp: 4.0.2
-      gulp-zip: 5.0.0_gulp@4.0.2
-      inherits: 2.0.4
-      karma: 4.2.0
-      karma-chrome-launcher: 3.1.0
-      karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
-      karma-env-preprocessor: 0.1.1
-      karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-json-preprocessor: 0.3.3_karma@4.2.0
-      karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 1.2.0_karma@4.2.0
-      karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
-      karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
-      mocha: 6.2.2
-      mocha-junit-reporter: 1.23.1_mocha@6.2.2
-      mocha-multi: 1.1.3_mocha@6.2.2
-      nise: 1.5.1
-      nock: 11.3.2
-      nyc: 14.1.1
-      prettier: 1.18.2
-      puppeteer: 1.19.0
-      query-string: 5.1.1
-      rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
-      rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
-      rollup-plugin-replace: 2.2.0
-      rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
-      source-map-support: 0.5.13
-      ts-node: 8.3.0_typescript@3.5.3
-      tslib: 1.10.0
-      typescript: 3.5.3
-      util: 0.12.1
-    dev: false
-    name: '@rush-temp/storage-blob'
-    resolution:
-      integrity: sha512-Ah2e75amB/pd/agYs9mtkjKeJO+Xo+2bEQ4h4VM6ZofV9S8b6Bm56sZ799j8KU6k2m4/dWYamBW4Jo7OD3SFBA==
-      tarball: 'file:projects/storage-blob.tgz'
-    version: 0.0.0
-  'file:projects/storage-file-share.tgz':
-    dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-paging': 1.0.0-preview.2
       '@microsoft/api-extractor': 7.5.2
       '@types/dotenv': 6.1.1
+      '@types/execa': 0.9.0
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/nise': 1.4.0
       '@types/nock': 10.0.3
-      '@types/node': 8.10.56
+      '@types/node': 8.10.58
       '@types/query-string': 6.2.0
-      '@typescript-eslint/eslint-plugin': 2.5.0_9532ddc6a515f233700227c4e2ab0e1c
-      '@typescript-eslint/parser': 2.5.0_eslint@6.5.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       cross-env: 5.2.1
       dotenv: 8.2.0
       es6-promise: 4.2.8
-      eslint: 6.5.1
-      eslint-config-prettier: 6.4.0_eslint@6.5.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.5.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
@@ -13398,22 +11588,92 @@ packages:
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
       nise: 1.5.2
-      nock: 11.6.0
+      nock: 11.7.0
       nyc: 14.1.1
       prettier: 1.18.2
       puppeteer: 1.20.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.25.2
-      rollup-plugin-commonjs: 10.1.0_rollup@1.25.2
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.25.2
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.25.2
-      rollup-plugin-terser: 5.1.2_rollup@1.25.2
-      rollup-plugin-visualizer: 2.6.0_rollup@1.25.2
-      source-map-support: 0.5.13
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
+      source-map-support: 0.5.16
+      ts-node: 8.4.1_typescript@3.6.4
+      tslib: 1.10.0
+      typescript: 3.6.4
+      util: 0.12.1
+    dev: false
+    name: '@rush-temp/storage-blob'
+    resolution:
+      integrity: sha512-SrGA2Vj+i9Qpi3cPq+t3W4WuXVeBhepjZtJYRgDLrCxswtrVqweCEyRMo6MiK/l7lyfBD0DTeRZZykqRtIuMsA==
+      tarball: 'file:projects/storage-blob.tgz'
+    version: 0.0.0
+  'file:projects/storage-file-share.tgz':
+    dependencies:
+      '@microsoft/api-extractor': 7.5.2
+      '@types/dotenv': 6.1.1
+      '@types/fs-extra': 8.0.1
+      '@types/mocha': 5.2.7
+      '@types/nise': 1.4.0
+      '@types/nock': 10.0.3
+      '@types/node': 8.10.58
+      '@types/query-string': 6.2.0
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
+      assert: 1.5.0
+      cross-env: 5.2.1
+      dotenv: 8.2.0
+      es6-promise: 4.2.8
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
+      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-promise: 4.2.1
+      events: 3.0.0
+      execa: 1.0.0
+      fs-extra: 8.1.0
+      gulp: 4.0.2
+      gulp-zip: 5.0.1_gulp@4.0.2
+      inherits: 2.0.4
+      karma: 4.4.1
+      karma-chrome-launcher: 3.1.0
+      karma-coverage: 2.0.1
+      karma-edge-launcher: 0.4.2_karma@4.4.1
+      karma-env-preprocessor: 0.1.1
+      karma-firefox-launcher: 1.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-json-preprocessor: 0.3.3_karma@4.4.1
+      karma-json-to-file-reporter: 1.0.1
+      karma-junit-reporter: 1.2.0_karma@4.4.1
+      karma-mocha: 1.3.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
+      karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
+      mocha: 6.2.2
+      mocha-junit-reporter: 1.23.1_mocha@6.2.2
+      mocha-multi: 1.1.3_mocha@6.2.2
+      nise: 1.5.2
+      nock: 11.7.0
+      nyc: 14.1.1
+      prettier: 1.18.2
+      puppeteer: 1.20.0
+      query-string: 5.1.1
+      rimraf: 3.0.0
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
+      rollup-plugin-multi-entry: 2.1.0
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
+      rollup-plugin-replace: 2.2.0
+      rollup-plugin-shim: 1.0.0
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
+      source-map-support: 0.5.16
       ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
@@ -13421,188 +11681,180 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-RLFFbLV2L5phPhQdoDnOUyo1N+9sUfEfZFJ/yvTqYhq58d4iq9BH7Ifn/6Y4t5i/Vnj0WX42SvsvdUQZiH4lUA==
+      integrity: sha512-yQcvssLa4npGyQwhy3B3sM6IZtBc1x0k6aRhRXdizlmJsUlKLsJvXTqEzMmRtCSctfq2wNIeitYqMV4Mtlleag==
       tarball: 'file:projects/storage-file-share.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
     dependencies:
-      '@azure/abort-controller': 1.0.0-preview.2
-      '@azure/core-paging': 1.0.0-preview.2
-      '@azure/ms-rest-js': 2.0.4
-      '@microsoft/api-extractor': 7.3.8
+      '@microsoft/api-extractor': 7.5.2
       '@types/dotenv': 6.1.1
-      '@types/fs-extra': 8.0.0
+      '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/nise': 1.4.0
       '@types/nock': 10.0.3
-      '@types/node': 8.10.52
+      '@types/node': 8.10.58
       '@types/query-string': 6.2.0
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.0
-      dotenv: 8.1.0
+      cross-env: 5.2.1
+      dotenv: 8.2.0
       es6-promise: 4.2.8
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       execa: 1.0.0
       fs-extra: 8.1.0
       gulp: 4.0.2
-      gulp-zip: 5.0.0_gulp@4.0.2
+      gulp-zip: 5.0.1_gulp@4.0.2
       inherits: 2.0.4
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-json-preprocessor: 0.3.3_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-json-preprocessor: 0.3.3_karma@4.4.1
       karma-json-to-file-reporter: 1.0.1
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
-      nise: 1.5.1
-      nock: 11.3.2
+      nise: 1.5.2
+      nock: 11.7.0
       nyc: 14.1.1
       prettier: 1.18.2
-      puppeteer: 1.19.0
+      puppeteer: 1.20.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
-      source-map-support: 0.5.13
-      ts-node: 8.3.0_typescript@3.5.3
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
+      source-map-support: 0.5.16
+      ts-node: 8.4.1_typescript@3.6.4
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       util: 0.12.1
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-Yfayesi/QrWNceKCoDBVb/w5jk5HkXvKNmgGq9G1KN4d0WF90AXJgC05NN2TGVuqfAlY/80Ctn84N6pGLLeAWA==
+      integrity: sha512-xCZNDDfSTWLjDHKy1i9Se6Z0eAuN6EMxgYUxnto+91C5kxfzEV7s7sapB6GPxO500cyOVv6jDGVB7ylu7/uuGg==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.3.8
+      '@microsoft/api-extractor': 7.5.2
       '@types/mocha': 5.2.7
-      '@types/node': 8.10.52
-      '@typescript-eslint/eslint-plugin': 2.0.0_3cafee28902d96627d4743e014bc28ff
-      '@typescript-eslint/parser': 2.0.0_eslint@6.2.1
+      '@types/node': 8.10.58
+      '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
+      '@typescript-eslint/parser': 2.6.1_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.0
-      eslint: 6.2.1
-      eslint-config-prettier: 6.1.0_eslint@6.2.1
-      eslint-plugin-no-null: 1.0.2_eslint@6.2.1
+      cross-env: 5.2.1
+      eslint: 6.6.0
+      eslint-config-prettier: 6.5.0_eslint@6.6.0
+      eslint-plugin-no-null: 1.0.2_eslint@6.6.0
       eslint-plugin-no-only-tests: 2.3.1
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
       inherits: 2.0.4
-      karma: 4.2.0
+      karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.1
-      karma-edge-launcher: 0.4.2_karma@4.2.0
+      karma-edge-launcher: 0.4.2_karma@4.4.1
       karma-env-preprocessor: 0.1.1
       karma-firefox-launcher: 1.2.0
-      karma-ie-launcher: 1.0.0_karma@4.2.0
-      karma-junit-reporter: 1.2.0_karma@4.2.0
+      karma-ie-launcher: 1.0.0_karma@4.4.1
+      karma-junit-reporter: 1.2.0_karma@4.4.1
       karma-mocha: 1.3.0
-      karma-mocha-reporter: 2.2.5_karma@4.2.0
+      karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-coverage: 0.1.5_karma-coverage@2.0.1
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.18.2
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-json: 4.0.0
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       util: 0.12.1
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-hFg1DGSrI5+8NCgaVLIk0FplmT4m7I9O7AraJpSgn5CVcL/LvnNCVjeMmb7bhICye0HX3eIgOw0KehS4Lk/H/A==
+      integrity: sha512-2XmSq3YECvO4sk8+8adzvj0A6YHOG5iC9+2hqvTpPJRbjTdYD/xMszf9Qu3wdJih4chevQLehyGF4uv0uV13+w==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/test-utils-recorder.tgz':
     dependencies:
-      '@types/fs-extra': 8.0.0
+      '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/nise': 1.4.0
       '@types/nock': 10.0.3
-      '@types/query-string': 6.2.0
       fs-extra: 8.1.0
-      nise: 1.5.1
-      nock: 11.3.2
-      query-string: 5.1.1
+      nise: 1.5.2
+      nock: 11.7.0
       rimraf: 3.0.0
-      rollup: 1.20.1
-      rollup-plugin-commonjs: 10.0.2_rollup@1.20.1
+      rollup: 1.26.3
+      rollup-plugin-commonjs: 10.1.0_rollup@1.26.3
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.20.1
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.26.3
       rollup-plugin-replace: 2.2.0
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.20.1
-      rollup-plugin-terser: 5.1.1_rollup@1.20.1
-      rollup-plugin-visualizer: 2.5.4_rollup@1.20.1
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.26.3
+      rollup-plugin-terser: 5.1.2_rollup@1.26.3
+      rollup-plugin-visualizer: 2.7.2_rollup@1.26.3
       tslib: 1.10.0
     dev: false
     name: '@rush-temp/test-utils-recorder'
     resolution:
-      integrity: sha512-SJjlxlVlW3QPkHFCP+M3QSAgrlVC50hl/ePd/Xmfixx8pl4uiLwm/ZOMmzQ59IfM1zryQw55BNPv2qu5/1hJXA==
+      integrity: sha512-5X0CLSRbJrplwH5JFkcDlSfzxzFeT/veoYhb9NB+q2hTDd9rXRjwePn76IWcVBtUzq2siSgvgrSsioDYiXMUsw==
       tarball: 'file:projects/test-utils-recorder.tgz'
     version: 0.0.0
   'file:projects/testhub.tgz':
     dependencies:
       '@azure/event-hubs': 2.1.1
-      '@types/node': 8.10.52
-      '@types/uuid': 3.4.5
-      '@types/yargs': 13.0.2
+      '@types/node': 8.10.58
+      '@types/uuid': 3.4.6
+      '@types/yargs': 13.0.3
       async-lock: 1.2.2
       death: 1.1.0
       debug: 4.1.1
-      rhea: 1.0.8
+      rhea: 1.0.11
       rimraf: 3.0.0
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.6.4
       uuid: 3.3.3
-      yargs: 14.0.0
+      yargs: 14.2.0
     dev: false
     name: '@rush-temp/testhub'
     resolution:
-      integrity: sha512-XZB/wnNqz04DCZBqyhzkkYG8c/XduwpKK8uJbRcnJrvTthx844ix8Cn3nDHaoLlxODmoxP4xosiCiKTIn7EuBw==
+      integrity: sha512-RkYcAmpRKuAXwbssMJGmc8uzm3LoQikdGvIqdwioQqURgLagimtd01yH+757XDMvMyOfVwejTTSCZHpqa2Bf6Q==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
-registry: ''
 specifiers:
   '@azure/amqp-common': 1.0.0-preview.6
   '@azure/arm-servicebus': ^3.2.0
   '@azure/eslint-plugin-azure-sdk': ^2.0.1
   '@azure/event-hubs': ^2.1.1
-  '@azure/keyvault-keys': 4.0.0-preview.9
-  '@azure/keyvault-secrets': 4.0.0-preview.9
   '@azure/logger-js': ^1.0.2
   '@azure/ms-rest-nodeauth': ^0.9.2
   '@azure/storage-blob': 12.0.0-preview.5


### PR DESCRIPTION
Ran `rush update --full` to get the latest semver compatible versions of all the packages we depend on. #4922 inadvertently downgraded many packages. This change effectively reverts those changes, and includes a few more updates.