### PR TITLE
[samples] Change all dotenv.config() in samples to remove path

### DIFF
--- a/sdk/appconfiguration/app-configuration/samples/typescript/src/getSettingOnlyIfChanged.ts
+++ b/sdk/appconfiguration/app-configuration/samples/typescript/src/getSettingOnlyIfChanged.ts
@@ -9,7 +9,7 @@ import { AppConfigurationClient } from "@azure/app-configuration";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   console.log("Running get setting only if changed sample");

--- a/sdk/appconfiguration/app-configuration/samples/typescript/src/helloworld.ts
+++ b/sdk/appconfiguration/app-configuration/samples/typescript/src/helloworld.ts
@@ -8,7 +8,7 @@ import { AppConfigurationClient } from "@azure/app-configuration";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   console.log(`Running helloworld sample`);

--- a/sdk/appconfiguration/app-configuration/samples/typescript/src/helloworldWithLabels.ts
+++ b/sdk/appconfiguration/app-configuration/samples/typescript/src/helloworldWithLabels.ts
@@ -12,7 +12,7 @@ import { AppConfigurationClient } from "@azure/app-configuration";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   console.log("Running helloworldWithLabels sample");

--- a/sdk/appconfiguration/app-configuration/samples/typescript/src/listRevisions.ts
+++ b/sdk/appconfiguration/app-configuration/samples/typescript/src/listRevisions.ts
@@ -8,7 +8,7 @@ import { AppConfigurationClient } from "@azure/app-configuration";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   console.log(`Running listRevisions sample`);

--- a/sdk/appconfiguration/app-configuration/samples/typescript/src/optimisticConcurrencyViaEtag.ts
+++ b/sdk/appconfiguration/app-configuration/samples/typescript/src/optimisticConcurrencyViaEtag.ts
@@ -8,7 +8,7 @@ import { AppConfigurationClient } from "@azure/app-configuration";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   console.log("Running optimistic concurrency sample");

--- a/sdk/appconfiguration/app-configuration/samples/typescript/src/setReadOnlySample.ts
+++ b/sdk/appconfiguration/app-configuration/samples/typescript/src/setReadOnlySample.ts
@@ -8,7 +8,7 @@ import { AppConfigurationClient } from "@azure/app-configuration";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   console.log("Running setReadOnly sample");

--- a/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts
@@ -16,7 +16,7 @@ import { EventHubConsumerClient } from "@azure/event-hubs";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";
 const eventHubName = process.env["EVENTHUB_NAME"] || "";

--- a/sdk/eventhub/event-hubs/samples/typescript/src/receiveEventsUsingCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/receiveEventsUsingCheckpointStore.ts
@@ -23,7 +23,7 @@ import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";
 const eventHubName = process.env["EVENTHUB_NAME"] || "";

--- a/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
@@ -13,7 +13,7 @@ import { EventHubProducerClient } from "@azure/event-hubs";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";

--- a/sdk/eventhub/event-hubs/samples/typescript/src/useWithIotHub.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/useWithIotHub.ts
@@ -8,7 +8,7 @@ import { EventHubConsumerClient } from "@azure/event-hubs";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // Define IoT Hub Event Hubs-compatible connection string here.
 // To find the correct connection string to use, visit:

--- a/sdk/eventhub/event-hubs/samples/typescript/src/usingAadAuth.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/usingAadAuth.ts
@@ -27,7 +27,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // Define Event Hubs Endpoint and related entity name here here
 const eventHubsFullyQualifiedName = process.env["EVENTHUB_FQDN"] || ""; // <your-eventhubs-namespace>.servicebus.windows.net

--- a/sdk/eventhub/event-hubs/samples/typescript/src/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/websockets.ts
@@ -22,7 +22,7 @@ import { EventHubConsumerClient } from "@azure/event-hubs";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // Define connection string and related Event Hubs entity name here
 const connectionString = process.env["EVENTHUB_CONNECTION_STRING"] || "";

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/backupAndRestore.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/backupAndRestore.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample creates a self-signed certificate, then makes a backup from it,
 // then deletes it and purges it, and finally restores it.

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/contacts.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/contacts.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample creates, updates and deletes certificate contacts.
 

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/deleteAndRecover.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/deleteAndRecover.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample creates a self-signed certificate, then deletes it, then recovers it.
 // Soft-delete is required for this sample to run: https://docs.microsoft.com/en-us/azure/key-vault/key-vault-ovw-soft-delete

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/helloWorld.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/helloWorld.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample creates a self-signed certificate, reads it in various ways,
 // updates the tags of the certificate and finally deletes the certificate.

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/issuers.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/issuers.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample creates, updates and deletes certificate issuers.
 

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/listCertificates.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/listCertificates.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample list previously created certificates in a single chunk and by page,
 // then changes one of them and lists all the versions of that certificate,

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/mergeCertificate.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/mergeCertificate.ts
@@ -9,7 +9,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample creates a certificate with an Unknown issuer, then signs this certificate using a fake
 // certificate authority and the mergeCertificate API method.

--- a/sdk/keyvault/keyvault-certificates/samples/typescript/src/operations.ts
+++ b/sdk/keyvault/keyvault-certificates/samples/typescript/src/operations.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // This sample creates, updates and deletes a certificate's operation.
 

--- a/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/src/cryptography.ts
@@ -8,7 +8,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main(): Promise<void> {
   // DefaultAzureCredential expects the following three environment variables:

--- a/sdk/keyvault/keyvault-keys/samples/typescript/src/helloWorld.ts
+++ b/sdk/keyvault/keyvault-keys/samples/typescript/src/helloWorld.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main(): Promise<void> {
   // DefaultAzureCredential expects the following three environment variables:

--- a/sdk/keyvault/keyvault-secrets/samples/typescript/src/backupAndRestore.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/typescript/src/backupAndRestore.ts
@@ -8,7 +8,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 function writeFile(filename: string, text: Uint8Array): Promise<void> {
   return new Promise((resolve, reject) => {

--- a/sdk/keyvault/keyvault-secrets/samples/typescript/src/deleteAndRecover.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/typescript/src/deleteAndRecover.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export function delay<T>(t: number, value?: T): Promise<T> {
   return new Promise((resolve) => setTimeout(() => resolve(value), t));

--- a/sdk/keyvault/keyvault-secrets/samples/typescript/src/helloWorld.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/typescript/src/helloWorld.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main(): Promise<void> {
   // DefaultAzureCredential expects the following three environment variables:

--- a/sdk/keyvault/keyvault-secrets/samples/typescript/src/listOperations.ts
+++ b/sdk/keyvault/keyvault-secrets/samples/typescript/src/listOperations.ts
@@ -6,7 +6,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main(): Promise<void> {
   // DefaultAzureCredential expects the following three environment variables:

--- a/sdk/storage/storage-blob/samples/typescript/src/advanced.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/advanced.ts
@@ -11,7 +11,7 @@ import { AnonymousCredential, BlobServiceClient, newPipeline } from "@azure/stor
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // Enabling logging may help uncover useful information about failures.
 // In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`.

--- a/sdk/storage/storage-blob/samples/typescript/src/anonymousCred.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/anonymousCred.ts
@@ -9,7 +9,7 @@ import { BlobServiceClient, AnonymousCredential } from "@azure/storage-blob";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and SAS

--- a/sdk/storage/storage-blob/samples/typescript/src/azureAdAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/azureAdAuth.ts
@@ -26,7 +26,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name

--- a/sdk/storage/storage-blob/samples/typescript/src/basic.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/basic.ts
@@ -13,7 +13,7 @@ import {
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/customPipeline.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/customPipeline.ts
@@ -9,7 +9,7 @@ import { BlobServiceClient, StorageSharedKeyCredential, newPipeline } from "@azu
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/customizedClientHeaders.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/customizedClientHeaders.ts
@@ -24,7 +24,7 @@ import {
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 // Create a policy factory with create() method provided
 class RequestIDPolicyFactory {

--- a/sdk/storage/storage-blob/samples/typescript/src/errorsAndResponses.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/errorsAndResponses.ts
@@ -9,7 +9,7 @@ import { BlobServiceClient } from "@azure/storage-blob";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Create Blob Service Client from Account connection string or SAS connection string

--- a/sdk/storage/storage-blob/samples/typescript/src/iterators-blobs-hierarchy.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/iterators-blobs-hierarchy.ts
@@ -9,7 +9,7 @@ import { ContainerClient, StorageSharedKeyCredential } from "@azure/storage-blob
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/iterators-blobs.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/iterators-blobs.ts
@@ -9,7 +9,7 @@ import { ContainerClient, StorageSharedKeyCredential } from "@azure/storage-blob
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/iterators-containers.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/iterators-containers.ts
@@ -9,7 +9,7 @@ import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-bl
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/iterators-without-await.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/iterators-without-await.ts
@@ -6,7 +6,7 @@ import { ContainerClient, StorageSharedKeyCredential, BlobItem } from "@azure/st
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/proxyAuth.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/proxyAuth.ts
@@ -9,7 +9,7 @@ import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-bl
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/readingSnapshot.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/readingSnapshot.ts
@@ -25,7 +25,7 @@ import { ContainerClient, StorageSharedKeyCredential } from "@azure/storage-blob
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/sharedKeyCred.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/sharedKeyCred.ts
@@ -9,7 +9,7 @@ import { BlobServiceClient, StorageSharedKeyCredential } from "@azure/storage-bl
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-blob/samples/typescript/src/withConnString.ts
+++ b/sdk/storage/storage-blob/samples/typescript/src/withConnString.ts
@@ -9,7 +9,7 @@ import { BlobServiceClient } from "@azure/storage-blob";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Create Blob Service Client from Account connection string or SAS connection string

--- a/sdk/storage/storage-file-share/samples/typescript/src/advanced.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/advanced.ts
@@ -12,7 +12,7 @@ import { AnonymousCredential, ShareServiceClient, newPipeline } from "@azure/sto
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Fill in following settings before running this sample

--- a/sdk/storage/storage-file-share/samples/typescript/src/anonymousCred.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/anonymousCred.ts
@@ -9,7 +9,7 @@ import { ShareServiceClient, AnonymousCredential } from "@azure/storage-file-sha
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and SAS

--- a/sdk/storage/storage-file-share/samples/typescript/src/basic.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/basic.ts
@@ -9,7 +9,7 @@ import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-f
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/src/customPipeline.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/customPipeline.ts
@@ -13,7 +13,7 @@ import {
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/src/iterators-files-and-directories.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/iterators-files-and-directories.ts
@@ -9,7 +9,7 @@ import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-f
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/src/iterators-handles.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/iterators-handles.ts
@@ -9,7 +9,7 @@ import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-f
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name, shared key, share name, and directory name.

--- a/sdk/storage/storage-file-share/samples/typescript/src/iterators-shares.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/iterators-shares.ts
@@ -9,7 +9,7 @@ import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-f
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/src/proxyAuth.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/proxyAuth.ts
@@ -9,7 +9,7 @@ import { StorageSharedKeyCredential, ShareServiceClient } from "@azure/storage-f
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/src/sharedKeyCred.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/sharedKeyCred.ts
@@ -9,7 +9,7 @@ import { ShareServiceClient, StorageSharedKeyCredential } from "@azure/storage-f
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-file-share/samples/typescript/src/withConnString.ts
+++ b/sdk/storage/storage-file-share/samples/typescript/src/withConnString.ts
@@ -9,7 +9,7 @@ import { ShareServiceClient } from "@azure/storage-file-share";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Create File Service Client from Account connection string or SAS connection string

--- a/sdk/storage/storage-queue/samples/typescript/src/anonymousCred.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/anonymousCred.ts
@@ -9,7 +9,7 @@ import { QueueServiceClient, AnonymousCredential } from "@azure/storage-queue";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and SAS

--- a/sdk/storage/storage-queue/samples/typescript/src/azureAdAuth.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/azureAdAuth.ts
@@ -26,7 +26,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-queue/samples/typescript/src/basic.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/basic.ts
@@ -9,7 +9,7 @@ import { QueueServiceClient, StorageSharedKeyCredential } from "@azure/storage-q
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-queue/samples/typescript/src/customPipeline.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/customPipeline.ts
@@ -9,7 +9,7 @@ import { QueueServiceClient, newPipeline, StorageSharedKeyCredential } from "@az
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-queue/samples/typescript/src/iterators.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/iterators.ts
@@ -9,7 +9,7 @@ import { QueueServiceClient, StorageSharedKeyCredential } from "@azure/storage-q
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-queue/samples/typescript/src/proxyAuth.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/proxyAuth.ts
@@ -9,7 +9,7 @@ import { StorageSharedKeyCredential, QueueServiceClient } from "@azure/storage-q
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-queue/samples/typescript/src/sharedKeyCred.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/sharedKeyCred.ts
@@ -9,7 +9,7 @@ import { QueueServiceClient, StorageSharedKeyCredential } from "@azure/storage-q
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Enter your storage account name and shared key

--- a/sdk/storage/storage-queue/samples/typescript/src/withConnString.ts
+++ b/sdk/storage/storage-queue/samples/typescript/src/withConnString.ts
@@ -9,7 +9,7 @@ import { QueueServiceClient } from "@azure/storage-queue";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
-dotenv.config({ path: "../.env" });
+dotenv.config();
 
 export async function main() {
   // Create Queue Service Client from Account connection string or SAS connection string


### PR DESCRIPTION
This fixes an issue with the resolution of .env in the TypeScript samples.

When I wrote and tested these samples on Windows I must have had environment variables set somewhere that prevented me from realizing that this path is relative to CWD and not relative to the file itself. Some combination of errors that I made when testing made me think it was the other way around.

This should fix dotenv resolution in the TypeScript sample files.