### PR TITLE
[storage] removed @example from all doc comments

### DIFF
--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -274,7 +274,7 @@ export class BlobBatchClient {
    *
    * Get `blobBatchClient` and other details before running the snippets.
    * `blobServiceClient.getBlobBatchClient()` gives the `blobBatchClient`
-   * @example
+   *
    * ```js
    * let batchRequest = new BlobBatch();
    * await batchRequest.deleteBlob(urlInString0, credential0);
@@ -285,7 +285,6 @@ export class BlobBatchClient {
    * console.log(batchResp.subResponsesSucceededCount);
    * ```
    *
-   * @example
    * ```js
    * let batchRequest = new BlobBatch();
    * await batchRequest.setBlobAccessTier(blockBlobClient0, "Cool");

--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -287,7 +287,7 @@ export class BlobBatchClient {
    * console.log(batchResp.subResponsesSucceededCount);
    * ```
    *
-   * Example usage with a lease:
+   * Example using a lease:
    *
    * ```js
    * let batchRequest = new BlobBatch();

--- a/sdk/storage/storage-blob/src/BlobBatchClient.ts
+++ b/sdk/storage/storage-blob/src/BlobBatchClient.ts
@@ -275,6 +275,8 @@ export class BlobBatchClient {
    * Get `blobBatchClient` and other details before running the snippets.
    * `blobServiceClient.getBlobBatchClient()` gives the `blobBatchClient`
    *
+   * Example usage:
+   *
    * ```js
    * let batchRequest = new BlobBatch();
    * await batchRequest.deleteBlob(urlInString0, credential0);
@@ -284,6 +286,8 @@ export class BlobBatchClient {
    * const batchResp = await blobBatchClient.submitBatch(batchRequest);
    * console.log(batchResp.subResponsesSucceededCount);
    * ```
+   *
+   * Example usage with a lease:
    *
    * ```js
    * let batchRequest = new BlobBatch();

--- a/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
@@ -160,7 +160,7 @@ export interface BlobSASSignatureValues {
  * this constructor.
  *
  * Fill in the required details before running the following snippets.
- * @example
+ *
  * ```js
  * // Generate service level SAS for a container
  * const containerSAS = generateBlobSASQueryParameters({
@@ -176,7 +176,6 @@ export interface BlobSASSignatureValues {
  * ).toString();
  * ```
  *
- * @example
  * ```js
  * // Generate service level SAS for a container with identifier
  * // startsOn & permissions are optional when identifier is provided
@@ -201,8 +200,6 @@ export interface BlobSASSignatureValues {
  * ).toString();
  * ```
  *
- * // Fill in the required details before running the snippet.
- * @example
  * ```js
  * // Generate service level SAS for a blob
  * const blobSAS = generateBlobSASQueryParameters({
@@ -240,7 +237,6 @@ export function generateBlobSASQueryParameters(
  * Creates an instance of SASQueryParameters.
  * WARNING: identifier will be ignored when generating user delegation SAS, permissions and expiresOn are required.
  *
- * @example
  * ```js
  * // Generate user delegation SAS for a container
  * const userDelegationKey = await blobServiceClient.getUserDelegationKey(startsOn, expiresOn);

--- a/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
@@ -161,6 +161,8 @@ export interface BlobSASSignatureValues {
  *
  * Fill in the required details before running the following snippets.
  *
+ * Example usage:
+ *
  * ```js
  * // Generate service level SAS for a container
  * const containerSAS = generateBlobSASQueryParameters({
@@ -175,6 +177,8 @@ export interface BlobSASSignatureValues {
  *   sharedKeyCredential // StorageSharedKeyCredential - `new StorageSharedKeyCredential(account, accountKey)`
  * ).toString();
  * ```
+ *
+ * Example using an identifier:
  *
  * ```js
  * // Generate service level SAS for a container with identifier
@@ -199,6 +203,8 @@ export interface BlobSASSignatureValues {
  *   sharedKeyCredential // StorageSharedKeyCredential - `new StorageSharedKeyCredential(account, accountKey)`
  * ).toString();
  * ```
+ *
+ * Example using a blob name:
  *
  * ```js
  * // Generate service level SAS for a blob
@@ -236,6 +242,8 @@ export function generateBlobSASQueryParameters(
  *
  * Creates an instance of SASQueryParameters.
  * WARNING: identifier will be ignored when generating user delegation SAS, permissions and expiresOn are required.
+ *
+ * Example usage:
  *
  * ```js
  * // Generate user delegation SAS for a container

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -331,6 +331,8 @@ export class BlobServiceClient extends StorageClient {
    * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
    * @memberof BlobServiceClient
    *
+   * Example usage with DefaultAzureCredential from `@azure/identity`:
+   *
    * ```js
    * const account = "<storage account name>";
    *
@@ -343,6 +345,8 @@ export class BlobServiceClient extends StorageClient {
    *   defaultAzureCredential
    * );
    * ```
+   *
+   * Example usage with an account name/key:
    *
    * ```js
    * const account = "<storage account name>"
@@ -402,6 +406,8 @@ export class BlobServiceClient extends StorageClient {
    * @param {string} containerName A container name
    * @returns {ContainerClient} A new ContainerClient object for the given container name.
    * @memberof BlobServiceClient
+   *
+   * Example usage:
    *
    * ```js
    * const containerClient = blobServiceClient.getContainerClient("<container name>");
@@ -715,12 +721,16 @@ export class BlobServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the containers in pages.
    *
+   * Example usage with `for await` syntax:
+   *
    * ```js
    *   let i = 1;
    *   for await (const container of blobServiceClient.listContainers()) {
    *     console.log(`Container ${i++}: ${container.name}`);
    *   }
    * ```
+   *
+   * Example using `iter.next()`:
    *
    * ```js
    *   // Generator syntax .next()
@@ -732,6 +742,8 @@ export class BlobServiceClient extends StorageClient {
    *     containerItem = await iter.next();
    *   }
    * ```
+   *
+   * Example usage with `byPage()`:
    *
    * ```js
    *   // Example for .byPage()
@@ -745,6 +757,8 @@ export class BlobServiceClient extends StorageClient {
    *     }
    *   }
    * ```
+   *
+   * Example resuming paging using a marker:
    *
    * ```js
    *   // Passing marker as an argument (similar to the previous example)

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -331,7 +331,7 @@ export class BlobServiceClient extends StorageClient {
    * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
    * @memberof BlobServiceClient
    *
-   * Example usage with DefaultAzureCredential from `@azure/identity`:
+   * Example using DefaultAzureCredential from `@azure/identity`:
    *
    * ```js
    * const account = "<storage account name>";
@@ -346,7 +346,7 @@ export class BlobServiceClient extends StorageClient {
    * );
    * ```
    *
-   * Example usage with an account name/key:
+   * Example using an account name/key:
    *
    * ```js
    * const account = "<storage account name>"
@@ -721,7 +721,7 @@ export class BlobServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the containers in pages.
    *
-   * Example usage with `for await` syntax:
+   * Example using `for await` syntax:
    *
    * ```js
    *   let i = 1;
@@ -743,7 +743,7 @@ export class BlobServiceClient extends StorageClient {
    *   }
    * ```
    *
-   * Example usage with `byPage()`:
+   * Example using `byPage()`:
    *
    * ```js
    *   // Example for .byPage()

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -331,7 +331,6 @@ export class BlobServiceClient extends StorageClient {
    * @param {StoragePipelineOptions} [options] Optional. Options to configure the HTTP pipeline.
    * @memberof BlobServiceClient
    *
-   * @example
    * ```js
    * const account = "<storage account name>";
    *
@@ -345,7 +344,6 @@ export class BlobServiceClient extends StorageClient {
    * );
    * ```
    *
-   * @example
    * ```js
    * const account = "<storage account name>"
    * const sharedKeyCredential = new StorageSharedKeyCredential(account, "<account key>");
@@ -405,7 +403,6 @@ export class BlobServiceClient extends StorageClient {
    * @returns {ContainerClient} A new ContainerClient object for the given container name.
    * @memberof BlobServiceClient
    *
-   * @example
    * ```js
    * const containerClient = blobServiceClient.getContainerClient("<container name>");
    * ```
@@ -718,7 +715,6 @@ export class BlobServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the containers in pages.
    *
-   * @example
    * ```js
    *   let i = 1;
    *   for await (const container of blobServiceClient.listContainers()) {
@@ -726,7 +722,6 @@ export class BlobServiceClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Generator syntax .next()
    *   let i = 1;
@@ -738,7 +733,6 @@ export class BlobServiceClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
@@ -752,7 +746,6 @@ export class BlobServiceClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -336,8 +336,6 @@ export class BlobServiceClient extends StorageClient {
    * ```js
    * const account = "<storage account name>";
    *
-   * // Use a TokenCredential implementation from the @azure/identity package.
-   * // In this case, a DefaultAzureCredential (recommended for most users)
    * const defaultAzureCredential = new DefaultAzureCredential();
    *
    * const blobServiceClient = new BlobServiceClient(
@@ -724,66 +722,66 @@ export class BlobServiceClient extends StorageClient {
    * Example using `for await` syntax:
    *
    * ```js
-   *   let i = 1;
-   *   for await (const container of blobServiceClient.listContainers()) {
-   *     console.log(`Container ${i++}: ${container.name}`);
-   *   }
+   * let i = 1;
+   * for await (const container of blobServiceClient.listContainers()) {
+   *   console.log(`Container ${i++}: ${container.name}`);
+   * }
    * ```
    *
    * Example using `iter.next()`:
    *
    * ```js
-   *   // Generator syntax .next()
-   *   let i = 1;
-   *   const iter = blobServiceClient.listContainers();
-   *   let containerItem = await iter.next();
-   *   while (!containerItem.done) {
-   *     console.log(`Container ${i++}: ${containerItem.value.name}`);
-   *     containerItem = await iter.next();
-   *   }
+   * let i = 1;
+   * const iter = blobServiceClient.listContainers();
+   * let containerItem = await iter.next();
+   * while (!containerItem.done) {
+   *   console.log(`Container ${i++}: ${containerItem.value.name}`);
+   *   containerItem = await iter.next();
+   * }
    * ```
    *
    * Example using `byPage()`:
    *
    * ```js
-   *   // Example for .byPage()
-   *   // passing optional maxPageSize in the page settings
-   *   let i = 1;
-   *   for await (const response of blobServiceClient.listContainers().byPage({ maxPageSize: 20 })) {
-   *     if (response.containerItems) {
-   *       for (const container of response.containerItems) {
-   *         console.log(`Container ${i++}: ${container.name}`);
-   *       }
-   *     }
-   *   }
-   * ```
-   *
-   * Example resuming paging using a marker:
-   *
-   * ```js
-   *   // Passing marker as an argument (similar to the previous example)
-   *   let i = 1;
-   *   let iterator = blobServiceClient.listContainers().byPage({ maxPageSize: 2 });
-   *   let response = (await iterator.next()).value;
-   *   // Prints 2 container names
+   * // passing optional maxPageSize in the page settings
+   * let i = 1;
+   * for await (const response of blobServiceClient.listContainers().byPage({ maxPageSize: 20 })) {
    *   if (response.containerItems) {
    *     for (const container of response.containerItems) {
    *       console.log(`Container ${i++}: ${container.name}`);
    *     }
    *   }
-   *   // Gets next marker
-   *   let marker = response.continuationToken;
-   *   // Passing next marker as continuationToken
-   *   iterator = blobServiceClient
-   *     .listContainers()
-   *     .byPage({ continuationToken: marker, maxPageSize: 10 });
-   *   response = (await iterator.next()).value;
-   *   // Prints 10 container names
-   *   if (response.containerItems) {
-   *     for (const container of response.containerItems) {
-   *        console.log(`Container ${i++}: ${container.name}`);
-   *     }
+   * }
+   * ```
+   *
+   * Example using paging with a marker:
+   *
+   * ```js
+   * let i = 1;
+   * let iterator = blobServiceClient.listContainers().byPage({ maxPageSize: 2 });
+   * let response = (await iterator.next()).value;
+   *
+   * // Prints 2 container names
+   * if (response.containerItems) {
+   *   for (const container of response.containerItems) {
+   *     console.log(`Container ${i++}: ${container.name}`);
    *   }
+   * }
+   *
+   * // Gets next marker
+   * let marker = response.continuationToken;
+   * // Passing next marker as continuationToken
+   * iterator = blobServiceClient
+   *   .listContainers()
+   *   .byPage({ continuationToken: marker, maxPageSize: 10 });
+   * response = (await iterator.next()).value;
+   *
+   * // Prints 10 container names
+   * if (response.containerItems) {
+   *   for (const container of response.containerItems) {
+   *      console.log(`Container ${i++}: ${container.name}`);
+   *   }
+   * }
    * ```
    *
    * @param {ServiceListContainersOptions} [options={}] Options to list containers.

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1064,7 +1064,6 @@ export class BlobClient extends StorageClient {
    * @returns {Promise<BlobDownloadResponseModel>}
    * @memberof BlobClient
    *
-   * @example
    * ```js
    * // Download and convert a blob to a string (Node.js only)
    * const downloadBlockBlobResponse = await blobClient.download();
@@ -1085,7 +1084,6 @@ export class BlobClient extends StorageClient {
    * }
    * ```
    *
-   * @example
    * ```js
    * // Download and convert a blob to a string (Browser only)
    * const downloadBlockBlobResponse = await blobClient.download();
@@ -3077,7 +3075,6 @@ export class BlockBlobClient extends BlobClient {
    * @returns {Promise<BlockBlobUploadResponse>} Response data for the Block Blob Upload operation.
    * @memberof BlockBlobClient
    *
-   * @example
    * ```js
    * const content = "Hello world!";
    * const uploadBlobResponse = await blockBlobClient.upload(content, content.length);
@@ -5557,7 +5554,6 @@ export class ContainerClient extends StorageClient {
    * @returns {Promise<ContainerCreateResponse>}
    * @memberof ContainerClient
    *
-   * @example
    * ```js
    * const containerClient = blobServiceClient.getContainerClient("<container name>");
    * const createContainerResponse = await containerClient.create();
@@ -5653,7 +5649,6 @@ export class ContainerClient extends StorageClient {
    * @returns {BlockBlobClient}
    * @memberof ContainerClient
    *
-   * @example
    * ```js
    * const content = "Hello world!";
    *
@@ -6185,7 +6180,6 @@ export class ContainerClient extends StorageClient {
    *
    * // Get the containerClient before you run these snippets,
    * // Can be obtained from `blobServiceClient.getContainerClient("<your-container-name>");`
-   * @example
    * ```js
    *   let i = 1;
    *   for await (const blob of containerClient.listBlobsFlat()) {
@@ -6193,7 +6187,6 @@ export class ContainerClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Generator syntax .next()
    *   let i = 1;
@@ -6205,7 +6198,6 @@ export class ContainerClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
@@ -6217,7 +6209,6 @@ export class ContainerClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;
@@ -6365,7 +6356,6 @@ export class ContainerClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the blobs by hierarchy in pages.
    *
-   * @example
    * ```js
    *   for await (const item of containerClient.listBlobsByHierarchy("/")) {
    *     if (item.kind === "prefix") {
@@ -6376,7 +6366,6 @@ export class ContainerClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    * // Generator syntax .next() and passing a prefix
    * let iter = await containerClient.listBlobsByHierarchy("/", { prefix: "prefix1/" });
@@ -6392,7 +6381,6 @@ export class ContainerClient extends StorageClient {
    * }
    * ```js
    *
-   * @example
    * ```js
    *   // byPage()
    *   console.log("Listing blobs by hierarchy by page");
@@ -6409,7 +6397,6 @@ export class ContainerClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // 4. byPage() and passing a prefix and max page size
    *   console.log("Listing blobs by hierarchy by page, specifying a prefix and a max page size");

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1064,7 +1064,7 @@ export class BlobClient extends StorageClient {
    * @returns {Promise<BlobDownloadResponseModel>}
    * @memberof BlobClient
    *
-   * Example usage with a Node.js Buffer:
+   * Example usage (Node.js):
    *
    * ```js
    * // Download and convert a blob to a string (Node.js only)
@@ -1086,7 +1086,7 @@ export class BlobClient extends StorageClient {
    * }
    * ```
    *
-   * Example usage in a browser:
+   * Example usage (browser):
    *
    * ```js
    * // Download and convert a blob to a string (Browser only)
@@ -1487,13 +1487,15 @@ export class BlobClient extends StorageClient {
    * operation to copy from another storage account.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob
    *
-   * Example usage of automatic polling:
+   * Example using automatic polling:
+   *
    * ```js
    * const copyPoller = await blobClient.beginCopyFromURL('url');
    * const result = await copyPoller.pollUntilDone();
    * ```
    *
-   * Example usage of manual polling:
+   * Example using manual polling:
+   *
    * ```js
    * const copyPoller = await blobClient.beginCopyFromURL('url');
    * while (!poller.isDone()) {
@@ -1502,7 +1504,8 @@ export class BlobClient extends StorageClient {
    * const result = copyPoller.getResult();
    * ```
    *
-   * Example usage of progress updates:
+   * Example using progress updates:
+   *
    * ```js
    * const copyPoller = await blobClient.beginCopyFromURL('url', {
    *   onProgress(state) {
@@ -1512,7 +1515,8 @@ export class BlobClient extends StorageClient {
    * const result = await copyPoller.pollUntilDone();
    * ```
    *
-   * Example usage of changing polling interval (default 15 seconds):
+   * Example using a changing polling interval (default 15 seconds):
+   *
    * ```js
    * const copyPoller = await blobClient.beginCopyFromURL('url', {
    *   intervalInMs: 1000 // poll blob every 1 second for copy progress
@@ -1520,7 +1524,8 @@ export class BlobClient extends StorageClient {
    * const result = await copyPoller.pollUntilDone();
    * ```
    *
-   * Example usage of copy cancellation:
+   * Example using copy cancellation:
+   *
    * ```js
    * const copyPoller = await blobClient.beginCopyFromURL('url');
    * // cancel operation after starting it.
@@ -6188,7 +6193,7 @@ export class ContainerClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the blobs in pages.
    *
-   * Example usage with `for await`:
+   * Example using `for await` syntax:
    *
    * ```js
    * // Get the containerClient before you run these snippets,
@@ -6199,7 +6204,7 @@ export class ContainerClient extends StorageClient {
    * }
    * ```
    *
-   * Example usage with `iter.next()`:
+   * Example using `iter.next()`:
    *
    * ```js
    * // Generator syntax .next()
@@ -6212,7 +6217,7 @@ export class ContainerClient extends StorageClient {
    * }
    * ```
    *
-   * Example usage with `byPage()`:
+   * Example using `byPage()`:
    *
    * ```js
    * // Example for .byPage()

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1067,7 +1067,7 @@ export class BlobClient extends StorageClient {
    * Example usage (Node.js):
    *
    * ```js
-   * // Download and convert a blob to a string (Node.js only)
+   * // Download and convert a blob to a string
    * const downloadBlockBlobResponse = await blobClient.download();
    * const downloaded = await streamToString(downloadBlockBlobResponse.readableStreamBody);
    * console.log("Downloaded blob content:", downloaded);
@@ -1089,7 +1089,7 @@ export class BlobClient extends StorageClient {
    * Example usage (browser):
    *
    * ```js
-   * // Download and convert a blob to a string (Browser only)
+   * // Download and convert a blob to a string
    * const downloadBlockBlobResponse = await blobClient.download();
    * const downloaded = await blobToString(await downloadBlockBlobResponse.blobBody);
    * console.log(
@@ -6207,7 +6207,6 @@ export class ContainerClient extends StorageClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * // Generator syntax .next()
    * let i = 1;
    * let iter = containerClient.listBlobsFlat();
    * let blobItem = await iter.next();
@@ -6220,7 +6219,6 @@ export class ContainerClient extends StorageClient {
    * Example using `byPage()`:
    *
    * ```js
-   * // Example for .byPage()
    * // passing optional maxPageSize in the page settings
    * let i = 1;
    * for await (const response of containerClient.listBlobsFlat().byPage({ maxPageSize: 20 })) {
@@ -6230,22 +6228,26 @@ export class ContainerClient extends StorageClient {
    * }
    * ```
    *
-   * Example resuming paging with a marker:
+   * Example using paging with a marker:
    *
    * ```js
-   * // Passing marker as an argument (similar to the previous example)
    * let i = 1;
    * let iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 2 });
    * let response = (await iterator.next()).value;
+   *
    * // Prints 2 blob names
    * for (const blob of response.segment.blobItems) {
    *   console.log(`Blob ${i++}: ${blob.name}`);
    * }
+   *
    * // Gets next marker
    * let marker = response.continuationToken;
+   * 
    * // Passing next marker as continuationToken
+   *
    * iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });
    * response = (await iterator.next()).value;
+   *
    * // Prints 10 blob names
    * for (const blob of response.segment.blobItems) {
    *   console.log(`Blob ${i++}: ${blob.name}`);
@@ -6394,7 +6396,6 @@ export class ContainerClient extends StorageClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * // Generator syntax .next() and passing a prefix
    * let iter = await containerClient.listBlobsByHierarchy("/", { prefix: "prefix1/" });
    * let entity = await iter.next();
    * while (!entity.done) {
@@ -6411,7 +6412,6 @@ export class ContainerClient extends StorageClient {
    * Example using `byPage()`:
    *
    * ```js
-   * // byPage()
    * console.log("Listing blobs by hierarchy by page");
    * for await (const response of containerClient.listBlobsByHierarchy("/").byPage()) {
    *   const segment = response.segment;
@@ -6429,17 +6429,19 @@ export class ContainerClient extends StorageClient {
    * Example using paging with a max page size:
    *
    * ```js
-   * // 4. byPage() and passing a prefix and max page size
    * console.log("Listing blobs by hierarchy by page, specifying a prefix and a max page size");
+   *
    * let i = 1;
    * for await (const response of containerClient.listBlobsByHierarchy("/", { prefix: "prefix2/sub1/"}).byPage({ maxPageSize: 2 })) {
    *   console.log(`Page ${i++}`);
    *   const segment = response.segment;
+   *
    *   if (segment.blobPrefixes) {
    *     for (const prefix of segment.blobPrefixes) {
    *       console.log(`\tBlobPrefix: ${prefix.name}`);
    *     }
    *   }
+   *
    *   for (const blob of response.segment.blobItems) {
    *     console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
    *   }

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1064,6 +1064,8 @@ export class BlobClient extends StorageClient {
    * @returns {Promise<BlobDownloadResponseModel>}
    * @memberof BlobClient
    *
+   * Example usage with a Node.js Buffer:
+   *
    * ```js
    * // Download and convert a blob to a string (Node.js only)
    * const downloadBlockBlobResponse = await blobClient.download();
@@ -1083,6 +1085,8 @@ export class BlobClient extends StorageClient {
    *   });
    * }
    * ```
+   *
+   * Example usage in a browser:
    *
    * ```js
    * // Download and convert a blob to a string (Browser only)
@@ -3074,6 +3078,8 @@ export class BlockBlobClient extends BlobClient {
    * @param {BlockBlobUploadOptions} [options] Options to the Block Blob Upload operation.
    * @returns {Promise<BlockBlobUploadResponse>} Response data for the Block Blob Upload operation.
    * @memberof BlockBlobClient
+   *
+   * Example usage:
    *
    * ```js
    * const content = "Hello world!";
@@ -5554,6 +5560,8 @@ export class ContainerClient extends StorageClient {
    * @returns {Promise<ContainerCreateResponse>}
    * @memberof ContainerClient
    *
+   * Example usage:
+   *
    * ```js
    * const containerClient = blobServiceClient.getContainerClient("<container name>");
    * const createContainerResponse = await containerClient.create();
@@ -5648,6 +5656,8 @@ export class ContainerClient extends StorageClient {
    * @param {string} blobName A block blob name
    * @returns {BlockBlobClient}
    * @memberof ContainerClient
+   *
+   * Example usage:
    *
    * ```js
    * const content = "Hello world!";
@@ -6178,55 +6188,63 @@ export class ContainerClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the blobs in pages.
    *
+   * Example usage with `for await`:
+   *
+   * ```js
    * // Get the containerClient before you run these snippets,
    * // Can be obtained from `blobServiceClient.getContainerClient("<your-container-name>");`
-   * ```js
-   *   let i = 1;
-   *   for await (const blob of containerClient.listBlobsFlat()) {
-   *     console.log(`Blob ${i++}: ${blob.name}`);
-   *   }
+   * let i = 1;
+   * for await (const blob of containerClient.listBlobsFlat()) {
+   *   console.log(`Blob ${i++}: ${blob.name}`);
+   * }
    * ```
    *
-   * ```js
-   *   // Generator syntax .next()
-   *   let i = 1;
-   *   let iter = containerClient.listBlobsFlat();
-   *   let blobItem = await iter.next();
-   *   while (!blobItem.done) {
-   *     console.log(`Blob ${i++}: ${blobItem.value.name}`);
-   *     blobItem = await iter.next();
-   *   }
-   * ```
+   * Example usage with `iter.next()`:
    *
    * ```js
-   *   // Example for .byPage()
-   *   // passing optional maxPageSize in the page settings
-   *   let i = 1;
-   *   for await (const response of containerClient.listBlobsFlat().byPage({ maxPageSize: 20 })) {
-   *     for (const blob of response.segment.blobItems) {
-   *       console.log(`Blob ${i++}: ${blob.name}`);
-   *     }
-   *   }
+   * // Generator syntax .next()
+   * let i = 1;
+   * let iter = containerClient.listBlobsFlat();
+   * let blobItem = await iter.next();
+   * while (!blobItem.done) {
+   *   console.log(`Blob ${i++}: ${blobItem.value.name}`);
+   *   blobItem = await iter.next();
+   * }
    * ```
    *
+   * Example usage with `byPage()`:
+   *
    * ```js
-   *   // Passing marker as an argument (similar to the previous example)
-   *   let i = 1;
-   *   let iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 2 });
-   *   let response = (await iterator.next()).value;
-   *   // Prints 2 blob names
-   *   for (const blob of response.segment.blobItems) {
-   *     console.log(`Blob ${i++}: ${blob.name}`);
-   *    }
-   *   // Gets next marker
-   *   let marker = response.continuationToken;
-   *    // Passing next marker as continuationToken
-   *   iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });
-   *   response = (await iterator.next()).value;
-   *   // Prints 10 blob names
+   * // Example for .byPage()
+   * // passing optional maxPageSize in the page settings
+   * let i = 1;
+   * for await (const response of containerClient.listBlobsFlat().byPage({ maxPageSize: 20 })) {
    *   for (const blob of response.segment.blobItems) {
    *     console.log(`Blob ${i++}: ${blob.name}`);
    *   }
+   * }
+   * ```
+   *
+   * Example resuming paging with a marker:
+   *
+   * ```js
+   * // Passing marker as an argument (similar to the previous example)
+   * let i = 1;
+   * let iterator = containerClient.listBlobsFlat().byPage({ maxPageSize: 2 });
+   * let response = (await iterator.next()).value;
+   * // Prints 2 blob names
+   * for (const blob of response.segment.blobItems) {
+   *   console.log(`Blob ${i++}: ${blob.name}`);
+   * }
+   * // Gets next marker
+   * let marker = response.continuationToken;
+   * // Passing next marker as continuationToken
+   * iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });
+   * response = (await iterator.next()).value;
+   * // Prints 10 blob names
+   * for (const blob of response.segment.blobItems) {
+   *   console.log(`Blob ${i++}: ${blob.name}`);
+   * }
    * ```
    *
    * @param {ContainerListBlobsOptions} [options={}] Options to list blobs.
@@ -6356,15 +6374,19 @@ export class ContainerClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the blobs by hierarchy in pages.
    *
+   * Example using `for await` syntax:
+   *
    * ```js
-   *   for await (const item of containerClient.listBlobsByHierarchy("/")) {
-   *     if (item.kind === "prefix") {
-   *       console.log(`\tBlobPrefix: ${item.name}`);
-   *     } else {
-   *       console.log(`\tBlobItem: name - ${item.name}, last modified - ${item.properties.lastModified}`);
-   *     }
+   * for await (const item of containerClient.listBlobsByHierarchy("/")) {
+   *   if (item.kind === "prefix") {
+   *     console.log(`\tBlobPrefix: ${item.name}`);
+   *   } else {
+   *     console.log(`\tBlobItem: name - ${item.name}, last modified - ${item.properties.lastModified}`);
    *   }
+   * }
    * ```
+   *
+   * Example using `iter.next()`:
    *
    * ```js
    * // Generator syntax .next() and passing a prefix
@@ -6381,38 +6403,42 @@ export class ContainerClient extends StorageClient {
    * }
    * ```js
    *
-   * ```js
-   *   // byPage()
-   *   console.log("Listing blobs by hierarchy by page");
-   *   for await (const response of containerClient.listBlobsByHierarchy("/").byPage()) {
-   *     const segment = response.segment;
-   *     if (segment.blobPrefixes) {
-   *       for (const prefix of segment.blobPrefixes) {
-   *         console.log(`\tBlobPrefix: ${prefix.name}`);
-   *       }
-   *     }
-   *     for (const blob of response.segment.blobItems) {
-   *       console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
-   *     }
-   *   }
-   * ```
+   * Example using `byPage()`:
    *
    * ```js
-   *   // 4. byPage() and passing a prefix and max page size
-   *   console.log("Listing blobs by hierarchy by page, specifying a prefix and a max page size");
-   *   let i = 1;
-   *   for await (const response of containerClient.listBlobsByHierarchy("/", { prefix: "prefix2/sub1/"}).byPage({ maxPageSize: 2 })) {
-   *     console.log(`Page ${i++}`);
-   *     const segment = response.segment;
-   *     if (segment.blobPrefixes) {
-   *       for (const prefix of segment.blobPrefixes) {
-   *         console.log(`\tBlobPrefix: ${prefix.name}`);
-   *       }
-   *     }
-   *     for (const blob of response.segment.blobItems) {
-   *       console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
+   * // byPage()
+   * console.log("Listing blobs by hierarchy by page");
+   * for await (const response of containerClient.listBlobsByHierarchy("/").byPage()) {
+   *   const segment = response.segment;
+   *   if (segment.blobPrefixes) {
+   *     for (const prefix of segment.blobPrefixes) {
+   *       console.log(`\tBlobPrefix: ${prefix.name}`);
    *     }
    *   }
+   *   for (const blob of response.segment.blobItems) {
+   *     console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
+   *   }
+   * }
+   * ```
+   *
+   * Example using paging with a max page size:
+   *
+   * ```js
+   * // 4. byPage() and passing a prefix and max page size
+   * console.log("Listing blobs by hierarchy by page, specifying a prefix and a max page size");
+   * let i = 1;
+   * for await (const response of containerClient.listBlobsByHierarchy("/", { prefix: "prefix2/sub1/"}).byPage({ maxPageSize: 2 })) {
+   *   console.log(`Page ${i++}`);
+   *   const segment = response.segment;
+   *   if (segment.blobPrefixes) {
+   *     for (const prefix of segment.blobPrefixes) {
+   *       console.log(`\tBlobPrefix: ${prefix.name}`);
+   *     }
+   *   }
+   *   for (const blob of response.segment.blobItems) {
+   *     console.log(`\tBlobItem: name - ${blob.name}, last modified - ${blob.properties.lastModified}`);
+   *   }
+   * }
    * ```
    *
    * @param {string} delimiter The charactor or string used to define the virtual hierarchy

--- a/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
@@ -870,7 +870,6 @@ export class ShareDirectoryClient extends StorageClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * // Generator syntax .next()
    * let i = 1;
    * let iter = await directoryClient.listFilesAndDirectories();
    * let entity = await iter.next();
@@ -887,7 +886,6 @@ export class ShareDirectoryClient extends StorageClient {
    * Example using `byPage()`:
    *
    * ```js
-   * // Example for .byPage()
    * // passing optional maxPageSize in the page settings
    * let i = 1;
    * for await (const response of directoryClient
@@ -902,10 +900,9 @@ export class ShareDirectoryClient extends StorageClient {
    * }
    * ```
    *
-   * Example resuming paging using a marker:
+   * Example using paging with a marker:
    *
    * ```js
-   * // Passing marker as an argument (similar to the previous example)
    * let i = 1;
    * let iterator = directoryClient.listFilesAndDirectories().byPage({ maxPageSize: 3 });
    * let response = (await iterator.next()).value;
@@ -1078,7 +1075,6 @@ export class ShareDirectoryClient extends StorageClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * // Generator syntax .next()
    * let i = 1;
    * let iter = await dirClient.listHandles();
    * let handleItem = await iter.next();
@@ -1088,10 +1084,9 @@ export class ShareDirectoryClient extends StorageClient {
    * }
    * ```
    *
-   * Examples using `byPage()`:
+   * Example using `byPage()`:
    *
    * ```js
-   * // Example for .byPage()
    * // passing optional maxPageSize in the page settings
    * let i = 1;
    * for await (const response of dirClient.listHandles({ recursive: true }).byPage({ maxPageSize: 20 })) {
@@ -1103,10 +1098,9 @@ export class ShareDirectoryClient extends StorageClient {
    * }
    * ```
    *
-   * Example resuming paging using a marker:
+   * Example using paging with a marker:
    *
    * ```js
-   * // Passing marker as an argument (similar to the previous example)
    * let i = 1;
    * let iterator = dirClient.listHandles().byPage({ maxPageSize: 2 });
    * let response = await iterator.next();
@@ -1117,6 +1111,7 @@ export class ShareDirectoryClient extends StorageClient {
    *     console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
    *   }
    * }
+   *
    * // Gets next marker
    * let marker = response.value.continuationToken;
    *

--- a/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
@@ -499,7 +499,6 @@ export class ShareDirectoryClient extends StorageClient {
    * @returns {ShareDirectoryClient} The ShareDirectoryClient object for the given subdirectory name.
    * @memberof ShareDirectoryClient
    *
-   * @example
    * ```js
    * const directoryClient = shareClient.getDirectoryClient("<directory name>");
    * await directoryClient.create();
@@ -680,7 +679,6 @@ export class ShareDirectoryClient extends StorageClient {
    * @returns {ShareFileClient} A new ShareFileClient object for the given file name.
    * @memberof ShareFileClient
    *
-   * @example
    * ```js
    * const content = "Hello world!"
    *
@@ -852,7 +850,6 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the files and directories in pages.
    *
-   * @example
    * ```js
    *   let i = 1;
    *   for await (const entity of directoryClient.listFilesAndDirectories()) {
@@ -864,7 +861,6 @@ export class ShareDirectoryClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Generator syntax .next()
    *   let i = 1;
@@ -880,7 +876,6 @@ export class ShareDirectoryClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
@@ -897,7 +892,6 @@ export class ShareDirectoryClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;
@@ -1053,7 +1047,6 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the handles in pages.
    *
-   * @example
    * ```js
    *   let i = 1;
    *   let iter = dirClient.listHandles();
@@ -1062,7 +1055,6 @@ export class ShareDirectoryClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Generator syntax .next()
    *   let i = 1;
@@ -1074,7 +1066,6 @@ export class ShareDirectoryClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
@@ -1088,7 +1079,6 @@ export class ShareDirectoryClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;

--- a/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
@@ -499,6 +499,8 @@ export class ShareDirectoryClient extends StorageClient {
    * @returns {ShareDirectoryClient} The ShareDirectoryClient object for the given subdirectory name.
    * @memberof ShareDirectoryClient
    *
+   * Example usage:
+   *
    * ```js
    * const directoryClient = shareClient.getDirectoryClient("<directory name>");
    * await directoryClient.create();
@@ -679,6 +681,8 @@ export class ShareDirectoryClient extends StorageClient {
    * @returns {ShareFileClient} A new ShareFileClient object for the given file name.
    * @memberof ShareFileClient
    *
+   * Example usage:
+   *
    * ```js
    * const content = "Hello world!"
    *
@@ -850,74 +854,88 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the files and directories in pages.
    *
-   * ```js
-   *   let i = 1;
-   *   for await (const entity of directoryClient.listFilesAndDirectories()) {
-   *     if (entity.kind === "directory") {
-   *       console.log(`${i++} - directory\t: ${entity.name}`);
-   *     } else {
-   *       console.log(`${i++} - file\t: ${entity.name}`);
-   *     }
-   *   }
-   * ```
+   * Example using `for await` syntax:
    *
    * ```js
-   *   // Generator syntax .next()
-   *   let i = 1;
-   *   let iter = await directoryClient.listFilesAndDirectories();
-   *   let entity = await iter.next();
-   *   while (!entity.done) {
-   *     if (entity.value.kind === "directory") {
-   *       console.log(`${i++} - directory\t: ${entity.value.name}`);
-   *     } else {
-   *       console.log(`${i++} - file\t: ${entity.value.name}`);
-   *     }
-   *     entity = await iter.next();
+   * let i = 1;
+   * for await (const entity of directoryClient.listFilesAndDirectories()) {
+   *   if (entity.kind === "directory") {
+   *     console.log(`${i++} - directory\t: ${entity.name}`);
+   *   } else {
+   *     console.log(`${i++} - file\t: ${entity.name}`);
    *   }
+   * }
    * ```
    *
-   * ```js
-   *   // Example for .byPage()
-   *   // passing optional maxPageSize in the page settings
-   *   let i = 1;
-   *   for await (const response of directoryClient
-   *     .listFilesAndDirectories()
-   *     .byPage({ maxPageSize: 20 })) {
-   *     for (const fileItem of response.segment.fileItems) {
-   *       console.log(`${i++} - file\t: ${fileItem.name}`);
-   *     }
-   *     for (const dirItem of response.segment.directoryItems) {
-   *       console.log(`${i++} - directory\t: ${dirItem.name}`);
-   *     }
-   *   }
-   * ```
+   * Example using `iter.next()`:
    *
    * ```js
-   *   // Passing marker as an argument (similar to the previous example)
-   *   let i = 1;
-   *   let iterator = directoryClient.listFilesAndDirectories().byPage({ maxPageSize: 3 });
-   *   let response = (await iterator.next()).value;
-   *   // Prints 3 file and directory names
+   * // Generator syntax .next()
+   * let i = 1;
+   * let iter = await directoryClient.listFilesAndDirectories();
+   * let entity = await iter.next();
+   * while (!entity.done) {
+   *   if (entity.value.kind === "directory") {
+   *     console.log(`${i++} - directory\t: ${entity.value.name}`);
+   *   } else {
+   *     console.log(`${i++} - file\t: ${entity.value.name}`);
+   *   }
+   *   entity = await iter.next();
+   * }
+   * ```
+   *
+   * Example using `byPage()`:
+   *
+   * ```js
+   * // Example for .byPage()
+   * // passing optional maxPageSize in the page settings
+   * let i = 1;
+   * for await (const response of directoryClient
+   *   .listFilesAndDirectories()
+   *   .byPage({ maxPageSize: 20 })) {
    *   for (const fileItem of response.segment.fileItems) {
    *     console.log(`${i++} - file\t: ${fileItem.name}`);
    *   }
    *   for (const dirItem of response.segment.directoryItems) {
    *     console.log(`${i++} - directory\t: ${dirItem.name}`);
    *   }
-   *   // Gets next marker
-   *   let dirMarker = response.continuationToken;
-   *   // Passing next marker as continuationToken
-   *   iterator = directoryClient
-   *     .listFilesAndDirectories()
-   *     .byPage({ continuationToken: dirMarker, maxPageSize: 4 });
-   *   response = (await iterator.next()).value;
-   *   // Prints 10 file and directory names
-   *   for (const fileItem of response.segment.fileItems) {
-   *     console.log(`${i++} - file\t: ${fileItem.name}`);
-   *   }
-   *   for (const dirItem of response.segment.directoryItems) {
-   *     console.log(`${i++} - directory\t: ${dirItem.name}`);
-   *   }
+   * }
+   * ```
+   *
+   * Example resuming paging using a marker:
+   *
+   * ```js
+   * // Passing marker as an argument (similar to the previous example)
+   * let i = 1;
+   * let iterator = directoryClient.listFilesAndDirectories().byPage({ maxPageSize: 3 });
+   * let response = (await iterator.next()).value;
+   *
+   * // Prints 3 file and directory names
+   * for (const fileItem of response.segment.fileItems) {
+   *   console.log(`${i++} - file\t: ${fileItem.name}`);
+   * }
+   *
+   * for (const dirItem of response.segment.directoryItems) {
+   *   console.log(`${i++} - directory\t: ${dirItem.name}`);
+   * }
+   *
+   * // Gets next marker
+   * let dirMarker = response.continuationToken;
+   *
+   * // Passing next marker as continuationToken
+   * iterator = directoryClient
+   *   .listFilesAndDirectories()
+   *   .byPage({ continuationToken: dirMarker, maxPageSize: 4 });
+   * response = (await iterator.next()).value;
+   *
+   * // Prints 10 file and directory names
+   * for (const fileItem of response.segment.fileItems) {
+   *   console.log(`${i++} - file\t: ${fileItem.name}`);
+   * }
+   *
+   * for (const dirItem of response.segment.directoryItems) {
+   *   console.log(`${i++} - directory\t: ${dirItem.name}`);
+   * }
    * ```
    *
    * @param {DirectoryListFilesAndDirectoriesOptions} [options] Options to list files and directories operation.
@@ -1047,61 +1065,72 @@ export class ShareDirectoryClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the handles in pages.
    *
+   * Example using `for await` syntax:
+   *
    * ```js
-   *   let i = 1;
-   *   let iter = dirClient.listHandles();
-   *   for await (const handle of iter) {
+   * let i = 1;
+   * let iter = dirClient.listHandles();
+   * for await (const handle of iter) {
+   *   console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
+   * }
+   * ```
+   *
+   * Example using `iter.next()`:
+   *
+   * ```js
+   * // Generator syntax .next()
+   * let i = 1;
+   * let iter = await dirClient.listHandles();
+   * let handleItem = await iter.next();
+   * while (!handleItem.done) {
+   *   console.log(`Handle ${i++}: ${handleItem.value.path}, opened time ${handleItem.value.openTime}, clientIp ${handleItem.value.clientIp}`);
+   *   handleItem = await iter.next();
+   * }
+   * ```
+   *
+   * Examples using `byPage()`:
+   *
+   * ```js
+   * // Example for .byPage()
+   * // passing optional maxPageSize in the page settings
+   * let i = 1;
+   * for await (const response of dirClient.listHandles({ recursive: true }).byPage({ maxPageSize: 20 })) {
+   *   if (response.handleList) {
+   *     for (const handle of response.handleList) {
+   *       console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   * Example resuming paging using a marker:
+   *
+   * ```js
+   * // Passing marker as an argument (similar to the previous example)
+   * let i = 1;
+   * let iterator = dirClient.listHandles().byPage({ maxPageSize: 2 });
+   * let response = await iterator.next();
+   *
+   * // Prints 2 handles
+   * if (response.value.handleList) {
+   *   for (const handle of response.value.handleList) {
    *     console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
    *   }
-   * ```
+   * }
+   * // Gets next marker
+   * let marker = response.value.continuationToken;
    *
-   * ```js
-   *   // Generator syntax .next()
-   *   let i = 1;
-   *   let iter = await dirClient.listHandles();
-   *   let handleItem = await iter.next();
-   *   while (!handleItem.done) {
-   *     console.log(`Handle ${i++}: ${handleItem.value.path}, opened time ${handleItem.value.openTime}, clientIp ${handleItem.value.clientIp}`);
-   *     handleItem = await iter.next();
-   *   }
-   * ```
+   * // Passing next marker as continuationToken
+   * console.log(`    continuation`);
+   * iterator = dirClient.listHandles().byPage({ continuationToken: marker, maxPageSize: 10 });
+   * response = await iterator.next();
    *
-   * ```js
-   *   // Example for .byPage()
-   *   // passing optional maxPageSize in the page settings
-   *   let i = 1;
-   *   for await (const response of dirClient.listHandles({ recursive: true }).byPage({ maxPageSize: 20 })) {
-   *     if (response.handleList) {
-   *       for (const handle of response.handleList) {
-   *         console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
-   *       }
-   *     }
+   * // Prints 2 more handles assuming you have more than four directory/files opened
+   * if (!response.done && response.value.handleList) {
+   *   for (const handle of response.value.handleList) {
+   *     console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
    *   }
-   * ```
-   *
-   * ```js
-   *   // Passing marker as an argument (similar to the previous example)
-   *   let i = 1;
-   *   let iterator = dirClient.listHandles().byPage({ maxPageSize: 2 });
-   *   let response = await iterator.next();
-   *   // Prints 2 handles
-   *   if (response.value.handleList) {
-   *     for (const handle of response.value.handleList) {
-   *       console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
-   *     }
-   *   }
-   *   // Gets next marker
-   *   let marker = response.value.continuationToken;
-   *   // Passing next marker as continuationToken
-   *   console.log(`    continuation`);
-   *   iterator = dirClient.listHandles().byPage({ continuationToken: marker, maxPageSize: 10 });
-   *   response = await iterator.next();
-   *   // Prints 2 more handles assuming you have more than four directory/files opened
-   *   if (!response.done && response.value.handleList) {
-   *     for (const handle of response.value.handleList) {
-   *       console.log(`Handle ${i++}: ${handle.path}, opened time ${handle.openTime}, clientIp ${handle.clientIp}`);
-   *     }
-   *   }
+   * }
    * ```
    *
    * @param {DirectoryListHandlesOptions} [options] Options to list handles operation.

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -865,7 +865,7 @@ export class ShareFileClient extends StorageClient {
    * @returns {Promise<FileDownloadResponse>} Response data for the File Download operation.
    * @memberof ShareFileClient
    *
-   * Example usage in Node.js:
+   * Example usage (Node.js):
    *
    * ```js
    * // Download a file to a string (Node.js only)
@@ -890,7 +890,7 @@ export class ShareFileClient extends StorageClient {
    * }
    * ```
    *
-   * Example usage in browsers:
+   * Example usage (browsers):
    *
    * ```js
    * // Download a file to a string (Browser only)

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -795,7 +795,6 @@ export class ShareFileClient extends StorageClient {
    * @returns {Promise<FileCreateResponse>} Response data for the File Create  operation.
    * @memberof ShareFileClient
    *
-   * @example
    * ```js
    * const content = "Hello world!";
    *
@@ -864,7 +863,6 @@ export class ShareFileClient extends StorageClient {
    * @returns {Promise<FileDownloadResponse>} Response data for the File Download operation.
    * @memberof ShareFileClient
    *
-   * @example
    * ```js
    * // Download a file to a string (Node.js only)
    * const downloadFileResponse = await fileClient.download();
@@ -888,7 +886,6 @@ export class ShareFileClient extends StorageClient {
    * }
    * ```
    *
-   * @example
    * ```js
    * // Download a file to a string (Browser only)
    * const downloadFileResponse = await fileClient.download(0);
@@ -1244,7 +1241,6 @@ export class ShareFileClient extends StorageClient {
    * @returns {Promise<FileUploadRangeResponse>} Response data for the File Upload Range operation.
    * @memberof ShareFileClient
    *
-   * @example
    * ```js
    * const content = "Hello world!";
    *

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -868,14 +868,14 @@ export class ShareFileClient extends StorageClient {
    * Example usage (Node.js):
    *
    * ```js
-   * // Download a file to a string (Node.js only)
+   * // Download a file to a string
    * const downloadFileResponse = await fileClient.download();
    * console.log(
    *   "Downloaded file content:",
    *   await streamToString(downloadFileResponse.readableStreamBody)}
    * );
    *
-   * // [Node.js only] A helper method used to read a Node.js readable stream into string
+   * // A helper method used to read a Node.js readable stream into string
    * async function streamToString(readableStream) {
    *   return new Promise((resolve, reject) => {
    *     const chunks = [];
@@ -893,14 +893,14 @@ export class ShareFileClient extends StorageClient {
    * Example usage (browsers):
    *
    * ```js
-   * // Download a file to a string (Browser only)
+   * // Download a file to a string
    * const downloadFileResponse = await fileClient.download(0);
    * console.log(
    *   "Downloaded file content:",
    *   await streamToString(downloadFileResponse.contentAsBlob)}
    * );
    *
-   * // [Browser only] A helper method used to convert a browser Blob into string.
+   * // A helper method used to convert a browser Blob into string.
    * export async function blobToString(blob: Blob): Promise<string> {
    *   const fileReader = new FileReader();
    *   return new Promise<string>((resolve, reject) => {

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -795,6 +795,8 @@ export class ShareFileClient extends StorageClient {
    * @returns {Promise<FileCreateResponse>} Response data for the File Create  operation.
    * @memberof ShareFileClient
    *
+   * Example usage:
+   *
    * ```js
    * const content = "Hello world!";
    *
@@ -863,6 +865,8 @@ export class ShareFileClient extends StorageClient {
    * @returns {Promise<FileDownloadResponse>} Response data for the File Download operation.
    * @memberof ShareFileClient
    *
+   * Example usage in Node.js:
+   *
    * ```js
    * // Download a file to a string (Node.js only)
    * const downloadFileResponse = await fileClient.download();
@@ -885,6 +889,8 @@ export class ShareFileClient extends StorageClient {
    *   });
    * }
    * ```
+   *
+   * Example usage in browsers:
    *
    * ```js
    * // Download a file to a string (Browser only)
@@ -1240,6 +1246,8 @@ export class ShareFileClient extends StorageClient {
    * @param {FileUploadRangeOptions} [options={}] Options to File Upload Range operation.
    * @returns {Promise<FileUploadRangeResponse>} Response data for the File Upload Range operation.
    * @memberof ShareFileClient
+   *
+   * Example usage:
    *
    * ```js
    * const content = "Hello world!";

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -254,7 +254,6 @@ export class ShareServiceClient extends StorageClient {
    * @returns {ShareClient} The ShareClient object for the given share name.
    * @memberof ShareServiceClient
    *
-   * @example
    * ```js
    * const shareClient = serviceClient.getShareClient("<share name>");
    * await shareClient.create();
@@ -451,7 +450,6 @@ export class ShareServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the shares in pages.
    *
-   * @example
    * ```js
    *   let i = 1;
    *   for await (const share of serviceClient.listShares()) {
@@ -459,7 +457,6 @@ export class ShareServiceClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Generator syntax .next()
    *   let i = 1;
@@ -471,7 +468,6 @@ export class ShareServiceClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Example for .byPage()
    *   // passing optional maxPageSize in the page settings
@@ -485,7 +481,6 @@ export class ShareServiceClient extends StorageClient {
    *   }
    * ```
    *
-   * @example
    * ```js
    *   // Passing marker as an argument (similar to the previous example)
    *   let i = 1;

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -254,6 +254,8 @@ export class ShareServiceClient extends StorageClient {
    * @returns {ShareClient} The ShareClient object for the given share name.
    * @memberof ShareServiceClient
    *
+   * Example usage:
+   *
    * ```js
    * const shareClient = serviceClient.getShareClient("<share name>");
    * await shareClient.create();
@@ -450,12 +452,16 @@ export class ShareServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the shares in pages.
    *
+   * Example using `for await` syntax:
+   *
    * ```js
    *   let i = 1;
    *   for await (const share of serviceClient.listShares()) {
    *     console.log(`Share ${i++}: ${share.name}`);
    *   }
    * ```
+   *
+   * Example using `iter.next()`:
    *
    * ```js
    *   // Generator syntax .next()
@@ -467,6 +473,8 @@ export class ShareServiceClient extends StorageClient {
    *     shareItem = await iter.next();
    *   }
    * ```
+   *
+   * Example using `byPage`:
    *
    * ```js
    *   // Example for .byPage()
@@ -480,6 +488,8 @@ export class ShareServiceClient extends StorageClient {
    *     }
    *   }
    * ```
+   *
+   * Example resuming paging using a marker:
    *
    * ```js
    *   // Passing marker as an argument (similar to the previous example)

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -455,64 +455,65 @@ export class ShareServiceClient extends StorageClient {
    * Example using `for await` syntax:
    *
    * ```js
-   *   let i = 1;
-   *   for await (const share of serviceClient.listShares()) {
-   *     console.log(`Share ${i++}: ${share.name}`);
-   *   }
+   * let i = 1;
+   * for await (const share of serviceClient.listShares()) {
+   *   console.log(`Share ${i++}: ${share.name}`);
+   * }
    * ```
    *
    * Example using `iter.next()`:
    *
    * ```js
-   *   // Generator syntax .next()
-   *   let i = 1;
-   *   let iter = await serviceClient.listShares();
-   *   let shareItem = await iter.next();
-   *   while (!shareItem.done) {
-   *     console.log(`Share ${i++}: ${shareItem.value.name}`);
-   *     shareItem = await iter.next();
-   *   }
+   * let i = 1;
+   * let iter = await serviceClient.listShares();
+   * let shareItem = await iter.next();
+   * while (!shareItem.done) {
+   *   console.log(`Share ${i++}: ${shareItem.value.name}`);
+   *   shareItem = await iter.next();
+   * }
    * ```
    *
-   * Example using `byPage`:
+   * Example using `byPage()`:
    *
    * ```js
-   *   // Example for .byPage()
-   *   // passing optional maxPageSize in the page settings
-   *   let i = 1;
-   *   for await (const response of serviceClient.listShares().byPage({ maxPageSize: 20 })) {
-   *     if (response.shareItems) {
-   *       for (const share of response.shareItems) {
-   *         console.log(`Share ${i++}: ${share.name}`);
-   *       }
+   * // passing optional maxPageSize in the page settings
+   * let i = 1;
+   * for await (const response of serviceClient.listShares().byPage({ maxPageSize: 20 })) {
+   *   if (response.shareItems) {
+   *    for (const share of response.shareItems) {
+   *        console.log(`Share ${i++}: ${share.name}`);
    *     }
    *   }
+   * }
    * ```
    *
-   * Example resuming paging using a marker:
+   * Example using paging with a marker:
    *
    * ```js
-   *   // Passing marker as an argument (similar to the previous example)
-   *   let i = 1;
-   *   let iterator = serviceClient.listShares().byPage({ maxPageSize: 2 });
-   *   let response = (await iterator.next()).value;
-   *   // Prints 2 share names
-   *   if (response.shareItems) {
-   *     for (const share of response.shareItems) {
-   *       console.log(`Share ${i++}: ${share.name}`);
-   *     }
+   * let i = 1;
+   * let iterator = serviceClient.listShares().byPage({ maxPageSize: 2 });
+   * let response = (await iterator.next()).value;
+   *
+   * // Prints 2 share names
+   * if (response.shareItems) {
+   *   for (const share of response.shareItems) {
+   *     console.log(`Share ${i++}: ${share.name}`);
    *   }
-   *   // Gets next marker
-   *   let marker = response.continuationToken;
-   *   // Passing next marker as continuationToken
-   *   iterator = serviceClient.listShares().byPage({ continuationToken: marker, maxPageSize: 10 });
-   *   response = (await iterator.next()).value;
-   *   // Prints 10 share names
-   *   if (response.shareItems) {
-   *     for (const share of response.shareItems) {
-   *       console.log(`Share ${i++}: ${share.name}`);
-   *     }
+   * }
+   *
+   * // Gets next marker
+   * let marker = response.continuationToken;
+   *
+   * // Passing next marker as continuationToken
+   * iterator = serviceClient.listShares().byPage({ continuationToken: marker, maxPageSize: 10 });
+   * response = (await iterator.next()).value;
+   *
+   * // Prints 10 share names
+   * if (response.shareItems) {
+   *   for (const share of response.shareItems) {
+   *     console.log(`Share ${i++}: ${share.name}`);
    *   }
+   * }
    * ```
    *
    * @param {ServiceListSharesOptions} [options] Options to list shares operation.

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -583,7 +583,6 @@ export class QueueClient extends StorageClient {
    * @returns {Promise<QueueCreateResponse>} Response data for the Queue create operation.
    * @memberof QueueClient
    *
-   * @example
    * ```js
    * const queueClient = queueServiceClient.getQueueClient("<new queue name>");
    * const createQueueResponse = await queueClient.create();
@@ -616,7 +615,6 @@ export class QueueClient extends StorageClient {
    * @returns {Promise<QueueDeleteResponse>} Response data for the Queue delete operation.
    * @memberof QueueClient
    *
-   * @example
    * ```js
    * const deleteQueueResponse = await queueClient.delete();
    * console.log(
@@ -843,7 +841,6 @@ export class QueueClient extends StorageClient {
    * @returns {Promise<QueueSendMessageResponse>} Response data for the send messages operation.
    * @memberof QueueClient
    *
-   * @example
    * ```js
    * const sendMessageResponse = await queueClient.sendMessage("Hello World!");
    * console.log(
@@ -901,7 +898,6 @@ export class QueueClient extends StorageClient {
    * @returns {Promise<QueueReceiveMessageResponse>} Response data for the receive messages operation.
    * @memberof QueueClient
    *
-   * @example
    * ```js
    * const response = await queueClient.receiveMessages();
    * if (response.receivedMessageItems.length == 1) {
@@ -963,7 +959,6 @@ export class QueueClient extends StorageClient {
    * @returns {QueuePeekMessagesResponse>} Response data for the peek messages operation.
    * @memberof QueueClient
    *
-   * @example
    * ```js
    * const peekMessagesResponse = await queueClient.peekMessages();
    * console.log("The peeked message is:", peekMessagesResponse.peekedMessageItems[0].messageText);

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -583,6 +583,8 @@ export class QueueClient extends StorageClient {
    * @returns {Promise<QueueCreateResponse>} Response data for the Queue create operation.
    * @memberof QueueClient
    *
+   * Example usage:
+   *
    * ```js
    * const queueClient = queueServiceClient.getQueueClient("<new queue name>");
    * const createQueueResponse = await queueClient.create();
@@ -614,6 +616,8 @@ export class QueueClient extends StorageClient {
    * @param {QueueDeleteOptions} [options] Options to Queue delete operation.
    * @returns {Promise<QueueDeleteResponse>} Response data for the Queue delete operation.
    * @memberof QueueClient
+   *
+   * Example usage:
    *
    * ```js
    * const deleteQueueResponse = await queueClient.delete();
@@ -841,6 +845,8 @@ export class QueueClient extends StorageClient {
    * @returns {Promise<QueueSendMessageResponse>} Response data for the send messages operation.
    * @memberof QueueClient
    *
+   * Example usage:
+   *
    * ```js
    * const sendMessageResponse = await queueClient.sendMessage("Hello World!");
    * console.log(
@@ -897,6 +903,8 @@ export class QueueClient extends StorageClient {
    * @param {QueueReceiveMessageOptions} [options] Options to receive messages operation.
    * @returns {Promise<QueueReceiveMessageResponse>} Response data for the receive messages operation.
    * @memberof QueueClient
+   *
+   * Example usage:
    *
    * ```js
    * const response = await queueClient.receiveMessages();
@@ -958,6 +966,8 @@ export class QueueClient extends StorageClient {
    * @param {QueuePeekMessagesOptions} [options] Options to peek messages operation.
    * @returns {QueuePeekMessagesResponse>} Response data for the peek messages operation.
    * @memberof QueueClient
+   *
+   * Example usage:
    *
    * ```js
    * const peekMessagesResponse = await queueClient.peekMessages();

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -219,6 +219,8 @@ export class QueueServiceClient extends StorageClient {
    * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueServiceClient
    *
+   * Example usage with DefaultAzureCredential from `@azure/identity`:
+   *
    * ```js
    * const account = "<account>";
    *
@@ -231,6 +233,8 @@ export class QueueServiceClient extends StorageClient {
    *   credential
    * }
    * ```
+   *
+   * Example usage with an account name/key:
    *
    * ```js
    * const account = "<account>";
@@ -295,6 +299,8 @@ export class QueueServiceClient extends StorageClient {
    * @param {string} queueName
    * @returns {QueueClient} a new QueueClient
    * @memberof QueueServiceClient
+   *
+   * Example usage:
    *
    * ```js
    * const queueClient = queueServiceClient.getQueueClient("<new queue name>");
@@ -397,63 +403,72 @@ export class QueueServiceClient extends StorageClient {
    * under the specified account.
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
-   * ```js
-   *    let i = 1;
-   *    for await (const item of queueServiceClient.listQueues()) {
-   *      console.log(`Queue${i}: ${item.name}`);
-   *      i++;
-   *    }
-   * ```
+   *
+   * Example usage with `for/await` syntax:
    *
    * ```js
-   *    // Generator syntax .next()
-   *    let i = 1;
-   *    let iterator = queueServiceClient.listQueues();
-   *    let item = await iterator.next();
-   *    while (!item.done) {
-   *      console.log(`Queue${i}: ${iterator.value.name}`);
-   *      i++;
-   *      item = await iterator.next();
-   *    }
+   * let i = 1;
+   * for await (const item of queueServiceClient.listQueues()) {
+   *   console.log(`Queue${i}: ${item.name}`);
+   *   i++;
+   * }
    * ```
    *
-   * ```js
-   *    // Example for .byPage()
-   *    // passing optional maxPageSize in the page settings
-   *    let i = 1;
-   *    for await (const item2 of queueServiceClient.listQueues().byPage({ maxPageSize: 20 })) {
-   *      if (item2.queueItems) {
-   *        for (const queueItem of item2.queueItems) {
-   *          console.log(`Queue${i}: ${queueItem.name}`);
-   *          i++;
-   *        }
-   *      }
-   *    }
-   * ```
+   * Example using `iter.next()`:
    *
    * ```js
-   *    let i = 1;
-   *    let iterator = queueServiceClient.listQueues().byPage({ maxPageSize: 2 });
-   *    let item = (await iterator.next()).value;
-   *    // Prints 2 queue names
-   *    if (item.queueItems) {
-   *      for (const queueItem of item.queueItems) {
-   *        console.log(`Queue${i}: ${queueItem.name}`);
-   *        i++;
-   *      }
-   *    }
-   *    // Gets next marker
-   *    let marker = item.continuationToken;
-   *    // Passing next marker as continuationToken
-   *    iterator = queueServiceClient.listQueues().byPage({ continuationToken: marker, maxPageSize: 10 });
-   *    item = (await iterator.next()).value;
-   *    // Prints 10 queue names
-   *    if (item.queueItems) {
-   *      for (const queueItem of item.queueItems) {
-   *        console.log(`Queue${i}: ${queueItem.name}`);
-   *        i++;
-   *      }
-   *    }
+   * // Generator syntax .next()
+   * let i = 1;
+   * let iterator = queueServiceClient.listQueues();
+   * let item = await iterator.next();
+   * while (!item.done) {
+   *   console.log(`Queue${i}: ${iterator.value.name}`);
+   *   i++;
+   *   item = await iterator.next();
+   * }
+   * ```
+   *
+   * Example using `byPage()`:
+   *
+   * ```js
+   * // Example for .byPage()
+   * // passing optional maxPageSize in the page settings
+   * let i = 1;
+   * for await (const item2 of queueServiceClient.listQueues().byPage({ maxPageSize: 20 })) {
+   *   if (item2.queueItems) {
+   *     for (const queueItem of item2.queueItems) {
+   *       console.log(`Queue${i}: ${queueItem.name}`);
+   *       i++;
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   * Example resuming paging using a marker:
+   *
+   * ```js
+   * let i = 1;
+   * let iterator = queueServiceClient.listQueues().byPage({ maxPageSize: 2 });
+   * let item = (await iterator.next()).value;
+   * // Prints 2 queue names
+   * if (item.queueItems) {
+   *   for (const queueItem of item.queueItems) {
+   *     console.log(`Queue${i}: ${queueItem.name}`);
+   *     i++;
+   *   }
+   * }
+   * // Gets next marker
+   * let marker = item.continuationToken;
+   * // Passing next marker as continuationToken
+   * iterator = queueServiceClient.listQueues().byPage({ continuationToken: marker, maxPageSize: 10 });
+   * item = (await iterator.next()).value;
+   * // Prints 10 queue names
+   * if (item.queueItems) {
+   *   for (const queueItem of item.queueItems) {
+   *     console.log(`Queue${i}: ${queueItem.name}`);
+   *     i++;
+   *   }
+   * }
    * ```
    *
    * @param {ServiceListQueuesOptions} [options] Options to list queues operation.

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -224,8 +224,6 @@ export class QueueServiceClient extends StorageClient {
    * ```js
    * const account = "<account>";
    *
-   * // Use a TokenCredential implementation from the @azure/identity package.
-   * // In this case, a DefaultAzureCredential (recommended for most users)
    * const credential = new DefaultAzureCredential();
    *
    * const queueServiceClient = new QueueServiceClient(
@@ -404,7 +402,7 @@ export class QueueServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
    *
-   * Example using `for/await` syntax:
+   * Example using `for await` syntax:
    *
    * ```js
    * let i = 1;
@@ -417,7 +415,6 @@ export class QueueServiceClient extends StorageClient {
    * Example using `iter.next()`:
    *
    * ```js
-   * // Generator syntax .next()
    * let i = 1;
    * let iterator = queueServiceClient.listQueues();
    * let item = await iterator.next();
@@ -431,7 +428,6 @@ export class QueueServiceClient extends StorageClient {
    * Example using `byPage()`:
    *
    * ```js
-   * // Example for .byPage()
    * // passing optional maxPageSize in the page settings
    * let i = 1;
    * for await (const item2 of queueServiceClient.listQueues().byPage({ maxPageSize: 20 })) {
@@ -444,7 +440,7 @@ export class QueueServiceClient extends StorageClient {
    * }
    * ```
    *
-   * Example resuming paging using a marker:
+   * Example using paging with a marker:
    *
    * ```js
    * let i = 1;

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -219,7 +219,6 @@ export class QueueServiceClient extends StorageClient {
    * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueServiceClient
    *
-   * @example
    * ```js
    * const account = "<account>";
    *
@@ -233,7 +232,6 @@ export class QueueServiceClient extends StorageClient {
    * }
    * ```
    *
-   * @example
    * ```js
    * const account = "<account>";
    *
@@ -298,7 +296,6 @@ export class QueueServiceClient extends StorageClient {
    * @returns {QueueClient} a new QueueClient
    * @memberof QueueServiceClient
    *
-   * @example
    * ```js
    * const queueClient = queueServiceClient.getQueueClient("<new queue name>");
    * const createQueueResponse = await queueClient.create();
@@ -400,7 +397,6 @@ export class QueueServiceClient extends StorageClient {
    * under the specified account.
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
-   * @example
    * ```js
    *    let i = 1;
    *    for await (const item of queueServiceClient.listQueues()) {
@@ -409,7 +405,6 @@ export class QueueServiceClient extends StorageClient {
    *    }
    * ```
    *
-   * @example
    * ```js
    *    // Generator syntax .next()
    *    let i = 1;
@@ -422,7 +417,6 @@ export class QueueServiceClient extends StorageClient {
    *    }
    * ```
    *
-   * @example
    * ```js
    *    // Example for .byPage()
    *    // passing optional maxPageSize in the page settings
@@ -437,7 +431,6 @@ export class QueueServiceClient extends StorageClient {
    *    }
    * ```
    *
-   * @example
    * ```js
    *    let i = 1;
    *    let iterator = queueServiceClient.listQueues().byPage({ maxPageSize: 2 });

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -219,7 +219,7 @@ export class QueueServiceClient extends StorageClient {
    * @param {StoragePipelineOptions} [options] Options to configure the HTTP pipeline.
    * @memberof QueueServiceClient
    *
-   * Example usage with DefaultAzureCredential from `@azure/identity`:
+   * Example using DefaultAzureCredential from `@azure/identity`:
    *
    * ```js
    * const account = "<account>";
@@ -234,7 +234,7 @@ export class QueueServiceClient extends StorageClient {
    * }
    * ```
    *
-   * Example usage with an account name/key:
+   * Example using an account name/key:
    *
    * ```js
    * const account = "<account>";
@@ -404,7 +404,7 @@ export class QueueServiceClient extends StorageClient {
    *
    * .byPage() returns an async iterable iterator to list the queues in pages.
    *
-   * Example usage with `for/await` syntax:
+   * Example using `for/await` syntax:
    *
    * ```js
    * let i = 1;
@@ -450,6 +450,7 @@ export class QueueServiceClient extends StorageClient {
    * let i = 1;
    * let iterator = queueServiceClient.listQueues().byPage({ maxPageSize: 2 });
    * let item = (await iterator.next()).value;
+   * 
    * // Prints 2 queue names
    * if (item.queueItems) {
    *   for (const queueItem of item.queueItems) {
@@ -459,9 +460,11 @@ export class QueueServiceClient extends StorageClient {
    * }
    * // Gets next marker
    * let marker = item.continuationToken;
+   * 
    * // Passing next marker as continuationToken
    * iterator = queueServiceClient.listQueues().byPage({ continuationToken: marker, maxPageSize: 10 });
    * item = (await iterator.next()).value;
+   *
    * // Prints 10 queue names
    * if (item.queueItems) {
    *   for (const queueItem of item.queueItems) {


### PR DESCRIPTION
Per previous discussions and reasoning outlined in #5997 

Removed `@example` from doc comments leaving only the code fences so they will render inline on docs.microsoft.com