### PR TITLE
Add default certificate policy

### DIFF
--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -120,6 +120,12 @@ export interface CertificatePolicy {
     validityInMonths?: number;
 }
 
+// @public (undocumented)
+export module CertificatePolicy {
+    const // (undocumented)
+    Default: CertificatePolicy;
+}
+
 // @public
 export interface CertificateProperties {
     readonly createdOn?: Date;

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/helloWorld.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/helloWorld.ts
@@ -1,4 +1,4 @@
-import { CertificateClient } from "../../src";
+import { CertificateClient, CertificatePolicy } from "../../src";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // This sample creates a self-signed certificate, reads it in various ways,
@@ -19,10 +19,7 @@ async function main(): Promise<void> {
   const certificateName = "MyCertificate";
 
   // Creating a self-signed certificate
-  const certificate = await client.createCertificate(certificateName, {
-    issuerName: "Self",
-    subject: "cn=MyCert"
-  });
+  const certificate = await client.createCertificate(certificateName, CertificatePolicy.Default);
 
   console.log("Certificate: ", certificate);
 

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -148,6 +148,13 @@ export interface CertificatePolicy {
   validityInMonths?: number;
 }
 
+export module CertificatePolicy {
+  export const Default: CertificatePolicy =  {
+     issuerName: "Self",
+     subject: "cn=MyCert"
+  };
+}
+
 /**
  * @interface
  * An interface representing the alternative names of the subject of a certificate contact.


### PR DESCRIPTION
This adds a default certificate policy that users can reference without having to remember one themselves. 

Example:
```typescript
// Creating a self-signed certificate
const certificate = await client.createCertificate(certificateName, CertificatePolicy.Default);
```

fixes https://github.com/Azure/azure-sdk-for-js/issues/6052