### PR TITLE
[event-hubs] Revert to the published version of @azure/storage-blob

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@azure/event-hubs": "5.0.0-preview.7",
-    "@azure/storage-blob": "^12.0.1",
+    "@azure/storage-blob": "^12.0.0",
     "debug": "^4.1.1",
     "events": "^3.0.0",
     "tslib": "^1.9.3"


### PR DESCRIPTION
Changing our dependency on @azure/storage-blob package version to an 
older release so we can release eventhubs-checkpointstore-blob without
waiting for a newer storage package.
