### PR TITLE
[Event Hubs] fix flaky live test

### DIFF
--- a/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
+++ b/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
@@ -69,7 +69,7 @@ export class ReceivedMessagesTester implements Required<SubscriptionEventHandler
     // only.
     if (
       this.multipleConsumers &&
-      error.message.indexOf("New receiver with higher epoch of") >= 0
+      error.name === 'ReceiverDisconnectedError'
     ) {
       return;
     }


### PR DESCRIPTION
The test utility wasn't properly recognizing errors that occur when a new receiver with a `>=` ownerLevel causes another receiver to disconnect.

/cc @richardpark-msft 