### PR TITLE
[event-hubs] Updating samples folder to make it a standalone project

### DIFF
--- a/sdk/eventhub/event-hubs/samples/README.md
+++ b/sdk/eventhub/event-hubs/samples/README.md
@@ -6,7 +6,7 @@ The samples in this folder are for version 5.0.0 and above of this library. If y
 
 Run the below in your samples folder to install the npm package for Event Hubs library.
 ```bash
-npm install @azure/event-hubs@next
+npm install
 ```
 
 ## Get connection string & Event Hubs name
@@ -20,35 +20,24 @@ npm install @azure/event-hubs@next
 
 Before running a sample, update it with the connection string and the Event Hub name you have noted above.
 
-## Running a sample
+## Running samples
 
-Start by copying the sample into a npm project.
-```bash
-mkdir event-hubs-samples
-cd event-hubs-samples
-npm init
-# copy sample into this directory
-```
+1. Copy this folder to your machine.
+2. Install dependencies for the samples project.
+  
+    ```bash
+    npm install
+    ```
 
-If you don't have Typescript installed, then use `npm` to install it first.
-```bash
-npm install -g typescript
-```
+3. Rename the `sample.env` file to `.env`
+4. Open the `.env` file in a text editor and fill in values related to the 
+   sample you'd like to run.
+5. Run the samples using ts-node:
 
-Install the `@azure/event-hubs@next` package into your project, as well as any other dependencies you might need.
-```bash
-npm install --save @azure/event-hubs@next
-```
+   For example, to run the `sendEvents.ts` sample:
 
-One way to run Typescript samples is to use `ts-node`. To install `ts-node`, run the below in your sample folder
-```bash
-npm install ts-node
-```
-
-Use `ts-node` to run the sample copied previously.
-```bash
-ts-node sample.ts
-```
-
+   ```bash
+   npx ts-node sendEvents.ts
+   ```
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Feventhub%2Fevent-hubs%2Fsamples%2FREADME.png)

--- a/sdk/eventhub/event-hubs/samples/README.md
+++ b/sdk/eventhub/event-hubs/samples/README.md
@@ -32,12 +32,10 @@ Before running a sample, update it with the connection string and the Event Hub 
 3. Rename the `sample.env` file to `.env`
 4. Open the `.env` file in a text editor and fill in values related to the 
    sample you'd like to run.
-5. Run the samples using ts-node:
-
-   For example, to run the `sendEvents.ts` sample:
+5. Run the samples:
 
    ```bash
-   npx ts-node sendEvents.ts
+   npm run samples
    ```
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Feventhub%2Fevent-hubs%2Fsamples%2FREADME.png)

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -30,6 +30,12 @@
     "@azure/core-amqp": "next",
     "@azure/event-hubs": "next",
     "@azure/eventhubs-checkpointstore-blob": "next",
-    "rhea-promise": "^1.0.0"
+    "@types/dotenv": "^8.2.0",
+    "@types/ws": "^6.0.4",
+    "dotenv": "^8.2.0",
+    "https-proxy-agent": "^3.0.1",
+    "rhea-promise": "^1.0.0",
+    "tslib": "^1.9.3",
+    "ws": "^7.2.0"
   }
 }

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "event-hubs-samples",
+  "name": "azure-event-hubs-samples",
   "version": "1.0.0",
   "description": "The samples in this folder are for version 5.0.0 and above of this library. If you are using version 2.1.0 or lower, then please use [samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples) instead",
   "main": "dist/runsamples.js",

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -4,7 +4,7 @@
   "description": "The samples in this folder are for version 5.0.0 and above of this library. If you are using version 2.1.0 or lower, then please use [samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples) instead",
   "main": "dist/runsamples.js",
   "scripts": {
-    "test": "ts-node ./runsamples.ts",
+    "samples": "ts-node ./runsamples.ts",
     "build": "tsc -p ."
   },
   "keywords": [

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -10,8 +10,8 @@
   },
   "keywords": [
     "Azure",
-    "Storage",
-    "File",
+    "EventHubs",
+    "CheckpointStore",
     "Node.js",
     "TypeScript"
   ],
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "devDependencies": {
     "ts-node": "^8.5.4",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.2",
+    "@types/node": "^12.12.17"
   },
   "dependencies": {
     "@azure/core-amqp": "next",

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "description": "The samples in this folder are for version 5.0.0 and above of this library. If you are using version 2.1.0 or lower, then please use [samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples) instead",
-  "main": "dist/runsamples.js",
+  "main": "dist-esm/runsamples.js",
   "scripts": {
     "samples": "ts-node ./runsamples.ts",
     "build": "tsc -p ."

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "eventhubs-samples",
+  "version": "1.0.0",
+  "description": "The samples in this folder are for version 5.0.0 and above of this library. If you are using version 2.1.0 or lower, then please use [samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples) instead",
+  "main": "dist/runsamples.js",
+  "scripts": {
+    "test": "ts-node ./runsamples.ts",
+    "build": "tsc -p ."
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "ts-node": "^8.5.4",
+    "typescript": "^3.7.2"
+  },
+  "dependencies": {
+    "@azure/core-amqp": "next",
+    "@azure/event-hubs": "next",
+    "@azure/eventhubs-checkpointstore-blob": "next",
+    "rhea-promise": "^1.0.0"
+  }
+}

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eventhubs-samples",
+  "name": "event-hubs-samples",
   "version": "1.0.0",
   "description": "The samples in this folder are for version 5.0.0 and above of this library. If you are using version 2.1.0 or lower, then please use [samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples) instead",
   "main": "dist/runsamples.js",
@@ -7,9 +7,19 @@
     "test": "ts-node ./runsamples.ts",
     "build": "tsc -p ."
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "Azure",
+    "Storage",
+    "File",
+    "Node.js",
+    "TypeScript"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "devDependencies": {
     "ts-node": "^8.5.4",
     "typescript": "^3.7.2"

--- a/sdk/eventhub/event-hubs/samples/package.json
+++ b/sdk/eventhub/event-hubs/samples/package.json
@@ -1,5 +1,6 @@
 {
   "name": "azure-event-hubs-samples",
+  "private": true,
   "version": "1.0.0",
   "description": "The samples in this folder are for version 5.0.0 and above of this library. If you are using version 2.1.0 or lower, then please use [samples for v2.1.0](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples) instead",
   "main": "dist/runsamples.js",

--- a/sdk/eventhub/event-hubs/samples/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEvents.ts
@@ -16,11 +16,13 @@ import {
   EventHubConsumerClient
 } from "@azure/event-hubs";
 
-const connectionString = "";
-const eventHubName = "";
-const consumerGroup = "";
+const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";
+const eventHubName = process.env["EVENTHUB_NAME"] || "";
+const consumerGroup = process.env["CONSUMER_GROUP_NAME"] || "";
 
-async function main() {
+export async function main() {
+  console.log(`Running receiveEvents sample`);
+  
   const consumerClient = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName);
 
   const subscription = consumerClient.subscribe({
@@ -45,8 +47,13 @@ async function main() {
       resolve();
     }, 30000);
   });
+
+  console.log(`Exiting receiveEvents sample`);
 }
 
-main().catch((err) => {
-  console.log("Error occurred: ", err);
-});
+if (!process.env["RUNNING_IN_TESTS"]) {
+  main().catch((err) => {
+    console.log("Error occurred: ", err);
+    process.exit(1);
+  });
+}

--- a/sdk/eventhub/event-hubs/samples/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEvents.ts
@@ -12,7 +12,7 @@
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
 
-import { runSample } from './sampleHelpers';
+import { runSample, cleanupAfterWaiting } from './sampleHelpers';
 import {
   EventHubConsumerClient
 } from "@azure/event-hubs";
@@ -40,14 +40,10 @@ export async function main() {
     }
   });
 
-  // after 30 seconds, stop processing
-  await new Promise((resolve) => {
-    setTimeout(async () => {
+  await cleanupAfterWaiting(async () => {
       await subscription.close();
       await consumerClient.close();
-      resolve();
-    }, 30000);
-  });
+  }, 30);
 
   console.log(`Exiting receiveEvents sample`);
 }

--- a/sdk/eventhub/event-hubs/samples/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEvents.ts
@@ -51,9 +51,5 @@ export async function main() {
   console.log(`Exiting receiveEvents sample`);
 }
 
-if (!process.env["RUNNING_IN_TESTS"]) {
-  main().catch((err) => {
-    console.log("Error occurred: ", err);
-    process.exit(1);
-  });
-}
+import { runSample } from './sampleHelpers';
+runSample(main);

--- a/sdk/eventhub/event-hubs/samples/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEvents.ts
@@ -12,6 +12,7 @@
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
 
+import { runSample } from './sampleHelpers';
 import {
   EventHubConsumerClient
 } from "@azure/event-hubs";
@@ -51,5 +52,4 @@ export async function main() {
   console.log(`Exiting receiveEvents sample`);
 }
 
-import { runSample } from './sampleHelpers';
 runSample(main);

--- a/sdk/eventhub/event-hubs/samples/receiveEventsUsingCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsUsingCheckpointStore.ts
@@ -16,6 +16,7 @@
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
 
+import { runSample } from './sampleHelpers';
 import {
   EventHubConsumerClient, CheckpointStore,
 } from "@azure/event-hubs";
@@ -80,6 +81,5 @@ export async function main() {
   console.log(`Exiting receiveEventsUsingCheckpointStore sample`);
 }
 
-import { runSample } from './sampleHelpers';
 runSample(main);
 

--- a/sdk/eventhub/event-hubs/samples/receiveEventsUsingCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsUsingCheckpointStore.ts
@@ -59,7 +59,7 @@ export async function main() {
         };
 
         console.log(
-          `Successfully checkpointed event with sequence number: ${events[events.length - 1].sequenceNumber} from partition: 'partitionContext.partitionId'`
+          `Successfully checkpointed event with sequence number: ${events[events.length - 1].sequenceNumber} from partition: '${context.partitionId}'`
         );
       },
       processError: async (err, context) => {
@@ -80,9 +80,6 @@ export async function main() {
   console.log(`Exiting receiveEventsUsingCheckpointStore sample`);
 }
 
-if (!process.env["RUNNING_IN_TESTS"]) {
-  main().catch((err) => {
-    console.log("Error occurred: ", err);
-    process.exit(1);
-  });
-}
+import { runSample } from './sampleHelpers';
+runSample(main);
+

--- a/sdk/eventhub/event-hubs/samples/receiveEventsUsingCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/samples/receiveEventsUsingCheckpointStore.ts
@@ -16,7 +16,7 @@
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
 
-import { runSample } from './sampleHelpers';
+import { runSample, cleanupAfterWaiting } from './sampleHelpers';
 import {
   EventHubConsumerClient, CheckpointStore,
 } from "@azure/event-hubs";
@@ -70,13 +70,10 @@ export async function main() {
   );
 
   // after 30 seconds, stop processing
-  await new Promise((resolve) => {
-    setTimeout(async () => {
-      await subscription.close();
-      await consumerClient.close();
-      resolve();
-    }, 30000);
-  });
+  await cleanupAfterWaiting(async () => {
+    await subscription.close();
+    await consumerClient.close();
+  }, 30);
 
   console.log(`Exiting receiveEventsUsingCheckpointStore sample`);
 }

--- a/sdk/eventhub/event-hubs/samples/runsamples.ts
+++ b/sdk/eventhub/event-hubs/samples/runsamples.ts
@@ -1,5 +1,10 @@
 import * as dotenv from "dotenv";
+import process from "process";
+
 dotenv.config();
+
+// don't have the samples execute - we'll run them manually in `main` below
+process.env["DO_NOT_EXECUTE_SAMPLE"] = "1";
 
 import { main as sendEventsMain } from "./sendEvents";
 import { main as receiveEventsMain } from "./receiveEvents";

--- a/sdk/eventhub/event-hubs/samples/runsamples.ts
+++ b/sdk/eventhub/event-hubs/samples/runsamples.ts
@@ -1,5 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import * as dotenv from "dotenv";
-import process from "process";
 
 dotenv.config();
 

--- a/sdk/eventhub/event-hubs/samples/runsamples.ts
+++ b/sdk/eventhub/event-hubs/samples/runsamples.ts
@@ -1,0 +1,23 @@
+import * as dotenv from "dotenv";
+dotenv.config();
+
+import { main as sendEventsMain } from "./sendEvents";
+import { main as receiveEventsMain } from "./receiveEvents";
+import { main as receiveEventsUsingCheckpointStoreMain } from "./receiveEventsUsingCheckpointStore";
+import { main as useWithIotHubMain } from "./useWithIotHub";
+import { main as usingAadAuthMain } from "./usingAadAuth";
+import { main as websocketsMain } from "./websockets";
+
+async function main() {
+  await sendEventsMain();
+  await receiveEventsMain();
+  await receiveEventsUsingCheckpointStoreMain();
+  await useWithIotHubMain();
+  await usingAadAuthMain();
+  await websocketsMain();
+}
+
+main().catch(err => {
+  console.log(err);
+  process.exit(1);
+})

--- a/sdk/eventhub/event-hubs/samples/sample.env
+++ b/sdk/eventhub/event-hubs/samples/sample.env
@@ -1,0 +1,28 @@
+# Used in most samples
+EVENTHUB_CONNECTION_STRING=<connection string WITHOUT an EntityPath>
+EVENTHUB_NAME=<name of a single eventhub>
+EVENTHUB_FQDN=<your-eventhubs-namespace>.servicebus.windows.net
+CONSUMER_GROUP_NAME=<name of a consumer group>
+
+# Used in the receiveEventsUsingCheckpointStore.ts sample
+STORAGE_CONTAINER_NAME=<storage account connection string for checkpoints>
+
+# Used in the useWithIotHub.ts sample
+IOTHUB_CONNECTION_STRING=<connection string with EntityPath>
+
+# Used in the usingAadAuth.ts sample
+#  Setup :
+#    Please ensure that your Azure Event Hubs resource is in US East, US East 2, or West Europe
+#    region. AAD Role Based Access Control is not supported in other regions yet.
+#   Register a new application in AAD and assign the "Azure Event Hubs Data Owner (Preview)" role to it
+#    - See https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
+#      to register a new application in the Azure Active Directory.
+#    - Note down the CLIENT_ID and TENANT_ID from the above step.
+#    - In the "Certificates & Secrets" tab, create a secret and note that down.
+#    - In the Azure portal, go to your Even Hubs resource and click on the Access control (IAM)
+#      tab. Here, assign the "Azure Event Hubs Data Owner (Preview)" role to the registered application.
+#    - For more information on Event Hubs RBAC setup, learn more at 
+#     https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-role-based-access-control)
+AZURE_CLIENT_ID=
+AZURE_TENANT_ID=
+AZURE_CLIENT_SECRET=

--- a/sdk/eventhub/event-hubs/samples/sampleHelpers.ts
+++ b/sdk/eventhub/event-hubs/samples/sampleHelpers.ts
@@ -20,3 +20,23 @@ export function runSample(main: () => Promise<void>) {
     process.exit(1);
   });
 }
+
+/**
+ * Runs your cleanupFn after waiting for `timeToWaitInSeconds` seconds
+ * @param cleanupFn Cleanup function to run.
+ * @param timeToWaitInSeconds Seconds to wait.
+ */
+export function cleanupAfterWaiting(cleanupFn: () => Promise<void>, timeToWaitInSeconds: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    console.log(`Waiting for ${timeToWaitInSeconds} seconds...`)
+
+    setTimeout(async () => {
+      try {
+        await cleanupFn();
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    }, timeToWaitInSeconds * 1000);
+  });
+}

--- a/sdk/eventhub/event-hubs/samples/sampleHelpers.ts
+++ b/sdk/eventhub/event-hubs/samples/sampleHelpers.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as dotenv from "dotenv";
+
+// initialize using the .env file in the current folder
+dotenv.config();
+
+/**
+ * Runs the async sample function, exiting if needed if it fails.
+ * @param main The 'main' function for the sample.
+ */
+export function runSample(main: () => Promise<void>) {
+  if (!process.env["DO_NOT_EXECUTE_SAMPLE"]) {
+    return Promise.resolve();
+  }
+
+  return main().catch((err) => {
+    console.log("Error occurred: ", err);
+    process.exit(1);
+  });
+}

--- a/sdk/eventhub/event-hubs/samples/sampleHelpers.ts
+++ b/sdk/eventhub/event-hubs/samples/sampleHelpers.ts
@@ -11,7 +11,7 @@ dotenv.config();
  * @param main The 'main' function for the sample.
  */
 export function runSample(main: () => Promise<void>) {
-  if (!process.env["DO_NOT_EXECUTE_SAMPLE"]) {
+  if (process.env["DO_NOT_EXECUTE_SAMPLE"]) {
     return Promise.resolve();
   }
 

--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -77,10 +77,5 @@ export async function main(): Promise<void> {
   console.log(`Exiting sendEvents sample`);
 }
 
-if (!process.env["RUNNING_IN_TESTS"]) {
-  main().catch((err) => {
-    console.log("Error occurred: ", err);
-    process.exit(1);
-  });
-}
-
+import { runSample } from './sampleHelpers';
+runSample(main);

--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -9,6 +9,7 @@
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
 
+import { runSample } from './sampleHelpers';
 import { EventHubProducerClient } from "@azure/event-hubs";
 
 // Define connection string and related Event Hubs entity name here
@@ -77,5 +78,4 @@ export async function main(): Promise<void> {
   console.log(`Exiting sendEvents sample`);
 }
 
-import { runSample } from './sampleHelpers';
 runSample(main);

--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -21,6 +21,9 @@ export async function main(): Promise<void> {
   const producer = new EventHubProducerClient(connectionString, eventHubName);
 
   console.log("Creating and sending a batch of events...");
+
+  const eventsToSend = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+
   try {
     // By not specifying a partition ID or a partition key we allow the server to choose
     // which partition will accept this message.
@@ -32,21 +35,40 @@ export async function main(): Promise<void> {
     // If you would like more control you can pass either a `partitionKey` or a `partitionId`
     // into the createBatch() `options` parameter which will allow you full control over the 
     // destination.
-    const batch = await producer.createBatch();
+    let batch = await producer.createBatch();
 
     // add events to our batch
-    for (let index = 0; index < 10; index++) {
+    for (const event of eventsToSend) {
       // messages can fail to be added to the batch if they exceed the maximum size configured for
       // the EventHub.
-      const isAdded = batch.tryAdd({ body: "Sent along with 9 other events using batch" });
+      const isAdded = batch.tryAdd({ body: event });
       
       if (!isAdded) {
-        console.log(`Unable to add event ${index} to the batch`);
-        break;
+        if (batch.count === 0) {
+          // if we can't add it and the batch is empty that means the message we're trying to send
+          // is too large, even when it would be the _only_ message in the batch.
+          //
+          // To fix this you'll need to potentially split the message up across multiple batches or 
+          // skip it. In this example, we'll skip the message.
+          console.log(`Message was too large and can't be sent until it's made smaller. Skipping...`);
+          continue;
+        }
+
+        // otherwise this just signals a good spot to send our batch
+        console.log(`Batch is full - sending ${batch.count} messages as a single batch.`)
+        await producer.sendBatch(batch);
+
+        // and create a new one to house the next set of messages
+        batch = await producer.createBatch();
+        continue;
       }
     }
-
-    await producer.sendBatch(batch);
+    
+    // send any remaining messages, if any.
+    if (batch.count > 0) {
+      console.log(`Sending remaining ${batch.count} messages as a single batch.`)
+      await producer.sendBatch(batch);
+    }
   } catch (err) {
     console.log("Error when creating & sending a batch of events: ", err);
   }

--- a/sdk/eventhub/event-hubs/samples/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/sendEvents.ts
@@ -12,10 +12,12 @@
 import { EventHubProducerClient } from "@azure/event-hubs";
 
 // Define connection string and related Event Hubs entity name here
-const connectionString = "";
-const eventHubName = "";
+const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";
+const eventHubName = process.env["EVENTHUB_NAME"] || "";
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
+  console.log(`Running sendEvents sample`);
+
   const producer = new EventHubProducerClient(connectionString, eventHubName);
 
   console.log("Creating and sending a batch of events...");
@@ -50,8 +52,13 @@ async function main(): Promise<void> {
   }
 
   await producer.close();
+  console.log(`Exiting sendEvents sample`);
 }
 
-main().catch((err) => {
-  console.log("Error occurred: ", err);
-});
+if (!process.env["RUNNING_IN_TESTS"]) {
+  main().catch((err) => {
+    console.log("Error occurred: ", err);
+    process.exit(1);
+  });
+}
+

--- a/sdk/eventhub/event-hubs/samples/tsconfig.json
+++ b/sdk/eventhub/event-hubs/samples/tsconfig.json
@@ -1,10 +1,32 @@
 {
-  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs"
+    /* Basic Options */
+    "target": "es2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
+    "sourceMap": true /* Generates corresponding '.map' file. */,
+    "outDir": "./dist-esm" /* Redirect output structure to the directory. */,
+    "declarationDir": "./typings" /* Output directory for generated declaration files.*/,
+    "importHelpers": true /* Import emit helpers from 'tslib'. */,
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    /* Module Resolution Options */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    /* Experimental Options */
+    "forceConsistentCasingInFileNames": true,
+    /* Other options */
+    "newLine": "LF" /*	Use the specified end of line sequence to be used when emitting files: "crlf" (windows) or "lf" (unix).”*/,
+    "allowJs": false /* Don't allow JavaScript files to be compiled.*/,
+    "resolveJsonModule": true
   },
   "include": [
-    "**/*.ts"
+    "*.ts"
   ],
   "exclude": [
     "../node_modules",

--- a/sdk/eventhub/event-hubs/samples/tsconfig.json
+++ b/sdk/eventhub/event-hubs/samples/tsconfig.json
@@ -29,7 +29,7 @@
     "*.ts"
   ],
   "exclude": [
-    "../node_modules",
-    "../typings/**"
+    "./node_modules",
+    "./typings/**"
   ]
 }

--- a/sdk/eventhub/event-hubs/samples/useWithIotHub.ts
+++ b/sdk/eventhub/event-hubs/samples/useWithIotHub.ts
@@ -23,9 +23,5 @@ export async function main(): Promise<void> {
   console.log(`Exiting useWithIotHub sample`);
 }
 
-if (!process.env["RUNNING_IN_TESTS"]) {
-  main().catch((err) => {
-    console.log("Error occurred: ", err);
-    process.exit(1);
-  });
-}
+import { runSample } from './sampleHelpers';
+runSample(main);

--- a/sdk/eventhub/event-hubs/samples/useWithIotHub.ts
+++ b/sdk/eventhub/event-hubs/samples/useWithIotHub.ts
@@ -9,18 +9,23 @@ import { EventHubConsumerClient } from "@azure/event-hubs";
 // Define IoT Hub Event Hubs-compatible connection string here.
 // To find the correct connection string to use, visit:
 // https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-read-builtin
-const connectionString = "";
-const consumerGroup = "";
+const connectionString = process.env["IOTHUB_CONNECTION_STRING"] || "";
+const consumerGroup = process.env["CONSUMER_GROUP_NAME"] || "";
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
+  console.log(`Running useWithIotHub sample`);
   const client = new EventHubConsumerClient(consumerGroup, connectionString);
   /*
    Refer to other samples, and place your code here to receive events using the above client.
    Please note that send operations are not supported when this client is used against an IotHub instance
   */
   await client.close();
+  console.log(`Exiting useWithIotHub sample`);
 }
 
-main().catch((err) => {
-  console.log("Error occurred: ", err);
-});
+if (!process.env["RUNNING_IN_TESTS"]) {
+  main().catch((err) => {
+    console.log("Error occurred: ", err);
+    process.exit(1);
+  });
+}

--- a/sdk/eventhub/event-hubs/samples/useWithIotHub.ts
+++ b/sdk/eventhub/event-hubs/samples/useWithIotHub.ts
@@ -4,6 +4,7 @@
 
  This sample demonstrates how to use the EventHubClient with an IotHub instance
 */
+import { runSample } from './sampleHelpers';
 import { EventHubConsumerClient } from "@azure/event-hubs";
 
 // Define IoT Hub Event Hubs-compatible connection string here.
@@ -23,5 +24,4 @@ export async function main(): Promise<void> {
   console.log(`Exiting useWithIotHub sample`);
 }
 
-import { runSample } from './sampleHelpers';
 runSample(main);

--- a/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
@@ -46,9 +46,5 @@ export async function main(): Promise<void> {
   console.log(`Exiting usingAadAuth sample`);
 }
 
-if (!process.env["RUNNING_IN_TESTS"]) {
-  main().catch((err) => {
-    console.log("Error occurred: ", err);
-    process.exit(1);
-  });
-}
+import { runSample } from './sampleHelpers';
+runSample(main);

--- a/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
@@ -22,6 +22,7 @@
   Note: If you are using version 2.1.0 or lower of @azure/event-hubs library, then please use the samples at
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
+import { runSample } from './sampleHelpers';
 import { EventHubConsumerClient } from "@azure/event-hubs";
 import { DefaultAzureCredential } from "@azure/identity";
 
@@ -46,5 +47,4 @@ export async function main(): Promise<void> {
   console.log(`Exiting usingAadAuth sample`);
 }
 
-import { runSample } from './sampleHelpers';
 runSample(main);

--- a/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples/usingAadAuth.ts
@@ -26,22 +26,29 @@ import { EventHubConsumerClient } from "@azure/event-hubs";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // Define Event Hubs Endpoint and related entity name here here
-const evenHubsEndpoint = ""; // <your-eventhubs-namespace>.servicebus.windows.net
-const eventHubName = "";
-const consumerGroup = "";
+const eventHubsFullyQualifiedName = process.env["EVENTHUB_FQDN"] || ""; // <your-eventhubs-namespace>.servicebus.windows.net
+const eventHubName = process.env["EVENTHUB_NAME"] || "";
+const consumerGroup = process.env["CONSUMER_GROUP_NAME"] || "";
 
 // Define AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET of your AAD application in your environment
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
+  console.log(`Running usingAadAuth sample`);
+
   const credential = new DefaultAzureCredential();
-  const client = new EventHubConsumerClient(consumerGroup, evenHubsEndpoint, eventHubName, credential);
+  const client = new EventHubConsumerClient(consumerGroup, eventHubsFullyQualifiedName, eventHubName, credential);
   /*
    Refer to other samples, and place your code here
    to send/receive events
   */
   await client.close();
+
+  console.log(`Exiting usingAadAuth sample`);
 }
 
-main().catch((err) => {
-  console.log("error: ", err);
-});
+if (!process.env["RUNNING_IN_TESTS"]) {
+  main().catch((err) => {
+    console.log("Error occurred: ", err);
+    process.exit(1);
+  });
+}

--- a/sdk/eventhub/event-hubs/samples/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/websockets.ts
@@ -14,6 +14,7 @@
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/event-hubs_2.1.0/sdk/eventhub/event-hubs/samples instead.
 */
 
+import { runSample } from './sampleHelpers';
 import { EventHubConsumerClient } from "@azure/event-hubs";
 import WebSocket from "ws";
 const url = require("url");
@@ -48,5 +49,4 @@ export async function main(): Promise<void> {
   console.log(`Exiting websockets sample`);
 }
 
-import { runSample } from './sampleHelpers';
 runSample(main);

--- a/sdk/eventhub/event-hubs/samples/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/websockets.ts
@@ -20,9 +20,9 @@ const url = require("url");
 const httpsProxyAgent = require("https-proxy-agent");
 
 // Define connection string and related Event Hubs entity name here
-const connectionString = "";
-const eventHubName = "";
-const consumerGroup = "";
+const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";
+const eventHubName = process.env["EVENTHUB_NAME"] || "";
+const consumerGroup = process.env["CONSUMER_GROUP_NAME"] || "";
 
 // Create an instance of the `HttpsProxyAgent` class with the proxy server information like
 // proxy url, username and password
@@ -31,7 +31,9 @@ const urlParts = url.parse("http://localhost:3128");
 urlParts.auth = "username:password"; // Skip this if proxy server does not need authentication.
 const proxyAgent = new httpsProxyAgent(urlParts);
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
+  console.log(`Running websockets sample`);
+
   const client = new EventHubConsumerClient(consumerGroup, connectionString, eventHubName, {
     webSocketOptions: {
       webSocket: WebSocket,
@@ -42,8 +44,13 @@ async function main(): Promise<void> {
    Refer to other samples, and place your code here to send/receive events
   */
   await client.close();
+
+  console.log(`Exiting websockets sample`);
 }
 
-main().catch(err => {
-  console.log("error: ", err);
-});
+if (!process.env["RUNNING_IN_TESTS"]) {
+  main().catch((err) => {
+    console.log("Error occurred: ", err);
+    process.exit(1);
+  });
+}

--- a/sdk/eventhub/event-hubs/samples/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/websockets.ts
@@ -48,9 +48,5 @@ export async function main(): Promise<void> {
   console.log(`Exiting websockets sample`);
 }
 
-if (!process.env["RUNNING_IN_TESTS"]) {
-  main().catch((err) => {
-    console.log("Error occurred: ", err);
-    process.exit(1);
-  });
-}
+import { runSample } from './sampleHelpers';
+runSample(main);


### PR DESCRIPTION
Improving the samples by making them:

* Simpler for users to just download and run.
* Makes it more effective for us as a testing tool since we can use it to test whatever is published based on using @next as the default version for the packages.
* Lets us use some convenient libraries like `dotenv`.

Also, made an improvement to the sendEvents.ts example, fixing #6254