### PR TITLE
[KeyVault] Require resources in challenge based auth to be https

### DIFF
--- a/sdk/keyvault/keyvault-certificates/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/challengeBasedAuthenticationPolicy.ts
@@ -73,11 +73,6 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
         // Remove the quotations around the string
         let resource = kv[1].trim().replace(/['"]+/g, '');
 
-        // Ensure that we're about to use a secure connection
-        if (!resource.startsWith("https:")) {
-          throw new Error("The resource address for authorization must use the 'https' protocol.");
-        }
-
         return resource;
       }
     }
@@ -92,6 +87,11 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
     webResource: WebResource
   ): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
+
+    // Ensure that we're about to use a secure connection
+    if (!webResource.url.startsWith("https:")) {
+      throw new Error("The resource address for authorization must use the 'https' protocol.");
+    }
 
     let originalBody = webResource.body;
 

--- a/sdk/keyvault/keyvault-certificates/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/challengeBasedAuthenticationPolicy.ts
@@ -72,6 +72,12 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       if (kv[0].trim() == "resource") {
         // Remove the quotations around the string
         let resource = kv[1].trim().replace(/['"]+/g, '');
+
+        // Ensure that we're about to use a secure connection
+        if (!resource.startsWith("https:")) {
+          throw new Error("The resource address for authorization must use the 'https' protocol.");
+        }
+
         return resource;
       }
     }

--- a/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
@@ -73,11 +73,6 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
         // Remove the quotations around the string
         let resource = kv[1].trim().replace(/['"]+/g, '');
 
-        // Ensure that we're about to use a secure connection
-        if (!resource.startsWith("https:")) {
-          throw new Error("The resource address for authorization must use the 'https' protocol.");
-        }
-
         return resource;
       }
     }
@@ -92,6 +87,11 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
     webResource: WebResource
   ): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
+
+    // Ensure that we're about to use a secure connection
+    if (!webResource.url.startsWith("https:")) {
+      throw new Error("The resource address for authorization must use the 'https' protocol.");
+    }
 
     let originalBody = webResource.body;
 

--- a/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/challengeBasedAuthenticationPolicy.ts
@@ -72,6 +72,12 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       if (kv[0].trim() == "resource") {
         // Remove the quotations around the string
         let resource = kv[1].trim().replace(/['"]+/g, '');
+
+        // Ensure that we're about to use a secure connection
+        if (!resource.startsWith("https:")) {
+          throw new Error("The resource address for authorization must use the 'https' protocol.");
+        }
+
         return resource;
       }
     }

--- a/sdk/keyvault/keyvault-secrets/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-secrets/src/core/challengeBasedAuthenticationPolicy.ts
@@ -73,11 +73,6 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
         // Remove the quotations around the string
         let resource = kv[1].trim().replace(/['"]+/g, '');
 
-        // Ensure that we're about to use a secure connection
-        if (!resource.startsWith("https:")) {
-          throw new Error("The resource address for authorization must use the 'https' protocol.");
-        }
-
         return resource;
       }
     }
@@ -92,6 +87,11 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
     webResource: WebResource
   ): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
+
+    // Ensure that we're about to use a secure connection
+    if (!webResource.url.startsWith("https:")) {
+      throw new Error("The resource address for authorization must use the 'https' protocol.");
+    }
 
     let originalBody = webResource.body;
 

--- a/sdk/keyvault/keyvault-secrets/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-secrets/src/core/challengeBasedAuthenticationPolicy.ts
@@ -72,6 +72,12 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       if (kv[0].trim() == "resource") {
         // Remove the quotations around the string
         let resource = kv[1].trim().replace(/['"]+/g, '');
+
+        // Ensure that we're about to use a secure connection
+        if (!resource.startsWith("https:")) {
+          throw new Error("The resource address for authorization must use the 'https' protocol.");
+        }
+
         return resource;
       }
     }


### PR DESCRIPTION
Adding a check to ensure the resources we use during challenge-based auth are https resources. Throws an exception if they aren't.

@schaabs - is this close to what you had in mind?