### PR TITLE
Change typescript dependency from caret to tilde

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-node-resolve": "^5.0.2",
     "rollup-plugin-sourcemaps": "^0.4.2",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uglify-js": "^3.4.9"
   },
   "//metadata": {

--- a/sdk/cognitiveservices/cognitiveservices-inkrecognizer/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-inkrecognizer/package.json
@@ -98,7 +98,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-uglify": "^6.0.0",
     "rollup-plugin-visualizer": "^2.0.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   }
 }

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -104,6 +104,6 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2"
+    "typescript": "~3.6.4"
   }
 }

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -121,7 +121,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^7.1.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "ws": "^7.1.1"
   }
 }

--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -118,7 +118,7 @@
     "rollup-plugin-visualizer": "^2.0.0",
     "shx": "^0.3.2",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uglify-js": "^3.4.9",
     "yarn": "^1.6.0"
   },

--- a/sdk/core/core-asynciterator-polyfill/package.json
+++ b/sdk/core/core-asynciterator-polyfill/package.json
@@ -65,6 +65,6 @@
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
     "prettier": "^1.16.4",
-    "typescript": "^3.2.2"
+    "typescript": "~3.6.4"
   }
 }

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -86,7 +86,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   }
 }

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -182,7 +182,7 @@
     "terser": "^4.0.2",
     "ts-loader": "^6.0.4",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uglify-js": "^3.4.9",
     "webpack": "^4.16.3",
     "webpack-cli": "^3.2.3",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -141,7 +141,7 @@
     "rollup-plugin-visualizer": "^2.0.0",
     "shx": "^0.3.2",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uglify-js": "^3.4.9",
     "yarn": "^1.6.0"
   }

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -69,6 +69,6 @@
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
     "prettier": "^1.16.4",
-    "typescript": "^3.2.2"
+    "typescript": "~3.6.4"
   }
 }

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -89,7 +89,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   }
 }

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -115,6 +115,6 @@
     "rollup-plugin-terser": "^5.1.1",
     "sinon": "^7.1.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2"
+    "typescript": "~3.6.4"
   }
 }

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -137,7 +137,7 @@
     "tslint": "^5.0.0",
     "tslint-config-prettier": "^1.14.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "webpack": "^4.16.3"
   }
 }

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -135,7 +135,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "ts-mocha": "^6.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "ws": "^7.1.1"
   },
   "//metadata": {

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -108,7 +108,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-uglify": "^6.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "ws": "^7.1.1"
   },
   "//metadata": {

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -118,7 +118,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   }
 }

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -43,7 +43,7 @@
     "rhea": "^1.0.4",
     "rimraf": "^3.0.0",
     "tslib": "^1.9.3",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uuid": "^3.3.2",
     "yargs": "^14.0.0"
   }

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -122,7 +122,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   }
 }

--- a/sdk/identity/identity/test/manual/package.json
+++ b/sdk/identity/identity/test/manual/package.json
@@ -24,7 +24,7 @@
     "@types/webpack": "^4.4.13",
     "@types/webpack-dev-middleware": "^2.0.2",
     "ts-loader": "^5.3.1",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "webpack": "^4.16.3",
     "webpack-cli": "^3.2.3",
     "webpack-dev-server": "^3.7.2"

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -130,7 +130,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uglify-js": "^3.4.9",
     "url": "^0.11.0"
   },

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -129,7 +129,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uglify-js": "^3.4.9",
     "url": "^0.11.0"
   },

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -129,7 +129,7 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "uglify-js": "^3.4.9",
     "url": "^0.11.0"
   },

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -139,7 +139,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "ws": "^7.1.1"
   },
   "//metadata": {

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -149,7 +149,7 @@
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   },
   "//metadata": {

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -147,7 +147,7 @@
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   },
   "//metadata": {

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -143,7 +143,7 @@
     "rollup-plugin-visualizer": "^2.0.0",
     "source-map-support": "^0.5.9",
     "ts-node": "^8.3.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   },
   "//metadata": {

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -102,7 +102,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.6.4",
     "util": "^0.12.1"
   }
 }


### PR DESCRIPTION
- TypeScript allows breaking changes between minor versions
- Prevents breaking repo when running "rush update --full"

This should have no impact on build or test, since `pnpm-lock.yaml` already contains `typescript: 3.6.4` from the last run of `rush update --full`.

Updating to `typescript@3.7.2` causes build breaks in our repo.