### PR TITLE
[WIP] [Common Recorder] Tests with this.skip() must execute the afterEach hook

### DIFF
--- a/sdk/appconfiguration/app-configuration/package.json
+++ b/sdk/appconfiguration/app-configuration/package.json
@@ -94,7 +94,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nock": "^11.7.0",

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -93,7 +93,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -103,7 +103,7 @@
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^3.0.0",
     "karma-mocha": "^1.3.0",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -115,7 +115,7 @@
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "npm-run-all": "^4.1.5",

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
     "inherits": "^2.0.3",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "prettier": "^1.16.4",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -173,7 +173,7 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-typescript-es6-transform": "^4.0.0",
     "karma-webpack": "^4.0.2",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-chrome": "^2.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",

--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -131,7 +131,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "npm-run-all": "^4.1.5",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -81,7 +81,7 @@
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
     "inherits": "^2.0.3",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "prettier": "^1.16.4",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -102,7 +102,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -121,7 +121,7 @@
     "karma-requirejs": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^4.0.2",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "prettier": "^1.16.4",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -130,7 +130,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -67,7 +67,7 @@
     ]
   },
   "dependencies": {
-    "@azure/event-hubs": "^2.1.4",
+    "@azure/event-hubs": "5.0.0-preview.8",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "async-lock": "^1.1.3",
     "azure-storage": "^2.10.2",
@@ -104,7 +104,7 @@
     "eslint-plugin-no-only-tests": "^2.3.0",
     "eslint-plugin-promise": "^4.1.1",
     "https-proxy-agent": "^3.0.1",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -106,7 +106,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "prettier": "^1.16.4",

--- a/sdk/eventhub/testhub/package.json
+++ b/sdk/eventhub/testhub/package.json
@@ -33,7 +33,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/event-hubs": "^2.1.4",
+    "@azure/event-hubs": "5.0.0-preview.8",
     "@azure/event-processor-host": "^2.0.0",
     "@types/node": "^8.0.0",
     "@types/uuid": "^3.4.3",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -109,7 +109,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "open": "^7.0.0",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -131,7 +131,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -128,7 +128,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -128,7 +128,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -88,7 +88,7 @@
     "long": "^4.0.0",
     "process": "^0.11.10",
     "rhea": "^1.0.15",
-    "rhea-promise": "^0.1.15",
+    "rhea-promise": "^1.0.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {
@@ -131,7 +131,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "moment": "^2.24.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -133,7 +133,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-istanbul": "^0.6.0",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -134,7 +134,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-istanbul": "^0.6.0",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nise": "^1.4.10",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -134,7 +134,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-istanbul": "^0.6.0",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -132,7 +132,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-istanbul": "^0.6.0",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "nyc": "^14.0.0",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -93,7 +93,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "prettier": "^1.16.4",

--- a/sdk/textanalytics/cognitiveservices-textanalytics/package.json
+++ b/sdk/textanalytics/cognitiveservices-textanalytics/package.json
@@ -95,7 +95,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-coverage": "^0.1.5",
-    "mocha": "^6.2.2",
+    "mocha": "^7.0.0",
     "mocha-junit-reporter": "^1.18.0",
     "mocha-multi": "^1.1.3",
     "prettier": "^1.16.4",


### PR DESCRIPTION
### Issue
This is a bug in the mocha library that afterEach block is not being executed if a test is skipped unlike beforeEach.

The issue is fixed in mocha 7.0.0  - https://github.com/mochajs/mocha/pull/3741
However, after updating mocha to 7.0.0 in the package.json, 
`rush update` failed as below.

![image](https://user-images.githubusercontent.com/10452642/71944256-1b2d1f80-3178-11ea-95c0-f2f3edbac8c8.png)

This issue occurred because `mocha-multi` is still relying on an older version of `mocha`.

For comparison, npm throws a warning only
![image](https://user-images.githubusercontent.com/10452642/71944662-6431a380-3179-11ea-89d6-e0a40e3f10f5.png)

Logged an issue in the mocha-multi repo asking them to support mocha@7.0.0

Issue - #5697 