### PR TITLE
[Storage] include code coverage report for source instead of te…

### DIFF
--- a/sdk/storage/storage-blob/.nycrc
+++ b/sdk/storage/storage-blob/.nycrc
@@ -1,22 +1,18 @@
 {
     "include": [
-      "dist-esm/test/*.spec.js",
-      "dist-esm/test/node/*.spec.js"
+      "dist-esm/src/**/*.js"
     ],
     "exclude": [
       "**/*.d.ts",
-      "src/BlobDownloadResponse.browser.ts",
-      "src/credentials/SharedKeyCredential.browser.ts",
-      "src/highlevel.browser.ts",
-      "src/highlevel.common.ts",
-      "src/models.ts",
-      "src/generated/lib/storageClient.ts"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
+      "dist-esm/src/StorageBrowserPolicyFactory.js",
+      "dist-esm/src/policies/StorageBrowserPolicy.js",
+      "dist-esm/src/BlobDownloadResponse.browser.js",
+      "dist-esm/src/credentials/StorageSharedKeyCredential.browser.js",
+      "dist-esm/src/models.js",
+      "dist-esm/src/index.browser.js",
+      "dist-esm/src/utils/utils.browser.js",
+      "dist-esm/src/BatchUtils.browser.js",
+      "dist-esm/src/generated/src/storageClient.js"
     ],
     "reporter": [
       "text-summary",

--- a/sdk/storage/storage-file-datalake/.nycrc
+++ b/sdk/storage/storage-file-datalake/.nycrc
@@ -1,19 +1,16 @@
 {
     "include": [
-      "dist-esm/test/*.spec.js",
-      "dist-esm/test/node/*.spec.js"
+      "dist-esm/src/**/*.js"
     ],
     "exclude": [
       "**/*.d.ts",
-      "src/credentials/SharedKeyCredential.browser.ts",
-      "src/models.ts",
-      "src/generated/lib/storageClient.ts"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
+      "dist-esm/src/StorageBrowserPolicyFactory.js",
+      "dist-esm/src/policies/StorageBrowserPolicy.js",
+      "dist-esm/src/credentials/StorageSharedKeyCredential.browser.js",
+      "dist-esm/src/models.js",
+      "dist-esm/src/index.browser.js",
+      "dist-esm/src/utils/utils.browser.js",
+      "dist-esm/src/generated/src/storageClient.js"
     ],
     "reporter": [
       "text-summary",

--- a/sdk/storage/storage-file-share/.nycrc
+++ b/sdk/storage/storage-file-share/.nycrc
@@ -1,25 +1,17 @@
 {
     "include": [
-      "dist-esm/test/*.spec.js",
-      "dist-esm/test/node/*.spec.js"
+      "dist-esm/src/**/*.js"
     ],
     "exclude": [
       "**/*.d.ts",
-      "src/FileDownloadResponse.browser.ts",
-      "src/credentials/SharedKeyCredential.browser.ts",
-      "src/highlevel.browser.ts",
-      "src/highlevel.common.ts",
-      "src/policies/BrowserPolicy.ts",
-      "src/models.ts",
-      "src/index.browser.ts",
-      "src/utils/utils.browser.ts",
-      "src/generated/lib/storageClient.ts"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
+      "dist-esm/src/StorageBrowserPolicyFactory.js",
+      "dist-esm/src/policies/StorageBrowserPolicy.js",
+      "dist-esm/src/FileDownloadResponse.browser.js",
+      "dist-esm/src/credentials/StorageSharedKeyCredential.browser.js",
+      "dist-esm/src/models.js",
+      "dist-esm/src/index.browser.js",
+      "dist-esm/src/utils/utils.browser.js",
+      "dist-esm/src/generated/src/storageClient.js"
     ],
     "reporter": [
       "text-summary",

--- a/sdk/storage/storage-queue/.nycrc
+++ b/sdk/storage/storage-queue/.nycrc
@@ -1,19 +1,15 @@
 {
     "include": [
-      "dist-esm/test/*.spec.js",
-      "dist-esm/test/node/*.spec.js"
+      "dist-esm/src/**/*.js"
     ],
     "exclude": [
       "**/*.d.ts",
-      "src/credentials/SharedKeyCredential.browser.ts",
-      "src/models.ts",
-      "src/generated/lib/storageClient.ts"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "require": [
-      "ts-node/register"
+      "dist-esm/src/StorageBrowserPolicyFactory.js",
+      "dist-esm/src/policies/StorageBrowserPolicy.js",
+      "dist-esm/src/credentials/StorageSharedKeyCredential.browser.js",
+      "dist-esm/src/models.js",
+      "dist-esm/src/index.browser.js",
+      "dist-esm/src/generated/src/storageClient.js"
     ],
     "reporter": [
       "text-summary",


### PR DESCRIPTION
In additional,

- remove ts-node related sections as we now run nyc on .js files.

- update excluded paths/names as they are now outdated in v12. Also
update them to .js files.

- add several browser specific files that are missing from the exclusion
lists.

Part of #2820