### PR TITLE
Publish test results even if build is canceled

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -267,7 +267,7 @@ jobs:
             searchFolder: '$(System.DefaultWorkingDirectory)/sdk'
             testResultsFiles: "**/test-results.xml"
             testRunTitle: "$(OSName) - NodeJS - Unit Tests - [Node $(NodeVersion)]"
-          condition: succeededOrFailed()
+          condition: always()
           displayName: "Publish NodeJS unit test results"
 
         # It's important for performance to pass "sdk" as "searchFolder" to avoid looking under root "node_modules".
@@ -277,5 +277,5 @@ jobs:
             searchFolder: '$(System.DefaultWorkingDirectory)/sdk'
             testResultsFiles: "**/test-results.browser.xml"
             testRunTitle: "$(OSName) - Browser - Unit Tests - [Node $(NodeVersion)]"
-          condition: succeededOrFailed()
+          condition: always()
           displayName: "Publish browser unit test results"

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -144,7 +144,7 @@ jobs:
           searchFolder: '$(System.DefaultWorkingDirectory)/sdk'
           testResultsFiles: "**/test-results.xml"
           testRunTitle: "$(OSName) - NodeJS - Integration Tests - [Node $(NodeVersion)]"
-        condition: and(succeededOrFailed(), eq(variables['TestType'], 'node'))
+        condition: and(always(), eq(variables['TestType'], 'node'))
         displayName: "Publish NodeJS integration test results"
 
       # It's important for performance to pass "sdk" as "searchFolder" to avoid looking under root "node_modules".
@@ -154,5 +154,5 @@ jobs:
           searchFolder: '$(System.DefaultWorkingDirectory)/sdk'
           testResultsFiles: "**/test-results.browser.xml"
           testRunTitle: "$(OSName) - Browser - Integration Tests - [Node $(NodeVersion)]"
-        condition: and(succeededOrFailed(), eq(variables['TestType'], 'browser'))
+        condition: and(always(), eq(variables['TestType'], 'browser'))
         displayName: "Publish browser integration test results"


### PR DESCRIPTION
- If build is cancelled due to agent timeout, some tests results may have already been generated and should still be published