### PR TITLE
[event-processor-host] update event-hubs dep

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -53,6 +53,6 @@
     // TODO: Remove this once Service Bus is updated to use current depenedencies as part of Track 2
     "rhea-promise": ["^0.1.15"],
     // Following is required to allow for backward compatibility with Event Processor Host Track 1
-    "@azure/event-hubs": ["^2.1.1"]
+    "@azure/event-hubs": ["^2.1.4"]
   }
 }

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -3,7 +3,7 @@
 - Updates minimum version of `@azure/event-hubs` from version 2.1.1 to version 2.1.4.
   This update brings in improvements when attempting to reconnect after a transient failure.
   See the [changelog](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/event-hubs_2.1.4/sdk/eventhub/event-hubs/changelog.md#2019-12-11-214)
-  for `@azure/event-hubs` for a full list of the improvements from version 2.1.1.
+  for `@azure/event-hubs` for a full list of the improvements since version 2.1.1.
 
 ### 2019-08-06 2.1.0
 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,9 +1,9 @@
 ### 2.1.1
 
-- Updates minimum version of `@azure/event-hubs` to version 2.1.4.
+- Updates minimum version of `@azure/event-hubs` from version 2.1.1 to version 2.1.4.
   This update brings in improvements when attempting to reconnect after a transient failure.
   See the [changelog](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/event-hubs_2.1.4/sdk/eventhub/event-hubs/changelog.md#2019-12-11-214)
-  for `@azure/event-hubs` for a full list of the improvements.
+  for `@azure/event-hubs` for a full list of the improvements from version 2.1.1.
 
 ### 2019-08-06 2.1.0
 

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -1,89 +1,108 @@
+### 2.1.1
+
+- Updates minimum version of `@azure/event-hubs` to version 2.1.4.
+  This update brings in improvements when attempting to reconnect after a transient failure.
+
 ### 2019-08-06 2.1.0
+
 - Added support for WebSockets. WebSockets enable Event processor Host to work over an HTTP proxy and in environments where the standard AMQP port 5671 is blocked.
-Refer to the [websockets](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-processor-host/samples/websockets.ts) sample to see how to use WebSockets. 
+  Refer to the [websockets](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-processor-host/samples/websockets.ts) sample to see how to use WebSockets.
 - Fixed [bug 4363](https://github.com/Azure/azure-sdk-for-js/issues/4363) which stopped users from providing their own LeaseManager. If both a lease manager and the options for leaseDuration/leaseRenewInterval are provided, then the latter will be ignored in favor of the leaseDuration/leaseRenewInterval properties on the lease manager.
 
 ## 2019-07-16 2.0.0
+
 - Use the latest version of the dependency on [@azure/event-hubs](https://www.npmjs.com/package/@azure/event-hubs/v/2.1.1) that has the following bug fixes
-    - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
-   - A network connection lost error is now treated as retryable error. A new error with name `ConnectionLostError` 
-      is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-processor-host#debug-logs).
-   - When recovering from an error that caused the underlying AMQP connection to get disconnected, 
-      [rhea](https://github.com/amqp/rhea/issues/205) reconnects all the older AMQP links on the connection 
-      resulting in the below 2 errors in the logs. We now clear rhea's internal map to avoid such reconnections. 
-      We already have code in place to create new AMQP links to resume send/receive operations.
-      - InvalidOperationError: A link to connection '.....' $cbs node has already been opened.
-      - UnauthorizedError: Unauthorized access. 'Listen' claim(s) are required to perform this operation.
+  - Added event handlers for `error` and `protocolError` events on the connection object to avoid the case of unhandled exceptions. This is related to the [bug 4136](https://github.com/Azure/azure-sdk-for-js/issues/4136)
+  - A network connection lost error is now treated as retryable error. A new error with name `ConnectionLostError`
+    is introduced for this scenario which you can see if you enable the [logs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-processor-host#debug-logs).
+  - When recovering from an error that caused the underlying AMQP connection to get disconnected,
+    [rhea](https://github.com/amqp/rhea/issues/205) reconnects all the older AMQP links on the connection
+    resulting in the below 2 errors in the logs. We now clear rhea's internal map to avoid such reconnections.
+    We already have code in place to create new AMQP links to resume send/receive operations.
+    - InvalidOperationError: A link to connection '.....' \$cbs node has already been opened.
+    - UnauthorizedError: Unauthorized access. 'Listen' claim(s) are required to perform this operation.
 
 #### Breaking Changes
-- If you have been using the `createFromAadTokenCredentials` function or the `createFromAadTokenCredentialsWithCustomCheckpointAndLeaseManager` function to create an instance of the 
-`EventProcessorHost`, you will now need to use the [@azure/ms-rest-nodeauth](https://www.npmjs.com/package/@azure/ms-rest-nodeauth) 
-library instead of [ms-rest-azure](https://www.npmjs.com/package/ms-rest-azure) library to create 
-the credentials that are needed by these functions.
-    - Typescript: Replace `import * from "ms-rest-azure";` with `import * from "@azure/ms-rest-nodeauth";`
-    - Javascript: Replace `require("ms-rest-azure")` with `require("@azure/ms-rest-nodeauth")`
+
+- If you have been using the `createFromAadTokenCredentials` function or the `createFromAadTokenCredentialsWithCustomCheckpointAndLeaseManager` function to create an instance of the
+  `EventProcessorHost`, you will now need to use the [@azure/ms-rest-nodeauth](https://www.npmjs.com/package/@azure/ms-rest-nodeauth)
+  library instead of [ms-rest-azure](https://www.npmjs.com/package/ms-rest-azure) library to create
+  the credentials that are needed by these functions. - Typescript: Replace `import * from "ms-rest-azure";` with `import * from "@azure/ms-rest-nodeauth";` - Javascript: Replace `require("ms-rest-azure")` with `require("@azure/ms-rest-nodeauth")`
 
 ## 2018-10-05 1.0.6
-- Remove `@azure/amqp-common` and `rhea-promise` as dependencies, since we use very little from 
-those libraries and there is a risk of having two instances of rhea in the dependency chain which 
-can cause problems while encoding types for filters.
+
+- Remove `@azure/amqp-common` and `rhea-promise` as dependencies, since we use very little from
+  those libraries and there is a risk of having two instances of rhea in the dependency chain which
+  can cause problems while encoding types for filters.
 - `HostContext.connectionConfig` is now of type `EventHubConnectionConfig`.
 - Minimum dependency on `@azure/event-hubs: "^1.0.6"`.
 
 ## 2018-10-01 1.0.5
+
 - Bumping minimum version of @azure/event-hubs to "1.0.5".
 - Taking a dependency on "@azure/amqp-common" for reusing the common parts.
 
 ## 2018-09-25 1.0.4
+
 - Bumping minimum version of @azure/event-hubs to "1.0.4".
 
 ## 2018-09-25 1.0.3
+
 - Ensures that amqp:link-stolen errors are not notified to the customer, since they are expected errors that
-happen during lease stealing or expiration as a part of load balancing.
+  happen during lease stealing or expiration as a part of load balancing.
 
 ## 2018-09-15 1.0.2
+
 - Ensures that messages are checkpointed in order.
 
 ## 2018-09-14 1.0.1
+
 - `eph.getPartitionInformation()` should works as expected when partitionId is of type `number | string`.
 - updated documentation for `eventHubPath` optional property in the `FromConnectionStringOptions` object.
 
 ## 2018-09-12 1.0.0
+
 - Stable version of the library.
 
 ## 2018-09-12 0.2.0
+
 - Added support to automatically balance the load of receiving messages across multiple partitions.
 - Added static method to create an EPH from an `IotHubConnectionString`
 - Added user-agent to the underlying amqp-connection. This would help in tracking usage of EPH.
 - Changed the overall design of EPH.
 - Instead of attaching handlers on `eph:message` and `eph:error`, now the handlers need to be passed
-as arguments to the `start()` method on EPH.
+  as arguments to the `start()` method on EPH.
 - Apart from that an additional handler/method can be passed as an optional property `onEphError`
-to EPH. This handler will receive notifications from EPH regarding any errors that occur during
-partition management.
+  to EPH. This handler will receive notifications from EPH regarding any errors that occur during
+  partition management.
 - Removed optional property `leasecontainerName` and replaced it with a required parameter `storageContainerName` wherever applicable in all the static methods on `EventProcessorHost`.
 - Removed optional property `autoCheckpoint` and added optional properties
-   - `checkpointManager`
-   - `onEphError`
-   - `leaseRenewInterval`
-   - `leaseDuration`
+  - `checkpointManager`
+  - `onEphError`
+  - `leaseRenewInterval`
+  - `leaseDuration`
 - Please take a look at the [examples](https://github.com/Azure/azure-sdk-for-js/tree/master/eventhub/event-processor-host/samples) for more details.
 
 ## 2018-07-16 0.1.4
+
 - Added an option `autoCheckpoint: false` to not checkpoint the received messages by default.
 
 ## 2018-06-13 0.1.3
+
 - `_storageBlobPrefix` is set if provided in the options, [#91](https://github.com/Azure/azure-event-hubs-node/pull/91).
 
 ## 2018-06-13 0.1.2
+
 - Fixed an issue reported in [#80](https://github.com/Azure/azure-event-hubs-node/issues/80).
 
 ## 2018-05-02 0.1.1
+
 - Fix dependency version.
 
 ## 2018-05-02 0.1.0
+
 - First version of `azure-event-processor-host` based on the new `azure-event-hubs` sdk.
 - This client library makes it easier to manage receivers for an EventHub.
 - You can checkpoint the received data to an Azure Storage Blob. The processor does checkpointing
-on your behalf at regular intervals. This makes it easy to start receiving events from the point you
-left at a later time.
+  on your behalf at regular intervals. This makes it easy to start receiving events from the point you
+  left at a later time.

--- a/sdk/eventhub/event-processor-host/changelog.md
+++ b/sdk/eventhub/event-processor-host/changelog.md
@@ -2,6 +2,8 @@
 
 - Updates minimum version of `@azure/event-hubs` to version 2.1.4.
   This update brings in improvements when attempting to reconnect after a transient failure.
+  See the [changelog](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/event-hubs_2.1.4/sdk/eventhub/event-hubs/changelog.md#2019-12-11-214)
+  for `@azure/event-hubs` for a full list of the improvements.
 
 ### 2019-08-06 2.1.0
 

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-processor-host",
   "sdk-type": "client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Azure Event Processor Host (Event Hubs) SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -59,7 +59,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "^2.1.1",
+    "@azure/event-hubs": "^2.1.4",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "async-lock": "^1.1.3",
     "azure-storage": "^2.10.2",

--- a/sdk/eventhub/event-processor-host/src/util/constants.ts
+++ b/sdk/eventhub/event-processor-host/src/util/constants.ts
@@ -18,5 +18,5 @@ export const leaseIdMismatchWithBlobOperation = "leaseidmismatchwithbloboperatio
 export const defaultConsumerGroup = "$default";
 export const packageInfo = {
   name: "@azure/event-processor-host",
-  version: "2.1.0"
+  version: "2.1.1"
 };

--- a/sdk/eventhub/event-processor-host/test/eph.spec.ts
+++ b/sdk/eventhub/event-processor-host/test/eph.spec.ts
@@ -14,6 +14,7 @@ const debug = debugModule("azure:eph:eph-spec");
 import { EventHubClient, EventData, EventPosition, delay, Dictionary } from "@azure/event-hubs";
 import dotenv from "dotenv";
 import { PartitionContext, OnReceivedMessage, EventProcessorHost, OnReceivedError } from "../src";
+import { packageInfo } from "../src/util/constants";
 dotenv.config();
 
 describe("EPH", function(): void {
@@ -48,9 +49,11 @@ describe("EPH", function(): void {
         }
       );
       const context = host["_context"];
-      const uaPrefix = "azsdk-js-azureeventprocessorhost/2.1.0 ";
+      const uaPrefix = `azsdk-js-azureeventprocessorhost/${packageInfo.version} `;
       context.userAgent.should.include(uaPrefix);
-      context.userAgent.should.include(`NODE-VERSION ${process.version}; ${os.type()} ${os.release()}`);
+      context.userAgent.should.include(
+        `NODE-VERSION ${process.version}; ${os.type()} ${os.release()}`
+      );
       const ehc: EventHubClient = context.getEventHubClient();
       const properties = ehc["_context"].connection.options.properties;
       properties["user-agent"].should.include(uaPrefix);
@@ -71,7 +74,7 @@ describe("EPH", function(): void {
         }
       );
       const context = host["_context"];
-      const uaPrefix = "azsdk-js-azureeventprocessorhost/2.1.0 ";
+      const uaPrefix = `azsdk-js-azureeventprocessorhost/${packageInfo.version} `;
       context.userAgent.should.startWith(uaPrefix);
       context.userAgent.should.endWith(customua);
       const ehc: EventHubClient = context.getEventHubClient();
@@ -128,7 +131,7 @@ describe("EPH", function(): void {
             }
           }
         };
-        const onError: OnReceivedError = err => {
+        const onError: OnReceivedError = (err) => {
           debug("An error occurred while receiving the message: %O", err);
           throw err;
         };
@@ -150,7 +153,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -160,7 +163,7 @@ describe("EPH", function(): void {
       const ehc = EventHubClient.createFromConnectionString(ehConnString!, hubName!);
       ehc
         .getPartitionIds()
-        .then(ids => {
+        .then((ids) => {
           debug(">>> Received partition ids: ", ids);
           host = EventProcessorHost.createFromConnectionString(
             EventProcessorHost.createHostName(),
@@ -184,9 +187,11 @@ describe("EPH", function(): void {
                     .checkpoint()
                     .then(() => {
                       debug(">>>> Checkpoint succesful...");
-                      return context["_context"].blobReferenceByPartition[context.partitionId].getContent();
+                      return context["_context"].blobReferenceByPartition[
+                        context.partitionId
+                      ].getContent();
                     })
-                    .then(content => {
+                    .then((content) => {
                       debug(">>>> Seen expected message. New lease contents: %s", content);
                       const parsed = JSON.parse(content);
                       parsed.offset.should.eql(data.offset);
@@ -201,22 +206,22 @@ describe("EPH", function(): void {
                       debug(">>>> closed the sender and the eph...");
                       return done();
                     })
-                    .catch(err => {
+                    .catch((err) => {
                       done(err);
                     });
                 }
               };
-              const onError: OnReceivedError = err => {
+              const onError: OnReceivedError = (err) => {
                 debug("An error occurred while receiving the message: %O", err);
                 done(err);
               };
               return host.start(onMessage, onError);
             })
-            .catch(err => {
+            .catch((err) => {
               done(err);
             });
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -227,7 +232,10 @@ describe("EPH", function(): void {
         const ehc = EventHubClient.createFromConnectionString(ehConnString!, hubName!);
         const leasecontainerName = EventProcessorHost.createHostName("tc");
         debug(">>>>> Lease container name: %s", leasecontainerName);
-        async function sendAcrossAllPartitions(ehc: EventHubClient, ids: string[]): Promise<Dictionary<EventData>> {
+        async function sendAcrossAllPartitions(
+          ehc: EventHubClient,
+          ids: string[]
+        ): Promise<Dictionary<EventData>> {
           const result: Promise<any>[] = [];
           const idMessage: Dictionary<EventData> = {};
           for (const id of ids) {
@@ -274,7 +282,7 @@ describe("EPH", function(): void {
             throw new Error(msg);
           }
         };
-        const onError: OnReceivedError = err => {
+        const onError: OnReceivedError = (err) => {
           debug("An error occurred while receiving the message: %O", err);
           throw err;
         };
@@ -293,7 +301,10 @@ describe("EPH", function(): void {
         debug(">>>>> Sending the second set of test messages...");
         const secondSend = await sendAcrossAllPartitions(ehc, ids);
         let count2 = 0;
-        const onMessage2: OnReceivedMessage = async (context: PartitionContext, data: EventData) => {
+        const onMessage2: OnReceivedMessage = async (
+          context: PartitionContext,
+          data: EventData
+        ) => {
           const partitionId = context.partitionId;
           debug(">>>>> Rx message from '%s': '%s'", partitionId, data);
           if (data.properties!.message_id === secondSend[partitionId].properties!.message_id) {
@@ -308,7 +319,7 @@ describe("EPH", function(): void {
             throw new Error(msg);
           }
         };
-        const onError2: OnReceivedError = err => {
+        const onError2: OnReceivedError = (err) => {
           debug("An error occurred while receiving the message: %O", err);
           throw err;
         };
@@ -330,7 +341,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -413,7 +424,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -441,7 +452,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -472,7 +483,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -502,7 +513,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -522,14 +533,16 @@ describe("EPH", function(): void {
         try {
           await host.getPartitionInformation(false as any);
         } catch (err) {
-          err.message.should.equal("'partitionId' is a required parameter and must be of type: 'string' | 'number'.");
+          err.message.should.equal(
+            "'partitionId' is a required parameter and must be of type: 'string' | 'number'."
+          );
         }
       };
       test()
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -560,7 +573,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -591,7 +604,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -600,7 +613,8 @@ describe("EPH", function(): void {
   describe("options", function(): void {
     it("should throw an error if the event hub name is neither provided in the connection string and nor in the options object", function(done: Mocha.Done): void {
       try {
-        const ehc = "Endpoint=sb://foo.bar.baz.net/;SharedAccessKeyName=somekey;SharedAccessKey=somesecret";
+        const ehc =
+          "Endpoint=sb://foo.bar.baz.net/;SharedAccessKeyName=somekey;SharedAccessKey=somesecret";
         EventProcessorHost.createFromConnectionString(
           EventProcessorHost.createHostName(),
           storageConnString!,
@@ -640,7 +654,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });
@@ -667,7 +681,7 @@ describe("EPH", function(): void {
         .then(() => {
           done();
         })
-        .catch(err => {
+        .catch((err) => {
           done(err);
         });
     });

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -33,7 +33,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "^2.1.1",
+    "@azure/event-hubs": "^2.1.4",
     "@azure/event-processor-host": "^2.0.0",
     "@types/node": "^8.0.0",
     "@types/uuid": "^3.4.3",


### PR DESCRIPTION
This updates the minimum version of event-hubs due to a number of bug fixes introduced between 2.1.1 and 2.1.4.

This should not have any tangible change for customers using `@azure/event-processor-host` version 2.1.0 today, except that it enforces the minimum version of event hubs.

(I apologize for the formatting changes!)