### PR TITLE
[Storage] disable execute:samples temporarily

### DIFF
--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -31,7 +31,7 @@
     "clean": "rimraf dist dist-esm dist-test typings temp browser/*.js* browser/*.zip statistics.html coverage coverage-browser .nyc_output *.tgz *.log test*.xml TEST*.xml",
     "clean:samples": "rimraf samples/javascript/node_modules samples/typescript/node_modules samples/typescript/dist",
     "extract-api": "tsc -p . && api-extractor run --local",
-    "execute:samples": "node execute-samples.js",
+    "execute:samples": "echo skipped for now due to https://github.com/Azure/azure-sdk-for-js/issues/6362",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",


### PR DESCRIPTION
Samples execution regressed after recent changes to samples. Disable this for
now until https://github.com/Azure/azure-sdk-for-js/issues/6362 is fixed.