### PR TITLE
[recorder] Improved getUniqueName

### DIFF
--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -28,12 +28,18 @@ export interface Recorder {
    * In playback mode, the string in the recordings associated to the `label` is returned.
    *
    * If the `label`(optional param) is not provided, `prefix` is used as the `label`.
+   * 
+   * The same prefix cannot exist for the same label. To ensure this is the case, both the prefix and the label used to keep a historical records of names in takenLabelPrefixPairs.
    *
    * @param {string} [prefix] Prefix for the generated random string
    * @param {string} [label] (Optional) Label to be assigned for the generated string [necessary for playing back the recordings]. If label is not provided, prefix is assumed as the label
    * @returns {string}
    */
   getUniqueName: (prefix: string, label?: string) => string;
+  /**
+   * Here's where the getUniqueNames are stored, so that we can throw if a repeated name is generated.
+   */
+  takenLabelPrefixPairs: { [key: string]: boolean },
   /**
    * In live test mode, `new Date();` is returned.
    *
@@ -87,6 +93,8 @@ export function record(testContext: Mocha.Context): Recorder {
     recorder.playback(testContext.currentTest!.file!);
   }
 
+  const takenLabelPrefixPairs: { [key: string]: boolean } = {};
+
   return {
     stop: function() {
       if (isRecordMode()) {
@@ -123,11 +131,18 @@ export function record(testContext: Mocha.Context): Recorder {
         }
       }
     },
+
+    takenLabelPrefixPairs,
+   
     getUniqueName: function(prefix: string, label?: string): string {
       let name: string;
       if (!label) {
         label = prefix;
       }
+      if (takenLabelPrefixPairs[`${label}-${prefix}`]) {
+        throw new Error(`Label ${label} is already taken for the prefix "${prefix}", please provide a different prefix OR give the same prefix to a different label.`);
+      }
+      takenLabelPrefixPairs[`${label}-${prefix}`] = true;
       if (isRecordMode()) {
         name = getUniqueName(prefix);
         recorder.uniqueTestInfo["uniqueName"][label] = name;

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -134,7 +134,7 @@ export function record(testContext: Mocha.Context): Recorder {
         if (recorder.uniqueTestInfo["uniqueName"][label]) {
           throw new Error(
             `getUniqueName: function(prefix: string, label?: string),
-            Label "${label}" is already taken for the prefix "${prefix}",
+            Label "${label}" is already taken,
             please provide a different prefix OR give a new label while keeping the same prefix "${prefix}".`
           );
         } else {
@@ -155,7 +155,14 @@ export function record(testContext: Mocha.Context): Recorder {
       let date: Date;
       if (isRecordMode()) {
         date = new Date();
-        recorder.uniqueTestInfo["newDate"][label] = date.toISOString();
+        if (recorder.uniqueTestInfo["newDate"][label]) {
+          throw new Error(
+            `newDate: function(label: string),
+            Label "${label}" is already taken, please provide a new label.`
+          );
+        } else {
+          recorder.uniqueTestInfo["newDate"][label] = date.toISOString();
+        }
       } else if (isPlaybackMode()) {
         if (recorder.uniqueTestInfo["newDate"]) {
           date = new Date(recorder.uniqueTestInfo["newDate"][label]);

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -131,7 +131,15 @@ export function record(testContext: Mocha.Context): Recorder {
       }
       if (isRecordMode()) {
         name = getUniqueName(prefix);
-        recorder.uniqueTestInfo["uniqueName"][label] = name;
+        if (recorder.uniqueTestInfo["uniqueName"][label]) {
+          throw new Error(
+            `getUniqueName: function(prefix: string, label?: string),
+            Label "${label}" is already taken for the prefix "${prefix}",
+            please provide a different prefix OR give a new label while keeping the same prefix "${prefix}".`
+          );
+        } else {
+          recorder.uniqueTestInfo["uniqueName"][label] = name;
+        }
       } else if (isPlaybackMode()) {
         if (recorder.uniqueTestInfo["uniqueName"]) {
           name = recorder.uniqueTestInfo["uniqueName"][label];

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -28,18 +28,12 @@ export interface Recorder {
    * In playback mode, the string in the recordings associated to the `label` is returned.
    *
    * If the `label`(optional param) is not provided, `prefix` is used as the `label`.
-   * 
-   * The same prefix cannot exist for the same label. To ensure this is the case, both the prefix and the label used to keep a historical records of names in takenLabelPrefixPairs.
    *
    * @param {string} [prefix] Prefix for the generated random string
    * @param {string} [label] (Optional) Label to be assigned for the generated string [necessary for playing back the recordings]. If label is not provided, prefix is assumed as the label
    * @returns {string}
    */
   getUniqueName: (prefix: string, label?: string) => string;
-  /**
-   * Here's where the getUniqueNames are stored, so that we can throw if a repeated name is generated.
-   */
-  takenLabelPrefixPairs: { [key: string]: boolean },
   /**
    * In live test mode, `new Date();` is returned.
    *
@@ -93,8 +87,6 @@ export function record(testContext: Mocha.Context): Recorder {
     recorder.playback(testContext.currentTest!.file!);
   }
 
-  const takenLabelPrefixPairs: { [key: string]: boolean } = {};
-
   return {
     stop: function() {
       if (isRecordMode()) {
@@ -132,17 +124,11 @@ export function record(testContext: Mocha.Context): Recorder {
       }
     },
 
-    takenLabelPrefixPairs,
-   
     getUniqueName: function(prefix: string, label?: string): string {
       let name: string;
       if (!label) {
         label = prefix;
       }
-      if (takenLabelPrefixPairs[`${label}-${prefix}`]) {
-        throw new Error(`Label ${label} is already taken for the prefix "${prefix}", please provide a different prefix OR give the same prefix to a different label.`);
-      }
-      takenLabelPrefixPairs[`${label}-${prefix}`] = true;
       if (isRecordMode()) {
         name = getUniqueName(prefix);
         recorder.uniqueTestInfo["uniqueName"][label] = name;

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -8,11 +8,11 @@ export interface TestInfo {
 
 export const env = isBrowser() ? (window as any).__env__ : process.env;
 
-export function isRecordMode() {
+export function isRecordMode(): boolean {
   return env.TEST_MODE === "record";
 }
 
-export function isPlaybackMode() {
+export function isPlaybackMode(): boolean {
   return env.TEST_MODE === "playback";
 }
 
@@ -35,8 +35,8 @@ export function escapeRegExp(str: string): string {
 export async function blobToString(blob: Blob): Promise<string> {
   const fileReader = new FileReader();
   return new Promise<string>((resolve, reject) => {
-    fileReader.onloadend = (ev: any) => {
-      resolve(ev.target!.result);
+    fileReader.onloadend = (ev: ProgressEvent<FileReader>) => {
+      resolve(ev.target!.result as string);
     };
     fileReader.onerror = reject;
     fileReader.readAsText(blob);
@@ -71,12 +71,17 @@ function padStart(currentString: string, targetLength: number, padString: string
 /**
  * @returns {string}
  */
+const namesAlreadyTaken: string[] = [];
 export function getUniqueName(prefix: string): string {
-  return `${prefix}${new Date().getTime()}${padStart(
+  const name = `${prefix}${new Date().getTime()}${padStart(
     Math.floor(Math.random() * 10000).toString(),
     5,
     "00000"
   )}`;
+  if (namesAlreadyTaken.indexOf(name) > -1) {
+    throw new Error(`Test name: ${name} is duplicated.`);
+  }
+  return name;
 }
 
 /**

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -71,19 +71,12 @@ function padStart(currentString: string, targetLength: number, padString: string
 /**
  * @returns {string}
  */
-const namesAlreadyTaken: { [key: string]: boolean } = {};
 export function getUniqueName(prefix: string): string {
-  const name = `${prefix}${new Date().getTime()}${padStart(
+  return `${prefix}${new Date().getTime()}${padStart(
     Math.floor(Math.random() * 10000).toString(),
     5,
     "00000"
   )}`;
-  if (namesAlreadyTaken[name]) {
-    throw new Error(`Test name: ${name} is duplicated.`);
-  } else {
-    namesAlreadyTaken[name] = true;
-  }
-  return name;
 }
 
 /**

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -8,11 +8,11 @@ export interface TestInfo {
 
 export const env = isBrowser() ? (window as any).__env__ : process.env;
 
-export function isRecordMode(): boolean {
+export function isRecordMode() {
   return env.TEST_MODE === "record";
 }
 
-export function isPlaybackMode(): boolean {
+export function isPlaybackMode() {
   return env.TEST_MODE === "playback";
 }
 
@@ -35,8 +35,8 @@ export function escapeRegExp(str: string): string {
 export async function blobToString(blob: Blob): Promise<string> {
   const fileReader = new FileReader();
   return new Promise<string>((resolve, reject) => {
-    fileReader.onloadend = (ev: ProgressEvent<FileReader>) => {
-      resolve(ev.target!.result as string);
+    fileReader.onloadend = (ev: any) => {
+      resolve(ev.target!.result);
     };
     fileReader.onerror = reject;
     fileReader.readAsText(blob);
@@ -71,15 +71,17 @@ function padStart(currentString: string, targetLength: number, padString: string
 /**
  * @returns {string}
  */
-const namesAlreadyTaken: string[] = [];
+const namesAlreadyTaken: { [key: string]: boolean } = {};
 export function getUniqueName(prefix: string): string {
   const name = `${prefix}${new Date().getTime()}${padStart(
     Math.floor(Math.random() * 10000).toString(),
     5,
     "00000"
   )}`;
-  if (namesAlreadyTaken.indexOf(name) > -1) {
+  if (namesAlreadyTaken[name]) {
     throw new Error(`Test name: ${name} is duplicated.`);
+  } else {
+    namesAlreadyTaken[name] = true;
   }
   return name;
 }


### PR DESCRIPTION
This is a simplistic solution. The idea is that, when the tests run, they will store these names in an in-memory array and throw if the name happens to be repeated. It's cheap enough.

I see a random number generator in the name, I wonder if we should remove that.

Fixes #5698