### PR TITLE
replace relative link in the root readme too

### DIFF
--- a/eng/pipelines/doc-index.yml
+++ b/eng/pipelines/doc-index.yml
@@ -13,6 +13,18 @@ jobs:
     pool:
       vmImage: "windows-2019"
     steps:
+      - task: UsePythonVersion@0
+        displayName: "Use Python 3.6"
+        inputs:
+          versionSpec: "3.6"
+
+      - template: eng/pipelines/templates/scripts/replace-relative-links.yml@azure-sdk-tools
+        parameters:
+          TargetFolder: .
+          RootFolder: .
+          BuildSHA: $(Build.SourceVersion)
+          RepoId: "Azure/azure-sdk-for-js"
+
       - pwsh: |
           Invoke-WebRequest -Uri "https://github.com/dotnet/docfx/releases/download/v2.43.2/docfx.zip" `
           -OutFile "docfx.zip" | Wait-Process; Expand-Archive -Path "docfx.zip" -DestinationPath "./docfx/"
@@ -58,11 +70,6 @@ jobs:
           Get-Content "$(Build.SourcesDirectory)/eng/tools/generate-static-index/static-files/main.js" |Out-File "$(Build.SourcesDirectory)/docfx_project/_site/styles/main.js"
           Get-Content "$(Build.SourcesDirectory)/eng/tools/generate-static-index/static-files/docfx.css" |Out-File "$(Build.SourcesDirectory)/docfx_project/_site/styles/docfx.css"
         displayName: Replace site assets
-
-      - task: UsePythonVersion@0
-        displayName: "Use Python 3.6"
-        inputs:
-          versionSpec: "3.6"
 
       - template: eng/pipelines/templates/scripts/mashup-doc-index.yml@azure-sdk-tools
         parameters:


### PR DESCRIPTION
This is for issue - #6323
The contributing link was not resolved to complete path since we are scoping the script to run within a service folder. But for links which are in the root readme, we will have  to run in the entire repo. The downside though is that the script also picks up other READMEs which are in the node-modules folder(s) of packages under `/common/temp/pnpm-store/2/registry.npmjs.org/`
Reference - https://dev.azure.com/azure-sdk/public/_build/results?buildId=216691&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=9a4ddc9a-5b6e-5495-335e-b34e54a89692
cc: @weshaggard @scbedd 