### PR TITLE
[Storage] Share a single httpClient among clients

### DIFF
--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -5,8 +5,7 @@ import {
   isTokenCredential,
   isNode,
   HttpResponse,
-  getDefaultProxySettings,
-  DefaultHttpClient
+  getDefaultProxySettings
 } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -36,6 +35,7 @@ import { truncatedISO8061Date } from "./utils/utils.common";
 import { createSpan } from "./utils/tracing";
 import { BlobBatchClient } from "./BlobBatchClient";
 import { CommonOptions, StorageClient } from "./StorageClient";
+import { getCachedDefaultHttpClient } from "./utils/cache";
 
 /**
  * Options to configure the {@link BlobServiceClient.getProperties} operation.
@@ -382,9 +382,13 @@ export class BlobServiceClient extends StorageClient {
       | Pipeline,
     options?: StoragePipelineOptions
   ) {
-    if (options && !options.httpClient) {
-      options.httpClient = new DefaultHttpClient();
-    }
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
+
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;
@@ -393,10 +397,10 @@ export class BlobServiceClient extends StorageClient {
       credentialOrPipeline instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipeline)
     ) {
-      pipeline = newPipeline(credentialOrPipeline, options);
+      pipeline = newPipeline(credentialOrPipeline, newOptions);
     } else {
       // The second parameter is undefined. Use anonymous credential
-      pipeline = newPipeline(new AnonymousCredential(), options);
+      pipeline = newPipeline(new AnonymousCredential(), newOptions);
     }
     super(url, pipeline);
     this.serviceContext = new Service(this.storageClientContext);

--- a/sdk/storage/storage-blob/src/BlobServiceClient.ts
+++ b/sdk/storage/storage-blob/src/BlobServiceClient.ts
@@ -5,7 +5,8 @@ import {
   isTokenCredential,
   isNode,
   HttpResponse,
-  getDefaultProxySettings
+  getDefaultProxySettings,
+  DefaultHttpClient
 } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import { AbortSignalLike } from "@azure/abort-controller";
@@ -381,6 +382,9 @@ export class BlobServiceClient extends StorageClient {
       | Pipeline,
     options?: StoragePipelineOptions
   ) {
+    if (options && !options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -6,7 +6,8 @@ import {
   TransferProgressEvent,
   TokenCredential,
   isTokenCredential,
-  getDefaultProxySettings
+  getDefaultProxySettings,
+  DefaultHttpClient
 } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import {
@@ -924,6 +925,9 @@ export class BlobClient extends StorageClient {
     options?: StoragePipelineOptions
   ) {
     options = options || {};
+    if (!options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     let pipeline: Pipeline;
     let url: string;
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
@@ -5510,6 +5514,9 @@ export class ContainerClient extends StorageClient {
     let pipeline: Pipeline;
     let url: string;
     options = options || {};
+    if (!options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
       // (url: string, pipeline: Pipeline)
       url = urlOrConnectionString;

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -6,9 +6,7 @@ import {
   TransferProgressEvent,
   TokenCredential,
   isTokenCredential,
-  getDefaultProxySettings,
-  DefaultHttpClient
-} from "@azure/core-http";
+  getDefaultProxySettings} from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import {
   BlobDownloadResponseModel,
@@ -138,6 +136,7 @@ import { ETagNone } from "./utils/constants";
 import { truncatedISO8061Date } from "./utils/utils.common";
 import "@azure/core-paging";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
+import { getCachedDefaultHttpClient } from "./utils/cache";
 
 /**
  * Options to configure the {@link BlobClient.beginCopyFromURL} operation.
@@ -924,10 +923,13 @@ export class BlobClient extends StorageClient {
     blobNameOrOptions?: string | StoragePipelineOptions,
     options?: StoragePipelineOptions
   ) {
-    options = options || {};
-    if (!options.httpClient) {
-      options.httpClient = new DefaultHttpClient();
-    }
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
+
     let pipeline: Pipeline;
     let url: string;
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
@@ -941,8 +943,13 @@ export class BlobClient extends StorageClient {
     ) {
       // (url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
       url = urlOrConnectionString;
-      options = blobNameOrOptions as StoragePipelineOptions;
-      pipeline = newPipeline(credentialOrPipelineOrContainerName, options);
+      // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+      // avoid each client creating its own http client.
+      const newOptions: StoragePipelineOptions = {
+        httpClient: getCachedDefaultHttpClient(),
+        ...(blobNameOrOptions as StoragePipelineOptions)
+      };
+      pipeline = newPipeline(credentialOrPipelineOrContainerName, newOptions);
     } else if (
       !credentialOrPipelineOrContainerName &&
       typeof credentialOrPipelineOrContainerName !== "string"
@@ -950,7 +957,7 @@ export class BlobClient extends StorageClient {
       // (url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
       // The second parameter is undefined. Use anonymous credential.
       url = urlOrConnectionString;
-      pipeline = newPipeline(new AnonymousCredential(), options);
+      pipeline = newPipeline(new AnonymousCredential(), newOptions);
     } else if (
       credentialOrPipelineOrContainerName &&
       typeof credentialOrPipelineOrContainerName === "string" &&
@@ -973,8 +980,8 @@ export class BlobClient extends StorageClient {
             encodeURIComponent(blobName)
           );
 
-          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
-          pipeline = newPipeline(sharedKeyCredential, options);
+          newOptions.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
+          pipeline = newPipeline(sharedKeyCredential, newOptions);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");
         }
@@ -986,7 +993,7 @@ export class BlobClient extends StorageClient {
           ) +
           "?" +
           extractedCreds.accountSas;
-        pipeline = newPipeline(new AnonymousCredential(), options);
+        pipeline = newPipeline(new AnonymousCredential(), newOptions);
       } else {
         throw new Error(
           "Connection string must be either an Account connection string or a SAS connection string"
@@ -5513,10 +5520,13 @@ export class ContainerClient extends StorageClient {
   ) {
     let pipeline: Pipeline;
     let url: string;
-    options = options || {};
-    if (!options.httpClient) {
-      options.httpClient = new DefaultHttpClient();
-    }
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
+
     if (credentialOrPipelineOrContainerName instanceof Pipeline) {
       // (url: string, pipeline: Pipeline)
       url = urlOrConnectionString;
@@ -5528,7 +5538,7 @@ export class ContainerClient extends StorageClient {
     ) {
       // (url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
       url = urlOrConnectionString;
-      pipeline = newPipeline(credentialOrPipelineOrContainerName, options);
+      pipeline = newPipeline(credentialOrPipelineOrContainerName, newOptions);
     } else if (
       !credentialOrPipelineOrContainerName &&
       typeof credentialOrPipelineOrContainerName !== "string"
@@ -5536,7 +5546,7 @@ export class ContainerClient extends StorageClient {
       // (url: string, credential?: StorageSharedKeyCredential | AnonymousCredential | TokenCredential, options?: StoragePipelineOptions)
       // The second parameter is undefined. Use anonymous credential.
       url = urlOrConnectionString;
-      pipeline = newPipeline(new AnonymousCredential(), options);
+      pipeline = newPipeline(new AnonymousCredential(), newOptions);
     } else if (
       credentialOrPipelineOrContainerName &&
       typeof credentialOrPipelineOrContainerName === "string"
@@ -5552,8 +5562,8 @@ export class ContainerClient extends StorageClient {
             extractedCreds.accountKey
           );
           url = appendToURLPath(extractedCreds.url, encodeURIComponent(containerName));
-          options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
-          pipeline = newPipeline(sharedKeyCredential, options);
+          newOptions.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
+          pipeline = newPipeline(sharedKeyCredential, newOptions);
         } else {
           throw new Error("Account connection string is only supported in Node.js environment");
         }
@@ -5562,7 +5572,7 @@ export class ContainerClient extends StorageClient {
           appendToURLPath(extractedCreds.url, encodeURIComponent(containerName)) +
           "?" +
           extractedCreds.accountSas;
-        pipeline = newPipeline(new AnonymousCredential(), options);
+        pipeline = newPipeline(new AnonymousCredential(), newOptions);
       } else {
         throw new Error(
           "Connection string must be either an Account connection string or a SAS connection string"
@@ -6267,7 +6277,7 @@ export class ContainerClient extends StorageClient {
    *
    * // Gets next marker
    * let marker = response.continuationToken;
-   * 
+   *
    * // Passing next marker as continuationToken
    *
    * iterator = containerClient.listBlobsFlat().byPage({ continuationToken: marker, maxPageSize: 10 });

--- a/sdk/storage/storage-blob/src/utils/cache.ts
+++ b/sdk/storage/storage-blob/src/utils/cache.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DefaultHttpClient } from "@azure/core-http";
+
+const _defaultHttpClient = new DefaultHttpClient();
+
+export function getCachedDefaultHttpClient() {
+  return _defaultHttpClient;
+}

--- a/sdk/storage/storage-file-datalake/src/DataLakeFileSystemClient.ts
+++ b/sdk/storage/storage-file-datalake/src/DataLakeFileSystemClient.ts
@@ -37,6 +37,7 @@ import { toContainerPublicAccessType, toPublicAccessType, toPermissions } from "
 import { createSpan } from "./utils/tracing";
 import { appendToURLPath } from "./utils/utils.common";
 import { DataLakeFileClient, DataLakeDirectoryClient } from "./clients";
+import { getCachedDefaultHttpClient } from "./utils/cache";
 
 /**
  * A DataLakeFileSystemClient represents a URL to the Azure Storage file system
@@ -102,6 +103,12 @@ export class DataLakeFileSystemClient extends StorageClient {
       | Pipeline,
     options?: StoragePipelineOptions
   ) {
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
     if (credentialOrPipeline instanceof Pipeline) {
       super(url, credentialOrPipeline);
     } else {
@@ -112,7 +119,7 @@ export class DataLakeFileSystemClient extends StorageClient {
         credential = credentialOrPipeline;
       }
 
-      const pipeline = newPipeline(credential, options);
+      const pipeline = newPipeline(credential, newOptions);
       super(url, pipeline);
     }
 

--- a/sdk/storage/storage-file-datalake/src/DataLakeServiceClient.ts
+++ b/sdk/storage/storage-file-datalake/src/DataLakeServiceClient.ts
@@ -3,7 +3,7 @@
 
 import "@azure/core-paging";
 
-import { TokenCredential } from "@azure/core-http";
+import { TokenCredential, DefaultHttpClient } from "@azure/core-http";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 import { BlobServiceClient } from "@azure/storage-blob";
 
@@ -81,6 +81,9 @@ export class DataLakeServiceClient extends StorageClient {
       | Pipeline,
     options?: StoragePipelineOptions
   ) {
+    if (options && !options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     if (credentialOrPipeline instanceof Pipeline) {
       super(url, credentialOrPipeline);
     } else {

--- a/sdk/storage/storage-file-datalake/src/clients.ts
+++ b/sdk/storage/storage-file-datalake/src/clients.ts
@@ -55,6 +55,7 @@ import {
 } from "./transforms";
 import { createSpan } from "./utils/tracing";
 import { appendToURLPath, setURLPath } from "./utils/utils.common";
+import { getCachedDefaultHttpClient } from "./utils/cache";
 
 /**
  * A DataLakePathClient represents a URL to the Azure Storage path (directory or file).
@@ -119,6 +120,12 @@ export class DataLakePathClient extends StorageClient {
       | Pipeline,
     options?: StoragePipelineOptions
   ) {
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
     if (credentialOrPipeline instanceof Pipeline) {
       super(url, credentialOrPipeline);
     } else {
@@ -129,7 +136,7 @@ export class DataLakePathClient extends StorageClient {
         credential = credentialOrPipeline;
       }
 
-      const pipeline = newPipeline(credential, options);
+      const pipeline = newPipeline(credential, newOptions);
       super(url, pipeline);
     }
 

--- a/sdk/storage/storage-file-datalake/src/utils/cache.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/cache.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DefaultHttpClient } from "@azure/core-http";
+
+const _defaultHttpClient = new DefaultHttpClient();
+
+export function getCachedDefaultHttpClient() {
+  return _defaultHttpClient;
+}

--- a/sdk/storage/storage-file-share/src/ShareClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { HttpResponse, isNode } from "@azure/core-http";
+import { HttpResponse, isNode, DefaultHttpClient } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import { AbortSignalLike } from "@azure/abort-controller";
 import {
@@ -406,6 +406,9 @@ export class ShareClient extends StorageClient {
     credentialOrPipelineOrShareName?: Credential | Pipeline | string,
     options?: StoragePipelineOptions
   ) {
+    if (options && !options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     let pipeline: Pipeline;
     let url: string;
     if (credentialOrPipelineOrShareName instanceof Pipeline) {

--- a/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareDirectoryClient.ts
@@ -40,7 +40,7 @@ import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import { FileSystemAttributes } from "./FileSystemAttributes";
 import { createSpan } from "./utils/tracing";
 import { CanonicalCode } from "@opentelemetry/types";
-import { HttpResponse } from "@azure/core-http";
+import { HttpResponse, DefaultHttpClient } from "@azure/core-http";
 
 /**
  * Options to configure {@link ShareDirectoryClient.create} operation.
@@ -433,6 +433,9 @@ export class ShareDirectoryClient extends StorageClient {
     credentialOrPipeline?: Credential | Pipeline,
     options: StoragePipelineOptions = {}
   ) {
+    if (options && !options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;

--- a/sdk/storage/storage-file-share/src/ShareFileClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareFileClient.ts
@@ -59,6 +59,7 @@ import { readStreamToLocalFile, fsStat } from "./utils/utils.node";
 import { FileSystemAttributes } from "./FileSystemAttributes";
 import { getShareNameAndPathFromUrl } from "./utils/utils.common";
 import { createSpan } from "./utils/tracing";
+import { getCachedDefaultHttpClient } from "./utils/cache";
 
 /**
  * Options to configure the {@link ShareFileClient.create} operation.
@@ -810,14 +811,20 @@ export class ShareFileClient extends StorageClient {
     credentialOrPipeline?: Credential | Pipeline,
     options?: StoragePipelineOptions
   ) {
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;
     } else if (credentialOrPipeline instanceof Credential) {
-      pipeline = newPipeline(credentialOrPipeline, options);
+      pipeline = newPipeline(credentialOrPipeline, newOptions);
     } else {
       // The second parameter is undefined. Use anonymous credential.
-      pipeline = newPipeline(new AnonymousCredential(), options);
+      pipeline = newPipeline(new AnonymousCredential(), newOptions);
     }
 
     super(url, pipeline);

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -22,7 +22,7 @@ import { StorageSharedKeyCredential } from "./credentials/StorageSharedKeyCreden
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import "@azure/core-paging";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
-import { isNode } from "@azure/core-http";
+import { isNode, DefaultHttpClient } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import { createSpan } from "./utils/tracing";
 
@@ -233,6 +233,9 @@ export class ShareServiceClient extends StorageClient {
     credentialOrPipeline?: Credential | Pipeline,
     options?: StoragePipelineOptions
   ) {
+    if (options && !options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;

--- a/sdk/storage/storage-file-share/src/ShareServiceClient.ts
+++ b/sdk/storage/storage-file-share/src/ShareServiceClient.ts
@@ -22,9 +22,10 @@ import { StorageSharedKeyCredential } from "./credentials/StorageSharedKeyCreden
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import "@azure/core-paging";
 import { PagedAsyncIterableIterator, PageSettings } from "@azure/core-paging";
-import { isNode, DefaultHttpClient } from "@azure/core-http";
+import { isNode } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import { createSpan } from "./utils/tracing";
+import { getCachedDefaultHttpClient } from "./utils/cache";
 
 /**
  * Options to configure Share - List Shares Segment operations.
@@ -183,6 +184,12 @@ export class ShareServiceClient extends StorageClient {
     connectionString: string,
     options?: StoragePipelineOptions
   ): ShareServiceClient {
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
     const extractedCreds = extractConnectionStringParts(connectionString);
     if (extractedCreds.kind === "AccountConnString") {
       if (isNode) {
@@ -190,13 +197,13 @@ export class ShareServiceClient extends StorageClient {
           extractedCreds.accountName!,
           extractedCreds.accountKey
         );
-        const pipeline = newPipeline(sharedKeyCredential, options);
+        const pipeline = newPipeline(sharedKeyCredential, newOptions);
         return new ShareServiceClient(extractedCreds.url, pipeline);
       } else {
         throw new Error("Account connection string is only supported in Node.js environment");
       }
     } else if (extractedCreds.kind === "SASConnString") {
-      const pipeline = newPipeline(new AnonymousCredential(), options);
+      const pipeline = newPipeline(new AnonymousCredential(), newOptions);
       return new ShareServiceClient(extractedCreds.url + "?" + extractedCreds.accountSas, pipeline);
     } else {
       throw new Error(
@@ -233,17 +240,21 @@ export class ShareServiceClient extends StorageClient {
     credentialOrPipeline?: Credential | Pipeline,
     options?: StoragePipelineOptions
   ) {
-    if (options && !options.httpClient) {
-      options.httpClient = new DefaultHttpClient();
-    }
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
+
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;
     } else if (credentialOrPipeline instanceof Credential) {
-      pipeline = newPipeline(credentialOrPipeline, options);
+      pipeline = newPipeline(credentialOrPipeline, newOptions);
     } else {
       // The second parameter is undefined. Use anonymous credential.
-      pipeline = newPipeline(new AnonymousCredential(), options);
+      pipeline = newPipeline(new AnonymousCredential(), newOptions);
     }
 
     super(url, pipeline);

--- a/sdk/storage/storage-file-share/src/utils/cache.ts
+++ b/sdk/storage/storage-file-share/src/utils/cache.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DefaultHttpClient } from "@azure/core-http";
+
+const _defaultHttpClient = new DefaultHttpClient();
+
+export function getCachedDefaultHttpClient() {
+  return _defaultHttpClient;
+}

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -5,9 +5,7 @@ import {
   TokenCredential,
   isTokenCredential,
   isNode,
-  getDefaultProxySettings,
-  DefaultHttpClient
-} from "@azure/core-http";
+  getDefaultProxySettings} from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import {
   ListQueuesIncludeType,
@@ -31,6 +29,7 @@ import { StorageSharedKeyCredential } from "./credentials/StorageSharedKeyCreden
 import { AnonymousCredential } from "./credentials/AnonymousCredential";
 import { createSpan } from "./utils/tracing";
 import { QueueClient, QueueCreateOptions, QueueDeleteOptions } from "./QueueClient";
+import { getCachedDefaultHttpClient } from "./utils/cache";
 
 /**
  * Options to configure {@link QueueServiceClient.getProperties} operation
@@ -177,7 +176,12 @@ export class QueueServiceClient extends StorageClient {
     connectionString: string,
     options?: StoragePipelineOptions
   ): QueueServiceClient {
-    options = options || {};
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
     const extractedCreds = extractConnectionStringParts(connectionString);
     if (extractedCreds.kind === "AccountConnString") {
       if (isNode) {
@@ -185,14 +189,14 @@ export class QueueServiceClient extends StorageClient {
           extractedCreds.accountName!,
           extractedCreds.accountKey
         );
-        options.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
-        const pipeline = newPipeline(sharedKeyCredential, options);
+        newOptions.proxyOptions = getDefaultProxySettings(extractedCreds.proxyUri);
+        const pipeline = newPipeline(sharedKeyCredential, newOptions);
         return new QueueServiceClient(extractedCreds.url, pipeline);
       } else {
         throw new Error("Account connection string is only supported in Node.js environment");
       }
     } else if (extractedCreds.kind === "SASConnString") {
-      const pipeline = newPipeline(new AnonymousCredential(), options);
+      const pipeline = newPipeline(new AnonymousCredential(), newOptions);
       return new QueueServiceClient(extractedCreds.url + "?" + extractedCreds.accountSas, pipeline);
     } else {
       throw new Error(
@@ -275,9 +279,13 @@ export class QueueServiceClient extends StorageClient {
       | Pipeline,
     options?: StoragePipelineOptions
   ) {
-    if (options && !options.httpClient) {
-      options.httpClient = new DefaultHttpClient();
-    }
+    // when options.httpClient is not specified, passing in a DefaultHttpClient instance to
+    // avoid each client creating its own http client.
+    const newOptions: StoragePipelineOptions = {
+      httpClient: getCachedDefaultHttpClient(),
+      ...options
+    };
+
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;
@@ -286,10 +294,10 @@ export class QueueServiceClient extends StorageClient {
       credentialOrPipeline instanceof AnonymousCredential ||
       isTokenCredential(credentialOrPipeline)
     ) {
-      pipeline = newPipeline(credentialOrPipeline, options);
+      pipeline = newPipeline(credentialOrPipeline, newOptions);
     } else {
       // The second paramter is undefined. Use anonymous credential.
-      pipeline = newPipeline(new AnonymousCredential(), options);
+      pipeline = newPipeline(new AnonymousCredential(), newOptions);
     }
     super(url, pipeline);
     this.serviceContext = new Service(this.storageClientContext);
@@ -463,7 +471,7 @@ export class QueueServiceClient extends StorageClient {
    * let i = 1;
    * let iterator = queueServiceClient.listQueues().byPage({ maxPageSize: 2 });
    * let item = (await iterator.next()).value;
-   * 
+   *
    * // Prints 2 queue names
    * if (item.queueItems) {
    *   for (const queueItem of item.queueItems) {
@@ -473,7 +481,7 @@ export class QueueServiceClient extends StorageClient {
    * }
    * // Gets next marker
    * let marker = item.continuationToken;
-   * 
+   *
    * // Passing next marker as continuationToken
    * iterator = queueServiceClient.listQueues().byPage({ continuationToken: marker, maxPageSize: 10 });
    * item = (await iterator.next()).value;

--- a/sdk/storage/storage-queue/src/QueueServiceClient.ts
+++ b/sdk/storage/storage-queue/src/QueueServiceClient.ts
@@ -5,7 +5,8 @@ import {
   TokenCredential,
   isTokenCredential,
   isNode,
-  getDefaultProxySettings
+  getDefaultProxySettings,
+  DefaultHttpClient
 } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import {
@@ -274,6 +275,9 @@ export class QueueServiceClient extends StorageClient {
       | Pipeline,
     options?: StoragePipelineOptions
   ) {
+    if (options && !options.httpClient) {
+      options.httpClient = new DefaultHttpClient();
+    }
     let pipeline: Pipeline;
     if (credentialOrPipeline instanceof Pipeline) {
       pipeline = credentialOrPipeline;

--- a/sdk/storage/storage-queue/src/utils/cache.ts
+++ b/sdk/storage/storage-queue/src/utils/cache.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { DefaultHttpClient } from "@azure/core-http";
+
+const _defaultHttpClient = new DefaultHttpClient();
+
+export function getCachedDefaultHttpClient() {
+  return _defaultHttpClient;
+}


### PR DESCRIPTION
Currently child clients obtained via `get*Client()` share their parent
client's pipeline. But when the pipeline doesn't have a httpClient
specified, a `DefaultHttpClient` will be created for each of the
clients.

There's no reason why we cannot share the http client instance among
storage clients.  This change create a default http client instance
for parent client's pipeline if none is specified.