### PR TITLE
Set rush parallelism to "max" (# of cores)

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -81,7 +81,7 @@ jobs:
           RepoId: "Azure/azure-sdk-for-js"
 
       - script: |
-          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p 3
+          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p max
         displayName: "Build libraries"
 
       - script: |
@@ -234,15 +234,15 @@ jobs:
           displayName: "Install dependencies"
 
         - script: |
-            node eng/tools/rush-runner.js build --verbose -p 3
+            node eng/tools/rush-runner.js build --verbose -p max
           displayName: "Build libraries"
 
         - script: |
-            node eng/tools/rush-runner.js build:test --verbose -p 3
+            node eng/tools/rush-runner.js build:test --verbose -p max
           displayName: "Build test assets"
 
         - script: |
-            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p 3
+            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"
 
         # Unlink node_modules folders to significantly improve performance of subsequent tasks

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -81,7 +81,7 @@ jobs:
           RepoId: "Azure/azure-sdk-for-js"
 
       - script: |
-          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose
+          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p max
         displayName: "Build libraries"
 
       - script: |
@@ -234,15 +234,15 @@ jobs:
           displayName: "Install dependencies"
 
         - script: |
-            node eng/tools/rush-runner.js build --verbose
+            node eng/tools/rush-runner.js build --verbose -p max
           displayName: "Build libraries"
 
         - script: |
-            node eng/tools/rush-runner.js build:test --verbose
+            node eng/tools/rush-runner.js build:test --verbose -p max
           displayName: "Build test assets"
 
         - script: |
-            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose
+            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"
 
         # Unlink node_modules folders to significantly improve performance of subsequent tasks

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -80,6 +80,8 @@ jobs:
           BuildSHA: $(Build.SourceVersion)
           RepoId: "Azure/azure-sdk-for-js"
 
+      # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
       - script: |
           node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p max
         displayName: "Build libraries"
@@ -233,14 +235,20 @@ jobs:
             node common/scripts/install-run-rush.js install
           displayName: "Install dependencies"
 
+        # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
+        # The default on Windows is "cores - 1" (microsoft/rushstack#436)
         - script: |
             node eng/tools/rush-runner.js build --verbose -p max
           displayName: "Build libraries"
 
+        # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
+        # The default on Windows is "cores - 1" (microsoft/rushstack#436)
         - script: |
             node eng/tools/rush-runner.js build:test --verbose -p max
           displayName: "Build test assets"
 
+        # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
+        # The default on Windows is "cores - 1" (microsoft/rushstack#436)
         - script: |
             node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -81,7 +81,7 @@ jobs:
           RepoId: "Azure/azure-sdk-for-js"
 
       - script: |
-          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p 4
+          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p 3
         displayName: "Build libraries"
 
       - script: |
@@ -234,15 +234,15 @@ jobs:
           displayName: "Install dependencies"
 
         - script: |
-            node eng/tools/rush-runner.js build --verbose -p 4
+            node eng/tools/rush-runner.js build --verbose -p 3
           displayName: "Build libraries"
 
         - script: |
-            node eng/tools/rush-runner.js build:test --verbose -p 4
+            node eng/tools/rush-runner.js build:test --verbose -p 3
           displayName: "Build test assets"
 
         - script: |
-            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p 4
+            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p 3
           displayName: "Test libraries"
 
         # Unlink node_modules folders to significantly improve performance of subsequent tasks

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -81,7 +81,7 @@ jobs:
           RepoId: "Azure/azure-sdk-for-js"
 
       # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
-      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436).
       - script: |
           node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p max
         displayName: "Build libraries"
@@ -236,19 +236,19 @@ jobs:
           displayName: "Install dependencies"
 
         # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
-        # The default on Windows is "cores - 1" (microsoft/rushstack#436)
+        # The default on Windows is "cores - 1" (microsoft/rushstack#436).
         - script: |
             node eng/tools/rush-runner.js build --verbose -p max
           displayName: "Build libraries"
 
         # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
-        # The default on Windows is "cores - 1" (microsoft/rushstack#436)
+        # The default on Windows is "cores - 1" (microsoft/rushstack#436).
         - script: |
             node eng/tools/rush-runner.js build:test --verbose -p max
           displayName: "Build test assets"
 
         # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
-        # The default on Windows is "cores - 1" (microsoft/rushstack#436)
+        # The default on Windows is "cores - 1" (microsoft/rushstack#436).
         - script: |
             node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -81,7 +81,7 @@ jobs:
           RepoId: "Azure/azure-sdk-for-js"
 
       - script: |
-          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p max
+          node eng/tools/rush-runner.js build "${{parameters.ServiceDirectory}}" --verbose -p 4
         displayName: "Build libraries"
 
       - script: |
@@ -234,15 +234,15 @@ jobs:
           displayName: "Install dependencies"
 
         - script: |
-            node eng/tools/rush-runner.js build --verbose -p max
+            node eng/tools/rush-runner.js build --verbose -p 4
           displayName: "Build libraries"
 
         - script: |
-            node eng/tools/rush-runner.js build:test --verbose -p max
+            node eng/tools/rush-runner.js build:test --verbose -p 4
           displayName: "Build test assets"
 
         - script: |
-            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p max
+            node eng/tools/rush-runner.js unit-test "${{parameters.ServiceDirectory}}" --verbose -p 4
           displayName: "Test libraries"
 
         # Unlink node_modules folders to significantly improve performance of subsequent tasks

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -84,10 +84,14 @@ jobs:
           node common/scripts/install-run-rush.js install
         displayName: "Install dependencies"
 
+      # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
       - script: |
           node common/scripts/install-run-rush.js build -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build libraries"
 
+      # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
       - script: |
           node common/scripts/install-run-rush.js build:test -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build test assets"
@@ -95,6 +99,8 @@ jobs:
       - ${{if ne(parameters.PreIntegrationSteps, '')}}:
           - template: ../steps/${{parameters.PreIntegrationSteps}}.yml
 
+      # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
       - script: |
           node common/scripts/install-run-rush.js integration-test:$(TestType) -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Integration test libraries"

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -85,18 +85,18 @@ jobs:
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build -t "${{parameters.PackageName}}" --verbose
+          node common/scripts/install-run-rush.js build -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build libraries"
 
       - script: |
-          node common/scripts/install-run-rush.js build:test -t "${{parameters.PackageName}}" --verbose
+          node common/scripts/install-run-rush.js build:test -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build test assets"
 
       - ${{if ne(parameters.PreIntegrationSteps, '')}}:
           - template: ../steps/${{parameters.PreIntegrationSteps}}.yml
 
       - script: |
-          node common/scripts/install-run-rush.js integration-test:$(TestType) -t "${{parameters.PackageName}}" --verbose
+          node common/scripts/install-run-rush.js integration-test:$(TestType) -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Integration test libraries"
         env: ${{parameters.EnvVars}}
         condition: ne(variables['TestType'],'sample')

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -85,13 +85,13 @@ jobs:
         displayName: "Install dependencies"
 
       # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
-      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436).
       - script: |
           node common/scripts/install-run-rush.js build -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build libraries"
 
       # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
-      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436).
       - script: |
           node common/scripts/install-run-rush.js build:test -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Build test assets"
@@ -100,7 +100,7 @@ jobs:
           - template: ../steps/${{parameters.PreIntegrationSteps}}.yml
 
       # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
-      # The default on Windows is "cores - 1" (microsoft/rushstack#436)
+      # The default on Windows is "cores - 1" (microsoft/rushstack#436).
       - script: |
           node common/scripts/install-run-rush.js integration-test:$(TestType) -t "${{parameters.PackageName}}" --verbose -p max
         displayName: "Integration test libraries"


### PR DESCRIPTION
- Default on Windows is "cores - 1" (microsoft/rushstack#436)
- Increasing to "max" ensures parallelism is set to the number of cores on all platforms
- Significantly improves Windows build times
