### PR TITLE
[test-utils-recorder] Add missing dev dependencies

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -76,5 +76,8 @@
     "rollup-plugin-terser": "^5.1.1",
     "rollup-plugin-visualizer": "^2.0.0",
     "tslib": "^1.9.3"
+  },
+  "devDependencies": {
+    "typescript": "~3.6.4"
   }
 }


### PR DESCRIPTION
- Missing dependencies were masked by Rush configuration which merges dependencies across packages