### PR TITLE
[event hubs] forward detached errors to user error handler (2.x)

### DIFF
--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -2,6 +2,9 @@
 
 - Errors thrown in the user-provided message and error handlers to `client.receive` are now properly caught and logged by the library. [PR 5781](https://github.com/Azure/azure-sdk-for-js/pull/5781)
 - Ensures that stale receivers no longer accumulate when recovering from failures while receiving. [PR 5781](https://github.com/Azure/azure-sdk-for-js/pull/5781)
+- Errors that arise from receivers failing to automatically reconnect after encountering a transient issue now triggers the user-provided `onError` callback passed to `client.receive()`.
+  When this occurs, it is recommended to restart the receiver.
+  [PR 6126](https://github.com/Azure/azure-sdk-for-js/pull/6216)
 
 ### 2019-07-15 2.1.1
 

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -498,6 +498,24 @@ export class EventHubReceiver extends LinkEntity {
         this.address,
         err
       );
+      if (typeof this._onError === "function") {
+        log.error(
+          "[%s] Unable to automatically reconnect Receiver '%s' with address '%s'. " +
+            "Invoking user-defined error handler.",
+          this._context.connectionId,
+          this.name,
+          this.address
+        );
+        try {
+          this._onError(err);
+        } catch (err) {
+          log.error(
+            "[%s] User-code error in error handler called after disconnect: %O",
+            this._context.connectionId,
+            err
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
When an event hubs receiver encounters a transient issue, it closes the link and attempts to create a new one.

Currently, if the receiver's attempt to recreate the link fails and it exhausts its retries, the user is never notified.

This change causes the user-provided error handler to be invoked with the final error that is thrown when the receiver fails to reconnect. At this point, the user can decide whether to restart their receiver by calling `client.receive()` again.