### PR TITLE
[Event Hubs] Fix for sequence number = 0 bug. 

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -329,7 +329,7 @@ export class EventProcessor {
       partitionProcessor.partitionManager = this._partitionManager;
       partitionProcessor.eventProcessorId = this.id;
 
-      const eventPosition = ownershipRequest.sequenceNumber
+      const eventPosition = ownershipRequest.sequenceNumber != null
         ? EventPosition.fromSequenceNumber(ownershipRequest.sequenceNumber)
         : (this._processorOptions.defaultEventPosition || EventPosition.earliest());
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobPartitionManager.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobPartitionManager.ts
@@ -50,9 +50,9 @@ export class BlobPartitionManager implements PartitionManager {
           consumerGroupName,
           ownerId: blob.metadata!.ownerid,
           partitionId: blobName,
-          offset: blob.metadata && blob.metadata.offset ? parseInt(blob.metadata.offset) : -1,
+          offset: blob.metadata && blob.metadata.offset != null ? parseInt(blob.metadata.offset) : -1,
           sequenceNumber:
-            blob.metadata && blob.metadata.sequencenumber
+            blob.metadata && blob.metadata.sequencenumber != null
               ? parseInt(blob.metadata.sequencenumber)
               : -1,
           lastModifiedTimeInMS:
@@ -87,8 +87,8 @@ export class BlobPartitionManager implements PartitionManager {
           updatedBlobResponse = await blobClient.setMetadata(
             {
               OwnerId: ownership.ownerId ? ownership.ownerId : "",
-              SequenceNumber: ownership.sequenceNumber ? ownership.sequenceNumber.toString() : "",
-              Offset: ownership.offset ? ownership.offset.toString() : ""
+              SequenceNumber: ownership.sequenceNumber != null ? ownership.sequenceNumber.toString() : "",
+              Offset: ownership.offset != null ? ownership.offset.toString() : ""
             },
             {
               conditions: {
@@ -101,8 +101,8 @@ export class BlobPartitionManager implements PartitionManager {
           updatedBlobResponse = await blockBlobClient.upload("", 0, {
             metadata: {
               OwnerId: ownership.ownerId,
-              SequenceNumber: ownership.sequenceNumber ? ownership.sequenceNumber.toString() : "",
-              Offset: ownership.offset ? ownership.offset.toString() : ""
+              SequenceNumber: ownership.sequenceNumber != null ? ownership.sequenceNumber.toString() : "",
+              Offset: ownership.offset != null ? ownership.offset.toString() : ""
             },
             conditions: {
               ifNoneMatch: "*"


### PR DESCRIPTION
This PR is meant to fix [this issue](https://github.com/Azure/azure-sdk-for-js/issues/6235) in which you can find all the details.

- **@azure/event-hubs**
Falsy value of offset and sequence number (`= 0`) are causing the `EventProcessor` to set the wrong `eventPosition` that is falledback to the defaultEventPosition or `EventPosition.earliest()`.
Checking for the `!= null`, instead (which both cover `undefined` and `null`).
Version of library and `changelog.md` were not updated on purpose since the [current version](https://github.com/Azure/azure-sdk-for-js/blob/aab5b7b79d771ed2780a0beaf04bd9d3ace800ca/sdk/eventhub/event-hubs/package.json#L4) pushed in the code is `5.0.0-preview.7` but the published [next version](https://www.npmjs.com/package/@azure/event-hubs/v/5.0.0-preview.6) is `next: 5.0.0-preview.6`.

- **@azure/eventhubs-checkpointstore-blob**
Falsy value of offset and sequence number were causing the checkpoint to be listed with `-1` and to be claimed with empty string `""`, when calling the `bobClient.setMetadata`. 
Version of library and `changelog.md` were not updated on purpose since the [current version](https://github.com/Azure/azure-sdk-for-js/blob/aab5b7b79d771ed2780a0beaf04bd9d3ace800ca/sdk/eventhub/eventhubs-checkpointstore-blob/package.json#L4) pushed in the code is `1.0.0-preview.5` but the published [next version](https://www.npmjs.com/package/@azure/eventhubs-checkpointstore-blob/v/1.0.0-preview.4) is `next: 1.0.0-preview.4`.