### PR TITLE
[core-lro] PollerLike<TResult>

### DIFF
--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 - 2019-12-03
+
+- Changed `PollerLike<TState, TResult>` to be `PollerLike<TResult>`.
+  Besides producing a cleaner API, the only consequence is that
+  the onProgress method now will only receive the basic version of the operation state.
+
 ## 1.0.0 - 2019-10-29
 
 This release marks the general availability of the `@azure/core-lro` package.

--- a/sdk/core/core-lro/CHANGELOG.md
+++ b/sdk/core/core-lro/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0 - 2019-12-03
+## 1.1.0 - TBD
 
 - Changed `PollerLike<TState, TResult>` to be `PollerLike<TResult>`.
   Besides producing a cleaner API, the only consequence is that

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js"
   },
   "sdk-type": "client",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "LRO Polling strtegy for the Azure SDK in TypeScript",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-lro/review/core-lro.api.md
+++ b/sdk/core/core-lro/review/core-lro.api.md
@@ -10,7 +10,7 @@ import { AbortSignalLike } from '@azure/abort-controller';
 export type CancelOnProgress = () => void;
 
 // @public (undocumented)
-export abstract class Poller<TState, TResult> implements PollerLike<TState, TResult> {
+export abstract class Poller<TState, TResult> implements PollerLike<TResult> {
     constructor(operation: PollOperation<TState, TResult>);
     // (undocumented)
     cancelOperation(options?: {
@@ -48,7 +48,7 @@ export class PollerCancelledError extends Error {
 }
 
 // @public (undocumented)
-export interface PollerLike<TState, TResult> {
+export interface PollerLike<TResult> {
     // (undocumented)
     cancelOperation(options?: {
         abortSignal?: AbortSignal;
@@ -62,7 +62,7 @@ export interface PollerLike<TState, TResult> {
     // (undocumented)
     isStopped(): boolean;
     // (undocumented)
-    onProgress(callback: (state: TState) => void): CancelOnProgress;
+    onProgress(callback: (state: PollOperationState<TResult>) => void): CancelOnProgress;
     // (undocumented)
     poll(options?: {
         abortSignal?: AbortSignal;

--- a/sdk/core/core-lro/samples/typescript/samplesClient.ts
+++ b/sdk/core/core-lro/samples/typescript/samplesClient.ts
@@ -196,7 +196,7 @@ class Client {
 
   public async beginLongOperation(options?: {
     resumeFrom?: string;
-  }): Promise<PollerLike<PollOperationState<ReturnValue>, ReturnValue>> {
+  }): Promise<PollerLike<ReturnValue>> {
     const poller = new SamplePoller({
       client: this,
       ...options

--- a/sdk/core/core-lro/src/poller.ts
+++ b/sdk/core/core-lro/src/poller.ts
@@ -24,10 +24,10 @@ export class PollerCancelledError extends Error {
   }
 }
 
-export interface PollerLike<TState, TResult> {
+export interface PollerLike<TResult> {
   poll(options?: { abortSignal?: AbortSignal }): Promise<void>;
   pollUntilDone(): Promise<TResult>;
-  onProgress(callback: (state: TState) => void): CancelOnProgress;
+  onProgress(callback: (state: PollOperationState<TResult>) => void): CancelOnProgress;
   isDone(): boolean;
   stopPolling(): void;
   isStopped(): boolean;
@@ -37,7 +37,7 @@ export interface PollerLike<TState, TResult> {
   toString(): string;
 }
 
-export abstract class Poller<TState, TResult> implements PollerLike<TState, TResult> {
+export abstract class Poller<TState, TResult> implements PollerLike<TResult> {
   private stopped: boolean = true;
   private resolve?: (value?: TResult) => void;
   private reject?: (error: PollerStoppedError | PollerCancelledError | Error) => void;


### PR DESCRIPTION
Fixes #6315

Changed `PollerLike<TState, TResult>` to be `PollerLike<TResult>`.
Besides producing a cleaner API, the only consequence is that
the onProgress method now will only receive the basic version of the operation state.

Should I also update the packages using core-lro as part of this PR?