### PR TITLE
[recorder] Fix prettier error in VS CODE for the test-utils/recorder folder

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -77,6 +77,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "typescript": "~3.6.4"
+    "typescript": "~3.6.4",
+    "prettier": "^1.16.4"
   }
 }


### PR DESCRIPTION
Fixes prettier error in VS CODE for the test-utils/recorder folder by adding prettier devDependency
![image](https://user-images.githubusercontent.com/10452642/71128721-bd25a180-21a2-11ea-8e5c-b40b3420f308.png)
