### PR TITLE
[event-hubs] Better error handling and reporting

### DIFF
--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -1,3 +1,8 @@
+### 5.0.0-preview.8
+
+- Fixed potential issues with claims being mismanaged when subscriptions terminate.
+- Improved reporting of errors that occur when attempting to claim partitions from CheckpointStores.
+
 ### 2019-12-03 5.0.0-preview.7
 
 - Improves load-balancing capabilities to reduce the frequency that partitions are claimed by other running

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.0.0-preview.7",
+  "version": "5.0.0-preview.8",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -498,8 +498,6 @@ export class EventProcessor {
    *
    */
   async stop(): Promise<void> {
-    await this.abandonPartitionOwnerships();
-
     log.eventProcessor(`[${this._id}] Stopping an EventProcessor.`);
     if (this._abortController) {
       // cancel the event processor loop
@@ -519,6 +517,8 @@ export class EventProcessor {
     } finally {
       log.eventProcessor(`[${this._id}] EventProcessor stopped.`);
     }
+
+    await this.abandonPartitionOwnerships();
   }
 
   private async abandonPartitionOwnerships() {
@@ -528,7 +528,7 @@ export class EventProcessor {
     for (const ownership of ourOwnerships) {
       ownership.ownerId = "";
     }
-    this._checkpointStore.claimOwnership(ourOwnerships);
+    return this._checkpointStore.claimOwnership(ourOwnerships);
   }
 }
 

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -6,7 +6,8 @@ import {
   InitializationContext,
   BasicPartitionProperties
 } from "./eventHubConsumerClientModels";
-import { EventPosition } from ".";
+import { EventPosition } from "./eventPosition";
+import * as log from "./log";
 
 /**
  * A checkpoint is meant to represent the last successfully processed event by the user from a particular
@@ -176,7 +177,11 @@ export class PartitionProcessor implements InitializationContext {
    */
   async processError(error: Error): Promise<void> {
     if (this._eventHandlers.processError) {
-      await this._eventHandlers.processError(error, this);
+      try {
+        await this._eventHandlers.processError(error, this);
+      } catch (err) {
+        log.partitionPump(`Error thrown from user's processError handler : ${err}`);
+      }
     }
   }
 

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -42,8 +42,9 @@ export class PartitionPump {
     let userRequestedDefaultPosition: EventPosition | undefined;
     try {
       userRequestedDefaultPosition = await this._partitionProcessor.initialize();
-    } catch {
+    } catch (err) {
       // swallow the error from the user-defined code
+      this._partitionProcessor.processError(err);
     }
 
     const startingPosition = getStartingPosition(
@@ -137,6 +138,7 @@ export class PartitionPump {
       await this._partitionProcessor.close(reason);
     } catch (err) {
       log.error("An error occurred while closing the receiver.", err);
+      this._partitionProcessor.processError(err);
       throw err;
     }
   }

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -13,8 +13,39 @@ import * as log from "./log";
  * It also starts a PartitionPump when it is created, and stops a
  * PartitionPump when it is removed.
  * @ignore
+ * @internal
  */
-export class PumpManager {
+export interface PumpManager {
+  /**
+   * Creates and starts a PartitionPump.
+   * @param eventHubClient The EventHubClient to forward to the PartitionPump.
+   * @param initialEventPosition The EventPosition to forward to the PartitionPump.
+   * @param partitionProcessor The PartitionProcessor to forward to the PartitionPump.
+   * @param abortSignal Used to cancel pump creation.
+   * @ignore
+   */
+  createPump(
+    eventHubClient: EventHubClient,
+    initialEventPosition: EventPosition | undefined,
+    partitionProcessor: PartitionProcessor
+  ): Promise<void>;
+
+  /**
+   * Stops all PartitionPumps and removes them from the internal map.
+   * @param reason The reason for removing the pump.
+   * @ignore
+   */
+  removeAllPumps(reason: CloseReason): Promise<void>;
+}
+
+/**
+ * The PumpManager handles the creation and removal of PartitionPumps.
+ * It also starts a PartitionPump when it is created, and stops a
+ * PartitionPump when it is removed.
+ * @ignore
+ * @internal
+ */
+export class PumpManagerImpl implements PumpManager {
   private readonly _eventProcessorName: string;
   private readonly _options: FullEventProcessorOptions;
   private _partitionIdToPumps: {

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,5 +6,5 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.0.0-preview.7"
+  version: "5.0.0-preview.8"
 };

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/changelog.md
@@ -1,3 +1,8 @@
+### 1.0.0-preview.6
+
+- `claimOwnership()` will throw on underlying issues with storage, rather than
+   failing silently.
+
 ### 2019-12-03 - 1.0.0-preview.5
 
 - Updated to use the latest version of the `@azure/event-hubs` package.

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/eventhubs-checkpointstore-blob",
   "sdk-type": "client",
-  "version": "1.0.0-preview.5",
+  "version": "1.0.0-preview.6",
   "description": "An Azure Storage Blob solution to store checkpoints when using Event Hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -63,7 +63,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "5.0.0-preview.7",
+    "@azure/event-hubs": "5.0.0-preview.8",
     "@azure/storage-blob": "^12.0.0",
     "debug": "^4.1.1",
     "events": "^3.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -113,6 +113,7 @@ export class BlobCheckpointStore implements CheckpointStore {
           // etag failures (precondition not met) aren't fatal errors. They happen
           // as multiple consumers attempt to claim the same partition (first one wins)
           // and losers get this error.
+          log.blobCheckpointStore(`[${ownership.ownerId}] Did not claim partition ${ownership.partitionId}. Another processor has already claimed it.`);
           continue;
         }
 

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/test/blob-checkpointstore.spec.ts
@@ -15,7 +15,7 @@ import { ContainerClient, RestError } from "@azure/storage-blob";
 import { PartitionOwnership, Checkpoint, EventHubConsumerClient } from "@azure/event-hubs";
 import { Guid } from "guid-typescript";
 import { parseIntOrThrow } from "../src/blobCheckpointStore";
-import { fail, AssertionError } from 'assert';
+import { fail } from 'assert';
 const env = getEnvVars();
 
 describe("Blob Checkpoint Store", function(): void {
@@ -103,10 +103,6 @@ describe("Blob Checkpoint Store", function(): void {
       }]);
       fail("Should have thrown an error - this isn't a normal claim collision issue");
     } catch (err) {
-      if (err instanceof AssertionError) {
-        throw err;
-      }
-
       (err instanceof RestError).should.be.ok;
       // 404 because the container is missing (since we deleted it up above)
       (err as RestError).statusCode!.should.equal(404);


### PR DESCRIPTION
Changes to error handling and reporting due to feature team discussion.

* If the _user's_ event handlers (processEvents, processInitialization, 
  processClose) throw errors we funnel those into their processError()
  handler so they'll know about it. 
* BlobCheckpointStore shouldn't eat all errors when claiming partitions. 
  Now, the only case where it _will_ eat errors is when we have an etag 
  conflict due to someone else taking partition ownership.

Fixes #6444