### PR TITLE
[Event Hubs] Include MessagingError in processError signature

### DIFF
--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -196,7 +196,7 @@ export interface PartitionProperties {
 export type ProcessCloseHandler = (reason: CloseReason, context: PartitionContext) => Promise<void>;
 
 // @public
-export type ProcessErrorHandler = (error: Error, context: PartitionContext) => Promise<void>;
+export type ProcessErrorHandler = (error: Error | MessagingError, context: PartitionContext) => Promise<void>;
 
 // @public
 export type ProcessEventsHandler = (events: ReceivedEventData[], context: PartitionContext) => Promise<void>;

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -3,6 +3,7 @@ import { ReceivedEventData } from "./eventData";
 import { LastEnqueuedEventProperties } from "./eventHubReceiver";
 import { EventPosition } from "./eventPosition";
 import { TracingOptions } from "./util/operationOptions";
+import { MessagingError } from '@azure/core-amqp';
 
 /**
  * @internal
@@ -81,7 +82,7 @@ export type ProcessEventsHandler = (
 /**
  * Called when errors occur during event receiving.
  */
-export type ProcessErrorHandler = (error: Error, context: PartitionContext) => Promise<void>;
+export type ProcessErrorHandler = (error: Error | MessagingError, context: PartitionContext) => Promise<void>;
 
 /**
  * Called when we first start processing events from a partition.


### PR DESCRIPTION
This PR adds `MessagingError` to the type supported by the error argument taken by the user provided `processError` callback.
This will help in typing when user wants to deal with the messaging error via its `code`