### PR TITLE
Update dev dependency api-extractor to latest

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
   '@azure/logger-js': 1.3.2
   '@azure/ms-rest-nodeauth': 0.9.3
   '@azure/storage-blob': 12.0.0-preview.5
-  '@microsoft/api-extractor': 7.5.2
+  '@microsoft/api-extractor': 7.5.4
   '@opencensus/web-types': 0.0.7
   '@rush-temp/abort-controller': 'file:projects/abort-controller.tgz'
   '@rush-temp/app-configuration': 'file:projects/app-configuration.tgz'
@@ -458,17 +458,17 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==
-  /@microsoft/api-extractor-model/7.5.2:
+  /@microsoft/api-extractor-model/7.5.4:
     dependencies:
-      '@microsoft/node-core-library': 3.16.0
+      '@microsoft/node-core-library': 3.17.0
       '@microsoft/tsdoc': 0.12.14
     dev: false
     resolution:
-      integrity: sha512-wDXQ6IvrVg7tp3iqA+7f7yrSzjUPQ2kVNKsrxD5AqbGeohsJYePbmWvz6V8yxxO7ZuM9W7V5zLY6pYh4epq8Dg==
-  /@microsoft/api-extractor/7.5.2:
+      integrity: sha512-pzY1EVHw8dMCRBba8PDEV71vnsmvhOSgLUIXxB45Ts0Po69tz2H7YZQ4DsAetyv0aSLHG5QVXmGEn65A1DDvDQ==
+  /@microsoft/api-extractor/7.5.4:
     dependencies:
-      '@microsoft/api-extractor-model': 7.5.2
-      '@microsoft/node-core-library': 3.16.0
+      '@microsoft/api-extractor-model': 7.5.4
+      '@microsoft/node-core-library': 3.17.0
       '@microsoft/ts-command-line': 4.3.4
       '@microsoft/tsdoc': 0.12.14
       colors: 1.2.5
@@ -479,17 +479,19 @@ packages:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-IGMpxhiTaUsGGdrGqCwhwGbyJNMwrVe0wi3vYqFL0G93N+DO2uI89/JNGxaiGjgQ8nCem6u8hPd0NhOcGU6DcA==
-  /@microsoft/node-core-library/3.16.0:
+      integrity: sha512-zt+1WAQ1VRMBltpmaRiycDphWvdOt2dQ9u5B1gG8hHL9kR07DHbAws5p3eUcTI3QBqtBVGGuhK8Kt8IRnKZGOw==
+  /@microsoft/node-core-library/3.17.0:
     dependencies:
       '@types/node': 8.10.54
       colors: 1.2.5
       fs-extra: 7.0.1
       jju: 1.4.0
+      semver: 5.3.0
+      timsort: 0.3.0
       z-schema: 3.18.4
     dev: false
     resolution:
-      integrity: sha512-zjgOAmOhWgE5eX8ofmRagcomeIhs96GizRm7m9UfAuzhEmWtQSOE33/WpZzoyw41S/bjevHi7YbkY+R70mdjFg==
+      integrity: sha512-i49LbZxPU35Vq50lV1oN331WPp+BmmhGs0Ee2PT/OAZR7qOm/UdQ3vpG70zhkLHymJNUyb0vUh0UU3ZHU6mgsg==
   /@microsoft/ts-command-line/4.3.4:
     dependencies:
       '@types/argparse': 1.0.33
@@ -4642,6 +4644,9 @@ packages:
       node: '>=8'
     peerDependencies:
       gulp: '>=4'
+    peerDependenciesMeta:
+      gulp:
+        optional: true
     resolution:
       integrity: sha512-M/IWLh9RvOpuofDZkgDirtiyz9J3yIqnDOJ3muzk2D/XnZ1ruqPlPLRIpXnl/aZU+xXwKPdOIxjRzkUcVEQyZQ==
   /gulp/4.0.2:
@@ -8458,6 +8463,11 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha1-E+jCZYq5aRywzXEJMkAoDTb3els=
+  /semver/5.3.0:
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha1-myzl094C0XxgEq0yaqa00M9U+U8=
   /semver/5.7.1:
     dev: false
     hasBin: true
@@ -9294,6 +9304,10 @@ packages:
       node: '>=0.6.0'
     resolution:
       integrity: sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
+  /timsort/0.3.0:
+    dev: false
+    resolution:
+      integrity: sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
   /tmp/0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -10422,7 +10436,7 @@ packages:
       integrity: sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==
   'file:projects/abort-controller.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/mocha': 5.2.7
       '@types/node': 8.10.58
       '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
@@ -10465,12 +10479,12 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-GRP0FEblaWYehNCxXr7lKsVkWcglIOWkYzCxXfXirEeoRsXCCWNYT24D2n9qovj7YbzdSf6eRWIrq7aY+COP4g==
+      integrity: sha512-kHfCjgB8CVkcWOZj5MVHOkLql6HmfB/DH8CxFeG+VneTKxpuSgLufwjG8cyhU9LMtHjzHNMR+FFEawJ2wLEa+w==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/app-configuration.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/dotenv': 6.1.1
       '@types/mocha': 5.2.7
       assert: 1.5.0
@@ -10496,12 +10510,12 @@ packages:
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
-      integrity: sha512-pJNMAf0RMhIDTN+9EuCKjROM9QCNRfLgSDk9tYoC3YaxjA/BeYGo/UFTTS9QOZFJyFmX4zXu6bmQW1Uzzxbkgw==
+      integrity: sha512-ALz8S3CURUtdSuDXrvW5LF49hCdr49SHzih2+7wTC6OhBp0zWO1N5CU9fJkJJRWL8vg/eAo4zto0M2/45PuKpQ==
       tarball: 'file:projects/app-configuration.tgz'
     version: 0.0.0
   'file:projects/cognitiveservices-inkrecognizer.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/mocha': 5.2.7
       '@types/node': 8.10.58
       '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
@@ -10539,7 +10553,7 @@ packages:
     dev: false
     name: '@rush-temp/cognitiveservices-inkrecognizer'
     resolution:
-      integrity: sha512-BwQDZ43P77tBMQaxuvYNY5CNqtL996JOteX1IYwWgTG2YLbDu3ODnj5UyL58JBcNR5Jj6jy7lnHKy7XvOTFl3A==
+      integrity: sha512-WBJspKKNEhzcfQaVar/pYimQY2WnS+lBHxSdC3sqMNRWjbyxfrnVgFL3HboPoJEqwTX+NOPMgIyU09bi23o3mQ==
       tarball: 'file:projects/cognitiveservices-inkrecognizer.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
@@ -10667,7 +10681,7 @@ packages:
   'file:projects/core-auth.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/mocha': 5.2.7
       '@types/node': 8.10.58
       '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
@@ -10700,7 +10714,7 @@ packages:
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-srhEmghmah8zyVEpORwaqYAgIXLwIZH+9nDCD4+XZafbUSDcChADN+arueSpBeR80mRc5ncO/xAcpMS6e9uyJQ==
+      integrity: sha512-vbfe00abmoy/YC+4rMWK/0gLH3+s29R4d7fXiKtYFCUEzjxoW577Ryp5uL5X942zcaZeNSAZ7bJL9z7K6xZ3kg==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -10787,7 +10801,7 @@ packages:
     version: 0.0.0
   'file:projects/core-lro.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/chai': 4.2.4
       '@types/mocha': 5.2.7
       '@types/node': 8.10.58
@@ -10834,7 +10848,7 @@ packages:
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
-      integrity: sha512-DTIeNPjGqEbzNK+7Req7RxSJtihR1AEnXXopfzFz3QO7Yl9c6b8AHXz43RUd+eop/uSvN8YgjmBtXS3zbGX7dg==
+      integrity: sha512-hLWlhkNTKWY3uzwNcrEhCoX03bj9H59Xlmv7yFAPlkBGJeicr4f5tP0EnNlx5sWT6VnVYH5jFqcgkd7n1qT5Og==
       tarball: 'file:projects/core-lro.tgz'
     version: 0.0.0
   'file:projects/core-paging.tgz':
@@ -10858,7 +10872,7 @@ packages:
   'file:projects/core-tracing.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@opencensus/web-types': 0.0.7
       '@types/mocha': 5.2.7
       '@types/node': 8.10.58
@@ -10892,13 +10906,13 @@ packages:
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-YdS71ViNSfXzoc4YC7cE+fx8UGIfuTZt1GD8YOvXPNs/zU2bJaxvjvHalVwdp04V4bQz2ou/nDOn1iJSGrPT9A==
+      integrity: sha512-WNv1q3q140V8w4YvioFM7a4c53HS+932COOUIJ+Y9mx5BhDt9b6P9ZyusworZcEJLNPa7oBkGPoTuWpYKOc10w==
       tarball: 'file:projects/core-tracing.tgz'
     version: 0.0.0
   'file:projects/cosmos.tgz_webpack@4.41.2':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/debug': 4.1.5
       '@types/fast-json-stable-stringify': 2.0.0
       '@types/mocha': 5.2.7
@@ -10965,13 +10979,13 @@ packages:
     peerDependencies:
       webpack: '*'
     resolution:
-      integrity: sha512-vA0zZ7IgRHanU9mttXqsQrEavnSJjQJa3/GK8EMHQAMmhoY+toRsgym1Eam//OrMrDlYjBh9kQMMwdDN0TK3cg==
+      integrity: sha512-RiB0tn094zx0nF1twOznWEUA0zCWUqiFYKl5PScjVccHc+q7Bp4xq3RVfU2aev/esDSgHhx7bni+ic8Od+TvZw==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/event-hubs.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/async-lock': 1.1.1
       '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
@@ -11041,7 +11055,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-FfwMPIntuJk7r6kI3i6xSad8SB7Vrj7NCHLSZ0b2sqcJVvkABJFHTmMmLpFCIDDHEMsO33UAWnloyp9+ZsFV4w==
+      integrity: sha512-9z2SktOwgEvHyqkgNN5m9q+3R4VlNt7HWSgCBZoAI1IsB2PWJ5ZR1Hgk8K3FITLTGpJ7qoS2T7Y63ly9LI89Ew==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -11049,7 +11063,7 @@ packages:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
       '@azure/event-hubs': 2.1.1
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/async-lock': 1.1.1
       '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
@@ -11099,13 +11113,13 @@ packages:
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-tyWDvaUzGva2ahhJobs9dwj3imJPSoEr2bDydX/aXPcnXbSQ1CeJx9xizllPYx6BEPv26jQW/94xXErig5QEGw==
+      integrity: sha512-EQuPlfYshNQSHpFmaNcJMqoDICtIZ0EnvlG2QolNzIZc9q1VF/CWacJB3t/rR/tFeRAalQaGXwGOUMMpQNgzuw==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
     dependencies:
       '@azure/storage-blob': 12.0.0-preview.5
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
@@ -11162,12 +11176,12 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-BnJn8JUK5qyQryO8/U8S7TPSYFkW/q1HTYVyYpE3fwFoJ3+4+usDhmt+0tdXwWPx4+wPT8c5G6gO4a6pSGyC5w==
+      integrity: sha512-Kr+YRlojQ8K4wG+98+46cquhlxxkAwb8m2gGBrtZhjRMUg6JJ6UPL2BHaFSETv6fXhqcTA9Bl6Z5SSd9DUNyKw==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/express': 4.17.2
       '@types/jws': 3.2.0
       '@types/mocha': 5.2.7
@@ -11218,13 +11232,13 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-3NKsPsFu/mOtZv2GqG2he44KyyRGelHi58SOdEHcznac8S5EIFGL2OqBqiVJGHRAtf7+AaJnGs85vQxOcPXVvg==
+      integrity: sha512-kWYqgH5uBybhS4LHCW/xyH3bkHQW0o8rLYTdqx4HGGsobS+NMEXX+AT/vJzlJPlj8MUkirC7Maup8ewG/3qleg==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/chai': 4.2.4
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 8.0.1
@@ -11281,13 +11295,13 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-KR/x7n9ahpAotFc67ywF6dmVgMelXDEAhYqruOJShF4t0CspYLnvRFx/nbQDDurn2YJXHaAuqNZp1GB4S6qD9g==
+      integrity: sha512-iSQmmYi1LwhCpIWO968Jd80zCgv40sBjmh9Rufo4uHhQiMtPfKzrxM1VhwEziuapTjM2F7y89dDJ9+8z6p7/uw==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/chai': 4.2.4
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 8.0.1
@@ -11344,13 +11358,13 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-c1T6cfy4EEBx+xqYMz4u0x97DDY6dtseegIyrhNjrtSIB/pj2evzP+uXS1vhzvM50/sE3fZHw+Ppn1H1uaYpPQ==
+      integrity: sha512-/Bs9GLCXWW9xX2oMqDJTKTVB6QWDD93BUYnPcfnNRndfyKsynq97v5I08OA6v+NA4V+mQ0yR4PztbUcX/Y48lA==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/chai': 4.2.4
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 8.0.1
@@ -11407,12 +11421,12 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-Ovjotq3PpgMTDU3WVikIl5nQn6LuJExNM6fvmKouDQmVG4lwO5V9avjSrMPCPwl62HoZvujIeJbxeKQ80D0aqQ==
+      integrity: sha512-ejBW3me99ie5uZ3vM9ah+snNg5w0W91NwW/SagGETy2GjRDgq1vH0pir9qIIUnsUsk4EJwL7t9HCyC9iXyAE9g==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/logger.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/chai': 4.2.4
       '@types/mocha': 5.2.7
       '@types/node': 8.10.58
@@ -11461,7 +11475,7 @@ packages:
     dev: false
     name: '@rush-temp/logger'
     resolution:
-      integrity: sha512-xgKVrXpxp8rzAbnQAg33MoEvgz/eBb5j/1FJhEz2+BXusX06Fl3hOM+g2I6O8In8qrlBDeERgrEmj0JzyiaEiw==
+      integrity: sha512-fDdILAzl1j406qaWH6zJ9Pk+n+8LdDysOYBInMy1immuQ7KLOjyuUO5vAbmpyuaj5nfb5v2kasdV8/piWY+bgg==
       tarball: 'file:projects/logger.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -11470,7 +11484,7 @@ packages:
       '@azure/arm-servicebus': 3.2.0
       '@azure/eslint-plugin-azure-sdk': 2.0.1_47985cb813de276321a61b23c1c6de5b
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/async-lock': 1.1.1
       '@types/chai': 4.2.4
       '@types/chai-as-promised': 7.1.2
@@ -11540,12 +11554,12 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-Art7x4ca+9R3Dtt843VjjfE46bkZoMbSX+35cq//5oqLra+dQLO1zuHYEOIx6olZTPt4PE8lrxf2xS8NE/YTUw==
+      integrity: sha512-uUY5B8EIiKmMLviPLFv/thK5v1O5Bc8Vrj5C7hXuFOe2HdeZqOdGAfNYUc9v9bQ+xJK7hN03CGpagUhaZXSa8g==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/dotenv': 6.1.1
       '@types/execa': 0.9.0
       '@types/fs-extra': 8.0.1
@@ -11611,12 +11625,12 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-SrGA2Vj+i9Qpi3cPq+t3W4WuXVeBhepjZtJYRgDLrCxswtrVqweCEyRMo6MiK/l7lyfBD0DTeRZZykqRtIuMsA==
+      integrity: sha512-J4MZCTwji1IS75RZC9jSOKCcGZDkHdtuNFaKEKEg4c5qLQbAXxI8Ima1xMm4bxE7fhjK6zqgjeHwuGBIz4r0Jg==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file-share.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
@@ -11681,12 +11695,12 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-yQcvssLa4npGyQwhy3B3sM6IZtBc1x0k6aRhRXdizlmJsUlKLsJvXTqEzMmRtCSctfq2wNIeitYqMV4Mtlleag==
+      integrity: sha512-QM5wctgeuQN1H8KfCSagygBrKpolDpn3tcvrZUF0lxHGB5N3PAI3AKvL3tb+7I1kzgfV/So6xPIgY4A/S1nEaA==
       tarball: 'file:projects/storage-file-share.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
@@ -11750,12 +11764,12 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-xCZNDDfSTWLjDHKy1i9Se6Z0eAuN6EMxgYUxnto+91C5kxfzEV7s7sapB6GPxO500cyOVv6jDGVB7ylu7/uuGg==
+      integrity: sha512-ARaoBMF7wqRD9DVtL4pd5PiWKXYF2e8XOp6bZKgjWMGHZVMjrco7gEQjjd3nVCtpUIz+w1+iYhIPcuolfE8PtQ==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
     dependencies:
-      '@microsoft/api-extractor': 7.5.2
+      '@microsoft/api-extractor': 7.5.4
       '@types/mocha': 5.2.7
       '@types/node': 8.10.58
       '@typescript-eslint/eslint-plugin': 2.6.1_f826f0ccb5c1fa5c7ef10e2b959e7a19
@@ -11800,7 +11814,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-2XmSq3YECvO4sk8+8adzvj0A6YHOG5iC9+2hqvTpPJRbjTdYD/xMszf9Qu3wdJih4chevQLehyGF4uv0uV13+w==
+      integrity: sha512-24L63qhdMrFZktKn+wc+i7kxsK4jrJxUsc4PZuw4ey8WsESw48CUWTyes7IdDfvaderxGrdSFTPBBdcSygrHHg==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/test-utils-recorder.tgz':
@@ -11850,6 +11864,7 @@ packages:
       integrity: sha512-RkYcAmpRKuAXwbssMJGmc8uzm3LoQikdGvIqdwioQqURgLagimtd01yH+757XDMvMyOfVwejTTSCZHpqa2Bf6Q==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure/amqp-common': 1.0.0-preview.6
   '@azure/arm-servicebus': ^3.2.0
@@ -11858,7 +11873,7 @@ specifiers:
   '@azure/logger-js': ^1.0.2
   '@azure/ms-rest-nodeauth': ^0.9.2
   '@azure/storage-blob': 12.0.0-preview.5
-  '@microsoft/api-extractor': ^7.1.5
+  '@microsoft/api-extractor': ^7.5.4
   '@opencensus/web-types': 0.0.7
   '@rush-temp/abort-controller': 'file:./projects/abort-controller.tgz'
   '@rush-temp/app-configuration': 'file:./projects/app-configuration.tgz'

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -67,7 +67,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/dotenv": "^6.1.0",
     "@types/mocha": "^5.2.5",
     "assert": "^1.4.1",

--- a/sdk/cognitiveservices/cognitiveservices-inkrecognizer/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-inkrecognizer/package.json
@@ -67,7 +67,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -66,7 +66,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -102,7 +102,7 @@
   "devDependencies": {
     "@azure/core-arm": "1.0.0-preview.7",
     "@azure/identity": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -71,7 +71,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/chai": "^4.1.6",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -87,7 +87,7 @@
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/fast-json-stable-stringify": "^2.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
     "@azure/identity": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -113,9 +113,9 @@ export interface EventHubConsumerOptions {
 
 // @public
 export class EventHubProducerClient {
-    constructor(host: string, eventHubName: string, credential: TokenCredential, options?: EventHubClientOptions);
-    constructor(connectionString: string, eventHubName: string, options?: EventHubClientOptions);
     constructor(connectionString: string, options?: EventHubClientOptions);
+    constructor(connectionString: string, eventHubName: string, options?: EventHubClientOptions);
+    constructor(host: string, eventHubName: string, credential: TokenCredential, options?: EventHubClientOptions);
     close(): Promise<void>;
     createBatch(options?: CreateBatchOptions): Promise<EventDataBatch>;
     readonly eventHubName: string;

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -69,7 +69,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/chai-string": "^1.4.1",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -82,7 +82,7 @@
   },
   "devDependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/express": "^4.16.0",
     "@types/jws": "^3.2.0",
     "@types/mocha": "^5.2.5",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -80,7 +80,7 @@
     "@azure/keyvault-keys": "^4.0.0",
     "@azure/keyvault-secrets": "^4.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "^8.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -79,7 +79,7 @@
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
     "@azure/identity": "^1.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "^8.0.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -79,7 +79,7 @@
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
     "@azure/identity": "^1.0.0",
     "@azure/test-utils-recorder": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/chai": "^4.1.6",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "^8.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@azure/arm-servicebus": "^3.2.0",
     "@azure/eslint-plugin-azure-sdk": "^2.0.1",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -156,8 +156,8 @@ export interface OnMessage {
 // @public
 export class QueueClient implements Client {
     close(): Promise<void>;
-    createReceiver(receiveMode: ReceiveMode, sessionOptions: SessionReceiverOptions): SessionReceiver;
     createReceiver(receiveMode: ReceiveMode): Receiver;
+    createReceiver(receiveMode: ReceiveMode, sessionOptions: SessionReceiverOptions): SessionReceiver;
     createSender(): Sender;
     readonly entityPath: string;
     static getDeadLetterQueuePath(queueName: string): string;

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "@azure/identity": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/dotenv": "^6.1.0",
     "@types/execa": "0.9.0",
     "@types/fs-extra": "^8.0.0",

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -272,8 +272,8 @@ export interface BlobAcquireLeaseOptions extends CommonOptions {
 // @public
 export class BlobBatch {
     constructor();
-    deleteBlob(blobClient: BlobClient, options?: BlobDeleteOptions): Promise<void>;
     deleteBlob(url: string, credential: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: BlobDeleteOptions): Promise<void>;
+    deleteBlob(blobClient: BlobClient, options?: BlobDeleteOptions): Promise<void>;
     getHttpRequestBody(): string;
     getMultiPartContentType(): string;
     getSubRequests(): Map<number, BatchSubRequest>;
@@ -356,8 +356,8 @@ export class BlobClient extends StorageClient {
     createSnapshot(options?: BlobCreateSnapshotOptions): Promise<BlobCreateSnapshotResponse>;
     delete(options?: BlobDeleteOptions): Promise<BlobDeleteResponse>;
     download(offset?: number, count?: number, options?: BlobDownloadOptions): Promise<BlobDownloadResponseModel>;
-    downloadToBuffer(buffer: Buffer, offset?: number, count?: number, options?: BlobDownloadToBufferOptions): Promise<Buffer>;
     downloadToBuffer(offset?: number, count?: number, options?: BlobDownloadToBufferOptions): Promise<Buffer>;
+    downloadToBuffer(buffer: Buffer, offset?: number, count?: number, options?: BlobDownloadToBufferOptions): Promise<Buffer>;
     downloadToFile(filePath: string, offset?: number, count?: number, options?: BlobDownloadOptions): Promise<BlobDownloadResponseModel>;
     exists(options?: BlobExistsOptions): Promise<boolean>;
     getAppendBlobClient(): AppendBlobClient;
@@ -763,8 +763,8 @@ export interface BlobSASSignatureValues {
 
 // @public
 export class BlobServiceClient extends StorageClient {
-    constructor(url: string, pipeline: Pipeline);
     constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
+    constructor(url: string, pipeline: Pipeline);
     createContainer(containerName: string, options?: ContainerCreateOptions): Promise<{
         containerClient: ContainerClient;
         containerCreateResponse: ContainerCreateResponse;
@@ -959,9 +959,9 @@ export interface Block {
 
 // @public
 export class BlockBlobClient extends BlobClient {
+    constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     constructor(url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
-    constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     commitBlockList(blocks: string[], options?: BlockBlobCommitBlockListOptions): Promise<BlockBlobCommitBlockListResponse>;
     getBlockList(listType: BlockListType, options?: BlockBlobGetBlockListOptions): Promise<BlockBlobGetBlockListResponse>;
     stageBlock(blockId: string, body: HttpRequestBody, contentLength: number, options?: BlockBlobStageBlockOptions): Promise<BlockBlobStageBlockResponse>;
@@ -1748,9 +1748,9 @@ export type PageBlobClearPagesResponse = PageBlobClearPagesHeaders & {
 
 // @public
 export class PageBlobClient extends BlobClient {
+    constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     constructor(url: string, credential: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
-    constructor(connectionString: string, containerName: string, blobName: string, options?: StoragePipelineOptions);
     clearPages(offset?: number, count?: number, options?: PageBlobClearPagesOptions): Promise<PageBlobClearPagesResponse>;
     create(size: number, options?: PageBlobCreateOptions): Promise<PageBlobCreateResponse>;
     getPageRanges(offset?: number, count?: number, options?: PageBlobGetPageRangesOptions): Promise<PageBlobGetPageRangesResponse>;

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -89,7 +89,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "^8.0.0",
     "@types/mocha": "^5.2.5",

--- a/sdk/storage/storage-file-share/review/storage-file-share.api.md
+++ b/sdk/storage/storage-file-share/review/storage-file-share.api.md
@@ -935,8 +935,8 @@ export class ShareDirectoryClient extends StorageClient {
 
 // @public
 export class ShareFileClient extends StorageClient {
-    constructor(url: string, pipeline: Pipeline);
     constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
+    constructor(url: string, pipeline: Pipeline);
     abortCopyFromURL(copyId: string, options?: FileAbortCopyFromURLOptions): Promise<FileAbortCopyResponse>;
     clearRange(offset: number, contentLength: number, options?: FileClearRangeOptions): Promise<FileUploadRangeResponse>;
     create(size: number, options?: FileCreateOptions): Promise<FileCreateResponse>;

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@azure/identity": "^1.0.0",
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/dotenv": "^6.1.0",
     "@types/fs-extra": "^8.0.0",
     "@types/mocha": "^5.2.5",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -64,7 +64,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.1.5",
+    "@microsoft/api-extractor": "^7.5.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.0.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",


### PR DESCRIPTION
- Fixes "Different ordering in api properties with node 10 and node 12" (microsoft/rushstack#1552)
