### PR TITLE
[KeyVault-Certificates] version IS a required property of update certificates

### DIFF
--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -76,7 +76,7 @@ export class CertificateClient {
     restoreCertificateBackup(backup: Uint8Array, options?: RestoreCertificateBackupOptions): Promise<KeyVaultCertificateWithPolicy>;
     setContacts(contacts: CertificateContact[], options?: SetContactsOptions): Promise<CertificateContact[] | undefined>;
     updateCertificatePolicy(certificateName: string, policy: CertificatePolicy, options?: UpdateCertificatePolicyOptions): Promise<CertificatePolicy>;
-    updateCertificateProperties(certificateName: string, version?: string, options?: UpdateCertificateOptions): Promise<KeyVaultCertificate>;
+    updateCertificateProperties(certificateName: string, version: string, options?: UpdateCertificateOptions): Promise<KeyVaultCertificate>;
     updateIssuer(issuerName: string, options?: UpdateIssuerOptions): Promise<CertificateIssuer>;
     readonly vaultUrl: string;
 }

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -1403,7 +1403,7 @@ export class CertificateClient {
    */
   public async updateCertificateProperties(
     certificateName: string,
-    version: string = "",
+    version: string,
     options: UpdateCertificatePropertiesOptions = {}
   ): Promise<KeyVaultCertificate> {
     const requestOptions = operationOptionsToRequestOptionsBase(options);


### PR DESCRIPTION
It still can be an empty string, but swagger has it required here: https://docs.microsoft.com/en-us/rest/api/keyvault/updatecertificate/updatecertificate

This is probably the best fix for typescript, since otherwise this would mean changing some GAd packages.

Fixes #6543