### PR TITLE
[Rush] Set resolutionStrategy=fewer-dependencies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1039,10 +1039,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-kbR5JYinc4wl813W9jdSovh3YTU=
-  /abbrev/1.1.1:
-    dev: false
-    resolution:
-      integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
   /accepts/1.3.7:
     dependencies:
       mime-types: 2.1.24
@@ -3673,12 +3669,6 @@ packages:
       '0': node >=0.6.0
     resolution:
       integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
-  /extsprintf/1.4.0:
-    dev: false
-    engines:
-      '0': node >=0.6.0
-    resolution:
-      integrity: sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
   /fast-deep-equal/2.0.1:
     dev: false
     resolution:
@@ -6200,7 +6190,7 @@ packages:
       integrity: sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
   /nopt/3.0.6:
     dependencies:
-      abbrev: 1.1.1
+      abbrev: 1.0.9
     dev: false
     hasBin: true
     resolution:
@@ -9010,7 +9000,7 @@ packages:
     dependencies:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
-      extsprintf: 1.4.0
+      extsprintf: 1.3.0
     dev: false
     engines:
       '0': node >=0.6.0

--- a/rush.json
+++ b/rush.json
@@ -56,7 +56,7 @@
      * is "fewer-dependencies", which causes PNPM to avoid installing a newer version if an already installed version
      * can be reused; this is more similar to NPM's algorithm.
      */
-    "resolutionStrategy": "fast"
+    "resolutionStrategy": "fewer-dependencies"
   },
   /**
    * Older releases of the NodeJS engine may be missing features required by your system.


### PR DESCRIPTION
- Rush recommends using "fewer-dependencies" by default
- https://github.com/microsoft/rushstack/issues/1415#issuecomment-524168914

The impact of this change is a small diff in `pnpm-lock.yaml`:

https://github.com/Azure/azure-sdk-for-js/pull/6058/commits/a6ba337bf85385276653ef3ab659bfdc4dbb51c2

This diff is expected, because the point of `fewer-dependencies` is to prefer re-using existing dependencies rather than always using latest.

This PR was generated via the following steps, each with a separate commit:

1. Run `rush update --full` to update all deps to latest (without changing `resolutionStrategy`)
2. Set `resolutionStrategy=fewer-dependencies`
3. Run `rush update -full` again to compute the diff solely caused by the different `resolutionStrategy`
  