### PR TITLE
[eventhubs-checkpointstore-blob] pins to major version of storage-blob dep

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
@@ -1,13 +1,14 @@
 ### 2019-12-02 - 1.0.0-preview.5
 
 - Updated to use the latest version of the `@azure/event-hubs` package.
+- Updated to use version 12.x.x of the `@azure/storage-blob` package.
 
 Breaking changes:
 
-- `BlobPartitionManager` has been renamed to `BlobCheckpointStore` to reflect naming changes 
-   made in the `@azure/event-hubs` package.
+- `BlobPartitionManager` has been renamed to `BlobCheckpointStore` to reflect naming changes
+  made in the `@azure/event-hubs` package.
 - `BlobCheckpointStore` storage layout has changed and is incompatible with checkpoints and ownerships
-   serialized from previous previews.
+  serialized from previous previews.
 - `updateCheckpoint` no longer returns an `Promise<string>` with an etag. It now returns `Promise<void>`.
 - `Checkpoint` and `PartitionOwnership` have had redundant/overlapping fields removed.
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@azure/event-hubs": "5.0.0-preview.7",
-    "@azure/storage-blob": "12.0.0",
+    "@azure/storage-blob": "^12.0.0",
     "debug": "^4.1.1",
     "events": "^3.0.0",
     "tslib": "^1.9.3"

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@azure/event-hubs": "5.0.0-preview.7",
-    "@azure/storage-blob": "^12.0.0",
+    "@azure/storage-blob": "^12.0.1",
     "debug": "^4.1.1",
     "events": "^3.0.0",
     "tslib": "^1.9.3"


### PR DESCRIPTION
Pins to version 12.x.x of `@azure/storage-blob` since storage-blob is no longer in preview.