### PR TITLE
[storage] document lower-casing of metadata in getProperties methods

### DIFF
--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1256,6 +1256,10 @@ export class BlobClient extends StorageClient {
    * for the blob. It does not return the content of the blob.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-properties
    *
+   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
+   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
+   * characters.
+   *
    * @param {BlobGetPropertiesOptions} [options] Optional options to Get Properties operation.
    * @returns {Promise<BlobGetPropertiesResponse>}
    * @memberof BlobClient

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1256,10 +1256,10 @@ export class BlobClient extends StorageClient {
    * for the blob. It does not return the content of the blob.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-properties
    *
-   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
-   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
-   * characters. This differs from the metadata keys returned by the methods of {@link ContainerClient} that list
-   * blobs, which will retain their original casing.
+   * WARNING: The `metadata` object returned in the response will have its keys in lowercase, even if
+   * they originally contained uppercase characters. This differs from the metadata keys returned by
+   * the methods of {@link ContainerClient} that list blobs using the `includeMetadata` option, which
+   * will retain their original casing.
    *
    * @param {BlobGetPropertiesOptions} [options] Optional options to Get Properties operation.
    * @returns {Promise<BlobGetPropertiesResponse>}
@@ -5710,10 +5710,10 @@ export class ContainerClient extends StorageClient {
    * container. The data returned does not include the container's list of blobs.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties
    *
-   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
-   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
-   * characters. This differs from the metadata keys returned by the `listContainers` method of
-   * {@link BlobServiceClient}, which will retain their original casing.
+   * WARNING: The `metadata` object returned in the response will have its keys in lowercase, even if
+   * they originally contained uppercase characters. This differs from the metadata keys returned by
+   * the `listContainers` method of {@link BlobServiceClient} using the `includeMetadata` option, which
+   * will retain their original casing.
    *
    * @param {ContainerGetPropertiesOptions} [options] Options to Container Get Properties operation.
    * @returns {Promise<ContainerGetPropertiesResponse>}

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1258,7 +1258,8 @@ export class BlobClient extends StorageClient {
    *
    * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
    * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
-   * characters.
+   * characters. This differs from the metadata keys returned by the methods of {@link ContainerClient} that list
+   * blobs, which will retain their original casing.
    *
    * @param {BlobGetPropertiesOptions} [options] Optional options to Get Properties operation.
    * @returns {Promise<BlobGetPropertiesResponse>}
@@ -5708,6 +5709,11 @@ export class ContainerClient extends StorageClient {
    * Returns all user-defined metadata and system properties for the specified
    * container. The data returned does not include the container's list of blobs.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-container-properties
+   *
+   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
+   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
+   * characters. This differs from the metadata keys returned by the `listContainers` method of
+   * {@link BlobServiceClient}, which will retain their original casing.
    *
    * @param {ContainerGetPropertiesOptions} [options] Options to Container Get Properties operation.
    * @returns {Promise<ContainerGetPropertiesResponse>}

--- a/sdk/storage/storage-file-share/src/ShareClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareClient.ts
@@ -688,6 +688,11 @@ export class ShareClient extends StorageClient {
    * share.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties
    *
+   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
+   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
+   * characters. This differs from the metadata keys returned by the `listShares` method of
+   * {@link ShareServiceClient}, which will retain their original casing.
+   *
    * @returns {Promise<ShareGetPropertiesResponse>} Response data for the Share Get Properties operation.
    * @memberof ShareClient
    */

--- a/sdk/storage/storage-file-share/src/ShareClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareClient.ts
@@ -688,10 +688,10 @@ export class ShareClient extends StorageClient {
    * share.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties
    *
-   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
-   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
-   * characters. This differs from the metadata keys returned by the `listShares` method of
-   * {@link ShareServiceClient}, which will retain their original casing.
+   * WARNING: The `metadata` object returned in the response will have its keys in lowercase, even if
+   * they originally contained uppercase characters. This differs from the metadata keys returned by
+   * the `listShares` method of {@link ShareServiceClient} using the `includeMetadata` option, which
+   * will retain their original casing.
    *
    * @returns {Promise<ShareGetPropertiesResponse>} Response data for the Share Get Properties operation.
    * @memberof ShareClient

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -649,6 +649,11 @@ export class QueueClient extends StorageClient {
    * queue. Metadata is associated with the queue as name-values pairs.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-metadata
    *
+   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
+   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
+   * characters. This differs from the metadata keys returned by the `listQueues` method of
+   * {@link QueueServiceClient}, which will retain their original casing.
+   *
    * @param {QueueGetPropertiesOptions} [options] Options to Queue get properties operation.
    * @returns {Promise<QueueGetPropertiesResponse>} Response data for the Queue get properties operation.
    * @memberof QueueClient

--- a/sdk/storage/storage-queue/src/QueueClient.ts
+++ b/sdk/storage/storage-queue/src/QueueClient.ts
@@ -649,10 +649,10 @@ export class QueueClient extends StorageClient {
    * queue. Metadata is associated with the queue as name-values pairs.
    * @see https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-metadata
    *
-   * WARNING: If the option to include metadata is specified (as in `getProperties({ include: ["metadata"] })`),
-   * the metadata keys returned in the response will be in lowercase, even if they originally contained uppercase
-   * characters. This differs from the metadata keys returned by the `listQueues` method of
-   * {@link QueueServiceClient}, which will retain their original casing.
+   * WARNING: The `metadata` object returned in the response will have its keys in lowercase, even if
+   * they originally contained uppercase characters. This differs from the metadata keys returned by
+   * the `listQueues` method of {@link QueueServiceClient} using the `includeMetadata` option, which
+   * will retain their original casing.
    *
    * @param {QueueGetPropertiesOptions} [options] Options to Queue get properties operation.
    * @returns {Promise<QueueGetPropertiesResponse>} Response data for the Queue get properties operation.


### PR DESCRIPTION
Discussion in #4966 , this behavior of `BlobClient.getProperties` should be documented. I have added  a warning to the documentation comments.

Some other clients have the same situation in which a sort of "higher-order" client (i.e. ContainerClient -> BlobClient, BlobServiceClient -> ContainerClient, etc.) has an `includeMetadata` key in its options bag for list methods that will result in metadata key-value pairs being returned in the XML body of the request. However, the "lower-order" clients also have a `getProperties` method that will return the metadata in the HTTP headers.

In those cases where an `includeMetadata` key exists in the list method options bag, I have added the warning.