### PR TITLE
[event-hubs] Addressing feedback from Brian

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -205,8 +205,9 @@ async function main() {
   const myEventHandler = (events, context) => {
     // your code here
   };
-  const subscription = consumer.subscribe(myEventHandler, {
-    onError: myErrorHandler
+  const subscription = consumer.subscribe({
+    processReceivedEvents: myEventHandler,
+    processError: myErrorHandler
   });
 
   // When ready to stop receiving
@@ -247,7 +248,9 @@ async function main() {
   const myEventHandler = (events, context) => {
     // your code here
   };
-  const subscription = consumer.subscribe(myEventHandler, partitionManager);
+  const subscription = consumer.subscribe(partitionManager, {
+    processReceivedEvents: myEventHandler
+  });
 
   // When ready to stop receiving
   await subscription.close();
@@ -279,7 +282,8 @@ async function main() {
   const myEventHandler = (events, context) => {
     // your code here
   };
-  const subscription = consumer.subscribe(myEventHandler, partitionIds[0], {
+  const subscription = consumer.subscribe(partitionIds[0], {
+    processReceivedEvents: myEventHandler,
     onError: myErrorHandler
   });
 

--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -206,7 +206,7 @@ async function main() {
     // your code here
   };
   const subscription = consumer.subscribe({
-    processReceivedEvents: myEventHandler,
+    processEvents: myEventHandler,
     processError: myErrorHandler
   });
 
@@ -249,7 +249,7 @@ async function main() {
     // your code here
   };
   const subscription = consumer.subscribe(partitionManager, {
-    processReceivedEvents: myEventHandler
+    processEvents: myEventHandler
   });
 
   // When ready to stop receiving
@@ -283,7 +283,7 @@ async function main() {
     // your code here
   };
   const subscription = consumer.subscribe(partitionIds[0], {
-    processReceivedEvents: myEventHandler,
+    processEvents: myEventHandler,
     onError: myErrorHandler
   });
 

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -157,10 +157,14 @@ export class EventPosition {
     }
 
 // @public
+export interface EventProcessorBatchOptions {
+    maxBatchSize?: number;
+    maxWaitTimeInSeconds?: number;
+}
+
+// @public
 export interface EventProcessorOptions {
     defaultEventPosition?: EventPosition;
-    maxBatchSize: number;
-    maxWaitTimeInSeconds: number;
     trackLastEnqueuedEventInfo?: boolean;
 }
 
@@ -294,7 +298,7 @@ export interface SubscriptionEventHandlers {
 }
 
 // @public
-export interface SubscriptionOptions extends SubscriptionEventHandlers, EventProcessorOptions {
+export interface SubscriptionOptions extends SubscriptionEventHandlers, EventProcessorOptions, EventProcessorBatchOptions {
 }
 
 export { TokenCredential }

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -99,9 +99,9 @@ export class EventHubConsumerClient {
     getPartitionIds(): Promise<string[]>;
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
     getProperties(options?: GetPropertiesOptions): Promise<EventHubProperties>;
-    subscribe(consumerGroupName: string, onReceivedEvents: OnReceivedEvents, options?: SubscriptionOptions): Subscription;
-    subscribe(consumerGroupName: string, onReceivedEvents: OnReceivedEvents, partitionId: string, options?: SubscriptionOptions): Subscription;
-    subscribe(consumerGroupName: string, onReceivedEvents: OnReceivedEvents, partitionManager: PartitionManager, options?: SubscriptionOptions): Subscription;
+    subscribe(consumerGroupName: string, options: SubscriptionOptions): Subscription;
+    subscribe(consumerGroupName: string, partitionId: string, options: SubscriptionOptions): Subscription;
+    subscribe(consumerGroupName: string, partitionManager: PartitionManager, options: SubscriptionOptions): Subscription;
 }
 
 // @public
@@ -197,25 +197,6 @@ export interface LastEnqueuedEventInfo {
 export { MessagingError }
 
 // @public
-export type OnCloseHandler = (reason: CloseReason, context: PartitionContext & PartitionCheckpointer) => Promise<void>;
-
-// @public
-export type OnErrorHandler = (error: Error, context: PartitionContext) => Promise<void>;
-
-// @public
-export type OnInitializeHandler = (context: PartitionContext) => Promise<void>;
-
-// @public
-export type OnReceivedEvents = (receivedEvents: ReceivedEventData[], context: PartitionContext & PartitionCheckpointer) => Promise<void>;
-
-// @public
-export interface OptionalEventHandlers {
-    onClose?: OnCloseHandler;
-    onError?: OnErrorHandler;
-    onInitialize?: OnInitializeHandler;
-}
-
-// @public
 export interface ParentSpanOptions {
     parentSpan?: Span | SpanContext;
 }
@@ -264,6 +245,18 @@ export interface PartitionProperties {
 }
 
 // @public
+export type ProcessCloseHandler = (reason: CloseReason, context: PartitionContext & PartitionCheckpointer) => Promise<void>;
+
+// @public
+export type ProcessErrorHandler = (error: Error, context: PartitionContext) => Promise<void>;
+
+// @public
+export type ProcessInitializeHandler = (context: PartitionContext) => Promise<void>;
+
+// @public
+export type ProcessReceivedEvents = (receivedEvents: ReceivedEventData[], context: PartitionContext & PartitionCheckpointer) => Promise<void>;
+
+// @public
 export interface ReceivedEventData {
     body: any;
     enqueuedTimeUtc: Date;
@@ -293,7 +286,15 @@ export interface Subscription {
 }
 
 // @public
-export interface SubscriptionOptions extends OptionalEventHandlers, EventProcessorOptions {
+export interface SubscriptionEventHandlers {
+    processClose?: ProcessCloseHandler;
+    processError?: ProcessErrorHandler;
+    processInitialize?: ProcessInitializeHandler;
+    processReceivedEvents: ProcessReceivedEvents;
+}
+
+// @public
+export interface SubscriptionOptions extends SubscriptionEventHandlers, EventProcessorOptions {
 }
 
 export { TokenCredential }

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -255,10 +255,10 @@ export type ProcessCloseHandler = (reason: CloseReason, context: PartitionContex
 export type ProcessErrorHandler = (error: Error, context: PartitionContext) => Promise<void>;
 
 // @public
-export type ProcessInitializeHandler = (context: PartitionContext) => Promise<void>;
+export type ProcessEvents = (receivedEvents: ReceivedEventData[], context: PartitionContext & PartitionCheckpointer) => Promise<void>;
 
 // @public
-export type ProcessReceivedEvents = (receivedEvents: ReceivedEventData[], context: PartitionContext & PartitionCheckpointer) => Promise<void>;
+export type ProcessInitializeHandler = (context: PartitionContext) => Promise<void>;
 
 // @public
 export interface ReceivedEventData {
@@ -293,8 +293,8 @@ export interface Subscription {
 export interface SubscriptionEventHandlers {
     processClose?: ProcessCloseHandler;
     processError?: ProcessErrorHandler;
+    processEvents: ProcessEvents;
     processInitialize?: ProcessInitializeHandler;
-    processReceivedEvents: ProcessReceivedEvents;
 }
 
 // @public

--- a/sdk/eventhub/event-hubs/samples/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEvents.ts
@@ -38,8 +38,9 @@ async function main() {
   };
 
   const subscription = consumerClient.subscribe(
-    EventHubConsumerClient.defaultConsumerGroupName,
-    processEvents
+    EventHubConsumerClient.defaultConsumerGroupName, {
+      processReceivedEvents: processEvents
+    }
   );
 
   // after 30 seconds, stop processing

--- a/sdk/eventhub/event-hubs/samples/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEvents.ts
@@ -39,7 +39,7 @@ async function main() {
 
   const subscription = consumerClient.subscribe(
     EventHubConsumerClient.defaultConsumerGroupName, {
-      processReceivedEvents: processEvents
+      processEvents: processEvents
     }
   );
 

--- a/sdk/eventhub/event-hubs/samples/receiveEventsWithLoadBalanced.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsWithLoadBalanced.ts
@@ -63,7 +63,7 @@ async function main() {
   const subscription = consumerClient.subscribe(
     EventHubConsumerClient.defaultConsumerGroupName,
     new BlobPartitionManager(containerClient), {
-      processReceivedEvents: processEvents
+      processEvents: processEvents
     }
   );
 

--- a/sdk/eventhub/event-hubs/samples/receiveEventsWithLoadBalanced.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsWithLoadBalanced.ts
@@ -62,8 +62,9 @@ async function main() {
   await containerClient.create();
   const subscription = consumerClient.subscribe(
     EventHubConsumerClient.defaultConsumerGroupName,
-    processEvents,
-    new BlobPartitionManager(containerClient)
+    new BlobPartitionManager(containerClient), {
+      processReceivedEvents: processEvents
+    }
   );
 
   // after 30 seconds, stop processing

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -378,7 +378,7 @@ export function createPartitionProcessorType(
     private _partitionCheckpointer?: SimplePartitionCheckpointer;
 
     async processEvents(events: ReceivedEventData[]): Promise<void> {
-      await options.processReceivedEvents(
+      await options.processEvents(
         events,
         this._partitionCheckpointer!
       );
@@ -443,7 +443,7 @@ export function isPartitionManager(
  * @ignore
  */
 function isSubscriptionOptions(possible: SubscriptionOptions | string | PartitionManager) : possible is SubscriptionOptions{
-  return typeof (possible as SubscriptionOptions).processReceivedEvents === "function";
+  return typeof (possible as SubscriptionOptions).processEvents === "function";
 }
 
 class SimplePartitionCheckpointer implements PartitionCheckpointer, PartitionContext {

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -10,7 +10,7 @@ import {
 import { PartitionProcessor, Checkpoint } from "./partitionProcessor";
 import { ReceivedEventData } from "./eventData";
 import { InMemoryPartitionManager } from "./inMemoryPartitionManager";
-import { EventProcessor, PartitionManager, CloseReason, PartitionContext, EventProcessorOptions } from "./eventProcessor";
+import { EventProcessor, PartitionManager, CloseReason, PartitionContext, EventProcessorBatchOptions } from "./eventProcessor";
 import { GreedyPartitionLoadBalancer } from "./partitionLoadBalancer";
 import { TokenCredential, Constants } from "@azure/core-amqp";
 import * as log from "./log";
@@ -54,7 +54,7 @@ export interface PartitionCheckpointer {
   ): Promise<void>;
 }
 
-const defaultConsumerClientOptions : EventProcessorOptions = {
+const defaultConsumerClientOptions : Required<EventProcessorBatchOptions> = {
   maxBatchSize: 10,
   maxWaitTimeInSeconds: 10
 };

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -10,23 +10,14 @@ import {
 import { PartitionProcessor, Checkpoint } from "./partitionProcessor";
 import { ReceivedEventData } from "./eventData";
 import { InMemoryPartitionManager } from "./inMemoryPartitionManager";
-import { EventProcessor, PartitionManager, CloseReason, PartitionContext } from "./eventProcessor";
+import { EventProcessor, PartitionManager, CloseReason, PartitionContext, EventProcessorOptions } from "./eventProcessor";
 import { GreedyPartitionLoadBalancer } from "./partitionLoadBalancer";
 import { TokenCredential, Constants } from "@azure/core-amqp";
 import * as log from "./log";
 
-import { SubscriptionOptions, Subscription, OptionalEventHandlers } from "./eventHubConsumerClientModels";
+import { SubscriptionOptions, Subscription, SubscriptionEventHandlers } from "./eventHubConsumerClientModels";
 import { isTokenCredential } from "@azure/core-amqp";
 import { PartitionProperties, EventHubProperties } from "./managementClient";
-
-/**
- * Event handler called when events are received. The `context` parameter can be 
- * used to get partition information as well as to checkpoint.
- */
-export type OnReceivedEvents = (
-  receivedEvents: ReceivedEventData[],
-  context: PartitionContext & PartitionCheckpointer
-) => Promise<void>;
 
 /**
  * Allow for checkpointing
@@ -63,7 +54,7 @@ export interface PartitionCheckpointer {
   ): Promise<void>;
 }
 
-const defaultConsumerClientOptions : SubscriptionOptions = {
+const defaultConsumerClientOptions : EventProcessorOptions = {
   maxBatchSize: 10,
   maxWaitTimeInSeconds: 10
 };
@@ -239,14 +230,12 @@ export class EventHubConsumerClient {
    * other subscribers.
    *
    * @param consumerGroupName The name of the consumer group from which you want to process events.
-   * @param onReceivedEvents Called when new events are received.
    * @param options Options to handle additional events related to partitions (errors,
    *                opening, closing) as well as batch sizing.
    */
   subscribe(
     consumerGroupName: string,
-    onReceivedEvents: OnReceivedEvents,
-    options?: SubscriptionOptions
+    options: SubscriptionOptions
   ): Subscription; // #1
   /**
    * Subscribe to all messages from a subset of partitions.
@@ -255,7 +244,6 @@ export class EventHubConsumerClient {
    * other subscribers.
    *
    * @param consumerGroupName The name of the consumer group from which you want to process events.
-   * @param onReceivedEvents Called when new events are received.
    * @param partitionId A partition id to subscribe to.
    * @param options Options to handle additional events related to partitions (errors,
    *                opening, closing) as well as batch sizing.
@@ -263,9 +251,8 @@ export class EventHubConsumerClient {
 
   subscribe(
     consumerGroupName: string,
-    onReceivedEvents: OnReceivedEvents,
     partitionId: string,
-    options?: SubscriptionOptions
+    options: SubscriptionOptions
   ): Subscription; // #2
   /**
    * Subscribes to multiple partitions.
@@ -273,7 +260,6 @@ export class EventHubConsumerClient {
    * Use this overload if you want to coordinate with other subscribers using a `PartitionManager`
    *
    * @param consumerGroupName The name of the consumer group from which you want to process events.
-   * @param onReceivedEvents Called when new events are received.
    *                         This is also a good place to update checkpoints as appropriate.
    * @param partitionManager A partition manager that manages ownership information and checkpoint details.
    * @param options Options to handle additional events related to partitions (errors,
@@ -281,25 +267,26 @@ export class EventHubConsumerClient {
    */
   subscribe(
     consumerGroupName: string,
-    onReceivedEvents: OnReceivedEvents,
     partitionManager: PartitionManager,
-    options?: SubscriptionOptions
+    options: SubscriptionOptions
   ): Subscription; // #3
   subscribe(
     consumerGroupName1: string, 
-    onReceivedEvents2: OnReceivedEvents,
-    optionsOrPartitionIdOrPartitionManager3:
+    optionsOrPartitionIdOrPartitionManager2:
       | SubscriptionOptions
-      | undefined
       | string
       | PartitionManager,
-    possibleOptions4?: SubscriptionOptions
+    possibleOptions3?: SubscriptionOptions
   ): Subscription {
     let eventProcessor: EventProcessor;
 
-    if (typeof optionsOrPartitionIdOrPartitionManager3 === "string") {
+    if (typeof optionsOrPartitionIdOrPartitionManager2 === "string") {
       // #2: subscribe overload (read from specific partition IDs), don't coordinate
-      const partitionId = optionsOrPartitionIdOrPartitionManager3;
+      if (possibleOptions3 == null) {
+        throw new TypeError("SubscriptionOptions is not defined");
+      }
+      
+      const partitionId = optionsOrPartitionIdOrPartitionManager2;
       log.consumerClient(
         `Subscribing to specific partition (${partitionId}), no coordination.`
       );
@@ -307,9 +294,8 @@ export class EventHubConsumerClient {
       const partitionManager = new InMemoryPartitionManager();
 
       const partitionProcessorType = createPartitionProcessorType(
-        onReceivedEvents2,
         partitionManager,
-        possibleOptions4
+        possibleOptions3
       );
 
       eventProcessor = new EventProcessor(
@@ -319,21 +305,24 @@ export class EventHubConsumerClient {
         partitionManager,
         {
           ...defaultConsumerClientOptions,
-          ...possibleOptions4,
+          ...possibleOptions3,
           // this load balancer will just grab _all_ the partitions, not looking at ownership
           partitionLoadBalancer: new GreedyPartitionLoadBalancer([partitionId])
         }
       );
-    } else if (isPartitionManager(optionsOrPartitionIdOrPartitionManager3)) {
+    } else if (isPartitionManager(optionsOrPartitionIdOrPartitionManager2)) {
       // #3: subscribe overload (read from all partitions and coordinate using a partition manager)
       log.consumerClient("Subscribing to all partitions, coordinating using a partition manager.");
 
-      const partitionManager = optionsOrPartitionIdOrPartitionManager3;
+      if (possibleOptions3 == null) {
+        throw new TypeError("SubscriptionOptions is not defined");
+      }
+
+      const partitionManager = optionsOrPartitionIdOrPartitionManager2;
 
       const partitionProcessorType = createPartitionProcessorType(
-        onReceivedEvents2,
         partitionManager,
-        possibleOptions4
+        possibleOptions3
       );
 
       eventProcessor = new EventProcessor(
@@ -341,18 +330,17 @@ export class EventHubConsumerClient {
         this._eventHubClient,
         partitionProcessorType,
         partitionManager,
-        { ...defaultConsumerClientOptions, ...possibleOptions4 }
+        { ...defaultConsumerClientOptions, ...possibleOptions3 }
       );
-    } else {
+    } else if (isSubscriptionOptions(optionsOrPartitionIdOrPartitionManager2)) {
       // #1: subscribe overload - read from all partitions, don't coordinate
       log.consumerClient("Subscribing to all partitions, don't coordinate.");
 
       const partitionManager = new InMemoryPartitionManager();
 
       const partitionProcessorType = createPartitionProcessorType(
-        onReceivedEvents2,
         partitionManager,
-        optionsOrPartitionIdOrPartitionManager3
+        optionsOrPartitionIdOrPartitionManager2
       );
 
       eventProcessor = new EventProcessor(
@@ -362,10 +350,12 @@ export class EventHubConsumerClient {
         partitionManager,
         {
           ...defaultConsumerClientOptions,
-          ...(optionsOrPartitionIdOrPartitionManager3 as SubscriptionOptions),
+          ...(optionsOrPartitionIdOrPartitionManager2 as SubscriptionOptions),
           partitionLoadBalancer: new GreedyPartitionLoadBalancer()
         }
       );
+    } else {
+      throw new TypeError("Unhandled subscribe() overload");
     }
 
     eventProcessor.start();
@@ -381,23 +371,22 @@ export class EventHubConsumerClient {
  * @ignore
  */
 export function createPartitionProcessorType(
-  onReceivedEvents: OnReceivedEvents,
   partitionManager: PartitionManager,
-  options: OptionalEventHandlers = {}
+  options: SubscriptionEventHandlers
 ): typeof PartitionProcessor {
   class DefaultPartitionProcessor extends PartitionProcessor {
     private _partitionCheckpointer?: SimplePartitionCheckpointer;
 
     async processEvents(events: ReceivedEventData[]): Promise<void> {
-      await onReceivedEvents(
+      await options.processReceivedEvents(
         events,
         this._partitionCheckpointer!
       );
     }
 
     async processError(error: Error): Promise<void> {
-      if (options.onError) {
-        await options.onError(error, {
+      if (options.processError) {
+        await options.processError(error, {
           partitionId: this.partitionId,
           consumerGroupName: this.consumerGroupName,
           eventHubName: this.eventHubName,
@@ -409,8 +398,8 @@ export function createPartitionProcessorType(
     async initialize() {
       this._partitionCheckpointer = new SimplePartitionCheckpointer(partitionManager, this, this.eventHubName, this.consumerGroupName, this.partitionId, this.fullyQualifiedNamespace);
 
-      if (options.onInitialize) {
-        await options.onInitialize({
+      if (options.processInitialize) {
+        await options.processInitialize({
           partitionId: this.partitionId,
           consumerGroupName: this.consumerGroupName,
           eventHubName: this.eventHubName,
@@ -420,8 +409,8 @@ export function createPartitionProcessorType(
     }
 
     async close(reason: CloseReason) {
-      if (options.onClose) {
-        await options.onClose(reason, this._partitionCheckpointer!);
+      if (options.processClose) {
+        await options.processClose(reason, this._partitionCheckpointer!);
       }
     }
   }
@@ -434,7 +423,7 @@ export function createPartitionProcessorType(
  * @ignore
  */
 export function isPartitionManager(
-  possible: SubscriptionOptions | undefined | string[] | PartitionManager
+  possible: SubscriptionOptions | string | PartitionManager
 ): possible is PartitionManager {
   if (!possible) {
     return false;
@@ -447,6 +436,14 @@ export function isPartitionManager(
     typeof partitionManager.listOwnership === "function" &&
     typeof partitionManager.updateCheckpoint === "function"
   );
+}
+
+/**
+ * @internal
+ * @ignore
+ */
+function isSubscriptionOptions(possible: SubscriptionOptions | string | PartitionManager) : possible is SubscriptionOptions{
+  return typeof (possible as SubscriptionOptions).processReceivedEvents === "function";
 }
 
 class SimplePartitionCheckpointer implements PartitionCheckpointer, PartitionContext {

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -1,5 +1,5 @@
 
-import { CloseReason, PartitionContext, EventProcessorOptions } from './eventProcessor';
+import { CloseReason, PartitionContext, EventProcessorOptions, EventProcessorBatchOptions } from './eventProcessor';
 import { PartitionCheckpointer } from './eventHubConsumerClient';
 import { ReceivedEventData } from '.';
 
@@ -53,7 +53,7 @@ export interface SubscriptionEventHandlers {
 /**
  * Options for subscribe.
  */
-export interface SubscriptionOptions extends SubscriptionEventHandlers, EventProcessorOptions {
+export interface SubscriptionOptions extends SubscriptionEventHandlers, EventProcessorOptions, EventProcessorBatchOptions {
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -1,45 +1,59 @@
 
 import { CloseReason, PartitionContext, EventProcessorOptions } from './eventProcessor';
 import { PartitionCheckpointer } from './eventHubConsumerClient';
+import { ReceivedEventData } from '.';
+
+/**
+ * Event handler called when events are received. The `context` parameter can be 
+ * used to get partition information as well as to checkpoint.
+ */
+export type ProcessReceivedEvents = (
+  receivedEvents: ReceivedEventData[],
+  context: PartitionContext & PartitionCheckpointer
+) => Promise<void>;
 
 /**
  * Called when errors occur during event receiving.
  */
-export type OnErrorHandler = (error: Error, context: PartitionContext) => Promise<void>;
+export type ProcessErrorHandler = (error: Error, context: PartitionContext) => Promise<void>;
 
 /**
  * Called when we first start processing events from a partition.
  */
-export type OnInitializeHandler = (context: PartitionContext) => Promise<void>;
+export type ProcessInitializeHandler = (context: PartitionContext) => Promise<void>;
 
 /**
  * Called when we stop processing events from a partition.
  */
-export type OnCloseHandler = (reason: CloseReason, context: PartitionContext & PartitionCheckpointer) => Promise<void>;
+export type ProcessCloseHandler = (reason: CloseReason, context: PartitionContext & PartitionCheckpointer) => Promise<void>;
 
 /**
  * Optional event handlers that provide more context when subscribing to events.
  */
-export interface OptionalEventHandlers {
+export interface SubscriptionEventHandlers {
+  /**
+   * Event handler called when events are received.    
+   */
+  processReceivedEvents: ProcessReceivedEvents
   /**
    * Called when errors occur during event receiving.
    */
-  onError?: OnErrorHandler;
+  processError?: ProcessErrorHandler;
   /**
    * Called when we first start processing events from a partition.
    */
-  onInitialize?: OnInitializeHandler;
+  processInitialize?: ProcessInitializeHandler;
   /**
    * Called when we stop processing events from a partition.
    */
-  onClose?: OnCloseHandler;
+  processClose?: ProcessCloseHandler;
 
 }
 
 /**
  * Options for subscribe.
  */
-export interface SubscriptionOptions extends OptionalEventHandlers, EventProcessorOptions {
+export interface SubscriptionOptions extends SubscriptionEventHandlers, EventProcessorOptions {
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -7,7 +7,7 @@ import { ReceivedEventData } from '.';
  * Event handler called when events are received. The `context` parameter can be 
  * used to get partition information as well as to checkpoint.
  */
-export type ProcessReceivedEvents = (
+export type ProcessEvents = (
   receivedEvents: ReceivedEventData[],
   context: PartitionContext & PartitionCheckpointer
 ) => Promise<void>;
@@ -34,7 +34,7 @@ export interface SubscriptionEventHandlers {
   /**
    * Event handler called when events are received.    
    */
-  processReceivedEvents: ProcessReceivedEvents
+  processEvents: ProcessEvents
   /**
    * Called when errors occur during event receiving.
    */

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -1,7 +1,7 @@
 
 import { CloseReason, PartitionContext, EventProcessorOptions, EventProcessorBatchOptions } from './eventProcessor';
 import { PartitionCheckpointer } from './eventHubConsumerClient';
-import { ReceivedEventData } from '.';
+import { ReceivedEventData } from './eventData';
 
 /**
  * Event handler called when events are received. The `context` parameter can be 

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -132,19 +132,25 @@ export interface PartitionManager {
 }
 
 /**
- * Common options for configuring `EventProcessor`, minus options that are only 
- * used internally (like `partitionLoadBalancer`)
+ * Configures batch related options for the event processor
  */
-export interface EventProcessorOptions {
+export interface EventProcessorBatchOptions {
   /**
    * The max size of the batch of events passed each time to user code for processing.
    */
-  maxBatchSize: number;
+  maxBatchSize?: number;
   /**
    * The maximum amount of time to wait to build up the requested message count before
    * passing the data to user code for processing. If not provided, it defaults to 60 seconds.
    */
-  maxWaitTimeInSeconds: number;
+  maxWaitTimeInSeconds?: number;
+}
+
+/**
+ * Common options for configuring `EventProcessor`, minus options that are only 
+ * used internally (like `partitionLoadBalancer`)
+ */
+export interface EventProcessorOptions {
   /**
    * @property
    * Indicates whether or not the consumer should request information on the last enqueued event on its
@@ -166,7 +172,6 @@ export interface EventProcessorOptions {
   defaultEventPosition?: EventPosition;  
 }
 
-
 /**
  * A set of options to pass to the constructor of `EventProcessor`.
  * You can specify
@@ -183,7 +188,7 @@ export interface EventProcessorOptions {
   * ```
   * @internal
   */
-export interface FullEventProcessorOptions extends EventProcessorOptions {
+export interface FullEventProcessorOptions extends EventProcessorOptions, Required<EventProcessorBatchOptions> {
   /**
    * A load balancer to use
    */

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -18,9 +18,9 @@ export {
   GetPropertiesOptions,
   ParentSpanOptions
 } from "./eventHubClient";
-export { EventHubConsumerClient, OnReceivedEvents, PartitionCheckpointer } from "./eventHubConsumerClient";
+export { EventHubConsumerClient, PartitionCheckpointer } from "./eventHubConsumerClient";
 export { EventHubProducerClient } from "./eventHubProducerClient";
-export { SubscriptionOptions, Subscription, OptionalEventHandlers, OnErrorHandler, OnInitializeHandler, OnCloseHandler } from "./eventHubConsumerClientModels";
+export { SubscriptionOptions, Subscription, SubscriptionEventHandlers, ProcessErrorHandler, ProcessInitializeHandler, ProcessCloseHandler, ProcessReceivedEvents } from "./eventHubConsumerClientModels";
 export { EventPosition } from "./eventPosition";
 export { PartitionProperties, EventHubProperties } from "./managementClient";
 export { EventDataBatch, TryAddOptions } from "./eventDataBatch";

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -20,7 +20,15 @@ export {
 } from "./eventHubClient";
 export { EventHubConsumerClient, PartitionCheckpointer } from "./eventHubConsumerClient";
 export { EventHubProducerClient } from "./eventHubProducerClient";
-export { SubscriptionOptions, Subscription, SubscriptionEventHandlers, ProcessErrorHandler, ProcessInitializeHandler, ProcessCloseHandler, ProcessReceivedEvents } from "./eventHubConsumerClientModels";
+export {
+  SubscriptionOptions,
+  Subscription,
+  SubscriptionEventHandlers,
+  ProcessErrorHandler,
+  ProcessInitializeHandler,
+  ProcessCloseHandler,
+  ProcessEvents
+} from "./eventHubConsumerClientModels";
 export { EventPosition } from "./eventPosition";
 export { PartitionProperties, EventHubProperties } from "./managementClient";
 export { EventDataBatch, TryAddOptions } from "./eventDataBatch";

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -28,6 +28,7 @@ export { Checkpoint } from "./partitionProcessor";
 export {
   CloseReason,
   EventProcessorOptions,
+  EventProcessorBatchOptions,
   PartitionContext,
   PartitionManager,
   PartitionOwnership

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { InMemoryPartitionManager, EventHubProducerClient, Subscription, EventProcessorOptions } from "../src";
+import { InMemoryPartitionManager, EventHubProducerClient, Subscription } from "../src";
 import { EventHubClient } from "../src/eventHubClient";
 import { EventHubConsumerClient, isPartitionManager } from "../src/eventHubConsumerClient";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
@@ -9,13 +9,14 @@ import chai from "chai";
 import { ReceivedMessagesTester } from "./utils/receivedMessagesTester";
 import * as log from "../src/log";
 import { LogTester } from "./utils/logTester";
+import { EventProcessorBatchOptions } from '../src/eventProcessor';
 
 const should = chai.should();
 const env = getEnvVars();
 
 // setting these to be really small since our tests deal with a
 // very low volume of messages.
-const defaultSubscriptionOptions: EventProcessorOptions = {
+const defaultSubscriptionOptions: EventProcessorBatchOptions = {
   maxBatchSize: 1,
   maxWaitTimeInSeconds: 10
 };

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { InMemoryPartitionManager, EventHubProducerClient, SubscriptionOptions, Subscription } from "../src";
+import { InMemoryPartitionManager, EventHubProducerClient, Subscription, EventProcessorOptions } from "../src";
 import { EventHubClient } from "../src/eventHubClient";
 import { EventHubConsumerClient, isPartitionManager } from "../src/eventHubConsumerClient";
 import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
@@ -15,7 +15,7 @@ const env = getEnvVars();
 
 // setting these to be really small since our tests deal with a
 // very low volume of messages.
-const defaultSubscriptionOptions: SubscriptionOptions = {
+const defaultSubscriptionOptions: EventProcessorOptions = {
   maxBatchSize: 1,
   maxWaitTimeInSeconds: 10
 };
@@ -25,11 +25,11 @@ describe("EventHubConsumerClient", () => {
     it("isPartitionManager", () => {
       isPartitionManager({
         ...defaultSubscriptionOptions,
-        onClose: async () => {}
+        processReceivedEvents: async () => { },
+        processClose: async () => {}
       }).should.not.ok;
 
-      isPartitionManager(undefined).should.not.ok;
-      isPartitionManager(["hello"]).should.not.ok;
+      isPartitionManager("hello").should.not.ok;
 
       isPartitionManager(new InMemoryPartitionManager()).should.ok;
     });
@@ -90,7 +90,6 @@ describe("EventHubConsumerClient", () => {
 
       const subscription = await client.subscribe(
         EventHubClient.defaultConsumerGroupName,
-        (events, context) => tester.onReceivedEvents(events, context),
         "0",
         tester
       );
@@ -116,7 +115,6 @@ describe("EventHubConsumerClient", () => {
 
       const subscription = await client.subscribe(
         EventHubClient.defaultConsumerGroupName,
-        (events, context) => tester.onReceivedEvents(events, context),
         tester
       );
 
@@ -144,12 +142,6 @@ describe("EventHubConsumerClient", () => {
 
       const subscriber1 = await client.subscribe(
         EventHubClient.defaultConsumerGroupName,
-        async (events, context) => {
-          if (events.length > 0) {
-            await context.updateCheckpoint(events[events.length - 1]);
-          }
-          return tester.onReceivedEvents(events, context);
-        },
         inMemoryPartitionManager,
         tester
       );
@@ -158,13 +150,6 @@ describe("EventHubConsumerClient", () => {
 
       const subscriber2 = await client.subscribe(
          EventHubClient.defaultConsumerGroupName,
-        async (events, context) => {
-          if (events.length > 0) {
-            await context.updateCheckpoint(events[events.length - 1]);
-          }
-
-          return tester.onReceivedEvents(events, context);
-        },
          inMemoryPartitionManager,
          tester
       );

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -26,7 +26,7 @@ describe("EventHubConsumerClient", () => {
     it("isPartitionManager", () => {
       isPartitionManager({
         ...defaultSubscriptionOptions,
-        processReceivedEvents: async () => { },
+        processEvents: async () => { },
         processClose: async () => {}
       }).should.not.ok;
 

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -271,7 +271,7 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
         maxBatchSize: 2,    // the Mike message was rejected so it's not in the batch
         maxWaitTimeInSeconds: 60,
         defaultEventPosition: EventPosition.latest(),
-        processReceivedEvents: async (events, context) => {
+        processEvents: async (events, context) => {
           receivedEvents.push(...events.map(e => e.body));
         },
         processInitialize: async (_) => {

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -267,13 +267,14 @@ describe("EventHub Sender #RunnableInBrowser", function(): void {
       let receivedEvents: string[] = [];
       let initialized = false;
 
-      const subscriber = consumerClient.subscribe(EventHubConsumerClient.defaultConsumerGroupName, async (events, context) => {
-        receivedEvents.push(...events.map(e => e.body));
-      }, "0", {
+      const subscriber = consumerClient.subscribe(EventHubConsumerClient.defaultConsumerGroupName, "0", {
         maxBatchSize: 2,    // the Mike message was rejected so it's not in the batch
         maxWaitTimeInSeconds: 60,
         defaultEventPosition: EventPosition.latest(),
-        onInitialize: async (_) => {
+        processReceivedEvents: async (events, context) => {
+          receivedEvents.push(...events.map(e => e.body));
+        },
+        processInitialize: async (_) => {
           initialized = true;
         }
       });

--- a/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
+++ b/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
@@ -43,7 +43,7 @@ export class ReceivedMessagesTester implements Required<SubscriptionEventHandler
     this.done = false;
   }
 
-  async processReceivedEvents(
+  async processEvents(
     receivedEvents: ReceivedEventData[],
     context: PartitionContext & PartitionCheckpointer
   ): Promise<void> {

--- a/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
+++ b/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
@@ -1,5 +1,5 @@
-import { CloseReason, ReceivedEventData, EventPosition, EventHubProducerClient } from "../../src/";
-import { OptionalEventHandlers, SubscriptionOptions } from "../../src/eventHubConsumerClientModels";
+import { CloseReason, ReceivedEventData, EventPosition, EventHubProducerClient, PartitionCheckpointer } from "../../src/";
+import { SubscriptionEventHandlers, SubscriptionOptions } from "../../src/eventHubConsumerClientModels";
 import { PartitionContext } from "../../src/eventProcessor";
 import chai from "chai";
 import { delay } from '@azure/core-amqp';
@@ -15,7 +15,7 @@ interface ReceivedMessages {
  * A simple tester that lets you easily poll for messages and check that they've
  * all been received at least once.
  */
-export class ReceivedMessagesTester implements Required<OptionalEventHandlers>, SubscriptionOptions {
+export class ReceivedMessagesTester implements Required<SubscriptionEventHandlers>, SubscriptionOptions {
   private data: Map<string, ReceivedMessages>;
   private expectedMessageBodies: Set<string>;
   public done: boolean;
@@ -43,11 +43,15 @@ export class ReceivedMessagesTester implements Required<OptionalEventHandlers>, 
     this.done = false;
   }
 
-  async onReceivedEvents(
+  async processReceivedEvents(
     receivedEvents: ReceivedEventData[],
-    context: PartitionContext
+    context: PartitionContext & PartitionCheckpointer
   ): Promise<void> {
     this.contextIsOk(context);
+
+    if (receivedEvents.length > 0) {
+      await context.updateCheckpoint(receivedEvents[receivedEvents.length - 1]);
+    }
 
     for (const event of receivedEvents) {
       this.expectedMessageBodies.delete(event.body);
@@ -58,7 +62,7 @@ export class ReceivedMessagesTester implements Required<OptionalEventHandlers>, 
     }
   }
 
-  async onError(error: Error, context: PartitionContext): Promise<void> {
+  async processError(error: Error, context: PartitionContext): Promise<void> {
     this.contextIsOk(context);
 
     // this can happen when multiple consumers are spinning up and load balancing. We'll ignore it for multi-consumers
@@ -74,7 +78,7 @@ export class ReceivedMessagesTester implements Required<OptionalEventHandlers>, 
     receivedData.lastError = error;
   }
 
-  async onInitialize(context: PartitionContext): Promise<void> {
+  async processInitialize(context: PartitionContext): Promise<void> {
     this.contextIsOk(context);
 
     if (!this.multipleConsumers) {
@@ -92,7 +96,7 @@ export class ReceivedMessagesTester implements Required<OptionalEventHandlers>, 
     });
   }
 
-  async onClose(reason: CloseReason, context: PartitionContext): Promise<void> {
+  async processClose(reason: CloseReason, context: PartitionContext): Promise<void> {
     this.contextIsOk(context);
 
     const receivedData = this.get(context.partitionId);


### PR DESCRIPTION
Renames and consolidation:

* on<events> renamed to process<events>
* Moving the one positional parameter that was an event handler (onReceivedEvents) into the options structure along with the other event handlers. Made it required.
* Changed the EventProcessorOptions interfaces to make it so batch options weren't required. I had to do this in a less terse way than I prefer because of typedoc but the important thing is that the public interfaces just use straight inheritance.