### PR TITLE
Update dev dependency cross-env

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -84,7 +84,7 @@ dependencies:
   chai-as-promised: 7.1.1_chai@4.2.0
   chai-exclude: 2.0.2_chai@4.2.0
   chai-string: 1.5.0_chai@4.2.0
-  cross-env: 5.2.1
+  cross-env: 6.0.3
   death: 1.1.0
   debug: 4.1.1
   delay: 4.3.0
@@ -2899,15 +2899,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==
-  /cross-env/5.2.1:
+  /cross-env/6.0.3:
     dependencies:
-      cross-spawn: 6.0.5
+      cross-spawn: 7.0.1
     dev: false
     engines:
-      node: '>=4.0'
+      node: '>=8.0'
     hasBin: true
     resolution:
-      integrity: sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==
+      integrity: sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
   /cross-spawn/4.0.2:
     dependencies:
       lru-cache: 4.1.5
@@ -2927,6 +2927,16 @@ packages:
       node: '>=4.8'
     resolution:
       integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+  /cross-spawn/7.0.1:
+    dependencies:
+      path-key: 3.1.0
+      shebang-command: 2.0.0
+      which: 2.0.2
+    dev: false
+    engines:
+      node: '>= 8'
+    resolution:
+      integrity: sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
   /crypt/0.0.2:
     dev: false
     resolution:
@@ -6843,6 +6853,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+  /path-key/3.1.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==
   /path-parse/1.0.6:
     dev: false
     resolution:
@@ -7946,12 +7962,26 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+  /shebang-command/2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   /shebang-regex/1.0.0:
     dev: false
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+  /shebang-regex/3.0.0:
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
   /shell-quote/1.7.2:
     dev: false
     resolution:
@@ -9313,6 +9343,15 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  /which/2.0.2:
+    dependencies:
+      isexe: 2.0.0
+    dev: false
+    engines:
+      node: '>= 8'
+    hasBin: true
+    resolution:
+      integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   /wide-align/1.1.3:
     dependencies:
       string-width: 2.1.1
@@ -9620,7 +9659,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       delay: 4.3.0
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
@@ -9656,7 +9695,7 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-vq32byoYU1GdZkU375cSImKJYVOePeP1pOhXI0R5XJQNsZ5U2fSMQ+w9lGHL8Z0YyCYZF4fTLn1Li10FYt8/Hw==
+      integrity: sha512-1lyiB2fJMPLay+bH152ImpKOa7qH3wsLWzRFILKV2N2fNLBWWihvSyYJ3xHPZSaZHBAeLAkpMzqT77uFD7yV6w==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/app-configuration.tgz':
@@ -9707,7 +9746,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       dotenv: 8.2.0
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
@@ -9737,7 +9776,7 @@ packages:
     dev: false
     name: '@rush-temp/cognitiveservices-inkrecognizer'
     resolution:
-      integrity: sha512-U7Rr8GPAvLnHLZAjXoX4AFcIV3R8qUrN6TKmQseCL3iHCSX26eq+iIrp6cJOcHA1Wwr8xv2FraCN/2F3GhCw/w==
+      integrity: sha512-hGCl74dd3rV2pUhx36FQ+oWMXNBND0K826h0qnXavV3Q2pNnj7rn/5GacAx3IOW8sqMWPxqWKyR+O/sy2l8ZMA==
       tarball: 'file:projects/cognitiveservices-inkrecognizer.tgz'
     version: 0.0.0
   'file:projects/core-amqp.tgz':
@@ -9761,7 +9800,7 @@ packages:
       buffer: 5.4.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       debug: 4.1.1
       dotenv: 8.2.0
       eslint: 6.6.0
@@ -9805,7 +9844,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-2V6jK50h1jRr0omxehfLC8abvhC8ziYREgyVHkNAUfljt52WAcyKqwk2e09L1HmUhbKhAPjJB9y5x3S2GXKWgg==
+      integrity: sha512-VoYlW67HppUC8dfvi6dit+pL9bSGWO4UKAKs0zKMe7CM4Sz7oPkWwv4Z+u27tMyEwbeZFQtXjfrRKXx0JP+rWg==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-arm.tgz':
@@ -9873,7 +9912,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
       eslint-plugin-no-null: 1.0.2_eslint@6.6.0
@@ -9898,7 +9937,7 @@ packages:
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-Mi4XMZedM942t+wD127Q53mBkshIa1woFf+QX6LlALN8PmWH1O0sbs3RNWpGM9Q0Krzt915PiW0WBAzfxfhQkA==
+      integrity: sha512-snFw5OdRCGILIO7TWVXMs8Sgh2nUNsmeinXejgCyD6OeyJ5cKih72SUQPkepjQQWsil6+OnwLK/aF091e7LGCg==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -10074,7 +10113,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
       eslint-plugin-no-null: 1.0.2_eslint@6.6.0
@@ -10099,7 +10138,7 @@ packages:
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-g+agYdAkEOCgLzAk/C1E9eKwPJRXYcU+ZxSA4bqfvVlOu5AGJUyK6802dcq9SsK+XhAvyrFSi4T7gXg2CsUjBA==
+      integrity: sha512-KVYz3UtzalzYhvKVRo+bGCaF5iensC+QUNOI8WFLQzgNYkHrzrGNNB/Nta1W45x3ZcKny8BRFRQyPA3UDwTSVw==
       tarball: 'file:projects/core-tracing.tgz'
     version: 0.0.0
   'file:projects/cosmos.tgz':
@@ -10121,7 +10160,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/eslint-plugin-tslint': 2.3.3_b59d477ade0dc5a661ef52efd8e8a8ce
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       debug: 4.1.1
       dotenv: 8.2.0
       eslint: 6.6.0
@@ -10170,7 +10209,7 @@ packages:
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-Cjnn87ZZ45smbLU/hnRqvOLIf9qmJzByJJN8QlShKJUX6PlbRPW+aCAPCyFpK8q16yPsuE2jQPqs2PUPeAQhHg==
+      integrity: sha512-Ldz1lk6Ainqv8jMnS8lnVe9Cdri/3kfMAbrAgzB4BfcLXJ1l0ouK66GF2O5STN0pJYOYWSoTf1aJnerwGXzrfg==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/event-hubs.tgz':
@@ -10198,7 +10237,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       debug: 4.1.1
       dotenv: 8.2.0
       eslint: 6.6.0
@@ -10246,7 +10285,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-u+j2bMazEviir7kVOcgiMTaCNB+CjiU3LFSlwIy5pNyN5MuQ83rE+/QbHk9B3tp7J8+ZoAwhOBI52nnVzYmD2w==
+      integrity: sha512-LIiZF7IRd/CqHSiUQUy27VK1O/DhLkZ0Eboxe19cB+PHVX6u82QEbv4DDiFgGysIuYsrT997zqWecceqGjXrrw==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -10273,7 +10312,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       debug: 4.1.1
       dotenv: 8.2.0
       eslint: 6.6.0
@@ -10303,7 +10342,7 @@ packages:
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-82ztfWI+NQcRDVlMOFfpcIbJ3lFUFDffNF6TwK4ihkTDFMEqvXitDqpKDRxPmrBZfyWGsXNDPFRa2nNzKG6Ifg==
+      integrity: sha512-kjSTJgdyaXbmKzGSS/ysTm7HLPfi8GWehWPwj4x0RjAoK+45mWnfmTrV1b9qcfNj41ahQBjn1WGv5y5EmsYU8A==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
@@ -10325,7 +10364,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       debug: 4.1.1
       dotenv: 8.2.0
       eslint: 6.6.0
@@ -10368,7 +10407,7 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-zi+qRDj6YNL1sPjrb9uiKyk9wPnnEPw6pa3lpIVSwxz4Qmmk3RLSoGoVucJICit7MP1RKupeR2rykxUs8ZCNyg==
+      integrity: sha512-enI+IvVw0MXRjPbOf5W3nWC583MXgxcuQfp4gteaPEf6A6sO3JcI5UY5CE1Z3Q5tvtgQfd25juW692xMxg26/g==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -10386,7 +10425,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       eslint: 6.6.0
       events: 3.0.0
       express: 4.17.1
@@ -10425,7 +10464,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-7j0cGF9vW9AVnQ3mIDtNnG3G9oJzmMO5B4/9m5oCZFQ41LxS6zfCVJAdcmyzaD1HsVUj1uwJyBnDJ/5Ud8YkMQ==
+      integrity: sha512-wRLV57VlgStdwZFJg8s6yYU9H588rLI9s6UoqsE8NttIsfZqIvTW09n0bpBrIQ29oE3DvakUr6IkTYa3KOYSoA==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -10444,7 +10483,7 @@ packages:
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       dotenv: 8.2.0
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
@@ -10489,7 +10528,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-Uc5+CAhws2IFMb8/OQ7CO/vq/0FDcQDOKFTgLk/tCd9z2envJCRmfkLurq7qUmGoYSAU3S6RnxEfStk+5GqSig==
+      integrity: sha512-+/OmUB2nmMacsoulRge8tkqeWQhCEcGGHCOuxfwDY79FRqk1lNn4pGKJgTVpzxXIH4C5cQq+sqcWmY0P7g/pbg==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
@@ -10507,7 +10546,7 @@ packages:
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       dotenv: 8.2.0
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
@@ -10552,7 +10591,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-9e1vLe3+dw9dHfCtEteEIrrqGYTfiTOoohlGCrvvHSP6ADS0ZwsUKmk5TVSs23g8aik20Rny1chjo3Hqu9wCUQ==
+      integrity: sha512-XfsAXsPNw7R9bsB931isYsjEk5dMvgDEJBugM3kSsww3UQn+UUGVqL/HkPRR7+05tWk+oIRwWZKT2ng4H+Rfyw==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -10570,7 +10609,7 @@ packages:
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       dotenv: 8.2.0
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
@@ -10615,7 +10654,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-Nz60gNFNprLVzS/jEYe1frnbnSO9Xv/vhYzD1OKFazPYhBfXV45igsUM4oU8eJ83Mr03Ohdp366tY+OvPv6t7A==
+      integrity: sha512-NMA150XH22WsJU8QT1UYPBSBK8yKpV5pY1WbXVd3rVoxl0IZXMJb/WwLI1/HNKeOoDyl1CNL3vZ8/nvLPVL4lg==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/logger.tgz':
@@ -10630,7 +10669,7 @@ packages:
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       delay: 4.3.0
       dotenv: 8.2.0
       eslint: 6.6.0
@@ -10669,7 +10708,7 @@ packages:
     dev: false
     name: '@rush-temp/logger'
     resolution:
-      integrity: sha512-2SfjSFfgiCyrtoTF9tYyDG1wEfW6KuzYcK45S2vi/IK+xKY38QMgDh0iHmlChSKffOVwWjnYCdAWR1DK2LhfSw==
+      integrity: sha512-K7OaVgBoaArNZiUNxyjgTvpXQehD4augCKX/2OGtapxzeljL1ZeLiB4B8U89HRIYl5l2RGh2l4YyS1HqkNS35w==
       tarball: 'file:projects/logger.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -10698,7 +10737,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-exclude: 2.0.2_chai@4.2.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       debug: 4.1.1
       delay: 4.3.0
       dotenv: 8.2.0
@@ -10748,7 +10787,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-/epHuRnXaf+587V04Kjb9g9i5/LWn2Mxda+IQga72RlI69XNKaGWH7758Z8+11gvb4G3UMD9UarixECDORaKXA==
+      integrity: sha512-3Wkms6oDNcREfLKPmSH1YwUycJR0jKaBiXTp6z//ZoZTKEF59KPn/LhTzkmMQe6C7IPHnLeXDajkCLSpzgx5Dg==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
@@ -10765,7 +10804,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       dotenv: 8.2.0
       es6-promise: 4.2.8
       eslint: 6.6.0
@@ -10816,7 +10855,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-fQ/p5pc71u+94DJiL0uiRypUivCNP4TFoSyEdIM5mjuw+JgdbFA8zCrW1y/lhRY1SfXBirU8YyVriTMlrvHTQA==
+      integrity: sha512-1G9DUSpB1u0UPZKCMkCBrsURKYrNQXhot1clpDv3QOEgMJVwxFNvZnLnIKfJhvCWhDzVVwtZ4+r8anpnlx+hfQ==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file-share.tgz':
@@ -10832,7 +10871,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       dotenv: 8.2.0
       es6-promise: 4.2.8
       eslint: 6.6.0
@@ -10883,7 +10922,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-A44ZxYfU/CANhwA/TADhi75lXM0iA0ymN7E3aKqU6XYRUxLUGC9ZovegGIpunAyKqKV930g9wdO3m8Xf2PMn+A==
+      integrity: sha512-T2WS22PU1tXuPXWf3MjE99wzvdc2ZkUvsGclA/621Q4Vx6xcfC60soa5vTZoWhsuOsyI8bZK/fWX6bjKVDhO3w==
       tarball: 'file:projects/storage-file-share.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -10899,7 +10938,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       dotenv: 8.2.0
       es6-promise: 4.2.8
       eslint: 6.6.0
@@ -10949,7 +10988,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-Jc1F7PC/5nhnpaLthRrPupxDmfzjlDVyIlDv+HEVefn95A6MriOKQI3SUgB/qPrboF1MjEjrN/DOi3y6/Efk7A==
+      integrity: sha512-u+8AhdtDwb1+q5Pwc7HhmpG3zQf1rEmrvcIxb11YsNdTBbeKHQK+Ook8EC9mDVXDMbl+X7/27WVX7TkdIPgP4A==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
@@ -10963,7 +11002,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.8.0_892bab88de961f0b2a7f511a2fa40150
       '@typescript-eslint/parser': 2.8.0_eslint@6.6.0+typescript@3.6.4
       assert: 1.5.0
-      cross-env: 5.2.1
+      cross-env: 6.0.3
       eslint: 6.6.0
       eslint-config-prettier: 6.7.0_eslint@6.6.0
       eslint-plugin-no-null: 1.0.2_eslint@6.6.0
@@ -11000,7 +11039,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-z0RCGVLdY7ibSCFeUpB9jMCjxR4RgXwF5C/7W+5Peg6o8b4DdJKSpYK6iDV56FBoihv8OUNyql1RDNkpzsblJw==
+      integrity: sha512-S/yTWYsDWihUSzuY0yxt/0Dl7vDXgLPGW5WGrEDyI1tn5iMvSNJOSO148fsXRQp7FyFUP5J8kjSp1GYl8f1saw==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/test-utils-recorder.tgz':
@@ -11137,7 +11176,7 @@ specifiers:
   chai-as-promised: ^7.1.1
   chai-exclude: ^2.0.2
   chai-string: ^1.5.0
-  cross-env: ^5.2.0
+  cross-env: ^6.0.3
   death: ^1.1.0
   debug: ^4.1.1
   delay: ^4.2.0

--- a/sdk/cognitiveservices/cognitiveservices-inkrecognizer/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-inkrecognizer/package.json
@@ -77,7 +77,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -74,7 +74,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "delay": "^4.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -91,7 +91,7 @@
     "assert": "^1.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -69,7 +69,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -73,7 +73,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -82,7 +82,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "delay": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -102,7 +102,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/eslint-plugin-tslint": "~2.3.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -100,7 +100,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -87,7 +87,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -85,7 +85,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "eslint": "^6.1.0",
     "express": "^4.16.3",
     "inherits": "^2.0.3",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -92,7 +92,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -92,7 +92,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -102,7 +102,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "delay": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -102,7 +102,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "es6-promise": "^4.2.5",
     "eslint": "^6.1.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -97,7 +97,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "es6-promise": "^4.2.5",
     "eslint": "^6.1.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "es6-promise": "^4.2.5",
     "eslint": "^6.1.0",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -74,7 +74,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^5.2.0",
+    "cross-env": "^6.0.3",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",


### PR DESCRIPTION
Only breaking change is dropping support for Node < 7:

https://github.com/kentcdodds/cross-env/releases/tag/v6.0.0