### PR TITLE
[KeyVault-Certificates] More clarity on the use cases of the Self issuerName

### DIFF
--- a/sdk/keyvault/keyvault-certificates/README.md
+++ b/sdk/keyvault/keyvault-certificates/README.md
@@ -176,6 +176,7 @@ const client = new CertificateClient(url, credential);
 const certificateName = "MyCertificateName";
 
 async function main() {
+  // Note: Sending `Self` as the `issuerName` of the certificate's policy will create a self-signed certificate.
   await client.beginCreateCertificate(certificateName, {
     issuerName: "Self",
     subject: "cn=MyCert"
@@ -202,6 +203,8 @@ const url = `https://${vaultName}.vault.azure.net`;
 const client = new CertificateClient(url, credential);
 
 const certificateName = "MyCertificateName";
+
+// Note: Sending `Self` as the `issuerName` of the certificate's policy will create a self-signed certificate.
 const certificatePolicy = {
   issuerName: "Self",
   subject: "cn=MyCert"
@@ -436,6 +439,7 @@ const certificateName = "MyCertificateName";
 
 async function main() {
   const result = client.getCertificate(certificateName);
+  // Note: Sending `Self` as the `issuerName` of the certificate's policy will create a self-signed certificate.
   await client.updateCertificatePolicy(certificateName, {
     issuerName: "Self",
     subject: "cn=MyCert"

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -957,6 +957,8 @@ export class CertificateClient {
    * Creates a new certificate. If this is the first version, the certificate resource is created.
    * This function returns a Long Running Operation poller that allows you to wait indefinitely until the certificate is fully recovered.
    *
+   * **Note:** Sending `Self` as the `issuerName` of the certificate's policy will create a self-signed certificate.
+   *
    * This operation requires the certificates/create permission.
    *
    * Example usage:


### PR DESCRIPTION
🌞 related to https://github.com/Azure/azure-sdk-for-js/issues/5489