### PR TITLE
Update changelogs for `@azure/core-tracing` update

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0-preview.8 (TBD)
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 # 1.0.0-preview.7 (2019-11-01)
 
 - Updated to use the latest versions of the `@azure/core-*` packages

--- a/sdk/core/core-auth/Changelog.md
+++ b/sdk/core/core-auth/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 1.0.1 - TBD
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 # 1.0.0 - 2019-10-29
 
 This release marks the general availability of the `@azure/core-auth` package.

--- a/sdk/core/core-http/Changelog.md
+++ b/sdk/core/core-http/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.1 - TBD
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 ## 1.0.0 - 2019-10-29
 
 - This release marks the general availability of the `@azure/core-http` package.

--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -1,3 +1,7 @@
+### TBD 5.0.0-preview.7
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 ### 2019-11-04 5.0.0-preview.6
 
 - Updated to use the latest version of the `@azure/core-tracing` & `@azure/core-amqp` package.
@@ -6,8 +10,8 @@
 
 `EventHubsClient` has been split into two separate clients: `EventHubProducerClient` and `EventHubConsumerClient`
 
-The `EventHubConsumerClient` provides several overloads for `subscribe` which all take event handlers rather than 
-requiring an `EventProcessor`. There are no longer any methods that directly return `ReceivedEventData` - all 
+The `EventHubConsumerClient` provides several overloads for `subscribe` which all take event handlers rather than
+requiring an `EventProcessor`. There are no longer any methods that directly return `ReceivedEventData` - all
 receiving is done via event handlers.
 
 The `EventHubProducerClient` has standardized on only providing sending via `sendBatch`.

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.1 - Coming Soon
 
 - Fixed an issue where an authorization error occurs due to wrong access token being returned by the MSI endpoint when using a user-assigned managed identity with `ManagedIdentityCredential` ([PR #6134](https://github.com/Azure/azure-sdk-for-js/pull/6134))
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 
 ## 1.0.0 - 2019-10-29
 
@@ -46,7 +47,7 @@
   - [`DeviceCodeCredential`](https://azure.github.io/azure-sdk-for-js/identity/classes/devicecodecredential.html)
   - [`InteractiveBrowserCredential`](https://azure.github.io/azure-sdk-for-js/identity/classes/interactivebrowsercredential.html)
   - [`UsernamePasswordCredential`](https://azure.github.io/azure-sdk-for-js/identity/classes/usernamepasswordcredential.html)
-- This library can now be used in the browser!  The following credential types supported in browser builds:
+- This library can now be used in the browser! The following credential types supported in browser builds:
   - `ClientSecretCredential`
   - `UsernamePasswordCredential`
   - `InteractiveBrowserCredential`

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.0.0-preview.10 (TBD)
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 ## 4.0.0-preview.9 (2019-11-04)
 
 - Updated dependencies to use the latest version of the `@azure/core-*` libraries.

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.0.1 (TBD)
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 ## 4.0.0 (2019-10-31)
 
 - This release marks the general availability of the `@azure/keyvault-keys` package.

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.0.1 (TBD)
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 ## 4.0.0 (2019-10-31)
 
 - This release marks the general availability of the `@azure/keyvault-secrets` package.

--- a/sdk/storage/storage-blob/ChangeLog.md
+++ b/sdk/storage/storage-blob/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD 12.0.1
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 ## 2019.11 12.0.0
 
 - This release marks the general availability of the `@azure/storage-blob` package.

--- a/sdk/storage/storage-file-share/ChangeLog.md
+++ b/sdk/storage/storage-file-share/ChangeLog.md
@@ -4,6 +4,7 @@
 
 - [Breaking] The default browser bundle has been removed from the npm package. Bundling your application with a bundler such as Webpack is the recommended approach to building a browser bundle. For details on how to do this, please refer to our [bundling documentation](https://aka.ms/AzureSDKBundling).
 - [Breaking] The `expiryTime` and `startTime` members of the `AccountSASSignatureValues` and `FileSASSignatureValues` types, as well as the `expiry` and `start` members of the `accessPolicy` field of the `SignedIdentifier` type, have all been renamed to `expiresOn` and `startsOn` respectively for consistency with `@azure/storage-blob` and `@azure/storage-queue`.
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 
 ## 2019.11 12.0.0-preview.6
 
@@ -13,24 +14,23 @@
   - `FileClient` becomes `ShareFileClient`
 - Bug Fix - Previous versions of `@azure/storage-file` library failed for the react-apps because of the usage of `fs.stat` method which is not available in browsers. The issue is fixed in this new release.
 - [Breaking] The custom browser and retry policies that are specific to the Storage libraries have been
-renamed to have the `Storage` prefix. [PR 5862](https://github.com/Azure/azure-sdk-for-js/pull/5862). 
-Below are the entities that now have the Storage prefix
-   - BrowserPolicy
-   - BrowserPolicyFactory
-   - RetryPolicy
-   - RetryPolicyType
-   - RetryOptions
-   - RetryPolicyFactory
+  renamed to have the `Storage` prefix. [PR 5862](https://github.com/Azure/azure-sdk-for-js/pull/5862).
+  Below are the entities that now have the Storage prefix
+  - BrowserPolicy
+  - BrowserPolicyFactory
+  - RetryPolicy
+  - RetryPolicyType
+  - RetryOptions
+  - RetryPolicyFactory
 - [Breaking] The properties in the StoragePipelineOptions interface have been updated as below:
-   - The `proxy` property of type `ProxySettings | string` has been renamed to `proxyOptions` and
- will be of type `ProxyOptions`. If you have been passing url directly, split the value into `host`
- and `port` then pass it as a json object.
-   - The `telemetry` property of type `TelemetryOptions` has been renamed to `userAgentOptions` of
- type `UserAgentOptions`.
-    - The `logger` is no longer a property available to configure. To enable logging, please see the
-[Troubleshooting](https://github.com/Azure/azure-sdk-for-js/blob/0ddc2f3c3d4658b20d96910acc37a77e5209e5e3/sdk/storage/storage-queue/README.md#troubleshooting) section of our readme.
+  - The `proxy` property of type `ProxySettings | string` has been renamed to `proxyOptions` and
+    will be of type `ProxyOptions`. If you have been passing url directly, split the value into `host`
+    and `port` then pass it as a json object.
+  - The `telemetry` property of type `TelemetryOptions` has been renamed to `userAgentOptions` of
+    type `UserAgentOptions`. - The `logger` is no longer a property available to configure. To enable logging, please see the
+    [Troubleshooting](https://github.com/Azure/azure-sdk-for-js/blob/0ddc2f3c3d4658b20d96910acc37a77e5209e5e3/sdk/storage/storage-queue/README.md#troubleshooting) section of our readme.
 - [Breaking] The `UniqueRequestIdPolicy` and `KeepAlivePolicy` are no longer exported from this library. The
- corresponding policies from the `@azure/core-http` library are meant to be used instead.
+  corresponding policies from the `@azure/core-http` library are meant to be used instead.
 - Bug Fix - Previous versions of `@azure/storage-file` library failed for the react-apps because of the usage of `fs.stat` method which is not available in browsers. The issue is fixed in this new release.
 
 ## 2019.10 12.0.0-preview.5

--- a/sdk/storage/storage-queue/ChangeLog.md
+++ b/sdk/storage/storage-queue/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## TBD 12.0.1
+
+- Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
+
 ## 2019.11 12.0.0
 
 - This release marks the general availability of the `@azure/storage-queue` package.


### PR DESCRIPTION
Add a note to unreleased packages about the recent adoption of OpenTelemetry 0.2 and upgrade of the `@azure/core-tracing` package.