### PR TITLE
[Core] Make AbortController/AbortSignal work in the browser with fetch

### DIFF
--- a/sdk/core/abort-controller/src/AbortSignal.ts
+++ b/sdk/core/abort-controller/src/AbortSignal.ts
@@ -1,4 +1,7 @@
 /// <reference path="./shims-public.d.ts" />
+
+import { AbortController } from "./AbortController";
+
 type AbortEventListener = (this: AbortSignalLike, ev?: any) => any;
 
 const listenersMap = new WeakMap<AbortSignal, AbortEventListener[]>();
@@ -76,7 +79,8 @@ export class AbortSignal implements AbortSignalLike {
    * @memberof AbortSignal
    */
   public static get none(): AbortSignal {
-    return new AbortSignal();
+    const controller = new AbortController();
+    return controller.signal;
   }
 
   /**
@@ -84,7 +88,7 @@ export class AbortSignal implements AbortSignalLike {
    *
    * @memberof AbortSignal
    */
-  public onabort: ((ev?: Event) => any) | null = null;
+  public onabort: ((ev: Event) => any) | null = null;
 
   /**
    * Added new "abort" event listener, only support "abort" event.
@@ -131,10 +135,12 @@ export class AbortSignal implements AbortSignalLike {
   }
 
   /**
-    * Dispatches a synthetic event to the AbortSignal.
-    */
+   * Dispatches a synthetic event to the AbortSignal.
+   */
   dispatchEvent(event: Event): boolean {
-    throw new Error("This is a stub dispatchEvent implementation that should not be used.  It only exists for type-checking purposes.")
+    throw new Error(
+      "This is a stub dispatchEvent implementation that should not be used.  It only exists for type-checking purposes."
+    );
   }
 }
 
@@ -154,7 +160,7 @@ export function abortSignal(signal: AbortSignal) {
   }
 
   if (signal.onabort) {
-    signal.onabort.call(signal);
+    signal.onabort.call(signal, { type: "abort" } as any);
   }
 
   const listeners = listenersMap.get(signal)!;

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -351,20 +351,22 @@ describe("AbortController", () => {
   });
 });
 
-describe("fetch integration", () => {
-  it("works", async () => {
-    const parentController = new AbortController();
-    const parentSignal = parentController.signal;
-    parentController.abort();
+if (typeof window !== undefined) {
+  describe("fetch integration", () => {
+    it("works", async () => {
+      const parentController = new AbortController();
+      const parentSignal = parentController.signal;
+      parentController.abort();
 
-    let error;
-    try {
-      await fetch("example.com", {
-        signal: parentSignal
-      });
-    } catch (e) {
-      error = e;
-    }
-    assert.equal(error.name, "AbortError");
+      let error;
+      try {
+        await fetch("example.com", {
+          signal: parentSignal
+        });
+      } catch (e) {
+        error = e;
+      }
+      assert.equal(error.name, "AbortError");
+    });
   });
-});
+}

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -351,7 +351,7 @@ describe("AbortController", () => {
   });
 });
 
-if (typeof window !== undefined && typeof window.fetch !== undefined) {
+if (typeof window !== "undefined" && typeof window.fetch !== "undefined") {
   describe("fetch integration", () => {
     it("works", async () => {
       const parentController = new AbortController();

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 import * as assert from "assert";
 import { AbortController, AbortSignal, AbortError } from "../src/aborter";
 
@@ -179,7 +181,7 @@ describe("AbortController", () => {
     assert.equal(s, "parent1");
   });
 
-  it("should call abort() on child signals that were created before parent abort() call", async function() {
+  it("should call abort() on child signals that were created before parent abort() call", async () => {
     const parentController = new AbortController();
     const parentSignal = parentController.signal;
 
@@ -276,7 +278,7 @@ describe("AbortController", () => {
     assert.equal(true, values.includes("child"));
   });
 
-  it("should call abort() on deeply nested child signals that were created before parent abort() call", async function() {
+  it("should call abort() on deeply nested child signals that were created before parent abort() call", async () => {
     const parentController = new AbortController();
     const parentSignal = parentController.signal;
 
@@ -307,7 +309,7 @@ describe("AbortController", () => {
     assert.equal(true, values.includes("child2"));
   });
 
-  it("should not call abort() on parent signals when child calls abort()", async function() {
+  it("should not call abort() on parent signals when child calls abort()", async () => {
     const parentController = new AbortController();
     const parentSignal = parentController.signal;
 
@@ -346,5 +348,23 @@ describe("AbortController", () => {
     assert.equal(true, values.includes("parent"));
     assert.equal(true, values.includes("child1"));
     assert.equal(true, values.includes("child2"));
+  });
+});
+
+describe("fetch integration", () => {
+  it("works", async () => {
+    const parentController = new AbortController();
+    const parentSignal = parentController.signal;
+    parentController.abort();
+
+    let error;
+    try {
+      await fetch("example.com", {
+        signal: parentSignal
+      });
+    } catch (e) {
+      error = e;
+    }
+    assert.equal(error.name, "AbortError");
   });
 });

--- a/sdk/core/abort-controller/test/aborter.spec.ts
+++ b/sdk/core/abort-controller/test/aborter.spec.ts
@@ -351,7 +351,7 @@ describe("AbortController", () => {
   });
 });
 
-if (typeof window !== undefined) {
+if (typeof window !== undefined && typeof window.fetch !== undefined) {
   describe("fetch integration", () => {
     it("works", async () => {
       const parentController = new AbortController();

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -19,7 +19,6 @@
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {
-    "./dist/index.js": "./browser/service-bus.js",
     "./dist-esm/test/utils/aadUtils.js": "./dist-esm/test/utils/aadUtils.browser.js",
     "./dist-esm/src/util/crypto.js": "./dist-esm/src/util/crypto.browser.js",
     "buffer": "buffer",

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -156,8 +156,8 @@ export interface OnMessage {
 // @public
 export class QueueClient implements Client {
     close(): Promise<void>;
-    createReceiver(receiveMode: ReceiveMode, sessionOptions: SessionReceiverOptions): SessionReceiver;
     createReceiver(receiveMode: ReceiveMode): Receiver;
+    createReceiver(receiveMode: ReceiveMode, sessionOptions: SessionReceiverOptions): SessionReceiver;
     createSender(): Sender;
     readonly entityPath: string;
     static getDeadLetterQueuePath(queueName: string): string;

--- a/sdk/servicebus/service-bus/rollup.base.config.js
+++ b/sdk/servicebus/service-bus/rollup.base.config.js
@@ -141,8 +141,7 @@ export function browserConfig({ test = false, production = false } = {}) {
 
       nodeResolve({
         mainFields: ["module", "browser"],
-        preferBuiltins: false,
-        dedupe: ["buffer"]
+        preferBuiltins: false
       }),
       cjs({
         namedExports: { events: ["EventEmitter"], long: ["ZERO"] }

--- a/sdk/servicebus/service-bus/rollup.config.js
+++ b/sdk/servicebus/service-bus/rollup.config.js
@@ -5,13 +5,6 @@ import * as base from "./rollup.base.config";
 
 const inputs = [];
 
-if (!process.env.ONLY_BROWSER) {
-  inputs.push(base.nodeConfig());
-}
-
-if (!process.env.ONLY_NODE) {
-  inputs.push(base.browserConfig());
-  inputs.push(base.browserConfig({ production: true }));
-}
+inputs.push(base.browserConfig());
 
 export default inputs;


### PR DESCRIPTION
This is accomplished by vending browser-native AbortSignals rather than custom AbortSignals. I'm not entirely sure this is a good approach. While what I have works, the vended signals aren't `instanceof AbortSignal`. This could be surprising. E.g. `AbortSignal.none instanceof AbortSignal` is false. There may be other downsides I'm not thinking of yet.

That said, I experimented with a number of techniques to subclass the built-in AbortSignal, and none of them worked particularly well. The only alternative to this design I can think of uses a browser map to completely swap our AbortController and Signal with their native versions in the browser, but then linked signals wouldn't be supported.