### PR TITLE
[Service Bus] Remove unnecessary docs from function overloads

### DIFF
--- a/sdk/servicebus/service-bus/src/queueClient.ts
+++ b/sdk/servicebus/service-bus/src/queueClient.ts
@@ -129,6 +129,7 @@ export class QueueClient implements Client {
    * `sessionOptions` argument)
    */
   public createReceiver(receiveMode: ReceiveMode): Receiver;
+  
   /**
    * Creates a Receiver for receiving messages from a session enabled Queue. When no sessionId is
    * given, a random session among the available sessions is used.
@@ -154,27 +155,7 @@ export class QueueClient implements Client {
     receiveMode: ReceiveMode,
     sessionOptions: SessionReceiverOptions
   ): SessionReceiver;
-  /**
-   * Create a Receiver for receiving messages from a Queue.
-   *
-   * @param receiveMode An enum indicating the mode in which messages should be received. Possible
-   * values are `ReceiveMode.peekLock` and `ReceiveMode.receiveAndDelete`
-   * @param sessionOptions Applicable only for Queues that have sessions enabled. Use these options
-   * to provide sessionId and duration for which automatic lock renewal for should be done for the
-   * receiver.
-   *
-   * @returns Receiver|SessionReceiver A receiver to receive from a session in the Queue if
-   * `sessionOptions` were provided. Else, a receiver to receive messages from the Queue.
-   * @returns SessionReceiver A receiver to receive from a session in the Queue.
-   * @throws Error if the QueueClient or the underlying connection is closed.
-   * @throws Error if an open receiver already exists on the QueueClient and for given sessionId if creating SessionReceiver.
-   * @throws MessagingError with name `InvalidOperationError` if the Queue has sessions enabled
-   * (in which case, use the overload of this method which takes
-   * `sessionOptions` argument)
-   * @throws MessagingError with name `SessionCannotBeLockedError` if the Queue does not have sessions enabled (in which
-   * case do not pass the `sessionOptions` argument) or if Service Bus is not able to get a lock on
-   * the session (in which case try again after some time)
-   */
+
   public createReceiver(
     receiveMode: ReceiveMode,
     sessionOptions?: SessionReceiverOptions

--- a/sdk/servicebus/service-bus/src/subscriptionClient.ts
+++ b/sdk/servicebus/service-bus/src/subscriptionClient.ts
@@ -128,6 +128,7 @@ export class SubscriptionClient implements Client {
    * `sessionOptions` argument)
    */
   public createReceiver(receiveMode: ReceiveMode): Receiver;
+  
   /**
    * Creates a Receiver for receiving messages from a session enabled Subscription. When no sessionId is
    * given, a random session among the available sessions is used.
@@ -152,26 +153,7 @@ export class SubscriptionClient implements Client {
     receiveMode: ReceiveMode,
     sessionOptions: SessionReceiverOptions
   ): SessionReceiver;
-  /**
-   * Create a Receiver for receiving messages from a Subscription.
-   *
-   * @param receiveMode An enum indicating the mode in which messages should be received. Possible
-   * values are `ReceiveMode.peekLock` and `ReceiveMode.receiveAndDelete`
-   * @param sessionOptions Applicable only for Subscriptions that have sessions enabled. Use these options
-   * to provide sessionId and duration for which automatic lock renewal for should be done for the
-   * receiver.
-   *
-   * @returns Receiver|SessionReceiver A receiver to receive from a session in the Subscription if
-   * `sessionOptions` were provided. Else, a receiver to receive messages from the Subscription.
-   * @throws Error if the SubscriptionClient or the underlying connection is closed.
-   * @throws Error if an open receiver already exists on the SubscriptionClient and for given sessionId if creating SessionReceiver.
-   * @throws MessagingError with name `InvalidOperationError` if the Queue has sessions enabled
-   * (in which case, use the overload of this method which takes
-   * `sessionOptions` argument)
-   * @throws MessagingError with name `SessionCannotBeLockedError` if the Queue does not have sessions enabled (in which
-   * case do not pass the `sessionOptions` argument) or if Service Bus is not able to get a lock on
-   * the session (in which case try again after some time)
-   */
+
   public createReceiver(
     receiveMode: ReceiveMode,
     sessionOptions?: SessionReceiverOptions


### PR DESCRIPTION
For more context refer to #6136 

Verified output using typedocs command `typedoc --excludePrivate --excludeNotExported --exclude "node_modules/**/*" --ignoreCompilerErrors --mode file --out ./docs ./src`