### PR TITLE
[WIP][Storage] fix rollup warnings

### DIFF
--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -94,7 +94,10 @@ export function browserConfig(test = false, production = false) {
       banner: banner,
       format: "umd",
       name: "azblob",
-      sourcemap: true
+      sourcemap: true,
+      globals: {
+        "fs-extra": "fs-extra"
+      }
     },
     preserveSymlinks: false,
     plugins: [


### PR DESCRIPTION
rollup reports warnings for browser test bundle:

  (!) Missing global variable name
  Use output.globals to specify browser global variable names corresponding to external modules
  fs-extra (guessing 'fs')
  created dist-test/index.browser.js in 3.7s

This address it by apply the suggestion.