### PR TITLE
[Cosmos] Synthesize 503 error when a 410 surfaces out of a query

### DIFF
--- a/sdk/cosmosdb/cosmos/changelog.md
+++ b/sdk/cosmosdb/cosmos/changelog.md
@@ -1,6 +1,6 @@
 ## 3.4.2
 
-- Fixes bug where query could may throw a 410 error during a split operation. Instead throw 503 (#6074)
+- Fixes bug where the query may throw a 410 error during a split operation. Instead, throw 503 (#6074)
 
 ## 3.4.1
 

--- a/sdk/cosmosdb/cosmos/changelog.md
+++ b/sdk/cosmosdb/cosmos/changelog.md
@@ -1,6 +1,6 @@
 ## 3.4.2
 
-- Fix bug where query could possible throw a 410 error during a split operation. Instead throw 503 (#6074)
+- Fixes bug where query could may throw a 410 error during a split operation. Instead throw 503 (#6074)
 
 ## 3.4.1
 

--- a/sdk/cosmosdb/cosmos/changelog.md
+++ b/sdk/cosmosdb/cosmos/changelog.md
@@ -1,3 +1,7 @@
+## 3.4.2
+
+- Fix bug where query could possible throw a 410 error during a split operation. Instead throw 503 (#6074)
+
 ## 3.4.1
 
 - Fix region drop failover scenario and add test (#5892)

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/cosmos",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Microsoft Azure Cosmos DB Service Node.js SDK for SQL API",
   "sdk-type": "client",
   "keywords": [

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -264,7 +264,9 @@ export class QueryIterator<T> {
 
   private handleSplitError(err: any) {
     if (err.code === 410) {
-      const error = new Error("Unhandled partition split error. This request is retryable") as any;
+      const error = new Error(
+        "Encountered partition split and could not recover. This request is retryable"
+      ) as any;
       error.code = 503;
       error.originalError = err;
       throw error;

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -81,7 +81,11 @@ export class QueryIterator<T> {
       } catch (error) {
         if (this.needsQueryPlan(error)) {
           await this.createPipelinedExecutionContext();
-          response = await this.queryExecutionContext.fetchMore();
+          try {
+            response = await this.queryExecutionContext.fetchMore();
+          } catch (error) {
+            this.handleSplitError(error);
+          }
         } else {
           throw error;
         }
@@ -113,7 +117,13 @@ export class QueryIterator<T> {
   public async fetchAll(): Promise<FeedResponse<T>> {
     this.reset();
     this.fetchAllTempResources = [];
-    return this.toArrayImplementation();
+    let response: FeedResponse<T>;
+    try {
+      response = await this.toArrayImplementation();
+    } catch (error) {
+      this.handleSplitError(error);
+    }
+    return response;
   }
 
   /**
@@ -135,7 +145,11 @@ export class QueryIterator<T> {
     } catch (error) {
       if (this.needsQueryPlan(error)) {
         await this.createPipelinedExecutionContext();
-        response = await this.queryExecutionContext.fetchMore();
+        try {
+          response = await this.queryExecutionContext.fetchMore();
+        } catch (error) {
+          this.handleSplitError(error);
+        }
       } else {
         throw error;
       }
@@ -246,5 +260,16 @@ export class QueryIterator<T> {
       await this.createPipelinedExecutionContext();
     }
     this.isInitialied = true;
+  }
+
+  private handleSplitError(err: any) {
+    if (err.code === 410) {
+      const error = new Error("Service Error. This request is retryable") as any;
+      error.code = 503;
+      error.originalError = err;
+      throw error;
+    } else {
+      throw err;
+    }
   }
 }

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -264,7 +264,7 @@ export class QueryIterator<T> {
 
   private handleSplitError(err: any) {
     if (err.code === 410) {
-      const error = new Error("Service Error. This request is retryable") as any;
+      const error = new Error("Unhandled partition split error. This request is retryable") as any;
       error.code = 503;
       error.originalError = err;
       throw error;

--- a/sdk/cosmosdb/cosmos/test/integration/split.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/integration/split.spec.ts
@@ -54,6 +54,7 @@ describe("Partition Splits", () => {
       {
         on: PluginOn.request,
         plugin: async (context, next) => {
+          // This plugin throws a single 410 on the *second* time we see the same partition key range ID
           const partitionKeyRangeId = context.headers[Constants.HttpHeaders.PartitionKeyRangeID];
           if (partitionKeyRanges.has(partitionKeyRangeId) && hasSplit === false) {
             hasSplit = true;
@@ -83,5 +84,69 @@ describe("Partition Splits", () => {
     // I suspect injecting a random 410 with out actually splitting the documents
     // results in duplicates by trying to read from two partitions
     assert(resources.length >= documentDefinitions.length);
+  });
+
+  it("split errors surface as 503", async () => {
+    const options: CosmosClientOptions = { endpoint, key: masterKey };
+    const plugins: PluginConfig[] = [
+      {
+        on: PluginOn.request,
+        plugin: async (context, next) => {
+          // This plugin throws a single 410 for partition key range ID 0 on every single request
+          const partitionKeyRangeId = context.headers[Constants.HttpHeaders.PartitionKeyRangeID];
+          if (partitionKeyRangeId === "0") {
+            const error = new Error("Fake Partition Split") as any;
+            error.code = 410;
+            error.substatus = SubStatusCodes.PartitionKeyRangeGone;
+            throw error;
+          }
+          return next(context);
+        }
+      }
+    ];
+    const client = new CosmosClient({
+      ...options,
+      plugins
+    } as any);
+
+    // fetchAll()
+    try {
+      await client
+        .database(container.database.id)
+        .container(container.id)
+        .items.query("SELECT * FROM root r", { maxItemCount: 2, maxDegreeOfParallelism: 1 })
+        .fetchAll();
+      assert.fail("Expected query to fail");
+    } catch (e) {
+      assert.strictEqual(e.code, 503);
+    }
+
+    // fetchNext()
+    try {
+      await client
+        .database(container.database.id)
+        .container(container.id)
+        .items.query("SELECT * FROM root r", { maxItemCount: 2, maxDegreeOfParallelism: 1 })
+        .fetchNext();
+      assert.fail("Expected query to fail");
+    } catch (e) {
+      assert.strictEqual(e.code, 503);
+    }
+
+    // asyncIterator
+    try {
+      const iterator = client
+        .database(container.database.id)
+        .container(container.id)
+        .items.query("SELECT * FROM root r", { maxItemCount: 2, maxDegreeOfParallelism: 1 })
+        .getAsyncIterator();
+      const results = [];
+      for await (const result of iterator) {
+        results.push(result);
+      }
+      assert.fail("Expected query to fail");
+    } catch (e) {
+      assert.strictEqual(e.code, 503);
+    }
   });
 });


### PR DESCRIPTION
410 is an internal error that signals a partition split. We should not surface these to the user, instead, we should throw a 503