### PR TITLE
[Event Hubs] Fix link by adding missing hash

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -54,9 +54,9 @@ For more concepts and deeper discussion, see: [Event Hubs Features](https://docs
 
 ### Authenticate the client
 
-Interaction with Event Hubs starts with either an instance of the 
+Interaction with Event Hubs starts with either an instance of the
 [EventHubConsumerClient](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventhubconsumerclient) class
-or an instance of the [EventHubProducerClient](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventhubproducerclient) class. 
+or an instance of the [EventHubProducerClient](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventhubproducerclient) class.
 There are constructor overloads to support different ways of instantiating these classes as shown below:
 
 ```javascript
@@ -140,9 +140,9 @@ In order to publish events, you'll need to create an `EventHubProducerClient`. W
 
 You may publish events to a specific partition, or allow the Event Hubs service to decide which partition events should be published to. It is recommended to use automatic routing when the publishing of events needs to be highly available or when event data should be distributed evenly among the partitions. In the example below, we will take advantage of automatic routing.
 
-- Create an `EventDataBatch` object using the [createBatch](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventhubproducerclient#createbatch-createbatchoptions-) 
+- Create an `EventDataBatch` object using the [createBatch](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventhubproducerclient#createbatch-createbatchoptions-)
 - Add events to the batch using the [tryAdd](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventdatabatch#tryadd-eventdata--tryaddoptions-)
-method. You can do this until the maximum batch size limit is reached or until you are done adding the number of events you liked, whichever comes first. This method would return `false` to indicate that no more events can be added to the batch due to the max batch size being reached.
+  method. You can do this until the maximum batch size limit is reached or until you are done adding the number of events you liked, whichever comes first. This method would return `false` to indicate that no more events can be added to the batch due to the max batch size being reached.
 - Send the batch of events using the [sendBatch](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventhubproducerclient#sendbatch-eventdatabatch--sendbatchoptions-) method.
 
 In the below example, we attempt to send 10 events to Azure Event Hubs.
@@ -184,16 +184,16 @@ For example: `body: { "message": "Hello World" }`
 
 ### Consume events from an Event Hub
 
-To consume events from an Event Hub instance, you also need to know which consumer group you want to target. 
+To consume events from an Event Hub instance, you also need to know which consumer group you want to target.
 Once you know this, you are ready to create an [EventHubConsumerClient](https://docs.microsoft.com/javascript/api/@azure/event-hubs/eventhubconsumerclient). While the below example shows one way to create the client, see the
 [Authenticate the client](#authenticate-the-client) section to learn other ways to instantiate the client.
 
 The `subscribe` method on the client has overloads which, combined with the constructor, can cater to several
 ways to consume events:
 
-- [Consume events in a single process](consume-events-in-a-single-process)
-- [Consume events with load balanced across multiple processes](consume-events-with-load-balanced-across-multiple-processes)
-- [Consume events from a single partition](consume-events-from-a-single-partition)
+- [Consume events in a single process](#consume-events-in-a-single-process)
+- [Consume events with load balanced across multiple processes](#consume-events-with-load-balanced-across-multiple-processes)
+- [Consume events from a single partition](#consume-events-from-a-single-partition)
 
 The `subscribe` method takes an optional parameter of type `SubscriptionOptions` which you can use to specify options like the maxBatchSize (number of events to wait for) and maxWaitTimeInSeconds (amount of time to wait for maxBatchSize events to arrive).
 
@@ -209,7 +209,11 @@ To stop receiving events, you can call `close()` on the object returned by the `
 const { EventHubConsumerClient } = require("@azure/event-hubs");
 
 async function main() {
-  const client = new EventHubConsumerClient("my-consumer-group", "connectionString", "eventHubName");
+  const client = new EventHubConsumerClient(
+    "my-consumer-group",
+    "connectionString",
+    "eventHubName"
+  );
 
   const subscription = consumer.subscribe({
     processEvents: (events, context) => {
@@ -234,9 +238,9 @@ Azure Event Hubs is capable of dealing with millions of events per second.
 To scale your processing application, you can run multiple instances of your application and have it balance the load among themselves.
 
 Begin by creating an instance of the `EventHubConsumerClient` using one of the
-constructor overloads that take a `CheckpointStore`, and then call the `subscribe()` 
-method to start consuming events. The checkpoint store will enable the subscribers 
-within a consumer group to coordinate the processing between multiple instances 
+constructor overloads that take a `CheckpointStore`, and then call the `subscribe()`
+method to start consuming events. The checkpoint store will enable the subscribers
+within a consumer group to coordinate the processing between multiple instances
 of your application.
 
 In this example, we will use the `BlobCheckpointStore` from the `@azure/eventhubs-checkpointstore-blob` package
@@ -255,10 +259,11 @@ async function main() {
   await blobContainerClient.create(); // This can be skipped if the container already exists
   const checkpointStore = new BlobCheckpointStore(blobContainerClient);
   const consumerClient = new EventHubConsumerClient(
-    "my-consumer-group", 
-    "connectionString", 
-    "eventHubName", 
-    checkpointStore);  
+    "my-consumer-group",
+    "connectionString",
+    "eventHubName",
+    checkpointStore
+  );
 
   const subscription = consumerClient.subscribe({
     processEvents: (events, context) => {
@@ -291,7 +296,11 @@ To stop receiving events, you can call `close()` on the object returned by the `
 const { EventHubConsumerClient } = require("@azure/event-hubs");
 
 async function main() {
-  const client = new EventHubConsumerClient("my-consumer-group", "connectionString", "eventHubName");
+  const client = new EventHubConsumerClient(
+    "my-consumer-group",
+    "connectionString",
+    "eventHubName"
+  );
   const partitionIds = await client.getPartitionIds();
 
   const subscription = consumer.subscribe(partitionIds[0], {


### PR DESCRIPTION
Broken links in the documentation for consuming events