### PR TITLE
[app-configuration] readOnly naming changes

### DIFF
--- a/sdk/appconfiguration/app-configuration/README.md
+++ b/sdk/appconfiguration/app-configuration/README.md
@@ -58,7 +58,7 @@ const client = new AppConfigurationClient("<connection string>");
 The [`AppConfigurationClient`](https://azure.github.io/azure-sdk-for-js/app-configuration/classes/appconfigurationclient.html) has some terminology changes from App Configuration in the portal. 
 
 * Key/Value pairs are represented as [`ConfigurationSetting`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsetting.html) objects
-* Locking and unlocking a setting is renamed to `readOnly`, which you can toggle using the `setReadOnly` and `clearReadOnly` methods.
+* Locking and unlocking a setting is represented in the `isReadOnly` field, which you can toggle using the `setReadOnly`.
 
 The client follows a simple design methodology - [`ConfigurationSetting`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsetting.html) can be passed into any method that takes a [`ConfigurationSettingParam`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsettingparam.html) or [`ConfigurationSettingId`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsettingid.html). 
 
@@ -74,7 +74,7 @@ await client.setConfigurationSetting(setting);
 
 // fields unrelated to just identifying the setting are simply 
 // ignored (for instance, the `value` field)
-await client.setReadOnly(setting);
+await client.setReadOnly(setting, true);
 
 // delete just needs to identify the setting so other fields are
 // just ignored

--- a/sdk/appconfiguration/app-configuration/README.md
+++ b/sdk/appconfiguration/app-configuration/README.md
@@ -58,7 +58,7 @@ const client = new AppConfigurationClient("<connection string>");
 The [`AppConfigurationClient`](https://azure.github.io/azure-sdk-for-js/app-configuration/classes/appconfigurationclient.html) has some terminology changes from App Configuration in the portal. 
 
 * Key/Value pairs are represented as [`ConfigurationSetting`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsetting.html) objects
-* Locking and unlocking a setting is represented in the `isReadOnly` field, which you can toggle using the `setReadOnly`.
+* Locking and unlocking a setting is represented in the `isReadOnly` field, which you can toggle using `setReadOnly`.
 
 The client follows a simple design methodology - [`ConfigurationSetting`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsetting.html) can be passed into any method that takes a [`ConfigurationSettingParam`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsettingparam.html) or [`ConfigurationSettingId`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsettingid.html). 
 

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -24,13 +24,12 @@ export interface AddConfigurationSettingResponse extends ConfigurationSetting, S
 export class AppConfigurationClient {
     constructor(connectionString: string);
     addConfigurationSetting(configurationSetting: AddConfigurationSettingParam, options?: AddConfigurationSettingOptions): Promise<AddConfigurationSettingResponse>;
-    clearReadOnly(id: ConfigurationSettingId, options?: ClearReadOnlyOptions): Promise<ClearReadOnlyResponse>;
     deleteConfigurationSetting(id: ConfigurationSettingId, options?: DeleteConfigurationSettingOptions): Promise<DeleteConfigurationSettingResponse>;
     getConfigurationSetting(id: ConfigurationSettingId, options?: GetConfigurationSettingOptions): Promise<GetConfigurationSettingResponse>;
     listConfigurationSettings(options?: ListConfigurationSettingsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListConfigurationSettingPage>;
     listRevisions(options?: ListRevisionsOptions): PagedAsyncIterableIterator<ConfigurationSetting, ListRevisionsPage>;
     setConfigurationSetting(configurationSetting: SetConfigurationSettingParam, options?: SetConfigurationSettingOptions): Promise<SetConfigurationSettingResponse>;
-    setReadOnly(id: ConfigurationSettingId, options?: SetReadOnlyOptions): Promise<SetReadOnlyResponse>;
+    setReadOnly(id: ConfigurationSettingId, readOnly: boolean, options?: SetReadOnlyOptions): Promise<SetReadOnlyResponse>;
     }
 
 // @public
@@ -43,8 +42,8 @@ export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHe
 
 // @public
 export interface ConfigurationSetting extends ConfigurationSettingParam {
+    isReadOnly: boolean;
     lastModified?: Date;
-    readOnly: boolean;
 }
 
 // @public

--- a/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
+++ b/sdk/appconfiguration/app-configuration/review/app-configuration.api.md
@@ -33,14 +33,6 @@ export class AppConfigurationClient {
     }
 
 // @public
-export interface ClearReadOnlyOptions extends HttpOnlyIfUnchangedField, OperationOptions {
-}
-
-// @public
-export interface ClearReadOnlyResponse extends ConfigurationSetting, SyncTokenHeaderField, HttpResponseField<SyncTokenHeaderField> {
-}
-
-// @public
 export interface ConfigurationSetting extends ConfigurationSettingParam {
     isReadOnly: boolean;
     lastModified?: Date;

--- a/sdk/appconfiguration/app-configuration/sample.env
+++ b/sdk/appconfiguration/app-configuration/sample.env
@@ -1,0 +1,3 @@
+# This is the connection string for your app-configuration resource
+# You can get this from the Azure portal.
+AZ_CONFIG_CONNECTION=<app-configuration connection string goes here>

--- a/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts
@@ -49,7 +49,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
   });
 
   for await (const setting of existingSettings) {
-    await client.clearReadOnly(setting);
+    await client.setReadOnly(setting, false);
     await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }

--- a/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
+++ b/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts
@@ -103,7 +103,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
   });
 
   for await (const setting of existingSettings) {
-    await client.clearReadOnly(setting);
+    await client.setReadOnly(setting, false);
     await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }

--- a/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
+++ b/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts
@@ -23,7 +23,7 @@ export async function run() {
 
   // now we'd like to prevent future modifications - let's set the key/label to read-only
   console.log("Setting a key to read-only. Any modifications will fail");
-  await client.setReadOnly({ key: readOnlySampleKey, label: "a label" });
+  await client.setReadOnly({ key: readOnlySampleKey, label: "a label" }, true);
 
   // any modifications to the key will now throw errors
   try {
@@ -38,7 +38,7 @@ export async function run() {
   
   // to make a key writable again we can clear the read-only status
   console.log("Clearing the read-only status on the key so we can update the value");
-  await client.clearReadOnly({ key: readOnlySampleKey, label: "a label" });
+  await client.setReadOnly({ key: readOnlySampleKey, label: "a label" }, false);
 
   // and now clients can change the value again
   const updatedSetting = await client.setConfigurationSetting({ key: readOnlySampleKey, label: "a label", value: "new value" });
@@ -53,7 +53,7 @@ async function cleanupSampleValues(keys: string[], client: AppConfigurationClien
   });
 
   for await (const setting of existingSettings) {
-    await client.clearReadOnly(setting);
+    await client.setReadOnly(setting, false);
     await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
   }
 }

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -372,7 +372,7 @@ export class AppConfigurationClient {
 
   /**
    * Sets or clears a key's read-only status.
-   * @param id The id of the configuration setting to modify
+   * @param id The id of the configuration setting to modify.
    */
   async setReadOnly(
     id: ConfigurationSettingId,

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -371,7 +371,7 @@ export class AppConfigurationClient {
   }
 
   /**
-   * Sets or clears a key's read-only status
+   * Sets or clears a key's read-only status.
    * @param id The id of the configuration setting to modify
    */
   async setReadOnly(

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -15,8 +15,6 @@ import {
   AddConfigurationSettingOptions,
   AddConfigurationSettingParam,
   AddConfigurationSettingResponse,
-  ClearReadOnlyOptions,
-  ClearReadOnlyResponse,
   ConfigurationSetting,
   ConfigurationSettingId,
   DeleteConfigurationSettingOptions,

--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -373,44 +373,34 @@ export class AppConfigurationClient {
   }
 
   /**
-   * Sets a key's value to read only
-   * @param id The id of the configuration setting to set to read-only.
+   * Sets or clears a key's read-only status
+   * @param id The id of the configuration setting to modify
    */
   async setReadOnly(
     id: ConfigurationSettingId,
+    readOnly: boolean,
     options: SetReadOnlyOptions = {}
   ): Promise<SetReadOnlyResponse> {
     const opts = operationOptionsToRequestOptionsBase(options);
 
     return this.spanner.trace("setReadOnly", opts, async (newOptions) => {
-      const response = await this.client.putLock(id.key, {
-        ...newOptions,
-        label: id.label,
-        ...checkAndFormatIfAndIfNoneMatch(id, options)
-      });
+      if (readOnly) {
+        const response = await this.client.putLock(id.key, {
+          ...newOptions,
+          label: id.label,
+          ...checkAndFormatIfAndIfNoneMatch(id, options)
+        });
 
-      return transformKeyValueResponse(response);
-    });
-  }
-
-  /**
-   * Makes the key's value writable again
-   * @param id The id of the configuration setting to make writable.
-   */
-  async clearReadOnly(
-    id: ConfigurationSettingId,
-    options: ClearReadOnlyOptions = {}
-  ): Promise<ClearReadOnlyResponse> {
-    const opts = operationOptionsToRequestOptionsBase(options);
-
-    return await this.spanner.trace("clearReadOnly", opts, async (newOptions) => {
-      const response = await this.client.deleteLock(id.key, {
-        ...newOptions,
-        label: id.label,
-        ...checkAndFormatIfAndIfNoneMatch(id, options)
-      });
-
-      return transformKeyValueResponse(response);
+        return transformKeyValueResponse(response);
+      } else {
+        const response = await this.client.deleteLock(id.key, {
+          ...newOptions,
+          label: id.label,
+          ...checkAndFormatIfAndIfNoneMatch(id, options)
+        });
+  
+        return transformKeyValueResponse(response);
+      }
     });
   }
 }

--- a/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/helpers.ts
@@ -95,7 +95,7 @@ export function formatWildcards(
   let fields: (keyof KeyValue)[] | undefined;
 
   if (listConfigOptions.fields) {
-    fields = listConfigOptions.fields.map((opt) => (opt === "readOnly" ? "locked" : opt));
+    fields = listConfigOptions.fields.map((opt) => (opt === "isReadOnly" ? "locked" : opt));
   }
 
   return {
@@ -137,7 +137,7 @@ export function makeConfigurationSettingEmpty(
     "etag",
     "label",
     "lastModified",
-    "readOnly",
+    "isReadOnly",
     "tags",
     "value"
   ];
@@ -154,7 +154,7 @@ export function makeConfigurationSettingEmpty(
 export function transformKeyValue(kvp: KeyValue): ConfigurationSetting {
   const obj: ConfigurationSetting & KeyValue = {
     ...kvp,
-    readOnly: !!kvp.locked
+    isReadOnly: !!kvp.locked
   };
 
   delete obj.locked;

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -52,7 +52,7 @@ export interface ConfigurationSetting extends ConfigurationSettingParam {
   /**
    * Whether or not the setting is read-only
    */
-  readOnly: boolean;
+  isReadOnly: boolean;
 
   /**
    * The date when this setting was last modified

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -282,19 +282,6 @@ export interface ListRevisionsPage extends HttpResponseField<SyncTokenHeaderFiel
 }
 
 /**
- * Options for clearReadOnly
- */
-export interface ClearReadOnlyOptions extends HttpOnlyIfUnchangedField, OperationOptions {}
-
-/**
- * Response when clearing the read-only status from a value
- */
-export interface ClearReadOnlyResponse
-  extends ConfigurationSetting,
-    SyncTokenHeaderField,
-    HttpResponseField<SyncTokenHeaderField> {}
-
-/**
  * Options for setReadOnly
  */
 export interface SetReadOnlyOptions extends HttpOnlyIfUnchangedField, OperationOptions {}

--- a/sdk/appconfiguration/app-configuration/test/etags.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/etags.spec.ts
@@ -104,7 +104,7 @@ describe("etags", () => {
     assert.ok(!response.etag);
     assert.ok(!response.label);
     assert.ok(!response.lastModified);
-    assert.ok(!response.readOnly);
+    assert.ok(!response.isReadOnly);
     assert.ok(!response.tags);
     assert.ok(!response.value);
 
@@ -142,7 +142,7 @@ describe("etags", () => {
     // etag won't match so we get a precondition failed
     await assertThrowsRestError(
       () =>
-        client.setReadOnly(badEtagSetting, {
+        client.setReadOnly(badEtagSetting, true, {
           onlyIfUnchanged: true
         }),
       412
@@ -150,18 +150,18 @@ describe("etags", () => {
 
     let actualSetting = await client.getConfigurationSetting(badEtagSetting);
     // should not be read-only since it didn't match
-    assert.ok(!actualSetting.readOnly);
+    assert.ok(!actualSetting.isReadOnly);
 
     // and now that the etag matches we should be able to set the
     // key's value to read-onlly
-    await client.setReadOnly(addedSetting, { onlyIfUnchanged: true });
+    await client.setReadOnly(addedSetting, true, { onlyIfUnchanged: true });
     actualSetting = await client.getConfigurationSetting(addedSetting);
-    assert.ok(actualSetting.readOnly);
+    assert.ok(actualSetting.isReadOnly);
 
     // now let's try to clear it (using a bogus etag so it won't match)
     await assertThrowsRestError(
       () =>
-        client.clearReadOnly(badEtagSetting, {
+        client.setReadOnly(badEtagSetting, false, {
           onlyIfUnchanged: true
         }),
       412
@@ -169,16 +169,16 @@ describe("etags", () => {
 
     // ...still readOnly
     actualSetting = await client.getConfigurationSetting(addedSetting);
-    assert.ok(actualSetting.readOnly);
+    assert.ok(actualSetting.isReadOnly);
 
     // now we'll use the right etag (from the setting we just retrieved)
-    await client.clearReadOnly(actualSetting, {
+    await client.setReadOnly(actualSetting, false, {
       onlyIfUnchanged: true
     });
 
     // and now it's no longer readOnly
     actualSetting = await client.getConfigurationSetting(addedSetting);
-    assert.ok(!actualSetting.readOnly);
+    assert.ok(!actualSetting.isReadOnly);
   });
 
   it("delete using etags", async () => {

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -115,7 +115,7 @@ describe("helper methods", () => {
 
     it("fields map properly", () => {
       const result = formatWildcards({
-        fields: ["readOnly", "value"]
+        fields: ["isReadOnly", "value"]
       });
 
       assert.deepEqual(["locked", "value"], result.select);
@@ -133,7 +133,7 @@ describe("helper methods", () => {
     const response: ConfigurationSetting & HttpResponseField<any> & HttpResponseFields = {
       key: "mykey",
       statusCode: 204,
-      readOnly: false,
+      isReadOnly: false,
       ...fakeHttp204Response
     };
 
@@ -163,7 +163,7 @@ describe("helper methods", () => {
       {
         // the 'locked' property should not be present in the object since
         // it should be 'renamed' to readOnly
-        readOnly: true,
+        isReadOnly: true,
         key: "hello"
       },
       configurationSetting
@@ -180,7 +180,7 @@ describe("helper methods", () => {
     const actualKeys = Object.keys(configurationSetting).sort();
 
     // _response is explictly set to not enumerate, even in our copied object.
-    assert.deepEqual(["key", "readOnly", "statusCode"], actualKeys);
+    assert.deepEqual(["isReadOnly", "key", "statusCode"], actualKeys);
 
     // now make it enumerable so we can do our comparison
     Object.defineProperty(configurationSetting, "_response", {
@@ -189,7 +189,7 @@ describe("helper methods", () => {
 
     assert.deepEqual(
       {
-        readOnly: true,
+        isReadOnly: true,
         key: "hello",
         statusCode: 204,
         _response: fakeHttp204Response._response
@@ -208,7 +208,7 @@ describe("helper methods", () => {
     const actualKeys = Object.keys(configurationSetting).sort();
 
     // _response is explictly set to not enumerate, even in our copied object.
-    assert.deepEqual(["key", "readOnly"], actualKeys);
+    assert.deepEqual(["isReadOnly", "key"], actualKeys);
 
     // now make it enumerable so we can do our comparison
     Object.defineProperty(configurationSetting, "_response", {
@@ -217,7 +217,7 @@ describe("helper methods", () => {
 
     assert.deepEqual(
       {
-        readOnly: true,
+        isReadOnly: true,
         key: "hello",
         _response: fakeHttp204Response._response
       },
@@ -232,7 +232,7 @@ describe("helper methods", () => {
       key: "",
       label: "",
       lastModified: new Date(),
-      readOnly: true,
+      isReadOnly: true,
       tags: {},
       value: ""
     };

--- a/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.readonlytests.spec.ts
@@ -33,15 +33,15 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
       key: testConfigSetting.key,
       label: testConfigSetting.label
     });
-    assert.ok(!storedSetting.readOnly);
+    assert.ok(!storedSetting.isReadOnly);
 
-    await client.setReadOnly(testConfigSetting);
+    await client.setReadOnly(testConfigSetting, true);
 
     storedSetting = await client.getConfigurationSetting({
       key: testConfigSetting.key,
       label: testConfigSetting.label
     });
-    assert.ok(storedSetting.readOnly);
+    assert.ok(storedSetting.isReadOnly);
 
     // any modification related methods throw exceptions
     await assertThrowsRestError(
@@ -67,10 +67,10 @@ describe("AppConfigurationClient (set|clear)ReadOnly", () => {
     });
 
     await assertThrowsAbortError(async () => {
-      await client.setReadOnly(testConfigSetting, { requestOptions: { timeout: 1 } });
+      await client.setReadOnly(testConfigSetting, true, { requestOptions: { timeout: 1 } });
     });
     await assertThrowsAbortError(async () => {
-      await client.clearReadOnly(testConfigSetting, { requestOptions: { timeout: 1 } });
+      await client.setReadOnly(testConfigSetting, false, { requestOptions: { timeout: 1 } });
     });
   });
 });

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -324,7 +324,7 @@ describe("AppConfigurationClient", () => {
         "Unexpected lastModified in result from addConfigurationSetting()."
       );
       assert.equal(
-        result.readOnly,
+        result.isReadOnly,
         false,
         "Unexpected readOnly in result from addConfigurationSetting()."
       );
@@ -362,7 +362,7 @@ describe("AppConfigurationClient", () => {
         "Unexpected lastModified in result from getConfigurationSetting()."
       );
       assert.equal(
-        remoteResult.readOnly,
+        remoteResult.isReadOnly,
         false,
         "Unexpected readOnly in result from getConfigurationSetting()."
       );
@@ -419,7 +419,7 @@ describe("AppConfigurationClient", () => {
 
     before(async () => {
       await client.addConfigurationSetting(productionASettingId);
-      await client.setReadOnly(productionASettingId);
+      await client.setReadOnly(productionASettingId, true);
 
       await client.addConfigurationSetting({
         key: `listConfigSettingA-${now}`,
@@ -457,13 +457,13 @@ describe("AppConfigurationClient", () => {
             key: `listConfigSettingA-${now}`,
             value: "[A] production value",
             label: uniqueLabel,
-            readOnly: true
+            isReadOnly: true
           },
           {
             key: `listConfigSettingB-${now}`,
             value: "[B] production value",
             label: uniqueLabel,
-            readOnly: false
+            isReadOnly: false
           }
         ],
         byLabelSettings
@@ -483,13 +483,13 @@ describe("AppConfigurationClient", () => {
             key: `listConfigSettingA-${now}`,
             value: "[A] production value",
             label: uniqueLabel,
-            readOnly: true
+            isReadOnly: true
           },
           {
             key: `listConfigSettingB-${now}`,
             value: "[B] production value",
             label: uniqueLabel,
-            readOnly: false
+            isReadOnly: false
           }
         ],
         byLabelSettings
@@ -506,13 +506,13 @@ describe("AppConfigurationClient", () => {
             key: `listConfigSettingA-${now}`,
             value: "[A] production value",
             label: uniqueLabel,
-            readOnly: true
+            isReadOnly: true
           },
           {
             key: `listConfigSettingA-${now}`,
             value: "[A] value",
             label: undefined,
-            readOnly: false
+            isReadOnly: false
           }
         ],
         byKeySettings
@@ -530,13 +530,13 @@ describe("AppConfigurationClient", () => {
             key: `listConfigSettingA-${now}`,
             value: "[A] production value",
             label: uniqueLabel,
-            readOnly: true
+            isReadOnly: true
           },
           {
             key: `listConfigSettingA-${now}`,
             value: "[A] value",
             label: undefined,
-            readOnly: false
+            isReadOnly: false
           }
         ],
         byKeySettings
@@ -547,13 +547,13 @@ describe("AppConfigurationClient", () => {
       // only fill in the 'readOnly' field (which is really the locked field in the REST model)
       let byKeyIterator = client.listConfigurationSettings({
         keys: [`listConfigSettingA-${now}`],
-        fields: ["key", "label", "readOnly"]
+        fields: ["key", "label", "isReadOnly"]
       });
       let settings = await toSortedArray(byKeyIterator);
 
       // the fields we retrieved
       assert.equal(productionASettingId.key, settings[0].key);
-      assert.ok(settings[0].readOnly);
+      assert.ok(settings[0].isReadOnly);
       assert.equal(uniqueLabel, settings[0].label);
 
       assert.ok(!settings[0].contentType);
@@ -572,7 +572,7 @@ describe("AppConfigurationClient", () => {
       assert.equal("[A] production value", settings[0].value);
       assert.equal(uniqueLabel, settings[0].label);
 
-      assert.ok(!settings[0].readOnly);
+      assert.ok(!settings[0].isReadOnly);
       assert.ok(!settings[0].contentType);
       assert.ok(!settings[0].etag);
     });
@@ -655,8 +655,8 @@ describe("AppConfigurationClient", () => {
 
       assertEqualSettings(
         [
-          { key, label: labelA, value: "fooA1", readOnly: false },
-          { key, label: labelA, value: "fooA2", readOnly: false }
+          { key, label: labelA, value: "fooA1", isReadOnly: false },
+          { key, label: labelA, value: "fooA2", isReadOnly: false }
         ],
         revisions
       );
@@ -670,8 +670,8 @@ describe("AppConfigurationClient", () => {
 
       assertEqualSettings(
         [
-          { key, label: labelA, value: "fooA1", readOnly: false },
-          { key, label: labelA, value: "fooA2", readOnly: false }
+          { key, label: labelA, value: "fooA1", isReadOnly: false },
+          { key, label: labelA, value: "fooA2", isReadOnly: false }
         ],
         revisions
       );
@@ -683,10 +683,10 @@ describe("AppConfigurationClient", () => {
 
       assertEqualSettings(
         [
-          { key, label: labelA, value: "fooA1", readOnly: false },
-          { key, label: labelA, value: "fooA2", readOnly: false },
-          { key, label: labelB, value: "fooB1", readOnly: false },
-          { key, label: labelB, value: "fooB2", readOnly: false }
+          { key, label: labelA, value: "fooA1", isReadOnly: false },
+          { key, label: labelA, value: "fooA2", isReadOnly: false },
+          { key, label: labelB, value: "fooB1", isReadOnly: false },
+          { key, label: labelB, value: "fooB2", isReadOnly: false }
         ],
         revisions
       );
@@ -700,10 +700,10 @@ describe("AppConfigurationClient", () => {
 
       assertEqualSettings(
         [
-          { key, label: labelA, value: "fooA1", readOnly: false },
-          { key, label: labelA, value: "fooA2", readOnly: false },
-          { key, label: labelB, value: "fooB1", readOnly: false },
-          { key, label: labelB, value: "fooB2", readOnly: false }
+          { key, label: labelA, value: "fooA1", isReadOnly: false },
+          { key, label: labelA, value: "fooA2", isReadOnly: false },
+          { key, label: labelB, value: "fooB1", isReadOnly: false },
+          { key, label: labelB, value: "fooB2", isReadOnly: false }
         ],
         revisions
       );
@@ -755,7 +755,7 @@ describe("AppConfigurationClient", () => {
         "Unexpected lastModified in result from addConfigurationSetting()."
       );
       assert.equal(
-        result.readOnly,
+        result.isReadOnly,
         false,
         "Unexpected readOnly in result from addConfigurationSetting()."
       );
@@ -793,7 +793,7 @@ describe("AppConfigurationClient", () => {
         "Unexpected lastModified in result from setConfigurationSetting()."
       );
       assert.equal(
-        replacedResult.readOnly,
+        replacedResult.isReadOnly,
         false,
         "Unexpected readOnly in result from setConfigurationSetting()."
       );
@@ -846,7 +846,7 @@ describe("AppConfigurationClient", () => {
         "Unexpected lastModified in result from addConfigurationSetting()."
       );
       assert.equal(
-        result.readOnly,
+        result.isReadOnly,
         false,
         "Unexpected readOnly in result from addConfigurationSetting()."
       );
@@ -892,7 +892,7 @@ describe("AppConfigurationClient", () => {
         "Unexpected lastModified in result from setConfigurationSetting()."
       );
       assert.equal(
-        replacedResult.readOnly,
+        replacedResult.isReadOnly,
         false,
         "Unexpected readOnly in result from setConfigurationSetting()."
       );
@@ -931,7 +931,7 @@ describe("AppConfigurationClient", () => {
         "Unexpected lastModified in result from setConfigurationSetting()."
       );
       assert.equal(
-        result.readOnly,
+        result.isReadOnly,
         false,
         "Unexpected readOnly in result from setConfigurationSetting()."
       );

--- a/sdk/appconfiguration/app-configuration/test/testHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/test/testHelpers.ts
@@ -40,8 +40,8 @@ export async function deleteKeyCompletely(keys: string[], client: AppConfigurati
   });
 
   for await (const setting of settingsIterator) {
-    if (setting.readOnly) {
-      await client.clearReadOnly(setting);
+    if (setting.isReadOnly) {
+      await client.setReadOnly(setting, false);
     }
 
     await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
@@ -77,7 +77,7 @@ export async function toSortedArray(
 }
 
 export function assertEqualSettings(
-  expected: Pick<ConfigurationSetting, "key" | "value" | "label" | "readOnly">[],
+  expected: Pick<ConfigurationSetting, "key" | "value" | "label" | "isReadOnly">[],
   actual: ConfigurationSetting[]
 ) {
   actual = actual.map((setting) => {
@@ -85,7 +85,7 @@ export function assertEqualSettings(
       key: setting.key,
       label: setting.label,
       value: setting.value,
-      readOnly: setting.readOnly
+      isReadOnly: setting.isReadOnly
     };
   });
 

--- a/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/throwOrNotThrow.spec.ts
@@ -61,15 +61,15 @@ describe("Various error cases", () => {
     });
 
     it("set: trying to modify a read-only setting throws 409", async () => {
-      await client.setReadOnly(addedSetting);
+      await client.setReadOnly(addedSetting, true);
 
       await assertThrowsRestError(() => client.setConfigurationSetting(addedSetting), 409);
     });
 
     it("delete: key that is set to read-only throws 409", async () => {
-      await client.setReadOnly(addedSetting);
+      await client.setReadOnly(addedSetting, true);
       await assertThrowsRestError(async () => client.deleteConfigurationSetting(addedSetting), 409);
-      await client.clearReadOnly(addedSetting);
+      await client.setReadOnly(addedSetting, false);
     });
   });
 


### PR DESCRIPTION
* clearReadOnly has been removed in favor of just adding a boolean parameter to setReadOnly that indicates if we're clearing or setting the readonly flag.
* The readonly field has been renamed to isReadOnly
* Updated readme and samples as well.