### PR TITLE
Add well-known issuers enum

### DIFF
--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -128,6 +128,14 @@ export interface KeyVaultCertificateWithPolicy extends KeyVaultCertificate {
 }
 
 /**
+ * Well known issuers for choosing a default
+ */
+export enum WellKnownIssuer {
+  Self = "Self",
+  Unknown = "Unknown",
+}
+
+/**
  * An interface representing a certificate's policy
  */
 export interface CertificatePolicy {
@@ -159,7 +167,7 @@ export interface CertificatePolicy {
   /**
    * Name of the referenced issuer object or reserved names; for example, 'Self' or 'Unknown'.
    */
-  issuerName?: string;
+  issuerName?: WellKnownIssuer | string;
   /**
    * Elliptic curve name. Possible values include: 'P-256', 'P-384', 'P-521', 'P-256K'
    */

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -53,6 +53,7 @@ import {
   UpdateIssuerOptions,
   UpdateCertificateOptions,
   UpdateCertificatePolicyOptions,
+  WellKnownIssuer,
   CertificateClientInterface,
   CertificatePollerOptions
 } from "./certificatesModels";
@@ -190,6 +191,7 @@ export {
   UpdateIssuerOptions,
   UpdateCertificateOptions,
   UpdateCertificatePolicyOptions,
+  WellKnownIssuer,
   X509CertificateProperties,
   logger
 };


### PR DESCRIPTION
This adds a WellKnownIssuers enum that users can use for picking default issuer values.