### PR TITLE
Tweak migration guide to have more comments, less types

### DIFF
--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -208,7 +208,7 @@ const subscription = eventHubConsumerClient.subscribe(
     // In V5 we deliver events in batches, rather than a single message at a time.
     // You can control the batch size via the options passed to the client.
     //
-    // If you have asynchronous code running in your callback, it will be awaited before the
+    // If your callback is an async function or returns a promise, it will be awaited before the
     // callback is called for the next batch of events. 
     processEvents: (events, context) => { /** your code here **/ },
 

--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -176,7 +176,7 @@ const eph = EventProcessorHost.createFromConnectionString(
     eventHubPath: eventHubName,
     onEphError: (error) => {
       // This is your error handler for errors occuring during load balancing.
-      console.log("[%s] Error: %O", ephName, error);
+      console.log("Error when running EPH: %O", error);
     }
   }
 );
@@ -187,7 +187,7 @@ const onMessage = (context, event) => { /** your code here **/ }
 
 // This is your error handler for errors occuring when receiving events.
 const onError = (error) => {
-  console.log("[%s] Received Error: %O", ephName, error);
+  console.log("Received Error: %O", error);
 };
 
 await eph.start(onMessage, onError);
@@ -210,13 +210,19 @@ const subscription = eventHubConsumerClient.subscribe(
     //
     // If you have asynchronous code running in your callback, it will be awaited before the
     // callback is called for the next batch of events. 
-    processEvents: (events, context) => {},
+    processEvents: (events, context) => { /** your code here **/ },
 
     // Prior to V5 errors were handled by separate callbacks depending 
     // on where they were thrown i.e when managing different partitions vs receiving from each partition.
     // 
     // In V5 you only need a single error handler for all of those cases.
-    processError: onErrorHandler
+    processError: (error, context) => { 
+      if (context.partitionId) {
+        console.log("Error when receiving events from partition %s: %O", context.partitionId, error)
+      } else {
+        console.log("Error from the consumer client: %O", error);
+      }
+    }
 });
   
 await subscription.close();

--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -174,15 +174,19 @@ const eph = EventProcessorHost.createFromConnectionString(
   ehConnectionString,
   {
     eventHubPath: eventHubName,
-    onEphError: (error: any) => {
+    onEphError: (error) => {
+      // This is your error handler for errors occuring during load balancing.
       console.log("[%s] Error: %O", ephName, error);
     }
   }
 );
 
-const onMessage: OnReceivedMessage = async (context: PartitionContext, event: EventData) => { }
+// In V2, you get a single event passed to your callback. If you had asynchronous code running in your callback,
+// it is not awaited before the callback is called for the next event.
+const onMessage = (context, event) => { /** your code here **/ }
 
-const onError: OnReceivedError = (error: any) => {
+// This is your error handler for errors occuring when receiving events.
+const onError = (error) => {
   console.log("[%s] Received Error: %O", ephName, error);
 };
 
@@ -201,9 +205,12 @@ const eventHubConsumerClient = new EventHubConsumerClient(consumerGroupName, ehC
 
 const subscription = eventHubConsumerClient.subscribe(
   partitionId, {
-    // In V5 we deliver messages in batches, rather than a single message 
-    // at a time. You can control the batch size via the options passed to the client.
-    processEvents: (messages, context) => {},
+    // In V5 we deliver events in batches, rather than a single message at a time.
+    // You can control the batch size via the options passed to the client.
+    //
+    // If you have asynchronous code running in your callback, it will be awaited before the
+    // callback is called for the next batch of events. 
+    processEvents: (events, context) => {},
 
     // Prior to V5 errors were handled by separate callbacks depending 
     // on where they were thrown i.e when managing different partitions vs receiving from each partition.


### PR DESCRIPTION
Updated migration guide to
- remove types from samples
- add note that we now await the async callbacks
- improved error handling