### PR TITLE
[Storage] Fix more code snippets in README

### DIFF
--- a/sdk/storage/README.md
+++ b/sdk/storage/README.md
@@ -135,16 +135,15 @@ The Azure Storage client libraries for JavaScript provides low-level and high-le
 ## Code Samples
 
 ```javascript
-const { BlobServiceClient, newPipeline, SharedKeyCredential } = require("@azure/storage-blob");
+const { AnonymousCredential, BlobServiceClient, StorageSharedKeyCredential } = require("@azure/storage-blob");
 
 async function main() {
-  // Enter your storage account name and shared key
-  const account = "";
-  const accountKey = "";
+  const account = "<account>";
+  const accountKey = "<accountkey>";
 
-  // Use SharedKeyCredential with storage account and account key
-  // SharedKeyCredential is only avaiable in Node.js runtime, not in browsers
-  const sharedKeyCredential = new SharedKeyCredential(account, accountKey);
+  // Use StorageSharedKeyCredential with storage account and account key
+  // StorageSharedKeyCredential is only avaiable in Node.js runtime, not in browsers
+  const sharedKeyCredential = new StorageSharedKeyCredential(account, accountKey);
 
   // You can find more TokenCredential implementations in the [@azure/identity](https://www.npmjs.com/package/@azure/identity) library
   // to use client secrets, certificates, or managed identities for authentication.

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -244,7 +244,7 @@ const queueServiceClient = new QueueServiceClient(
   credential
 );
 
-const queueName = "aNewQueue";
+const queueName = "<valid queue name>";
 
 async function main() {
   const queueClient = queueServiceClient.getQueueClient(queueName);
@@ -273,7 +273,7 @@ const queueServiceClient = new QueueServiceClient(
   credential
 );
 
-const queueName = "aNewQueue";
+const queueName = "<valid queue name>";
 
 async function main() {
   const queueClient = queueServiceClient.getQueueClient(queueName);
@@ -304,7 +304,7 @@ const queueServiceClient = new QueueServiceClient(
   credential
 );
 
-const queueName = "aNewQueue";
+const queueName = "<valid queue name>";
 
 async function main() {
   const queueClient = queueServiceClient.getQueueClient(queueName);
@@ -336,7 +336,7 @@ const queueServiceClient = new QueueServiceClient(
   credential
 );
 
-const queueName = "aNewQueue";
+const queueName = "<valid queue name>";
 
 async function main() {
   const queueClient = queueServiceClient.getQueueClient(queueName);
@@ -371,7 +371,7 @@ const queueServiceClient = new QueueServiceClient(
   credential
 );
 
-const queueName = "aNewQueue";
+const queueName = "<valid queue name>";
 
 async function main() {
   const queueClient = queueServiceClient.getQueueClient(queueName);


### PR DESCRIPTION
The Queue code snippets probably were not tested when we replace the queue name
with a place holder name.

The snippets in storage/README.md was not updated when we did rename
refactoring.

This change fixes them to a working version.