### PR TITLE
Remove packaging diff from Analyze step

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -142,31 +142,6 @@ jobs:
     steps:
       - template: ../steps/common.yml
 
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          buildType: "current"
-          artifactName: packages
-          itemPattern: "*.tgz"
-          targetPath: "$(Agent.TempDirectory)/packagesCurrent"
-        displayName: "Download Current Build artifacts"
-
-      - task: DownloadPipelineArtifact@2
-        inputs:
-          buildType: "specific"
-          project: "29ec6040-b234-4e31-b139-33dc4287b756" #guid for public project
-          definition: 614 #system.definitionId for js - client -ci
-          buildVersionToDownload: "latest"
-          branchName: "master"
-          artifactName: packages
-          itemPattern: "*.tgz"
-          targetPath: "$(Agent.TempDirectory)/packagesMaster"
-        displayName: "Download Latest Master (PipelineTask) artifacts"
-
-      - pwsh: |
-          eng/tools/compare-packages.ps1 "$(Agent.TempDirectory)/packagesMaster" "$(Agent.TempDirectory)/packagesCurrent" "$(Build.BuildNumber)" "$(System.ArtifactsDirectory)"
-        displayName: "Diff Generated Packages"
-        errorActionPreference: "continue"
-
       - task: PublishPipelineArtifact@1
         condition: succeededOrFailed()
         displayName: "Publish Report Artifacts"


### PR DESCRIPTION
At least for now we are deleting the packaging diffing option
in the analyze step because we don't have a great way to get
the latest package to compare against. We can consider enabling
this again in the future but for now we are removing to unblock
builds.

PTAL @KarishmaGhiya @mitchdenny @mikeharder 

cc @azure/azure-sdk-eng