### PR TITLE
[samples] Removed module.exports from js samples

### DIFF
--- a/common/scripts/prep-samples.js
+++ b/common/scripts/prep-samples.js
@@ -130,7 +130,7 @@ async function enableLocalRun(fileName, baseDir, pkgName) {
   // Remove trailing call to main()
   const updatedContents = importRenamedContents.replace(
     new RegExp("main\\(\\)\\.catch.*", "s"),
-    ""
+    isTs ? "" : "module.exports = { main };\n"
   );
 
   console.log("[prep-samples] Updating imports in", fileName);

--- a/sdk/appconfiguration/app-configuration/samples/javascript/getSettingOnlyIfChanged.js
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/getSettingOnlyIfChanged.js
@@ -53,8 +53,6 @@ async function cleanupSampleValues(keys, client) {
   }
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Failed to run sample:", error);
 });

--- a/sdk/appconfiguration/app-configuration/samples/javascript/helloworld.js
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/helloworld.js
@@ -49,8 +49,6 @@ async function cleanupSampleValues(keys, client) {
   }
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Failed to run sample:", error);
 });

--- a/sdk/appconfiguration/app-configuration/samples/javascript/helloworldWithLabels.js
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/helloworldWithLabels.js
@@ -60,8 +60,6 @@ async function cleanupSampleValues(keys, client) {
   }
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Failed to run sample:", error);
 });

--- a/sdk/appconfiguration/app-configuration/samples/javascript/listRevisions.js
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/listRevisions.js
@@ -59,8 +59,6 @@ async function cleanupSampleValues(keys, client) {
   }
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Failed to run sample:", error);
 });

--- a/sdk/appconfiguration/app-configuration/samples/javascript/optimisticConcurrencyViaEtag.js
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/optimisticConcurrencyViaEtag.js
@@ -120,8 +120,6 @@ async function cleanupSampleValues(keys, client) {
   }
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Failed to run sample:", error);
 });

--- a/sdk/appconfiguration/app-configuration/samples/javascript/setReadOnlySample.js
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/setReadOnlySample.js
@@ -70,8 +70,6 @@ async function cleanupSampleValues(keys, client) {
   }
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Failed to run sample:", error);
 });

--- a/sdk/eventhub/event-hubs/samples/javascript/receiveEvents.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/receiveEvents.js
@@ -48,8 +48,6 @@ async function main() {
   }, 30 * 1000);
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Error running sample:", error);
 });

--- a/sdk/eventhub/event-hubs/samples/javascript/receiveEventsUsingCheckpointStore.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/receiveEventsUsingCheckpointStore.js
@@ -84,8 +84,6 @@ async function main() {
   }, 30 * 1000);
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Error running sample:", error);
 });

--- a/sdk/eventhub/event-hubs/samples/javascript/sendEvents.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/sendEvents.js
@@ -107,8 +107,6 @@ async function main() {
   console.log(`Exiting sendEvents sample`);
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Error running sample:", error);
 });

--- a/sdk/eventhub/event-hubs/samples/javascript/useWithIotHub.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/useWithIotHub.js
@@ -30,8 +30,6 @@ async function main() {
   console.log(`Exiting useWithIotHub sample`);
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Error running sample:", error);
 });

--- a/sdk/eventhub/event-hubs/samples/javascript/usingAadAuth.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/usingAadAuth.js
@@ -57,8 +57,6 @@ async function main() {
   console.log(`Exiting usingAadAuth sample`);
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Error running sample:", error);
 });

--- a/sdk/eventhub/event-hubs/samples/javascript/websockets.js
+++ b/sdk/eventhub/event-hubs/samples/javascript/websockets.js
@@ -53,8 +53,6 @@ async function main() {
   console.log(`Exiting websockets sample`);
 }
 
-module.exports = { main };
-
 main().catch((error) => {
   console.error("Error running sample:", error);
 });

--- a/sdk/storage/storage-blob/samples/javascript/advanced.js
+++ b/sdk/storage/storage-blob/samples/javascript/advanced.js
@@ -133,8 +133,6 @@ async function main() {
   console.log("deleted container");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/anonymousCred.js
+++ b/sdk/storage/storage-blob/samples/javascript/anonymousCred.js
@@ -43,8 +43,6 @@ async function main() {
   console.log("deleted container");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/azureAdAuth.js
+++ b/sdk/storage/storage-blob/samples/javascript/azureAdAuth.js
@@ -69,8 +69,6 @@ async function main() {
   console.log(`Created container ${containerName} successfully`, createContainerResponse.requestId);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/basic.js
+++ b/sdk/storage/storage-blob/samples/javascript/basic.js
@@ -99,8 +99,6 @@ async function streamToString(readableStream) {
   });
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/customPipeline.js
+++ b/sdk/storage/storage-blob/samples/javascript/customPipeline.js
@@ -54,8 +54,6 @@ async function main() {
   console.log("deleted container");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/customizedClientHeaders.js
+++ b/sdk/storage/storage-blob/samples/javascript/customizedClientHeaders.js
@@ -86,8 +86,6 @@ async function main() {
   console.log(response._response.request.headers.get("x-ms-client-request-id"));
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/errorsAndResponses.js
+++ b/sdk/storage/storage-blob/samples/javascript/errorsAndResponses.js
@@ -151,8 +151,6 @@ async function streamToString(readableStream) {
   });
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/iterators-blobs-hierarchy.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-blobs-hierarchy.js
@@ -136,8 +136,6 @@ async function main() {
   console.log("deleted container");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-blobs.js
@@ -125,8 +125,6 @@ async function main() {
   console.log("deleted container");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/iterators-containers.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-containers.js
@@ -117,8 +117,6 @@ async function main() {
   }
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/iterators-without-await.js
+++ b/sdk/storage/storage-blob/samples/javascript/iterators-without-await.js
@@ -55,8 +55,6 @@ async function main() {
   asyncIter.next().then(printBlob);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.log(err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-blob/samples/javascript/proxyAuth.js
@@ -51,8 +51,6 @@ async function main() {
   console.log(`Created container ${containerName} successfully`, createContainerResponse.requestId);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/readingSnapshot.js
+++ b/sdk/storage/storage-blob/samples/javascript/readingSnapshot.js
@@ -86,8 +86,6 @@ async function streamToString(readableStream) {
   });
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/sharedKeyCred.js
+++ b/sdk/storage/storage-blob/samples/javascript/sharedKeyCred.js
@@ -43,8 +43,6 @@ async function main() {
   console.log("deleted container");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-blob/samples/javascript/withConnString.js
+++ b/sdk/storage/storage-blob/samples/javascript/withConnString.js
@@ -36,8 +36,6 @@ async function main() {
   console.log("deleted container");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/advanced.js
+++ b/sdk/storage/storage-file-share/samples/javascript/advanced.js
@@ -106,8 +106,6 @@ async function main() {
   console.log("deleted share");
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/anonymousCred.js
+++ b/sdk/storage/storage-file-share/samples/javascript/anonymousCred.js
@@ -42,8 +42,6 @@ async function main() {
   console.log(`deleted share ${shareName}`);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/basic.js
+++ b/sdk/storage/storage-file-share/samples/javascript/basic.js
@@ -97,8 +97,6 @@ async function streamToString(readableStream) {
   });
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/customPipeline.js
+++ b/sdk/storage/storage-file-share/samples/javascript/customPipeline.js
@@ -53,8 +53,6 @@ async function main() {
   console.log(`deleted share ${shareName}`);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/iterators-files-and-directories.js
+++ b/sdk/storage/storage-file-share/samples/javascript/iterators-files-and-directories.js
@@ -163,8 +163,6 @@ async function main() {
   console.log(`deleted share ${shareName}`);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/iterators-handles.js
+++ b/sdk/storage/storage-file-share/samples/javascript/iterators-handles.js
@@ -163,8 +163,6 @@ async function main() {
   }
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/iterators-shares.js
+++ b/sdk/storage/storage-file-share/samples/javascript/iterators-shares.js
@@ -108,8 +108,6 @@ async function main() {
   }
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-file-share/samples/javascript/proxyAuth.js
@@ -54,8 +54,6 @@ async function main() {
   console.log(`deleted share ${shareName}`);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/sharedKeyCred.js
+++ b/sdk/storage/storage-file-share/samples/javascript/sharedKeyCred.js
@@ -42,8 +42,6 @@ async function main() {
   console.log(`deleted share ${shareName}`);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-file-share/samples/javascript/withConnString.js
+++ b/sdk/storage/storage-file-share/samples/javascript/withConnString.js
@@ -35,8 +35,6 @@ async function main() {
   console.log(`deleted share ${shareName}`);
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/anonymousCred.js
+++ b/sdk/storage/storage-queue/samples/javascript/anonymousCred.js
@@ -39,8 +39,6 @@ async function main() {
   );
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/azureAdAuth.js
+++ b/sdk/storage/storage-queue/samples/javascript/azureAdAuth.js
@@ -68,8 +68,6 @@ async function main() {
   }
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/basic.js
+++ b/sdk/storage/storage-queue/samples/javascript/basic.js
@@ -93,8 +93,6 @@ async function main() {
   );
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/customPipeline.js
+++ b/sdk/storage/storage-queue/samples/javascript/customPipeline.js
@@ -59,8 +59,6 @@ async function main() {
   );
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/iterators.js
+++ b/sdk/storage/storage-queue/samples/javascript/iterators.js
@@ -112,8 +112,6 @@ async function main() {
   }
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/proxyAuth.js
+++ b/sdk/storage/storage-queue/samples/javascript/proxyAuth.js
@@ -58,8 +58,6 @@ async function main() {
   );
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/sharedKeyCred.js
+++ b/sdk/storage/storage-queue/samples/javascript/sharedKeyCred.js
@@ -39,8 +39,6 @@ async function main() {
   );
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });

--- a/sdk/storage/storage-queue/samples/javascript/withConnString.js
+++ b/sdk/storage/storage-queue/samples/javascript/withConnString.js
@@ -33,8 +33,6 @@ async function main() {
   );
 }
 
-module.exports = { main };
-
 main().catch((err) => {
   console.error("Error running sample:", err.message);
 });


### PR DESCRIPTION
Does what the title says.

The prep-samples script now adds the module.exports line when it removes the call to main(), and so we don't need to check that in anymore.