### PR TITLE
[App Config] Initial setup for record and playback

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -53,10 +53,15 @@
     "prebuild": "npm run clean",
     "pack": "npm pack 2>&1",
     "swagger": "autorest --typescript swagger/swagger.md",
-    "test": "npm run build:test && mocha -t 1200000 test-dist/index.node.js --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
+    "integration-test:browser": "echo skipped",
+    "integration-test:node": "npm run build:test && mocha -t 1200000 test-dist/index.node.js --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=-",
+    "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "unit-test:browser": "echo skipped",
     "unit-test:node": "npm run test",
-    "unit-test": "npm run unit-test:node && npm run unit-test:browser"
+    "unit-test": "npm run unit-test:node && npm run unit-test:browser",
+    "test": "npm run build:test && npm run unit-test",
+    "test:node:playback": "cross-env TEST_MODE=playback npm run integration-test:node",    
+    "test:node:record": "cross-env TEST_MODE=record npm run integration-test:node"    
   },
   "sideEffects": false,
   "autoPublish": false,
@@ -78,6 +83,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.5.4",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/chai": "^4.1.6",
@@ -86,6 +92,7 @@
     "@types/sinon": "^7.0.13",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
+    "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_invalid_connection_string_gives_a_decent_error_message.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_invalid_connection_string_gives_a_decent_error_message.js
@@ -1,3 +1,3 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"":"157618858141009226"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"":"157619056626402313"},"newDate":{}}

--- a/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_invalid_connection_string_gives_a_decent_error_message.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_invalid_connection_string_gives_a_decent_error_message.js
@@ -1,0 +1,3 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{"":"157618858141009226"},"newDate":{}}

--- a/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_token_authentication_works.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_token_authentication_works.js
@@ -1,6 +1,6 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"":"157618858141607651"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"":"157619056627005659"},"newDate":{}}
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   .post('/AZURE_TENANT_ID/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&scope=https%3A%2F%2Fmyappconfig.azconfig.io%2F.default")
@@ -18,31 +18,31 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'x-ms-request-id',
-  'e2dc9e1f-4343-4e48-b658-39d5ffdf0a00',
+  'b8e3ac01-8b3c-4846-a394-f914ed090c00',
   'x-ms-ests-server',
   '2.1.9707.19 - WST ProdSlices',
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'Set-Cookie',
-  'fpc=AtPuEiFxJGhOn11AF25HqzCknlA2AQAAAKWxhNUOAAAA; expires=Sat, 11-Jan-2020 22:09:41 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AgeCss6i-a1ErAaFouNHNVSknlA2AQAAAGa5hNUOAAAA; expires=Sat, 11-Jan-2020 22:42:46 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=prod; path=/; SameSite=None; secure; HttpOnly',
   'Set-Cookie',
   'stsservicecookie=ests; path=/; SameSite=None; secure; HttpOnly',
   'Date',
-  'Thu, 12 Dec 2019 22:09:41 GMT',
+  'Thu, 12 Dec 2019 22:42:46 GMT',
   'Content-Length',
   '1244'
 ]);
 
 nock('https://myappconfig.azconfig.io:443', {"encodedQueryParams":true})
-  .put('/kv/token-authentication-test-157618858141607651', {"key":"token-authentication-test-157618858141607651","value":"hello"})
+  .put('/kv/token-authentication-test-157619056627005659', {"key":"token-authentication-test-157619056627005659","value":"hello"})
   .query(true)
-  .reply(200, {"etag":"STgd4ieb5Jw7WrQTDO3bUCoAfdH","key":"token-authentication-test-157618858141607651","label":null,"content_type":null,"value":"hello","tags":{},"locked":false,"last_modified":"2019-12-12T22:09:42+00:00"}, [
+  .reply(200, {"etag":"Xwpyie1gpbhFkzOPm0Ac4rnmokA","key":"token-authentication-test-157619056627005659","label":null,"content_type":null,"value":"hello","tags":{},"locked":false,"last_modified":"2019-12-12T22:42:47+00:00"}, [
   'Server',
   'openresty/1.15.8.1',
   'Date',
-  'Thu, 12 Dec 2019 22:09:41 GMT',
+  'Thu, 12 Dec 2019 22:42:46 GMT',
   'Content-Type',
   'application/vnd.microsoft.appconfig.kv+json; charset=utf-8',
   'Transfer-Encoding',
@@ -50,15 +50,15 @@ nock('https://myappconfig.azconfig.io:443', {"encodedQueryParams":true})
   'Connection',
   'close',
   'Last-Modified',
-  'Thu, 12 Dec 2019 22:09:42 GMT',
+  'Thu, 12 Dec 2019 22:42:47 GMT',
   'ETag',
-  '"STgd4ieb5Jw7WrQTDO3bUCoAfdH"',
+  '"Xwpyie1gpbhFkzOPm0Ac4rnmokA"',
   'Sync-Token',
-  'zAJw6V16=NjotMSMxMzUyMDU0;sn=1352054',
+  'zAJw6V16=NjotMSMxMzUyNTk3;sn=1352597',
   'x-ms-request-id',
-  '7ba486dc-b096-4b1b-8ff9-009d3f2bcf77',
+  'b11ed118-fecc-4eae-a8ac-e6073d3f76c6',
   'x-ms-correlation-request-id',
-  '7ba486dc-b096-4b1b-8ff9-009d3f2bcf77',
+  'b11ed118-fecc-4eae-a8ac-e6073d3f76c6',
   'Access-Control-Allow-Origin',
   '*',
   'Access-Control-Allow-Credentials',

--- a/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_token_authentication_works.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/authentication/recording_token_authentication_works.js
@@ -1,0 +1,74 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{"":"157618858141607651"},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/AZURE_TENANT_ID/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=AZURE_CLIENT_ID&client_secret=AZURE_CLIENT_SECRET&scope=https%3A%2F%2Fmyappconfig.azconfig.io%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3600,"ext_expires_in":3600,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  'e2dc9e1f-4343-4e48-b658-39d5ffdf0a00',
+  'x-ms-ests-server',
+  '2.1.9707.19 - WST ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=AtPuEiFxJGhOn11AF25HqzCknlA2AQAAAKWxhNUOAAAA; expires=Sat, 11-Jan-2020 22:09:41 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=prod; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=ests; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 12 Dec 2019 22:09:41 GMT',
+  'Content-Length',
+  '1244'
+]);
+
+nock('https://myappconfig.azconfig.io:443', {"encodedQueryParams":true})
+  .put('/kv/token-authentication-test-157618858141607651', {"key":"token-authentication-test-157618858141607651","value":"hello"})
+  .query(true)
+  .reply(200, {"etag":"STgd4ieb5Jw7WrQTDO3bUCoAfdH","key":"token-authentication-test-157618858141607651","label":null,"content_type":null,"value":"hello","tags":{},"locked":false,"last_modified":"2019-12-12T22:09:42+00:00"}, [
+  'Server',
+  'openresty/1.15.8.1',
+  'Date',
+  'Thu, 12 Dec 2019 22:09:41 GMT',
+  'Content-Type',
+  'application/vnd.microsoft.appconfig.kv+json; charset=utf-8',
+  'Transfer-Encoding',
+  'chunked',
+  'Connection',
+  'close',
+  'Last-Modified',
+  'Thu, 12 Dec 2019 22:09:42 GMT',
+  'ETag',
+  '"STgd4ieb5Jw7WrQTDO3bUCoAfdH"',
+  'Sync-Token',
+  'zAJw6V16=NjotMSMxMzUyMDU0;sn=1352054',
+  'x-ms-request-id',
+  '7ba486dc-b096-4b1b-8ff9-009d3f2bcf77',
+  'x-ms-correlation-request-id',
+  '7ba486dc-b096-4b1b-8ff9-009d3f2bcf77',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Credentials',
+  'true',
+  'Access-Control-Allow-Methods',
+  'GET, PUT, POST, DELETE, PATCH, OPTIONS',
+  'Access-Control-Allow-Headers',
+  'DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate',
+  'Access-Control-Expose-Headers',
+  'DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate',
+  'Strict-Transport-Security',
+  'max-age=15724800; includeSubDomains'
+]);

--- a/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_requestreply_tests_for_header/recording_addconfigurationsetting.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_requestreply_tests_for_header/recording_addconfigurationsetting.js
@@ -1,0 +1,33 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{"":"157618984727104376"},"newDate":{}}
+
+nock('https://myappconfig.azconfig.io:443', {"encodedQueryParams":true})
+  .put('/kv/doesntmatter', {"key":"doesntmatter"})
+  .query(true)
+  .reply(412, "", [
+  'Server',
+  'openresty/1.15.8.1',
+  'Date',
+  'Thu, 12 Dec 2019 22:30:47 GMT',
+  'Content-Length',
+  '0',
+  'Connection',
+  'close',
+  'x-ms-request-id',
+  'c24818bf-6f0c-4196-9eaf-282058d77832',
+  'x-ms-correlation-request-id',
+  'c24818bf-6f0c-4196-9eaf-282058d77832',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Credentials',
+  'true',
+  'Access-Control-Allow-Methods',
+  'GET, PUT, POST, DELETE, PATCH, OPTIONS',
+  'Access-Control-Allow-Headers',
+  'DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate',
+  'Access-Control-Expose-Headers',
+  'DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate',
+  'Strict-Transport-Security',
+  'max-age=15724800; includeSubDomains'
+]);

--- a/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_requestreply_tests_for_header/recording_policy_is_setup_properly_to_send_sync_tokens.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_requestreply_tests_for_header/recording_policy_is_setup_properly_to_send_sync_tokens.js
@@ -1,0 +1,41 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{"":"157618984697508084"},"newDate":{}}
+
+nock('https://myappconfig.azconfig.io:443', {"encodedQueryParams":true})
+  .get('/kv/doesntmatter')
+  .query(true)
+  .reply(200, {"etag":"APHBiOVQK7e2Yx8bMixUd8I7Xf8","key":"doesntmatter","label":null,"content_type":null,"value":null,"tags":{},"locked":false,"last_modified":"2019-12-12T22:19:02+00:00"}, [
+  'Server',
+  'openresty/1.15.8.1',
+  'Date',
+  'Thu, 12 Dec 2019 22:30:47 GMT',
+  'Content-Type',
+  'application/vnd.microsoft.appconfig.kv+json; charset=utf-8',
+  'Transfer-Encoding',
+  'chunked',
+  'Connection',
+  'close',
+  'Last-Modified',
+  'Thu, 12 Dec 2019 22:19:02 GMT',
+  'ETag',
+  '"APHBiOVQK7e2Yx8bMixUd8I7Xf8"',
+  'Sync-Token',
+  'zAJw6V16=NjotMSMxMzUyNTYw;sn=1352560',
+  'x-ms-request-id',
+  'dd521f13-8558-4dc6-9e54-766a9e844c88',
+  'x-ms-correlation-request-id',
+  'dd521f13-8558-4dc6-9e54-766a9e844c88',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Access-Control-Allow-Credentials',
+  'true',
+  'Access-Control-Allow-Methods',
+  'GET, PUT, POST, DELETE, PATCH, OPTIONS',
+  'Access-Control-Allow-Headers',
+  'DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate',
+  'Access-Control-Expose-Headers',
+  'DNT, X-CustomHeader, Keep-Alive, User-Agent, X-Requested-With, If-Modified-Since, Cache-Control, Content-Type, Authorization, x-ms-client-request-id, x-ms-content-sha256, x-ms-date, host, Accept, Accept-Datetime, Date, If-Match, If-None-Match, Sync-Token, x-ms-return-client-request-id, ETag, Last-Modified, Link, Memento-Datetime, x-ms-retry-after, x-ms-request-id, WWW-Authenticate',
+  'Strict-Transport-Security',
+  'max-age=15724800; includeSubDomains'
+]);

--- a/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_unit_tests_parsesynctoken/recording_can_parse_various_sync_tokens.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_unit_tests_parsesynctoken/recording_can_parse_various_sync_tokens.js
@@ -1,0 +1,3 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{"":"157619056665000109"},"newDate":{}}

--- a/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_unit_tests_parsesynctoken/recording_throws_on_invalid_sync_tokens.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_unit_tests_parsesynctoken/recording_throws_on_invalid_sync_tokens.js
@@ -1,0 +1,3 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{"":"157619056665204591"},"newDate":{}}

--- a/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_unit_tests_synctokens/recording_basic.js
+++ b/sdk/appconfiguration/app-configuration/recordings/node/sync_tokens_unit_tests_synctokens/recording_basic.js
@@ -1,0 +1,3 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{"":"157619056665404007"},"newDate":{}}

--- a/sdk/appconfiguration/app-configuration/test/auth.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/auth.spec.ts
@@ -1,25 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { env, record, Recorder } from "@azure/test-utils-recorder";
 import { AppConfigurationClient } from "../src";
-import { getTokenAuthenticationCredential, CredsAndEndpoint } from "./testHelpers";
+import { applyReplacements, getTokenAuthenticationCredential, CredsAndEndpoint } from "./testHelpers";
 import * as assert from "assert";
 
-describe("Authentication", () => {
+describe.only("Authentication", () => {
   let credsAndEndpoint: CredsAndEndpoint;
+  let recorder: Recorder;
+  let uniqueId: string;
 
-  before(function() {
+  beforeEach(function() {
+    applyReplacements();
+    recorder = record(this);
+    uniqueId = recorder.getUniqueName("");
     credsAndEndpoint = getTokenAuthenticationCredential() || this.skip();
   });
 
-  it("invalid connection string gives a decent error message", () => {
+  afterEach(function() {
+    recorder.stop();
+  });
+
+  it("invalid connection string gives a decent error message", function() {
     assert.throws(
       () => new AppConfigurationClient("an invalid connection string"),
       /Invalid connection string\. Valid connection strings should match the regex 'Endpoint=\(\.\*\);Id=\(\.\*\);Secret=\(\.\*\)'/
     );
   });
 
-  it("token authentication works", async () => {
+  it("token authentication works", async function() {
     const client = new AppConfigurationClient(
       credsAndEndpoint.endpoint,
       credsAndEndpoint.credential
@@ -28,7 +38,7 @@ describe("Authentication", () => {
     // it doesn't matter if any data comes in so long as we were
     // able to connect and call the service
     await client.addConfigurationSetting({
-      key: `token-authentication-test-${Date.now()}`,
+      key: `token-authentication-test-${uniqueId}`,
       value: "hello"
     });
   });


### PR DESCRIPTION
Please read this through and make sure that you agree.

This PR only adds record and playback to the test files `auth.spec.ts` and `synctokenpolicy.spec.ts`. The changes to the other test files should look similar to the changes to `auth.spec.ts`. Please take over this PR as soon as you find time.

Some tests of `synctokenpolicy.spec.ts` have been skipped only for test modes record and playback. These tests use the `nock` package, just like the recorder tool. The recorder tool probably doesn't clean `nock` properly to have something else using it.

Some of the custom replacements should not be necessary. I filed this bug to fix the underlying issue: https://github.com/Azure/azure-sdk-for-js/issues/6539