### PR TITLE
READMEs: Formatted and removed all other links to azure.github.io API docs

### DIFF
--- a/sdk/appconfiguration/app-configuration/README.md
+++ b/sdk/appconfiguration/app-configuration/README.md
@@ -4,13 +4,13 @@
 
 Use the client library for App Configuration to:
 
-* Create flexible key representations and mappings
-* Tag keys with labels
-* Replay settings from any point in time
+- Create flexible key representations and mappings
+- Tag keys with labels
+- Replay settings from any point in time
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/appconfiguration/app-configuration/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/app-configuration) |
-[API reference documentation](https://azure.github.io/azure-sdk-for-js/appconfiguration.html) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/app-configuration) |
 [Product documentation](https://docs.microsoft.com/en-us/azure/azure-app-configuration/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples)
 
@@ -33,13 +33,14 @@ npm install @azure/app-configuration
 You can use the [Azure Portal](https://portal.azure.com) or the [Azure CLI](https://docs.microsoft.com/cli/azure) to create an Azure App Configuration resource.
 
 Example (Azure CLI):
+
 ```
 az appconfig create --name <app-configuration-resource-name> --resource-group <resource-group-name> --location eastus
 ```
 
 ### 3. Create and authenticate an `AppConfigurationClient`
 
-App Configuration uses connection strings for authentication. 
+App Configuration uses connection strings for authentication.
 
 To get the Primary **connection string** for an App Configuration resource you can use this Azure CLI command:
 
@@ -55,12 +56,12 @@ const client = new AppConfigurationClient("<connection string>");
 
 ## Key concepts
 
-The [`AppConfigurationClient`](https://azure.github.io/azure-sdk-for-js/app-configuration/classes/appconfigurationclient.html) has some terminology changes from App Configuration in the portal. 
+The [`AppConfigurationClient`](https://docs.microsoft.com/javascript/api/@azure/app-configuration/appconfigurationclient) has some terminology changes from App Configuration in the portal.
 
-* Key/Value pairs are represented as [`ConfigurationSetting`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsetting.html) objects
-* Locking and unlocking a setting is represented in the `isReadOnly` field, which you can toggle using `setReadOnly`.
+- Key/Value pairs are represented as [`ConfigurationSetting`](https://docs.microsoft.com/javascript/api/@azure/app-configuration/configurationsetting) objects
+- Locking and unlocking a setting is represented in the `isReadOnly` field, which you can toggle using `setReadOnly`.
 
-The client follows a simple design methodology - [`ConfigurationSetting`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsetting.html) can be passed into any method that takes a [`ConfigurationSettingParam`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsettingparam.html) or [`ConfigurationSettingId`](https://azure.github.io/azure-sdk-for-js/app-configuration/interfaces/configurationsettingid.html). 
+The client follows a simple design methodology - [`ConfigurationSetting`](https://docs.microsoft.com/javascript/api/@azure/app-configuration/configurationsetting) can be passed into any method that takes a [`ConfigurationSettingParam`](https://docs.microsoft.com/javascript/api/@azure/app-configuration/configurationsettingparam) or [`ConfigurationSettingId`](https://docs.microsoft.com/javascript/api/@azure/app-configuration/configurationsettingid).
 
 This means this pattern works:
 
@@ -72,7 +73,7 @@ const setting = await client.getConfigurationSetting({
 setting.value = "new value!";
 await client.setConfigurationSetting(setting);
 
-// fields unrelated to just identifying the setting are simply 
+// fields unrelated to just identifying the setting are simply
 // ignored (for instance, the `value` field)
 await client.setReadOnly(setting, true);
 
@@ -89,7 +90,7 @@ let setting = await client.getConfigurationSetting({
 });
 
 // re-get the setting
-setting = await.getConfigurationSetting(setting); 
+setting = await.getConfigurationSetting(setting);
 ```
 
 ## Examples
@@ -99,11 +100,13 @@ setting = await.getConfigurationSetting(setting);
 ```javascript
 const appConfig = require("@azure/app-configuration");
 
-const client = new appConfig.AppConfigurationClient("<App Configuration connection string goes here>");
+const client = new appConfig.AppConfigurationClient(
+  "<App Configuration connection string goes here>"
+);
 
 async function run() {
   const newSetting = await client.setConfigurationSetting({
-    key: "testkey", 
+    key: "testkey",
     value: "testvalue",
     // Labels allow you to create variants of a key tailored
     // for specific use-cases like supporting multiple environments.
@@ -111,30 +114,32 @@ async function run() {
     label: "optional-label"
   });
 
-  let retrievedSetting = await client.getConfigurationSetting("testkey", { label: "optional-label" });
+  let retrievedSetting = await client.getConfigurationSetting("testkey", {
+    label: "optional-label"
+  });
 
   console.log("Retrieved value:", retrievedSetting.value);
 }
 
-run().catch(err => console.log("ERROR:", err));
+run().catch((err) => console.log("ERROR:", err));
 ```
 
 ## Next steps
 
 The following samples show you the various ways you can interact with App Configuration:
 
-* [`helloworld.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/helloworld.ts) - Get, set, and delete configuration values.
-* [`helloworldWithLabels.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts) - Use labels to add additional dimensions to your settings for scenarios like beta vs production.
-* [`optimisticConcurrencyViaEtag.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts) - Set values using etags to prevent accidental overwrites.
-* [`setReadOnlySample.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts) - Marking settings as read-only to prevent modification.
-* [`getSettingOnlyIfChanged.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts) - Get a setting only if it changed from the last time you got it.
-* [`listRevisions.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/listRevisions.ts) - List the revisions of a key, allowing you to see previous values and when they were set.
+- [`helloworld.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/helloworld.ts) - Get, set, and delete configuration values.
+- [`helloworldWithLabels.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/helloworldWithLabels.ts) - Use labels to add additional dimensions to your settings for scenarios like beta vs production.
+- [`optimisticConcurrencyViaEtag.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/optimisticConcurrencyViaEtag.ts) - Set values using etags to prevent accidental overwrites.
+- [`setReadOnlySample.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/setReadOnlySample.ts) - Marking settings as read-only to prevent modification.
+- [`getSettingOnlyIfChanged.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/getSettingOnlyIfChanged.ts) - Get a setting only if it changed from the last time you got it.
+- [`listRevisions.ts`](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples/listRevisions.ts) - List the revisions of a key, allowing you to see previous values and when they were set.
 
 More in-depth examples can be found in the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/appconfiguration/app-configuration/samples) folder on GitHub.
 
 ## Contributing
 
-This project welcomes contributions and suggestions.  Most contributions require you to agree to a
+This project welcomes contributions and suggestions. Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
@@ -149,6 +154,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code.
 
 This module's tests are a mixture of live and unit tests, which require you to have an Azure App Configuration instance. To execute the tests you'll need to run:
+
 1. `rush update`
 2. `rush build -t @azure/app-configuration`
 3. Create a .env file with these contents in the `sdk\appconfiguration\app-configuration` folder:  

--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -4,10 +4,10 @@ Azure Event Hubs is a highly scalable publish-subscribe service that can ingest 
 
 The Azure Event Hubs client library allows you to send and receive events in your Node.js application.
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs) | 
-[Package (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/next) | 
-[API Reference Documentation](https://azure.github.io/azure-sdk-for-js/eventhub.html) |
-[Product documentation](https://azure.microsoft.com/en-us/services/event-hubs/) | 
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs) |
+[Package (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/next) |
+[API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/event-hubs) |
+[Product documentation](https://azure.microsoft.com/en-us/services/event-hubs/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/samples)
 
 **NOTE**: If you are using version 2.1.0 or lower, then please use the below links instead
@@ -54,17 +54,20 @@ For more concepts and deeper discussion, see: [Event Hubs Features](https://docs
 
 ### Authenticate the client
 
-Interaction with Event Hubs starts with either an instance of the 
+Interaction with Event Hubs starts with either an instance of the
 [EventHubConsumerClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html) class
-or an instance of the [EventHubProducerClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducerclient.html) class. 
+or an instance of the [EventHubProducerClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducerclient.html) class.
 There are constructor overloads to support different ways of instantiating these classes as shown below:
-
 
 ```javascript
 const { EventHubProducerClient, EventHubConsumerClient } = require("@azure/event-hubs");
 
 const producerClient = new EventHubProducerClient("my-connection-string", "my-event-hub");
-const consumerClient = new EventHubConsumerClient("my-consumer-group", "my-connection-string", "my-event-hub");
+const consumerClient = new EventHubConsumerClient(
+  "my-consumer-group",
+  "my-connection-string",
+  "my-event-hub"
+);
 ```
 
 - This constructor takes a connection string of the form 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;' and entity name to your Event Hub instance. You can create a consumer group, get the connection string as well as the entity name from the [Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string#get-connection-string-from-the-portal).
@@ -73,7 +76,10 @@ const consumerClient = new EventHubConsumerClient("my-consumer-group", "my-conne
 const { EventHubProducerClient, EventHubConsumerClient } = require("@azure/event-hubs");
 
 const producerClient = new EventHubProducerClient("my-connection-string-with-entity-path");
-const consumerClient = new EventHubConsumerClient("my-consumer-group", "my-connection-string-with-entity-path");
+const consumerClient = new EventHubConsumerClient(
+  "my-consumer-group",
+  "my-connection-string-with-entity-path"
+);
 ```
 
 - The [connection string from the Azure Portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string#get-connection-string-from-the-portal) is for the entire Event Hubs namespace and will not contain the path to the desired Event Hub instance which is needed for this constructor overload. In this case, the path can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the connection string. For example, ";EntityPath=my-event-hub-name".
@@ -86,7 +92,12 @@ const { EventHubProducerClient, EventHubConsumerClient } = require("@azure/event
 const { DefaultAzureCredential } = require("@azure/identity");
 const credential = new DefaultAzureCredential();
 const producerClient = new EventHubProducerClient("my-host-name", "my-event-hub", credential);
-const consumerClient = new EventHubConsumerClient("my-consumer-group", "my-host-name", "my-event-hub", credential);
+const consumerClient = new EventHubConsumerClient(
+  "my-consumer-group",
+  "my-host-name",
+  "my-event-hub",
+  credential
+);
 ```
 
 - This constructor takes the host name and entity name of your Event Hub instance and credential that implements the TokenCredential interface. There are implementations of the `TokenCredential` interface available in the [@azure/identity](https://www.npmjs.com/package/@azure/identity) package. The host name is of the format `<yournamespace>.servicebus.windows.net`.
@@ -129,9 +140,9 @@ In order to publish events, you'll need to create an `EventHubProducerClient`. W
 
 You may publish events to a specific partition, or allow the Event Hubs service to decide which partition events should be published to. It is recommended to use automatic routing when the publishing of events needs to be highly available or when event data should be distributed evenly among the partitions. In the example below, we will take advantage of automatic routing.
 
-- Create an `EventDataBatch` object using the [createBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducer.html#createbatch) 
+- Create an `EventDataBatch` object using the [createBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducer.html#createbatch)
 - Add events to the batch using the [tryAdd](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventdatabatch.html#tryadd)
-method. You can do this until the maximum batch size limit is reached or until you are done adding the number of events you liked, whichever comes first. This method would return `false` to indicate that no more events can be added to the batch due to the max batch size being reached.
+  method. You can do this until the maximum batch size limit is reached or until you are done adding the number of events you liked, whichever comes first. This method would return `false` to indicate that no more events can be added to the batch due to the max batch size being reached.
 - Send the batch of events using the [sendBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubproducerclient.html#sendbatch) method.
 
 In the below example, we attempt to send 10 events to Azure Event Hubs.
@@ -165,16 +176,15 @@ There are options you can pass at different stages to control the process of sen
 - The `EventHubProducerClient` constructor takes an optional parameter of type `EventHubClientOptions` which you can use to specify options like number of retries.
 - The `createBatch` method takes an optional parameter of type `CreateBatchOptions` which you can use to speicify the max batch size supported by the batch being created.
 - The `sendBatch` method takes an optional parameter of type `SendBatchOptions` which you can use to specify `abortSignal` to cancel current operation.
-- In case you want to send to a specific partition, an overload of the `sendBatch` method allows you to pass the id of the partition to send events to. 
-The [Inspect an Event Hub](#inspect-an-event-hub) example above shows how to fetch the available partitions ids.
-
+- In case you want to send to a specific partition, an overload of the `sendBatch` method allows you to pass the id of the partition to send events to.
+  The [Inspect an Event Hub](#inspect-an-event-hub) example above shows how to fetch the available partitions ids.
 
 **Note**: When working with Azure Stream Analytics, the body of the event being sent should be a JSON object as well.
 For example: `body: { "message": "Hello World" }`
 
 ### Consume events from an Event Hub
 
-To consume events from an Event Hub instance, you also need to know which consumer group you want to target. 
+To consume events from an Event Hub instance, you also need to know which consumer group you want to target.
 Once you know this, you are ready to create an [EventHubConsumerClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html). While the below example shows one way to create the client, see the
 [Authenticate the client](#authenticate-the-client) section to learn other ways to instantiate the client.
 
@@ -187,13 +197,12 @@ method on the client has 3 overloads to cater to the 3 ways you can consume even
 
 The `subscribe` method takes an optional parameter of type [SubscriptionOptions](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/interfaces/subscriptionoptions.html) which you can use to specify options like the maxBatchSize (number of events to wait for) and maxWaitTimeInSeconds (amount of time to wait for maxBatchSize events to arrive).
 
-
 #### Consume events in a single process
 
 Begin by creating an instance of the `EventHubConsumerClient`, and then call the `subscribe()` method on it to start
 consuming events.
 
-The [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html#subscribe) 
+The [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html#subscribe)
 method takes callbacks to process events as they are receivied from Azure Event Hubs.
 To stop receiving events, you can call `close()` on the object returned by the `subscribe()` method.
 
@@ -220,17 +229,17 @@ main();
 
 #### Consume events with load balanced across multiple processes
 
-Azure Event Hubs is capable of dealing with millions of events per second. 
+Azure Event Hubs is capable of dealing with millions of events per second.
 To scale your processing application, you can run multiple instances of your application and have it balance the load among themselves.
 
 Begin by creating an instance of the `EventHubConsumerClient`, and then call the `subscribe()` method on it to start
-consuming events. Pass an instance of a `PartitionManager` to the `subscribe()` method which the `EventHubConsumerClient` can 
+consuming events. Pass an instance of a `PartitionManager` to the `subscribe()` method which the `EventHubConsumerClient` can
 use to co-ordinate the processing between the multiple instances of your application.
 
 In this example, we will use the `PartitionManger` from the `@azure/eventhubs-checkpointstore-blob` package
 which implements the required read/writes to a durable store by using Azure Blob Storage.
 
-The [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html#subscribe) 
+The [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html#subscribe)
 method takes callbacks to process events as they are receivied from Azure Event Hubs.
 To stop receiving events, you can call `close()` on the object returned by the `subscribe()` method.
 
@@ -240,10 +249,14 @@ const { ContainerClient } = require("@azure/storage-blob");
 const { BlobPartitionManager } = require("@azure/eventhubs-checkpointstore-blob");
 
 async function main() {
-  const consumerClient = new EventHubConsumerClient("my-consumer-group", "connectionString", "eventHubName");
+  const consumerClient = new EventHubConsumerClient(
+    "my-consumer-group",
+    "connectionString",
+    "eventHubName"
+  );
   const blobContainerClient = new ContainerClient("storage-connection-string", "container-name");
   await blobContainerClient.create(); // This can be skipped if the container already exists
-  const partitionManager =  new BlobPartitionManager(blobContainerClient);
+  const partitionManager = new BlobPartitionManager(blobContainerClient);
 
   const myEventHandler = (events, context) => {
     // your code here
@@ -264,7 +277,6 @@ async function main() {
 main();
 ```
 
-
 #### Consume events from a single partition
 
 Begin by creating an instance of the `EventHubConsumerClient`, and then call the `subscribe()` method on it to start
@@ -272,10 +284,9 @@ consuming events. Pass the id of the partition you want to target to the `subscr
 
 In the below example, we are using the first partition.
 
-The [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html#subscribe) 
+The [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-event-hubs/5.0.0-preview.6/classes/eventhubconsumerclient.html#subscribe)
 method takes callbacks to process events as they are receivied from Azure Event Hubs.
 To stop receiving events, you can call `close()` on the object returned by the `subscribe()` method.
-
 
 ```javascript
 const { EventHubConsumerClient } = require("@azure/event-hubs");
@@ -288,7 +299,7 @@ async function main() {
   };
   const myErrorHandler = (err, context) => {
     // your error handling code here
-  }
+  };
 
   const subscription = consumer.subscribe(partitionIds[0], {
     processEvents: myEventHandler,

--- a/sdk/keyvault/README.md
+++ b/sdk/keyvault/README.md
@@ -11,7 +11,7 @@ This project provides client libraries in JavaScript that makes it easy to consu
 - @azure/keyvault-keys [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-keys)
 - @azure/keyvault-secrets [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-secrets)
 - @azure/keyvault-certificates [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-certificates)
-- [API Reference documentation](https://azure.github.io/azure-sdk-for-js)
+- [API Reference documentation](https://docs.microsoft.com/javascript/api/overview/azure/key-vault)
 - [Azure Key Vault REST APIs](https://docs.microsoft.com/en-us/rest/api/keyvault/)
 
 ## Getting started
@@ -177,6 +177,5 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fkeyvault%2FREADME.png)

--- a/sdk/keyvault/keyvault-certificates/README.md
+++ b/sdk/keyvault/keyvault-certificates/README.md
@@ -18,7 +18,7 @@ Use the client library for Azure Key Vault Certificates in your Node.js applicat
 
 **Please Note:** This is a preview version of the Key Vault Certificates library.
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-certificates) | [API Reference Documentation](https://azure.github.io/azure-sdk-for-js/keyvault.html#azure-keyvault-certificates) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates) | [Package (npm)](https://www.npmjs.com/package/@azure/keyvault-certificates) | [API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/keyvault-certificates) | [Product documentation](https://azure.microsoft.com/en-us/services/key-vault/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples)
 
 ## Getting started
 

--- a/sdk/storage/README.md
+++ b/sdk/storage/README.md
@@ -11,7 +11,7 @@ This project provides client libraries in JavaScript that makes it easy to consu
 - @azure/storage-blob [Package (npm)](https://www.npmjs.com/package/@azure/storage-blob)
 - @azure/storage-file-share [Package (npm)](https://www.npmjs.com/package/@azure/storage-file-share/v/12.0.0-preview.6)
 - @azure/storage-queue [Package (npm)](https://www.npmjs.com/package/@azure/storage-queue)
-- [API Reference documentation](https://azure.github.io/azure-sdk-for-js)
+- [API Reference documentation](https://docs.microsoft.com/javascript/api/overview/azure/storage)
 - [Azure Storage REST APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/)
 
 ## Key concepts
@@ -291,6 +291,5 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fstorage%2FREADME.png)

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -17,7 +17,7 @@ Use the client libraries in this package to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share) |
 [Package (npm)](https://www.npmjs.com/package/@azure/storage-file-share/) |
-[API Reference Documentation](https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share) |
+[API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/storage-file-share) |
 [Product documentation](https://docs.microsoft.com/azure/storage/files/storage-files-introduction) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples) |
 [Azure Storage File REST APIs](https://docs.microsoft.com/rest/api/storageservices/file-service-rest-api)
@@ -34,7 +34,6 @@ The following components and their corresponding client libraries make up the Az
 ## Getting started
 
 **Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a [Storage Account](https://docs.microsoft.com/azure/storage/files/storage-how-to-use-files-portal) to use this package. If you are using this package in a Node.js application, then Node.js version 8.0.0 or higher is required.
-
 
 ### Install the package
 
@@ -243,9 +242,7 @@ const shareName = "<share name>";
 const directoryName = "<directory name>";
 
 async function main() {
-  const directoryClient = serviceClient
-    .getShareClient(shareName)
-    .getDirectoryClient(directoryName);
+  const directoryClient = serviceClient.getShareClient(shareName).getDirectoryClient(directoryName);
 
   const content = "Hello World!";
   const fileName = "newfile" + new Date().getTime();
@@ -283,9 +280,7 @@ const shareName = "<share name>";
 const directoryName = "<directory name>";
 
 async function main() {
-  const directoryClient = serviceClient
-    .getShareClient(shareName)
-    .getDirectoryClient(directoryName);
+  const directoryClient = serviceClient.getShareClient(shareName).getDirectoryClient(directoryName);
 
   let dirIter = directoryClient.listFilesAndDirectories();
   let i = 1;
@@ -320,9 +315,7 @@ const shareName = "<share name>";
 const directoryName = "<directory name>";
 
 async function main() {
-  const directoryClient = serviceClient
-    .getShareClient(shareName)
-    .getDirectoryClient(directoryName);
+  const directoryClient = serviceClient.getShareClient(shareName).getDirectoryClient(directoryName);
 
   let dirIter = await directoryClient.listFilesAndDirectories();
   let i = 1;
@@ -376,8 +369,7 @@ async function streamToString(readableStream) {
 async function main() {
   const fileClient = serviceClient
     .getShareClient(shareName)
-    .rootDirectoryClient
-    .getFileClient(fileName);
+    .rootDirectoryClient.getFileClient(fileName);
 
   // Get file content from position 0 to the end
   // In Node.js, get downloaded data by accessing downloadFileResponse.readableStreamBody
@@ -448,6 +440,5 @@ provided by the bot. You will only need to do this once across all repos using o
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fstorage%2Fstorage-file-share%2FREADME.png)

--- a/sdk/storage/storage-file-share/samples/javascript/README.md
+++ b/sdk/storage/storage-file-share/samples/javascript/README.md
@@ -1,10 +1,10 @@
 ---
 page_type: sample
 languages:
-- javascript
+  - javascript
 products:
-- azure
-- azure-storage
+  - azure
+  - azure-storage
 urlFragment: storage-file-share-javascript
 ---
 
@@ -12,18 +12,18 @@ urlFragment: storage-file-share-javascript
 
 These sample programs show how to use the JavaScript client libraries for Azure Storage File Shares in some common scenarios.
 
-|__File Name__|__Description__|
-|-------------|---------------|
-|[basic.js][basic]|authenticate with the service using an account name & key (or anonymously with a SAS URL), upload a file, list files and directories, and download a file to a string|
-|[withConnString.js][withConnString]|connect to and authenticate with the service using a connection string|
-|[sharedKeyCred.js][sharedKeyCred]|authenticate with the service using an account name and a shared key|
-|[anonymousCred.js][anonymousCred]|authenticate with the service anonymously using a SAS URL|
-|[proxyAuth.js][proxyAuth]|connect to the service using a proxy and authenticate with an account name & key|
-|[iterators-shares.js][iterators-shares]|connect to the service and iterate through the shares in the account|
-|[iterators-files-and-directories.js][iterators-files-and-directories]|create a few directories and iterate through them individually (using async `for await` syntax), by page, and resuming paging using a marker|
-|[iterators-handles.js][iterators-handles]|connect to the service and iterate through open handles|
-|[customPipeline.js][customPipeline]|use custom HTTP pipeline options when connecting to the service|
-|[advanced.js][advanced]|use custom logging and pipeline options, then upload a local file to a share|
+| **File Name**                                                         | **Description**                                                                                                                                                       |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [basic.js][basic]                                                     | authenticate with the service using an account name & key (or anonymously with a SAS URL), upload a file, list files and directories, and download a file to a string |
+| [withConnString.js][withconnstring]                                   | connect to and authenticate with the service using a connection string                                                                                                |
+| [sharedKeyCred.js][sharedkeycred]                                     | authenticate with the service using an account name and a shared key                                                                                                  |
+| [anonymousCred.js][anonymouscred]                                     | authenticate with the service anonymously using a SAS URL                                                                                                             |
+| [proxyAuth.js][proxyauth]                                             | connect to the service using a proxy and authenticate with an account name & key                                                                                      |
+| [iterators-shares.js][iterators-shares]                               | connect to the service and iterate through the shares in the account                                                                                                  |
+| [iterators-files-and-directories.js][iterators-files-and-directories] | create a few directories and iterate through them individually (using async `for await` syntax), by page, and resuming paging using a marker                          |
+| [iterators-handles.js][iterators-handles]                             | connect to the service and iterate through open handles                                                                                                               |
+| [customPipeline.js][custompipeline]                                   | use custom HTTP pipeline options when connecting to the service                                                                                                       |
+| [advanced.js][advanced]                                               | use custom logging and pipeline options, then upload a local file to a share                                                                                          |
 
 ## Prerequisites
 
@@ -38,10 +38,13 @@ Adapting the samples to run in the browser requires some additional consideratio
 To run the samples using the published version of the package:
 
 1. Install the dependencies using `npm`:
+
 ```bash
 npm install
 ```
+
 2. Run the sample with the correct environment variables set, for example (cross-platform):
+
 ```bash
 npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node basic.js
 ```
@@ -51,17 +54,16 @@ npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node bas
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
 [basic]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/basic.js
-[proxyAuth]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/proxyAuth.js
-[withConnString]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/withConnString.js
+[proxyauth]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/proxyAuth.js
+[withconnstring]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/withConnString.js
 [iterators-files-and-directories]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/iterators-files-and-directories.js
-[sharedKeyCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/sharedKeyCred.js
-[anonymousCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/anonymousCred.js
+[sharedkeycred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/sharedKeyCred.js
+[anonymouscred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/anonymousCred.js
 [iterators-handles]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/iterators-handles.js
-[customPipeline]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/customPipeline.js
+[custompipeline]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/customPipeline.js
 [advanced]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/advanced.js
 [iterators-shares]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/javascript/iterators-shares.js
-
-[apiref]: https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share
+[apiref]: https://docs.microsoft.com/javascript/api/@azure/storage-file-share
 [azstorage]: https://docs.microsoft.com/azure/storage/common/storage-account-overview
 [freesub]: https://azure.microsoft.com/free/
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/README.md

--- a/sdk/storage/storage-file-share/samples/typescript/README.md
+++ b/sdk/storage/storage-file-share/samples/typescript/README.md
@@ -1,10 +1,10 @@
 ---
 page_type: sample
 languages:
-- typescript
+  - typescript
 products:
-- azure
-- azure-storage
+  - azure
+  - azure-storage
 urlFragment: storage-file-share-typescript
 ---
 
@@ -12,18 +12,18 @@ urlFragment: storage-file-share-typescript
 
 These sample programs show how to use the TypeScript client libraries for Azure Storage File Shares in some common scenarios.
 
-|__File Name__|__Description__|
-|-------------|---------------|
-|[basic.ts][basic]|authenticate with the service using an account name & key (or anonymously with a SAS URL), upload a file, list files and directories, and download a file to a string|
-|[withConnString.ts][withConnString]|connect to and authenticate with the service using a connection string|
-|[sharedKeyCred.ts][sharedKeyCred]|authenticate with the service using an account name and a shared key|
-|[anonymousCred.ts][anonymousCred]|authenticate with the service anonymously using a SAS URL|
-|[proxyAuth.ts][proxyAuth]|connect to the service using a proxy and authenticate with an account name & key|
-|[iterators-shares.ts][iterators-shares]|connect to the service and iterate through the shares in the account|
-|[iterators-files-and-directories.ts][iterators-files-and-directories]|create a few directories and iterate through them individually (using async `for await` syntax), by page, and resume paging using a marker|
-|[iterators-handles.ts][iterators-handles]|connect to the service and iterate through open handles|
-|[customPipeline.ts][customPipeline]|use custom HTTP pipeline options when connecting to the service|
-|[advanced.ts][advanced]|use custom logging and pipeline options, then upload a local file to a share|
+| **File Name**                                                         | **Description**                                                                                                                                                       |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [basic.ts][basic]                                                     | authenticate with the service using an account name & key (or anonymously with a SAS URL), upload a file, list files and directories, and download a file to a string |
+| [withConnString.ts][withconnstring]                                   | connect to and authenticate with the service using a connection string                                                                                                |
+| [sharedKeyCred.ts][sharedkeycred]                                     | authenticate with the service using an account name and a shared key                                                                                                  |
+| [anonymousCred.ts][anonymouscred]                                     | authenticate with the service anonymously using a SAS URL                                                                                                             |
+| [proxyAuth.ts][proxyauth]                                             | connect to the service using a proxy and authenticate with an account name & key                                                                                      |
+| [iterators-shares.ts][iterators-shares]                               | connect to the service and iterate through the shares in the account                                                                                                  |
+| [iterators-files-and-directories.ts][iterators-files-and-directories] | create a few directories and iterate through them individually (using async `for await` syntax), by page, and resume paging using a marker                            |
+| [iterators-handles.ts][iterators-handles]                             | connect to the service and iterate through open handles                                                                                                               |
+| [customPipeline.ts][custompipeline]                                   | use custom HTTP pipeline options when connecting to the service                                                                                                       |
+| [advanced.ts][advanced]                                               | use custom logging and pipeline options, then upload a local file to a share                                                                                          |
 
 ## Prerequisites
 
@@ -44,14 +44,19 @@ Adapting the samples to run in the browser requires some additional consideratio
 To run the samples using the published version of the package:
 
 1. Install the dependencies using `npm`:
+
 ```bash
 npm install
 ```
+
 2. Compile the samples
+
 ```bash
 npm run build
 ```
+
 3. Run the sample with the correct environment variables set, for example (cross-platform):
+
 ```bash
 npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node dist/basic.js
 ```
@@ -61,17 +66,16 @@ npx cross-env ACCOUNT_NAME="<account name>" ACCOUNT_KEY="<account key>" node dis
 Take a look at our [API Documentation][apiref] for more information about the APIs that are available in the clients.
 
 [basic]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/basic.ts
-[proxyAuth]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/proxyAuth.ts
-[withConnString]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/withConnString.ts
+[proxyauth]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/proxyAuth.ts
+[withconnstring]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/withConnString.ts
 [iterators-files-and-directories]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/iterators-files-and-directories.ts
-[sharedKeyCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/sharedKeyCred.ts
-[anonymousCred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/anonymousCred.ts
+[sharedkeycred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/sharedKeyCred.ts
+[anonymouscred]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/anonymousCred.ts
 [iterators-handles]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/iterators-handles.ts
-[customPipeline]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/customPipeline.ts
+[custompipeline]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/customPipeline.ts
 [advanced]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/advanced.ts
 [iterators-shares]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples/typescript/iterators-shares.ts
-
-[apiref]: https://azure.github.io/azure-sdk-for-js/storage.html#azure-storage-file-share
+[apiref]: https://docs.microsoft.com/javascript/api/@azure/storage-file-share
 [azstorage]: https://docs.microsoft.com/azure/storage/common/storage-account-overview
 [freesub]: https://azure.microsoft.com/free/
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/README.md


### PR DESCRIPTION
#6311 

Due to workspace settings, the formatter also ran on some of the files.

I replaced all of the azure.github.io API reference links with docs.microsoft.com, except for eventhubs-checkpointstore, which doesn't have a docs.microsoft.com page.