### PR TITLE
[Identity] Send user-assigned managed identity ID as 'clientid' with no '_'

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 - Coming Soon
+
+- Fixed an issue that occurs when using a user-assigned managed identity with `ManagedIdentityCredential` ([PR #6134](https://github.com/Azure/azure-sdk-for-js/pull/6134))
+
 ## 1.0.0 - 2019-10-29
 
 - This release marks the general availability of the `@azure/identity` package.

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.1 - Coming Soon
 
-- Fixed an issue that occurs when using a user-assigned managed identity with `ManagedIdentityCredential` ([PR #6134](https://github.com/Azure/azure-sdk-for-js/pull/6134))
+- Fixed an issue where an authorization error occurs due to wrong access token being returned by the MSI endpoint when using a user-assigned managed identity with `ManagedIdentityCredential` ([PR #6134](https://github.com/Azure/azure-sdk-for-js/pull/6134))
 
 ## 1.0.0 - 2019-10-29
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -113,7 +113,7 @@ export class ManagedIdentityCredential implements TokenCredential {
     };
 
     if (clientId) {
-      queryParameters.client_id = clientId;
+      queryParameters.clientid = clientId;
     }
 
     return {

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -35,9 +35,10 @@ export class ManagedIdentityCredential implements TokenCredential {
   private isEndpointUnavailable: boolean | null = null;
 
   /**
-   * Creates an instance of ManagedIdentityCredential with a client ID
+   * Creates an instance of ManagedIdentityCredential with the client ID of a
+   * user-assigned identity.
    *
-   * @param clientId The client (application) ID of an App Registration in the tenant.
+   * @param clientId The client ID of the user-assigned identity.
    * @param options Options for configuring the client which makes the access token request.
    */
   constructor(clientId: string, options?: TokenCredentialOptions);

--- a/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
@@ -136,7 +136,7 @@ describe("ManagedIdentityCredential", function() {
     assert.ok(authRequest.query, "No query string parameters on request");
     if (authRequest.query) {
       assert.equal(authRequest.method, "GET");
-      assert.equal(authRequest.query["client_id"], "client");
+      assert.equal(authRequest.query["clientid"], "client");
       assert.equal(decodeURIComponent(authRequest.query["resource"]), "https://service");
       assert.ok(
         authRequest.url.startsWith(process.env.MSI_ENDPOINT),


### PR DESCRIPTION
This change fixes an issue that occurs when authenticating with a user-assigned managed identity inside of an application deployed to Azure App Service or Azure Functions.  The issue manifests as an authorization error when accessing a resource (like Blob Storage) because the wrong access token gets returned by the MSI endpoint.

There is a slight implementation difference in how App Service / Functions accepts the client ID of the user-assigned identity: it is [expected to be sent as `clientid`](https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=dotnet#using-the-rest-protocol) rather than `client_id` as in other services which provide MSI authentication.

This issue was originally identified by @jianghaolu and fixed in the Java SDK in PR [#5897]( https://github.com/Azure/azure-sdk-for-java/pull/5897/files#diff-56093106beda983b28894478869221c6R329).