### PR TITLE
[KeyVault-Certificates] Fixes for the API inconsistencies

### DIFF
--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -52,7 +52,7 @@ export interface BeginRecoverDeletedCertificateOptions extends CertificatePoller
 export class CertificateClient {
     constructor(vaultUrl: string, credential: TokenCredential, pipelineOptions?: PipelineOptions);
     backupCertificate(certificateName: string, options?: BackupCertificateOptions): Promise<Uint8Array | undefined>;
-    beginCreateCertificate(certificateName: string, certificatePolicy: CertificatePolicy, options?: BeginCreateCertificateOptions): Promise<PollerLike<PollOperationState<KeyVaultCertificateWithPolicy>, KeyVaultCertificateWithPolicy>>;
+    beginCreateCertificate(certificateName: string, policy: CertificatePolicy, options?: BeginCreateCertificateOptions): Promise<PollerLike<PollOperationState<KeyVaultCertificateWithPolicy>, KeyVaultCertificateWithPolicy>>;
     beginDeleteCertificate(certificateName: string, options?: BeginDeleteCertificateOptions): Promise<PollerLike<PollOperationState<DeletedCertificate>, DeletedCertificate>>;
     beginRecoverDeletedCertificate(certificateName: string, options?: BeginRecoverDeletedCertificateOptions): Promise<PollerLike<PollOperationState<KeyVaultCertificate>, KeyVaultCertificate>>;
     createIssuer(issuerName: string, provider: string, options?: CreateIssuerOptions): Promise<CertificateIssuer>;
@@ -76,7 +76,7 @@ export class CertificateClient {
     restoreCertificateBackup(backup: Uint8Array, options?: RestoreCertificateBackupOptions): Promise<KeyVaultCertificateWithPolicy>;
     setContacts(contacts: CertificateContact[], options?: SetContactsOptions): Promise<CertificateContact[] | undefined>;
     updateCertificatePolicy(certificateName: string, policy: CertificatePolicy, options?: UpdateCertificatePolicyOptions): Promise<CertificatePolicy>;
-    updateCertificateProperties(certificateName: string, version: string, options?: UpdateCertificateOptions): Promise<KeyVaultCertificate>;
+    updateCertificateProperties(certificateName: string, version?: string, options?: UpdateCertificateOptions): Promise<KeyVaultCertificate>;
     updateIssuer(issuerName: string, options?: UpdateIssuerOptions): Promise<CertificateIssuer>;
     readonly vaultUrl: string;
 }
@@ -92,27 +92,20 @@ export interface CertificateContactAll {
 }
 
 // @public
-export interface CertificateContacts {
-    contactList?: CertificateContact[];
-    readonly id?: string;
-}
-
-// @public
 export type CertificateContentType = "application/x-pem-file" | "application/x-pkcs12" | undefined;
 
 // @public
 export interface CertificateIssuer {
     accountId?: string;
     administratorContacts?: AdministratorContact[];
-    createdOn?: Date;
-    credentials?: IssuerCredentials;
+    readonly createdOn?: Date;
     enabled?: boolean;
     id?: string;
     issuerProperties?: IssuerProperties;
-    name?: string;
+    readonly name?: string;
     organizationId?: string;
     password?: string;
-    updatedOn?: Date;
+    readonly updatedOn?: Date;
 }
 
 // @public
@@ -137,27 +130,11 @@ export interface CertificateOperationError {
     readonly message?: string;
 }
 
+// Warning: (ae-forgotten-export) The symbol "CertificatePolicyProperties" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "PolicySubjectProperties" needs to be exported by the entry point index.d.ts
+//
 // @public
-export interface CertificatePolicy {
-    certificateTransparency?: boolean;
-    certificateType?: string;
-    contentType?: CertificateContentType;
-    readonly createdOn?: Date;
-    enabled?: boolean;
-    enhancedKeyUsage?: string[];
-    exportable?: boolean;
-    issuerName?: WellKnownIssuer | string;
-    keyCurveName?: KeyCurveName;
-    keySize?: number;
-    keyType?: KeyType;
-    keyUsage?: KeyUsageType[];
-    lifetimeActions?: LifetimeAction[];
-    reuseKey?: boolean;
-    subject?: string;
-    subjectAlternativeNames?: SubjectAlternativeNames;
-    readonly updatedOn?: Date;
-    validityInMonths?: number;
-}
+export type CertificatePolicy = CertificatePolicyProperties & RequireAtLeastOne<PolicySubjectProperties>;
 
 // @public
 export module CertificatePolicy {
@@ -178,14 +155,14 @@ export interface CertificateProperties {
     readonly createdOn?: Date;
     enabled?: boolean;
     readonly expiresOn?: Date;
-    id?: string;
-    name?: string;
+    readonly id?: string;
+    readonly name?: string;
     notBefore?: Date;
     readonly recoveryLevel?: DeletionRecoveryLevel;
     tags?: CertificateTags;
-    updatedOn?: Date;
+    readonly updatedOn?: Date;
     vaultUrl?: string;
-    version?: string;
+    readonly version?: string;
     readonly x509Thumbprint?: Uint8Array;
 }
 
@@ -306,7 +283,7 @@ export interface IssuerParameters {
 // @public
 export interface IssuerProperties {
     id?: string;
-    name?: string;
+    readonly name?: string;
     provider?: string;
 }
 
@@ -324,7 +301,7 @@ export interface KeyVaultCertificate {
     cer?: Uint8Array;
     id?: string;
     readonly keyId?: string;
-    name: string;
+    readonly name: string;
     properties: CertificateProperties;
     readonly secretId?: string;
 }

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -109,6 +109,12 @@ export interface CertificateIssuer {
 }
 
 // @public
+export type CertificateKeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
+
+// @public
+export type CertificateKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM";
+
+// @public
 export interface CertificateOperation {
     cancellationRequested?: boolean;
     certificateTransparency?: boolean;
@@ -286,12 +292,6 @@ export interface IssuerProperties {
     readonly name?: string;
     provider?: string;
 }
-
-// @public
-export type KeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
-
-// @public
-export type KeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM";
 
 // @public
 export type KeyUsageType = "digitalSignature" | "nonRepudiation" | "keyEncipherment" | "dataEncipherment" | "keyAgreement" | "keyCertSign" | "cRLSign" | "encipherOnly" | "decipherOnly";

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -140,11 +140,6 @@ export interface CertificateOperationError {
 export type CertificatePolicy = CertificatePolicyProperties & RequireAtLeastOne<PolicySubjectProperties>;
 
 // @public
-export module CertificatePolicy {
-    const Default: CertificatePolicy;
-}
-
-// @public
 export type CertificatePolicyAction = "EmailContacts" | "AutoRenew";
 
 // @public
@@ -213,6 +208,12 @@ export interface CreateIssuerOptions extends coreHttp.OperationOptions {
     organizationId?: string;
     password?: string;
 }
+
+// @public
+export const DefaultCertificatePolicy: {
+    issuerName: string;
+    subject: string;
+};
 
 // @public
 export interface DeleteCertificateOperationOptions extends coreHttp.OperationOptions {

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -101,10 +101,10 @@ export interface CertificateIssuer {
     readonly createdOn?: Date;
     enabled?: boolean;
     id?: string;
-    issuerProperties?: IssuerProperties;
     readonly name?: string;
     organizationId?: string;
     password?: string;
+    properties?: IssuerProperties;
     readonly updatedOn?: Date;
 }
 

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -136,9 +136,6 @@ export interface CertificateOperationError {
     readonly message?: string;
 }
 
-// Warning: (ae-forgotten-export) The symbol "CertificatePolicyProperties" needs to be exported by the entry point index.d.ts
-// Warning: (ae-forgotten-export) The symbol "PolicySubjectProperties" needs to be exported by the entry point index.d.ts
-//
 // @public
 export type CertificatePolicy = CertificatePolicyProperties & RequireAtLeastOne<PolicySubjectProperties>;
 
@@ -149,6 +146,26 @@ export module CertificatePolicy {
 
 // @public
 export type CertificatePolicyAction = "EmailContacts" | "AutoRenew";
+
+// @public
+export interface CertificatePolicyProperties {
+    certificateTransparency?: boolean;
+    certificateType?: string;
+    contentType?: CertificateContentType;
+    readonly createdOn?: Date;
+    enabled?: boolean;
+    enhancedKeyUsage?: string[];
+    exportable?: boolean;
+    issuerName?: WellKnownIssuer | string;
+    keyCurveName?: CertificateKeyCurveName;
+    keySize?: number;
+    keyType?: CertificateKeyType;
+    keyUsage?: KeyUsageType[];
+    lifetimeActions?: LifetimeAction[];
+    reuseKey?: boolean;
+    readonly updatedOn?: Date;
+    validityInMonths?: number;
+}
 
 // @public
 export interface CertificatePollerOptions extends coreHttp.OperationOptions {
@@ -348,6 +365,12 @@ export interface MergeCertificateOptions extends coreHttp.OperationOptions {
 }
 
 export { PipelineOptions }
+
+// @public
+export interface PolicySubjectProperties {
+    subject: string;
+    subjectAlternativeNames: SubjectAlternativeNames;
+}
 
 // @public
 export interface PurgeDeletedCertificateOptions extends coreHttp.OperationOptions {

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/helloWorld.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/helloWorld.ts
@@ -1,4 +1,4 @@
-import { CertificateClient, CertificatePolicy } from "../../src";
+import { CertificateClient, DefaultCertificatePolicy } from "../../src";
 import { DefaultAzureCredential } from "@azure/identity";
 
 // This sample creates a self-signed certificate, reads it in various ways,
@@ -19,7 +19,7 @@ async function main(): Promise<void> {
   const certificateName = "MyCertificate";
 
   // Creating a self-signed certificate
-  const createPoller = await client.beginCreateCertificate(certificateName, CertificatePolicy.Default);
+  const createPoller = await client.beginCreateCertificate(certificateName, DefaultCertificatePolicy);
 
   const pendingCertificate = createPoller.getResult();
   console.log("Certificate: ", pendingCertificate);

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -1,9 +1,7 @@
 import * as coreHttp from "@azure/core-http";
 import {
-  CertificateOperation,
   DeletionRecoveryLevel,
-  KeyUsageType,
-  IssuerCredentials
+  KeyUsageType
 } from "./core/models";
 
 /**
@@ -188,7 +186,7 @@ export interface KeyVaultCertificate {
   /**
    * The name of certificate.
    */
-  name: string;
+  readonly name: string;
   /**
    * The properties of the certificate
    */
@@ -314,9 +312,9 @@ export interface LifetimeAction {
 export type CertificatePolicyAction = "EmailContacts" | "AutoRenew";
 
 /**
- * An interface representing a certificate's policy.
+ * An interface representing a certificate's policy (without the subject properties).
  */
-export interface CertificatePolicy {
+export interface CertificatePolicyProperties {
   /**
    * Indicates if the certificates generated under this policy should be published to certificate
    * transparency logs.
@@ -383,15 +381,27 @@ export interface CertificatePolicy {
    * The duration that the certificate is valid in months.
    */
   validityInMonths?: number;
+}
+
+/**
+ * An interface representing the possible subject properties of a certificate's policy.
+ * The final type requires at least one of these properties to exist.
+ */
+export interface PolicySubjectProperties {
   /**
    * The subject name. Should be a valid X509 distinguished Name.
    */
-  subject?: string;
+  subject: string;
   /**
    * The subject alternative names.
    */
-  subjectAlternativeNames?: SubjectAlternativeNames;
+  subjectAlternativeNames: SubjectAlternativeNames;  
 }
+
+/**
+ * An type representing a certificate's policy with at least one of the subject properties.
+ */
+export type CertificatePolicy = CertificatePolicyProperties & RequireAtLeastOne<PolicySubjectProperties>;
 
 /**
  * The CertificatePolicy module exports values that
@@ -430,11 +440,11 @@ export interface CertificateProperties {
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  id?: string;
+  readonly id?: string;
   /**
    * The name of certificate.
    */
-  name?: string;
+  readonly name?: string;
   /**
    * Not before date in UTC.
    */
@@ -456,7 +466,7 @@ export interface CertificateProperties {
   /**
    * When the issuer was updated.
    */
-  updatedOn?: Date;
+  readonly updatedOn?: Date;
   /**
    * The vault URI.
    */
@@ -464,7 +474,7 @@ export interface CertificateProperties {
   /**
    * The version of certificate. May be undefined.
    */
-  version?: string;
+  readonly version?: string;
   /**
    * Thumbprint of the certificate.
    */
@@ -728,7 +738,7 @@ export interface IssuerProperties {
   /**
    * Name of the issuer.
    */
-  name?: string;
+  readonly name?: string;
   /**
    * The issuer provider.
    */
@@ -750,15 +760,15 @@ export interface CertificateIssuer {
   /**
    * When the issuer was created.
    */
-  createdOn?: Date;
+  readonly createdOn?: Date;
   /**
    * When the issuer was updated.
    */
-  updatedOn?: Date;
+  readonly updatedOn?: Date;
   /**
    * Name of the issuer
    */
-  name?: string;
+  readonly name?: string;
   /**
    * The user name/account name/account id.
    */
@@ -767,10 +777,6 @@ export interface CertificateIssuer {
    * The password/secret/account key.
    */
   password?: string;
-  /**
-   * The credentials to be used for the issuer.
-   */
-  credentials?: IssuerCredentials;
   /**
    * Id of the organization.
    */

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -786,7 +786,7 @@ export interface CertificateIssuer {
   /**
    * A small set of useful properties of a certificate issuer
    */
-  issuerProperties?: IssuerProperties;
+  properties?: IssuerProperties;
 }
 
 /**

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -2,20 +2,20 @@ import * as coreHttp from "@azure/core-http";
 import { DeletionRecoveryLevel, KeyUsageType } from "./core/models";
 
 /**
- * Defines values for KeyType.
+ * Defines values for CertificateKeyType.
  * Possible values include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM'
  * @readonly
  * @enum {string}
  */
-export type KeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM";
+export type CertificateKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM";
 
 /**
- * Defines values for KeyCurveName.
+ * Defines values for CertificateKeyCurveName.
  * Possible values include: 'P-256', 'P-384', 'P-521', 'P-256K'
  * @readonly
  * @enum {string}
  */
-export type KeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
+export type CertificateKeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
 
 /**
  * @internal
@@ -348,7 +348,7 @@ export interface CertificatePolicyProperties {
   /**
    * Elliptic curve name. Possible values include: 'P-256', 'P-384', 'P-521', 'P-256K'
    */
-  keyCurveName?: KeyCurveName;
+  keyCurveName?: CertificateKeyCurveName;
   /**
    * The key size in bits. For example: 2048, 3072, or 4096 for RSA.
    */
@@ -357,7 +357,7 @@ export interface CertificatePolicyProperties {
    * The type of key pair to be used for the certificate. Possible values include: 'EC', 'EC-HSM',
    * 'RSA', 'RSA-HSM', 'oct'
    */
-  keyType?: KeyType;
+  keyType?: CertificateKeyType;
   /**
    * List of key usages.
    */

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -402,20 +402,14 @@ export type CertificatePolicy = CertificatePolicyProperties &
   RequireAtLeastOne<PolicySubjectProperties>;
 
 /**
- * The CertificatePolicy module exports values that
+ * The DefaultCertificatePolicy exports values that
  * are useful as default parameters to methods that
  * modify the certificate's policy.
  */
-export module CertificatePolicy {
-  /**
-   * The minimum working properties for a Certificate's Policy.
-   * If used, the certificate will be a self-signed certificate.
-   */
-  export const Default: CertificatePolicy = {
-    issuerName: "Self",
-    subject: "cn=MyCert"
-  };
-}
+export const DefaultCertificatePolicy = {
+  issuerName: "Self",
+  subject: "cn=MyCert"
+};
 
 /**
  * An interface representing the properties of a certificate

--- a/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
+++ b/sdk/keyvault/keyvault-certificates/src/certificatesModels.ts
@@ -1,8 +1,5 @@
 import * as coreHttp from "@azure/core-http";
-import {
-  DeletionRecoveryLevel,
-  KeyUsageType
-} from "./core/models";
+import { DeletionRecoveryLevel, KeyUsageType } from "./core/models";
 
 /**
  * Defines values for KeyType.
@@ -395,13 +392,14 @@ export interface PolicySubjectProperties {
   /**
    * The subject alternative names.
    */
-  subjectAlternativeNames: SubjectAlternativeNames;  
+  subjectAlternativeNames: SubjectAlternativeNames;
 }
 
 /**
  * An type representing a certificate's policy with at least one of the subject properties.
  */
-export type CertificatePolicy = CertificatePolicyProperties & RequireAtLeastOne<PolicySubjectProperties>;
+export type CertificatePolicy = CertificatePolicyProperties &
+  RequireAtLeastOne<PolicySubjectProperties>;
 
 /**
  * The CertificatePolicy module exports values that

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -44,8 +44,8 @@ import {
   GetDeletedCertificateOptions,
   CertificateTags,
   ImportCertificateOptions,
-  KeyType,
-  KeyCurveName,
+  CertificateKeyType,
+  CertificateKeyCurveName,
   ListPropertiesOfCertificatesOptions,
   ListPropertiesOfCertificateVersionsOptions,
   ListPropertiesOfIssuersOptions,
@@ -178,8 +178,8 @@ export {
   IssuerCredentials,
   IssuerParameters,
   IssuerProperties,
-  KeyType,
-  KeyCurveName,
+  CertificateKeyType,
+  CertificateKeyCurveName,
   KeyUsageType,
   LifetimeAction,
   ListPropertiesOfCertificatesOptions,
@@ -319,7 +319,7 @@ function toPublicPolicy(policy: CoreCertificatePolicy = {}): CertificatePolicy {
   }
 
   if (policy.keyProperties) {
-    certificatePolicy.keyType = policy.keyProperties.keyType as KeyType;
+    certificatePolicy.keyType = policy.keyProperties.keyType as CertificateKeyType;
     certificatePolicy.keySize = policy.keyProperties.keySize;
     certificatePolicy.reuseKey = policy.keyProperties.reuseKey;
     certificatePolicy.keyCurveName = policy.keyProperties.curve;

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -733,7 +733,7 @@ export class CertificateClient {
     let coreContacts = contacts.map((x) => ({
       emailAddress: x ? x.email : undefined,
       name: x ? x.name : undefined,
-      phone: x ? x.phone : undefined,
+      phone: x ? x.phone : undefined
     }));
     const requestOptions = operationOptionsToRequestOptionsBase(options);
 

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -350,7 +350,7 @@ function toPublicIssuer(issuer: IssuerBundle = {}): CertificateIssuer {
     updatedOn: attributes.updated
   };
 
-  publicIssuer.issuerProperties = {
+  publicIssuer.properties = {
     id: publicIssuer.id,
     name: parsedId.name,
     provider: issuer.provider

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -73,7 +73,8 @@ import {
   ArrayOneOrMore,
   SubjectAlternativeNamesAll,
   CertificatePolicyProperties,
-  PolicySubjectProperties
+  PolicySubjectProperties,
+  DefaultCertificatePolicy
 } from "./certificatesModels";
 import {
   CertificateBundle,
@@ -168,6 +169,7 @@ export {
   DeleteIssuerOptions,
   DeletedCertificate,
   DeletionRecoveryLevel,
+  DefaultCertificatePolicy,
   ErrorModel,
   GetContactsOptions,
   GetIssuerOptions,

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -71,7 +71,9 @@ import {
   LifetimeAction,
   RequireAtLeastOne,
   ArrayOneOrMore,
-  SubjectAlternativeNamesAll
+  SubjectAlternativeNamesAll,
+  CertificatePolicyProperties,
+  PolicySubjectProperties
 } from "./certificatesModels";
 import {
   CertificateBundle,
@@ -152,6 +154,8 @@ export {
   CertificateOperationError,
   CertificatePolicy,
   CertificatePolicyAction,
+  CertificatePolicyProperties,
+  PolicySubjectProperties,
   CertificateTags,
   CreateCertificateOptions,
   CertificatePollerOptions,

--- a/sdk/keyvault/keyvault-certificates/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/CRUD.test.ts
@@ -362,7 +362,7 @@ describe("Certificates client - create, read, update and delete", () => {
 
     // Read
     getResponse = await client.getIssuer(issuerName);
-    assert.equal(getResponse.issuerProperties.provider, "Test");
+    assert.equal(getResponse.properties.provider, "Test");
 
     // Update
     await client.updateIssuer(issuerName, {

--- a/sdk/keyvault/keyvault-certificates/test/lro.create.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/lro.create.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import { CertificateClient, KeyVaultCertificate, CertificatePolicy } from "../src";
+import { CertificateClient, KeyVaultCertificate, DefaultCertificatePolicy } from "../src";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
@@ -34,7 +34,7 @@ describe("Certificates client - LRO - create", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     const poller = await client.beginCreateCertificate(
       certificateName,
-      CertificatePolicy.Default,
+      DefaultCertificatePolicy,
       testPollerProperties
     );
     assert.ok(poller.getOperationState().isStarted);
@@ -56,7 +56,7 @@ describe("Certificates client - LRO - create", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     const poller = await client.beginCreateCertificate(
       certificateName,
-      CertificatePolicy.Default,
+      DefaultCertificatePolicy,
       testPollerProperties
     );
     assert.ok(poller.getOperationState().isStarted);
@@ -73,7 +73,7 @@ describe("Certificates client - LRO - create", () => {
 
     const serialized = poller.toString();
 
-    const resumePoller = await client.beginCreateCertificate(certificateName, CertificatePolicy.Default, {
+    const resumePoller = await client.beginCreateCertificate(certificateName, DefaultCertificatePolicy, {
       resumeFrom: serialized,
       ...testPollerProperties
     });

--- a/sdk/keyvault/keyvault-certificates/test/lro.delete.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/lro.delete.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import { CertificateClient, DeletedCertificate, CertificatePolicy } from "../src";
+import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from "../src";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
@@ -34,7 +34,7 @@ describe("Certificates client - lro - delete", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     await client.beginCreateCertificate(
       certificateName,
-      CertificatePolicy.Default,
+      DefaultCertificatePolicy,
       testPollerProperties
     );
     const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
@@ -57,7 +57,7 @@ describe("Certificates client - lro - delete", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     await client.beginCreateCertificate(
         certificateName,
-        CertificatePolicy.Default,
+        DefaultCertificatePolicy,
         testPollerProperties
       );
     const poller = await client.beginDeleteCertificate(certificateName, testPollerProperties);

--- a/sdk/keyvault/keyvault-certificates/test/lro.operation.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/lro.operation.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import { CertificateClient, CertificateOperation, CertificatePolicy } from "../src";
+import { CertificateClient, CertificateOperation, DefaultCertificatePolicy } from "../src";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
@@ -34,7 +34,7 @@ describe("Certificates client - LRO - certificate operation", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     const createPoller = await client.beginCreateCertificate(
       certificateName,
-      CertificatePolicy.Default,
+      DefaultCertificatePolicy,
       testPollerProperties
     );
     createPoller.stopPolling();
@@ -58,7 +58,7 @@ describe("Certificates client - LRO - certificate operation", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     const createPoller = await client.beginCreateCertificate(
         certificateName,
-        CertificatePolicy.Default,
+        DefaultCertificatePolicy,
         testPollerProperties
       );
       createPoller.stopPolling();

--- a/sdk/keyvault/keyvault-certificates/test/lro.recover.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/lro.recover.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import { CertificateClient, DeletedCertificate, CertificatePolicy } from "../src";
+import { CertificateClient, DeletedCertificate, DefaultCertificatePolicy } from "../src";
 import { isNode } from "@azure/core-http";
 import { isPlayingBack, testPollerProperties } from "./utils/recorderUtils";
 import { env } from "@azure/test-utils-recorder";
@@ -36,7 +36,7 @@ describe("Certificates client - LRO - recoverDelete", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     await client.beginCreateCertificate(
       certificateName,
-      CertificatePolicy.Default,
+      DefaultCertificatePolicy,
       testPollerProperties
     );
 
@@ -63,7 +63,7 @@ describe("Certificates client - LRO - recoverDelete", () => {
     const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
     await client.beginCreateCertificate(
         certificateName,
-        CertificatePolicy.Default,
+        DefaultCertificatePolicy,
         testPollerProperties
       );
     const deletePoller = await client.beginDeleteCertificate(certificateName, testPollerProperties);
@@ -105,7 +105,7 @@ describe("Certificates client - LRO - recoverDelete", () => {
       const certificateName = testClient.formatName(`${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`);
       await client.beginCreateCertificate(
         certificateName,
-        CertificatePolicy.Default,
+        DefaultCertificatePolicy,
         testPollerProperties
       );
       const deletePoller = await client.beginDeleteCertificate(certificateName, testPollerProperties);


### PR DESCRIPTION
Fixes #6518

What this PR fixes:

- certificatePolicy parameter -> policy in beginCreateCertificate
- version parameter in updateCertificateProperties should be optional
- Should enforce that CertificatePolicy gets issuerName and one or both of subject and subjectAlternativeNames
- JsonWebKeyType enum name -> CertificateKeyType
- id, name, createdOn, and updatedOn should be readonly for CertificateIssuer. Go over others to make sure what should be readonly is readonly
- issuerProperties property -> properties in CertificateIssuer 
- Remove credentials property from CertificateIssuer

Tasks that weren't fixed as part of this PR because they are fixed on master:  
See _Fixed on master_ here: https://github.com/Azure/azure-sdk-for-js/issues/6518#issuecomment-565083908

All the questions have been resolved so far.

**NOTE ON SAMPLES:**
This code should work as is for all of the current samples, even the samples in the documentation.