### PR TITLE
[event-processor-host] update ci.yml

### DIFF
--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -43,3 +43,5 @@ stages:
           safeName: azureeventhubs
         - name: azure-eventhubs-checkpointstore-blob
           safeName: azureeventhubscheckpointstoreblob
+        - name: azure-event-processor-host
+          safename: azureeventprocessorhost


### PR DESCRIPTION
I noticed that event-processor-host is not included in the release pipeline, and I can't run the legacy pipeline from master anymore.

I believe this update should add event-processor-host to the release pipeline, but would like confirmation from @mitchdenny 
/cc @ramya-rao-a