### PR TITLE
[service bus] forward detached errors to user error handler

### DIFF
--- a/sdk/servicebus/service-bus/changelog.md
+++ b/sdk/servicebus/service-bus/changelog.md
@@ -1,12 +1,13 @@
 # Coming Soon 1.1.1
 
 - Ensure handlers passed to `registerMessageHandlers` are re-registered when the underlyng receiver encounters
-error and is re-initialized. Fixes [Bug 5541](https://github.com/Azure/azure-sdk-for-js/issues/5541) with
-[PR 5693](https://github.com/Azure/azure-sdk-for-js/pull/5693).
+  error and is re-initialized. Fixes [Bug 5541](https://github.com/Azure/azure-sdk-for-js/issues/5541) with
+  [PR 5693](https://github.com/Azure/azure-sdk-for-js/pull/5693).
+- Errors that arise from receivers failing to automatically reconnect after encountering a transient issue now trigger the user-provided `onError` callback passed to `receiver.registerMessageHandler`.
 - Update jsdocs for the `receiveMessages` method to include a note that the number of messages that can
-be received in `PeekLock` mode is capped at 2047. [PR 5758](https://github.com/Azure/azure-sdk-for-js/pull/5758).
+  be received in `PeekLock` mode is capped at 2047. [PR 5758](https://github.com/Azure/azure-sdk-for-js/pull/5758).
 - Update jsdocs for user facing apis to include information on possible errors that can be thrown.
-[PR 6088](https://github.com/Azure/azure-sdk-for-js/pull/6088)
+  [PR 6088](https://github.com/Azure/azure-sdk-for-js/pull/6088)
 
 # 2019-09-26 1.1.0
 

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -964,6 +964,23 @@ export class MessageReceiver extends LinkEntity {
         this.address,
         err
       );
+      if (typeof this._onError === "function") {
+        log.error(
+          "[%s] Unable to automatically reconnect Receiver '%s' with address '%s'.",
+          connectionId,
+          this.name,
+          this.address
+        );
+        try {
+          this._onError(err);
+        } catch (err) {
+          log.error(
+            "[%s] User-code error in error handler called after disconnect: %O",
+            connectionId,
+            err
+          );
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
When a customer is using a streaming receiver (via receiveMessagehandler) and the receiver encounters a transient issue, the SDK will attempt to reconnect to the service in the background.

If all of the retries are exhausted, or a non-retryable error is encountered, the SDK will stop trying to reconnect the receiver. However, the final error received is not passed to the user-provided error handler if one was registered.

This change updates `MessageReceiver.onDetached` to forward the last error it receives to the user-provided error handler if it exists.

## Tests
I added a test that creates a StreamingReceiver directly, updates `_init` to throw a non-retryable error and calls `onDetached` directly. The test then valdiates that the error thrown by `_init` is caught by the user's error handler.

The formatter adds more white-space changes to the files I touched.