### PR TITLE
Separating nyc from the integration tests for Node

### DIFF
--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -52,7 +52,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"samples/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 2000000 --full-trace dist-test/index.node.js",
+    "integration-test:node": "mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 2000000 --full-trace dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json tsconfig.json \"src/**/*.ts\" --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json tsconfig.json src test samples --ext .ts -f html -o keyvault-certificates-lintReport.html || exit 0",
@@ -64,7 +64,9 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "sideEffects": false,
   "dependencies": {

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -51,7 +51,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 5000000 --full-trace dist-test/index.node.js",
+    "integration-test:node": "mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 5000000 --full-trace dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json tsconfig.json src test samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json tsconfig.json src test samples --ext .ts -f html -o keyvault-keys-lintReport.html || exit 0",
@@ -64,7 +64,9 @@
     "unit-test:browser": "echo skipped",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "test:node:record": "cross-env TEST_MODE=record npm run integration-test:node"
+    "test:node:record": "cross-env TEST_MODE=record npm run integration-test:node",
+    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "sideEffects": false,
   "dependencies": {

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -51,7 +51,7 @@
     "extract-api": "tsc -p . && api-extractor run --local",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 1200000 --full-trace dist-test/index.node.js",
+    "integration-test:node": "mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --timeout 1200000 --full-trace dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json tsconfig.json src test samples --ext .ts --fix --fix-type [problem,suggestion]",
     "lint": "eslint package.json tsconfig.json src test samples --ext .ts -f html -o keyvault-secrets-lintReport.html || exit 0",
@@ -64,7 +64,9 @@
     "unit-test:browser": "echo skipped",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "test:node:record": "cross-env TEST_MODE=record npm run integration-test:node"
+    "test:node:record": "cross-env TEST_MODE=record npm run integration-test:node",
+    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "sideEffects": false,
   "dependencies": {

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -34,7 +34,7 @@
     "execute:samples": "node execute-samples.js",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
+    "integration-test:node": "mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.json src test samples --ext .ts --fix",
     "lint": "eslint -c ../../.eslintrc.json src test samples --ext .ts -f html -o storage-blob-lintReport.html || exit 0",
@@ -46,7 +46,9 @@
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node"
+    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node",
+    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
     "BreakingChanges.md",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -32,7 +32,7 @@
     "execute:samples": "echo skipped until samples automation ready",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
+    "integration-test:node": "mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.json src test samples --ext .ts --fix",
     "lint": "eslint -c ../../.eslintrc.json src test samples --ext .ts -f html -o storage-file-share-lintReport.html || exit 0",
@@ -43,7 +43,9 @@
     "test": "npm run clean && npm run build:test && npm run integration-test",
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
     "BreakingChanges.md",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -34,7 +34,7 @@
     "execute:samples": "echo skipped for now due to https://github.com/Azure/azure-sdk-for-js/issues/6362",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
+    "integration-test:node": "mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.json src test samples --ext .ts --fix",
     "lint": "eslint -c ../../.eslintrc.json src test samples --ext .ts -f html -o storage-file-share-lintReport.html || exit 0",
@@ -45,7 +45,9 @@
     "test": "npm run clean && npm run build:test && npm run integration-test",
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
     "BreakingChanges.md",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -31,7 +31,7 @@
     "execute:samples": "node execute-samples.js",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
+    "integration-test:node": "mocha --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-test/index.node.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.json src test samples --ext .ts --fix",
     "lint": "eslint -c ../../.eslintrc.json src test samples --ext .ts -f html -o storage-queue-lintReport.html || exit 0",
@@ -43,7 +43,9 @@
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node"
+    "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node",
+    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
     "BreakingChanges.md",


### PR DESCRIPTION
nyc is obscuring Mocha's stack traces. It's unable to follow through the references. This is the fastest fix (probably by days of separation from the next fastest fix), and this will incidentally make our Node tests faster.

![image](https://user-images.githubusercontent.com/417016/70282818-177b3700-178d-11ea-9ed2-ab63101218bf.png)

Fixes #6298