### PR TITLE
[app-configuration] Remove manual instrumentation of each method for syncToken

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/synctokenpolicy.ts
@@ -39,7 +39,9 @@ class SyncTokenPolicy extends BaseRequestPolicy {
       webResource.headers.set(SyncTokenHeaderName, syncTokenHeaderValue);
     }
 
-    return this._nextPolicy.sendRequest(webResource);
+    const response = await this._nextPolicy.sendRequest(webResource);
+    this._syncTokens.addSyncTokenFromHeaderValue(response.headers.get(SyncTokenHeaderName));
+    return response;
   }
 }
 


### PR DESCRIPTION
The sync token policy that's already in place can handle both requests and responses