### PR TITLE
[Identity] EnvironmentCredential now throws an error with missing env variables

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.1 - Coming Soon
 
 - Fixed an issue where an authorization error occurs due to wrong access token being returned by the MSI endpoint when using a user-assigned managed identity with `ManagedIdentityCredential` ([PR #6134](https://github.com/Azure/azure-sdk-for-js/pull/6134))
+- Fixed an issue in `EnvironmentCredential` where authentication silently fails when one or more of the expected environment variables is not present ([PR #6313](https://github.com/Azure/azure-sdk-for-js/pull/6313))
 - Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 
 ## 1.0.0 - 2019-10-29

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -52,11 +52,9 @@ export class EnvironmentCredential implements TokenCredential {
    */
   constructor(options?: TokenCredentialOptions) {
     // Keep track of any missing environment variables for error details
-    AllSupportedEnvironmentVariables.forEach((v) => {
-      if (process.env[v] === undefined) {
-        this._environmentVarsMissing.push(v);
-      }
-    });
+    this._environmentVarsMissing = AllSupportedEnvironmentVariables.filter(
+      (v) => process.env[v] === undefined
+    );
 
     const tenantId = process.env.AZURE_TENANT_ID,
       clientId = process.env.AZURE_CLIENT_ID,

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -133,6 +133,8 @@ export class EnvironmentCredential implements TokenCredential {
 
     // If by this point we don't have a credential, throw an exception so that
     // the user knows the credential was not configured appropriately
+    span.setStatus({ code: CanonicalCode.UNAUTHENTICATED });
+    span.end();
     throw new AuthenticationError(400, {
       error: "missing_environment_variables",
       error_description: `EnvironmentCredential cannot return a token because one or more of the following environment varibles is missing:

--- a/sdk/identity/identity/src/credentials/environmentCredential.ts
+++ b/sdk/identity/identity/src/credentials/environmentCredential.ts
@@ -137,9 +137,12 @@ export class EnvironmentCredential implements TokenCredential {
     span.end();
     throw new AuthenticationError(400, {
       error: "missing_environment_variables",
-      error_description: `EnvironmentCredential cannot return a token because one or more of the following environment varibles is missing:
+      error_description: `EnvironmentCredential cannot return a token because one or more of the following environment variables is missing:
 
-${this._environmentVarsMissing.join("\n")}`
+${this._environmentVarsMissing.join("\n")}
+
+To authenticate with a service principal AZURE_TENANT_ID, AZURE_CLIENT_ID, and either AZURE_CLIENT_SECRET or AZURE_CLIENT_CERTIFICATE_PATH must be set.  To authenticate with a user account AZURE_TENANT_ID, AZURE_USERNAME, and AZURE_PASSWORD must be set.
+`
     });
   }
 }

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -3,13 +3,15 @@
 
 import assert from "assert";
 import path from "path";
-import { EnvironmentCredential } from "../../src";
+import { EnvironmentCredential, AuthenticationError } from "../../src";
 import {
   MockAuthHttpClient,
   assertClientCredentials,
-  assertClientUsernamePassword
+  assertClientUsernamePassword,
+  assertRejects
 } from "../authTestUtils";
 import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
+import { AllSupportedEnvironmentVariables } from "../../src/credentials/environmentCredential";
 
 describe("EnvironmentCredential", function() {
   it("finds and uses client credential environment variables", async () => {
@@ -132,5 +134,28 @@ describe("EnvironmentCredential", function() {
 
     assert.deepStrictEqual(tracer.getSpanGraph(rootSpan.context().traceId), expectedGraph);
     assert.strictEqual(tracer.getActiveSpans().length, 0, "All spans should have had end called");
+  });
+
+  it("throws an AuthenticationError when getToken is called and no credential was configured", async () => {
+    const mockHttpClient = new MockAuthHttpClient();
+
+    const credential = new EnvironmentCredential(mockHttpClient.tokenCredentialOptions);
+    await assertRejects(
+      credential.getToken("scope"),
+      (error: AuthenticationError) =>
+        error.errorResponse.errorDescription.indexOf(AllSupportedEnvironmentVariables.join("\n")) >
+        -1
+    );
+
+    process.env.AZURE_TENANT_ID = "It me";
+
+    const credentialDeux = new EnvironmentCredential(mockHttpClient.tokenCredentialOptions);
+    await assertRejects(
+      credentialDeux.getToken("scope"),
+      (error: AuthenticationError) =>
+        error.errorResponse.errorDescription.indexOf("AZURE_TENANT_ID") === -1
+    );
+
+    delete process.env.AZURE_TENANT_ID;
   });
 });

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -153,7 +153,7 @@ describe("EnvironmentCredential", function() {
     await assertRejects(
       credentialDeux.getToken("scope"),
       (error: AuthenticationError) =>
-        error.errorResponse.errorDescription.indexOf("AZURE_TENANT_ID") === -1
+        error.errorResponse.errorDescription.match(/^AZURE_TENANT_ID/gm) === null
     );
 
     delete process.env.AZURE_TENANT_ID;


### PR DESCRIPTION
A customer [recently reported](https://github.com/Azure/azure-sdk-for-js/issues/5882) that they were not able to authenticate with `@azure/keyvault-secrets` using an `EnvironmentCredential`.  No error was being thrown at the time of authentication.  It turns out that they had misspelled one of the environment variables that `EnvironmentCredential` expects and, upon being invoked, `getToken` returned `null` instead of throwing an exception to alert the user of this fact.  This caused authentication to silently fail.

This change causes `EnvironmentCredential` to throw an error listing any missing environment variables when `getToken` has been called without having an inner credential configured (as it happens when no appropriate set of environment variables are found).

Note that I am not throwing the exception in the constructor so that the creation of `DefaultAzureCredential` is not obstructed when the expected environment variables are missing.  Throwing in `EnvironmentCredential.getToken` means that an `AggregateAuthenticationException` will bubble up only if no other credential in the chain returns a token.

Fixes #5882.