### PR TITLE
Add jsdoc for partitionKey

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Container/ContainerDefinition.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/ContainerDefinition.ts
@@ -7,7 +7,7 @@ import { UniqueKeyPolicy } from "./UniqueKeyPolicy";
 export interface ContainerDefinition {
   /** The id of the container. */
   id?: string;
-  /**  TODO */
+  /** The partition key for the container. */
   partitionKey?: PartitionKeyDefinition;
   /** The indexing policy associated with the container. */
   indexingPolicy?: IndexingPolicy;
@@ -15,6 +15,6 @@ export interface ContainerDefinition {
   defaultTtl?: number;
   /** The conflict resolution policy used to resolve conflicts in a container. */
   conflictResolutionPolicy?: ConflictResolutionPolicy;
-  /** Policy for additional keys that must be unique per partion key */
+  /** Policy for additional keys that must be unique per partition key */
   uniqueKeyPolicy?: UniqueKeyPolicy;
 }

--- a/sdk/cosmosdb/cosmos/src/documents/PartitionKeyDefinition.ts
+++ b/sdk/cosmosdb/cosmos/src/documents/PartitionKeyDefinition.ts
@@ -1,7 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 export interface PartitionKeyDefinition {
+  /**
+   * An array of paths for which data within the collection can be partitioned. Paths must not contain a wildcard or
+   * a trailing slash. For example, the JSON property “AccountNumber” is specified as “/AccountNumber”. The array must
+   * contain only a single value.
+   */
   paths: string[];
+  /**
+   * An optional field, if not specified the default value is 1. To use the large partition key set the version to 2.
+   * To learn about large partition keys, see [how to create containers with large partition key](https://docs.microsoft.com/en-us/azure/cosmos-db/large-partition-keys) article.
+   */
   version?: number;
   systemKey?: boolean;
 }


### PR DESCRIPTION
Description came from the create a collection article on docs.ms

I didn't see any links in existing definitions but markdown formatted links should show up in VS Code.