### PR TITLE
[Event Hubs] Update API reference docs, changelog & migration guide

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -13,8 +13,8 @@
   the `processInitialize()` callback.
   - The `MessagingError` class is updated to have the `code` property instead of `name` to contain the error
   type that the user can use to differentiate errors that can occur during communication with the service.
-  The `name` property of this class will always have the value "MessagingError" and will not change on the error
-  type.
+  The `name` property of this class will always have the value "MessagingError" and will not change based
+  on the error type.
   - System errors around network issues like ENOTFOUND, ECONNREFUSED will retain their `code` value even after
   getting converted to a `MessagingError` object and being passed to the user.
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -7,6 +7,18 @@
 - Updated to use the latest version of the `@azure/core-amqp` package.
   This update allows the SDK to detect when a connection has gone idle for 60 seconds and attempt to reconnect.
 
+
+### Breaking changes:
+  - Starting event positions are now passed in the `options` to the `subscribe()` method instead of using 
+  the `processInitialize()` callback.
+  - The `MessagingError` class is updated to have the `code` property instead of `name` to contain the error
+  type that the user can use to differentiate errors that can occur during communication with the service.
+  The `name` property of this class will always have the value "MessagingError" and will not change on the error
+  type.
+  - System errors around network issues like ENOTFOUND, ECONNREFUSED will retain their `code` value even after
+  getting converted to a `MessagingError` object and being passed to the user.
+
+
 ## 5.0.0-preview.7 (2019-12-03)
 
 - Improves load-balancing capabilities to reduce the frequency that partitions are claimed by other running
@@ -14,7 +26,7 @@
   ([PR #6294](https://github.com/Azure/azure-sdk-for-js/pull/6294))
 - Updated to use OpenTelemetry 0.2 via `@azure/core-tracing`
 
-Breaking changes:
+### Breaking changes:
 
 - CheckpointStore and consumer group are now passed to the EventHubConsumerClient
   constructor rather than being passed to subscribe().

--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -30,7 +30,7 @@ point of entry for receiving of any type (from single partition, all partitions,
 Other noteworthy changes:
 - In v5, the `EventHubConsumerClient` class takes the consumer group name as a mandatory argument in its constructor.
 If you havent created any consumer groups explicitly, then use the name of the default consumer group which is `$Default`.
-- For checkpoint store implementation using Azure Storage Blobs, use the 
+- For a checkpoint store implementation using Azure Storage Blobs, use the 
 [@azure/eventhubs-checkpointstore-blob](https://www.npmjs.com/package/@azure/eventhubs-checkpointstore-blob) package.
 
 ### Receiving events 
@@ -42,7 +42,7 @@ If you havent created any consumer groups explicitly, then use the name of the d
 Other noteworthy changes:
 - Use the `options` parameter to the `subscribe()` method to specify starting position to receive events from.
 - The `subscribe()` method allows you to receive events in batches whose size can be configured using the `options` parameter.
-- The user provided function to process events will be invoked only after the previous invocation completes.
+- The user provided `processEvents` function to process events will be invoked only after the previous invocation completes.
 This is different from v2 where the function was invoked for each event without waiting for the previous call to complete.
 
 ### Sending events

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -190,9 +190,16 @@ export function toAmqpMessage(data: EventData, partitionKey?: string): Message {
 }
 
 /**
- * `EventData` is the interface that describes the event data to be sent to Event Hub.
- * A simple instance can be `{ body: "your-data" }`.
- * @interface
+ * The interface that describes the data to be sent to Event Hub.
+ * Use this as a reference when creating the object to be sent when using the `EventHubProducerClient`.
+ * For example, `{ body: "your-data" }` or 
+ * ```
+ * {
+ *    body: "your-data",
+ *    properties: {
+ *       propertyName: "property value"
+ *    }
+ * }
  */
 export interface EventData {
   /**
@@ -208,7 +215,9 @@ export interface EventData {
 }
 
 /**
- * Describes the structure of an event received from Event Hub.
+ * The interface that describes the structure of the event received from Event Hub.
+ * Use this as a reference when creating the `processEvents` function to process the events
+ * recieved from an Event Hub when using the `EventHubConsumerClient`.
  */
 export interface ReceivedEventData {
   /**

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -78,7 +78,8 @@ export interface EventDataBatch {
 
   /**
    * The maximum size of the batch, in bytes. The `tryAdd` function on the batch will return `false`
-   * after the size of the batch reaches this limit.
+   * after the size of the batch reaches this limit. Use the `createBatch()` method on
+   * the `EventHubProducerClient` to set the maxSizeInBytes.
    * @readonly.
    */
   readonly maxSizeInBytes: number;

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -78,7 +78,7 @@ export interface EventDataBatch {
 
   /**
    * The maximum size of the batch, in bytes. The `tryAdd` function on the batch will return `false`
-   * after the size of the batch reaches this limit. Use the `createBatch()` method on
+   * if the event being added causes the size of the batch to exceed this limit. Use the `createBatch()` method on
    * the `EventHubProducerClient` to set the maxSizeInBytes.
    * @readonly.
    */

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -36,7 +36,7 @@ export interface TryAddOptions {
 }
 
 /**
- * A interface representing a batch of events which can be used to send events to Event Hub.
+ * An interface representing a batch of events which can be used to send events to Event Hub.
  * 
  * To create the batch, use the `createBatch()` method on the `EventHubProducerClient`.
  * To send the batch, use the `sendBatch()` method on the same client.

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -85,8 +85,8 @@ export class EventHubConsumerClient {
 
   /**
    * @constructor
-   * The `EventHubConsumerClient` is the main point of interaction for consuming events from an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hub instance.
    * It is expected that the shared key properties and the Event Hub path are contained in this connection string.
@@ -100,8 +100,8 @@ export class EventHubConsumerClient {
   constructor(consumerGroup: string, connectionString: string, options?: EventHubClientOptions); // #1
   /**
    * @constructor
-   * The `EventHubConsumerClient` is the main point of interaction for consuming events from an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hub instance.
    * It is expected that the shared key properties and the Event Hub path are contained in this connection string.
@@ -123,8 +123,8 @@ export class EventHubConsumerClient {
   ); // #1.1
   /**
    * @constructor
-   * The `EventHubConsumerClient` is the main point of interaction for consuming events from an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hubs namespace.
    * It is expected that the shared key properties are contained in this connection string, but not the Event Hub path,
@@ -144,8 +144,8 @@ export class EventHubConsumerClient {
   ); // #2
   /**
    * @constructor
-   * The `EventHubConsumerClient` is the main point of interaction for consuming events from an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
    * @param connectionString - The connection string to use for connecting to the Event Hubs namespace.
    * It is expected that the shared key properties are contained in this connection string, but not the Event Hub path,
@@ -169,8 +169,8 @@ export class EventHubConsumerClient {
   ); // #2.1
   /**
    * @constructor
-   * The `EventHubConsumerClient` is the main point of interaction for consuming events from an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
    * @param fullyQualifiedNamespace - The full namespace which is likely to be similar to
    * <yournamespace>.servicebus.windows.net
@@ -192,8 +192,8 @@ export class EventHubConsumerClient {
   ); // #3
   /**
    * @constructor
-   * The `EventHubConsumerClient` is the main point of interaction for consuming events from an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubConsumerClient` class is used to consume events from an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param consumerGroup The name of the consumer group from which you want to process events.
    * @param fullyQualifiedNamespace - The full namespace which is likely to be similar to
    * <yournamespace>.servicebus.windows.net

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -96,7 +96,7 @@ export type ProcessErrorHandler = (
 export type ProcessInitializeHandler = (context: PartitionContext) => Promise<void>;
 
 /**
- * Signature of the user provided function invoked by `EventHubConsumerClient` just before stopping to receive
+ * Signature of the user provided function invoked by `EventHubConsumerClient` just after stopping to receive
  * events from a partition.
  */
 export type ProcessCloseHandler = (reason: CloseReason, context: PartitionContext) => Promise<void>;

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -32,7 +32,7 @@ export interface BasicPartitionProperties {
 /**
  * Interface that describes the context passed to each of the functions that are a part
  * of the `SubscriptionEventHandlers`. When implementing any of these functions, use
- * the context object to get a set of basic information about the partition as well as the
+ * the context object to get information about the partition as well as the
  * ability to checkpoint.
  */
 export interface PartitionContext {
@@ -73,7 +73,7 @@ export interface PartitionContext {
 }
 
 /**
- * Signature of the user provided function invoked by `EventHubConsumerClient` as and when a set of events is received.
+ * Signature of the user provided function invoked by `EventHubConsumerClient` when a set of events is received.
  */
 export type ProcessEventsHandler = (
   events: ReceivedEventData[],
@@ -108,7 +108,7 @@ export type ProcessCloseHandler = (reason: CloseReason, context: PartitionContex
  */
 export interface SubscriptionEventHandlers {
   /**
-   * The function invoked by `EventHubConsumerClient` as and when a set of events is received.
+   * The function invoked by `EventHubConsumerClient` when a set of events is received.
    */
   processEvents: ProcessEventsHandler;
   /**
@@ -118,13 +118,13 @@ export interface SubscriptionEventHandlers {
   processError: ProcessErrorHandler;
   /**
    * The function invoked by `EventHubConsumerClient` just before starting to receive events from
-   * a partition. Use this to carry out any set up tasks you would like to have before the client
+   * a partition. Use this to carry out any setup tasks you would like to have before the client
    * starts processing a partition.
    */
   processInitialize?: ProcessInitializeHandler;
   /**
    * The function invoked by `EventHubConsumerClient` just before stopping to receive events from
-   * a partition. Use this to carry out any tear down tasks you would like to have for the partition.
+   * a partition. Use this to carry out any teardown tasks you would like to have for the partition.
    */
   processClose?: ProcessCloseHandler;
 }

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -3,7 +3,7 @@ import { ReceivedEventData } from "./eventData";
 import { LastEnqueuedEventProperties } from "./eventHubReceiver";
 import { EventPosition } from "./eventPosition";
 import { TracingOptions } from "./util/operationOptions";
-import { MessagingError } from '@azure/core-amqp';
+import { MessagingError } from "@azure/core-amqp";
 
 /**
  * @internal
@@ -30,7 +30,9 @@ export interface BasicPartitionProperties {
 }
 
 /**
- * Provides a set of basic information about the partition as well as the
+ * Interface that describes the context passed to each of the functions that are a part
+ * of the `SubscriptionEventHandlers`. When implementing any of these functions, use
+ * the context object to get a set of basic information about the partition as well as the
  * ability to checkpoint.
  */
 export interface PartitionContext {
@@ -71,8 +73,7 @@ export interface PartitionContext {
 }
 
 /**
- * Event handler called when events are received. The `context` parameter can be
- * used to get partition information as well as to checkpoint.
+ * Signature of the user provided function invoked by `EventHubConsumerClient` as and when a set of events is received.
  */
 export type ProcessEventsHandler = (
   events: ReceivedEventData[],
@@ -80,61 +81,59 @@ export type ProcessEventsHandler = (
 ) => Promise<void>;
 
 /**
- * Called when errors occur during event receiving.
+ * Signature of the user provided function invoked by `EventHubConsumerClient` for errors that occur when
+ * receiving events or when executing any of the user provided functions passed to the `subscribe()` method.
  */
-export type ProcessErrorHandler = (error: Error | MessagingError, context: PartitionContext) => Promise<void>;
+export type ProcessErrorHandler = (
+  error: Error | MessagingError,
+  context: PartitionContext
+) => Promise<void>;
 
 /**
- * Called when we first start processing events from a partition.
+ * Signature of the user provided function invoked by `EventHubConsumerClient` just before starting to receive 
+ * events from a partition.
  */
 export type ProcessInitializeHandler = (context: PartitionContext) => Promise<void>;
 
 /**
- * Called when we stop processing events from a partition.
+ * Signature of the user provided function invoked by `EventHubConsumerClient` just before stopping to receive
+ * events from a partition.
  */
 export type ProcessCloseHandler = (reason: CloseReason, context: PartitionContext) => Promise<void>;
 
 /**
- * Optional event handlers that provide more context when subscribing to events.
+ * Interface that describes the functions to be implemented by the user which are invoked by
+ * the `EventHubConsumerClient` when the `subscribe()` method is called to receive events
+ * from Event Hub.
  */
 export interface SubscriptionEventHandlers {
   /**
-   * Event handler called when events are received.
+   * The function invoked by `EventHubConsumerClient` as and when a set of events is received.
    */
   processEvents: ProcessEventsHandler;
   /**
-   * Called when errors occur during event receiving.
+   * The function invoked by `EventHubConsumerClient` for errors that occur when receiving events
+   * or when executing any of the user provided functions passed to the `subscribe()` method.
    */
   processError: ProcessErrorHandler;
   /**
-   * Called when we first start processing events from a partition.
+   * The function invoked by `EventHubConsumerClient` just before starting to receive events from
+   * a partition. Use this to carry out any set up tasks you would like to have before the client
+   * starts processing a partition.
    */
   processInitialize?: ProcessInitializeHandler;
   /**
-   * Called when we stop processing events from a partition.
+   * The function invoked by `EventHubConsumerClient` just before stopping to receive events from
+   * a partition. Use this to carry out any tear down tasks you would like to have for the partition.
    */
   processClose?: ProcessCloseHandler;
 }
 
 /**
- * Options for subscribe.
+ * Options to configure the `subscribe` method on the `EventHubConsumerClient`.
+ * For example, `{ maxBatchSize: 20, maxWaitTimeInSeconds: 120, startPosition: { sequenceNumber: 123 } }
  */
 export interface SubscribeOptions extends TracingOptions {
-  /**
-   * @property
-   * Indicates whether or not the consumer should request information on the last enqueued event on its
-   * associated partition, and track that information as events are received.
-
-   * When information about the partition's last enqueued event is being tracked, each event received 
-   * from the Event Hubs service will carry metadata about the partition that it otherwise would not. This results in a small amount of
-   * additional network bandwidth consumption that is generally a favorable trade-off when considered
-   * against periodically making requests for partition properties using the Event Hub client.
-   */
-  trackLastEnqueuedEventProperties?: boolean;
-  /**
-   * The owner level to use as this subscription subscribes to partitions.
-   */
-  ownerLevel?: number;
   /**
    * The number of events to request per batch
    */
@@ -150,10 +149,25 @@ export interface SubscribeOptions extends TracingOptions {
    * position for each partition.
    */
   startPosition?: EventPosition | { [partitionId: string]: EventPosition };
+  /**
+   * @property
+   * Indicates whether or not the consumer should request information on the last enqueued event on its
+   * associated partition, and track that information as events are received.
+
+   * When information about the partition's last enqueued event is being tracked, each event received 
+   * from the Event Hubs service will carry metadata about the partition that it otherwise would not. This results in a small amount of
+   * additional network bandwidth consumption that is generally a favorable trade-off when considered
+   * against periodically making requests for partition properties using the Event Hub client.
+   */
+  trackLastEnqueuedEventProperties?: boolean;
+  /**
+   * The owner level to use as this subscription subscribes to partitions.
+   */
+  ownerLevel?: number;
 }
 
 /**
- * Represents the status of a subscribe() call and can be used to stop a subscription.
+ * Interface that describes the object returned by the `subscribe()` method on the `EventHubConsumerClient`.
  */
 export interface Subscription {
   /**

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -53,8 +53,8 @@ export class EventHubProducerClient {
 
   /**
    * @constructor
-   * The `EventHubProducerClient` is the main point of interaction for sending events to an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubProducerClient` class is used to send events to an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param connectionString - The connection string to use for connecting to the Event Hub instance.
    * It is expected that the shared key properties and the Event Hub path are contained in this connection string.
    * e.g. 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;EntityPath=my-event-hub-name'.
@@ -67,8 +67,8 @@ export class EventHubProducerClient {
   constructor(connectionString: string, options?: EventHubClientOptions);
   /**
    * @constructor
-   * The `EventHubProducerClient` is the main point of interaction for sending events to an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubProducerClient` class is used to send events to an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param connectionString - The connection string to use for connecting to the Event Hubs namespace.
    * It is expected that the shared key properties are contained in this connection string, but not the Event Hub path,
    * e.g. 'Endpoint=sb://my-servicebus-namespace.servicebus.windows.net/;SharedAccessKeyName=my-SA-name;SharedAccessKey=my-SA-key;'.
@@ -82,8 +82,8 @@ export class EventHubProducerClient {
   constructor(connectionString: string, eventHubName: string, options?: EventHubClientOptions);
   /**
    * @constructor
-   * The `EventHubProducerClient` is the main point of interaction for sending events to an
-   * Event Hub instance. Use the `options` parmeter to configure retry policy or proxy settings.
+   * The `EventHubProducerClient` class is used to send events to an Event Hub.
+   * Use the `options` parmeter to configure retry policy or proxy settings.
    * @param fullyQualifiedNamespace - The full namespace which is likely to be similar to
    * <yournamespace>.servicebus.windows.net
    * @param eventHubName - The name of the specific Event Hub to connect the client to.

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -14,8 +14,8 @@ import { EventPosition, latestEventPosition } from "./eventPosition";
 import { delayWithoutThrow } from "./util/delayWithoutThrow";
 
 /**
- * An enum representing the different reasons for an `EventProcessor` to stop processing
- * events from a partition in a consumer group of an Event Hub instance.
+ * An enum representing the different reasons for an `EventHubConsumerClient` to stop processing
+ * events from a partition in a consumer group of an Event Hub.
  */
 export enum CloseReason {
   /**
@@ -72,11 +72,9 @@ export interface PartitionOwnership {
  *
  * Users are not meant to implement an `CheckpointStore`.
  * Users are expected to choose existing implementations of this interface, instantiate it, and pass
- * it to the constructor of `EventProcessor`.
- *
- * To get started, you can use the `InMemoryCheckpointStore` which will store the relevant information in memory.
- * But in production, you should choose an implementation of the `CheckpointStore` interface that will
- * store the checkpoints and partition ownerships to a durable store instead.
+ * it to the `subscribe()` method of the `EventHubConsumerClient` class.
+ * Users are not expected to use any of the methods on a checkpoint store, these are used internally by
+ * the client.
  *
  * Implementations of `CheckpointStore` can be found on npm by searching for packages with the prefix &commat;azure/eventhub-checkpointstore-.
  */

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -72,7 +72,7 @@ export interface PartitionOwnership {
  *
  * Users are not meant to implement an `CheckpointStore`.
  * Users are expected to choose existing implementations of this interface, instantiate it, and pass
- * it to the `subscribe()` method of the `EventHubConsumerClient` class.
+ * it to the `EventHubConsumerClient` class constructor when instantiating a client.
  * Users are not expected to use any of the methods on a checkpoint store, these are used internally by
  * the client.
  *

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -87,7 +87,7 @@ export interface EventHubProducerOptions {
 }
 
 /**
- * The set of options to configure the `send` operation on the `EventHubProducerClient`.
+ * Options to configure the `sendBatch` method on the `EventHubProducerClient`.
  * - `abortSignal`  : A signal used to cancel the send operation.
  */
 export interface SendBatchOptions extends OperationOptions {}
@@ -117,10 +117,9 @@ export interface SendOptions extends SendBatchOptions {
 }
 
 /**
- * The set of options to configure the `createBatch` operation on the `EventProducer`.
+ * Options to configure the `createBatch` method on the `EventHubProducerClient`.
  * - `partitionKey`  : A value that is hashed to produce a partition assignment.
- * Not applicable if the `EventHubProducer` was created using a `partitionId`.
- * - `maxSizeInBytes`: The upper limit for the size of batch. The `tryAdd` function will return `false` after this limit is reached.
+ * - `maxSizeInBytes`: The upper limit for the size of batch.
  * - `abortSignal`   : A signal the request to cancel the send operation.
  *
  * Example usage:
@@ -224,40 +223,24 @@ export interface EventHubConsumerOptions {
 export interface EventHubClientOptions {
   /**
    * @property
-   * The data transformer that will be used to encode and decode the sent and received messages respectively.
-   * If not provided then the `DefaultDataTransformer` is used which has the below `encode` & `decode` features
-   * - `encode`:
-   *    - If event body is a Buffer, then the event is sent without any data transformation
-   *    - Else, JSON.stringfy() is run on the body, and then converted to Buffer before sending the event
-   *    - If JSON.stringify() fails at this point, the send operation fails too.
-   * - `decode`
-   *    - The body receivied via the AMQP protocol is always of type Buffer
-   *    - UTF-8 encoding is used to convert Buffer to string, and then JSON.parse() is run on it to get the event body
-   *    - If the JSON.parse() fails at this point, then the originally received Buffer object is returned in the event body.
+   * Options to configure the retry policy for all the operations on the client.
+   * For example, `{ "maxRetries": 4 }` or `{ "maxRetries": 4, "retryDelayInMs": 30000 }`.
    */
-  // re-enabling this will be a post-GA discussion.
-  //dataTransformer?: DataTransformer;
+  retryOptions?: RetryOptions;
   /**
    * @property
-   * The user agent that will be appended to the built in user agent string that is passed as a
-   * connection property to the Event Hubs service.
-   */
-  userAgent?: string;
-  /**
-   * @property
-   * Options related to websockets
+   * Options to configure the channelling of the AMQP connection over Web Sockets.
    */
   webSocketOptions?: WebSocketOptions;
   /**
    * @property
-   * The retry options for all the operations on the client/producer/consumer.
-   * This can be overridden by the retry options set on the producer and consumer.
+   * Value that is appended to the built in user agent string that is passed to the Event Hubs service.
    */
-  retryOptions?: RetryOptions;
+  userAgent?: string;
 }
 
 /**
- * Options for the websocket implementation used for AMQP.
+ * Options to configure the channelling of the AMQP connection over Web Sockets.
  */
 export interface WebSocketOptions {
   /**


### PR DESCRIPTION
This PR attempts to 
- make general improvements to docs on the interfaces
- fix a few more places have stale references in the docs for user facing APIs.
- re-order properties of some of the interfaces in the order of most common usage.
- `EventDataBatch` is no longer a class. So "instance of EventDataBatch` is inaccurate
- update changelog
- update migration guide with behavioral changes when compared to previous version
