### PR TITLE
Pipe through logic to disable unit tests.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,5 +1,4 @@
 parameters:
-  RunUnitTests: true
   Artifacts: []
   ServiceDirectory: not-specified
   Matrix:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,6 +1,5 @@
 parameters:
   Artifacts: []
-  RunUnitTests: ${{ coalesce(parameters.RunUnitTests, true )}}
   ServiceDirectory: not-specified
   Matrix:
     Linux_Node8:
@@ -228,47 +227,47 @@ jobs:
         displayName: "Component Detection"
 
   # Only run tests if the matrix has entries
-  - ${{ if eq(parameters.RunUnitTests, 'true') }}:
-      - job: "UnitTest"
+  - ${{ if eq(parameters.RunUnitTests, true) }}:
+    - job: "UnitTest"
 
-        strategy:
-          matrix: ${{parameters.Matrix}}
+      strategy:
+        matrix: ${{parameters.Matrix}}
 
-        pool:
-          vmImage: "$(OSVmImage)"
+      pool:
+        vmImage: "$(OSVmImage)"
 
-        variables:
-          - template: ../variables/globals.yml
+      variables:
+        - template: ../variables/globals.yml
 
-        steps:
-          - template: ../steps/common.yml
+      steps:
+        - template: ../steps/common.yml
 
-          - script: |
-              node common/scripts/install-run-rush.js install
-            displayName: "Install dependencies"
+        - script: |
+            node common/scripts/install-run-rush.js install
+          displayName: "Install dependencies"
 
-          - script: |
-              node eng/tools/rush-runner.js build --verbose
-            displayName: "Build libraries"
+        - script: |
+            node eng/tools/rush-runner.js build --verbose
+          displayName: "Build libraries"
 
-          - script: |
-              node eng/tools/rush-runner.js build:test --verbose
-            displayName: "Build test assets"
+        - script: |
+            node eng/tools/rush-runner.js build:test --verbose
+          displayName: "Build test assets"
 
-          - script: |
-              node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose
-            displayName: "Test libraries"
+        - script: |
+            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose
+          displayName: "Test libraries"
 
-          - task: PublishTestResults@2
-            inputs:
-              testResultsFiles: "**/test-results.xml"
-              testRunTitle: "$(OSName) - NodeJS - Unit Tests - [Node $(NodeVersion)]"
-            condition: succeededOrFailed()
-            displayName: "Publish NodeJS unit test results"
+        - task: PublishTestResults@2
+          inputs:
+            testResultsFiles: "**/test-results.xml"
+            testRunTitle: "$(OSName) - NodeJS - Unit Tests - [Node $(NodeVersion)]"
+          condition: succeededOrFailed()
+          displayName: "Publish NodeJS unit test results"
 
-          - task: PublishTestResults@2
-            inputs:
-              testResultsFiles: "**/test-results.browser.xml"
-              testRunTitle: "$(OSName) - Browser - Unit Tests - [Node $(NodeVersion)]"
-            condition: succeededOrFailed()
-            displayName: "Publish browser unit test results"
+        - task: PublishTestResults@2
+          inputs:
+            testResultsFiles: "**/test-results.browser.xml"
+            testRunTitle: "$(OSName) - Browser - Unit Tests - [Node $(NodeVersion)]"
+          condition: succeededOrFailed()
+          displayName: "Publish browser unit test results"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,6 +1,6 @@
 parameters:
   Artifacts: []
-  RunUnitTests: true
+  RunUnitTests: ${{ coalesce(parameters.RunUnitTests, true )}}
   ServiceDirectory: not-specified
   Matrix:
     Linux_Node8:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -227,7 +227,7 @@ jobs:
         displayName: "Component Detection"
 
   # Only run tests if the matrix has entries
-  - ${{ if eq(parameters.RunUnitTests, true) }}:
+  - ${{ if ne(parameters.RunUnitTests, false) }}:
     - job: "UnitTest"
 
       strategy:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -1,5 +1,6 @@
 parameters:
   Artifacts: []
+  RunUnitTests: true
   ServiceDirectory: not-specified
   Matrix:
     Linux_Node8:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -1,18 +1,20 @@
 parameters:
   Artifacts: []
+  RunUnitTests: true
   ServiceDirectory: not-specified
 
 stages:
-- stage: Build
-  jobs:
-  - template: ../jobs/archetype-sdk-client.yml
-    parameters:
-      ServiceDirectory: ${{parameters.ServiceDirectory}}
+  - stage: Build
+    jobs:
+      - template: ../jobs/archetype-sdk-client.yml
+        parameters:
+          ServiceDirectory: ${{parameters.ServiceDirectory}}
 
-# The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-- ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-  - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
-    parameters:
-      DependsOn: Build
-      Artifacts: ${{parameters.Artifacts}}
-      ArtifactName: packages
+  # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
+  - ? ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}
+    : - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
+        parameters:
+          DependsOn: Build
+          Artifacts: ${{parameters.Artifacts}}
+          ArtifactName: packages
+          RunUnitTests: ${{parameters.RunUnitTests}}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -1,6 +1,5 @@
 parameters:
   Artifacts: []
-  RunUnitTests: true
   ServiceDirectory: not-specified
 
 stages:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -8,6 +8,7 @@ stages:
   - template: ../jobs/archetype-sdk-client.yml
     parameters:
       ServiceDirectory: ${{parameters.ServiceDirectory}}
+      RunUnitTests: ${{parameters.RunUnitTests}}
 
 # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
 - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
@@ -16,4 +17,3 @@ stages:
       DependsOn: Build
       Artifacts: ${{parameters.Artifacts}}
       ArtifactName: packages
-      RunUnitTests: ${{parameters.RunUnitTests}}

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -4,17 +4,17 @@ parameters:
   ServiceDirectory: not-specified
 
 stages:
-  - stage: Build
-    jobs:
-      - template: ../jobs/archetype-sdk-client.yml
-        parameters:
-          ServiceDirectory: ${{parameters.ServiceDirectory}}
+- stage: Build
+  jobs:
+  - template: ../jobs/archetype-sdk-client.yml
+    parameters:
+      ServiceDirectory: ${{parameters.ServiceDirectory}}
 
-  # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ? ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}
-    : - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
-        parameters:
-          DependsOn: Build
-          Artifacts: ${{parameters.Artifacts}}
-          ArtifactName: packages
-          RunUnitTests: ${{parameters.RunUnitTests}}
+# The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
+- ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+  - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
+    parameters:
+      DependsOn: Build
+      Artifacts: ${{parameters.Artifacts}}
+      ArtifactName: packages
+      RunUnitTests: ${{parameters.RunUnitTests}}

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -33,10 +33,11 @@ pr:
     include:
       - sdk/eventhub/
 
-stages: 
+stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
     parameters:
       ServiceDirectory: eventhub
+      RunUnitTests: false
       Artifacts:
         - name: azure-event-hubs
           safeName: azureeventhubs


### PR DESCRIPTION
The EvenHubs pipelines are wasting significant amounts of time spinning up agents to run tests that are then just skipped. This plumbs through a pre-existing variable to disable unit tests so that it can be turned off for the EventHubs pipeline.