### PR TITLE
[Storage] Fix browser code snippets in README and comments

### DIFF
--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -345,7 +345,7 @@ const containerName = "<container name>";
 
 async function main() {
   const containerClient = blobServiceClient.getContainerClient(containerName);
-  
+
   let i = 1;
   let iter = await containerClient.listBlobsFlat();
   for await (const blob of iter) {
@@ -403,22 +403,21 @@ async function main() {
 main();
 ```
 
-### Download a blob and convert it to a string (Browsers)
+### Download a blob and convert it to a string (Browsers).
+
+Please refer to the [JavaScript Bundle](#javascript-bundle) section for more information on using this library in the browser.
 
 ```javascript
-const { DefaultAzureCredential } = require("@azure/identity");
 const { BlobServiceClient } = require("@azure/storage-blob");
 
-const account = "<account>";
-const defaultAzureCredential = new DefaultAzureCredential();
-
-const blobServiceClient = new BlobServiceClient(
-  `https://${account}.blob.core.windows.net`,
-  defaultAzureCredential
-);
-
+const account = "<account name>";
+const sas = "<service Shared Access Token>";
 const containerName = "<container name>";
 const blobName = "<blob name>"
+
+const blobServiceClient = new BlobServiceClient(
+  `https://${account}.blob.core.windows.net${sas}`
+);
 
 async function main() {
   const containerClient = blobServiceClient.getContainerClient(containerName);
@@ -434,11 +433,11 @@ async function main() {
   );
 
   // [Browsers only] A helper method used to convert a browser Blob into string.
-  async function blobToString(blob: Blob): Promise<string> {
+  async function blobToString(blob){
     const fileReader = new FileReader();
-    return new Promise<string>((resolve, reject) => {
-      fileReader.onloadend = (ev: any) => {
-        resolve(ev.target!.result);
+    return new Promise((resolve, reject) => {
+      fileReader.onloadend = (ev) => {
+        resolve(ev.target.result);
       };
       fileReader.onerror = reject;
       fileReader.readAsText(blob);

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -411,7 +411,7 @@ Please refer to the [JavaScript Bundle](#javascript-bundle) section for more inf
 const { BlobServiceClient } = require("@azure/storage-blob");
 
 const account = "<account name>";
-const sas = "<service Shared Access Token>";
+const sas = "<service Shared Access Signature Token>";
 const containerName = "<container name>";
 const blobName = "<blob name>"
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -390,7 +390,7 @@ Please refer to the [JavaScript Bundle](#javascript-bundle) section for more inf
 const { ShareServiceClient } = require("@azure/storage-file-share");
 
 const account = "<account name>";
-const sas = "<service Shared Access Token>";
+const sas = "<service Shared Access Signature Token>";
 const shareName = "<share name>";
 const fileName = "<file name>"
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -384,27 +384,48 @@ main();
 
 ### Download a file and convert it to a string (Browsers)
 
+Please refer to the [JavaScript Bundle](#javascript-bundle) section for more information on using this library in the browser.
+
 ```javascript
-  // Get file content from position 0 to the end
-  // In browsers, get downloaded data by accessing downloadFileResponse.blobBody
+const { ShareServiceClient } = require("@azure/storage-file-share");
+
+const account = "<account name>";
+const sas = "<service Shared Access Token>";
+const shareName = "<share name>";
+const fileName = "<file name>"
+
+const serviceClient = new ShareServiceClient(
+  `https://${account}.file.core.windows.net${sas}`
+);
+
+async function main() {
+  const fileClient = serviceClient.getShareClient(shareName)
+    .rootDirectoryClient
+    .getFileClient(fileName);
+
+    // Get file content from position 0 to the end
+    // In browsers, get downloaded data by accessing downloadFileResponse.blobBody
   const downloadFileResponse = await fileClient.download(0);
   console.log(
-    `Downloaded file content: ${await streamToString(
-      downloadFileResponse.blobBody
+    `Downloaded file content: ${await blobToString(
+      await downloadFileResponse.blobBody
     )}`
   );
+}
 
 // [Browser only] A helper method used to convert a browser Blob into string.
-export async function blobToString(blob: Blob): Promise<string> {
+async function blobToString(blob) {
   const fileReader = new FileReader();
-  return new Promise<string>((resolve, reject) => {
-    fileReader.onloadend = (ev: any) => {
-      resolve(ev.target!.result);
+  return new Promise((resolve, reject) => {
+    fileReader.onloadend = (ev) => {
+      resolve(ev.target.result);
     };
     fileReader.onerror = reject;
     fileReader.readAsText(blob);
   });
 }
+
+main()
 ```
 
 A complete example of basic scenarios is at [samples/basic.ts](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-share/samples/typescript/basic.ts).

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -897,7 +897,7 @@ export class ShareFileClient extends StorageClient {
    * const downloadFileResponse = await fileClient.download(0);
    * console.log(
    *   "Downloaded file content:",
-   *   await streamToString(downloadFileResponse.contentAsBlob)}
+   *   await blobToString(await downloadFileResponse.blobBody)}
    * );
    *
    * // A helper method used to convert a browser Blob into string.


### PR DESCRIPTION
The code snippets for browsers in the README have never been tested.  This change updates them to a working version.  A reference back to the JavaScript Bundle section is also added.