### PR TITLE
[event-hubs] fix version test

### DIFF
--- a/sdk/eventhub/event-hubs/test/packageInfo.spec.ts
+++ b/sdk/eventhub/event-hubs/test/packageInfo.spec.ts
@@ -11,7 +11,7 @@ import { packageJsonInfo } from "../src/util/constants";
 // following test is in place to ensure the values in package.json and in this file are consistent
 describe("Ensure package name and version are consistent in SDK and package.json", function(): void {
   it("Ensure constants.ts file is consistent with package.json", () => {
-    const packageJsonFilePath = path.join(__dirname, "../package.json");
+    const packageJsonFilePath = path.join(__dirname, "..", "..", "package.json");
     const rawFileContents = fs.readFileSync(packageJsonFilePath, { encoding: "utf-8" });
     const packageJsonContents = JSON.parse(rawFileContents);
 


### PR DESCRIPTION
#6744 Changed the `integration-test:node` script to pull test files from `dist-esm` instead of `dist`. This caused the test that validates that the version constant matches the package.json to fail since it used a relative path to get the package.json.

For now I'm just updating the relative path in the test to unblock our live tests.

I'm a little worried that our script no longer uses the same (bundled) version of the SDK that node.js users would use when running the tests. Getting our samples run in an automated fashion will help with this, and we manually run the samples now before releasing, but would like to make sure we don't miss this going forward.