### PR TITLE
Event Hubs & Service Bus to use latest version of core-amqp & amqp-common

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 /sdk/batch/ @xingwu1 @matthchr @bgklein
 /sdk/cosmosdb/ @southpolesteve
 
-/sdk/eventhub/ @ramya-rao-a @chradek
+/sdk/eventhub/ @ramya-rao-a @chradek @richardpark-msft
 /sdk/servicebus/ @ramya-rao-a @chradek @ramya0820
 
 /sdk/identity/ @daviwil @jonathandturner

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -34,7 +34,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==
-  /@azure/amqp-common/1.0.0-preview.6_rhea-promise@0.1.15:
+  /@azure/amqp-common/1.0.0-preview.9:
     dependencies:
       '@azure/ms-rest-nodeauth': 0.9.3
       '@types/async-lock': 1.1.1
@@ -46,42 +46,19 @@ packages:
       is-buffer: 2.0.4
       jssha: 2.3.1
       process: 0.11.10
+      rhea: 1.0.15
       rhea-promise: 0.1.15
       stream-browserify: 2.0.2
       tslib: 1.10.0
       url: 0.11.0
       util: 0.11.1
     dev: false
-    peerDependencies:
-      rhea-promise: ^0.1.15
     resolution:
-      integrity: sha512-5XJZaJGtGoPmLhFx5y0vfCXiAHksoA4fdSnHAfkgEm4krhCW1jt1LH/6aJdUwUTJe+bz6m3Pv0sG/ILG0Vd65g==
-  /@azure/amqp-common/1.0.0-preview.8_rhea-promise@0.1.15:
-    dependencies:
-      '@azure/ms-rest-nodeauth': 0.9.3
-      '@types/async-lock': 1.1.1
-      '@types/is-buffer': 2.0.0
-      async-lock: 1.2.2
-      buffer: 5.4.3
-      debug: 3.2.6
-      events: 3.0.0
-      is-buffer: 2.0.4
-      jssha: 2.3.1
-      process: 0.11.10
-      rhea-promise: 0.1.15
-      stream-browserify: 2.0.2
-      tslib: 1.10.0
-      url: 0.11.0
-      util: 0.11.1
-    dev: false
-    peerDependencies:
-      rhea-promise: ^0.1.15
-    resolution:
-      integrity: sha512-Fn13SPn03FaWXeh07/QKGrX2KKszxly74hapQ0jAAoA6iwD3YlPaqEg/FoX6Sd7MSIldJrPqjNADlrtPVPmjTA==
+      integrity: sha512-RVG1Ad3Afv9gwFFmpeCXQAm+Sa0L8KEZRJJAAZEGoYDb6EoO1iQDVmoBz720h8mdrGpi0D60xNU/KhriIwuZfQ==
   /@azure/arm-servicebus/3.2.0:
     dependencies:
       '@azure/ms-rest-azure-js': 1.3.8
-      '@azure/ms-rest-js': 1.8.13
+      '@azure/ms-rest-js': 1.8.14
       tslib: 1.10.0
     dev: false
     resolution:
@@ -168,9 +145,9 @@ packages:
       eslint: ^6.1.0
     resolution:
       integrity: sha512-HszGr6szVke1FOr07hy+JojKm36qh9n3IfYdehZRx7Wi19cY1EUmFq1PT5OasbNC/DoVqB3yx8Olfw4t5YBxVA==
-  /@azure/event-hubs/2.1.3:
+  /@azure/event-hubs/2.1.4:
     dependencies:
-      '@azure/amqp-common': 1.0.0-preview.6_rhea-promise@0.1.15
+      '@azure/amqp-common': 1.0.0-preview.9
       '@azure/ms-rest-nodeauth': 0.9.3
       async-lock: 1.2.2
       debug: 3.2.6
@@ -181,7 +158,7 @@ packages:
       uuid: 3.3.3
     dev: false
     resolution:
-      integrity: sha512-o5+bdr8PpszUj24NHf/sYrvoEuJsO1kX2jlZlcAM5J/bP3P3w9aNaERjcL0SH6Zx1brHkJD/+GQI8Xruv41JfQ==
+      integrity: sha512-CxaMaEjwtsmIhWtjHyGimKO7RmES0YxPqGQ9+jKqGygNlhG5NYHktDaiQu6w7k3g+I51VaLXtVSt+BVFd6VWfQ==
   /@azure/logger-js/1.3.2:
     dependencies:
       tslib: 1.10.0
@@ -200,12 +177,12 @@ packages:
       integrity: sha512-l7z0DPCi2Hp88w12JhDTtx5d0Y3+vhfE7JKJb9O7sEz71Cwp053N8piTtTnnk/tUor9oZHgEKi/p3tQQmLPjvA==
   /@azure/ms-rest-azure-js/1.3.8:
     dependencies:
-      '@azure/ms-rest-js': 1.8.13
+      '@azure/ms-rest-js': 1.8.14
       tslib: 1.10.0
     dev: false
     resolution:
       integrity: sha512-AHLfDTCyIH6wBK6+CpImI6sc9mLZ17ZgUrTx3Rhwv+3Mb3Z73BxormkarfR6Stb6scrBYitxJ27FXyndXlGAYg==
-  /@azure/ms-rest-js/1.8.13:
+  /@azure/ms-rest-js/1.8.14:
     dependencies:
       '@types/tunnel': 0.0.0
       axios: 0.19.0
@@ -217,11 +194,11 @@ packages:
       xml2js: 0.4.22
     dev: false
     resolution:
-      integrity: sha512-jAa6Y2XrvwbEqkaEXDHK+ReNo0WnCPS+LgQ1dRAJUUNxK4CghF5u+SXsVtPENritilVE7FVteqsLOtlhTk+haA==
+      integrity: sha512-IrCPN22c8RbKWA06ZXuFwwEb15cSnr0zZ6J8Fspp9ns1SSNTERf7hv+gWvTIis1FlwHy42Mfk8hVu0/r3a0AWA==
   /@azure/ms-rest-nodeauth/0.9.3:
     dependencies:
       '@azure/ms-rest-azure-env': 1.1.2
-      '@azure/ms-rest-js': 1.8.13
+      '@azure/ms-rest-js': 1.8.14
       adal-node: 0.1.28
     dev: false
     resolution:
@@ -373,19 +350,19 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-GtwNB6BNDdsIPAYEdpp3JnOGO/3AJxjPvny53s3HERBdXSJTGQw8IRhiaTEX0b3w9P8+FwFZde4k+qkjn67aVw==
-  /@rollup/plugin-json/4.0.0_rollup@1.27.9:
+  /@rollup/plugin-json/4.0.0_rollup@1.27.10:
     dependencies:
-      rollup: 1.27.9
+      rollup: 1.27.10
       rollup-pluginutils: 2.8.2
     dev: false
     peerDependencies:
       rollup: ^1.20.0
     resolution:
       integrity: sha512-Z65CtEVWv40+ri4CvmswyhtuUtki9yP5p0UJN/GyCKKyU4jRuDS9CG0ZuV7/XuS7zGkoajyE7E4XBEaC4GW62A==
-  /@rollup/plugin-replace/2.2.1_rollup@1.27.9:
+  /@rollup/plugin-replace/2.2.1_rollup@1.27.10:
     dependencies:
       magic-string: 0.25.4
-      rollup: 1.27.9
+      rollup: 1.27.10
       rollup-pluginutils: 2.8.2
     dev: false
     peerDependencies:
@@ -436,33 +413,33 @@ packages:
   /@types/body-parser/1.17.1:
     dependencies:
       '@types/connect': 3.4.32
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
     dev: false
     resolution:
       integrity: sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==
   /@types/chai-as-promised/7.1.2:
     dependencies:
-      '@types/chai': 4.2.6
+      '@types/chai': 4.2.7
     dev: false
     resolution:
       integrity: sha512-PO2gcfR3Oxa+u0QvECLe1xKXOqYTzCmWf0FhLhjREoW3fPAVamjihL7v1MOVLJLsnAMdLcjkfrs01yvDMwVK4Q==
   /@types/chai-string/1.4.2:
     dependencies:
-      '@types/chai': 4.2.6
+      '@types/chai': 4.2.7
     dev: false
     resolution:
       integrity: sha512-ld/1hV5qcPRGuwlPdvRfvM3Ka/iofOk2pH4VkasK4b1JJP1LjNmWWn0LsISf6RRzyhVOvs93rb9tM09e+UuF8Q==
-  /@types/chai/4.2.6:
+  /@types/chai/4.2.7:
     dev: false
     resolution:
-      integrity: sha512-HF8faEUA4JurIm+68VaA2KedtZf5LYdXpQEAbIAN79DwWQbO82BNTksZgCH3UMqbZHXex9C6TrBfg7OUInRISQ==
+      integrity: sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==
   /@types/color-name/1.1.1:
     dev: false
     resolution:
       integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
   /@types/connect/3.4.32:
     dependencies:
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
     dev: false
     resolution:
       integrity: sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==
@@ -500,7 +477,7 @@ packages:
       integrity: sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==
   /@types/express-serve-static-core/4.17.0:
     dependencies:
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
       '@types/range-parser': 1.2.3
     dev: false
     resolution:
@@ -570,7 +547,7 @@ packages:
       integrity: sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
   /@types/memory-fs/0.3.2:
     dependencies:
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
     dev: false
     resolution:
       integrity: sha512-j5AcZo7dbMxHoOimcHEIh0JZe5e1b8q8AqGSpZJrYc7xOgCIP79cIjTdx5jSDLtySnQDwkDTqwlC7Xw7uXw7qg==
@@ -602,10 +579,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==
-  /@types/node/12.12.16:
+  /@types/node/12.12.17:
     dev: false
     resolution:
-      integrity: sha512-vRuMyoOr5yfNf8QWxXegOjeyjpWJxFePzHzmBOIzDIzo+rSqF94RW0PkS6y4T2+VjAWLXHWrfbIJY3E3aS7lUw==
+      integrity: sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA==
   /@types/node/8.10.54:
     dev: false
     resolution:
@@ -632,7 +609,7 @@ packages:
       integrity: sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
     dev: false
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
@@ -665,7 +642,7 @@ packages:
       integrity: sha512-wHNBMnkoEBiRAd3s8KTKwIuO9biFtTf0LehITzBhSco+HQI0xkXZbLOD55SW3Aqw3oUkHstkm5SPv58yaAdFPQ==
   /@types/tunnel/0.0.0:
     dependencies:
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
     dev: false
     resolution:
       integrity: sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==
@@ -702,7 +679,7 @@ packages:
       integrity: sha512-DzNJJ6ah/6t1n8sfAgQyEbZ/OMmFcF9j9P3aesnm7G6/iBFR/qiGin8K89J0RmaWIBzhTMdDg3I5PmKmSv7N9w==
   /@types/webpack-sources/0.1.5:
     dependencies:
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
       '@types/source-list-map': 0.1.2
       source-map: 0.6.1
     dev: false
@@ -2366,7 +2343,7 @@ packages:
       integrity: sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==
   /chrome-launcher/0.11.2:
     dependencies:
-      '@types/node': 12.12.16
+      '@types/node': 12.12.17
       is-wsl: 2.1.1
       lighthouse-logger: 1.2.0
       mkdirp: 0.5.1
@@ -2374,14 +2351,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==
-  /chrome-remote-interface/0.28.0:
+  /chrome-remote-interface/0.28.1:
     dependencies:
       commander: 2.11.0
-      ws: 6.2.1
+      ws: 7.2.0
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-md2qSn6rc/fADlN+Blk2UWNg0SGPYjH2s68piaPN9e62HItKm6uWeXXHh0+28Bq10oaWw8fzNAm1itDFJ+nS4w==
+      integrity: sha512-OnVjEOuZtPDImShaWSQPKPZMNnUnoZfLKhayeXUWOyqir3MT1OTqMzUDEnIVx1itPnsW7CiKgyNLLgvgdniJgQ==
   /chrome-trace-event/1.0.2:
     dependencies:
       tslib: 1.10.0
@@ -4333,10 +4310,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-  /highlight.js/9.16.2:
+  /highlight.js/9.17.0:
+    dependencies:
+      handlebars: 4.5.3
     dev: false
     resolution:
-      integrity: sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw==
+      integrity: sha512-PyO7FK7z8ZC7FqBlmAxm4d+1DYaoS6+uaxt9KGkyP1AnmGRLnWmNod1yp9BFjUyHoDF00k+V57gF6X9ifY7f/A==
   /hmac-drbg/1.0.1:
     dependencies:
       hash.js: 1.1.7
@@ -5281,11 +5260,11 @@ packages:
       requirejs: ^2.1.0
     resolution:
       integrity: sha1-/driy4fX68FvsCIok1ZNf+5Xh5g=
-  /karma-rollup-preprocessor/7.0.2_rollup@1.27.9:
+  /karma-rollup-preprocessor/7.0.2_rollup@1.27.10:
     dependencies:
       chokidar: 3.3.0
       debounce: 1.2.0
-      rollup: 1.27.9
+      rollup: 1.27.10
     dev: false
     engines:
       node: '>= 8.0.0'
@@ -5944,7 +5923,7 @@ packages:
     dependencies:
       chalk: 2.4.2
       chrome-launcher: 0.11.2
-      chrome-remote-interface: 0.28.0
+      chrome-remote-interface: 0.28.1
       chrome-unmirror: 0.1.0
       debug: 4.1.1
       deep-assign: 3.0.0
@@ -6044,14 +6023,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-  /msal/1.1.3:
+  /msal/1.2.0:
     dependencies:
       tslib: 1.10.0
     dev: false
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha512-cdShb+N1H3OyR1y46ij6OO7QzeqC6BxrbrNcouS4JBrr1+DnZ55TumxQKEzWmTXHvsbsuz5PCyXZl812Un8L9g==
+      integrity: sha512-Z74fTT8G1s1YKcqup6PTQ4Y4z0zh5n7fdK+RXZ47+yLH4/z1Y5LualkRuHr6C7vi74l0daNZn2nj159AV5mhOQ==
   /mute-stream/0.0.8:
     dev: false
     resolution:
@@ -7527,13 +7506,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
-  /rollup-plugin-commonjs/10.1.0_rollup@1.27.9:
+  /rollup-plugin-commonjs/10.1.0_rollup@1.27.10:
     dependencies:
       estree-walker: 0.6.1
       is-reference: 1.1.4
       magic-string: 0.25.4
       resolve: 1.13.1
-      rollup: 1.27.9
+      rollup: 1.27.10
       rollup-pluginutils: 2.8.2
     dev: false
     peerDependencies:
@@ -7569,13 +7548,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-xRkB+W/m1KLIzPUmG0ofvR+CPNcvuCuNdjVBVS7ALKSxr3EDhnzNceGkGi1m8MToSli13AzKFYH4ie9w3I5L3g==
-  /rollup-plugin-node-resolve/5.2.0_rollup@1.27.9:
+  /rollup-plugin-node-resolve/5.2.0_rollup@1.27.10:
     dependencies:
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       is-module: 1.0.0
       resolve: 1.13.1
-      rollup: 1.27.9
+      rollup: 1.27.10
       rollup-pluginutils: 2.8.2
     dev: false
     peerDependencies:
@@ -7586,9 +7565,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-rZqFD43y4U9nSqVq3iyWBiDwmBQJY8Txi04yI9jTKD3xcl7CbFjh1qRpQshUB3sONLubDzm7vJiwB+1MEGv67w==
-  /rollup-plugin-sourcemaps/0.4.2_rollup@1.27.9:
+  /rollup-plugin-sourcemaps/0.4.2_rollup@1.27.10:
     dependencies:
-      rollup: 1.27.9
+      rollup: 1.27.10
       rollup-pluginutils: 2.8.2
       source-map-resolve: 0.5.2
     dev: false
@@ -7599,38 +7578,38 @@ packages:
       rollup: '>=0.31.2'
     resolution:
       integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
-  /rollup-plugin-terser/5.1.2_rollup@1.27.9:
+  /rollup-plugin-terser/5.1.3_rollup@1.27.10:
     dependencies:
       '@babel/code-frame': 7.5.5
       jest-worker: 24.9.0
-      rollup: 1.27.9
+      rollup: 1.27.10
       rollup-pluginutils: 2.8.2
-      serialize-javascript: 1.9.1
+      serialize-javascript: 2.1.2
       terser: 4.4.2
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <2'
     resolution:
-      integrity: sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==
-  /rollup-plugin-uglify/6.0.3_rollup@1.27.9:
+      integrity: sha512-FuFuXE5QUJ7snyxHLPp/0LFXJhdomKlIx/aK7Tg88Yubsx/UU/lmInoJafXJ4jwVVNcORJ1wRUC5T9cy5yk0wA==
+  /rollup-plugin-uglify/6.0.4_rollup@1.27.10:
     dependencies:
       '@babel/code-frame': 7.5.5
       jest-worker: 24.9.0
-      rollup: 1.27.9
-      serialize-javascript: 1.9.1
+      rollup: 1.27.10
+      serialize-javascript: 2.1.2
       uglify-js: 3.7.2
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <2'
     resolution:
-      integrity: sha512-PIv3CfhZJlOG8C85N0GX+uK09TPggmAS6Nk6fpp2ELzDAV5VUhNzOURDU2j7+MwuRr0zq9IZttUTADc/jH8Gkg==
-  /rollup-plugin-visualizer/3.3.0_rollup@1.27.9:
+      integrity: sha512-ddgqkH02klveu34TF0JqygPwZnsbhHVI6t8+hGTcYHngPkQb5MIHI0XiztXIN/d6V9j+efwHAqEL7LspSxQXGw==
+  /rollup-plugin-visualizer/3.3.0_rollup@1.27.10:
     dependencies:
       mkdirp: 0.5.1
       nanoid: 2.1.7
       open: 6.4.0
       pupa: 2.0.1
-      rollup: 1.27.9
+      rollup: 1.27.10
       source-map: 0.7.3
       yargs: 15.0.2
     dev: false
@@ -7647,7 +7626,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  /rollup/1.27.9:
+  /rollup/1.27.10:
     dependencies:
       '@types/estree': 0.0.40
       '@types/node': 8.10.59
@@ -7655,7 +7634,7 @@ packages:
     dev: false
     hasBin: true
     resolution:
-      integrity: sha512-8AfW4cJTPZfG6EXWwT/ujL4owUsDI1Xl8J1t+hvK4wDX81F5I4IbwP9gvGbHzxnV19fnU4rRABZQwZSX9J402Q==
+      integrity: sha512-5PjBSKney8zLu7tTn/y4iVBL3OyK+G9rA/wfkcY78bZ9kAMtgNqb8nOfR5KpoDYyt8Vs5o2o8DyDjf9RpwYbAg==
   /run-async/2.3.0:
     dependencies:
       is-promise: 2.1.0
@@ -7755,10 +7734,6 @@ packages:
       node: '>= 0.8.0'
     resolution:
       integrity: sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==
-  /serialize-javascript/1.9.1:
-    dev: false
-    resolution:
-      integrity: sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
   /serialize-javascript/2.1.2:
     dev: false
     resolution:
@@ -8457,7 +8432,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
-  /terser-webpack-plugin/1.4.2_webpack@4.41.2:
+  /terser-webpack-plugin/1.4.3_webpack@4.41.2:
     dependencies:
       cacache: 12.0.3
       find-cache-dir: 2.1.0
@@ -8475,7 +8450,7 @@ packages:
     peerDependencies:
       webpack: ^4.0.0
     resolution:
-      integrity: sha512-fdEb91kR2l+BVgES77N/NTXWZlpX6vX+pYPjnX5grcDYBF2CMnzJiXX4NNlna4l04lvCW39lZ+O/jSvUhHH/ew==
+      integrity: sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==
   /terser/4.4.2:
     dependencies:
       commander: 2.20.3
@@ -8853,7 +8828,7 @@ packages:
       '@types/minimatch': 3.0.3
       fs-extra: 8.1.0
       handlebars: 4.5.3
-      highlight.js: 9.16.2
+      highlight.js: 9.17.0
       lodash: 4.17.15
       marked: 0.7.0
       minimatch: 3.0.4
@@ -9178,7 +9153,7 @@ packages:
       node-libs-browser: 2.2.1
       schema-utils: 1.0.0
       tapable: 1.1.3
-      terser-webpack-plugin: 1.4.2_webpack@4.41.2
+      terser-webpack-plugin: 1.4.3_webpack@4.41.2
       watchpack: 1.6.0
       webpack-sources: 1.4.3
     dev: false
@@ -9475,13 +9450,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-GH/X/hYt+x5hOat4LMnCqMd8r5Cv78heOMIJn1hr7QPPBqfeC6p89Y78+WB9yGDvfpCvgasfmWLzNzEioOUD9Q==
-  /yarn/1.21.0:
+  /yarn/1.21.1:
     dev: false
     engines:
       node: '>=4.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-g9cvrdKXPZlz1eJYpKanQm3eywEmecudeyDkwiVWeswBrpHK3nJFBholkphHF9eNc8y/FNEhSQ8Et5ZAx4XyLw==
+      integrity: sha512-dQgmJv676X/NQczpbiDtc2hsE/pppGDJAzwlRiADMTvFzYbdxPj2WO4PcNyriSt2c4jsCMpt8UFRKHUozt21GQ==
   /yauzl/2.4.1:
     dependencies:
       fd-slicer: 1.0.1
@@ -9518,7 +9493,7 @@ packages:
   'file:projects/abort-controller.tgz':
     dependencies:
       '@microsoft/api-extractor': 7.7.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@typescript-eslint/eslint-plugin': 2.11.0_f7075e6e0f0ded741b43d31cdfc430d3
@@ -9548,12 +9523,12 @@ packages:
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
@@ -9567,8 +9542,8 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@types/sinon': 7.5.1
@@ -9587,12 +9562,12 @@ packages:
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
       sinon: 7.5.0
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
@@ -9607,10 +9582,10 @@ packages:
   'file:projects/core-amqp.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.6
+      '@types/chai': 4.2.7
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 4.1.5
       '@types/is-buffer': 2.0.0
@@ -9649,15 +9624,15 @@ packages:
       rhea: 1.0.15
       rhea-promise: 1.0.0
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-inject: 3.0.2
       rollup-plugin-multi-entry: 2.1.0
       rollup-plugin-node-globals: 1.4.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
       sinon: 7.5.0
       stream-browserify: 2.0.2
       ts-node: 8.5.4_typescript@3.6.4
@@ -9674,7 +9649,7 @@ packages:
     version: 0.0.0
   'file:projects/core-arm.tgz':
     dependencies:
-      '@types/chai': 4.2.6
+      '@types/chai': 4.2.7
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@typescript-eslint/eslint-plugin': 2.11.0_f7075e6e0f0ded741b43d31cdfc430d3
@@ -9691,16 +9666,16 @@ packages:
       npm-run-all: 4.1.5
       nyc: 14.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       shx: 0.3.2
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
       uglify-js: 3.7.2
-      yarn: 1.21.0
+      yarn: 1.21.1
     dev: false
     name: '@rush-temp/core-arm'
     resolution:
@@ -9730,8 +9705,8 @@ packages:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@typescript-eslint/eslint-plugin': 2.11.0_f7075e6e0f0ded741b43d31cdfc430d3
@@ -9749,13 +9724,13 @@ packages:
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       tslib: 1.10.0
       typescript: 3.6.4
       util: 0.12.1
@@ -9770,8 +9745,8 @@ packages:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@azure/logger-js': 1.3.2
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/express': 4.17.2
       '@types/glob': 7.1.1
       '@types/karma': 3.0.4
@@ -9802,7 +9777,7 @@ packages:
       karma-chai: 0.1.0_chai@4.2.0+karma@4.4.1
       karma-chrome-launcher: 3.1.0
       karma-mocha: 1.3.0
-      karma-rollup-preprocessor: 7.0.2_rollup@1.27.9
+      karma-rollup-preprocessor: 7.0.2_rollup@1.27.10
       karma-sourcemap-loader: 0.3.7
       karma-typescript-es6-transform: 4.1.1
       karma-webpack: 4.0.2_webpack@4.41.2
@@ -9818,12 +9793,12 @@ packages:
       puppeteer: 2.0.0
       regenerator-runtime: 0.13.3
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       shx: 0.3.2
       sinon: 7.5.0
       terser: 4.4.2
@@ -9840,7 +9815,7 @@ packages:
       webpack-dev-middleware: 3.7.2_webpack@4.41.2
       xhr-mock: 2.5.1
       xml2js: 0.4.22
-      yarn: 1.21.0
+      yarn: 1.21.1
     dev: false
     name: '@rush-temp/core-http'
     resolution:
@@ -9852,8 +9827,8 @@ packages:
       '@azure/core-arm': 1.0.0-preview.7
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@typescript-eslint/eslint-plugin': 2.11.0_f7075e6e0f0ded741b43d31cdfc430d3
@@ -9886,20 +9861,20 @@ packages:
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       shx: 0.3.2
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
       uglify-js: 3.7.2
-      yarn: 1.21.0
+      yarn: 1.21.1
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
@@ -9930,8 +9905,8 @@ packages:
       '@microsoft/api-extractor': 7.7.0
       '@opencensus/web-types': 0.0.7
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@typescript-eslint/eslint-plugin': 2.11.0_f7075e6e0f0ded741b43d31cdfc430d3
@@ -9949,13 +9924,13 @@ packages:
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       tslib: 1.10.0
       typescript: 3.6.4
       util: 0.12.1
@@ -9969,7 +9944,7 @@ packages:
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@microsoft/api-extractor': 7.7.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
       '@types/debug': 4.1.5
       '@types/fast-json-stable-stringify': 2.0.0
       '@types/mocha': 5.2.7
@@ -10015,7 +9990,7 @@ packages:
       proxy-agent: 3.1.1
       requirejs: 2.3.6
       rimraf: 3.0.0
-      rollup: 1.27.9
+      rollup: 1.27.10
       rollup-plugin-local-resolve: 1.0.7
       rollup-plugin-multi-entry: 2.1.0
       semaphore: 1.1.0
@@ -10042,10 +10017,10 @@ packages:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.6
+      '@types/chai': 4.2.7
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.5
@@ -10094,14 +10069,14 @@ packages:
       puppeteer: 2.0.0
       rhea-promise: 1.0.0
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-inject: 3.0.2
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
       sinon: 7.5.0
       ts-mocha: 6.0.0_mocha@6.2.2
       ts-node: 8.5.4_typescript@3.6.4
@@ -10112,19 +10087,19 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-V7lQ6nh67y8MBg11mF3iA5VfchcUZwnLFvilKiwl5AtwdzmXFpTtWv1CkJhWLRBZS+hTM9tKQFKoAjHEuCeMNg==
+      integrity: sha512-YOoLD66Fmz2fiw5Aj7oTxeBeAvy+SF+KGIY8NeuSQut/9kkXVyUg6J4F2CVVvSvvyvjFQjfPOjSPfl9jURRaKQ==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
-      '@azure/event-hubs': 2.1.3
+      '@azure/event-hubs': 2.1.4
       '@azure/ms-rest-nodeauth': 0.9.3
       '@microsoft/api-extractor': 7.7.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.6
+      '@types/chai': 4.2.7
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.5
@@ -10155,12 +10130,12 @@ packages:
       path-browserify: 1.0.0
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-uglify: 6.0.3_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-uglify: 6.0.4_rollup@1.27.10
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
@@ -10175,9 +10150,9 @@ packages:
   'file:projects/eventhubs-checkpointstore-blob.tgz':
     dependencies:
       '@microsoft/api-extractor': 7.7.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.5
@@ -10216,15 +10191,15 @@ packages:
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-inject: 3.0.2
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
@@ -10232,15 +10207,15 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-VkZY023E9a5gI3Wn0Q/HfuU1UJ/gKjrRrvLVc4AvImEggW/sCUiAEKsMZa+pYpiTxmb4QiAvDP8CNiMFBRM+vA==
+      integrity: sha512-pPpcLDx4HDIVpZbNC9+78duy8DBwS3bnsEUhdFMA/BBNKrcZR21WHfmrMwjSn0SuVOZC1HOF+j8C4LkPRWAKPg==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
     dependencies:
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/express': 4.17.2
       '@types/jws': 3.2.1
       '@types/mocha': 5.2.7
@@ -10269,19 +10244,19 @@ packages:
       mocha: 6.2.2
       mocha-junit-reporter: 1.23.1_mocha@6.2.2
       mocha-multi: 1.1.3_mocha@6.2.2
-      msal: 1.1.3
+      msal: 1.2.0
       open: 7.0.0
       prettier: 1.19.1
       puppeteer: 2.0.0
       qs: 6.9.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       tslib: 1.10.0
       typescript: 3.6.4
       util: 0.12.1
@@ -10297,8 +10272,8 @@ packages:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
@@ -10336,14 +10311,14 @@ packages:
       puppeteer: 2.0.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       source-map-support: 0.5.16
       tslib: 1.10.0
       typescript: 3.6.4
@@ -10360,8 +10335,8 @@ packages:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
@@ -10399,14 +10374,14 @@ packages:
       puppeteer: 2.0.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       source-map-support: 0.5.16
       tslib: 1.10.0
       typescript: 3.6.4
@@ -10423,8 +10398,8 @@ packages:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
@@ -10462,14 +10437,14 @@ packages:
       puppeteer: 2.0.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       source-map-support: 0.5.16
       tslib: 1.10.0
       typescript: 3.6.4
@@ -10484,8 +10459,8 @@ packages:
   'file:projects/logger.tgz':
     dependencies:
       '@microsoft/api-extractor': 7.7.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
-      '@types/chai': 4.2.6
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
+      '@types/chai': 4.2.7
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@types/sinon': 7.5.1
@@ -10519,12 +10494,12 @@ packages:
       prettier: 1.19.1
       puppeteer: 2.0.0
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
       sinon: 7.5.0
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
@@ -10537,16 +10512,16 @@ packages:
     version: 0.0.0
   'file:projects/service-bus.tgz':
     dependencies:
-      '@azure/amqp-common': 1.0.0-preview.8_rhea-promise@0.1.15
+      '@azure/amqp-common': 1.0.0-preview.9
       '@azure/arm-servicebus': 3.2.0
       '@azure/eslint-plugin-azure-sdk': 2.0.1_941bfbd66607e40eaf4ff1b6e0744479
       '@azure/ms-rest-nodeauth': 0.9.3
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/async-lock': 1.1.1
-      '@types/chai': 4.2.6
+      '@types/chai': 4.2.7
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 4.1.5
       '@types/is-buffer': 2.0.0
@@ -10596,14 +10571,14 @@ packages:
       rhea: 1.0.15
       rhea-promise: 0.1.15
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-inject: 3.0.2
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
       typescript: 3.6.4
@@ -10611,14 +10586,14 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-txAzZJSshDRxNPixPpjnpTz35Q+twuk0BXb0oaHOlDV2sH5T6wCxR7LM9Fy73GWqmEd15ZV7KBUOiV8IOK+Tqg==
+      integrity: sha512-mB5rw2UVBvcY2Os0izg54pmh4FS7tz/29CESzALfG+LzPTW0yyrKTG+o8QInngFwspWahZls9eAtijBh85iZlg==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
     dependencies:
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/nise': 1.4.0
@@ -10662,14 +10637,14 @@ packages:
       puppeteer: 2.0.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       source-map-support: 0.5.16
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
@@ -10685,7 +10660,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/dotenv': 6.1.1
       '@types/execa': 0.9.0
       '@types/fs-extra': 8.0.1
@@ -10732,14 +10707,14 @@ packages:
       puppeteer: 2.0.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       source-map-support: 0.5.16
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
@@ -10755,7 +10730,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/nise': 1.4.0
@@ -10799,14 +10774,14 @@ packages:
       puppeteer: 2.0.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       source-map-support: 0.5.16
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
@@ -10822,7 +10797,7 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/nise': 1.4.0
@@ -10865,14 +10840,14 @@ packages:
       puppeteer: 2.0.0
       query-string: 5.1.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       source-map-support: 0.5.16
       ts-node: 8.5.4_typescript@3.6.4
       tslib: 1.10.0
@@ -10888,8 +10863,8 @@ packages:
     dependencies:
       '@microsoft/api-extractor': 7.7.0
       '@opentelemetry/types': 0.2.0
-      '@rollup/plugin-json': 4.0.0_rollup@1.27.9
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-json': 4.0.0_rollup@1.27.10
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/mocha': 5.2.7
       '@types/node': 8.10.59
       '@typescript-eslint/eslint-plugin': 2.11.0_f7075e6e0f0ded741b43d31cdfc430d3
@@ -10919,13 +10894,13 @@ packages:
       mocha-multi: 1.1.3_mocha@6.2.2
       prettier: 1.19.1
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       tslib: 1.10.0
       typescript: 3.6.4
       util: 0.12.1
@@ -10937,7 +10912,7 @@ packages:
     version: 0.0.0
   'file:projects/test-utils-recorder.tgz':
     dependencies:
-      '@rollup/plugin-replace': 2.2.1_rollup@1.27.9
+      '@rollup/plugin-replace': 2.2.1_rollup@1.27.10
       '@types/fs-extra': 8.0.1
       '@types/mocha': 5.2.7
       '@types/nise': 1.4.0
@@ -10945,14 +10920,14 @@ packages:
       nise: 1.5.2
       nock: 11.7.0
       rimraf: 3.0.0
-      rollup: 1.27.9
-      rollup-plugin-commonjs: 10.1.0_rollup@1.27.9
+      rollup: 1.27.10
+      rollup-plugin-commonjs: 10.1.0_rollup@1.27.10
       rollup-plugin-multi-entry: 2.1.0
-      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.9
+      rollup-plugin-node-resolve: 5.2.0_rollup@1.27.10
       rollup-plugin-shim: 1.0.0
-      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.9
-      rollup-plugin-terser: 5.1.2_rollup@1.27.9
-      rollup-plugin-visualizer: 3.3.0_rollup@1.27.9
+      rollup-plugin-sourcemaps: 0.4.2_rollup@1.27.10
+      rollup-plugin-terser: 5.1.3_rollup@1.27.10
+      rollup-plugin-visualizer: 3.3.0_rollup@1.27.10
       tslib: 1.10.0
       typescript: 3.6.4
     dev: false
@@ -10963,7 +10938,7 @@ packages:
     version: 0.0.0
   'file:projects/testhub.tgz':
     dependencies:
-      '@azure/event-hubs': 2.1.3
+      '@azure/event-hubs': 2.1.4
       '@types/node': 8.10.59
       '@types/uuid': 3.4.6
       '@types/yargs': 13.0.3

--- a/sdk/eventhub/event-hubs/changelog.md
+++ b/sdk/eventhub/event-hubs/changelog.md
@@ -2,6 +2,8 @@
 
 - Fixed potential issues with claims being mismanaged when subscriptions terminate.
 - Improved reporting of errors that occur when attempting to claim partitions from CheckpointStores.
+- Updated to use the latest version of the `@azure/core-amqp` package.
+  This update allows the SDK to detect when a connection has gone idle for 60 seconds and attempt to reconnect.
 
 ### 2019-12-03 5.0.0-preview.7
 

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "1.0.0-preview.6",
+    "@azure/core-amqp": "1.0.0-preview.7",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/identity": "^1.0.0",

--- a/sdk/servicebus/service-bus/changelog.md
+++ b/sdk/servicebus/service-bus/changelog.md
@@ -1,11 +1,16 @@
+# 1.1.2
+
+- Updates `@azure/amqp-common` to version 1.0.0-preview.9.
+  This update allows the SDK to detect when a connection has gone idle for 60 seconds and attempt to reconnect.
+
 # 2019-11-27 1.1.1
 
 - Fix [bug 5757](https://github.com/Azure/azure-sdk-for-js/issues/5757) where `receiveMessages` used in `ReceiveAndDelete` mode results in data loss. [PR 6265](https://github.com/Azure/azure-sdk-for-js/pull/6265).
 - Updated network status detection to treat DNS timeouts as a `ConnectionLostError` by using the latest version
-of the `@azure/amqp-common` package.
+  of the `@azure/amqp-common` package.
 - We do not have retries for errors during receiver set up. User is expected to retry on their own.
-There was a misleading retry due to a failed receiver being cached which is now fixed. Related to 
-[bug 5541](https://github.com/Azure/azure-sdk-for-js/issues/5541).
+  There was a misleading retry due to a failed receiver being cached which is now fixed. Related to
+  [bug 5541](https://github.com/Azure/azure-sdk-for-js/issues/5541).
 - Errors that arise from receivers failing to automatically reconnect after encountering a transient issue now trigger the user-provided `onError` callback passed to `receiver.registerMessageHandler`. Related to [bug 2540](https://github.com/Azure/azure-sdk-for-js/issues/2540)
 - Update jsdocs for the `receiveMessages` method to include a note that the number of messages that can
   be received in `PeekLock` mode is capped at 2047. [PR 5758](https://github.com/Azure/azure-sdk-for-js/pull/5758).

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "description": "Azure Service Bus SDK for Node.js",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus",
@@ -69,7 +69,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/ms-rest-nodeauth": "^0.9.2",
-    "@azure/amqp-common": "1.0.0-preview.8",
+    "@azure/amqp-common": "1.0.0-preview.9",
     "@azure/core-http": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "@types/is-buffer": "^2.0.0",

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -3,7 +3,7 @@
 
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "1.1.1"
+  version: "1.1.2"
 };
 
 export const messageDispositionTimeout = 20000;


### PR DESCRIPTION
Fixes #6118 

`@azure/event-hubs@2.1.4` includes this fix. This updates the preview version of `@azure/event-hubs` and `@azure/service-bus` to depend on the version of their core amqp libraries that has a 1 minute idle timeout.