### PR TITLE
[event-hubs] Updates subscribe recovery to be more robust

### DIFF
--- a/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
+++ b/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
@@ -28,7 +28,7 @@ export interface PartitionLoadBalancer {
  * This class does no load balancing - it's intended to be used when
  * you want to avoid load balancing and consume a set of partitions (or all
  * available partitions)
- * @intenal
+ * @internal
  * @ignore
  */
 export class GreedyPartitionLoadBalancer implements PartitionLoadBalancer {
@@ -71,7 +71,7 @@ export class GreedyPartitionLoadBalancer implements PartitionLoadBalancer {
  * partition ownership entry has not be updated for a specified duration of time, the owner of that partition is
  * considered inactive and the partition is available for other EventProcessors to own.
  * @class PartitionLoadBalancer
- * @intenal
+ * @internal
  * @ignore
  */
 export class FairPartitionLoadBalancer implements PartitionLoadBalancer {

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -19,7 +19,7 @@ export interface PumpManager {
   /**
    * Creates and starts a PartitionPump.
    * @param startPosition The position in the partition to start reading from.
-   * @param eventHubClient The EventHubClient to forward to the PartitionPump.   
+   * @param eventHubClient The EventHubClient to forward to the PartitionPump.
    * @param partitionProcessor The PartitionProcessor to forward to the PartitionPump.
    * @param abortSignal Used to cancel pump creation.
    * @ignore
@@ -29,6 +29,14 @@ export interface PumpManager {
     eventHubClient: EventHubClient,
     partitionProcessor: PartitionProcessor
   ): Promise<void>;
+
+  /**
+   * Indicates whether the pump manager is actively receiving events from a given partition.
+   * @param partitionId The partition to check.
+   * @ignore
+   * @internal
+   */
+  isReceivingFromPartition(partitionId: string): boolean;
 
   /**
    * Stops all PartitionPumps and removes them from the internal map.
@@ -69,6 +77,17 @@ export class PumpManagerImpl implements PumpManager {
       const pump = this._partitionIdToPumps[id];
       return Boolean(pump && pump.isReceiving);
     });
+  }
+
+  /**
+   * Indicates whether the pump manager is actively receiving events from a given partition.
+   * @param partitionId
+   * @ignore
+   * @internal
+   */
+  public isReceivingFromPartition(partitionId: string): boolean {
+    const pump = this._partitionIdToPumps[partitionId];
+    return Boolean(pump && pump.isReceiving);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
+++ b/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { delay } from "@azure/core-amqp";
+import { AbortSignalLike } from "@azure/abort-controller";
+
+/**
+ * @param delayInMs The number of milliseconds to be delayed.
+ * @param abortSignal The abortSignal associated with the containing operation.
+ * @internal
+ * @ignore
+ */
+export async function delayWithoutThrow(
+  delayInMs: number,
+  abortSignal?: AbortSignalLike
+): Promise<void> {
+  try {
+    await delay(delayInMs, abortSignal);
+  } catch {} // swallow AbortError
+}

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -710,7 +710,6 @@ describe("Event Processor", function(): void {
     // start it again
     loggerForTest(`Starting processor again`);
     subscriptionEventHandler.clear();
-    partitionLoadBalancer.expireAll();
 
     processor.start();
 

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -122,10 +122,7 @@ describe("Event Processor", function(): void {
       });
 
       it("using a single default event position for any partition", async () => {
-        const processor = createEventProcessor(
-          emptyCheckpointStore,
-          { offset: 1009 }
-        );
+        const processor = createEventProcessor(emptyCheckpointStore, { offset: 1009 });
 
         let eventPosition = await processor["_getStartingPosition"]("0");
         eventPosition!.offset!.should.equal(1009);
@@ -280,7 +277,11 @@ describe("Event Processor", function(): void {
           pumpManager.createPumpCalled = true;
         },
 
-        async removeAllPumps() {}
+        async removeAllPumps() {},
+
+        isReceivingFromPartition() {
+          return false;
+        }
       };
 
       const eventProcessor = new EventProcessor(
@@ -355,7 +356,10 @@ describe("Event Processor", function(): void {
           maxWaitTimeInSeconds: 1,
           pumpManager: {
             async createPump() {},
-            async removeAllPumps(): Promise<void> {}
+            async removeAllPumps(): Promise<void> {},
+            isReceivingFromPartition() {
+              return false;
+            }
           }
         }
       );

--- a/sdk/eventhub/event-hubs/test/loadBalancer.spec.ts
+++ b/sdk/eventhub/event-hubs/test/loadBalancer.spec.ts
@@ -22,7 +22,7 @@ describe("PartitionLoadBalancer", () => {
       m.should.be.empty;
     });
 
-    it("don't claim partitions we already own", () => {
+    it("claim partitions we already own", () => {
       const m = new Map<string, PartitionOwnership>();
 
       m.set("1", {
@@ -39,15 +39,15 @@ describe("PartitionLoadBalancer", () => {
         consumerGroup: "",
         fullyQualifiedNamespace: "",
         eventHubName: "",
-        // owned by someone else - we'll steal this 
+        // owned by someone else - we'll steal this
         // partition
         ownerId: "someOtherOwnerId",
         partitionId: ""
-      })
+      });
 
       const lb = new GreedyPartitionLoadBalancer(["1", "2", "3"]);
 
-      lb.loadBalance("ownerId", m, ["1", "2", "3"]).should.deep.eq(["2", "3"]);
+      lb.loadBalance("ownerId", m, ["1", "2", "3"]).should.deep.eq(["1", "2", "3"]);
     });
   });
 });


### PR DESCRIPTION
This PR is meant to fix a few issues found while doing some manual testing.

1. [x] consumerClient.subscribe with a single partition should recover until explicitly stopped.
2. [x] Errors related to load-balancing should honor the event processor loop delay. Currently, network connection errors will cause the event processor loop to iterate very quickly without the 10 second delay.
3. [x] When `processClose` is called, the partition should be considered abandoned so it can be reclaimed on the next loop iteration. This currently works when a CheckpointStore is provided, but does not otherwise when reading from all partitions.
4. [x] Swallow errors thrown from user's error handler. Without this, errors could lead to uncaught promise warnings.

~~I still need to tackle the 3rd item as it's a bit more complicated than I originally thought. I can put this in a separate PR if that's preferred.~~
I updated the GreedyLoadBalancer to return the partitions that are already owned by the EventProcessor so they can be reclaimed. We already do this with the FairLoadBalancer (used when the user passes in a checkpointstore). I think when we updated the FairLoadBalancer to reclaim partitions that we already owned, we missed updating GreedyLoadBalancer to do the same.