### PR TITLE
[Cosmos] Add dev dependency webpack

### DIFF
--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -137,6 +137,7 @@
     "tslint": "^5.0.0",
     "tslint-config-prettier": "^1.14.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.2.2",
+    "webpack": "^4.16.3"
   }
 }


### PR DESCRIPTION
- karma-webpack has a peer dependency on webpack
- The missing dependency should have caused an error, but it was masked by a Rush feature "implicitlyPreferredVersions" which basically merges dependencies across projects
- We are planning to disable this rush feature (to address unrelated issues) which requires adding this missing dependency
- microsoft/rushstack#1415
