### PR TITLE
[abort-controller] prepare for 1.0.1 release

### DIFF
--- a/sdk/core/abort-controller/changelog.md
+++ b/sdk/core/abort-controller/changelog.md
@@ -1,7 +1,7 @@
 ## 1.0.1 - 2019-12-04
 
-Fixes an issue that can occur with angular prod builds due to triple-slash directives.
-([6344](https://github.com/Azure/azure-sdk-for-js/pull/6344))
+Fixes the [bug 6271](https://github.com/Azure/azure-sdk-for-js/pull/6271) that can occur with angular prod builds due to triple-slash directives.
+([PR 6344](https://github.com/Azure/azure-sdk-for-js/pull/6344))
 
 ## 1.0.0 - 2019-10-29
 

--- a/sdk/core/abort-controller/changelog.md
+++ b/sdk/core/abort-controller/changelog.md
@@ -1,6 +1,6 @@
 ## 1.0.1 - 2019-12-04
 
-Fixes the [bug 6271](https://github.com/Azure/azure-sdk-for-js/pull/6271) that can occur with angular prod builds due to triple-slash directives.
+Fixes the [bug 6271](https://github.com/Azure/azure-sdk-for-js/issues/6271) that can occur with angular prod builds due to triple-slash directives.
 ([PR 6344](https://github.com/Azure/azure-sdk-for-js/pull/6344))
 
 ## 1.0.0 - 2019-10-29

--- a/sdk/core/abort-controller/changelog.md
+++ b/sdk/core/abort-controller/changelog.md
@@ -1,3 +1,8 @@
+## 1.0.1 - 2019-12-04
+
+Fixes an issue that can occur with angular prod builds due to triple-slash directives.
+([6344](https://github.com/Azure/azure-sdk-for-js/pull/6344))
+
 ## 1.0.0 - 2019-10-29
 
 This release marks the general availability of the `@azure/abort-controller` package.


### PR DESCRIPTION
Updates changelog entry.

package.json already shows the correct version (1.0.1)