### PR TITLE
[core-http] Fix tracingPolicy() to set standard span attributes

### DIFF
--- a/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
+++ b/sdk/appconfiguration/app-configuration/src/appConfigurationClient.ts
@@ -14,7 +14,7 @@ import {
   systemErrorRetryPolicy,
   ServiceClientCredentials,
   UserAgentOptions,
-  getDefaultUserAgentValue as getCoreHttpDefaultUserAgentValue,
+  getDefaultUserAgentValue as getCoreHttpDefaultUserAgentValue
 } from "@azure/core-http";
 import { throttlingRetryPolicy } from "./policies/throttlingRetryPolicy";
 import { TokenCredential } from "@azure/identity";
@@ -53,13 +53,16 @@ import {
 } from "./internal/helpers";
 import { tracingPolicy, isNode as coreHttpIsNode } from "@azure/core-http";
 import { Spanner } from "./internal/tracingHelpers";
-import { GetKeyValuesResponse, AppConfigurationOptions as GeneratedAppConfigurationClientOptions } from "./generated/src/models";
-import { syncTokenPolicy, SyncTokens } from './internal/synctokenpolicy';
+import {
+  GetKeyValuesResponse,
+  AppConfigurationOptions as GeneratedAppConfigurationClientOptions
+} from "./generated/src/models";
+import { syncTokenPolicy, SyncTokens } from "./internal/synctokenpolicy";
 
 const packageName = "azsdk-js-app-configuration";
 
 /**
- * This constant should always be the same as the package.json's version - we use it when forming the 
+ * This constant should always be the same as the package.json's version - we use it when forming the
  * User - Agent header. There's a unit test that makes sure it always stays in sync.
  * @internal
  * @ignore
@@ -82,17 +85,17 @@ const deserializationContentTypes = {
  */
 export interface AppConfigurationClientOptions {
   // NOTE: AppConfigurationClient is currently using it's own version of the ThrottlingRetryPolicy
-  // which we are going to unify with core-http. When we do that we can have this options 
+  // which we are going to unify with core-http. When we do that we can have this options
   // interface extend PipelineOptions, and also switch over to using`createPipelineFromOptions`
   // which will auto-create all of these policies and remove a lot of code.
-  // 
+  //
   // In the meantime we'll just deal with having our own interface that's compatible with PipelineOptions
   // for the small subset we absolutely need to support.
-  
+
   /**
    * Options for adding user agent details to outgoing requests.
    */
-  userAgentOptions?: UserAgentOptions; 
+  userAgentOptions?: UserAgentOptions;
 }
 
 /**
@@ -127,17 +130,21 @@ export class AppConfigurationClient {
    */
   constructor(connectionString: string, options?: AppConfigurationClientOptions);
   /**
-   * Initializes a new instance of the AppConfigurationClient class using 
+   * Initializes a new instance of the AppConfigurationClient class using
    * a TokenCredential.
    * @param endpoint The endpoint of the App Configuration service (ex: https://sample.azconfig.io).
    * @param tokenCredential An object that implements the `TokenCredential` interface used to authenticate requests to the service. Use the @azure/identity package to create a credential that suits your needs.
    * @param options Options for the AppConfigurationClient.
    */
-  constructor(endpoint: string, tokenCredential: TokenCredential, options?:AppConfigurationClientOptions);
+  constructor(
+    endpoint: string,
+    tokenCredential: TokenCredential,
+    options?: AppConfigurationClientOptions
+  );
   constructor(
     connectionStringOrEndpoint: string,
     tokenCredentialOrOptions?: TokenCredential | AppConfigurationClientOptions,
-    options?:AppConfigurationClientOptions
+    options?: AppConfigurationClientOptions
   ) {
     let appConfigOptions: InternalAppConfigurationClientOptions = {};
     let appConfigCredential: ServiceClientCredentials | TokenCredential;
@@ -169,7 +176,7 @@ export class AppConfigurationClient {
       apiVersion,
       getGeneratedClientOptions(appConfigEndpoint, syncTokens, appConfigOptions)
     );
-    
+
     this.spanner = new Spanner<AppConfigurationClient>("Azure.Data.AppConfiguration", "appconfig");
   }
 
@@ -496,7 +503,7 @@ export class AppConfigurationClient {
           label: id.label,
           ...checkAndFormatIfAndIfNoneMatch(id, options)
         });
-        
+
         return transformKeyValueResponse(response);
       }
     });
@@ -513,12 +520,16 @@ export function getGeneratedClientOptions(
   syncTokens: SyncTokens,
   internalAppConfigOptions: InternalAppConfigurationClientOptions
 ): GeneratedAppConfigurationClientOptions {
-
   const retryPolicies = [
     exponentialRetryPolicy(),
     systemErrorRetryPolicy(),
     throttlingRetryPolicy()
   ];
+
+  const userAgent = getUserAgentPrefix(
+    internalAppConfigOptions.userAgentOptions &&
+      internalAppConfigOptions.userAgentOptions.userAgentPrefix
+  );
 
   return {
     baseUri,
@@ -526,13 +537,13 @@ export function getGeneratedClientOptions(
     // we'll add in our own custom retry policies
     noRetryPolicy: true,
     requestPolicyFactories: (defaults) => [
-      tracingPolicy(),
+      tracingPolicy({ userAgent }),
       syncTokenPolicy(syncTokens),
       ...retryPolicies,
-      ...defaults,
+      ...defaults
     ],
     userAgentHeaderName: getUserAgentHeaderName(internalAppConfigOptions.isNodeOverride),
-    userAgent: getUserAgentPrefix(internalAppConfigOptions.userAgentOptions && internalAppConfigOptions.userAgentOptions.userAgentPrefix)    
+    userAgent
   };
 }
 
@@ -542,8 +553,8 @@ export function getGeneratedClientOptions(
  */
 export function getUserAgentPrefix(userSuppliedUserAgent: string | undefined): string {
   const appConfigDefaultUserAgent = `${packageName}/${packageVersion} ${getCoreHttpDefaultUserAgentValue()}`;
-  
-  if (userSuppliedUserAgent == null) {
+
+  if (!userSuppliedUserAgent) {
     return appConfigDefaultUserAgent;
   }
 
@@ -555,15 +566,13 @@ export function getUserAgentPrefix(userSuppliedUserAgent: string | undefined): s
  * @internal
  */
 function getUserAgentHeaderName(isNodeOverride: boolean | undefined): string {
-  const definitelyIsNode = isNodeOverride != null
-    ? isNodeOverride
-    : coreHttpIsNode;
-  
+  const definitelyIsNode = isNodeOverride != null ? isNodeOverride : coreHttpIsNode;
+
   if (definitelyIsNode) {
     return "User-Agent";
   } else {
     // we only need to override this when we're in the browser
-    // where we're (mostly) not allowed to override the User-Agent 
+    // where we're (mostly) not allowed to override the User-Agent
     // header.
     return "x-ms-useragent";
   }

--- a/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
+++ b/sdk/appconfiguration/app-configuration/src/internal/tracingHelpers.ts
@@ -53,10 +53,8 @@ export class Spanner<TClient> {
   private createSpan<T extends Spannable>(options: T, operationName: keyof TClient) {
     const span = getTracer().startSpan(`${this.baseOperationName}.${operationName}`, {
       ...options.spanOptions,
-      kind: SpanKind.CLIENT
+      kind: SpanKind.INTERNAL
     });
-
-    span.setAttribute("component", this.componentName);
 
     let newOptions = options;
 

--- a/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/helpers.spec.ts
@@ -154,10 +154,9 @@ describe("helper methods", () => {
   });
 
   it("transformKeyValue", () => {
-
     const configurationSetting = transformKeyValue({
       key: "hello",
-      locked: true,
+      locked: true
     });
 
     assert.deepEqual(
@@ -192,7 +191,7 @@ describe("helper methods", () => {
       {
         isReadOnly: true,
         key: "hello",
-        
+
         statusCode: 204,
         _response: fakeHttp204Response._response
       },
@@ -227,7 +226,7 @@ describe("helper methods", () => {
     );
   });
 
-  function getAllConfigurationSettingFields(): (Exclude<keyof ConfigurationSetting, "key">)[] {
+  function getAllConfigurationSettingFields(): Exclude<keyof ConfigurationSetting, "key">[] {
     const configObjectWithAllFieldsRequired: Required<ConfigurationSetting> = {
       contentType: "",
       etag: "",
@@ -240,7 +239,7 @@ describe("helper methods", () => {
     };
 
     const keys = Object.keys(configObjectWithAllFieldsRequired).filter((key) => key !== "key");
-    return keys as (Exclude<keyof ConfigurationSetting, "key">[]);
+    return keys as Exclude<keyof ConfigurationSetting, "key">[];
   }
 
   const fakeHttp204Response: HttpResponseField<any> = {
@@ -256,6 +255,7 @@ describe("helper methods", () => {
         withCredentials: false,
         headers: new HttpHeaders(),
         timeout: 0,
+        requestId: "",
         clone: function() {
           return this;
         },

--- a/sdk/core/core-http/lib/policies/generateClientRequestIdPolicy.ts
+++ b/sdk/core/core-http/lib/policies/generateClientRequestIdPolicy.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
-import * as utils from "../util/utils";
 import { WebResource } from "../webResource";
 import {
   BaseRequestPolicy,
@@ -32,7 +31,7 @@ export class GenerateClientRequestIdPolicy extends BaseRequestPolicy {
 
   public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
     if (!request.headers.contains(this._requestIdHeaderName)) {
-      request.headers.set(this._requestIdHeaderName, utils.generateUuid());
+      request.headers.set(this._requestIdHeaderName, request.requestId);
     }
     return this._nextPolicy.sendRequest(request);
   }

--- a/sdk/core/core-http/lib/serviceClient.ts
+++ b/sdk/core/core-http/lib/serviceClient.ts
@@ -677,7 +677,7 @@ export function createPipelineFromOptions(
   };
 
   requestPolicyFactories.push(
-    tracingPolicy(),
+    tracingPolicy({ userAgent: userAgentValue }),
     keepAlivePolicy(keepAliveOptions),
     userAgentPolicy({ value: userAgentValue }),
     generateClientRequestIdPolicy(),

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -75,6 +75,7 @@ export class WebResource {
   timeout: number;
   proxySettings?: ProxySettings;
   keepAlive?: boolean;
+  requestId: string;
 
   abortSignal?: AbortSignalLike;
 
@@ -118,6 +119,7 @@ export class WebResource {
     this.onDownloadProgress = onDownloadProgress;
     this.proxySettings = proxySettings;
     this.keepAlive = keepAlive;
+    this.requestId = this.headers.get("x-ms-client-request-id") || generateUuid();
   }
 
   /**
@@ -299,7 +301,7 @@ export class WebResource {
     }
     // ensure the request-id is set correctly
     if (!this.headers.get("x-ms-client-request-id") && !options.disableClientRequestId) {
-      this.headers.set("x-ms-client-request-id", generateUuid());
+      this.headers.set("x-ms-client-request-id", this.requestId);
     }
 
     // default

--- a/sdk/core/core-http/rollup.config.ts
+++ b/sdk/core/core-http/rollup.config.ts
@@ -32,7 +32,8 @@ const nodeConfig = {
     "tunnel",
     "uuid/v4",
     "xml2js",
-    "@azure/core-tracing"
+    "@azure/core-tracing",
+    "@opentelemetry/types"
   ],
   output: {
     file: "./dist/coreHttp.node.js",

--- a/sdk/core/core-http/test/logFilterTests.ts
+++ b/sdk/core/core-http/test/logFilterTests.ts
@@ -96,6 +96,7 @@ Headers: {
       "x-ms-safe-header": "It me",
       "x-ms-oh-noes": ":-p"
     });
+    delete request.requestId;
     assertLog(request, expected, done);
   });
 
@@ -119,6 +120,7 @@ Headers: {
 `;
 
     const request = new WebResource("https://foo.com", "PUT", { a: 1 });
+    delete request.requestId;
     assertLog(request, expected, done, {
       "x-ms-safe-header": "It me",
       "x-ms-oh-noes": ":-p"
@@ -146,11 +148,11 @@ Headers: {
 
     const request = new WebResource("https://foo.com", "PUT", { a: 1 }, undefined, {
       "Capitalized-Header": "Don't redact me, bro",
-      "x-ms-safe-header": "It me",
+      "x-ms-safe-header": "It me"
     });
+    delete request.requestId;
     assertLog(request, expected, done);
   });
-
 
   it("redacts query parameters in the query field", (done) => {
     const expected = `Request: {
@@ -178,6 +180,7 @@ Headers: {
       { a: 1 },
       { "api-version": "1.0", secret: "goose" }
     );
+    delete request.requestId;
     assertLog(request, expected, done);
   });
 
@@ -200,6 +203,7 @@ Headers: {
     const request = new WebResource("https://foo.com?api-version=1.0&secret=goose", "PUT", {
       a: 1
     });
+    delete request.requestId;
     assertLog(request, expected, done);
   });
 });

--- a/sdk/core/core-http/test/policies/throttlingRetryPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/throttlingRetryPolicyTests.ts
@@ -65,6 +65,8 @@ describe("ThrottlingRetryPolicy", () => {
 
       const policy = createDefaultThrottlingRetryPolicy();
       const response = await policy.sendRequest(request);
+      delete response.request.requestId;
+      delete request.requestId;
 
       assert.deepEqual(response.request, request);
     });
@@ -83,6 +85,8 @@ describe("ThrottlingRetryPolicy", () => {
       });
 
       const response = await policy.sendRequest(request);
+      delete request.requestId;
+      delete response.request.requestId;
 
       assert.deepEqual(response, mockResponse);
     });
@@ -97,11 +101,15 @@ describe("ThrottlingRetryPolicy", () => {
         request: request
       };
       const policy = createDefaultThrottlingRetryPolicy(mockResponse, (_, response) => {
+        delete response.request.requestId;
+        delete mockResponse.request.requestId;
         assert.deepEqual(response, mockResponse);
         return Promise.resolve(response);
       });
 
       const response = await policy.sendRequest(request);
+      delete request.requestId;
+      delete response.request.requestId;
       assert.deepEqual(response, mockResponse);
     });
   });

--- a/sdk/core/core-tracing/lib/tracers/test/testSpan.ts
+++ b/sdk/core/core-tracing/lib/tracers/test/testSpan.ts
@@ -7,7 +7,8 @@ import {
   SpanKind,
   Status,
   SpanContext,
-  CanonicalCode
+  CanonicalCode,
+  Attributes
 } from "@opentelemetry/types";
 import { TestTracer } from "./testTracer";
 
@@ -45,6 +46,11 @@ export class TestSpan extends NoOpSpan {
    */
   readonly parentSpanId?: string;
 
+  /**
+   * Known attributes, if any.
+   */
+  readonly attributes: Attributes;
+
   private _context: SpanContext;
   private readonly _tracer: Tracer;
 
@@ -76,6 +82,7 @@ export class TestSpan extends NoOpSpan {
     };
     this.endCalled = false;
     this._context = context;
+    this.attributes = {};
   }
 
   /**
@@ -115,5 +122,26 @@ export class TestSpan extends NoOpSpan {
    */
   isRecording(): boolean {
     return true;
+  }
+
+  /**
+   * Sets an attribute on the Span
+   * @param key the attribute key
+   * @param value the attribute value
+   */
+  setAttribute(key: string, value: unknown): this {
+    this.attributes[key] = value;
+    return this;
+  }
+
+  /**
+   * Sets attributes on the Span
+   * @param attributes the attributes to add
+   */
+  setAttributes(attributes: Attributes): this {
+    for (const key of Object.keys(attributes)) {
+      this.attributes[key] = attributes[key];
+    }
+    return this;
   }
 }

--- a/sdk/core/core-tracing/review/core-tracing.api.md
+++ b/sdk/core/core-tracing/review/core-tracing.api.md
@@ -99,6 +99,7 @@ export interface SpanGraphNode {
 // @public
 export class TestSpan extends NoOpSpan {
     constructor(parentTracer: TestTracer, name: string, context: SpanContext, kind: SpanKind, parentSpanId?: string, startTime?: TimeInput);
+    readonly attributes: Attributes;
     context(): SpanContext;
     end(_endTime?: number): void;
     endCalled: boolean;
@@ -106,6 +107,8 @@ export class TestSpan extends NoOpSpan {
     kind: SpanKind;
     name: string;
     readonly parentSpanId?: string;
+    setAttribute(key: string, value: unknown): this;
+    setAttributes(attributes: Attributes): this;
     setStatus(status: Status): this;
     readonly startTime: TimeInput;
     status: Status;

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -407,10 +407,14 @@ export class EventHubClient {
     this._context = ConnectionContext.create(config, credential, this._clientOptions);
   }
 
-  private _createClientSpan(operationName: OperationNames, parentSpan?: Span | SpanContext): Span {
+  private _createClientSpan(
+    operationName: OperationNames,
+    parentSpan?: Span | SpanContext,
+    internal: boolean = false
+  ): Span {
     const tracer = getTracer();
     const span = tracer.startSpan(`Azure.EventHubs.${operationName}`, {
-      kind: SpanKind.INTERNAL,
+      kind: internal ? SpanKind.INTERNAL : SpanKind.CLIENT,
       parent: parentSpan
     });
 
@@ -585,7 +589,7 @@ export class EventHubClient {
    */
   async getPartitionIds(options: GetPartitionIdsOptions): Promise<Array<string>> {
     throwErrorIfConnectionClosed(this._context);
-    const clientSpan = this._createClientSpan("getPartitionIds", getParentSpan(options));
+    const clientSpan = this._createClientSpan("getPartitionIds", getParentSpan(options), true);
     try {
       const runtimeInfo = await this.getProperties({
         ...options,

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -410,11 +410,10 @@ export class EventHubClient {
   private _createClientSpan(operationName: OperationNames, parentSpan?: Span | SpanContext): Span {
     const tracer = getTracer();
     const span = tracer.startSpan(`Azure.EventHubs.${operationName}`, {
-      kind: SpanKind.CLIENT,
+      kind: SpanKind.INTERNAL,
       parent: parentSpan
     });
 
-    span.setAttribute("component", "eventhubs");
     span.setAttribute("message_bus.destination", this.eventHubName);
     span.setAttribute("peer.address", this._endpoint);
 

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -255,7 +255,6 @@ export class EventHubProducer {
       links
     });
 
-    span.setAttribute("component", "eventhubs");
     span.setAttribute("message_bus.destination", this._eventHubName);
     span.setAttribute("peer.address", this._endpoint);
 

--- a/sdk/identity/identity/src/util/tracing.ts
+++ b/sdk/identity/identity/src/util/tracing.ts
@@ -23,11 +23,10 @@ export function createSpan(
 
   tracingOptions.spanOptions = {
     ...tracingOptions.spanOptions,
-    kind: SpanKind.CLIENT
+    kind: SpanKind.INTERNAL
   };
 
   const span = tracer.startSpan(`Azure.Identity.${operationName}`, tracingOptions.spanOptions);
-  span.setAttribute("component", "identity");
 
   let newOptions = options;
   if (span.isRecording()) {

--- a/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/authorizationCodeCredential.spec.ts
@@ -121,7 +121,7 @@ describe("AuthorizationCodeCredential", function() {
               children: [
                 {
                   children: [],
-                  name: "core-http"
+                  name: "/tenant/oauth2/v2.0/token"
                 }
               ]
             }

--- a/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
@@ -118,7 +118,7 @@ describe("ClientCertificateCredential", function() {
               children: [
                 {
                   children: [],
-                  name: "core-http"
+                  name: "/tenantId/oauth2/v2.0/token"
                 }
               ]
             }

--- a/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
+++ b/sdk/identity/identity/test/node/deviceCodeCredential.spec.ts
@@ -136,7 +136,7 @@ describe("DeviceCodeCredential", function() {
       "tenant",
       "client",
       (details) => assert.equal(details.message, deviceCodeResponse.message),
-      { ...mockHttpClient.tokenCredentialOptions, }
+      { ...mockHttpClient.tokenCredentialOptions }
     );
 
     await credential.getToken("scope");
@@ -161,7 +161,17 @@ describe("DeviceCodeCredential", function() {
         { status: 200, parsedBody: deviceCodeResponse },
         { status: 400, parsedBody: pendingResponse },
         { status: 400, parsedBody: pendingResponse },
-        { status: 400, parsedBody: { error: "authorization_declined", error_description: "", correlation_id: "correlation_id", trace_id: "trace_id", error_codes: [ 1, 2, 3], timestamp: "timestamp" } as OAuthErrorResponse }
+        {
+          status: 400,
+          parsedBody: {
+            error: "authorization_declined",
+            error_description: "",
+            correlation_id: "correlation_id",
+            trace_id: "trace_id",
+            error_codes: [1, 2, 3],
+            timestamp: "timestamp"
+          } as OAuthErrorResponse
+        }
       ]
     });
 
@@ -179,7 +189,7 @@ describe("DeviceCodeCredential", function() {
       assert.strictEqual(authError.errorResponse.correlationId, "correlation_id");
       assert.strictEqual(authError.errorResponse.traceId, "trace_id");
       assert.strictEqual(authError.errorResponse.timestamp, "timestamp");
-      assert.deepStrictEqual(authError.errorResponse.errorCodes, [ 1, 2, 3]);
+      assert.deepStrictEqual(authError.errorResponse.errorCodes, [1, 2, 3]);
       return true;
     });
   });
@@ -351,7 +361,7 @@ describe("DeviceCodeCredential", function() {
                   children: [
                     {
                       children: [],
-                      name: "core-http"
+                      name: "/tenant/oauth2/v2.0/devicecode"
                     }
                   ]
                 },
@@ -362,19 +372,19 @@ describe("DeviceCodeCredential", function() {
                     // this test polls 4 times for the authorization code.
                     {
                       children: [],
-                      name: "core-http"
+                      name: "/tenant/oauth2/v2.0/token"
                     },
                     {
                       children: [],
-                      name: "core-http"
+                      name: "/tenant/oauth2/v2.0/token"
                     },
                     {
                       children: [],
-                      name: "core-http"
+                      name: "/tenant/oauth2/v2.0/token"
                     },
                     {
                       children: [],
-                      name: "core-http"
+                      name: "/tenant/oauth2/v2.0/token"
                     }
                   ]
                 }

--- a/sdk/identity/identity/test/node/environmentCredential.spec.ts
+++ b/sdk/identity/identity/test/node/environmentCredential.spec.ts
@@ -121,7 +121,7 @@ describe("EnvironmentCredential", function() {
                   children: [
                     {
                       children: [],
-                      name: "core-http"
+                      name: "/tenant/oauth2/v2.0/token"
                     }
                   ]
                 }

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -183,10 +183,11 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
 
+  const telemetryPolicy = new TelemetryPolicyFactory(pipelineOptions.userAgentOptions);
   const factories: RequestPolicyFactory[] = [
-    tracingPolicy(),
+    tracingPolicy({ userAgent: telemetryPolicy.telemetryString }),
     keepAlivePolicy(pipelineOptions.keepAliveOptions),
-    new TelemetryPolicyFactory(pipelineOptions.userAgentOptions),
+    telemetryPolicy,
     generateClientRequestIdPolicy(),
     new StorageBrowserPolicyFactory(),
     deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer

--- a/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
@@ -21,6 +21,10 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
+  /**
+   * @internal
+   * @ignore
+   */
   public readonly telemetryString: string;
 
   /**

--- a/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-blob/src/TelemetryPolicyFactory.ts
@@ -21,7 +21,7 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
-  private telemetryString: string;
+  public readonly telemetryString: string;
 
   /**
    * Creates an instance of TelemetryPolicyFactory.

--- a/sdk/storage/storage-blob/src/utils/tracing.ts
+++ b/sdk/storage/storage-blob/src/utils/tracing.ts
@@ -17,11 +17,10 @@ export function createSpan(
   const tracer = getTracer();
   const spanOptions: SpanOptions = {
     ...tracingOptions.spanOptions,
-    kind: SpanKind.CLIENT
+    kind: SpanKind.INTERNAL
   };
 
   const span = tracer.startSpan(`Azure.Storage.Blob.${operationName}`, spanOptions);
-  span.setAttribute("component", "storage");
 
   let newOptions = tracingOptions.spanOptions || {};
   if (span.isRecording()) {

--- a/sdk/storage/storage-blob/test/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/containerclient.spec.ts
@@ -9,6 +9,7 @@ import {
   setupEnvironment
 } from "./utils";
 import { record, Recorder } from "@azure/test-utils-recorder";
+import { URLBuilder } from "@azure/core-http";
 import { ContainerClient, BlockBlobTier, ContainerListBlobHierarchySegmentResponse } from "../src";
 import { Test_CPK_INFO } from "./utils/constants";
 dotenv.config({ path: "../.env" });
@@ -88,10 +89,12 @@ describe("ContainerClient", () => {
       blobClients.push(blobClient);
     }
 
-    const result = (await containerClient
-      .listBlobsFlat()
-      .byPage()
-      .next()).value;
+    const result = (
+      await containerClient
+        .listBlobsFlat()
+        .byPage()
+        .next()
+    ).value;
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result.containerName));
     assert.deepStrictEqual(result.continuationToken, "");
@@ -112,10 +115,12 @@ describe("ContainerClient", () => {
       blobClients.push(blobClient);
     }
 
-    const result = (await containerClient
-      .listBlobsFlat({ prefix: "" })
-      .byPage()
-      .next()).value;
+    const result = (
+      await containerClient
+        .listBlobsFlat({ prefix: "" })
+        .byPage()
+        .next()
+    ).value;
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result.containerName));
     assert.deepStrictEqual(result.continuationToken, "");
@@ -144,17 +149,19 @@ describe("ContainerClient", () => {
       blobClients.push(blobClient);
     }
 
-    const result = (await containerClient
-      .listBlobsFlat({
-        includeCopy: true,
-        includeDeleted: true,
-        includeMetadata: true,
-        includeSnapshots: true,
-        includeUncommitedBlobs: true,
-        prefix
-      })
-      .byPage({ maxPageSize: 1 })
-      .next()).value;
+    const result = (
+      await containerClient
+        .listBlobsFlat({
+          includeCopy: true,
+          includeDeleted: true,
+          includeMetadata: true,
+          includeSnapshots: true,
+          includeUncommitedBlobs: true,
+          prefix
+        })
+        .byPage({ maxPageSize: 1 })
+        .next()
+    ).value;
 
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result.containerName));
@@ -163,17 +170,19 @@ describe("ContainerClient", () => {
     assert.ok(isSuperSet(result.segment.blobItems![0].metadata, metadata));
     assert.equal(result.segment.blobItems![0].properties.accessTier, BlockBlobTier.Cool);
 
-    const result2 = (await containerClient
-      .listBlobsFlat({
-        includeCopy: true,
-        includeDeleted: true,
-        includeMetadata: true,
-        includeSnapshots: true,
-        includeUncommitedBlobs: true,
-        prefix
-      })
-      .byPage({ continuationToken: result.continuationToken, maxPageSize: 2 })
-      .next()).value;
+    const result2 = (
+      await containerClient
+        .listBlobsFlat({
+          includeCopy: true,
+          includeDeleted: true,
+          includeMetadata: true,
+          includeSnapshots: true,
+          includeUncommitedBlobs: true,
+          prefix
+        })
+        .byPage({ continuationToken: result.continuationToken, maxPageSize: 2 })
+        .next()
+    ).value;
 
     assert.ok(result2.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result2.containerName));
@@ -204,17 +213,19 @@ describe("ContainerClient", () => {
       blobURLs.push(blobClient);
     }
 
-    const result = (await containerClient
-      .listBlobsFlat({
-        includeCopy: true,
-        includeDeleted: true,
-        includeMetadata: true,
-        includeSnapshots: true,
-        includeUncommitedBlobs: true,
-        prefix
-      })
-      .byPage({ maxPageSize: 1 })
-      .next()).value;
+    const result = (
+      await containerClient
+        .listBlobsFlat({
+          includeCopy: true,
+          includeDeleted: true,
+          includeMetadata: true,
+          includeSnapshots: true,
+          includeUncommitedBlobs: true,
+          prefix
+        })
+        .byPage({ maxPageSize: 1 })
+        .next()
+    ).value;
 
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result.containerName));
@@ -405,10 +416,12 @@ describe("ContainerClient", () => {
     }
 
     const delimiter = "/";
-    const result = (await containerClient
-      .listBlobsByHierarchy(delimiter)
-      .byPage()
-      .next()).value;
+    const result = (
+      await containerClient
+        .listBlobsByHierarchy(delimiter)
+        .byPage()
+        .next()
+    ).value;
 
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result.containerName));
@@ -438,10 +451,12 @@ describe("ContainerClient", () => {
     }
 
     const delimiter = "/";
-    const result: ContainerListBlobHierarchySegmentResponse = (await containerClient
-      .listBlobsByHierarchy(delimiter, { prefix: "" })
-      .byPage()
-      .next()).value;
+    const result: ContainerListBlobHierarchySegmentResponse = (
+      await containerClient
+        .listBlobsByHierarchy(delimiter, { prefix: "" })
+        .byPage()
+        .next()
+    ).value;
 
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result.containerName));
@@ -478,16 +493,18 @@ describe("ContainerClient", () => {
       blobClients.push(blobClient);
     }
 
-    const result = (await containerClient
-      .listBlobsByHierarchy(delimiter, {
-        includeCopy: true,
-        includeDeleted: true,
-        includeMetadata: true,
-        includeUncommitedBlobs: true,
-        prefix
-      })
-      .byPage({ maxPageSize: 1 })
-      .next()).value;
+    const result = (
+      await containerClient
+        .listBlobsByHierarchy(delimiter, {
+          includeCopy: true,
+          includeDeleted: true,
+          includeMetadata: true,
+          includeUncommitedBlobs: true,
+          prefix
+        })
+        .byPage({ maxPageSize: 1 })
+        .next()
+    ).value;
 
     assert.ok(result.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result.containerName));
@@ -495,16 +512,18 @@ describe("ContainerClient", () => {
     assert.deepStrictEqual(result.segment.blobItems!.length, 0);
     assert.ok(blobClients[0].url.indexOf(result.segment.blobPrefixes![0].name));
 
-    const result2 = (await containerClient
-      .listBlobsByHierarchy(delimiter, {
-        includeCopy: true,
-        includeDeleted: true,
-        includeMetadata: true,
-        includeUncommitedBlobs: true,
-        prefix
-      })
-      .byPage({ continuationToken: result.continuationToken, maxPageSize: 2 })
-      .next()).value;
+    const result2 = (
+      await containerClient
+        .listBlobsByHierarchy(delimiter, {
+          includeCopy: true,
+          includeDeleted: true,
+          includeMetadata: true,
+          includeUncommitedBlobs: true,
+          prefix
+        })
+        .byPage({ continuationToken: result.continuationToken, maxPageSize: 2 })
+        .next()
+    ).value;
 
     assert.ok(result2.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result2.containerName));
@@ -512,16 +531,18 @@ describe("ContainerClient", () => {
     assert.deepStrictEqual(result2.segment.blobItems!.length, 0);
     assert.ok(blobClients[0].url.indexOf(result2.segment.blobPrefixes![0].name));
 
-    const result3 = (await containerClient
-      .listBlobsByHierarchy(delimiter, {
-        includeCopy: true,
-        includeDeleted: true,
-        includeMetadata: true,
-        includeUncommitedBlobs: true,
-        prefix: `${prefix}0${delimiter}`
-      })
-      .byPage({ maxPageSize: 2 })
-      .next()).value;
+    const result3 = (
+      await containerClient
+        .listBlobsByHierarchy(delimiter, {
+          includeCopy: true,
+          includeDeleted: true,
+          includeMetadata: true,
+          includeUncommitedBlobs: true,
+          prefix: `${prefix}0${delimiter}`
+        })
+        .byPage({ maxPageSize: 2 })
+        .next()
+    ).value;
 
     assert.ok(result3.serviceEndpoint.length > 0);
     assert.ok(containerClient.url.indexOf(result3.containerName));
@@ -635,6 +656,7 @@ describe("ContainerClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
+    const urlPath = URLBuilder.parse(blockBlobClient.url).getPath() || "";
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -647,7 +669,7 @@ describe("ContainerClient", () => {
                   name: "Azure.Storage.Blob.BlockBlobClient-upload",
                   children: [
                     {
-                      name: "core-http",
+                      name: urlPath,
                       children: []
                     }
                   ]

--- a/sdk/storage/storage-file-datalake/src/Pipeline.ts
+++ b/sdk/storage/storage-file-datalake/src/Pipeline.ts
@@ -30,7 +30,7 @@ import { logger } from "./log";
 import { StorageBrowserPolicyFactory } from "./StorageBrowserPolicyFactory";
 import { StorageRetryOptions, StorageRetryPolicyFactory } from "./StorageRetryPolicyFactory";
 import { TelemetryPolicyFactory } from "./TelemetryPolicyFactory";
-import { Pipeline as BlobPipeline } from '@azure/storage-blob';
+import { Pipeline as BlobPipeline } from "@azure/storage-blob";
 import {
   StorageDataLakeLoggingAllowedHeaderNames,
   StorageDataLakeLoggingAllowedQueryParameters,
@@ -185,10 +185,11 @@ export function newPipeline(
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
 
+  const telemetryPolicy = new TelemetryPolicyFactory(pipelineOptions.userAgentOptions);
   const factories: RequestPolicyFactory[] = [
-    tracingPolicy(),
+    tracingPolicy({ userAgent: telemetryPolicy.telemetryString }),
     keepAlivePolicy(pipelineOptions.keepAliveOptions),
-    new TelemetryPolicyFactory(pipelineOptions.userAgentOptions),
+    telemetryPolicy,
     generateClientRequestIdPolicy(),
     new StorageBrowserPolicyFactory(),
     deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer

--- a/sdk/storage/storage-file-datalake/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-datalake/src/TelemetryPolicyFactory.ts
@@ -21,6 +21,10 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
+  /**
+   * @internal
+   * @ignore
+   */
   public readonly telemetryString: string;
 
   /**

--- a/sdk/storage/storage-file-datalake/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-datalake/src/TelemetryPolicyFactory.ts
@@ -21,7 +21,7 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
-  private telemetryString: string;
+  public readonly telemetryString: string;
 
   /**
    * Creates an instance of TelemetryPolicyFactory.

--- a/sdk/storage/storage-file-datalake/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/tracing.ts
@@ -5,7 +5,6 @@ import { Span, SpanKind, SpanOptions } from "@opentelemetry/types";
 
 import { OperationTracingOptions } from "../StorageClient";
 
-
 /**
  * Creates a span using the global tracer.
  * @param name The name of the operation being performed.
@@ -18,11 +17,10 @@ export function createSpan(
   const tracer = getTracer();
   const spanOptions: SpanOptions = {
     ...tracingOptions.spanOptions,
-    kind: SpanKind.CLIENT
+    kind: SpanKind.INTERNAL
   };
 
   const span = tracer.startSpan(`Azure.Storage.DataLake.${operationName}`, spanOptions);
-  span.setAttribute("component", "storage");
 
   let newOptions = tracingOptions.spanOptions || {};
   if (span.isRecording()) {

--- a/sdk/storage/storage-file-datalake/test/filesystemclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/filesystemclient.spec.ts
@@ -5,6 +5,7 @@ import * as dotenv from "dotenv";
 
 import { DataLakeFileSystemClient, FileSystemListPathsResponse } from "../src";
 import { getDataLakeServiceClient, setupEnvironment } from "./utils";
+import { URLBuilder } from "@azure/core-http";
 
 dotenv.config({ path: "../.env" });
 
@@ -59,6 +60,7 @@ describe("DataLakeFileSystemClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
+    const urlPath = URLBuilder.parse(fileSystemClient.url).getPath() || "";
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -71,7 +73,7 @@ describe("DataLakeFileSystemClient", () => {
                   name: "Azure.Storage.Blob.ContainerClient-setMetadata",
                   children: [
                     {
-                      name: "core-http",
+                      name: urlPath,
                       children: []
                     }
                   ]

--- a/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
+++ b/sdk/storage/storage-file-datalake/test/pathclient.spec.ts
@@ -1,5 +1,5 @@
 import { AbortController } from "@azure/abort-controller";
-import { isNode } from "@azure/core-http";
+import { isNode, URLBuilder } from "@azure/core-http";
 import { setTracer, SpanGraph, TestTracer } from "@azure/core-tracing";
 import { record } from "@azure/test-utils-recorder";
 import * as assert from "assert";
@@ -164,6 +164,7 @@ describe("DataLakePathClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
+    const urlPath = URLBuilder.parse(fileClient.url).getPath() || "";
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -176,7 +177,7 @@ describe("DataLakePathClient", () => {
                   name: "Azure.Storage.Blob.BlobClient-download",
                   children: [
                     {
-                      name: "core-http",
+                      name: urlPath,
                       children: []
                     }
                   ]

--- a/sdk/storage/storage-file-share/src/Pipeline.ts
+++ b/sdk/storage/storage-file-share/src/Pipeline.ts
@@ -176,10 +176,11 @@ export function newPipeline(
   // Order is important. Closer to the API at the top & closer to the network at the bottom.
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
+  const telemetryPolicy = new TelemetryPolicyFactory(pipelineOptions.userAgentOptions);
   const factories: RequestPolicyFactory[] = [
-    tracingPolicy(),
+    tracingPolicy({ userAgent: telemetryPolicy.telemetryString }),
     keepAlivePolicy(pipelineOptions.keepAliveOptions),
-    new TelemetryPolicyFactory(pipelineOptions.userAgentOptions),
+    telemetryPolicy,
     generateClientRequestIdPolicy(),
     new StorageBrowserPolicyFactory(),
     deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer

--- a/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
@@ -21,6 +21,10 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
+  /**
+   * @internal
+   * @ignore
+   */
   public readonly telemetryString: string;
 
   /**

--- a/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-file-share/src/TelemetryPolicyFactory.ts
@@ -21,7 +21,7 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
-  private telemetryString: string;
+  public readonly telemetryString: string;
 
   /**
    * Creates an instance of TelemetryPolicyFactory.

--- a/sdk/storage/storage-file-share/src/utils/tracing.ts
+++ b/sdk/storage/storage-file-share/src/utils/tracing.ts
@@ -17,11 +17,10 @@ export function createSpan(
   const tracer = getTracer();
   const spanOptions: SpanOptions = {
     ...tracingOptions.spanOptions,
-    kind: SpanKind.CLIENT
+    kind: SpanKind.INTERNAL
   };
 
   const span = tracer.startSpan(`Azure.Storage.File.${operationName}`, spanOptions);
-  span.setAttribute("component", "storage");
 
   let newOptions = tracingOptions.spanOptions || {};
   if (span.isRecording()) {

--- a/sdk/storage/storage-file-share/test/directoryclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/directoryclient.spec.ts
@@ -6,6 +6,7 @@ import { record, Recorder } from "@azure/test-utils-recorder";
 import { DirectoryCreateResponse } from "../src/generated/src/models";
 import { truncatedISO8061Date } from "../src/utils/utils.common";
 import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
+import { URLBuilder } from "@azure/core-http";
 dotenv.config({ path: "../.env" });
 
 describe("DirectoryClient", () => {
@@ -667,6 +668,9 @@ describe("DirectoryClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
+    const subDirPath = URLBuilder.parse(subDirClient.url).getPath() || "";
+    const filePath = URLBuilder.parse(fileClient.url).getPath() || "";
+
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -679,7 +683,7 @@ describe("DirectoryClient", () => {
                   name: "Azure.Storage.File.ShareDirectoryClient-create",
                   children: [
                     {
-                      name: "core-http",
+                      name: subDirPath,
                       children: []
                     }
                   ]
@@ -693,7 +697,7 @@ describe("DirectoryClient", () => {
                   name: "Azure.Storage.File.ShareFileClient-create",
                   children: [
                     {
-                      name: "core-http",
+                      name: filePath,
                       children: []
                     }
                   ]
@@ -704,7 +708,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareFileClient-getProperties",
               children: [
                 {
-                  name: "core-http",
+                  name: filePath,
                   children: []
                 }
               ]
@@ -716,7 +720,7 @@ describe("DirectoryClient", () => {
                   name: "Azure.Storage.File.ShareFileClient-delete",
                   children: [
                     {
-                      name: "core-http",
+                      name: filePath,
                       children: []
                     }
                   ]
@@ -727,7 +731,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareFileClient-getProperties",
               children: [
                 {
-                  name: "core-http",
+                  name: filePath,
                   children: []
                 }
               ]
@@ -736,7 +740,7 @@ describe("DirectoryClient", () => {
               name: "Azure.Storage.File.ShareDirectoryClient-delete",
               children: [
                 {
-                  name: "core-http",
+                  name: subDirPath,
                   children: []
                 }
               ]

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { isNode } from "@azure/core-http";
+import { isNode, URLBuilder } from "@azure/core-http";
 import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 import { AbortController } from "@azure/abort-controller";
 import { record, delay, Recorder } from "@azure/test-utils-recorder";
@@ -581,6 +581,8 @@ describe("FileClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
+    const urlPath = URLBuilder.parse(fileClient.url).getPath() || "";
+
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -590,7 +592,7 @@ describe("FileClient", () => {
               name: "Azure.Storage.File.ShareFileClient-create",
               children: [
                 {
-                  name: "core-http",
+                  name: urlPath,
                   children: []
                 }
               ]

--- a/sdk/storage/storage-queue/src/Pipeline.ts
+++ b/sdk/storage/storage-queue/src/Pipeline.ts
@@ -182,10 +182,11 @@ export function newPipeline(
   // Order is important. Closer to the API at the top & closer to the network at the bottom.
   // The credential's policy factory must appear close to the wire so it can sign any
   // changes made by other factories (like UniqueRequestIDPolicyFactory)
+  const telemetryPolicy = new TelemetryPolicyFactory(pipelineOptions.userAgentOptions);
   const factories: RequestPolicyFactory[] = [
-    tracingPolicy(),
+    tracingPolicy({ userAgent: telemetryPolicy.telemetryString }),
     keepAlivePolicy(pipelineOptions.keepAliveOptions),
-    new TelemetryPolicyFactory(pipelineOptions.userAgentOptions),
+    telemetryPolicy,
     generateClientRequestIdPolicy(),
     new StorageBrowserPolicyFactory(),
     deserializationPolicy(), // Default deserializationPolicy is provided by protocol layer

--- a/sdk/storage/storage-queue/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-queue/src/TelemetryPolicyFactory.ts
@@ -21,6 +21,10 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
+  /**
+   * @internal
+   * @ignore
+   */
   public readonly telemetryString: string;
 
   /**

--- a/sdk/storage/storage-queue/src/TelemetryPolicyFactory.ts
+++ b/sdk/storage/storage-queue/src/TelemetryPolicyFactory.ts
@@ -21,7 +21,7 @@ import { SDK_VERSION } from "./utils/constants";
  * @implements {RequestPolicyFactory}
  */
 export class TelemetryPolicyFactory implements RequestPolicyFactory {
-  private telemetryString: string;
+  public readonly telemetryString: string;
 
   /**
    * Creates an instance of TelemetryPolicyFactory.

--- a/sdk/storage/storage-queue/src/utils/tracing.ts
+++ b/sdk/storage/storage-queue/src/utils/tracing.ts
@@ -17,11 +17,10 @@ export function createSpan(
   const tracer = getTracer();
   const spanOptions: SpanOptions = {
     ...tracingOptions.spanOptions,
-    kind: SpanKind.CLIENT
+    kind: SpanKind.INTERNAL
   };
 
   const span = tracer.startSpan(`Azure.Storage.Queue.${operationName}`, spanOptions);
-  span.setAttribute("component", "storage");
 
   let newOptions = tracingOptions.spanOptions || {};
   if (span.isRecording()) {

--- a/sdk/storage/storage-queue/test/queueclient.spec.ts
+++ b/sdk/storage/storage-queue/test/queueclient.spec.ts
@@ -5,6 +5,7 @@ import * as dotenv from "dotenv";
 import { QueueClient } from "../src";
 import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
 import { setupEnvironment } from "./utils/testutils.common";
+import { URLBuilder } from "@azure/core-http";
 dotenv.config({ path: "../.env" });
 
 describe("QueueClient", () => {
@@ -182,6 +183,8 @@ describe("QueueClient", () => {
     assert.strictEqual(rootSpans.length, 1, "Should only have one root span.");
     assert.strictEqual(rootSpan, rootSpans[0], "The root span should match what was passed in.");
 
+    const urlPath = URLBuilder.parse(queueClient.url).getPath() || "";
+
     const expectedGraph: SpanGraph = {
       roots: [
         {
@@ -191,7 +194,7 @@ describe("QueueClient", () => {
               name: "Azure.Storage.Queue.QueueClient-getProperties",
               children: [
                 {
-                  name: "core-http",
+                  name: urlPath,
                   children: []
                 }
               ]


### PR DESCRIPTION
Azure Monitor wasn't able to format spans collected from the JS SDK very nicely because we didn't set a number of expected attributes. 

This PR tweaks the policy arguments slightly so we can set all expected attributes on spans.

Fixes #6310 