### PR TITLE
Improve `@azure/core-tracing` behavior when dealing with OpenTelemetry mismatches

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,7 +1,7 @@
-# 1.0.0-preview.8 (2019-12-02)
+# 1.0.0-preview.9 (2019-12-03)
 
 - Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`.
-- Added support for TokenCredential in `AppConfigurationClient`, allowing 
+- Added support for TokenCredential in `AppConfigurationClient`, allowing
   credentials from the `@azure/identity` package for authentication.
 - Added support for sync-tokens, providing a consistent view of your App
   Configuration service even when doing rapid sets/updates and reads.

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/app-configuration",
   "author": "Microsoft Corporation",
   "description": "An isomorphic client library for the Azure App Configuration service.",
-  "version": "1.0.0-preview.8",
+  "version": "1.0.0-preview.9",
   "sdk-type": "client",
   "keywords": [
     "node",

--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -65,7 +65,7 @@
     "@azure/core-http": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
     "@azure/identity": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"
   },

--- a/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
+++ b/sdk/appconfiguration/app-configuration/src/generated/src/appConfigurationContext.ts
@@ -12,8 +12,7 @@ import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 
 const packageName = "app-configuration";
-export const
-  packageVersion = "1.0.0-preview.8";
+export const packageVersion = "1.0.0-preview.9";
 
 export class AppConfigurationContext extends coreHttp.ServiceClient {
   syncToken?: string;
@@ -26,7 +25,11 @@ export class AppConfigurationContext extends coreHttp.ServiceClient {
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, apiVersion: string, options?: Models.AppConfigurationOptions) {
+  constructor(
+    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
+    apiVersion: string,
+    options?: Models.AppConfigurationOptions
+  ) {
     if (apiVersion == undefined) {
       throw new Error("'apiVersion' cannot be null.");
     }

--- a/sdk/core/core-auth/Changelog.md
+++ b/sdk/core/core-auth/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 1.0.1 - 2019-12-02
+# 1.0.2 - 2019-12-02
 
 - Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -55,7 +55,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"
   },

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-auth",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/core/core-http/Changelog.md
+++ b/sdk/core/core-http/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.1 - 2019-12-02
+## 1.0.2 - 2019-12-02
 
 - Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 

--- a/sdk/core/core-http/lib/util/constants.ts
+++ b/sdk/core/core-http/lib/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  coreHttpVersion: "1.0.1",
+  coreHttpVersion: "1.0.2",
 
   /**
    * Specifies HTTP.

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -6,7 +6,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-js"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -112,7 +112,7 @@
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-auth": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "@types/node-fetch": "^2.5.0",

--- a/sdk/core/core-tracing/Changelog.md
+++ b/sdk/core/core-tracing/Changelog.md
@@ -1,3 +1,7 @@
+# 1.0.0-preview.7 TBD
+
+- Updated the behavior of how incompatible versions of OpenTelemetry Tracer are handled. Now, if two incompatible versions of `@azure/core-tracing` are found, we will log a warning instead of throwing on `getTracer()`/`setTracer()`, but only if the user has manually set a Tracer. This means that incompatible versions will be silently ignored when tracing is not enabled.
+
 # 1.0.0-preview.6 2nd December 2019
 
 - Updated to use OpenTelemetry 0.2 via the `@opentelemetry/types` package. There were two breaking changes in this update:

--- a/sdk/core/core-tracing/Changelog.md
+++ b/sdk/core/core-tracing/Changelog.md
@@ -1,4 +1,4 @@
-# 1.0.0-preview.7 TBD
+# 1.0.0-preview.7 2nd December 2019
 
 - Updated the behavior of how incompatible versions of OpenTelemetry Tracer are handled. Now, if two incompatible versions of `@azure/core-tracing` are found, we will log a warning instead of throwing on `getTracer()`/`setTracer()`, but only if the user has manually set a Tracer. This means that incompatible versions will be silently ignored when tracing is not enabled.
 

--- a/sdk/core/core-tracing/Changelog.md
+++ b/sdk/core/core-tracing/Changelog.md
@@ -1,9 +1,6 @@
 # 1.0.0-preview.7 2nd December 2019
 
 - Updated the behavior of how incompatible versions of OpenTelemetry Tracer are handled. Now, if two incompatible versions of `@azure/core-tracing` are found, we will log a warning instead of throwing on `getTracer()`/`setTracer()`, but only if the user has manually set a Tracer. This means that incompatible versions will be silently ignored when tracing is not enabled.
-
-# 1.0.0-preview.6 2nd December 2019
-
 - Updated to use OpenTelemetry 0.2 via the `@opentelemetry/types` package. There were two breaking changes in this update:
   - `isRecordingEvents` on `Span` was renamed to `isRecording`. [PR link](https://github.com/open-telemetry/opentelemetry-js/pull/454)
   - `addLink` was removed from `Span` as links are now only allowed to be added during span creation. This is possible by specifying any necessary links inside `SpanOptions`. [PR link](https://github.com/open-telemetry/opentelemetry-js/pull/449)

--- a/sdk/core/core-tracing/Changelog.md
+++ b/sdk/core/core-tracing/Changelog.md
@@ -1,6 +1,6 @@
 # 1.0.0-preview.7 2nd December 2019
 
-- Updated the behavior of how incompatible versions of OpenTelemetry Tracer are handled. Now, if two incompatible versions of `@azure/core-tracing` are found, we will log a warning instead of throwing on `getTracer()`/`setTracer()`, but only if the user has manually set a Tracer. This means that incompatible versions will be silently ignored when tracing is not enabled.
+- Updated the behavior of how incompatible versions of OpenTelemetry Tracer are handled. Now, errors will be thrown only if the user has manually set a Tracer. This means that incompatible versions will be silently ignored when tracing is not enabled.
 - Updated to use OpenTelemetry 0.2 via the `@opentelemetry/types` package. There were two breaking changes in this update:
   - `isRecordingEvents` on `Span` was renamed to `isRecording`. [PR link](https://github.com/open-telemetry/opentelemetry-js/pull/454)
   - `addLink` was removed from `Span` as links are now only allowed to be added during span creation. This is possible by specifying any necessary links inside `SpanOptions`. [PR link](https://github.com/open-telemetry/opentelemetry-js/pull/449)

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -12,6 +12,7 @@ import { getCache } from "./utils/cache";
 export function setTracer(tracer: Tracer) {
   const cache = getCache();
   cache.tracer = tracer;
+  cache.userProvidedTracer = true;
 }
 
 /**

--- a/sdk/core/core-tracing/lib/tracerProxy.ts
+++ b/sdk/core/core-tracing/lib/tracerProxy.ts
@@ -5,6 +5,15 @@ import { NoOpTracer } from "./tracers/noop/noOpTracer";
 import { Tracer } from "@opentelemetry/types";
 import { getCache } from "./utils/cache";
 
+let defaultTracer: Tracer;
+
+function getDefaultTracer(): Tracer {
+  if (!defaultTracer) {
+    defaultTracer = new NoOpTracer();
+  }
+  return defaultTracer;
+}
+
 /**
  * Sets the global tracer, enabling tracing for the Azure SDK.
  * @param tracer An OpenTelemetry Tracer instance.
@@ -12,7 +21,6 @@ import { getCache } from "./utils/cache";
 export function setTracer(tracer: Tracer) {
   const cache = getCache();
   cache.tracer = tracer;
-  cache.userProvidedTracer = true;
 }
 
 /**
@@ -22,7 +30,7 @@ export function setTracer(tracer: Tracer) {
 export function getTracer() {
   const cache = getCache();
   if (!cache.tracer) {
-    cache.tracer = new NoOpTracer();
+    return getDefaultTracer();
   }
   return cache.tracer;
 }

--- a/sdk/core/core-tracing/lib/utils/cache.ts
+++ b/sdk/core/core-tracing/lib/utils/cache.ts
@@ -3,15 +3,15 @@
 
 import { Tracer } from "@opentelemetry/types";
 import { getGlobalObject } from "./global";
-import { logger } from "./log";
 
 const GLOBAL_TRACER_VERSION = 2;
-const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache");
+// preview5 shipped with @azure/core-tracing.tracerCache
+// and didn't have smart detection for collisions
+const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache2");
 
 export interface TracerCache {
   version: number;
   tracer?: Tracer;
-  userProvidedTracer?: boolean;
 }
 
 let cache: TracerCache;
@@ -25,8 +25,8 @@ function loadTracerCache(): void {
       cache = existingCache;
     } else {
       setGlobalCache = false;
-      if (existingCache.userProvidedTracer) {
-        logger.warning(
+      if (existingCache.tracer) {
+        throw new Error(
           `Two incompatible versions of @azure/core-tracing have been loaded.
           This library is ${GLOBAL_TRACER_VERSION}, existing is ${existingCache.version}.`
         );

--- a/sdk/core/core-tracing/lib/utils/cache.ts
+++ b/sdk/core/core-tracing/lib/utils/cache.ts
@@ -3,13 +3,15 @@
 
 import { Tracer } from "@opentelemetry/types";
 import { getGlobalObject } from "./global";
+import { logger } from "./log";
 
-const GLOBAL_TRACER_VERSION = 1;
+const GLOBAL_TRACER_VERSION = 2;
 const GLOBAL_TRACER_SYMBOL = Symbol.for("@azure/core-tracing.tracerCache");
 
 export interface TracerCache {
   version: number;
   tracer?: Tracer;
+  userProvidedTracer?: boolean;
 }
 
 let cache: TracerCache;
@@ -17,19 +19,28 @@ let cache: TracerCache;
 function loadTracerCache(): void {
   const globalObj = getGlobalObject();
   const existingCache: TracerCache = globalObj[GLOBAL_TRACER_SYMBOL];
+  let setGlobalCache = true;
   if (existingCache) {
-    if (existingCache.version !== GLOBAL_TRACER_VERSION) {
-      throw new Error(
-        `Two incompatible versions of @azure/core-tracing have been loaded.
-         This library is ${GLOBAL_TRACER_VERSION}, existing is ${existingCache.version}.`
-      );
+    if (existingCache.version === GLOBAL_TRACER_VERSION) {
+      cache = existingCache;
+    } else {
+      setGlobalCache = false;
+      if (existingCache.userProvidedTracer) {
+        logger.warning(
+          `Two incompatible versions of @azure/core-tracing have been loaded.
+          This library is ${GLOBAL_TRACER_VERSION}, existing is ${existingCache.version}.`
+        );
+      }
     }
-    cache = existingCache;
-  } else {
+  }
+
+  if (!cache) {
     cache = {
       tracer: undefined,
       version: GLOBAL_TRACER_VERSION
     };
+  }
+  if (setGlobalCache) {
     globalObj[GLOBAL_TRACER_SYMBOL] = cache;
   }
 }

--- a/sdk/core/core-tracing/lib/utils/log.ts
+++ b/sdk/core/core-tracing/lib/utils/log.ts
@@ -1,5 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-import { createClientLogger } from "@azure/logger";
-export const logger = createClientLogger("core-tracing");

--- a/sdk/core/core-tracing/lib/utils/log.ts
+++ b/sdk/core/core-tracing/lib/utils/log.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("core-tracing");

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/core-tracing",
-  "version": "1.0.0-preview.6",
+  "version": "1.0.0-preview.7",
   "description": "Provides low-level interfaces and helper methods for tracing in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",
@@ -59,6 +59,7 @@
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/core/core-tracing",
   "sideEffects": false,
   "dependencies": {
+    "@azure/logger": "^1.0.0",
     "@opencensus/web-types": "0.0.7",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -59,7 +59,6 @@
   "homepage": "https://github.com/azure/azure-sdk-for-js/tree/master/sdk/core/core-tracing",
   "sideEffects": false,
   "dependencies": {
-    "@azure/logger": "^1.0.0",
     "@opencensus/web-types": "0.0.7",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"

--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -1,12 +1,13 @@
-### 2019-12-02 5.0.0-preview.7
+### 2019-12-03 5.0.0-preview.7
 
 - Improves load-balancing capabilities to reduce the frequency that partitions are claimed by other running
-instances of `EventHubConsumerClient.subscribe` after all partitions are being read.
-([PR #6294](https://github.com/Azure/azure-sdk-for-js/pull/6294))
+  instances of `EventHubConsumerClient.subscribe` after all partitions are being read.
+  ([PR #6294](https://github.com/Azure/azure-sdk-for-js/pull/6294))
 - Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 
 Breaking changes:
-- CheckpointStore and consumer group are now passed to the EventHubConsumerClient 
+
+- CheckpointStore and consumer group are now passed to the EventHubConsumerClient
   constructor rather than being passed to subscribe().
 
 ### 2019-11-04 5.0.0-preview.6

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -74,7 +74,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-amqp": "1.0.0-preview.6",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/identity": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "async-lock": "^1.1.3",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
@@ -1,13 +1,13 @@
-### 2019-12-02 - 1.0.0-preview.5
+### 2019-12-03 - 1.0.0-preview.5
 
 - Updated to use the latest version of the `@azure/event-hubs` package.
 
 Breaking changes:
 
-- `BlobPartitionManager` has been renamed to `BlobCheckpointStore` to reflect naming changes 
-   made in the `@azure/event-hubs` package.
+- `BlobPartitionManager` has been renamed to `BlobCheckpointStore` to reflect naming changes
+  made in the `@azure/event-hubs` package.
 - `BlobCheckpointStore` storage layout has changed and is incompatible with checkpoints and ownerships
-   serialized from previous previews.
+  serialized from previous previews.
 - `updateCheckpoint` no longer returns an `Promise<string>` with an etag. It now returns `Promise<void>`.
 - `Checkpoint` and `PartitionOwnership` have had redundant/overlapping fields removed.
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.0.1 - 2019-12-02
+## 1.0.2 - 2019-12-03
 
 - Fixed an issue where an authorization error occurs due to wrong access token being returned by the MSI endpoint when using a user-assigned managed identity with `ManagedIdentityCredential` ([PR #6134](https://github.com/Azure/azure-sdk-for-js/pull/6134))
 - Fixed an issue in `EnvironmentCredential` where authentication silently fails when one or more of the expected environment variables is not present ([PR #6313](https://github.com/Azure/azure-sdk-for-js/pull/6313))

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -72,7 +72,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/core-http": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "events": "^3.0.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/identity",
   "sdk-type": "client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides credential implementations for Azure SDK libraries that can authenticate with Azure Active Directory",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",

--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Release History
 
-## 4.0.0-preview.10 (2019-12-02)
+## 4.0.0-preview.10 (2019-12-03)
 
 - To better align keyvault-certificate APIs across languages, we've made a number of improvements and updates. For the full list, please see https://github.com/Azure/azure-sdk-for-js/issues/6291
 - Long-running operations are now done through 'pollers' which will poll the long-running operation to see when it has completed
-- Cancellation of a certificate request now happens on the poller rather than via the client 
+- Cancellation of a certificate request now happens on the poller rather than via the client
 - Removed an unused core-arm dependency
 - Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -72,7 +72,7 @@
     "@azure/core-http": "^1.0.0",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"

--- a/sdk/keyvault/keyvault-keys/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-keys/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.1 (2019-12-02)
+## 4.0.1 (2019-12-03)
 
 - Updated dependencies to their latest available versions.
 - Fixed the support of dotenv while testing.

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -71,7 +71,7 @@
     "@azure/core-http": "^1.0.0",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"

--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 4.0.1 (2019-12-02)
+## 4.0.1 (2019-12-03)
 
 - Updated dependencies to their latest available versions.
 - Fixed the support of dotenv while testing.

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -72,7 +72,7 @@
     "@azure/core-http": "^1.0.0",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -82,7 +82,7 @@
     "@azure/core-http": "^1.0.0",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -93,7 +93,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@opentelemetry/types": "^0.2.0",
     "@azure/logger": "^1.0.0",
     "events": "^3.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -78,7 +78,7 @@
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.6",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.9.3"


### PR DESCRIPTION
I realized that preview6 didn't bump the OT compatibility version for our global singleton despite taking breaking changes.

This PR not only bumps the version, but also improves upon our conflict logic. Previously we just threw an error to alert users to the mismatch, but this feels bad in the case where a consumer doesn't care about tracing at all.

Instead, we will now throw only when a tracer has explicitly been set by the user. We also have changed our singleton name so that we never run into a case where a preview5 consumer gets an unexpected error.

Fixes #6371