### PR TITLE
Update gitattributes to mark generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,7 @@ yarn.lock                    merge=binary
 
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+# Mark recordings as auto generated
+**/recordings/**/*.js linguist-generated=true
+**/recordings/**/*.json linguist-generated=true


### PR DESCRIPTION
Generated files are collapsed by default in the diff view. This will make reviewing PRs a bit easier.