### PR TITLE
sendOperationRequest can receive OperationOptions

### DIFF
--- a/sdk/core/core-http/lib/operationArguments.ts
+++ b/sdk/core/core-http/lib/operationArguments.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { RequestOptionsBase } from "./webResource";
+import { OperationOptions } from "./operationOptions";
 
 /**
  * A collection of properties that apply to a single invocation of an operation.
@@ -15,5 +16,5 @@ export interface OperationArguments {
   /**
    * The optional arugments that are provided to an operation.
    */
-  options?: RequestOptionsBase;
+  options?: RequestOptionsBase | OperationOptions;
 }

--- a/sdk/core/core-http/lib/operationOptions.ts
+++ b/sdk/core/core-http/lib/operationOptions.ts
@@ -20,6 +20,22 @@ export interface OperationOptions {
   tracingOptions?: OperationTracingOptions;
 }
 
+const OperationOptionsValues: Set<string> = new Set<keyof OperationOptions>([
+  "abortSignal",
+  "requestOptions",
+  "tracingOptions"
+]);
+
+/**
+ * Returns true if `options` adheres to the `OperationOptions` interface.
+ * @param options  An options bag that is either an `OperationOptions` or a `RequestOptionsBase`
+ */
+export function isOperationOptions(
+  options: OperationOptions | RequestOptionsBase
+): options is OperationOptions {
+  return Object.keys(options).every((value) => OperationOptionsValues.has(value));
+}
+
 export interface OperationTracingOptions {
   /**
    * OpenTelemetry SpanOptions used to create a span when tracing is enabled.

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -382,6 +382,10 @@ export class WebResource {
       result.operationResponseGetter = this.operationResponseGetter;
     }
 
+    if (this.spanOptions) {
+      result.spanOptions = this.spanOptions;
+    }
+
     return result;
   }
 }


### PR DESCRIPTION
This PR seeks to address #6457 by extending sendOperationRequest.

I wanted to get some feedback on the implementation before I spent time adopting this in libraries. 

I believe this change would necessitate bumping core-http to 1.1 so we can express a dependency on that from libs that want to take advantage of this new signature.

All feedback is appreciated! :heart: