### PR TITLE
Remove deprecated option for prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,6 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "javascript.preferences.quoteStyle": "double",
-  "prettier.eslintIntegration": true,
   "typescript.disableAutomaticTypeAcquisition": true,
   "typescript.preferences.quoteStyle": "double",
   "git.ignoreLimitWarning": true

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "minimist": "^1.2.0",
     "npm-run-all": "^4.1.5",
     "path": "^0.12.7",
+    "prettier": "^1.16.4",
     "plugin-error": "^1.0.1",
     "ts-node": "^7.0.1",
     "typescript": "^3.2.2",


### PR DESCRIPTION
VS Code was complaining about us using a deprecated settings.json option for prettier `prettier.eslintIntegration`. 

I also added prettier to our root package.json so we control the version of prettier being used instead of defaulting to the one bundled with the extension. 

I realized that the eslint extension hasn't been working for me ever (which explains how lint errors keep creeping in), but I wasn't able to fix that as part of this PR. I filed #6155 to track that work.