### PR TITLE
[Storage] fix nyc code coverage exclusion issue

### DIFF
--- a/sdk/storage/storage-blob/.nycrc
+++ b/sdk/storage/storage-blob/.nycrc
@@ -1,6 +1,7 @@
 {
     "include": [
-      "dist-test/index.node.js"
+      "dist-esm/test/*.spec.js",
+      "dist-esm/test/node/*.spec.js"
     ],
     "exclude": [
       "**/*.d.ts",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -50,7 +50,7 @@
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node",
-    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
@@ -82,6 +82,14 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/utils/constants.ts",
+        "prefix": "SDK_VERSION"
+      }
+    ]
+  },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.0.0",
@@ -94,8 +102,8 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@azure/test-utils-recorder": "^1.0.0",
     "@azure/identity": "^1.0.0",
+    "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.5.4",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/fs-extra": "^8.0.0",
@@ -114,6 +122,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
+    "esm": "^3.2.18",
     "execa": "^3.3.0",
     "fs-extra": "^8.1.0",
     "inherits": "^2.0.3",
@@ -152,13 +161,5 @@
     "ts-node": "^8.3.0",
     "typescript": "~3.6.4",
     "util": "^0.12.1"
-  },
-  "//metadata": {
-    "constantPaths": [
-      {
-        "path": "src/utils/constants.ts",
-        "prefix": "SDK_VERSION"
-      }
-    ]
   }
 }

--- a/sdk/storage/storage-file-datalake/.nycrc
+++ b/sdk/storage/storage-file-datalake/.nycrc
@@ -1,6 +1,7 @@
 {
     "include": [
-      "dist-test/index.node.js"
+      "dist-esm/test/*.spec.js",
+      "dist-esm/test/node/*.spec.js"
     ],
     "exclude": [
       "**/*.d.ts",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -44,7 +44,7 @@
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
@@ -57,20 +57,50 @@
     "tsconfig.json"
   ],
   "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
+  },
+  "keywords": [
+    "Azure",
+    "Storage",
+    "ADLS",
+    "DFS",
+    "DataLake",
+    "Node.js",
+    "TypeScript",
+    "JavaScript",
+    "Browser"
+  ],
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/utils/constants.ts",
+        "prefix": "SDK_VERSION"
+      }
+    ]
+  },
   "dependencies": {
-    "@azure/storage-blob": "^12.0.0",
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
+    "@azure/storage-blob": "^12.0.0",
     "events": "^3.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@azure/test-utils-recorder": "^1.0.0",
     "@azure/identity": "^1.0.0",
+    "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "^7.5.4",
+    "@opentelemetry/types": "^0.2.0",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/fs-extra": "^8.0.0",
     "@types/mocha": "^5.2.5",
@@ -79,7 +109,6 @@
     "@types/query-string": "6.2.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "@opentelemetry/types": "^0.2.0",
     "assert": "^1.4.1",
     "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
@@ -89,6 +118,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
+    "esm": "^3.2.18",
     "execa": "^3.3.0",
     "fs-extra": "^8.1.0",
     "inherits": "^2.0.3",
@@ -127,34 +157,5 @@
     "ts-node": "^8.3.0",
     "typescript": "~3.6.4",
     "util": "^0.12.1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Azure/azure-sdk-for-js.git"
-  },
-  "keywords": [
-    "Azure",
-    "Storage",
-    "ADLS",
-    "DFS",
-    "DataLake",
-    "Node.js",
-    "TypeScript",
-    "JavaScript",
-    "Browser"
-  ],
-  "author": "Microsoft Corporation",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
-  "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
-  "//metadata": {
-    "constantPaths": [
-      {
-        "path": "src/utils/constants.ts",
-        "prefix": "SDK_VERSION"
-      }
-    ]
   }
 }

--- a/sdk/storage/storage-file-share/.nycrc
+++ b/sdk/storage/storage-file-share/.nycrc
@@ -1,6 +1,7 @@
 {
     "include": [
-      "dist-test/index.node.js"
+      "dist-esm/test/*.spec.js",
+      "dist-esm/test/node/*.spec.js"
     ],
     "exclude": [
       "**/*.d.ts",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -48,7 +48,7 @@
     "unit-test:browser": "cross-env TEST_MODE=playback npm run integration-test:browser",
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
-    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
@@ -98,14 +98,14 @@
     "@azure/core-http": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",
-    "@opentelemetry/types": "^0.2.0",
     "@azure/logger": "^1.0.0",
+    "@opentelemetry/types": "^0.2.0",
     "events": "^3.0.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.5.4",
     "@azure/test-utils-recorder": "^1.0.0",
+    "@microsoft/api-extractor": "^7.5.4",
     "@rollup/plugin-replace": "^2.2.0",
     "@types/fs-extra": "^8.0.0",
     "@types/mocha": "^5.2.5",
@@ -123,6 +123,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
+    "esm": "^3.2.18",
     "execa": "^3.3.0",
     "fs-extra": "^8.1.0",
     "inherits": "^2.0.3",

--- a/sdk/storage/storage-queue/.nycrc
+++ b/sdk/storage/storage-queue/.nycrc
@@ -1,6 +1,7 @@
 {
     "include": [
-      "dist-test/index.node.js"
+      "dist-esm/test/*.spec.js",
+      "dist-esm/test/node/*.spec.js"
     ],
     "exclude": [
       "**/*.d.ts",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -47,7 +47,7 @@
     "unit-test:node": "cross-env TEST_MODE=playback npm run integration-test:node",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "emulator-tests": "cross-env STORAGE_CONNECTION_STRING=UseDevelopmentStorage=true && npm run test:node",
-    "coverage-integration-test:node": "nyc npm run integration-test:node",
+    "coverage-integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000 --retries 2 dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "coverage-unit-test:node": "cross-env TEST_MODE=playback npm run coverage-integration-test:node"
   },
   "files": [
@@ -79,6 +79,18 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
+  "//metadata": {
+    "constantPaths": [
+      {
+        "path": "src/generated/src/storageClientContext.ts",
+        "prefix": "packageVersion"
+      },
+      {
+        "path": "src/utils/constants.ts",
+        "prefix": "SDK_VERSION"
+      }
+    ]
+  },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
     "@azure/core-http": "^1.0.0",
@@ -109,6 +121,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
+    "esm": "^3.2.18",
     "execa": "^3.3.0",
     "fs-extra": "^8.1.0",
     "inherits": "^2.0.3",
@@ -147,17 +160,5 @@
     "ts-node": "^8.3.0",
     "typescript": "~3.6.4",
     "util": "^0.12.1"
-  },
-  "//metadata": {
-    "constantPaths": [
-      {
-        "path": "src/generated/src/storageClientContext.ts",
-        "prefix": "packageVersion"
-      },
-      {
-        "path": "src/utils/constants.ts",
-        "prefix": "SDK_VERSION"
-      }
-    ]
   }
 }


### PR DESCRIPTION
The code coverage report include data for dependencies (`dotenv` for
example). This is because we run the test on the one single bundled
file, while nyc exclusion works by not instrumenting imported or
required modules in the exclusion list.

This change run nyc on individual spec.js files instead. A dev
dependency `esm` is introduced so that nyc can load our test modules.

NodeJS part of #2820.