### PR TITLE
[storage-file-share] naming consistency around content bodies

### DIFF
--- a/sdk/storage/storage-file-share/samples/javascript/basic.js
+++ b/sdk/storage/storage-file-share/samples/javascript/basic.js
@@ -65,7 +65,7 @@ async function main() {
 
   // Get file content from position 0 to the end
   // In Node.js, get downloaded data by accessing downloadFileResponse.readableStreamBody
-  // In browsers, get downloaded data by accessing downloadFileResponse.blobBody
+  // In browsers, get downloaded data by accessing downloadFileResponse.contentAsBlob
   const downloadFileResponse = await fileClient.download(0);
   console.log(
     `Downloaded file content${await streamToString(downloadFileResponse.readableStreamBody)}`

--- a/sdk/storage/storage-file-share/samples/typescript/basic.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/basic.ts
@@ -65,7 +65,7 @@ async function main() {
 
   // Get file content from position 0 to the end
   // In Node.js, get downloaded data by accessing downloadFileResponse.readableStreamBody
-  // In browsers, get downloaded data by accessing downloadFileResponse.blobBody
+  // In browsers, get downloaded data by accessing downloadFileResponse.contentAsBlob
   const downloadFileResponse = await fileClient.download(0);
   console.log(
     `Downloaded file content${await streamToString(downloadFileResponse.readableStreamBody!)}`

--- a/sdk/storage/storage-file-share/src/FileDownloadResponse.ts
+++ b/sdk/storage/storage-file-share/src/FileDownloadResponse.ts
@@ -411,7 +411,7 @@ export class FileDownloadResponse implements FileDownloadResponseModel {
    * @type {(Promise<Blob> | undefined)}
    * @memberof FileDownloadResponse
    */
-  public get blobBody(): Promise<Blob> | undefined {
+  public get contentAsBlob(): Promise<Blob> | undefined {
     return this.originalResponse.blobBody;
   }
 

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -829,7 +829,7 @@ export class ShareFileClient extends StorageClient {
    * Reads or downloads a file from the system, including its metadata and properties.
    *
    * * In Node.js, data returns in a Readable stream `readableStreamBody`
-   * * In browsers, data returns in a promise `blobBody`
+   * * In browsers, data returns in a promise `contentAsBlob`
    *
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-file
    *
@@ -869,7 +869,7 @@ export class ShareFileClient extends StorageClient {
    * const downloadFileResponse = await fileClient.download(0);
    * console.log(
    *   "Downloaded file content:",
-   *   await streamToString(downloadFileResponse.blobBody)}
+   *   await streamToString(downloadFileResponse.contentAsBlob)}
    * );
    *
    * // [Browser only] A helper method used to convert a browser Blob into string.

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -1260,7 +1260,7 @@ export class ShareFileClient extends StorageClient {
           abortSignal: options.abortSignal,
           contentMD5: options.contentMD5,
           onUploadProgress: options.onProgress,
-          optionalbody: body,
+          body: body,
           spanOptions
         }
       );

--- a/sdk/storage/storage-file-share/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/models/index.ts
@@ -912,7 +912,7 @@ export interface FileUploadRangeOptionalParams extends coreHttp.RequestOptionsBa
   /**
    * Initial data.
    */
-  optionalbody?: coreHttp.HttpRequestBody;
+  body?: coreHttp.HttpRequestBody;
   /**
    * The timeout parameter is expressed in seconds. For more information, see <a
    * href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting

--- a/sdk/storage/storage-file-share/src/generated/src/operations/file.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/operations/file.ts
@@ -709,10 +709,10 @@ const uploadRangeOperationSpec: coreHttp.OperationSpec = {
   requestBody: {
     parameterPath: [
       "options",
-      "optionalbody"
+      "body"
     ],
     mapper: {
-      serializedName: "optionalbody",
+      serializedName: "body",
       type: {
         name: "Stream"
       }

--- a/sdk/storage/storage-file-share/swagger/README.md
+++ b/sdk/storage/storage-file-share/swagger/README.md
@@ -246,4 +246,14 @@ directive:
       $.Expiry["x-ms-client-name"] = "expiresOn";
 ```
 
+### Rename optionalbody -> body
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.parameters.OptionalBody
+    transform: >
+      $["x-ms-client-name"] = "body";
+```
+
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fstorage%2Fstorage-file-share%2Fswagger%2FREADME.png)


### PR DESCRIPTION
Fix #6020 and #6023 

- rename the `optionalbody` parameter of file operations in the generated models to `body` using swagger transformation
- rename `blobBody` accessor to `contentAsBlob` to align with other storage clients.