### PR TITLE
[Common Recorder] Tests with abortSignals cause the other playback tests to be skipped 

### DIFF
--- a/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_abort_after_aborter_timeout.json
+++ b/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_abort_after_aborter_timeout.json
@@ -2,7 +2,7 @@
  "recordings": [],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container157370436801004831"
+   "container": "container157715193540406536"
   },
   "newDate": {}
  }

--- a/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_abort_after_father_aborter_calls_abort.json
+++ b/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_abort_after_father_aborter_calls_abort.json
@@ -2,7 +2,7 @@
  "recordings": [],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container157370436864500308"
+   "container": "container157715193606000895"
   },
   "newDate": {}
  }

--- a/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_abort_when_calling_abort_before_request_finishes.json
+++ b/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_abort_when_calling_abort_before_request_finishes.json
@@ -2,7 +2,7 @@
  "recordings": [],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container157370436846205704"
+   "container": "container157715193604802965"
   },
   "newDate": {}
  }

--- a/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_not_abort_after_calling_abort.json
+++ b/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_not_abort_after_calling_abort.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003454310905670",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container157715193540901496",
    "query": {
     "restype": "container"
    },
@@ -10,18 +10,21 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:23 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:23 GMT",
+    "content-length": "0",
+    "date": "Tue, 24 Dec 2019 01:45:35 GMT",
+    "etag": "\"0x8D78812F8B26A20\"",
+    "last-modified": "Tue, 24 Dec 2019 01:45:35 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D747577FF5D739\"",
-    "x-ms-request-id": "215ef5aa-201e-0080-5840-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "8e255aad-ade4-4d52-88a3-76be5fede412",
-    "content-length": "0"
+    "x-ms-client-request-id": "c7e4f726-dce5-44ab-b4c2-efd33f8d04fa",
+    "x-ms-request-id": "6278d045-201e-006a-4dfb-b93a57000000",
+    "x-ms-version": "2019-02-02"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003454310905670"
+  "uniqueName": {
+   "container": "container157715193540901496"
+  },
+  "newDate": {}
  }
 }

--- a/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_not_abort_when_calling_abort_after_request_finishes.json
+++ b/sdk/storage/storage-blob/recordings/browsers/aborter/recording_should_not_abort_when_calling_abort_after_request_finishes.json
@@ -1,27 +1,9 @@
 {
- "recordings": [
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003454357107417",
-   "query": {
-    "restype": "container"
-   },
-   "requestBody": null,
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:23 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:23 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D74757801526A7\"",
-    "x-ms-request-id": "215ef688-201e-0080-1f40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "2e1a5b40-11f0-499c-8777-8665acb1dd60",
-    "content-length": "0"
-   }
-  }
- ],
+ "recordings": [],
  "uniqueTestInfo": {
-  "container": "container157003454357107417"
+  "uniqueName": {
+   "container": "container157715193605304145"
+  },
+  "newDate": {}
  }
 }

--- a/sdk/storage/storage-blob/test/aborter.spec.ts
+++ b/sdk/storage/storage-blob/test/aborter.spec.ts
@@ -26,67 +26,63 @@ describe("Aborter", () => {
     recorder.stop();
   });
 
-  it("Should abort after aborter timeout", async () => {
-    recorder.skip(
-      "browser",
-      "Abort: browser testing unexpectedly finishes when a request is aborted during playback, shortcomings of `nise` library"
-    );
-    try {
-      await containerClient.create({ abortSignal: AbortController.timeout(1) });
-      assert.fail();
-    } catch (err) {
-      assert.equal(err.name, "AbortError");
-      assert.equal(err.message, "The operation was aborted.", "Unexpected error caught: " + err);
-    }
+  it("Should abort after aborter timeout", function() {
+    async () => {
+      try {
+        await containerClient.create({ abortSignal: AbortController.timeout(1) });
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.name, "AbortError");
+        assert.equal(err.message, "The operation was aborted.", "Unexpected error caught: " + err);
+      }
+    };
   });
 
   it("Should not abort after calling abort()", async () => {
     await containerClient.create({ abortSignal: AbortSignal.none });
   });
 
-  it("Should abort when calling abort() before request finishes", async () => {
-    recorder.skip(
-      "browser",
-      "Abort: browser testing unexpectedly finishes when a request is aborted during playback, shortcomings of `nise` library"
-    );
-    const aborter = new AbortController();
-    const response = containerClient.create({ abortSignal: aborter.signal });
-    aborter.abort();
-    try {
-      await response;
-      assert.fail();
-    } catch (err) {
-      assert.equal(err.name, "AbortError");
-      assert.equal(err.message, "The operation was aborted.", "Unexpected error caught: " + err);
-    }
-  });
-
-  it("Should not abort when calling abort() after request finishes", async () => {
-    const aborter = new AbortController();
-    await containerClient.create({ abortSignal: aborter.signal });
-    aborter.abort();
-  });
-
-  it("Should abort after father aborter calls abort()", async () => {
-    recorder.skip(
-      "browser",
-      "Abort: browser testing unexpectedly finishes when a request is aborted during playback, shortcomings of `nise` library"
-    );
-    try {
+  it("Should abort when calling abort() before request finishes", function() {
+    async () => {
       const aborter = new AbortController();
-      const childAborter = new AbortController(
-        aborter.signal,
-        AbortController.timeout(10 * 60 * 1000)
-      );
-      const response = containerClient.create({
-        abortSignal: childAborter.signal
-      });
+      const response = containerClient.create({ abortSignal: aborter.signal });
       aborter.abort();
-      await response;
-      assert.fail();
-    } catch (err) {
-      assert.equal(err.name, "AbortError");
-      assert.equal(err.message, "The operation was aborted.", "Unexpected error caught: " + err);
-    }
+      try {
+        await response;
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.name, "AbortError");
+        assert.equal(err.message, "The operation was aborted.", "Unexpected error caught: " + err);
+      }
+    };
+  });
+
+  it("Should not abort when calling abort() after request finishes", function() {
+    async () => {
+      const aborter = new AbortController();
+      await containerClient.create({ abortSignal: aborter.signal });
+      aborter.abort();
+    };
+  });
+
+  it("Should abort after father aborter calls abort()", function() {
+    async () => {
+      try {
+        const aborter = new AbortController();
+        const childAborter = new AbortController(
+          aborter.signal,
+          AbortController.timeout(10 * 60 * 1000)
+        );
+        const response = containerClient.create({
+          abortSignal: childAborter.signal
+        });
+        aborter.abort();
+        await response;
+        assert.fail();
+      } catch (err) {
+        assert.equal(err.name, "AbortError");
+        assert.equal(err.message, "The operation was aborted.", "Unexpected error caught: " + err);
+      }
+    };
   });
 });


### PR DESCRIPTION
## Abort signal issue with the recorder in the browser tests

### Investigation
- During playback, browser testing unexpectedly finishes when a request is aborted 
   - Suppose there are 5 consecutive tests in test-suite leveraging abort signals,  
       - the first test succeeds...
       - mocha outputs the summary...
       - and exits as if there are no other tests to be run in the test-suite. 
   -  Probably, because of the un-resolved async function [might be MOCHA drawbacks!!]
- Related issue - https://github.com/mochajs/mocha/issues/2537
   - un-resolved async function leads nowhere - No throw, no error, no next test running. 
      (I could also repro the issue with mocha in a fresh project)
   - This issue was acknowledged by the mocha team since 2016 but no one has provided a fix so far.

### Solution in this PR
- A workaround that fixes abort signal issues while playing back the browser tests.
- Wrapping the async function with a non-async function seems to fix the issue, 
   (I could record as well as playback the browser tests with abort signal)
  ![image](https://user-images.githubusercontent.com/10452642/71388768-838fd480-25ae-11ea-90f8-c10d1366a27a.png)


**Issue** - #6297