### PR TITLE
[amqp-common] add logging to dns.resolve

### DIFF
--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,6 +1,7 @@
 ### TBD 1.0.0-preview.9
 
 - Improved detection of when an established socket is no longer receiving data from the service.
+- Added logging around the network connectivity check.
 
 ### 2019-11-26 1.0.0-preview.8
 

--- a/sdk/core/amqp-common/src/retry.ts
+++ b/sdk/core/amqp-common/src/retry.ts
@@ -97,12 +97,22 @@ async function checkNetworkConnection(host: string): Promise<boolean> {
   if (isNode) {
     return new Promise((res) => {
       resolve(host, function(err: any): void {
-        // List of possible DNS error codes: https://nodejs.org/dist/latest-v12.x/docs/api/dns.html#dns_error_codes
-        if (err && (err.code === "ECONNREFUSED" || err.code === "ETIMEOUT")) {
-          res(false);
+        if (err) {
+          log.retry(
+            "Error thrown from dns.resolve in network connection check: '%s', %O",
+            err.code || err.name,
+            err
+          );
+
+          // List of possible DNS error codes: https://nodejs.org/dist/latest-v12.x/docs/api/dns.html#dns_error_codes
+          if (err.code === "ECONNREFUSED" || err.code === "ETIMEOUT") {
+            return res(false);
+          }
         } else {
-          res(true);
+          log.retry("Successfully resolved host via dns.resolve in network connection check");
         }
+
+        return res(true);
       });
     });
   } else {

--- a/sdk/core/amqp-common/src/retry.ts
+++ b/sdk/core/amqp-common/src/retry.ts
@@ -96,6 +96,7 @@ function validateRetryConfig<T>(config: RetryConfig<T>): void {
 async function checkNetworkConnection(host: string): Promise<boolean> {
   if (isNode) {
     return new Promise((res) => {
+      log.retry("Calling dns.resolve to determine network connection status.");
       resolve(host, function(err: any): void {
         if (err) {
           log.retry(

--- a/sdk/core/amqp-common/src/retry.ts
+++ b/sdk/core/amqp-common/src/retry.ts
@@ -105,6 +105,7 @@ async function checkNetworkConnection(host: string): Promise<boolean> {
           );
 
           // List of possible DNS error codes: https://nodejs.org/dist/latest-v12.x/docs/api/dns.html#dns_error_codes
+          // Only when dns.resolve returns an error we expect to see when the network is down, resolve as 'false'.
           if (err.code === "ECONNREFUSED" || err.code === "ETIMEOUT") {
             return res(false);
           }


### PR DESCRIPTION
This change adds logging around the dns.resolve call in `checkNetworkConnection`. We recently found that `ETIMEOUT` could be returned by dns.resolve which we didn't expect to see previously. This logging should help us troubleshoot issues around troubleshooting network connection errors.

I manually tested this change by running an event hubs receiver sample and disconnecting my network.