### PR TITLE
[amqp-common] Sets connection idle timeout to 60 seconds

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -5,7 +5,7 @@ dependencies:
   '@azure/ms-rest-azure-js': 1.3.8
   '@azure/ms-rest-js': 1.8.13
   '@azure/ms-rest-nodeauth': 0.9.3
-  '@microsoft/api-extractor': 7.6.2
+  '@microsoft/api-extractor': 7.7.0
   '@rush-temp/abort-controller': 'file:projects/abort-controller.tgz'
   '@rush-temp/amqp-common': 'file:projects/amqp-common.tgz'
   '@rush-temp/core-http': 'file:projects/core-http.tgz'
@@ -23,7 +23,7 @@ dependencies:
   '@rush-temp/template': 'file:projects/template.tgz'
   '@rush-temp/testhub': 'file:projects/testhub.tgz'
   '@types/async-lock': 1.1.1
-  '@types/chai': 4.2.5
+  '@types/chai': 4.2.6
   '@types/chai-as-promised': 7.1.2
   '@types/chai-string': 1.4.2
   '@types/debug': 0.0.31
@@ -42,7 +42,7 @@ dependencies:
   '@types/node': 8.10.59
   '@types/semver': 5.5.0
   '@types/sinon': 5.0.7
-  '@types/tough-cookie': 2.3.5
+  '@types/tough-cookie': 2.3.6
   '@types/tunnel': 0.0.0
   '@types/uuid': 3.4.6
   '@types/webpack': 4.41.0
@@ -72,7 +72,7 @@ dependencies:
   eslint-config-prettier: 4.3.0
   eslint-detailed-reporter: 0.8.0
   eslint-plugin-no-null: 1.0.2
-  eslint-plugin-no-only-tests: 2.3.1
+  eslint-plugin-no-only-tests: 2.4.0
   eslint-plugin-promise: 4.2.1
   events: 3.0.0
   express: 4.17.1
@@ -124,7 +124,7 @@ dependencies:
   puppeteer: 1.20.0
   query-string: 6.9.0
   resolve: 1.11.0
-  rhea: 1.0.13
+  rhea: 1.0.15
   rhea-promise: 0.1.15
   rimraf: 2.7.1
   rollup: 1.13.1
@@ -157,7 +157,7 @@ dependencies:
   tunnel: 0.0.6
   typescript: 3.6.4
   uglify: 0.1.5
-  uglify-js: 3.7.0
+  uglify-js: 3.7.1
   url: 0.11.0
   util: 0.11.1
   uuid: 3.3.3
@@ -168,7 +168,7 @@ dependencies:
   xhr-mock: 2.5.1
   xml2js: 0.4.22
   yargs: 11.1.1
-  yarn: 1.19.2
+  yarn: 1.21.0
 lockfileVersion: 5
 packages:
   /@azure/amqp-common/0.1.9_rhea-promise@0.1.15:
@@ -315,17 +315,17 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==
-  /@babel/parser/7.7.4:
+  /@babel/parser/7.7.5:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==
+      integrity: sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==
   /@babel/template/7.7.4:
     dependencies:
       '@babel/code-frame': 7.5.5
-      '@babel/parser': 7.7.4
+      '@babel/parser': 7.7.5
       '@babel/types': 7.7.4
     dev: false
     resolution:
@@ -336,7 +336,7 @@ packages:
       '@babel/generator': 7.7.4
       '@babel/helper-function-name': 7.7.4
       '@babel/helper-split-export-declaration': 7.7.4
-      '@babel/parser': 7.7.4
+      '@babel/parser': 7.7.5
       '@babel/types': 7.7.4
       debug: 4.1.1
       globals: 11.12.0
@@ -352,16 +352,16 @@ packages:
     dev: false
     resolution:
       integrity: sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==
-  /@microsoft/api-extractor-model/7.6.0:
+  /@microsoft/api-extractor-model/7.7.0:
     dependencies:
       '@microsoft/node-core-library': 3.18.0
       '@microsoft/tsdoc': 0.12.14
     dev: false
     resolution:
-      integrity: sha512-7gtxCxUMLDv3k1NE7MCaUaQeAwH5dEt/vjnq22cOUiCfiYOxdrvolab+WIXSNKV6rhe+AnIovR9tkxtxw5OiYA==
-  /@microsoft/api-extractor/7.6.2:
+      integrity: sha512-9yrSr9LpdNnx7X8bXVb/YbcQopizsr43McAG7Xno5CMNFzbSkmIr8FJL0L+WGfrSWSTms9Bngfz7d1ScP6zbWQ==
+  /@microsoft/api-extractor/7.7.0:
     dependencies:
-      '@microsoft/api-extractor-model': 7.6.0
+      '@microsoft/api-extractor-model': 7.7.0
       '@microsoft/node-core-library': 3.18.0
       '@microsoft/ts-command-line': 4.3.5
       '@microsoft/tsdoc': 0.12.14
@@ -369,11 +369,11 @@ packages:
       lodash: 4.17.15
       resolve: 1.8.1
       source-map: 0.6.1
-      typescript: 3.7.2
+      typescript: 3.7.3
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-4nK2uAWwC1nfzpEbyCwPfe/39aHkoWIhsodj8yrWTxMpH0eI7Ik/SdHtn3bDKVHIK67EnaR5//fnevpj9ACByw==
+      integrity: sha512-1ngy95VA1s7GTE+bkS7QoYTg/TZs54CdJ46uAhl6HlyDJut4p/aH46W70g2XQs9VniIymW1Qe6fqNmcQUx5CVg==
   /@microsoft/node-core-library/3.18.0:
     dependencies:
       '@types/node': 8.10.54
@@ -448,20 +448,20 @@ packages:
       integrity: sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==
   /@types/chai-as-promised/7.1.2:
     dependencies:
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
     dev: false
     resolution:
       integrity: sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==
   /@types/chai-string/1.4.2:
     dependencies:
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
     dev: false
     resolution:
       integrity: sha512-ld/1hV5qcPRGuwlPdvRfvM3Ka/iofOk2pH4VkasK4b1JJP1LjNmWWn0LsISf6RRzyhVOvs93rb9tM09e+UuF8Q==
-  /@types/chai/4.2.5:
+  /@types/chai/4.2.6:
     dev: false
     resolution:
-      integrity: sha512-YvbLiIc0DbbhiANrfVObdkLEHJksQZVq0Uvfg550SRAKVYaEJy+V70j65BVe2WNp6E3HtKsUczeijHFCjba3og==
+      integrity: sha512-HF8faEUA4JurIm+68VaA2KedtZf5LYdXpQEAbIAN79DwWQbO82BNTksZgCH3UMqbZHXex9C6TrBfg7OUInRISQ==
   /@types/connect/3.4.32:
     dependencies:
       '@types/node': 8.10.59
@@ -630,10 +630,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
-  /@types/tough-cookie/2.3.5:
+  /@types/tough-cookie/2.3.6:
     dev: false
     resolution:
-      integrity: sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==
+      integrity: sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==
   /@types/tunnel/0.0.0:
     dependencies:
       '@types/node': 8.10.59
@@ -1008,9 +1008,9 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
-  /acorn-jsx/5.1.0_acorn@6.3.0:
+  /acorn-jsx/5.1.0_acorn@6.4.0:
     dependencies:
-      acorn: 6.3.0
+      acorn: 6.4.0
     dev: false
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0
@@ -1029,13 +1029,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
-  /acorn/6.3.0:
+  /acorn/6.4.0:
     dev: false
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
+      integrity: sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
   /adal-node/0.1.28:
     dependencies:
       '@types/node': 8.10.59
@@ -1481,10 +1481,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-  /aws4/1.8.0:
+  /aws4/1.9.0:
     dev: false
     resolution:
-      integrity: sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+      integrity: sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==
   /axios-mock-adapter/1.17.0:
     dependencies:
       deep-equal: 1.1.1
@@ -2080,10 +2080,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
-  /bluebird/3.7.1:
+  /bluebird/3.7.2:
     dev: false
     resolution:
-      integrity: sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
+      integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
   /bn.js/4.11.8:
     dev: false
     resolution:
@@ -2204,8 +2204,8 @@ packages:
       integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
   /browserslist/3.2.8:
     dependencies:
-      caniuse-lite: 1.0.30001012
-      electron-to-chromium: 1.3.314
+      caniuse-lite: 1.0.30001015
+      electron-to-chromium: 1.3.322
     dev: false
     hasBin: true
     resolution:
@@ -2290,7 +2290,7 @@ packages:
       integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
   /cacache/12.0.3:
     dependencies:
-      bluebird: 3.7.1
+      bluebird: 3.7.2
       chownr: 1.1.3
       figgy-pudding: 3.5.1
       glob: 7.1.6
@@ -2394,10 +2394,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
-  /caniuse-lite/1.0.30001012:
+  /caniuse-lite/1.0.30001015:
     dev: false
     resolution:
-      integrity: sha512-7RR4Uh04t9K1uYRWzOJmzplgEOAXbfK72oVNokCdMzA67trrhPzy93ahKk1AWHiA0c58tD2P+NHqxrA8FZ+Trg==
+      integrity: sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==
   /caseless/0.12.0:
     dev: false
     resolution:
@@ -3310,10 +3310,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
-  /electron-to-chromium/1.3.314:
+  /electron-to-chromium/1.3.322:
     dev: false
     resolution:
-      integrity: sha512-IKDR/xCxKFhPts7h+VaSXS02Z1mznP3fli1BbXWXeN89i2gCzKraU8qLpEid8YzKcmZdZD3Mly3cn5/lY9xsBQ==
+      integrity: sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==
   /elliptic/6.5.2:
     dependencies:
       bn.js: 4.11.8
@@ -3422,7 +3422,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.16.2:
+  /es-abstract/1.16.3:
     dependencies:
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
@@ -3438,7 +3438,7 @@ packages:
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==
+      integrity: sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==
   /es-to-primitive/1.2.1:
     dependencies:
       is-callable: 1.1.4
@@ -3486,7 +3486,7 @@ packages:
   /es6-symbol/3.1.3:
     dependencies:
       d: 1.0.1
-      ext: 1.2.0
+      ext: 1.4.0
     dev: false
     resolution:
       integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
@@ -3577,12 +3577,12 @@ packages:
       eslint: '>=3.0.0'
     resolution:
       integrity: sha1-EjaoEjkTkKGHetQAfCbnRTQclR8=
-  /eslint-plugin-no-only-tests/2.3.1:
+  /eslint-plugin-no-only-tests/2.4.0:
     dev: false
     engines:
       node: '>=4.0.0'
     resolution:
-      integrity: sha512-LzCzeQrlkNjEwUWEoGhfjz+Kgqe0080W6qC8I8eFwSMXIsr1zShuIQnRuSZc4Oi7k1vdUaNGDc+/GFvg6IHSHA==
+      integrity: sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
   /eslint-plugin-promise/4.2.1:
     dev: false
     engines:
@@ -3658,8 +3658,8 @@ packages:
       integrity: sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
   /espree/5.0.1:
     dependencies:
-      acorn: 6.3.0
-      acorn-jsx: 5.1.0_acorn@6.3.0
+      acorn: 6.4.0
+      acorn-jsx: 5.1.0_acorn@6.4.0
       eslint-visitor-keys: 1.1.0
     dev: false
     engines:
@@ -3847,12 +3847,12 @@ packages:
       node: '>= 0.10.0'
     resolution:
       integrity: sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
-  /ext/1.2.0:
+  /ext/1.4.0:
     dependencies:
       type: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==
+      integrity: sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
   /extend-shallow/1.1.4:
     dependencies:
       kind-of: 1.1.0
@@ -4737,7 +4737,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     resolution:
       integrity: sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   /har-schema/2.0.0:
@@ -5486,7 +5486,7 @@ packages:
   /istanbul-lib-instrument/3.3.0:
     dependencies:
       '@babel/generator': 7.7.4
-      '@babel/parser': 7.7.4
+      '@babel/parser': 7.7.5
       '@babel/template': 7.7.4
       '@babel/traverse': 7.7.4
       '@babel/types': 7.7.4
@@ -5908,7 +5908,7 @@ packages:
       integrity: sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=
   /karma-typescript-es6-transform/4.1.1:
     dependencies:
-      acorn: 6.3.0
+      acorn: 6.4.0
       acorn-walk: 6.2.0
       babel-core: 6.26.3
       babel-preset-env: 1.7.0
@@ -5950,7 +5950,7 @@ packages:
       integrity: sha512-970/okAsdUOmiMOCY8sb17A2I8neS25Ad9uhyK3GHgmRSIFJbDcNEFE8dqqUhNe9OHiCC9k3DMrSmtd/0ymP1A==
   /karma/4.4.1:
     dependencies:
-      bluebird: 3.7.1
+      bluebird: 3.7.2
       body-parser: 1.19.0
       braces: 3.0.2
       chokidar: 3.3.0
@@ -6906,7 +6906,7 @@ packages:
       lodash: 4.17.15
       mkdirp: 0.5.1
       propagate: 1.0.0
-      qs: 6.7.0
+      qs: 6.9.1
       semver: 5.7.1
     dev: false
     engines:
@@ -7129,7 +7129,7 @@ packages:
   /object.getownpropertydescriptors/2.0.3:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.16.2
+      es-abstract: 1.16.3
     dev: false
     engines:
       node: '>= 0.8'
@@ -7716,10 +7716,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
-  /psl/1.4.0:
+  /psl/1.6.0:
     dev: false
     resolution:
-      integrity: sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==
+      integrity: sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==
   /public-encrypt/4.0.3:
     dependencies:
       bn.js: 4.11.8
@@ -7801,6 +7801,12 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+  /qs/6.9.1:
+    dev: false
+    engines:
+      node: '>=0.6'
+    resolution:
+      integrity: sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
   /query-string/6.9.0:
     dependencies:
       decode-uri-component: 0.2.0
@@ -8121,7 +8127,7 @@ packages:
   /request/2.88.0:
     dependencies:
       aws-sign2: 0.7.0
-      aws4: 1.8.0
+      aws4: 1.9.0
       caseless: 0.12.0
       combined-stream: 1.0.8
       extend: 3.0.2
@@ -8248,17 +8254,17 @@ packages:
   /rhea-promise/0.1.15:
     dependencies:
       debug: 3.2.6
-      rhea: 1.0.13
+      rhea: 1.0.15
       tslib: 1.10.0
     dev: false
     resolution:
       integrity: sha512-+6uilZXSJGyiqVeHQI3Krv6NTAd8cWRCY2uyCxmzR4/5IFtBqqFem1HV2OiwSj0Gu7OFChIJDfH2JyjN7J0vRA==
-  /rhea/1.0.13:
+  /rhea/1.0.15:
     dependencies:
       debug: 3.2.6
     dev: false
     resolution:
-      integrity: sha512-gJJMJglV94vns97DVVRAAgyOZ7L8Pp99eFArx4szSiJNqgDPJAIh+yPkv88e1CzOFr4XkL2Vof6v/kdbWTpugQ==
+      integrity: sha512-Rxc8r5zJyPj6aCfGEq2iwbYoQouZJKUTQGCi3bk5IyT9oRwqrdrsjdSIl5H5Bg7M4f7aTO489FFiS5T5l6IAEA==
   /rimraf/2.2.8:
     dev: false
     hasBin: true
@@ -8425,7 +8431,7 @@ packages:
       '@babel/code-frame': 7.5.5
       jest-worker: 24.9.0
       serialize-javascript: 1.9.1
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <2'
@@ -8437,7 +8443,7 @@ packages:
       jest-worker: 24.9.0
       rollup: 1.13.1
       serialize-javascript: 1.9.1
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <2'
@@ -8480,7 +8486,7 @@ packages:
     dependencies:
       '@types/estree': 0.0.39
       '@types/node': 12.12.14
-      acorn: 6.3.0
+      acorn: 6.4.0
     dev: false
     hasBin: true
     resolution:
@@ -8600,6 +8606,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
+  /serialize-javascript/2.1.1:
+    dev: false
+    resolution:
+      integrity: sha512-MPLPRpD4FNqWq9tTIjYG5LesFouDhdyH0EPY3gVK4DRD5+g4aDqdNSzLIwceulo3Yj+PL1bPh6laE5+H6LTcrQ==
   /serve-static/1.14.1:
     dependencies:
       encodeurl: 1.0.2
@@ -9058,7 +9068,7 @@ packages:
   /string.prototype.padend/3.0.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.16.2
+      es-abstract: 1.16.3
       function-bind: 1.1.1
     dev: false
     engines:
@@ -9245,15 +9255,15 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=
-  /terser-webpack-plugin/1.4.1:
+  /terser-webpack-plugin/1.4.2:
     dependencies:
       cacache: 12.0.3
       find-cache-dir: 2.1.0
       is-wsl: 1.1.0
       schema-utils: 1.0.0
-      serialize-javascript: 1.9.1
+      serialize-javascript: 2.1.1
       source-map: 0.6.1
-      terser: 4.4.0
+      terser: 4.4.2
       webpack-sources: 1.4.3
       worker-farm: 1.7.0
     dev: false
@@ -9262,7 +9272,7 @@ packages:
     peerDependencies:
       webpack: ^4.0.0
     resolution:
-      integrity: sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==
+      integrity: sha512-fdEb91kR2l+BVgES77N/NTXWZlpX6vX+pYPjnX5grcDYBF2CMnzJiXX4NNlna4l04lvCW39lZ+O/jSvUhHH/ew==
   /terser/3.17.0:
     dependencies:
       commander: 2.20.3
@@ -9274,7 +9284,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
-  /terser/4.4.0:
+  /terser/4.4.2:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -9284,7 +9294,7 @@ packages:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==
+      integrity: sha512-Uufrsvhj9O1ikwgITGsZ5EZS6qPokUOkCegS7fYOdGTv+OA90vndUbU6PEjr5ePqHfNUbGyMO7xyIZv2MhsALQ==
   /test-exclude/5.2.3:
     dependencies:
       glob: 7.1.6
@@ -9432,7 +9442,7 @@ packages:
       integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
   /tough-cookie/2.4.3:
     dependencies:
-      psl: 1.4.0
+      psl: 1.6.0
       punycode: 1.4.1
     dev: false
     engines:
@@ -9441,7 +9451,7 @@ packages:
       integrity: sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
   /tough-cookie/2.5.0:
     dependencies:
-      psl: 1.4.0
+      psl: 1.6.0
       punycode: 2.1.1
     dev: false
     engines:
@@ -9765,13 +9775,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
-  /typescript/3.7.2:
+  /typescript/3.7.3:
     dev: false
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+      integrity: sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
   /uglify-js/2.4.24:
     dependencies:
       async: 0.2.10
@@ -9784,7 +9794,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=
-  /uglify-js/3.7.0:
+  /uglify-js/3.7.1:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -9793,7 +9803,7 @@ packages:
       node: '>=0.8.0'
     hasBin: true
     resolution:
-      integrity: sha512-PC/ee458NEMITe1OufAjal65i6lB58R1HWMRcxwvdz1UopW0DYqlRL3xdu3IcTvTXsB02CRHykidkTRL+A3hQA==
+      integrity: sha512-pnOF7jY82wdIhATVn87uUY/FHU+MDUdPLkmGFvGoclQmeu229eTkbG5gjGGBi3R7UuYYSEeYXY/TTY5j2aym2g==
   /uglify-to-browserify/1.0.2:
     dev: false
     resolution:
@@ -10222,7 +10232,7 @@ packages:
       '@webassemblyjs/helper-module-context': 1.8.5
       '@webassemblyjs/wasm-edit': 1.8.5
       '@webassemblyjs/wasm-parser': 1.8.5
-      acorn: 6.3.0
+      acorn: 6.4.0
       ajv: 6.10.2
       ajv-keywords: 3.4.1_ajv@6.10.2
       chrome-trace-event: 1.0.2
@@ -10238,7 +10248,7 @@ packages:
       node-libs-browser: 2.2.1
       schema-utils: 1.0.0
       tapable: 1.1.3
-      terser-webpack-plugin: 1.4.1
+      terser-webpack-plugin: 1.4.2
       watchpack: 1.6.0
       webpack-sources: 1.4.3
     dev: false
@@ -10546,13 +10556,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=
-  /yarn/1.19.2:
+  /yarn/1.21.0:
     dev: false
     engines:
       node: '>=4.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-OdLN/K/sA+KnW4ggNQwHYK6YJdLkSWxbx6IYd+WIQJ6xDfk8CIYKckBfwGxTBmDaEluWs83InzjFCmUqPtpY+w==
+      integrity: sha512-g9cvrdKXPZlz1eJYpKanQm3eywEmecudeyDkwiVWeswBrpHK3nJFBholkphHF9eNc8y/FNEhSQ8Et5ZAx4XyLw==
   /yauzl/2.4.1:
     dependencies:
       fd-slicer: 1.0.1
@@ -10593,7 +10603,7 @@ packages:
   'file:projects/abort-controller.tgz':
     dependencies:
       '@azure/ms-rest-js': 1.8.12
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       assert: 1.5.0
@@ -10635,7 +10645,7 @@ packages:
     dependencies:
       '@azure/ms-rest-nodeauth': 0.9.3
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 0.0.31
       '@types/dotenv': 6.1.1
@@ -10658,7 +10668,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
       is-buffer: 2.0.4
@@ -10673,7 +10683,7 @@ packages:
       prettier: 1.19.1
       process: 0.11.10
       puppeteer: 1.20.0
-      rhea: 1.0.13
+      rhea: 1.0.15
       rhea-promise: 0.1.15
       rimraf: 2.7.1
       rollup: 1.13.1
@@ -10699,13 +10709,13 @@ packages:
     dev: false
     name: '@rush-temp/amqp-common'
     resolution:
-      integrity: sha512-5tn4C6deH6x6rxTyFKxjS8x0zTgCXxza9jSziyTG5ZdFegsXsGbEOZw0mnNA0EmN4cND3gQgSn4eLQ5K1AceFg==
+      integrity: sha512-vF9EfeF1AGcpCVwIgjhrqAp4tpoNFDb8lerRDV/Ejs0C5/N0mbqU9hF6NPB5Bb1mpNVK6RUJlwn1LT7I2OgQeA==
       tarball: 'file:projects/amqp-common.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
     dependencies:
       '@azure/logger-js': 1.3.2
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
       '@types/express': 4.17.2
       '@types/form-data': 2.5.0
       '@types/glob': 7.1.1
@@ -10714,7 +10724,7 @@ packages:
       '@types/node': 8.10.59
       '@types/semver': 5.5.0
       '@types/sinon': 5.0.7
-      '@types/tough-cookie': 2.3.5
+      '@types/tough-cookie': 2.3.6
       '@types/tunnel': 0.0.0
       '@types/uuid': 3.4.6
       '@types/webpack': 4.41.0
@@ -10764,14 +10774,14 @@ packages:
       tslint-eslint-rules: 5.4.0_tslint@5.20.1+typescript@3.6.4
       tunnel: 0.0.6
       typescript: 3.6.4
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
       uuid: 3.3.3
       webpack: 4.41.2
       webpack-cli: 3.3.10_webpack@4.41.2
       webpack-dev-middleware: 3.7.2_webpack@4.41.2
       xhr-mock: 2.5.1
       xml2js: 0.4.22
-      yarn: 1.19.2
+      yarn: 1.21.0
     dev: false
     name: '@rush-temp/core-http'
     resolution:
@@ -10787,7 +10797,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       prettier: 1.19.1
       typescript: 3.6.4
@@ -10800,9 +10810,9 @@ packages:
   'file:projects/event-hubs.tgz':
     dependencies:
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 0.0.31
@@ -10826,7 +10836,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       https-proxy-agent: 2.2.4
       is-buffer: 2.0.4
@@ -10869,15 +10879,15 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-ImLH2ct30mX9p9jN4c0mZ3XKiHRTBlrJlMKY7SHxaMXdly3Xx22QVEmUtVZiBqhPZSz6k3BoI+RS1ojDc292fw==
+      integrity: sha512-JxWJdl87nRyZLyPJ3SUKet9qgBfLHjGhH/trjvaiMStdsv7wRfTg+oTRJOmICrNE+VlRN12agEGEYc+H+UiI2Q==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
     dependencies:
       '@azure/event-hubs': 1.0.8
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 0.0.31
@@ -10899,7 +10909,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       mocha: 5.2.0
       mocha-junit-reporter: 1.23.1_mocha@5.2.0
@@ -10933,7 +10943,7 @@ packages:
       '@azure/ms-rest-azure-js': 1.3.8
       '@azure/ms-rest-js': 1.8.13
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
       chai: 4.2.0
       prettier: 1.19.1
       rimraf: 2.7.1
@@ -10942,7 +10952,7 @@ packages:
       rollup-plugin-node-resolve: 4.2.4
       tslib: 1.10.0
       typescript: 3.6.4
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
@@ -10954,8 +10964,8 @@ packages:
       '@azure/ms-rest-azure-js': 1.3.8
       '@azure/ms-rest-js': 1.8.13
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@microsoft/api-extractor': 7.6.2
-      '@types/chai': 4.2.5
+      '@microsoft/api-extractor': 7.7.0
+      '@types/chai': 4.2.6
       '@types/mocha': 5.2.7
       chai: 4.2.0
       mocha: 5.2.0
@@ -10967,7 +10977,7 @@ packages:
       ts-mocha: 6.0.0_mocha@5.2.0
       tslib: 1.10.0
       typescript: 3.6.4
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
@@ -10979,7 +10989,7 @@ packages:
       '@azure/ms-rest-azure-js': 1.3.8
       '@azure/ms-rest-js': 1.8.13
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
       '@types/mocha': 5.2.7
       chai: 4.2.0
       mocha: 5.2.0
@@ -10991,7 +11001,7 @@ packages:
       ts-mocha: 6.0.0_mocha@5.2.0
       tslib: 1.10.0
       typescript: 3.6.4
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
@@ -11002,9 +11012,9 @@ packages:
     dependencies:
       '@azure/arm-servicebus': 0.1.0
       '@azure/ms-rest-nodeauth': 0.9.3
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.5
+      '@types/chai': 4.2.6
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 0.0.31
       '@types/dotenv': 6.1.1
@@ -11027,7 +11037,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       https-proxy-agent: 2.2.4
       is-buffer: 2.0.4
@@ -11052,7 +11062,7 @@ packages:
       process: 0.11.10
       promise: 8.0.3
       puppeteer: 1.20.0
-      rhea: 1.0.13
+      rhea: 1.0.15
       rhea-promise: 0.1.15
       rimraf: 2.7.1
       rollup: 1.13.1
@@ -11073,13 +11083,13 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-/U6s0htPHxWQN101+eQqJRrA7K/AFuq7I0FPBap27hIl52m3yGGkDc9hyyapx55NfdZnQroWLAA7fsaHgVCcYA==
+      integrity: sha512-eCzWGM92ItJWe4fx4jlf9MZeA6PusHrx1yV/LPIvrrUA206IdJdNJqr3pNRw9qv9fxKaTzdXkDa/gqN7jYzPzQ==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
     dependencies:
       '@azure/ms-rest-js': 1.8.13
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/dotenv': 6.1.1
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
@@ -11093,7 +11103,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
       gulp: 4.0.2
@@ -11147,7 +11157,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       rollup: 1.13.1
       rollup-plugin-node-resolve: 4.2.4
@@ -11155,7 +11165,7 @@ packages:
       tslib: 1.10.0
       typescript: 3.6.4
       uglify: 0.1.5
-      uglify-js: 3.7.0
+      uglify-js: 3.7.1
     dev: false
     name: '@rush-temp/storage-datalake'
     resolution:
@@ -11165,7 +11175,7 @@ packages:
   'file:projects/storage-file.tgz':
     dependencies:
       '@azure/ms-rest-js': 1.8.13
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/dotenv': 6.1.1
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
@@ -11179,7 +11189,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
       gulp: 4.0.2
@@ -11226,7 +11236,7 @@ packages:
   'file:projects/storage-queue.tgz':
     dependencies:
       '@azure/ms-rest-js': 1.8.13
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/dotenv': 6.1.1
       '@types/fs-extra': 7.0.0
       '@types/mocha': 5.2.7
@@ -11243,7 +11253,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       fs-extra: 8.0.1
       gulp: 4.0.2
@@ -11295,7 +11305,7 @@ packages:
   'file:projects/template.tgz':
     dependencies:
       '@azure/ms-rest-js': 1.8.13
-      '@microsoft/api-extractor': 7.6.2
+      '@microsoft/api-extractor': 7.7.0
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@typescript-eslint/eslint-plugin': 1.9.0_eslint@5.16.0+typescript@3.6.4
@@ -11306,7 +11316,7 @@ packages:
       eslint-config-prettier: 4.3.0_eslint@5.16.0
       eslint-detailed-reporter: 0.8.0_eslint@5.16.0
       eslint-plugin-no-null: 1.0.2_eslint@5.16.0
-      eslint-plugin-no-only-tests: 2.3.1
+      eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       events: 3.0.0
       inherits: 2.0.4
@@ -11346,7 +11356,7 @@ packages:
       jssha: 2.3.1
       ms-rest: 2.5.3
       ms-rest-azure: 2.6.0
-      rhea: 1.0.13
+      rhea: 1.0.15
       rimraf: 2.7.1
       tslib: 1.10.0
       typescript: 3.6.4
@@ -11355,7 +11365,7 @@ packages:
     dev: false
     name: '@rush-temp/testhub'
     resolution:
-      integrity: sha512-H3cVbgTktZXQAz1m8T7IjVxHYFgXtPIcd5wRHkRkNDECMz0OcowszMFQytwHu5Edam45xPJGoLOfnQqSK27gjQ==
+      integrity: sha512-R8lRD0v6Jed425hnvhHFpDAzqqoA3lGsB6fXln71Wn4A9XFjdEYe/y9fbGbcqE8wckr8nH0cSVHOLCQxR1fuIw==
       tarball: 'file:projects/testhub.tgz'
     version: 0.0.0
 registry: ''
@@ -11485,7 +11495,7 @@ specifiers:
   puppeteer: ^1.11.0
   query-string: ^6.5.0
   resolve: 1.11.0
-  rhea: ^1.0.4
+  rhea: ^1.0.15
   rhea-promise: ^0.1.15
   rimraf: ^2.6.2
   rollup: ~1.13.1

--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,3 +1,7 @@
+### TBD 1.0.0-preview.9
+
+- Improved detection of when an established socket is no longer receiving data from the service.
+
 ### 2019-11-26 1.0.0-preview.8
 
 - Updated network status detection to treat DNS timeouts as a `ConnectionLostError`.

--- a/sdk/core/amqp-common/package.json
+++ b/sdk/core/amqp-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/amqp-common",
   "sdk-type": "client",
-  "version": "1.0.0-preview.8",
+  "version": "1.0.0-preview.9",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -19,6 +19,8 @@
     "is-buffer": "^2.0.3",
     "jssha": "^2.3.1",
     "process": "^0.11.10",
+    "rhea": "^1.0.15",
+    "rhea-promise": "^0.1.15",
     "stream-browserify": "^2.0.2",
     "tslib": "^1.9.3",
     "url": "^0.11.0",
@@ -29,9 +31,6 @@
     "./dist-esm/src/index.node.js": "./dist-esm/src/index.browser.js",
     "buffer": "buffer",
     "stream": "stream-browserify"
-  },
-  "peerDependencies": {
-    "rhea-promise": "^0.1.15"
   },
   "devDependencies": {
     "@types/chai": "^4.1.6",
@@ -64,8 +63,6 @@
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
     "puppeteer": "^1.11.0",
-    "rhea": "^1.0.4",
-    "rhea-promise": "^0.1.15",
     "rimraf": "^2.6.2",
     "rollup": "~1.13.1",
     "rollup-plugin-commonjs": "^9.2.0",

--- a/sdk/core/amqp-common/rollup.base.config.js
+++ b/sdk/core/amqp-common/rollup.base.config.js
@@ -14,9 +14,7 @@ import shim from "rollup-plugin-shim";
 import json from "rollup-plugin-json";
 
 const pkg = require("./package.json");
-const depNames = Object.keys(pkg.dependencies).concat(
-  Object.keys(pkg.peerDependencies)
-);
+const depNames = Object.keys(pkg.dependencies);
 
 const input = "dist-esm/src/index.js";
 const production = process.env.NODE_ENV === "production";

--- a/sdk/core/amqp-common/src/ConnectionContextBase.ts
+++ b/sdk/core/amqp-common/src/ConnectionContextBase.ts
@@ -130,21 +130,15 @@ export module ConnectionContextBase {
    * @param {CreateConnectionContextBaseParameters} parameters Parameters to be provided to create
    * the base connection context.
    */
-  export function create(
-    parameters: CreateConnectionContextBaseParameters
-  ): ConnectionContextBase {
+  export function create(parameters: CreateConnectionContextBaseParameters): ConnectionContextBase {
     ConnectionConfig.validate(parameters.config, {
       isEntityPathRequired: parameters.isEntityPathRequired || false
     });
     const userAgent = parameters.connectionProperties.userAgent;
     if (userAgent.length > Constants.maxUserAgentLength) {
       throw new Error(
-        `The user-agent string cannot be more than ${
-          Constants.maxUserAgentLength
-        } characters in length.` +
-          `The given user-agent string is: ${userAgent} with length: ${
-            userAgent.length
-          }`
+        `The user-agent string cannot be more than ${Constants.maxUserAgentLength} characters in length.` +
+          `The given user-agent string is: ${userAgent} with length: ${userAgent.length}`
       );
     }
 
@@ -162,7 +156,8 @@ export module ConnectionContextBase {
         platform: `(${os.arch()}-${os.type()}-${os.release()})`,
         framework: `Node/${process.version}`
       },
-      operationTimeoutInSeconds: parameters.operationTimeoutInSeconds
+      operationTimeoutInSeconds: parameters.operationTimeoutInSeconds,
+      idle_time_out: Constants.defaultConnectionIdleTimeoutInMs
     };
 
     if (
@@ -183,9 +178,7 @@ export module ConnectionContextBase {
     }
 
     const connection = new Connection(connectionOptions);
-    const connectionLock = `${
-      Constants.establishConnection
-    }-${generate_uuid()}`;
+    const connectionLock = `${Constants.establishConnection}-${generate_uuid()}`;
     const connectionContextBase: ConnectionContextBase = {
       wasConnectionCloseCalled: false,
       connectionLock: connectionLock,
@@ -201,8 +194,7 @@ export module ConnectionContextBase {
           parameters.config.sharedAccessKeyName,
           parameters.config.sharedAccessKey
         ),
-      dataTransformer:
-        parameters.dataTransformer || new DefaultDataTransformer()
+      dataTransformer: parameters.dataTransformer || new DefaultDataTransformer()
     };
 
     return connectionContextBase;

--- a/sdk/core/amqp-common/src/util/constants.ts
+++ b/sdk/core/amqp-common/src/util/constants.ts
@@ -48,6 +48,7 @@ export const senderError = "sender_error";
 export const sessionError = "session_error";
 export const connectionError = "connection_error";
 export const defaultOperationTimeoutInSeconds = 60;
+export const defaultConnectionIdleTimeoutInMs = 60000;
 export const managementRequestKey = "managementRequest";
 export const negotiateCbsKey = "negotiateCbs";
 export const negotiateClaim = "negotiateClaim";
@@ -67,9 +68,7 @@ export const maxDeadLetterReasonLength = 4096;
 export const maxDurationValue = 922337203685477;
 export const minDurationValue = -922337203685477;
 // https://github.com/Azure/azure-amqp/blob/master/Microsoft.Azure.Amqp/Amqp/AmqpConstants.cs#L47
-export const maxAbsoluteExpiryTime = new Date(
-  "9999-12-31T07:59:59.000Z"
-).getTime();
+export const maxAbsoluteExpiryTime = new Date("9999-12-31T07:59:59.000Z").getTime();
 export const aadTokenValidityMarginSeconds = 5;
 export const connectionReconnectDelay = 300;
 export const defaultRetryAttempts = 3;

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -62,7 +62,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/amqp-common": "^1.0.0-preview.5",
+    "@azure/amqp-common": "^1.0.0-preview.9",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "async-lock": "^1.1.3",
     "debug": "^3.1.0",

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -139,11 +139,11 @@ export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
 
 // @public
 export interface EventHubMessageAnnotations extends MessageAnnotations {
-    [x: string]: any;
     "x-opt-enqueued-time"?: number;
     "x-opt-offset"?: string;
     "x-opt-partition-key"?: string | null;
     "x-opt-sequence-number"?: number;
+    [x: string]: any;
 }
 
 // @public

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -19,7 +19,7 @@
     "jssha": "^2.3.1",
     "ms-rest-azure": "^2.5.9",
     "ms-rest": "^2.3.3",
-    "rhea": "^1.0.4",
+    "rhea": "^1.0.15",
     "rimraf": "^2.6.2",
     "tslib": "^1.9.3",
     "typescript": "~3.6.2",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -29,7 +29,7 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "@azure/amqp-common": "^1.0.0-preview.5",
+    "@azure/amqp-common": "^1.0.0-preview.9",
     "@types/is-buffer": "^2.0.0",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "@types/long": "^4.0.0",
@@ -37,7 +37,7 @@
     "is-buffer": "^2.0.3",
     "long": "^4.0.0",
     "process": "^0.11.10",
-    "rhea": "^1.0.4",
+    "rhea": "^1.0.15",
     "rhea-promise": "^0.1.15",
     "tslib": "^1.9.3"
   },

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -64,12 +64,12 @@ export interface OnMessage {
 }
 
 // Warning: (ae-forgotten-export) The symbol "Client" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export class QueueClient implements Client {
     close(): Promise<void>;
-    createReceiver(receiveMode: ReceiveMode, sessionOptions: SessionReceiverOptions): SessionReceiver;
     createReceiver(receiveMode: ReceiveMode): Receiver;
+    createReceiver(receiveMode: ReceiveMode, sessionOptions: SessionReceiverOptions): SessionReceiver;
     createSender(): Sender;
     readonly entityPath: string;
     static getDeadLetterQueuePath(queueName: string): string;
@@ -170,7 +170,7 @@ export interface ServiceBusClientOptions {
 }
 
 // Warning: (ae-forgotten-export) The symbol "ReceivedMessage" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export class ServiceBusMessage implements ReceivedMessage {
     abandon(propertiesToModify?: {


### PR DESCRIPTION
This change is needed to fix #6118 

The idle_time_out is used by rhea. If no data has been sent from the service within the idle_time_out period, then rhea will trigger a `disconnect` event on the `Connection` object. There is a heartbeat sent by rhea when the SDK isn't actively sending or receiving data.

## Testing
To test, I set up a linux-based docker container with a simple event hubs script that receives messages.
I then would use iptables to block traffic on the port communicating to event hubs to allow the idle_time_out to be met.
I also observed that when the connection disconnected, event hubs reconnected and continued receiving events.

### Prereqs
Setup an npm package that depends on:
- `@azure/event-hubs`
- `@azure/amqp-common-preview.9`

#### Dockerfile
```docker
FROM node:12.13.0

WORKDIR /usr/src/app

RUN apt-get update
RUN apt-get install -y iptables
RUN apt-get install -y net-tools

COPY . .
```
#### test.js
```js
const {EventHubClient, EventPosition} = require('@azure/event-hubs');

const client = EventHubClient.createFromConnectionString(
  "NAMESPACE_CONNECTION_STRING",
  "EVENTHUB_NAME"
);

let eventCount = 0;
console.log(`Begin receiving...`);
client.receive('0', () => {
  eventCount++;
}, (err) => {
  console.log(`Error received: ${err.message}`, err);
}, {
  eventPosition: EventPosition.fromEnd()
});

let prevTime = Date.now();
let currentTime = Date.now();

setInterval(() => {
  currentTime = Date.now();

  const timeInSeconds = (currentTime - prevTime) / 1000;

  console.log(`Read ${eventCount} events in ${timeInSeconds} seconds.`);
  eventCount = 0;
  prevTime = currentTime;
}, 10000);
```
### Steps
1. Build docker image.
2. Start docker container in privileged/interactive mode (so that you can run iptables)
3. Start test.js in docker container.
4. Run `netstat -natd` to find which port is communicating to service
5. Run the following to disable traffic on local port:
`iptables -A INPUT -p tcp --destination-port PORT -j DROP`
`iptables -A OUTPUT-p tcp --destination-port PORT -j DROP`
`iptables -A FORWARD-p tcp --destination-port PORT -j DROP`
6. Run `netstat -natd` again to validate that a new port is being used to communicate with the service.
7. Observe messages still being received.
