### PR TITLE
[event-hubs] Remove the processing loop when processing single vs multiple partitions

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -402,7 +402,7 @@ export class EventHubConsumerClient {
         ...defaultConsumerClientOptions,
         ...(options as SubscribeOptions),
         ownerLevel: getOwnerLevel(options, this._userChoseCheckpointStore),
-        partitionLoadBalancer: this._userChoseCheckpointStore
+        processingTarget: this._userChoseCheckpointStore
           ? undefined
           : new GreedyPartitionLoadBalancer(),
         // make it so all the event processors process work with the same overarching owner ID
@@ -441,9 +441,8 @@ export class EventHubConsumerClient {
       {
         ...defaultConsumerClientOptions,
         ...options,
-        // this load balancer will just grab _all_ the partitions, not looking at ownership
-        partitionLoadBalancer: new GreedyPartitionLoadBalancer([partitionId]),
-        ownerLevel: getOwnerLevel(subscribeOptions, this._userChoseCheckpointStore)
+        processingTarget: partitionId,
+        ownerLevel: getOwnerLevel(subscribeOptions, this._userChoseCheckpointStore),
       }
     );
 

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -422,11 +422,11 @@ export class EventHubConsumerClient {
     this._partitionGate.add(partitionId);
 
     const subscribeOptions = options as SubscribeOptions | undefined;
-    
+
     if (this._userChoseCheckpointStore) {
       log.consumerClient(
         `Subscribing to specific partition (${partitionId}), using a checkpoint store`
-      );      
+      );
     } else {
       log.consumerClient(
         `Subscribing to specific partition (${partitionId}), no checkpoint store.`
@@ -442,7 +442,7 @@ export class EventHubConsumerClient {
         ...defaultConsumerClientOptions,
         ...options,
         processingTarget: partitionId,
-        ownerLevel: getOwnerLevel(subscribeOptions, this._userChoseCheckpointStore),
+        ownerLevel: getOwnerLevel(subscribeOptions, this._userChoseCheckpointStore)
       }
     );
 

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -143,9 +143,8 @@ export interface CheckpointStore {
  * ```
  * @internal
  */
-export interface FullEventProcessorOptions  // make the 'maxBatchSize', 'maxWaitTimeInSeconds', 'ownerLevel' fields required extends
-  extends // for our internal classes (these are optional for external users)
-    Required<Pick<SubscribeOptions, "maxBatchSize" | "maxWaitTimeInSeconds">>,
+export interface FullEventProcessorOptions  // make the 'maxBatchSize', 'maxWaitTimeInSeconds', 'ownerLevel' fields required extends // for our internal classes (these are optional for external users)
+  extends Required<Pick<SubscribeOptions, "maxBatchSize" | "maxWaitTimeInSeconds">>,
     Pick<
       SubscribeOptions,
       Exclude<
@@ -547,7 +546,7 @@ export class EventProcessor {
     }
 
     if (targetWithoutOwnership(this._processingTarget)) {
-      log.eventProcessor(`[${this._id}] No partitions owned, skipping abandoning.`)
+      log.eventProcessor(`[${this._id}] No partitions owned, skipping abandoning.`);
     } else {
       await this.abandonPartitionOwnerships();
     }
@@ -573,6 +572,6 @@ function isAbandoned(ownership: PartitionOwnership): boolean {
   return ownership.ownerId === "";
 }
 
-function targetWithoutOwnership(target: PartitionLoadBalancer | string) : target is string {
+function targetWithoutOwnership(target: PartitionLoadBalancer | string): target is string {
   return typeof target === "string";
 }

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -251,7 +251,7 @@ describe("EventHubConsumerClient", () => {
       subscriptions.push(subscription);
 
       await tester.runTestAndPoll(producerClient);
-      await subscription.close();   // or else we won't see the partition abandoning messages
+      await subscription.close(); // or else we won't see the partition abandoning messages
 
       logTester.assert();
     });

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -124,7 +124,7 @@ describe("EventHubConsumerClient", () => {
 
           // and if you don't specify a CheckpointStore we also assume you just want to read all partitions
           // immediately so we bypass the FairPartitionLoadBalancer entirely
-          options.partitionLoadBalancer!.constructor.name.should.equal(
+          options.processingTarget!.constructor.name.should.equal(
             "GreedyPartitionLoadBalancer"
           );
         };
@@ -147,7 +147,7 @@ describe("EventHubConsumerClient", () => {
 
           // We're falling back to the actual production load balancer
           // (which means we just don't override the partition load balancer field)
-          should.not.exist(options.partitionLoadBalancer);
+          should.not.exist(options.processingTarget);
         };
 
         clientWithCheckpointStore.subscribe(subscriptionHandlers);
@@ -156,7 +156,7 @@ describe("EventHubConsumerClient", () => {
       it("subscribe to all partitions, no checkpoint store", () => {
         validateOptions = (options) => {
           should.not.exist(options.ownerLevel);
-          options.partitionLoadBalancer!.constructor.name.should.equal(
+          options.processingTarget!.constructor.name.should.equal(
             "GreedyPartitionLoadBalancer"
           );
         };
@@ -167,7 +167,7 @@ describe("EventHubConsumerClient", () => {
       it("subscribe to all partitions, WITH checkpoint store", () => {
         validateOptions = (options) => {
           options.ownerLevel!.should.equal(0);
-          should.not.exist(options.partitionLoadBalancer);
+          should.not.exist(options.processingTarget);
         };
 
         clientWithCheckpointStore.subscribe(subscriptionHandlers);
@@ -228,9 +228,9 @@ describe("EventHubConsumerClient", () => {
       const logTester = new LogTester(
         [
           "Subscribing to specific partition (0), no checkpoint store.",
-          "GreedyPartitionLoadBalancer created. Watching (0)."
+          "Single partition target: 0"
         ],
-        [log.consumerClient, log.partitionLoadBalancer]
+        [log.consumerClient, log.partitionLoadBalancer, log.eventProcessor]
       );
 
       const tester = new ReceivedMessagesTester(["0"], false);
@@ -259,7 +259,7 @@ describe("EventHubConsumerClient", () => {
           "Subscribing to all partitions, no checkpoint store.",
           "GreedyPartitionLoadBalancer created. Watching all."
         ],
-        [log.consumerClient, log.partitionLoadBalancer]
+        [log.consumerClient, log.partitionLoadBalancer, log.eventProcessor]
       );
 
       const tester = new ReceivedMessagesTester(partitionIds, false);
@@ -286,9 +286,9 @@ describe("EventHubConsumerClient", () => {
       const logTester = new LogTester(
         [
           ...(partitionIds.map(partitionId => `Subscribing to specific partition (${partitionId}), no checkpoint store.` )),
-          ...(partitionIds.map(partitionId => `GreedyPartitionLoadBalancer created. Watching (${partitionId}).` ))
+          ...(partitionIds.map(partitionId => `Single partition target: ${partitionId}`))
         ],
-        [log.consumerClient, log.partitionLoadBalancer]
+        [log.consumerClient, log.partitionLoadBalancer, log.eventProcessor]
       );
 
       const tester = new ReceivedMessagesTester(partitionIds, false);
@@ -321,7 +321,7 @@ describe("EventHubConsumerClient", () => {
           "Subscribing to all partitions, using a checkpoint store.",
           /Starting event processor with ID /
         ],
-        [log.consumerClient, log.eventProcessor]
+        [log.consumerClient, log.eventProcessor, log.eventProcessor]
       );
 
       clients.push(

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -76,8 +76,8 @@ describe("EventHubConsumerClient", () => {
         );
 
         subscriptionHandlers = {
-          processEvents: async () => { },
-          processError: async () => { }
+          processEvents: async () => {},
+          processError: async () => {}
         };
 
         const fakeEventProcessorConstructor = (
@@ -102,15 +102,21 @@ describe("EventHubConsumerClient", () => {
       });
 
       it("conflicting subscribes", () => {
-        validateOptions = () => { };
-        
+        validateOptions = () => {};
+
         client.subscribe(subscriptionHandlers);
         // invalid - we're already subscribed to a conflicting partition
-        should.throw(() => client.subscribe("0", subscriptionHandlers), /Partition already has a subscriber/);
+        should.throw(
+          () => client.subscribe("0", subscriptionHandlers),
+          /Partition already has a subscriber/
+        );
 
         clientWithCheckpointStore.subscribe("0", subscriptionHandlers);
         // invalid - we're already subscribed to a conflicting partition
-        should.throw(() => clientWithCheckpointStore.subscribe(subscriptionHandlers), /Partition already has a subscriber/);
+        should.throw(
+          () => clientWithCheckpointStore.subscribe(subscriptionHandlers),
+          /Partition already has a subscriber/
+        );
       });
 
       it("subscribe to single partition, no checkpoint store", () => {
@@ -124,9 +130,7 @@ describe("EventHubConsumerClient", () => {
 
           // and if you don't specify a CheckpointStore we also assume you just want to read all partitions
           // immediately so we bypass the FairPartitionLoadBalancer entirely
-          options.processingTarget!.constructor.name.should.equal(
-            "GreedyPartitionLoadBalancer"
-          );
+          options.processingTarget!.constructor.name.should.equal("GreedyPartitionLoadBalancer");
         };
 
         const subscription = client.subscribe(subscriptionHandlers);
@@ -156,9 +160,7 @@ describe("EventHubConsumerClient", () => {
       it("subscribe to all partitions, no checkpoint store", () => {
         validateOptions = (options) => {
           should.not.exist(options.ownerLevel);
-          options.processingTarget!.constructor.name.should.equal(
-            "GreedyPartitionLoadBalancer"
-          );
+          options.processingTarget!.constructor.name.should.equal("GreedyPartitionLoadBalancer");
         };
 
         client.subscribe(subscriptionHandlers);
@@ -174,7 +176,7 @@ describe("EventHubConsumerClient", () => {
       });
 
       it("multiple subscribe calls from the same eventhubconsumerclient use the same owner ID", async () => {
-        let ownerId: string|undefined = undefined;
+        let ownerId: string | undefined = undefined;
 
         validateOptions = (options) => {
           should.exist(options.ownerId);
@@ -285,8 +287,11 @@ describe("EventHubConsumerClient", () => {
     > {
       const logTester = new LogTester(
         [
-          ...(partitionIds.map(partitionId => `Subscribing to specific partition (${partitionId}), no checkpoint store.` )),
-          ...(partitionIds.map(partitionId => `Single partition target: ${partitionId}`))
+          ...partitionIds.map(
+            (partitionId) =>
+              `Subscribing to specific partition (${partitionId}), no checkpoint store.`
+          ),
+          ...partitionIds.map((partitionId) => `Single partition target: ${partitionId}`)
         ],
         [log.consumerClient, log.partitionLoadBalancer, log.eventProcessor]
       );
@@ -307,7 +312,7 @@ describe("EventHubConsumerClient", () => {
       }
 
       await tester.runTestAndPoll(producerClient);
-      
+
       logTester.assert();
     });
 

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -32,8 +32,8 @@ import {
 } from "./utils/subscriptionHandlerForTests";
 import { GreedyPartitionLoadBalancer, PartitionLoadBalancer } from "../src/partitionLoadBalancer";
 import { AbortError } from "@azure/abort-controller";
-import { FakeSubscriptionEventHandlers } from './utils/fakeSubscriptionEventHandlers';
-import sinon from 'sinon';
+import { FakeSubscriptionEventHandlers } from "./utils/fakeSubscriptionEventHandlers";
+import sinon from "sinon";
 const env = getEnvVars();
 
 describe("Event Processor", function(): void {
@@ -91,42 +91,47 @@ describe("Event Processor", function(): void {
         }
       ];
 
-        const checkpointStore: CheckpointStore = {
-          claimOwnership: async () => {
-            return [];
-          },
-          listCheckpoints: async () => {
-            return checkpoints;
-          },
-          listOwnership: async () => {
-            return [];
-          },
-          updateCheckpoint: async () => { }
-        };
+      const checkpointStore: CheckpointStore = {
+        claimOwnership: async () => {
+          return [];
+        },
+        listCheckpoints: async () => {
+          return checkpoints;
+        },
+        listOwnership: async () => {
+          return [];
+        },
+        updateCheckpoint: async () => {}
+      };
 
       // we're not actually going to start anything here so there's nothing
       // to stop
-      const processor = new EventProcessor(EventHubClient.defaultConsumerGroupName, client, {
-        processEvents: async () => { },
-        processError: async () => { },
-      }, checkpointStore, {
+      const processor = new EventProcessor(
+        EventHubClient.defaultConsumerGroupName,
+        client,
+        {
+          processEvents: async () => {},
+          processError: async () => {}
+        },
+        checkpointStore,
+        {
           maxBatchSize: 1,
           maxWaitTimeInSeconds: 1
         }
       );
 
       // checkpoint is available for partition 0
-      let eventPosition = await processor['_getStartingPosition']("0");
+      let eventPosition = await processor["_getStartingPosition"]("0");
       eventPosition!.offset!.should.equal(1009);
       should.not.exist(eventPosition!.sequenceNumber);
 
       //checkpoint is available for partition 1
-      eventPosition = await processor['_getStartingPosition']("1");
+      eventPosition = await processor["_getStartingPosition"]("1");
       eventPosition!.offset!.should.equal(0);
       should.not.exist(eventPosition!.sequenceNumber);
 
       // no checkpoint available for partition 2
-      eventPosition = await processor['_getStartingPosition']("2");
+      eventPosition = await processor["_getStartingPosition"]("2");
       should.not.exist(eventPosition);
     });
 
@@ -143,11 +148,11 @@ describe("Event Processor", function(): void {
 
         // note: we're not starting this event processor so there's nothing to stop()
         // it's only here so we can call a few private methods on it.
-        eventProcessor = new EventProcessor(        
+        eventProcessor = new EventProcessor(
           EventHubClient.defaultConsumerGroupName,
           client,
           {
-            processEvents: async () => { },
+            processEvents: async () => {},
             processError: async (err, context) => {
               // simulate the user messing up and accidentally throwing an error
               // we should just log it and not kill anything.
@@ -157,7 +162,7 @@ describe("Event Processor", function(): void {
               if (userCallback) {
                 userCallback();
               }
-            },
+            }
           },
           new InMemoryCheckpointStore(),
           defaultOptions
@@ -199,27 +204,31 @@ describe("Event Processor", function(): void {
         },
 
         // (these aren't used for this test)
-        async listOwnership(): Promise<PartitionOwnership[]> { return []; },
-        async updateCheckpoint(): Promise<void> { },
-        async listCheckpoints(): Promise<Checkpoint[]> { return []; }        
+        async listOwnership(): Promise<PartitionOwnership[]> {
+          return [];
+        },
+        async updateCheckpoint(): Promise<void> {},
+        async listCheckpoints(): Promise<Checkpoint[]> {
+          return [];
+        }
       };
 
       const pumpManager = {
         createPumpCalled: false,
-          
+
         async createPump() {
           pumpManager.createPumpCalled = true;
         },
 
-        async removeAllPumps() { }
-      }
+        async removeAllPumps() {}
+      };
 
       const eventProcessor = new EventProcessor(
         EventHubClient.defaultConsumerGroupName,
         client,
         {
-          processEvents: async () => { },
-          processError: async () => { },
+          processEvents: async () => {},
+          processError: async () => {}
         },
         checkpointStore,
         {
@@ -228,7 +237,7 @@ describe("Event Processor", function(): void {
         }
       );
 
-      await eventProcessor['_claimOwnership']({
+      await eventProcessor["_claimOwnership"]({
         consumerGroup: "cgname",
         eventHubName: "ehname",
         fullyQualifiedNamespace: "fqdn",
@@ -258,7 +267,7 @@ describe("Event Processor", function(): void {
         // abandoned claim
         { ...commonFields, partitionId: "1001", ownerId: "", etag: "abandoned etag" },
         // normally owned claim
-        { ...commonFields, partitionId: "1002", ownerId: "owned partition", etag: "owned etag" },
+        { ...commonFields, partitionId: "1002", ownerId: "owned partition", etag: "owned etag" }
         // 1003 - completely unowned
       ]);
 
@@ -268,64 +277,118 @@ describe("Event Processor", function(): void {
       const partitionIds = ["1001", "1002", "1003"];
 
       fakeEventHubClient.getPartitionIds.resolves(partitionIds);
-      sinon.replaceGetter(fakeEventHubClient, 'eventHubName', () => commonFields.eventHubName);
-      sinon.replaceGetter(fakeEventHubClient, 'fullyQualifiedNamespace', () => commonFields.fullyQualifiedNamespace);
+      sinon.replaceGetter(fakeEventHubClient, "eventHubName", () => commonFields.eventHubName);
+      sinon.replaceGetter(
+        fakeEventHubClient,
+        "fullyQualifiedNamespace",
+        () => commonFields.fullyQualifiedNamespace
+      );
 
-      const ep = new EventProcessor(commonFields.consumerGroup, fakeEventHubClient as any, handlers, checkpointStore, {
-        maxBatchSize: 1,
-        loopIntervalInMs: 1,
-        maxWaitTimeInSeconds: 1,
-        pumpManager: {
-          async createPump() { },
-          async removeAllPumps(): Promise<void> { }
+      const ep = new EventProcessor(
+        commonFields.consumerGroup,
+        fakeEventHubClient as any,
+        handlers,
+        checkpointStore,
+        {
+          maxBatchSize: 1,
+          loopIntervalInMs: 1,
+          maxWaitTimeInSeconds: 1,
+          pumpManager: {
+            async createPump() {},
+            async removeAllPumps(): Promise<void> {}
+          }
         }
-      });
+      );
 
-      // allow three iterations through the loop - one for each partition that 
+      // allow three iterations through the loop - one for each partition that
       // we expect to be claimed
       //
-      // we'll let one more go through just to make sure we're not going to 
+      // we'll let one more go through just to make sure we're not going to
       // pick up an extra surprise partition
       //
       // This particular behavior is really specific to the FairPartitionLoadBalancer but that's okay for now.
       const numTimesAbortedIsCheckedInLoop = 3;
-      await ep['_runLoopWithLoadBalancing'](
-        ep['_processingTarget'] as PartitionLoadBalancer,
+      await ep["_runLoopWithLoadBalancing"](
+        ep["_processingTarget"] as PartitionLoadBalancer,
         triggerAbortedSignalAfterNumCalls(partitionIds.length * numTimesAbortedIsCheckedInLoop)
       );
 
       handlers.errors.should.be.empty;
 
-      const currentOwnerships = await checkpointStore.listOwnership(commonFields.fullyQualifiedNamespace, commonFields.eventHubName, commonFields.consumerGroup);
+      const currentOwnerships = await checkpointStore.listOwnership(
+        commonFields.fullyQualifiedNamespace,
+        commonFields.eventHubName,
+        commonFields.consumerGroup
+      );
       currentOwnerships.sort((a, b) => a.partitionId.localeCompare(b.partitionId));
 
       currentOwnerships.should.deep.equal([
-        { ...commonFields, partitionId: "1001", ownerId: ep.id, etag: currentOwnerships[0].etag, lastModifiedTimeInMs: currentOwnerships[0].lastModifiedTimeInMs },
+        {
+          ...commonFields,
+          partitionId: "1001",
+          ownerId: ep.id,
+          etag: currentOwnerships[0].etag,
+          lastModifiedTimeInMs: currentOwnerships[0].lastModifiedTimeInMs
+        },
         // 1002 is not going to be claimed since it's already owned so it should be untouched
         originalClaimedPartitions[1],
-        { ...commonFields, partitionId: "1003", ownerId: ep.id, etag: currentOwnerships[2].etag,  lastModifiedTimeInMs: currentOwnerships[2].lastModifiedTimeInMs }
+        {
+          ...commonFields,
+          partitionId: "1003",
+          ownerId: ep.id,
+          etag: currentOwnerships[2].etag,
+          lastModifiedTimeInMs: currentOwnerships[2].lastModifiedTimeInMs
+        }
       ]);
 
       // now let's "unclaim" everything by stopping our event processor
       await ep.stop();
-      
+
       // sanity check - we were previously modifying the original instances
       // in place which...isn't right.
       currentOwnerships.should.deep.equal([
-        { ...commonFields, partitionId: "1001", ownerId: ep.id, etag: currentOwnerships[0].etag, lastModifiedTimeInMs: currentOwnerships[0].lastModifiedTimeInMs },
+        {
+          ...commonFields,
+          partitionId: "1001",
+          ownerId: ep.id,
+          etag: currentOwnerships[0].etag,
+          lastModifiedTimeInMs: currentOwnerships[0].lastModifiedTimeInMs
+        },
         // 1002 is not going to be claimed since it's already owned so it should be untouched
         originalClaimedPartitions[1],
-        { ...commonFields, partitionId: "1003", ownerId: ep.id, etag: currentOwnerships[2].etag,  lastModifiedTimeInMs: currentOwnerships[2].lastModifiedTimeInMs }
+        {
+          ...commonFields,
+          partitionId: "1003",
+          ownerId: ep.id,
+          etag: currentOwnerships[2].etag,
+          lastModifiedTimeInMs: currentOwnerships[2].lastModifiedTimeInMs
+        }
       ]);
 
-      const ownershipsAfterStop = await checkpointStore.listOwnership(commonFields.fullyQualifiedNamespace, commonFields.eventHubName, commonFields.consumerGroup);
+      const ownershipsAfterStop = await checkpointStore.listOwnership(
+        commonFields.fullyQualifiedNamespace,
+        commonFields.eventHubName,
+        commonFields.consumerGroup
+      );
       ownershipsAfterStop.sort((a, b) => a.partitionId.localeCompare(b.partitionId));
 
       ownershipsAfterStop.should.deep.equal([
-        { ...commonFields, partitionId: "1001", ownerId: "", etag: ownershipsAfterStop[0].etag, lastModifiedTimeInMs: ownershipsAfterStop[0].lastModifiedTimeInMs },
+        {
+          ...commonFields,
+          partitionId: "1001",
+          ownerId: "",
+          etag: ownershipsAfterStop[0].etag,
+          lastModifiedTimeInMs: ownershipsAfterStop[0].lastModifiedTimeInMs
+        },
         // 1002 is not going to be claimed since it's already owned so it should be untouched
         originalClaimedPartitions[1],
-        { ...commonFields, partitionId: "1003", ownerId: "", etag: ownershipsAfterStop[2].etag,  lastModifiedTimeInMs: ownershipsAfterStop[2].lastModifiedTimeInMs }
+        {
+          ...commonFields,
+          partitionId: "1003",
+          ownerId: "",
+          etag: ownershipsAfterStop[2].etag,
+          lastModifiedTimeInMs: ownershipsAfterStop[2].lastModifiedTimeInMs
+        }
       ]);
     });
   });
@@ -390,9 +453,15 @@ describe("Event Processor", function(): void {
       EventHubClient.defaultConsumerGroupName,
       client,
       {
-        processClose: async () => { throw new Error("processClose() error") },
-        processEvents: async () => { throw new Error("processEvents() error"); },
-        processInitialize: async () => { throw new Error("processInitialize() error") },
+        processClose: async () => {
+          throw new Error("processClose() error");
+        },
+        processEvents: async () => {
+          throw new Error("processEvents() error");
+        },
+        processInitialize: async () => {
+          throw new Error("processInitialize() error");
+        },
         processError: async (err, _) => {
           errors.add(err);
           throw new Error("These are logged but ignored");
@@ -417,7 +486,7 @@ describe("Event Processor", function(): void {
         until: async () => errors.size >= 3
       });
 
-      const messages = [...errors].map(e => e.message);
+      const messages = [...errors].map((e) => e.message);
       messages.sort();
 
       messages.should.deep.equal([
@@ -437,7 +506,7 @@ describe("Event Processor", function(): void {
       {
         processEvents: async () => {},
         processInitialize: async (context) => context.setStartingPosition(EventPosition.latest()),
-        processError: async () => { },
+        processError: async () => {}
       },
       new InMemoryCheckpointStore(),
       defaultOptions
@@ -454,7 +523,7 @@ describe("Event Processor", function(): void {
       {
         processEvents: async () => {},
         processInitialize: async (context) => context.setStartingPosition(EventPosition.latest()),
-        processError: async () => { },
+        processError: async () => {}
       },
       new InMemoryCheckpointStore(),
       { ...defaultOptions, ownerId: "hello" }
@@ -510,8 +579,8 @@ describe("Event Processor", function(): void {
           didPartitionProcessorStart = true;
           context.setStartingPosition(EventPosition.latest());
         },
-        processEvents: async (event, context) => { },
-        processError: async () => { },
+        processEvents: async (event, context) => {},
+        processError: async () => {}
       },
       new InMemoryCheckpointStore(),
       defaultOptions
@@ -823,7 +892,7 @@ describe("Event Processor", function(): void {
       const basicProperties = {
         consumerGroup: "initial consumer group",
         eventHubName: "initial event hub name",
-        fullyQualifiedNamespace: "initial fully qualified namespace",
+        fullyQualifiedNamespace: "initial fully qualified namespace"
       };
 
       const originalPartitionOwnership = {
@@ -835,13 +904,11 @@ describe("Event Processor", function(): void {
       const copyOfPartitionOwnership = {
         ...originalPartitionOwnership
       };
-      
+
       assertUnique(originalPartitionOwnership);
 
       for (let i = 0; i < 2; ++i) {
-        const ownerships = await checkpointStore.claimOwnership([
-          originalPartitionOwnership
-        ]);
+        const ownerships = await checkpointStore.claimOwnership([originalPartitionOwnership]);
 
         // second sanity check - we were also modifying the input parameter
         // (which was also bad)
@@ -851,11 +918,15 @@ describe("Event Processor", function(): void {
       }
 
       for (let i = 0; i < 2; ++i) {
-        const ownerships = await checkpointStore.listOwnership(basicProperties.fullyQualifiedNamespace, basicProperties.eventHubName, basicProperties.consumerGroup);
+        const ownerships = await checkpointStore.listOwnership(
+          basicProperties.fullyQualifiedNamespace,
+          basicProperties.eventHubName,
+          basicProperties.consumerGroup
+        );
         assertUnique(...ownerships);
       }
 
-      const originalCheckpoint : Checkpoint = {
+      const originalCheckpoint: Checkpoint = {
         ...basicProperties,
         sequenceNumber: 1,
         partitionId: "1",
@@ -872,7 +943,11 @@ describe("Event Processor", function(): void {
       copyOfOriginalCheckpoint.should.deep.equal(originalCheckpoint);
 
       for (let i = 0; i < 2; ++i) {
-        const checkpoints = await checkpointStore.listCheckpoints(basicProperties.fullyQualifiedNamespace, basicProperties.eventHubName, basicProperties.consumerGroup);
+        const checkpoints = await checkpointStore.listCheckpoints(
+          basicProperties.fullyQualifiedNamespace,
+          basicProperties.eventHubName,
+          basicProperties.consumerGroup
+        );
         assertUnique(...checkpoints);
       }
     });
@@ -920,7 +995,7 @@ describe("Event Processor", function(): void {
         async processEvents(events: ReceivedEventData[], context: PartitionContext) {
           partitionOwnershipArr.add(context.partitionId);
           const existingEvents = partitionResultsMap.get(context.partitionId)!.events;
-          existingEvents.push(...events.map(event => event.body));
+          existingEvents.push(...events.map((event) => event.body));
         }
         async processError(err: Error, context: PartitionContext) {
           loggerForTest(`processError(${context.partitionId})`);
@@ -1109,8 +1184,8 @@ describe("Event Processor", function(): void {
           claimedPartitions.add(partitionId);
           claimedPartitionsMap[eventProcessorId] = claimedPartitions;
         },
-        async processEvents() { },
-        async processError() { },
+        async processEvents() {},
+        async processError() {},
         async processClose(reason, context) {
           const eventProcessorId: string = (context as any).eventProcessorId;
           const partitionId = context.partitionId;
@@ -1216,7 +1291,7 @@ describe("Event Processor", function(): void {
   describe("with trackLastEnqueuedEventProperties #RunnableInBrowser", function(): void {
     it("should have lastEnqueuedEventProperties populated when trackLastEnqueuedEventProperties is set to true", async function(): Promise<
       void
-      > {
+    > {
       const partitionIds = await client.getPartitionIds({});
       for (const partitionId of partitionIds) {
         const producer = client.createProducer({ partitionId: `${partitionId}` });
@@ -1237,8 +1312,7 @@ describe("Event Processor", function(): void {
             context.lastEnqueuedEventProperties!
           );
         }
-        async processError(err: Error, context: PartitionContext) {          
-        }
+        async processError(err: Error, context: PartitionContext) {}
       }
 
       const processor = new EventProcessor(
@@ -1295,9 +1369,9 @@ function triggerAbortedSignalAfterNumCalls(maxCalls: number): AbortSignal {
 
       return false;
     },
-    addEventListener: () => { },
-    removeEventListener: () => { },
-    onabort: () => { },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    onabort: () => {},
     dispatchEvent: () => true
   };
 


### PR DESCRIPTION
When reading from a single partition we can completely forgo any of the processing we do in the normal multi-partition loop. 

This should let users get the benefits of all the other infrastructure (checkpointing) without having to pay a performance penalty for load balancing and ownership.

Fixes #6554