### PR TITLE
[Common Recorder] Update the recording only if the env variable is non null

### DIFF
--- a/sdk/test-utils/recorder/src/baseRecorder.ts
+++ b/sdk/test-utils/recorder/src/baseRecorder.ts
@@ -91,11 +91,13 @@ export abstract class BaseRecorder {
   protected filterSecrets(recording: string): string {
     let updatedRecording = recording;
     for (const k of Object.keys(replaceableVariables)) {
-      const escaped = escapeRegExp(env[k]);
-      updatedRecording = updatedRecording.replace(
-        new RegExp(escaped, "g"),
-        replaceableVariables[k]
-      );
+      if (env[k]) {
+        const escaped = escapeRegExp(env[k]);
+        updatedRecording = updatedRecording.replace(
+          new RegExp(escaped, "g"),
+          replaceableVariables[k]
+        );
+      }
     }
     for (const map of replacements) {
       updatedRecording = map(updatedRecording);


### PR DESCRIPTION
Found a bug that can potentially corrupt the recordings if a required environment variable is null or an empty string.

**Fix in this PR**
Update the recordings with dummy environment variables only if the corresponding actual environment variable is non-null.