### PR TITLE
[keyvault] Updating core dependencies

### DIFF
--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -69,7 +69,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
+    "@azure/core-http": "^1.0.2",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -68,7 +68,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "^1.0.0",
+    "@azure/core-http": "^1.0.2",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -69,7 +69,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
+    "@azure/core-http": "^1.0.2",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",


### PR DESCRIPTION
Only core-http seems to be affected. We don't depend on core-auth, and core-tracing is in preview.7, as it should.