### PR TITLE
[storage-file-share] overload downloadToBuffer with internal buffer option

### DIFF
--- a/sdk/storage/storage-file-share/recordings/node/highlevel_nodejs_only/recording_downloadtobuffer_should_throw_an_error_if_the_count_size_in_bytes_is_too_large.js
+++ b/sdk/storage/storage-file-share/recordings/node/highlevel_nodejs_only/recording_downloadtobuffer_should_throw_an_error_if_the_count_size_in_bytes_is_too_large.js
@@ -1,53 +1,53 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"share":"share157307943298805253","dir":"dir157307943340005734","file":"file157307943346505070"}
+module.exports.testInfo = {"share":"share157324721723109893","dir":"dir157324721746100709","file":"file157324721764205868"}
 
 nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/share157307943298805253')
+  .put('/share157324721723109893')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 06 Nov 2019 22:30:33 GMT',
+  'Fri, 08 Nov 2019 21:06:57 GMT',
   'ETag',
-  '"0x8D76308EFF8B5F8"',
+  '"0x8D7648F971481AB"',
   'Server',
   'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '47c58e6b-101a-0039-36f1-948443000000',
+  '53b6991a-801a-0092-0e78-96fb89000000',
   'x-ms-client-request-id',
-  '55843082-a5e7-4193-bbe6-ce17f32e60d6',
+  '31e718d6-274f-433c-9d52-b3c0624e9239',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 06 Nov 2019 22:30:32 GMT'
+  'Fri, 08 Nov 2019 21:06:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/share157307943298805253/dir157307943340005734')
+  .put('/share157324721723109893/dir157324721746100709')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 06 Nov 2019 22:30:33 GMT',
+  'Fri, 08 Nov 2019 21:06:57 GMT',
   'ETag',
-  '"0x8D76308F006AAFD"',
+  '"0x8D7648F97321E74"',
   'Server',
   'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'cf5225bb-c01a-0067-68f1-946fa3000000',
+  'cbb203cb-601a-008a-6f78-9624ee000000',
   'x-ms-client-request-id',
-  '4e1bbe5b-72c5-4cfe-977c-a1c267aeb1c7',
+  '742d8f91-6f11-4626-bb81-e515630e99aa',
   'x-ms-version',
   '2019-02-02',
   'x-ms-file-change-time',
-  '2019-11-06T22:30:33.4071549Z',
+  '2019-11-08T21:06:57.5959668Z',
   'x-ms-file-last-write-time',
-  '2019-11-06T22:30:33.4071549Z',
+  '2019-11-08T21:06:57.5959668Z',
   'x-ms-file-creation-time',
-  '2019-11-06T22:30:33.4071549Z',
+  '2019-11-08T21:06:57.5959668Z',
   'x-ms-file-permission-key',
   '3771195323339035646*6669510238408230007',
   'x-ms-file-attributes',
@@ -59,11 +59,11 @@ nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 06 Nov 2019 22:30:32 GMT'
+  'Fri, 08 Nov 2019 21:06:57 GMT'
 ]);
 
 nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/share157307943298805253')
+  .delete('/share157324721723109893')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -71,11 +71,11 @@ nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '47c58e6f-101a-0039-37f1-948443000000',
+  '53b6991d-801a-0092-0f78-96fb89000000',
   'x-ms-client-request-id',
-  'ab170548-90e7-49df-ac3b-194ae3f2581e',
+  'cc98e2f4-0045-4b0d-befe-a3ab87443c6b',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 06 Nov 2019 22:30:33 GMT'
+  'Fri, 08 Nov 2019 21:06:58 GMT'
 ]);

--- a/sdk/storage/storage-file-share/recordings/node/highlevel_nodejs_only/recording_downloadtobuffer_should_throw_an_error_if_the_count_size_in_bytes_is_too_large.js
+++ b/sdk/storage/storage-file-share/recordings/node/highlevel_nodejs_only/recording_downloadtobuffer_should_throw_an_error_if_the_count_size_in_bytes_is_too_large.js
@@ -1,0 +1,81 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"share":"share157307943298805253","dir":"dir157307943340005734","file":"file157307943346505070"}
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157307943298805253')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Wed, 06 Nov 2019 22:30:33 GMT',
+  'ETag',
+  '"0x8D76308EFF8B5F8"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '47c58e6b-101a-0039-36f1-948443000000',
+  'x-ms-client-request-id',
+  '55843082-a5e7-4193-bbe6-ce17f32e60d6',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Wed, 06 Nov 2019 22:30:32 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157307943298805253/dir157307943340005734')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Wed, 06 Nov 2019 22:30:33 GMT',
+  'ETag',
+  '"0x8D76308F006AAFD"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'cf5225bb-c01a-0067-68f1-946fa3000000',
+  'x-ms-client-request-id',
+  '4e1bbe5b-72c5-4cfe-977c-a1c267aeb1c7',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-11-06T22:30:33.4071549Z',
+  'x-ms-file-last-write-time',
+  '2019-11-06T22:30:33.4071549Z',
+  'x-ms-file-creation-time',
+  '2019-11-06T22:30:33.4071549Z',
+  'x-ms-file-permission-key',
+  '3771195323339035646*6669510238408230007',
+  'x-ms-file-attributes',
+  'Directory',
+  'x-ms-file-id',
+  '13835128424026341376',
+  'x-ms-file-parent-id',
+  '0',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Wed, 06 Nov 2019 22:30:32 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share157307943298805253')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '47c58e6f-101a-0039-37f1-948443000000',
+  'x-ms-client-request-id',
+  'ab170548-90e7-49df-ac3b-194ae3f2581e',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Wed, 06 Nov 2019 22:30:33 GMT'
+]);

--- a/sdk/storage/storage-file-share/review/storage-file-share.api.md
+++ b/sdk/storage/storage-file-share/review/storage-file-share.api.md
@@ -935,14 +935,15 @@ export class ShareDirectoryClient extends StorageClient {
 
 // @public
 export class ShareFileClient extends StorageClient {
-    constructor(url: string, pipeline: Pipeline);
     constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
+    constructor(url: string, pipeline: Pipeline);
     abortCopyFromURL(copyId: string, options?: FileAbortCopyFromURLOptions): Promise<FileAbortCopyResponse>;
     clearRange(offset: number, contentLength: number, options?: FileClearRangeOptions): Promise<FileUploadRangeResponse>;
     create(size: number, options?: FileCreateOptions): Promise<FileCreateResponse>;
     delete(options?: FileDeleteOptions): Promise<FileDeleteResponse>;
     download(offset?: number, count?: number, options?: FileDownloadOptions): Promise<FileDownloadResponseModel>;
-    downloadToBuffer(buffer: Buffer, offset?: number, count?: number, options?: FileDownloadToBufferOptions): Promise<void>;
+    downloadToBuffer(buffer: Buffer, offset?: number, count?: number, options?: FileDownloadToBufferOptions): Promise<Buffer>;
+    downloadToBuffer(offset?: number, count?: number, options?: FileDownloadToBufferOptions): Promise<Buffer>;
     downloadToFile(filePath: string, offset?: number, count?: number, options?: FileDownloadOptions): Promise<FileDownloadResponseModel>;
     forceCloseAllHandles(options?: FileForceCloseHandlesOptions): Promise<number>;
     forceCloseHandle(handleId: string, options?: FileForceCloseHandlesOptions): Promise<FileForceCloseHandlesResponse>;

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -1703,36 +1703,6 @@ export class ShareFileClient extends StorageClient {
       options.tracingOptions
     );
 
-    if (!count) {
-      // User did not specify the bytes, so we need to ask the service how large the file is
-      const response = await this.getProperties({
-        ...options,
-        tracingOptions: {
-          ...options.tracingOptions,
-          spanOptions
-        }
-      });
-
-      count = response.contentLength! - offset;
-      if (count < 0) {
-        throw new RangeError(
-          `offset ${offset} shouldn't be larger than the blob size ${response.contentLength}`
-        );
-      }
-    }
-
-    if (!buffer) {
-      try {
-        buffer = Buffer.alloc(count);
-      } catch (error) {
-        throw new Error(
-          `Unable to allocate a buffer of size: ${count} bytes. Please try passing your own Buffer to ` +
-            'the "downloadToBuffer method or try using other moethods like "download" or "downloadToFile".' +
-            `\t ${error.message}`
-        );
-      }
-    }
-
     try {
       if (!options.rangeSize) {
         options.rangeSize = FILE_RANGE_MAX_SIZE_BYTES;
@@ -1766,6 +1736,18 @@ export class ShareFileClient extends StorageClient {
         if (count < 0) {
           throw new RangeError(
             `offset ${offset} shouldn't be larger than file size ${response.contentLength!}`
+          );
+        }
+      }
+
+      if (!buffer) {
+        try {
+          buffer = Buffer.alloc(count);
+        } catch (error) {
+          throw new Error(
+            `Unable to allocate a buffer of size: ${count} bytes. Please try passing your own Buffer to ` +
+              'the "downloadToBuffer method or try using other moethods like "download" or "downloadToFile".' +
+              `\t ${error.message}`
           );
         }
       }

--- a/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
@@ -208,6 +208,32 @@ describe("Highlevel Node.js only", () => {
     assert.ok(eventTriggered);
   });
 
+  it("downloadToBuffer should succeed - without passing the buffer", async () => {
+    const rs = fs.createReadStream(tempFileLarge);
+    await fileClient.uploadStream(rs, tempFileLargeLength, 4 * 1024 * 1024, 20);
+
+    const buf = await fileClient.downloadToBuffer(0, undefined, {
+      concurrency: 20,
+      rangeSize: 4 * 1024 * 1024
+    });
+
+    const localFileContent = fs.readFileSync(tempFileLarge);
+    assert.ok(localFileContent.equals(buf));
+  });
+
+  it("downloadToBuffer should throw an error if the count (size in bytes) is too large", async () => {
+    let error;
+    try {
+      await fileClient.downloadToBuffer(undefined, 4*1024*1024*1024);
+    } catch (err) {
+      error = err;
+    }
+    assert.ok(
+      error.message.includes("Unable to allocate a buffer of size:"),
+      "Error is not thrown when the count (size in bytes) is too large"
+    );
+  });
+
   it("downloadToBuffer should success", async () => {
     const rs = fs.createReadStream(tempFileLarge);
     await fileClient.uploadStream(rs, tempFileLargeLength, 4 * 1024 * 1024, 20);

--- a/sdk/storage/storage-file-share/test/utils/recorder.ts
+++ b/sdk/storage/storage-file-share/test/utils/recorder.ts
@@ -132,6 +132,8 @@ const skip = [
   "node/highlevel_nodejs_only/recording_downloadtobuffer_should_abort.js",
   // Size (526MB), Tempfile
   "node/highlevel_nodejs_only/recording_downloadtobuffer_should_success.js",
+  // Size (4MB), Tempfile
+  "node/highlevel_nodejs_only/recording_downloadtobuffer_should_succeed__without_passing_the_buffer.js",
   // Progress, Size (15MB), Tempfile
   "node/highlevel_nodejs_only/recording_downloadtobuffer_should_update_progress_event.js",
   // Size (526MB), Tempfile


### PR DESCRIPTION
Addresses #6016 

This is not a breaking API change (see diff of api.md file).

Changes:
- Modified signature of `downloadToBuffer` to return a `Promise<Buffer>` instead of a `Promise<void>`
- Overloaded `downloadToBuffer`
  - passing a `Buffer` as the first argument is now optional, with a three-argument overload with `offset` as its first argument
  - if no buffer is given, then we will allocate a buffer of `count` bytes (given by second argument)
  - if no count is given, we will ask the service for the size of the file and allocate enough space to store the contents of the file beginning from `offset` to the end
- Added tests for the new overload
- Recorded test runs from live integration tests, skipping one because it does not run in playback
- Updated API reference