### PR TITLE
Update dev dependency karma-webpack

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -162,7 +162,7 @@
     "karma-rollup-preprocessor": "^7.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-typescript-es6-transform": "^4.0.0",
-    "karma-webpack": "^4.0.0-rc.6",
+    "karma-webpack": "^4.0.2",
     "mocha": "^6.2.2",
     "mocha-chrome": "^2.0.0",
     "mocha-junit-reporter": "^1.18.0",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -119,7 +119,7 @@
     "karma-mocha-reporter": "^2.2.5",
     "karma-requirejs": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
-    "karma-webpack": "^4.0.0-rc.6",
+    "karma-webpack": "^4.0.2",
     "mocha": "^6.2.2",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",


### PR DESCRIPTION
Change is effectively a no-op, since `pnpm-lock.yaml` already contains `karma-webpack@4.0.2`.  However, we prefer to use GA versions instead of previews in our `package.json` files.