### PR TITLE
[storage] Add warning about limits of Node.js buffer sizes to documentation

### DIFF
--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1682,6 +1682,10 @@ export class BlobClient extends StorageClient {
    * Downloads an Azure Blob in parallel to a buffer.
    * Offset and count are optional, downloads the entire blob if they are not provided.
    *
+   * Warning: Buffers can only support files up to about one gigabyte on 32-bit systems or about two
+   * gigabytes on 64-bit systems due to limitations of Node.js/V8. For blobs larger than this size,
+   * consider {@link downloadToFile}.
+   *
    * @export
    * @param {number} offset From which position of the block blob to download(in bytes)
    * @param {number} [count] How much data(in bytes) to be downloaded. Will download to the end when passing undefined
@@ -1699,6 +1703,10 @@ export class BlobClient extends StorageClient {
    *
    * Downloads an Azure Blob in parallel to a buffer.
    * Offset and count are optional, downloads the entire blob if they are not provided.
+   *
+   * Warning: Buffers can only support files up to about one gigabyte on 32-bit systems or about two
+   * gigabytes on 64-bit systems due to limitations of Node.js/V8. For blobs larger than this size,
+   * consider {@link downloadToFile}.
    *
    * @export
    * @param {Buffer} buffer Buffer to be fill, must have length larger than count

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -966,11 +966,13 @@ export class ShareFileClient extends StorageClient {
           //   }, options: ${JSON.stringify(updatedOptions)}`
           // );
 
-          return (await this.context.download({
-            abortSignal: options.abortSignal,
-            ...updatedOptions,
-            spanOptions
-          })).readableStreamBody!;
+          return (
+            await this.context.download({
+              abortSignal: options.abortSignal,
+              ...updatedOptions,
+              spanOptions
+            })
+          ).readableStreamBody!;
         },
         offset,
         res.contentLength!,
@@ -1767,6 +1769,10 @@ export class ShareFileClient extends StorageClient {
    * Downloads an Azure file in parallel to a buffer.
    * Offset and count are optional, pass 0 for both to download the entire file.
    *
+   * Warning: Buffers can only support files up to about one gigabyte on 32-bit systems or about two
+   * gigabytes on 64-bit systems due to limitations of Node.js/V8. For files larger than this size,
+   * consider {@link downloadToFile}.
+   *
    * @param {Buffer} buffer Buffer to be fill, must have length larger than count
    * @param {number} offset From which position of the Azure File to download
    * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined
@@ -1785,6 +1791,10 @@ export class ShareFileClient extends StorageClient {
    *
    * Downloads an Azure file in parallel to a buffer.
    * Offset and count are optional, pass 0 for both to download the entire file
+   *
+   * Warning: Buffers can only support files up to about one gigabyte on 32-bit systems or about two
+   * gigabytes on 64-bit systems due to limitations of Node.js/V8. For files larger than this size,
+   * consider {@link downloadToFile}.
    *
    * @param {number} offset From which position of the Azure file to download
    * @param {number} [count] How much data to be downloaded. Will download to the end when passing undefined


### PR DESCRIPTION
Address #6213

Just adds a couple of lines to the `downloadToBuffer` docs explaining Buffer limitations and referencing `downloadToFile` as an alternative if size is a consideration.