### PR TITLE
Unlink dependencies if tests fail

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -257,6 +257,7 @@ jobs:
         # which need to walk the directory tree (and are hardcoded to follow symlinks).
         - script: |
             node eng/tools/rush-runner.js unlink
+          condition: succeededOrFailed()
           displayName: "Unlink dependencies"
 
         # It's important for performance to pass "sdk" as "searchFolder" to avoid looking under root "node_modules".

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -134,6 +134,7 @@ jobs:
       # which need to walk the directory tree (and are hardcoded to follow symlinks).
       - script: |
           node eng/tools/rush-runner.js unlink
+        condition: succeededOrFailed()
         displayName: "Unlink dependencies"
 
       # It's important for performance to pass "sdk" as "searchFolder" to avoid looking under root "node_modules".


### PR DESCRIPTION
- Results are published for both success and failure
- Unlink dependencies should use the same condition as publish
- Continuation of #6418

Example where "unlink dependencies" step was skipped due to test failures:

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=206607