### PR TITLE
[Cosmos] Improve error for mixed type orderby

### DIFF
--- a/sdk/cosmosdb/cosmos/changelog.md
+++ b/sdk/cosmosdb/cosmos/changelog.md
@@ -1,6 +1,7 @@
 ## 3.5.1
 
 - Fix bug when paginating GROUP BY queries or using in conjunction with TOP/OFFSET/LIMIT (#6003)
+- Improve error message for mixed type ORDER BY (#6306)
 
 ## 3.5.0
 

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByDocumentProducerComparator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByDocumentProducerComparator.ts
@@ -35,9 +35,9 @@ const TYPEORDCOMPARATOR: {
 
 /** @hidden */
 export class OrderByDocumentProducerComparator {
-  constructor(public sortOrder: string[]) {} // TODO: This should be an enum
+  constructor(public sortOrder: string[]) { } // TODO: This should be an enum
 
-  public targetPartitionKeyRangeDocProdComparator(
+  private targetPartitionKeyRangeDocProdComparator(
     docProd1: DocumentProducer,
     docProd2: DocumentProducer
   ) {
@@ -109,45 +109,43 @@ export class OrderByDocumentProducerComparator {
     return compFunc(item1, item2);
   }
 
-  public compareOrderByItem(orderByItem1: any, orderByItem2: any) {
+  private compareOrderByItem(orderByItem1: any, orderByItem2: any) {
     const type1 = this.getType(orderByItem1);
     const type2 = this.getType(orderByItem2);
     return this.compareValue(orderByItem1["item"], type1, orderByItem2["item"], type2);
   }
 
-  public validateOrderByItems(res1: string[], res2: string[]) {
-    this._throwIf(res1.length !== res2.length, `Expected ${res1.length}, but got ${res2.length}.`);
-    this._throwIf(
-      res1.length !== this.sortOrder.length,
-      "orderByItems cannot have a different size than sort orders."
-    );
+  private validateOrderByItems(res1: string[], res2: string[]) {
+    if (res1.length !== res2.length) {
+      throw new Error(`Expected ${res1.length}, but got ${res2.length}.`);
+    }
+    if (res1.length !== this.sortOrder.length) {
+      throw new Error("orderByItems cannot have a different size than sort orders.");
+    }
 
     for (let i = 0; i < this.sortOrder.length; i++) {
       const type1 = this.getType(res1[i]);
       const type2 = this.getType(res2[i]);
-      this._throwIf(type1 !== type2, `Expected ${type1}, but got ${type2}.`);
+      if (type1 !== type2) {
+        throw new Error(`Expected ${type1}, but got ${type2}.Cannot execute cross partition order - by queries on mix types.Consider filtering your query using IS_STRING / IS_NUMBER to get around this exception.`);
+      }
     }
   }
 
-  public getType(orderByItem: any) {
+  private getType(orderByItem: any) {
     // TODO: any item?
     if (orderByItem === undefined || orderByItem.item === undefined) {
       return "NoValue";
     }
     const type = typeof orderByItem.item;
-    this._throwIf(TYPEORDCOMPARATOR[type] === undefined, `unrecognizable type ${type}`);
+    if (TYPEORDCOMPARATOR[type] === undefined) {
+      throw new Error(`unrecognizable type ${type}`);
+    }
     return type;
   }
 
-  public getOrderByItems(res: any) {
+  private getOrderByItems(res: any) {
     // TODO: any res?
     return res["orderByItems"];
-  }
-
-  // TODO: this should be done differently...
-  public _throwIf(condition: boolean, msg: string) {
-    if (condition) {
-      throw Error(msg);
-    }
   }
 }

--- a/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByDocumentProducerComparator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryExecutionContext/orderByDocumentProducerComparator.ts
@@ -127,7 +127,7 @@ export class OrderByDocumentProducerComparator {
       const type1 = this.getType(res1[i]);
       const type2 = this.getType(res2[i]);
       if (type1 !== type2) {
-        throw new Error(`Expected ${type1}, but got ${type2}.Cannot execute cross partition order - by queries on mix types.Consider filtering your query using IS_STRING / IS_NUMBER to get around this exception.`);
+        throw new Error(`Expected ${type1}, but got ${type2}. Cannot execute cross partition order-by queries on mixed types. Consider filtering your query using IS_STRING or IS_NUMBER to get around this exception.`);
       }
     }
   }

--- a/sdk/cosmosdb/cosmos/src/request/StatusCodes.ts
+++ b/sdk/cosmosdb/cosmos/src/request/StatusCodes.ts
@@ -37,7 +37,7 @@ export const StatusCode = {
 /**
  * @ignore
  */
-export type StatusCode = (typeof StatusCode)[keyof typeof StatusCode];
+export type StatusCode = typeof StatusCode[keyof typeof StatusCode];
 
 /**
  * @ignore
@@ -58,4 +58,4 @@ export const SubStatusCode = {
   WriteForbidden: 3
 };
 
-export type SubStatusCode = (typeof SubStatusCode)[keyof typeof SubStatusCode];
+export type SubStatusCode = typeof SubStatusCode[keyof typeof SubStatusCode];

--- a/sdk/cosmosdb/cosmos/test/functional/sproc.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/sproc.spec.ts
@@ -120,10 +120,11 @@ describe("NodeJS CRUD Tests", function() {
       const sproc2: StoredProcedureDefinition = {
         id: "storedProcedure2",
         body: function() {
-          for (let i = 0; i < 10; i++)
-            {getContext()
+          for (let i = 0; i < 10; i++) {
+            getContext()
               .getResponse()
-              .appendValue("Body", i);}
+              .appendValue("Body", i);
+          }
         }
       };
 

--- a/sdk/cosmosdb/cosmos/test/integration/crossPartition.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/integration/crossPartition.spec.ts
@@ -87,7 +87,10 @@ describe("Cross Partition", function() {
         "actual results length doesn't match with expected results length."
       );
       if (expectedOrderIds) {
-        assert.deepStrictEqual(actualResults.map((doc) => doc.id || doc), expectedOrderIds);
+        assert.deepStrictEqual(
+          actualResults.map((doc) => doc.id || doc),
+          expectedOrderIds
+        );
       }
     };
 


### PR DESCRIPTION
The current error when doing on ORDER BY query on a field that contains mixed types is not very helpful. This improves the error message to direct the user toward `IS_NUMBER` or ` IS_STRING`

Example erroring query: `SELECT * from C ORDER BY c.name`

Where c.name could be a string or boolean.

Working query: `SELECT * from C ORDER BY c.name WHERE IS_STRING(c.name)`

Fixes #4954