### PR TITLE
[Storage Blob] Fix - Build warning "Import declaration conflicts"

### DIFF
--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -137,7 +137,6 @@ import { ETagNone } from "./utils/constants";
 import { truncatedISO8061Date } from "./utils/utils.common";
 import "@azure/core-paging";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
-import { BlockBlobUploadOptions, BlobDeleteOptions } from "./Clients";
 
 /**
  * Options to configure the {@link BlobClient.beginCopyFromURL} operation.


### PR DESCRIPTION
Not importing `BlockBlobUploadOptions` and `BlobDeleteOptions` since they are exported from the same file.

Fixes #6160 