### PR TITLE
[storage-file-share] shareName/name fields for Share clients

### DIFF
--- a/sdk/storage/storage-file-share/recordings/browsers/directoryclient/recording_verify_directoryclient_name_matches_file_name.json
+++ b/sdk/storage/storage-file-share/recordings/browsers/directoryclient/recording_verify_directoryclient_name_matches_file_name.json
@@ -1,0 +1,74 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157326051475205242",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Sat, 09 Nov 2019 00:48:34 GMT",
+    "last-modified": "Sat, 09 Nov 2019 00:48:34 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D764AE8CFE697F\"",
+    "x-ms-request-id": "77b1ae3b-801a-002b-1197-96ff93000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "81125a2d-351b-4307-bbdb-5bead0fab09d",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157326051475205242/dir157326051492700342",
+   "query": {
+    "restype": "directory"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Sat, 09 Nov 2019 00:48:34 GMT",
+    "x-ms-file-change-time": "2019-11-09T00:48:35.0050950Z",
+    "x-ms-file-attributes": "Directory",
+    "x-ms-file-id": "13835128424026341376",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-11-09T00:48:35.0050950Z",
+    "x-ms-file-parent-id": "0",
+    "x-ms-file-permission-key": "3771195323339035646*6669510238408230007",
+    "x-ms-client-request-id": "2c9e0d09-e2e7-4d3a-afb0-1e7e7ce5aca2",
+    "content-length": "0",
+    "last-modified": "Sat, 09 Nov 2019 00:48:35 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D764AE8D11BA86\"",
+    "x-ms-request-id": "77b1ae3e-801a-002b-1397-96ff93000000",
+    "x-ms-file-last-write-time": "2019-11-09T00:48:35.0050950Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157326051475205242",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "date": "Sat, 09 Nov 2019 00:48:34 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "77b1ae40-801a-002b-1597-96ff93000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "2c677395-a90c-493e-bd23-96744ee6287c",
+    "content-length": "0"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "share": "share157326051475205242",
+  "dir": "dir157326051492700342"
+ }
+}

--- a/sdk/storage/storage-file-share/recordings/browsers/fileclient/recording_verify_fileclient_name_matches_file_name.json
+++ b/sdk/storage/storage-file-share/recordings/browsers/fileclient/recording_verify_fileclient_name_matches_file_name.json
@@ -1,0 +1,75 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157326051512601498",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Sat, 09 Nov 2019 00:48:34 GMT",
+    "last-modified": "Sat, 09 Nov 2019 00:48:35 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D764AE8D29A040\"",
+    "x-ms-request-id": "77b1ae43-801a-002b-1797-96ff93000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "f097395f-0eea-4039-b983-4176306b38e5",
+    "content-length": "0"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157326051512601498/dir157326051517402336",
+   "query": {
+    "restype": "directory"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "date": "Sat, 09 Nov 2019 00:48:34 GMT",
+    "x-ms-file-change-time": "2019-11-09T00:48:35.2211081Z",
+    "x-ms-file-attributes": "Directory",
+    "x-ms-file-id": "13835128424026341376",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-file-creation-time": "2019-11-09T00:48:35.2211081Z",
+    "x-ms-file-parent-id": "0",
+    "x-ms-file-permission-key": "3771195323339035646*6669510238408230007",
+    "x-ms-client-request-id": "145fd591-1449-4df2-8b44-1c87dc40367c",
+    "content-length": "0",
+    "last-modified": "Sat, 09 Nov 2019 00:48:35 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "etag": "\"0x8D764AE8D32B089\"",
+    "x-ms-request-id": "77b1ae46-801a-002b-1997-96ff93000000",
+    "x-ms-file-last-write-time": "2019-11-09T00:48:35.2211081Z",
+    "x-ms-version": "2019-02-02"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.file.core.windows.net/share157326051512601498",
+   "query": {
+    "restype": "share"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "date": "Sat, 09 Nov 2019 00:48:34 GMT",
+    "server": "Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-request-id": "77b1ae48-801a-002b-1b97-96ff93000000",
+    "x-ms-version": "2019-02-02",
+    "x-ms-client-request-id": "f438f435-6ee2-488e-8daa-6eeaf6b2b30c",
+    "content-length": "0"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "share": "share157326051512601498",
+  "dir": "dir157326051517402336",
+  "file": "file157326051524001609"
+ }
+}

--- a/sdk/storage/storage-file-share/recordings/node/directoryclient/recording_verify_directoryclient_name_matches_file_name.js
+++ b/sdk/storage/storage-file-share/recordings/node/directoryclient/recording_verify_directoryclient_name_matches_file_name.js
@@ -1,0 +1,81 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"share":"share157326050405208320","dir":"dir157326050427607950"}
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157326050405208320')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Sat, 09 Nov 2019 00:48:24 GMT',
+  'ETag',
+  '"0x8D764AE869FD866"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'bfe3026f-d01a-006b-7697-96f8ab000000',
+  'x-ms-client-request-id',
+  'ad72dd49-1897-4e3e-934e-e7b3a556bd50',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Sat, 09 Nov 2019 00:48:23 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157326050405208320/dir157326050427607950')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Sat, 09 Nov 2019 00:48:24 GMT',
+  'ETag',
+  '"0x8D764AE86C9DAA0"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '58f1f7b7-301a-004c-5597-96ef6f000000',
+  'x-ms-client-request-id',
+  '2fa758ef-b105-47c1-bcba-5c9808c142b2',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-11-09T00:48:24.4677280Z',
+  'x-ms-file-last-write-time',
+  '2019-11-09T00:48:24.4677280Z',
+  'x-ms-file-creation-time',
+  '2019-11-09T00:48:24.4677280Z',
+  'x-ms-file-permission-key',
+  '3771195323339035646*6669510238408230007',
+  'x-ms-file-attributes',
+  'Directory',
+  'x-ms-file-id',
+  '13835128424026341376',
+  'x-ms-file-parent-id',
+  '0',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Sat, 09 Nov 2019 00:48:24 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share157326050405208320')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'bfe3027f-d01a-006b-0497-96f8ab000000',
+  'x-ms-client-request-id',
+  '3a3fe79d-75ed-4e73-a7a0-ee89c8234f29',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Sat, 09 Nov 2019 00:48:24 GMT'
+]);

--- a/sdk/storage/storage-file-share/recordings/node/fileclient/recording_verify_fileclient_name_matches_file_name.js
+++ b/sdk/storage/storage-file-share/recordings/node/fileclient/recording_verify_fileclient_name_matches_file_name.js
@@ -1,0 +1,81 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"share":"share157326050458609312","dir":"dir157326050473704397","file":"file157326050484704489"}
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157326050458609312')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Sat, 09 Nov 2019 00:48:24 GMT',
+  'ETag',
+  '"0x8D764AE86E89BC8"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '7d425987-a01a-0085-1b97-965282000000',
+  'x-ms-client-request-id',
+  'd77e07ef-7fca-4ebd-ac92-7bb4caba7b29',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Sat, 09 Nov 2019 00:48:23 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share157326050458609312/dir157326050473704397')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Sat, 09 Nov 2019 00:48:24 GMT',
+  'ETag',
+  '"0x8D764AE8700A290"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'dd07723c-d01a-007b-7897-963dc3000000',
+  'x-ms-client-request-id',
+  '8d316c83-9092-4123-a394-586802ca5804',
+  'x-ms-version',
+  '2019-02-02',
+  'x-ms-file-change-time',
+  '2019-11-09T00:48:24.8267408Z',
+  'x-ms-file-last-write-time',
+  '2019-11-09T00:48:24.8267408Z',
+  'x-ms-file-creation-time',
+  '2019-11-09T00:48:24.8267408Z',
+  'x-ms-file-permission-key',
+  '3771195323339035646*6669510238408230007',
+  'x-ms-file-attributes',
+  'Directory',
+  'x-ms-file-id',
+  '13835128424026341376',
+  'x-ms-file-parent-id',
+  '0',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Sat, 09 Nov 2019 00:48:24 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share157326050458609312')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '7d42598a-a01a-0085-1c97-965282000000',
+  'x-ms-client-request-id',
+  '1f44046a-a76d-4cb7-b5f5-1fdc50972cd6',
+  'x-ms-version',
+  '2019-02-02',
+  'Date',
+  'Sat, 09 Nov 2019 00:48:23 GMT'
+]);

--- a/sdk/storage/storage-file-share/recordings/node/shareclient/recording_throws_error_if_constructor_sharename_parameter_is_empty.js
+++ b/sdk/storage/storage-file-share/recordings/node/shareclient/recording_throws_error_if_constructor_sharename_parameter_is_empty.js
@@ -1,41 +1,43 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"share":"share156816847432502605"}
+module.exports.testInfo = {"share":"share157325702912607298"}
 
 nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/share156816847432502605')
+  .put('/share157325702912607298')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:21:14 GMT',
+  'Fri, 08 Nov 2019 23:50:29 GMT',
   'ETag',
-  '"0x8D7365EB882BB85"',
+  '"0x8D764A66F803912"',
   'Server',
   'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'bcc18c6f-b01a-0064-2147-68d65c000000',
+  'acaaf6c3-301a-0073-2b8f-9627cc000000',
   'x-ms-client-request-id',
-  '45336da7-5852-4aaf-8b63-f853a7c3f618',
+  '8b36b789-d117-4334-99aa-a31327431c0b',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 11 Sep 2019 02:21:13 GMT' ]);
-
+  'Fri, 08 Nov 2019 23:50:29 GMT'
+]);
 
 nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/share156816847432502605')
+  .delete('/share157325702912607298')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f431eadf-201a-006a-0347-683a57000000',
+  'acaaf6c6-301a-0073-2c8f-9627cc000000',
   'x-ms-client-request-id',
-  '1ffe191b-8a5f-41f1-bbd0-47db7941fa0c',
+  'e816dad9-585a-46de-87be-2736cd6f5201',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 11 Sep 2019 02:21:14 GMT' ]);
-
+  'Fri, 08 Nov 2019 23:50:29 GMT'
+]);

--- a/sdk/storage/storage-file-share/review/storage-file-share.api.md
+++ b/sdk/storage/storage-file-share/review/storage-file-share.api.md
@@ -803,7 +803,7 @@ export interface SetPropertiesResponse extends FileSetHTTPHeadersResponse {
 // 
 // @public
 export class ShareClient extends StorageClient {
-    constructor(connectionString: string, shareName: string, options?: StoragePipelineOptions);
+    constructor(connectionString: string, name: string, options?: StoragePipelineOptions);
     constructor(url: string, credential?: Credential, options?: StoragePipelineOptions);
     constructor(url: string, pipeline: Pipeline);
     create(options?: ShareCreateOptions): Promise<ShareCreateResponse>;
@@ -825,12 +825,11 @@ export class ShareClient extends StorageClient {
     getPermission(filePermissionKey: string, options?: ShareGetPermissionOptions): Promise<ShareGetPermissionResponse>;
     getProperties(options?: ShareGetPropertiesOptions): Promise<ShareGetPropertiesResponse>;
     getStatistics(options?: ShareGetStatisticsOptions): Promise<ShareGetStatisticsResponse>;
+    readonly name: string;
     readonly rootDirectoryClient: ShareDirectoryClient;
     setAccessPolicy(shareAcl?: SignedIdentifier[], options?: ShareSetAccessPolicyOptions): Promise<ShareSetAccessPolicyResponse>;
     setMetadata(metadata?: Metadata, options?: ShareSetMetadataOptions): Promise<ShareSetMetadataResponse>;
     setQuota(quotaInGB: number, options?: ShareSetQuotaOptions): Promise<ShareSetQuotaResponse>;
-    // (undocumented)
-    readonly shareName: string;
     withSnapshot(snapshot: string): ShareClient;
 }
 
@@ -925,11 +924,10 @@ export class ShareDirectoryClient extends StorageClient {
         kind: "directory";
     } & DirectoryItem, DirectoryListFilesAndDirectoriesSegmentResponse>;
     listHandles(options?: DirectoryListHandlesOptions): PagedAsyncIterableIterator<HandleItem, DirectoryListHandlesResponse>;
-    // (undocumented)
+    readonly name: string;
     readonly path: string;
     setMetadata(metadata?: Metadata, options?: DirectorySetMetadataOptions): Promise<DirectorySetMetadataResponse>;
     setProperties(properties?: DirectoryProperties): Promise<DirectorySetPropertiesResponse>;
-    // (undocumented)
     readonly shareName: string;
     }
 
@@ -949,13 +947,12 @@ export class ShareFileClient extends StorageClient {
     getProperties(options?: FileGetPropertiesOptions): Promise<FileGetPropertiesResponse>;
     getRangeList(options?: FileGetRangeListOptions): Promise<FileGetRangeListResponse>;
     listHandles(options?: FileListHandlesOptions): PagedAsyncIterableIterator<HandleItem, FileListHandlesResponse>;
-    // (undocumented)
+    readonly name: string;
     readonly path: string;
     resize(length: number, options?: FileResizeOptions): Promise<FileSetHTTPHeadersResponse>;
     setHttpHeaders(fileHttpHeaders?: FileHttpHeaders, options?: FileSetHttpHeadersOptions): Promise<FileSetHTTPHeadersResponse>;
     setMetadata(metadata?: Metadata, options?: FileSetMetadataOptions): Promise<FileSetMetadataResponse>;
     setProperties(properties?: FileProperties): Promise<SetPropertiesResponse>;
-    // (undocumented)
     readonly shareName: string;
     startCopyFromURL(copySource: string, options?: FileStartCopyOptions): Promise<FileStartCopyResponse>;
     uploadBrowserData(browserData: Blob | ArrayBuffer | ArrayBufferView, options?: FileParallelUploadOptions): Promise<void>;

--- a/sdk/storage/storage-file-share/src/ShareClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareClient.ts
@@ -351,9 +351,17 @@ export class ShareClient extends StorageClient {
    * @memberof ShareClient
    */
   private context: Share;
-  private _shareName: string;
-  public get shareName(): string {
-    return this._shareName;
+
+  private _name: string;
+
+  /**
+   * The name of the share
+   *
+   * @type {string}
+   * @memberof ShareClient
+   */
+  public get name(): string {
+    return this._name;
   }
 
   /**
@@ -363,11 +371,11 @@ export class ShareClient extends StorageClient {
    *                                  `DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=accountKey;EndpointSuffix=core.windows.net`
    *                                  SAS connection string example -
    *                                  `BlobEndpoint=https://myaccount.blob.core.windows.net/;QueueEndpoint=https://myaccount.queue.core.windows.net/;FileEndpoint=https://myaccount.file.core.windows.net/;TableEndpoint=https://myaccount.table.core.windows.net/;SharedAccessSignature=sasString`
-   * @param {string} shareName Share name.
+   * @param {string} name Share name.
    * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
    * @memberof ShareClient
    */
-  constructor(connectionString: string, shareName: string, options?: StoragePipelineOptions);
+  constructor(connectionString: string, name: string, options?: StoragePipelineOptions);
   /**
    * Creates an instance of ShareClient.
    *
@@ -420,22 +428,22 @@ export class ShareClient extends StorageClient {
       credentialOrPipelineOrShareName &&
       typeof credentialOrPipelineOrShareName === "string"
     ) {
-      // (connectionString: string, shareName: string, options?: StoragePipelineOptions)
+      // (connectionString: string, name: string, options?: StoragePipelineOptions)
       const extractedCreds = extractConnectionStringParts(urlOrConnectionString);
-      const shareName = credentialOrPipelineOrShareName;
+      const name = credentialOrPipelineOrShareName;
       if (extractedCreds.kind === "AccountConnString") {
         if (isNode) {
           const sharedKeyCredential = new StorageSharedKeyCredential(
             extractedCreds.accountName!,
             extractedCreds.accountKey
           );
-          url = appendToURLPath(extractedCreds.url, shareName);
+          url = appendToURLPath(extractedCreds.url, name);
           pipeline = newPipeline(sharedKeyCredential, options);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");
         }
       } else if (extractedCreds.kind === "SASConnString") {
-        url = appendToURLPath(extractedCreds.url, shareName) + "?" + extractedCreds.accountSas;
+        url = appendToURLPath(extractedCreds.url, name) + "?" + extractedCreds.accountSas;
         pipeline = newPipeline(new AnonymousCredential(), options);
       } else {
         throw new Error(
@@ -443,10 +451,10 @@ export class ShareClient extends StorageClient {
         );
       }
     } else {
-      throw new Error("Expecting non-empty strings for shareName parameter");
+      throw new Error("Expecting non-empty strings for name parameter");
     }
     super(url, pipeline);
-    this._shareName = getShareNameAndPathFromUrl(this.url).shareName;
+    this._name = getShareNameAndPathFromUrl(this.url).shareName;
     this.context = new Share(this.storageClientContext);
   }
 

--- a/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
@@ -317,15 +317,39 @@ export class ShareDirectoryClient extends StorageClient {
    * @memberof ShareDirectoryClient
    */
   private context: Directory;
+
   private _shareName: string;
   private _path: string;
+  private _name: string;
 
+  /**
+   * The share name corresponding to this directory client
+   *
+   * @type {string}
+   * @memberof ShareDirectoryClient
+   */
   public get shareName(): string {
     return this._shareName;
   }
 
+  /**
+   * The full path of the directory
+   *
+   * @type {string}
+   * @memberof ShareDirectoryClient
+   */
   public get path(): string {
     return this._path;
+  }
+
+  /**
+   * The name of the directory
+   *
+   * @type {string}
+   * @memberof ShareDirectoryClient
+   */
+  public get name(): string {
+    return this._name;
   }
 
   /**
@@ -378,8 +402,9 @@ export class ShareDirectoryClient extends StorageClient {
 
     super(url, pipeline);
     ({
+      baseName: this._name,
       shareName: this._shareName,
-      filePathOrDirectoryPath: this._path
+      path: this._path
     } = getShareNameAndPathFromUrl(this.url));
     this.context = new Directory(this.storageClientContext);
   }

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -694,15 +694,39 @@ export class ShareFileClient extends StorageClient {
    * @memberof ShareFileClient
    */
   private context: File;
+
   private _shareName: string;
   private _path: string;
+  private _name: string;
 
+  /**
+   * The share name corresponding to this file client
+   *
+   * @type {string}
+   * @memberof ShareFileClient
+   */
   public get shareName(): string {
     return this._shareName;
   }
 
+  /**
+   * The full path of the file
+   *
+   * @type {string}
+   * @memberof ShareFileClient
+   */
   public get path(): string {
     return this._path;
+  }
+
+  /**
+   * The name of the file
+   *
+   * @type {string}
+   * @memberof ShareFileClient
+   */
+  public get name(): string {
+    return this._name;
   }
 
   /**
@@ -755,8 +779,9 @@ export class ShareFileClient extends StorageClient {
 
     super(url, pipeline);
     ({
+      baseName: this._name,
       shareName: this._shareName,
-      filePathOrDirectoryPath: this._path
+      path: this._path
     } = getShareNameAndPathFromUrl(this.url));
     this.context = new File(this.storageClientContext);
   }

--- a/sdk/storage/storage-file-share/src/utils/utils.common.ts
+++ b/sdk/storage/storage-file-share/src/utils/utils.common.ts
@@ -442,7 +442,7 @@ export function getAccountNameFromUrl(url: string): string {
 
 export function getShareNameAndPathFromUrl(
   url: string
-): { shareName: string; filePathOrDirectoryPath: string } {
+): { baseName: string; shareName: string; path: string } {
   //  URL may look like the following
   // "https://myaccount.file.core.windows.net/myshare/mydirectory/file?sasString";
   // "https://myaccount.file.core.windows.net/myshare/mydirectory/file";
@@ -460,12 +460,16 @@ export function getShareNameAndPathFromUrl(
 
     // decode the encoded shareName and filePath - to get all the special characters that might be present in it
     const shareName = decodeURIComponent(shareNameAndFilePath![3]);
-    const filePathOrDirectoryPath = decodeURIComponent(shareNameAndFilePath![5]);
+    const path = decodeURIComponent(shareNameAndFilePath![5]);
+
+    // Cast to string is required as TypeScript cannot infer that split() always returns
+    // an array with length >= 1
+    const baseName = path.split("/").pop() as string;
 
     if (!shareName) {
       throw new Error("Provided shareName is invalid.");
     } else {
-      return { shareName, filePathOrDirectoryPath };
+      return { baseName, shareName, path };
     }
   } catch (error) {
     throw new Error(

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -747,4 +747,16 @@ describe("DirectoryClient", () => {
       "Account name is not the same as the one provided."
     );
   });
+
+  it("verify DirectoryClient name matches file name", async () => {
+    const accountName = "myaccount";
+    const newClient = new ShareDirectoryClient(
+      `https://${accountName}.file.core.windows.net/${shareName}/${dirName}`
+    );
+    assert.equal(
+      newClient.name,
+      dirName,
+      "DirectoryClient name is not the same as the baseName of the provided directory URI"
+    );
+  });
 });

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -516,6 +516,18 @@ describe("FileClient", () => {
     );
   });
 
+  it("verify FileClient name matches file name", async () => {
+    const accountName = "myaccount";
+    const newClient = new ShareFileClient(
+      `https://${accountName}.file.core.windows.net/${shareName}/${dirName}/${fileName}`
+    );
+    assert.equal(
+      newClient.name,
+      fileName,
+      "FileClient name is not the same as the baseName of the provided file URI"
+    );
+  });
+
   it("create with tracing", async () => {
     const tracer = new TestTracer();
     setTracer(tracer);

--- a/sdk/storage/storage-file-share/test/node/sas.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/sas.spec.ts
@@ -189,7 +189,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
         ipRange: { start: "0.0.0.0", end: "255.255.255.255" },
         permissions: ShareSASPermissions.parse("rcwdl"),
         protocol: SASProtocol.HttpsAndHttp,
-        shareName: shareClient.shareName,
+        shareName: shareClient.name,
         startTime: now,
         version: "2018-03-28"
       },

--- a/sdk/storage/storage-file-share/test/shareclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/shareclient.spec.ts
@@ -170,7 +170,7 @@ describe("ShareClient", () => {
       assert.fail("Expecting an thrown error but didn't get one.");
     } catch (error) {
       assert.equal(
-        "Expecting non-empty strings for shareName parameter",
+        "Expecting non-empty strings for name parameter",
         error.message,
         "Error message is different than expected."
       );
@@ -201,7 +201,7 @@ describe("ShareClient", () => {
   it("verify accountName and shareName passed to the client", async () => {
     const accountName = "myaccount";
     const newClient = new ShareClient(`https://${accountName}.file.core.windows.net/` + shareName);
-    assert.equal(newClient.shareName, shareName, "Queue name is not the same as the one provided.");
+    assert.equal(newClient.name, shareName, "Queue name is not the same as the one provided.");
     assert.equal(
       newClient.accountName,
       accountName,


### PR DESCRIPTION
Addresses #5568 for file-shares

This is a breaking change.

Changes:
- Renamed `shareName` to `name` in ShareClient
- added `name` fields to FileClient and Directory client that return only the basename portion of the file path
- added basic tests
- added doc strings to path, name, and shareName fields