### PR TITLE
[Storage] Rename the build:js-samples NPM script

### DIFF
--- a/sdk/storage/storage-blob/.vscode/launch.json
+++ b/sdk/storage/storage-blob/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Debug Javascript Samples",
       "program": "${workspaceFolder}/samples/javascript/basic.js",
-      "preLaunchTask": "npm: build:js-samples"
+      "preLaunchTask": "npm: build:node-clean"
     },
     {
       "type": "node",

--- a/sdk/storage/storage-blob/execute-samples.js
+++ b/sdk/storage/storage-blob/execute-samples.js
@@ -39,7 +39,7 @@ async function runSamples(language) {
     cmd = "ts-node";
   } else {
     cmd = "node";
-    await exec(`npm run build:js-samples`, directory);
+    await exec(`npm run build:node-clean`, directory);
   }
 
   console.log(`Running ${language} samples...`);

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -24,7 +24,7 @@
     "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:js-samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
+    "build:node-clean": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:ts-samples": "npm run clean && cd samples && tsc -p . ",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",

--- a/sdk/storage/storage-file-share/.vscode/launch.json
+++ b/sdk/storage/storage-file-share/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Debug Javascript Samples",
       "program": "${workspaceFolder}/samples/javascript/basic.js",
-      "preLaunchTask": "npm: build:js-samples"
+      "preLaunchTask": "npm: build:node-clean"
     },
     {
       "type": "node",

--- a/sdk/storage/storage-file-share/execute-samples.js
+++ b/sdk/storage/storage-file-share/execute-samples.js
@@ -39,7 +39,7 @@ async function runSamples(language) {
     cmd = "ts-node";
   } else {
     cmd = "node";
-    await exec(`npm run build:js-samples`, directory);
+    await exec(`npm run build:node-clean`, directory);
   }
 
   console.log(`Running ${language} samples...`);

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -23,7 +23,7 @@
     "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:js-samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
+    "build:node-clean": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:ts-samples": "npm run clean && node ../../../common/scripts/prep-samples.js && cd samples && tsc -p . ",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",

--- a/sdk/storage/storage-queue/.vscode/launch.json
+++ b/sdk/storage/storage-queue/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Debug Javascript Samples",
       "program": "${workspaceFolder}/samples/javascript/basic.js",
-      "preLaunchTask": "npm: build:js-samples"
+      "preLaunchTask": "npm: build:node-clean"
     },
     {
       "type": "node",

--- a/sdk/storage/storage-queue/execute-samples.js
+++ b/sdk/storage/storage-queue/execute-samples.js
@@ -39,7 +39,7 @@ async function runSamples(language) {
     cmd = "ts-node";
   } else {
     cmd = "node";
-    await exec(`npm run build:js-samples`, directory);
+    await exec(`npm run build:node-clean`, directory);
   }
 
   console.log(`Running ${language} samples...`);

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -21,7 +21,7 @@
     "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
-    "build:js-samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
+    "build:node-clean": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:ts-samples": "npm run clean && cd samples && tsc -p . ",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",


### PR DESCRIPTION
since they are really building the library for NodeJS to ensure JS samples are using the current code.

Resolves #5397.