### PR TITLE
[Core-http] Move getDefaultProxySettings into proxyPolicy

### DIFF
--- a/sdk/core/core-http/lib/policies/proxyPolicy.ts
+++ b/sdk/core/core-http/lib/policies/proxyPolicy.ts
@@ -47,6 +47,9 @@ export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | unde
 }
 
 export function proxyPolicy(proxySettings?: ProxySettings): RequestPolicyFactory {
+  if (!proxySettings) {
+    proxySettings = getDefaultProxySettings();
+  }
   return {
     create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
       return new ProxyPolicy(nextPolicy, options, proxySettings!);

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -44,7 +44,7 @@ import { stringifyXML } from "./util/xml";
 import { RequestOptionsBase, RequestPrepareOptions, WebResource } from "./webResource";
 import { OperationResponse } from "./operationResponse";
 import { ServiceCallback, isNode } from "./util/utils";
-import { proxyPolicy, getDefaultProxySettings } from "./policies/proxyPolicy";
+import { proxyPolicy } from "./policies/proxyPolicy";
 import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
 import { ServiceClientCredentials } from "./credentials/serviceClientCredentials";
 import { signingPolicy } from "./policies/signingPolicy";
@@ -618,9 +618,8 @@ function createDefaultRequestPolicyFactories(
 
   factories.push(deserializationPolicy(options.deserializationContentTypes));
 
-  const proxySettings = options.proxySettings || getDefaultProxySettings();
-  if (proxySettings) {
-    factories.push(proxyPolicy(proxySettings));
+  if (isNode) {
+    factories.push(proxyPolicy(options.proxySettings));
   }
 
   factories.push(logPolicy({ logger: logger.info }));
@@ -664,9 +663,8 @@ export function createPipelineFromOptions(
     ...pipelineOptions.redirectOptions
   };
 
-  const proxySettings = pipelineOptions.proxyOptions;
   if (isNode) {
-    requestPolicyFactories.push(proxyPolicy(proxySettings));
+    requestPolicyFactories.push(proxyPolicy(pipelineOptions.proxyOptions));
   }
 
   const deserializationOptions = {

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -664,8 +664,8 @@ export function createPipelineFromOptions(
     ...pipelineOptions.redirectOptions
   };
 
-  const proxySettings = pipelineOptions.proxyOptions || getDefaultProxySettings();
-  if (isNode && proxySettings) {
+  const proxySettings = pipelineOptions.proxyOptions;
+  if (isNode) {
     requestPolicyFactories.push(proxyPolicy(proxySettings));
   }
 


### PR DESCRIPTION
so that libraries that don't use the PipelineOptions from core-http can use
this behavior without duplicating code.

Resolves #6387 