### PR TITLE
[Core-http] Fix issue of data being pushed twice when reporting progress

### DIFF
--- a/sdk/core/core-http/lib/fetchHttpClient.ts
+++ b/sdk/core/core-http/lib/fetchHttpClient.ts
@@ -17,13 +17,13 @@ interface FetchError extends Error {
   type?: string;
 }
 
-class ReportTransform extends Transform {
+export class ReportTransform extends Transform {
   private loadedBytes: number = 0;
   _transform(chunk: string | Buffer, _encoding: string, callback: Function) {
     this.push(chunk);
     this.loadedBytes += chunk.length;
     this.progressCallback!({ loadedBytes: this.loadedBytes });
-    callback(undefined, chunk);
+    callback(undefined);
   }
 
   constructor(private progressCallback: (progress: TransferProgressEvent) => void) {

--- a/sdk/core/core-http/test/defaultHttpClientTests.ts
+++ b/sdk/core/core-http/test/defaultHttpClientTests.ts
@@ -13,6 +13,8 @@ import { isNode } from "../lib/util/utils";
 import { WebResource, HttpRequestBody, TransferProgressEvent } from "../lib/webResource";
 import { getHttpMock, HttpMockFacade } from "./mockHttp";
 import { TestFunction } from "mocha";
+import { PassThrough } from 'stream';
+import { ReportTransform } from '../lib/fetchHttpClient';
 
 const nodeIt = (isNode ? it : it.skip) as TestFunction;
 
@@ -370,5 +372,18 @@ describe("defaultHttpClient", function() {
     assert.strictEqual(responseBody, responseContent);
 
     httpMock.teardown();
+  });
+});
+
+describe("ReportTransform", function() {
+  it("should not modify the stream data", function() {
+    const a = new PassThrough();
+    const b = new PassThrough();
+    const callback = () => {};
+    const report = new ReportTransform(callback);
+    a.pipe(report, { end: false }).pipe(b, { end: false });
+    a.write("hello");
+    const transformed = b.read();
+    transformed.toString().should.equal("hello");
   });
 });


### PR DESCRIPTION
The regression was introduced in #5298. If a second argument `data`
is passed to `callback()` in `_transform()`, `data` will be pushed
again.  I misread the doc when adding the report transform.

This change removes the second argument from `callback()`.

Fixes #6352.