### PR TITLE
[storage-file-share] README files for samples directories

### DIFF
--- a/.docsettings.yml
+++ b/.docsettings.yml
@@ -10,6 +10,8 @@ omitted_paths:
   - "sdk/cosmosdb/cosmos/samples/*"
   - eng/tools/versioning/*
   - samples/Bundling/**
+  - "sdk/**/samples/javascript/README.md"
+  - "sdk/**/samples/typescript/README.md"
 language: js
 root_check_enabled: True
 required_readme_sections:

--- a/.docsettings.yml
+++ b/.docsettings.yml
@@ -10,8 +10,7 @@ omitted_paths:
   - "sdk/cosmosdb/cosmos/samples/*"
   - eng/tools/versioning/*
   - samples/Bundling/**
-  - "sdk/**/samples/javascript/README.md"
-  - "sdk/**/samples/typescript/README.md"
+  - "sdk/**/samples/*/README.md"
 language: js
 root_check_enabled: True
 required_readme_sections:

--- a/common/scripts/prep-samples.js
+++ b/common/scripts/prep-samples.js
@@ -50,9 +50,9 @@ async function* findAllTsFiles(tsDir) {
   // BFS Queue and queue index
   const q = initialFiles.map(f => [f, tsDir]);
 
-  for (let idx = 0; idx !== q.length; idx++) {
+  while (q.length) {
     // [fs.Dirent, string] (file and dirName part of the full path)
-    const [entry, dirName] = q[idx];
+    const [entry, dirName] = q.shift();
     const fullPath = path.join(dirName, entry.name);
 
     if (entry.isDirectory()) {

--- a/common/scripts/prep-samples.js
+++ b/common/scripts/prep-samples.js
@@ -77,7 +77,7 @@ function enableLocalRun(file, baseDir, pkgName) {
   const depth =
     relativeDir.length - relativeDir.split(path.sep).join("").length;
 
-  const relativeImportPath = new Array(depth).fill("..").join(path.sep);
+  const relativeImportPath = new Array(depth).fill("..").join("/") + "/src";
   const updatedContents = fileContents.replace(
     sbregex,
     `import $1 from "${relativeImportPath}";`

--- a/common/scripts/prep-samples.js
+++ b/common/scripts/prep-samples.js
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+const fs = require("fs");
+const path = require("path");
+
+// Accept a base directory (package directory) as an argument or use CWD
+const args = process.argv.slice(2);
+
+let baseDir;
+if (args.length > 0) {
+  baseDir = path.resolve(args[0]);
+} else {
+  baseDir = process.cwd();
+}
+const tsDir = path.join(baseDir, "samples", "typescript");
+
+/**
+ * Breadth-first search for files ending in .ts
+ */
+function findAllTsFiles(filesAndFolders) {
+  const q = filesAndFolders.map(function(f) {
+    return [f, tsDir];
+  });
+  const tsFiles = [];
+
+  let idx = 0;
+
+  while (idx !== q.length) {
+    // [fs.Dirent, string] (file and dirName part of the full path)
+    const [file, dirName] = q[idx];
+    const fullPath = path.join(dirName, file.name);
+
+    if (file.isSymbolicLink()) {
+      continue;
+    }
+
+    if (file.isDirectory()) {
+      // Enqueue children of this directory to the bfs
+      fs.readdirSync(fullPath, { withFileTypes: true }).forEach(function(
+        child
+      ) {
+        q.push([child, fullPath]);
+      });
+    } else if (file.isFile() && file.name.match(/.*\.ts$/)) {
+      tsFiles.push(fullPath);
+    }
+
+    idx += 1;
+  }
+
+  return tsFiles;
+}
+
+/**
+ * Replaces package imports with relative imports for CI
+ *
+ * @param {string} file the name of the file to open and process
+ * @param {string} baseDir The base directory of the package
+ * @param {string} pkgName name of the package to use when looking for package-local imports
+ */
+function enableLocalRun(file, baseDir, pkgName) {
+  const fileContents = fs.readFileSync(file, { encoding: "utf-8" });
+  const sbregex = new RegExp(
+    `import\\s+(.*)\\s+from\\s+"${pkgName}";?\\s?`,
+    "s"
+  );
+  if (!fileContents.match(sbregex)) {
+    throw new Error(`Sample ${file} did not contain an import statement!`);
+  }
+
+  const relativeDir = path.dirname(file.replace(baseDir, ""));
+
+  // `string.length - string.split(path.sep).join("").length` is a dirty but well-supported way to
+  // count the depth of a path and that avoids the difficulty of creating a regexp constructor
+  // that can escape both linux and windows path separators
+  const depth =
+    relativeDir.length - relativeDir.split(path.sep).join("").length;
+
+  const relativeImportPath = new Array(depth).fill("..").join(path.sep);
+  const updatedContents = fileContents.replace(
+    sbregex,
+    `import $1 from "${relativeImportPath}";`
+  );
+
+  fs.writeFileSync(file, updatedContents, { encoding: "utf-8" });
+}
+
+function main() {
+  const package = require(path.join(baseDir, "package.json"));
+  console.log(
+    `Preparing samples for package: ${package.name}@${package.version}`
+  );
+  console.log("Package name", package.name);
+  fs.readdir(tsDir, { withFileTypes: true }, function(err, files) {
+    if (err) {
+      console.error("Failed to read TypeScript samples directory:", args[0]);
+      process.exit(1);
+    }
+
+    findAllTsFiles(files).forEach(function(fileName) {
+      console.log("Updating imports in", fileName, "...");
+      enableLocalRun(fileName, baseDir, package.name);
+    });
+  });
+}
+
+main();

--- a/common/scripts/prep-samples.js
+++ b/common/scripts/prep-samples.js
@@ -21,8 +21,21 @@
  * will completely overwrite them!
  */
 
-const fs = require("fs").promises;
+const baseFS = require("fs");
 const path = require("path");
+
+// Node >= 10 provide fs.promises, but since we're still building Node 8 for now
+// we need to use util.promisify if fs.promises doesn't exist
+const fs =
+  baseFS.promises ||
+  (() => {
+    const promisify = require("util").promisify;
+    return {
+      readdir: promisify(baseFS.readdir),
+      readFile: promisify(baseFS.readFile),
+      writeFile: promisify(baseFS.writeFile)
+    };
+  })();
 
 /**
  * Breadth-first search for files ending in .ts, starting from `tsDir`
@@ -110,7 +123,7 @@ async function main() {
   const args = process.argv.slice(2);
 
   let baseDir;
-  if (args.length > 0) {
+  if (args.length) {
     baseDir = path.resolve(args[0]);
   } else {
     baseDir = process.cwd();

--- a/common/scripts/prep-samples.js
+++ b/common/scripts/prep-samples.js
@@ -49,9 +49,8 @@ async function* findAllTsFiles(tsDir) {
 
   // BFS Queue and queue index
   const q = initialFiles.map(f => [f, tsDir]);
-  let idx = 0;
 
-  while (idx !== q.length) {
+  for (let idx = 0; idx !== q.length; idx++) {
     // [fs.Dirent, string] (file and dirName part of the full path)
     const [entry, dirName] = q[idx];
     const fullPath = path.join(dirName, entry.name);
@@ -80,8 +79,6 @@ async function* findAllTsFiles(tsDir) {
         fullPath
       );
     }
-
-    idx += 1;
   }
 
   // The full trace of files visited by the iterator is returned and can be accessed using `iter.value`

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -29,6 +29,7 @@
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-test typings temp browser/*.js* browser/*.zip statistics.html coverage coverage-browser .nyc_output *.tgz *.log test*.xml TEST*.xml",
+    "clean:samples": "rimraf samples/javascript/node_modules samples/typescript/node_modules samples/typescript/dist",
     "extract-api": "tsc -p . && api-extractor run --local",
     "execute:samples": "node execute-samples.js",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -24,7 +24,7 @@
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:js-samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
-    "build:ts-samples": "npm run clean && cd samples && tsc -p . ",
+    "build:ts-samples": "npm run clean && node ../../../common/scripts/prep-samples.js && cd samples && tsc -p . ",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",

--- a/sdk/storage/storage-file-share/samples/javascript/README.md
+++ b/sdk/storage/storage-file-share/samples/javascript/README.md
@@ -1,0 +1,68 @@
+---
+page_type: sample
+languages:
+- javascript
+products:
+- azure
+- azure-storage
+urlFragment: storage-file-share-javascript
+---
+
+# Azure Storage File Share client library samples for JavaScript
+
+These sample programs show how to use the JavaScript client libraries for Azure Storage File Shares in some common scenarios.
+
+|__File Name__|__Description__|
+|-------------|---------------|
+|[basic.js][basic]|authenticate with the service using an account name & key (or anonymously with a SAS URL), upload a file, list files and directories, and download a file to a string|
+|[withConnString.js][withConnString]|connect to and authenticate with the service using a connection string|
+|[sharedKeyCred.js][sharedKeyCred]|authenticate with the service using an account name and a shared key|
+|[anonymousCred.js][anonymousCred]|authenticate with the service anonymously using a SAS URL|
+|[proxyAuth.js][proxyAuth]|connect to the service using a proxy and authenticate with an account name & key|
+|[iterators-shares.js][iterators-shares]|connect to the service and iterate through the shares in the account|
+|[iterators-files-and-directories.js][iterators-files-and-directories]|create a few directories and iterate through them individually (using async `for await` syntax), by page, and resuming paging using a marker|
+|[iterators-handles.js][iterators-handles]|connect to the service and iterate through open handles|
+|[customPipeline.js][customPipeline]|use custom HTTP pipeline options when connecting to the service|
+|[advanced.js][advanced]|use custom logging and pipeline options, then upload a local file to a share|
+
+## Prerequisites
+
+The sample code is compatible with Node.js. The samples are compatible with Node.js >= 8.0.0, except the samples that use the async `for await` syntax. Samples that use the async `for await` syntax require a version of Node that is compatible with that syntax (>= 10.0.0).
+
+You need [an Azure subscription][freesub] and [an Azure Storage account][azstorage] to run these sample programs. Samples retrieve credentials to access the storage account from environment variables. See each individual sample for details on which environment variables it requires to function.
+
+Adapting the samples to run in the browser requires some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the client library using `npm`:
+```bash
+npm install @azure/storage-file-share
+```
+2. Copy and modify the sample code, replacing the relative `require('../../')` statements with `require('@azure/storage-file-share')`)
+3. Run the sample with the correct environment variables set, for example (cross-platform):
+```bash
+npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node basic.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[basic]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/basic.js
+[proxyAuth]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/proxyAuth.js
+[withConnString]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/withConnString.js
+[iterators-files-and-directories]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/iterators-files-and-directories.js
+[sharedKeyCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/sharedKeyCred.js
+[anonymousCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/anonymousCred.js
+[iterators-handles]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/iterators-handles.js
+[customPipeline]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/customPipeline.js
+[advanced]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/advanced.js
+[iterators-shares]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/iterators-shares.js
+
+[apiref]: https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share
+[azstorage]: https://docs.microsoft.com/azure/storage/common/storage-account-overview
+[freesub]: https://azure.microsoft.com/free/
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/README.md

--- a/sdk/storage/storage-file-share/samples/javascript/README.md
+++ b/sdk/storage/storage-file-share/samples/javascript/README.md
@@ -27,7 +27,7 @@ These sample programs show how to use the JavaScript client libraries for Azure 
 
 ## Prerequisites
 
-The sample code is compatible with Node.js. The samples are compatible with Node.js >= 8.0.0, except the samples that use the async `for await` syntax. Samples that use the async `for await` syntax require a version of Node that is compatible with that syntax (>= 10.0.0).
+The sample are compatible with Node.js >= 8.0.0, except for the samples that use the async `for await` syntax, which require Node.js >= 10.0.0.
 
 You need [an Azure subscription][freesub] and [an Azure Storage account][azstorage] to run these sample programs. Samples retrieve credentials to access the storage account from environment variables. See each individual sample for details on which environment variables it requires to function.
 
@@ -37,12 +37,11 @@ Adapting the samples to run in the browser requires some additional consideratio
 
 To run the samples using the published version of the package:
 
-1. Install the client library using `npm`:
+1. Install the dependencies using `npm`:
 ```bash
-npm install @azure/storage-file-share
+npm install
 ```
-2. Copy and modify the sample code, replacing the relative `require('../../')` statements with `require('@azure/storage-file-share')`)
-3. Run the sample with the correct environment variables set, for example (cross-platform):
+2. Run the sample with the correct environment variables set, for example (cross-platform):
 ```bash
 npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node basic.js
 ```

--- a/sdk/storage/storage-file-share/samples/javascript/advanced.js
+++ b/sdk/storage/storage-file-share/samples/javascript/advanced.js
@@ -4,7 +4,11 @@
 
 const fs = require("fs");
 const { AbortController } = require("@azure/abort-controller");
-const { AnonymousCredential, ShareServiceClient, newPipeline } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const {
+  AnonymousCredential,
+  ShareServiceClient,
+  newPipeline
+} = require("@azure/storage-file-share");
 
 // Enabling logging may help uncover useful information about failures.
 // In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`.

--- a/sdk/storage/storage-file-share/samples/javascript/anonymousCred.js
+++ b/sdk/storage/storage-file-share/samples/javascript/anonymousCred.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and SAS in main()
 */
 
-const { ShareServiceClient, AnonymousCredential } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient, AnonymousCredential } = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name and SAS

--- a/sdk/storage/storage-file-share/samples/javascript/basic.js
+++ b/sdk/storage/storage-file-share/samples/javascript/basic.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient, StorageSharedKeyCredential } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/javascript/customPipeline.js
+++ b/sdk/storage/storage-file-share/samples/javascript/customPipeline.js
@@ -2,7 +2,11 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient, StorageSharedKeyCredential, newPipeline } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const {
+  ShareServiceClient,
+  StorageSharedKeyCredential,
+  newPipeline
+} = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/javascript/iterators-files-and-directories.js
+++ b/sdk/storage/storage-file-share/samples/javascript/iterators-files-and-directories.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient, StorageSharedKeyCredential } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/javascript/iterators-handles.js
+++ b/sdk/storage/storage-file-share/samples/javascript/iterators-handles.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient, StorageSharedKeyCredential } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name, shared key, share name, and directory name.

--- a/sdk/storage/storage-file-share/samples/javascript/iterators-shares.js
+++ b/sdk/storage/storage-file-share/samples/javascript/iterators-shares.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient, StorageSharedKeyCredential } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/javascript/package.json
+++ b/sdk/storage/storage-file-share/samples/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "azure-file-share-samples-ts",
+  "name": "azure-file-share-samples-js",
   "private": true,
   "version": "0.1.0",
   "description": "Azure Storage File Share client library samples for TypeScript",
@@ -19,7 +19,7 @@
     "Storage",
     "File",
     "Node.js",
-    "TypeScript"
+    "JavaScript"
   ],
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/storage/storage-file-share/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-file-share/samples/javascript/proxyAuth.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient, StorageSharedKeyCredential } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/javascript/sharedKeyCred.js
+++ b/sdk/storage/storage-file-share/samples/javascript/sharedKeyCred.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient, StorageSharedKeyCredential } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/javascript/withConnString.js
+++ b/sdk/storage/storage-file-share/samples/javascript/withConnString.js
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-const { ShareServiceClient } = require("../.."); // Change to "@azure/storage-file-share" in your package
+const { ShareServiceClient } = require("@azure/storage-file-share");
 
 async function main() {
   // Create File Service Client from Account connection string or SAS connection string

--- a/sdk/storage/storage-file-share/samples/tsconfig.json
+++ b/sdk/storage/storage-file-share/samples/tsconfig.json
@@ -1,13 +1,8 @@
 {
-    "extends": "../tsconfig.json",
-    "compilerOptions": {
-        "module": "commonjs"
-    },
-    "include": [
-        "**/*.ts"
-    ],
-    "exclude": [
-        "../node_modules",
-        "../typings/**",
-    ]
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "include": ["typescript/**/*.ts"],
+  "exclude": ["typescript/*.json", "**/node_modules/", "../node_modules", "../typings"]
 }

--- a/sdk/storage/storage-file-share/samples/typescript/README.md
+++ b/sdk/storage/storage-file-share/samples/typescript/README.md
@@ -1,0 +1,79 @@
+---
+page_type: sample
+languages:
+- typescript
+products:
+- azure
+- azure-storage
+urlFragment: storage-file-share-typescript
+---
+
+# Azure Storage File Share client library samples for TypeScript
+
+These sample programs show how to use the TypeScript client libraries for Azure Storage File Shares in some common scenarios.
+
+|__File Name__|__Description__|
+|-------------|---------------|
+|[basic.ts][basic]|authenticate with the service using an account name & key (or anonymously with a SAS URL), upload a file, list files and directories, and download a file to a string|
+|[withConnString.ts][withConnString]|connect to and authenticate with the service using a connection string|
+|[sharedKeyCred.ts][sharedKeyCred]|authenticate with the service using an account name and a shared key|
+|[anonymousCred.ts][anonymousCred]|authenticate with the service anonymously using a SAS URL|
+|[proxyAuth.ts][proxyAuth]|connect to the service using a proxy and authenticate with an account name & key|
+|[iterators-shares.ts][iterators-shares]|connect to the service and iterate through the shares in the account|
+|[iterators-files-and-directories.ts][iterators-files-and-directories]|create a few directories and iterate through them individually (using async `for await` syntax), by page, and resuming paging using a marker|
+|[iterators-handles.ts][iterators-handles]|connect to the service and iterate through open handles|
+|[customPipeline.ts][customPipeline]|use custom HTTP pipeline options when connecting to the service|
+|[advanced.ts][advanced]|use custom logging and pipeline options, then upload a local file to a share|
+
+## Prerequisites
+
+The sample code is compatible with Node.js. The samples are compatible with Node.js >= 8.0.0, except the samples that use the async `for await` syntax. Samples that use the async `for await` syntax require a version of Node that is compatible with that syntax (>= 10.0.0).
+
+Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using
+
+```bash
+npm install -g typescript
+```
+
+You need [an Azure subscription][freesub] and [an Azure Storage account][azstorage] to run these sample programs. Samples retrieve credentials to access the storage account from environment variables. See each individual sample for details on which environment variables it requires to function.
+
+Adapting the samples to run in the browser requires some additional consideration. For details, please see the [package README][package].
+
+## Setup
+
+To run the samples using the published version of the package:
+
+1. Install the client library using `npm`:
+```bash
+npm install @azure/storage-file-share
+```
+2. Copy and modify the sample code, replacing the relative `require('../../')` statements with `require('@azure/storage-file-share')`
+3. Compile the sample
+```bash
+tsc --out basic.js basic.ts
+```
+4. Run the sample with the correct environment variables set, for example (cross-platform):
+```bash
+npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node basic.js
+```
+
+## Next Steps
+
+Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
+
+[basic]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/basic.ts
+[proxyAuth]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/proxyAuth.ts
+[withConnString]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/withConnString.ts
+[iterators-files-and-directories]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/iterators-files-and-directories.ts
+[sharedKeyCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/sharedKeyCred.ts
+[anonymousCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/anonymousCred.ts
+[iterators-handles]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/iterators-handles.ts
+[customPipeline]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/customPipeline.ts
+[advanced]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/advanced.ts
+[iterators-shares]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/iterators-shares.ts
+
+[apiref]: https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share
+[azstorage]: https://docs.microsoft.com/azure/storage/common/storage-account-overview
+[freesub]: https://azure.microsoft.com/free/
+[package]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/README.md
+[typescript]: https://www.typescriptlang.org/docs/home.html

--- a/sdk/storage/storage-file-share/samples/typescript/README.md
+++ b/sdk/storage/storage-file-share/samples/typescript/README.md
@@ -47,7 +47,7 @@ To run the samples using the published version of the package:
 ```bash
 npm install @azure/storage-file-share
 ```
-2. Copy and modify the sample code, replacing the relative `require('../../')` statements with `require('@azure/storage-file-share')`
+2. Copy and modify the sample code, replacing the relative `import { ... } from '../../src'` statements with `import { ... } from '@azure/storage-file-share'`
 3. Compile the sample
 ```bash
 tsc --out basic.js basic.ts

--- a/sdk/storage/storage-file-share/samples/typescript/README.md
+++ b/sdk/storage/storage-file-share/samples/typescript/README.md
@@ -20,14 +20,14 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 |[anonymousCred.ts][anonymousCred]|authenticate with the service anonymously using a SAS URL|
 |[proxyAuth.ts][proxyAuth]|connect to the service using a proxy and authenticate with an account name & key|
 |[iterators-shares.ts][iterators-shares]|connect to the service and iterate through the shares in the account|
-|[iterators-files-and-directories.ts][iterators-files-and-directories]|create a few directories and iterate through them individually (using async `for await` syntax), by page, and resuming paging using a marker|
+|[iterators-files-and-directories.ts][iterators-files-and-directories]|create a few directories and iterate through them individually (using async `for await` syntax), by page, and resume paging using a marker|
 |[iterators-handles.ts][iterators-handles]|connect to the service and iterate through open handles|
 |[customPipeline.ts][customPipeline]|use custom HTTP pipeline options when connecting to the service|
 |[advanced.ts][advanced]|use custom logging and pipeline options, then upload a local file to a share|
 
 ## Prerequisites
 
-The sample code is compatible with Node.js. The samples are compatible with Node.js >= 8.0.0, except the samples that use the async `for await` syntax. Samples that use the async `for await` syntax require a version of Node that is compatible with that syntax (>= 10.0.0).
+The samples are compatible with Node.js >= 8.0.0, except for the samples that use the async `for await` syntax, which require a Node.js >= 10.0.0.
 
 Before running the samples in Node, they must be compiled to JavaScript using the TypeScript compiler. For more information on TypeScript, see the [TypeScript documentation][typescript]. Install the TypeScript compiler using
 
@@ -43,18 +43,17 @@ Adapting the samples to run in the browser requires some additional consideratio
 
 To run the samples using the published version of the package:
 
-1. Install the client library using `npm`:
+1. Install the dependencies using `npm`:
 ```bash
-npm install @azure/storage-file-share
+npm install
 ```
-2. Copy and modify the sample code, replacing the relative `import { ... } from '../../src'` statements with `import { ... } from '@azure/storage-file-share'`
-3. Compile the sample
+2. Compile the samples
 ```bash
-tsc --out basic.js basic.ts
+npm run build
 ```
-4. Run the sample with the correct environment variables set, for example (cross-platform):
+3. Run the sample with the correct environment variables set, for example (cross-platform):
 ```bash
-npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node basic.js
+npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node dist/basic.js
 ```
 
 ## Next Steps

--- a/sdk/storage/storage-file-share/samples/typescript/advanced.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/advanced.ts
@@ -4,7 +4,7 @@
 
 import fs from "fs";
 import { AbortController } from "@azure/abort-controller";
-import { AnonymousCredential, ShareServiceClient, newPipeline } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { AnonymousCredential, ShareServiceClient, newPipeline } from "@azure/storage-file-share";
 
 async function main() {
   // Fill in following settings before running this sample

--- a/sdk/storage/storage-file-share/samples/typescript/anonymousCred.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/anonymousCred.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and SAS in main()
 */
 
-import { ShareServiceClient, AnonymousCredential } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { ShareServiceClient, AnonymousCredential } from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name and SAS

--- a/sdk/storage/storage-file-share/samples/typescript/basic.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/basic.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { ShareServiceClient, StorageSharedKeyCredential } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/customPipeline.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/customPipeline.ts
@@ -2,7 +2,11 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { newPipeline, ShareServiceClient, StorageSharedKeyCredential } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import {
+  newPipeline,
+  ShareServiceClient,
+  StorageSharedKeyCredential
+} from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/iterators-files-and-directories.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/iterators-files-and-directories.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { ShareServiceClient, StorageSharedKeyCredential } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/iterators-handles.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/iterators-handles.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { ShareServiceClient, StorageSharedKeyCredential } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name, shared key, share name, and directory name.

--- a/sdk/storage/storage-file-share/samples/typescript/iterators-shares.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/iterators-shares.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { ShareServiceClient, StorageSharedKeyCredential } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/package.json
+++ b/sdk/storage/storage-file-share/samples/typescript/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "azure-file-share-samples",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Azure Storage File Share client library samples for TypeScript",
+  "engine": {
+    "node": ">=8.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prebuild": "rimraf dist/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
+  },
+  "keywords": [
+    "Azure",
+    "Storage",
+    "File",
+    "Node.js",
+    "TypeScript",
+    "Browser"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
+  "sideEffects": false,
+  "dependencies": {
+    "@azure/abort-controller": "^1.0.0",
+    "@azure/storage-file-share": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^8.0.0",
+    "rimraf": "^3.0.0",
+    "typescript": "~3.6.4"
+  }
+}

--- a/sdk/storage/storage-file-share/samples/typescript/proxyAuth.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/proxyAuth.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { StorageSharedKeyCredential, ShareServiceClient } from "../../src"; // Change to "@azure/storage-blob" in your package
+import { StorageSharedKeyCredential, ShareServiceClient } from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name and shared key
@@ -20,7 +20,12 @@ async function main() {
       // proxy can either be a URL like "http://localhost:3128"
       // or
       // an option bag consisting {host, port, username, password }
-      proxyOptions: { host: "http://localhost", port: 3128, username: "username", password: "password" }
+      proxyOptions: {
+        host: "http://localhost",
+        port: 3128,
+        username: "username",
+        password: "password"
+      }
       // if proxy is undefined, the library tries to load the proxy settings from the environment variables like HTTP_PROXY
     }
   );

--- a/sdk/storage/storage-file-share/samples/typescript/sharedKeyCred.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/sharedKeyCred.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { ShareServiceClient, StorageSharedKeyCredential } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-file-share";
 
 async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/tsconfig.json
+++ b/sdk/storage/storage-file-share/samples/typescript/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+
+    "lib": ["dom", "dom.iterable", "esnext.asynciterable"],
+
+    "allowSyntheticDefaultImports": true,
+
+    "outDir": "dist"
+  },
+  "include": ["**/*.ts"]
+}

--- a/sdk/storage/storage-file-share/samples/typescript/tsconfig.json
+++ b/sdk/storage/storage-file-share/samples/typescript/tsconfig.json
@@ -8,6 +8,5 @@
     "allowSyntheticDefaultImports": true,
 
     "outDir": "dist"
-  },
-  "include": ["**/*.ts"]
+  }
 }

--- a/sdk/storage/storage-file-share/samples/typescript/withConnString.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/withConnString.ts
@@ -2,7 +2,7 @@
  Setup: Enter your storage account name and shared key in main()
 */
 
-import { ShareServiceClient } from "../../src"; // Change to "@azure/storage-file-share" in your package
+import { ShareServiceClient } from "@azure/storage-file-share";
 
 async function main() {
   // Create File Service Client from Account connection string or SAS connection string


### PR DESCRIPTION
Addresses #5679 for file-shares.

I'm starting here and getting some feedback before I proceed to the rest of the packages. I'll want to add similar files for all the packages that are GA or that are going GA. I'll leave some comments on the files below with some open questions for anyone with input.

We need to have README files in each of the packages' `samples/typescript` and `samples/javascript` folders (with YAML front-matter configured like this) in order for our sample code to be ingested to docs.microsoft.com/samples

This is, to the best of my knowledge, the recommended formatting.

CC @kaerm @ramya-rao-a 