### PR TITLE
Fix up README issues for Text Analytics

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -18,7 +18,7 @@ Use the client library to:
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/textanalytics/ai-text-analytics/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/ai-text-analytics) |
-[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/ai-text-analytics) |
+[API reference documentation](https://aka.ms/azsdk-js-textanalytics-ref-docs) |
 [Product documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/samples)
 
@@ -159,7 +159,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Ftextanalytics%ai-text-analytics%2FREADME.png)
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Ftextanalytics%2Fai-text-analytics%2FREADME.png)
 
 [azure_cli]: https://docs.microsoft.com/cli/azure
 [azure_sub]: https://azure.microsoft.com/free/


### PR DESCRIPTION
The impressions link was improperly formatted after the package rename. Also switched the reference docs to be an aka.ms link so we can forward to the proper docs (on github.io and later docs.microsoft.com)