### PR TITLE
Pin dependency @azure/event-hubs to 2.1.1

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -45,6 +45,6 @@
     // TODO: Remove this once Service Bus is updated to use current depenedencies as part of Track 2
     "rhea-promise": ["^0.1.15"],
     // Following is required to allow for backward compatibility with Event Processor Host Track 1
-    "@azure/event-hubs": ["^2.1.1"]
+    "@azure/event-hubs": ["2.1.1"]
   }
 }

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -59,7 +59,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "^2.1.1",
+    "@azure/event-hubs": "2.1.1",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "async-lock": "^1.1.3",
     "azure-storage": "^2.10.2",

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -33,7 +33,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "^2.1.1",
+    "@azure/event-hubs": "2.1.1",
     "@azure/event-processor-host": "^2.0.0",
     "@types/node": "^8.0.0",
     "@types/uuid": "^3.4.3",


### PR DESCRIPTION
- 2.1.2 causes a type-related build break in event-processor-host