### PR TITLE
[identity] Update dev dependency "open"

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -141,7 +141,7 @@ dependencies:
   node-fetch: 2.6.0
   npm-run-all: 4.1.5
   nyc: 14.1.1
-  open: 6.4.0
+  open: 7.0.0
   os-name: 3.1.0
   path-browserify: 1.0.0
   prettier: 1.19.1
@@ -6578,6 +6578,14 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==
+  /open/7.0.0:
+    dependencies:
+      is-wsl: 2.1.1
+    dev: false
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==
   /optimist/0.6.1:
     dependencies:
       minimist: 0.0.10
@@ -10458,7 +10466,7 @@ packages:
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
       msal: 1.1.3
-      open: 6.4.0
+      open: 7.0.0
       prettier: 1.19.1
       puppeteer: 2.0.0
       qs: 6.9.1
@@ -10477,7 +10485,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-K60XC9rbU6jib8oHXnDYgWAzr5kg+p+wSE5lpPdhzuuVaTeVpFNUJIlUIEyF0vtosvfs0diqkTb/3q0ReUC81Q==
+      integrity: sha512-ePTSSn5QTHILN8SwFksg5nB2WsKMZnKhimjZlxQzKB3L9MdLMfFnJAqExvMJDKm/OSg9tzuqI5YAH0ccsRsmoQ==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -11243,7 +11251,7 @@ specifiers:
   node-fetch: ^2.6.0
   npm-run-all: ^4.1.5
   nyc: ^14.0.0
-  open: ^6.4.0
+  open: ^7.0.0
   os-name: ^3.1.0
   path-browserify: ^1.0.0
   prettier: ^1.16.4

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -113,7 +113,7 @@
     "mocha": "^6.2.2",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
-    "open": "^6.4.0",
+    "open": "^7.0.0",
     "prettier": "^1.16.4",
     "puppeteer": "^2.0.0",
     "rimraf": "^3.0.0",

--- a/sdk/identity/identity/samples/authorizationCodeSample.ts
+++ b/sdk/identity/identity/samples/authorizationCodeSample.ts
@@ -90,7 +90,7 @@ async function getCredential(): Promise<AuthorizationCodeCredential> {
   // using a Location header (web apps and APIs).
   const authenticateUrl = getAuthorizeUrl(tenantId!, clientId!, scopes);
   console.log("Opening user's browser to URL:", authenticateUrl);
-  await open(authenticateUrl, { url: true });
+  await open(authenticateUrl);
 
   // Wait for the authorization response to be send to the redirect URI
   const authorizationCode = await authCodePromise;

--- a/sdk/identity/identity/samples/authorizationCodeSample.ts
+++ b/sdk/identity/identity/samples/authorizationCodeSample.ts
@@ -90,7 +90,7 @@ async function getCredential(): Promise<AuthorizationCodeCredential> {
   // using a Location header (web apps and APIs).
   const authenticateUrl = getAuthorizeUrl(tenantId!, clientId!, scopes);
   console.log("Opening user's browser to URL:", authenticateUrl);
-  await open(authenticateUrl);
+  await open(authenticateUrl, { url: true });
 
   // Wait for the authorization response to be send to the redirect URI
   const authorizationCode = await authCodePromise;


### PR DESCRIPTION
@daviwil: Note the code change to the sample, as recommended by the docs for `open@7.0.0`:

> Correctly handle URL and path escaping on Windows (#146) 7ef15d2
> If you use open with URLs, you'll want to use the new {url: true} option.
> 
> https://github.com/sindresorhus/open/releases/tag/v7.0.0

How can I validate the change to this sample?  Do any of our pipelines run the sample, or does it need to be run manually?