### PR TITLE
[Service Bus] Cache receiver only if it is initialized successfully

### DIFF
--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -80,9 +80,14 @@ export class StreamingReceiver extends MessageReceiver {
 
   /**
    * Starts the receiver by establishing an AMQP session and an AMQP receiver link on the session.
-   **/
-  receive(): void {
+   *
+   * @param {OnMessage} onMessage The message handler to receive servicebus messages.
+   * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
+   */
+  receive(onMessage: OnMessage, onError: OnError): void {
     throwErrorIfConnectionClosed(this._context.namespace);
+    this._onMessage = onMessage;
+    this._onError = onError;
 
     if (this._receiver) {
       this._receiver.addCredit(this.maxConcurrentCalls);
@@ -94,23 +99,17 @@ export class StreamingReceiver extends MessageReceiver {
    * @static
    *
    * @param {ClientEntityContext} context    The connection context.
-   * @param {OnMessage} onMessage The message handler to receive servicebus messages.
-   * @param {OnError} onError The error handler to receive an error that occurs while receivin messages.
    * @param {ReceiveOptions} [options]     Receive options.
    * @return {Promise<StreamingReceiver>} A promise that resolves with an instance of StreamingReceiver.
    */
   static async create(
     context: ClientEntityContext,
-    onMessage: OnMessage,
-    onError: OnError,
     options?: ReceiveOptions
   ): Promise<StreamingReceiver> {
     throwErrorIfConnectionClosed(context.namespace);
     if (!options) options = {};
     if (options.autoComplete == null) options.autoComplete = true;
     const sReceiver = new StreamingReceiver(context, options);
-    sReceiver._onMessage = onMessage;
-    sReceiver._onError = onError;
     context.streamingReceiver = sReceiver;
     await sReceiver._init();
     return sReceiver;

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -110,8 +110,8 @@ export class StreamingReceiver extends MessageReceiver {
     if (!options) options = {};
     if (options.autoComplete == null) options.autoComplete = true;
     const sReceiver = new StreamingReceiver(context, options);
-    context.streamingReceiver = sReceiver;
     await sReceiver._init();
+    context.streamingReceiver = sReceiver;
     return sReceiver;
   }
 }

--- a/sdk/servicebus/service-bus/src/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receiver.ts
@@ -130,7 +130,7 @@ export class Receiver {
       throw new TypeError("The parameter 'onError' must be of type 'function'.");
     }
 
-    StreamingReceiver.create(this._context, onMessage, onError, {
+    StreamingReceiver.create(this._context, {
       ...options,
       receiveMode: this._receiveMode
     })
@@ -139,7 +139,7 @@ export class Receiver {
           return;
         }
         if (!this.isClosed) {
-          sReceiver.receive();
+          sReceiver.receive(onMessage, onError);
         } else {
           await sReceiver.close();
         }

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -859,7 +859,7 @@ describe("Streaming - User Error", function(): void {
     const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
 
     should.equal(msgsCheck, true, `Expected 1, received ${receivedMsgs.length} messages.`);
-    should.equal(!!((receiverClient as any)._context.streamingReceiver), true, "Expected streaming receiver noto be cached.");
+    should.equal(!!((receiverClient as any)._context.streamingReceiver), true, "Expected streaming receiver not to be cached.");
 
     await receiver.close();
 

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -25,6 +25,9 @@ import {
   TestMessage,
   getServiceBusClient
 } from "./utils/testUtils";
+import { SasTokenProvider, TokenInfo, parseConnectionString } from "@azure/amqp-common";
+import { getEnvVars, EnvVarKeys } from './utils/envVarUtils';
+
 const should = chai.should();
 chai.use(chaiAsPromised);
 
@@ -72,7 +75,7 @@ async function beforeEachTest(
     );
   }
 
-  if (receiverClient instanceof SubscriptionClient) {
+if (receiverClient instanceof SubscriptionClient) {
     deadLetterClient = sbClient.createSubscriptionClient(
       TopicClient.getDeadLetterTopicPath(senderClient.entityPath, receiverClient.subscriptionName),
       receiverClient.subscriptionName
@@ -856,6 +859,8 @@ describe("Streaming - User Error", function(): void {
     const msgsCheck = await checkWithTimeout(() => receivedMsgs.length === 1);
 
     should.equal(msgsCheck, true, `Expected 1, received ${receivedMsgs.length} messages.`);
+    should.equal(!!((receiverClient as any)._context.streamingReceiver), true, "Expected streaming receiver noto be cached.");
+
     await receiver.close();
 
     should.equal(
@@ -896,6 +901,76 @@ describe("Streaming - User Error", function(): void {
     );
     await testUserError();
   });
+});
+
+describe("Streaming - Failed init should not cache recevier", function(): void {
+  afterEach(async () => {
+    await afterEachTest();
+  });
+
+  class TestTokenProvider extends SasTokenProvider {		
+    private firstCall = true;		
+    static errorMessage = "This is a faulty token provider.";
+    constructor(connectionObject: {
+      Endpoint: string,
+      SharedAccessKeyName: string,
+      SharedAccessKey: string
+    }) {		
+      super(		
+        connectionObject.Endpoint,		
+        connectionObject.SharedAccessKeyName,		
+        connectionObject.SharedAccessKey		
+      );		
+    }		
+
+     async getToken(audience: string): Promise<TokenInfo> {		
+      if (this.firstCall) {		
+        this.firstCall = false;		
+        throw new Error(TestTokenProvider.errorMessage);		
+      }		
+      return super.getToken(audience);		
+    }		
+  }
+
+  it("UnPartitioned Queue: Receiver is not cached when not initialized #RunInBrowser", async function(): Promise<
+    void
+  > {
+    const env = getEnvVars();
+
+    // Send a message using service bus client created with connection string
+    sbClient = getServiceBusClient();
+    let clients = await getSenderReceiverClients(sbClient, TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+    sender = clients.senderClient.createSender();
+    await sender.send(TestMessage.getSample());
+    await sbClient.close();
+ 
+    // Receive using service bus client created with faulty token provider
+    const connectionObject: {
+      Endpoint: string,
+      SharedAccessKeyName: string,
+      SharedAccessKey: string
+    } = parseConnectionString(env[EnvVarKeys.SERVICEBUS_CONNECTION_STRING]);
+    const tokenProvider = new TestTokenProvider(connectionObject);
+    sbClient = ServiceBusClient.createFromTokenProvider(connectionObject.Endpoint.substr(5), tokenProvider);
+    clients = await getSenderReceiverClients(sbClient, TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+    receiver = clients.receiverClient.createReceiver(ReceiveMode.peekLock);
+
+    let actualError: Error;
+    receiver.registerMessageHandler(async (msg: ServiceBusMessage) => {
+      throw new Error("No messages should have been received with faulty token provider");
+    }, (err) => {
+      actualError = err;
+    });
+
+    // Check for expected error and that receiver was not cached
+    const errCheck = await checkWithTimeout(() => !!actualError === true);
+    should.equal(errCheck, true, "Expected error to be thrown, but no error found.");
+    should.equal(actualError!.message, TestTokenProvider.errorMessage, 'Expected error from token provider, but unexpected error found.')
+    should.equal(!!((clients.receiverClient as any)._context.streamingReceiver), false, "Expected Streaming receiver to not be cached");
+    
+    await receiver.close();
+  });
+
 });
 
 describe("Streaming - maxConcurrentCalls", function(): void {


### PR DESCRIPTION
The retry that results in the behavior described in #5541 happens due to the below sequence of events
- The receiver is [cached before it is initialized](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/service-bus_1.1.0/sdk/servicebus/service-bus/src/core/streamingReceiver.ts#L113).
- The claim negotiation which is part of the initialization process fails due to the token provider throwing an error.
- 60 seconds later, there is a connection error (condition: `amqp:connection:forced`, description: `The connection was inactive for more than the allowed 60000 milliseconds and is closed by container 'LinkTracker'`) coming from the service as there has been no activity on it for over a minute.  
    - This is a retryable error which results in the library trying to [recover cached senders and receivers](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/service-bus_1.1.0/sdk/servicebus/service-bus/src/clientEntityContext.ts#L202). 
    - Since the receiver was cached, an attempt to bring it back up is made.

The PR #5693 makes a change so that when the receiver is brought back up as described above, the user provided handlers are available to be called. 

But, the fact that an attempt is made to bring back a receiver that was never initialized successfully in the first place is itself is a bug. The feature of recovering senders and receivers when retryable errors occur is only applicable when the said senders and receivers have been running as expected before the error occurred.

Therefore, the fix to the problem in #5541 should be to not cache the receiver if it hasn't been initialized successfully. External errors such as a faulty token provider in #5541 are not retryable. If the consumer application deems such errors to be retryable, then the onus is on the application to detect such errors and retry.

This PR has 3 commits
- https://github.com/Azure/azure-sdk-for-js/commit/27d06d1b13dabb69bc72ff41332b3fcd00c3d69a which reverts the changes made as part of #5693
- https://github.com/Azure/azure-sdk-for-js/commit/43bfadddc8e80960d8b88721e2e92cfa0fd4ba7a which avoids caching the receiver if it was not successfully initialized.
- https://github.com/Azure/azure-sdk-for-js/pull/6322/commits/68cde03a10b2b08ac92585c9401ad84d0859c191 which adds a test case for the above

cc @ramya0820, @chradek, @AlexGhiondea 
