### PR TITLE
[event-hubs] cleanup docs for unexported members

### DIFF
--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -17,6 +17,7 @@ export const TRACEPARENT_PROPERTY = "Diagnostic-Id";
  * @param eventData The `EventData` to instrument.
  * @param span The `Span` containing the context to propagate tracing information.
  * @ignore
+ * @internal
  */
 export function instrumentEventData(eventData: EventData, span: Span): EventData {
   if (eventData.properties && eventData.properties[TRACEPARENT_PROPERTY]) {
@@ -37,6 +38,8 @@ export function instrumentEventData(eventData: EventData, span: Span): EventData
 /**
  * Extracts the `SpanContext` from an `EventData` if the context exists.
  * @param eventData An individual `EventData` object.
+ * @internal
+ * @ignore
  */
 export function extractSpanContextFromEventData(eventData: EventData): SpanContext | undefined {
   if (!eventData.properties || !eventData.properties[TRACEPARENT_PROPERTY]) {

--- a/sdk/eventhub/event-hubs/src/diagnostics/messageSpan.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/messageSpan.ts
@@ -4,6 +4,10 @@
 import { getTracer } from "@azure/core-tracing";
 import { Span, SpanContext, SpanKind } from "@opentelemetry/types";
 
+/**
+ * @internal
+ * @ignore
+ */
 export function createMessageSpan(parentSpan?: Span | SpanContext): Span {
   const tracer = getTracer();
   const span = tracer.startSpan("Azure.EventHubs.message", {

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -60,16 +60,22 @@ export interface LastEnqueuedEventProperties {
 
 /**
  * Describes the message handler signature.
+ * @internal
+ * @ignore
  */
 export type OnMessage = (eventData: ReceivedEventData) => void;
 
 /**
  * Describes the error handler signature.
+ * @internal
+ * @ignore
  */
 export type OnError = (error: MessagingError | Error) => void;
 
 /**
  * Describes the abort handler signature.
+ * @internal
+ * @ignore
  */
 export type OnAbort = () => void;
 

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -76,6 +76,10 @@ export function getEventPositionFilter(eventPosition: EventPosition): string {
   return result;
 }
 
+/**
+ * @internal
+ * @ignore
+ */
 export function isLatestPosition(eventPosition: EventPosition): boolean {
   if (eventPosition.offset === "@latest") {
     return true;

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -140,6 +140,7 @@ export interface CheckpointStore {
  * }
  * ```
  * @internal
+ * @ignore
  */
 export interface FullEventProcessorOptions  // make the 'maxBatchSize', 'maxWaitTimeInSeconds', 'ownerLevel' fields required extends // for our internal classes (these are optional for external users)
   extends Required<Pick<SubscribeOptions, "maxBatchSize" | "maxWaitTimeInSeconds">>,
@@ -210,6 +211,8 @@ export interface FullEventProcessorOptions  // make the 'maxBatchSize', 'maxWait
  * Implementations of `CheckpointStore` can be found on npm by searching for packages with the prefix &commat;azure/eventhub-checkpointstore-.
  *
  * @class EventProcessor
+ * @internal
+ * @ignore
  */
 export class EventProcessor {
   private _consumerGroup: string;

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -69,6 +69,8 @@ export interface GetPartitionIdsOptions extends OperationOptions {}
  * - `partitionId`  : The string identifier of the partition that the producer can be bound to.
  * - `retryOptions` : The retry options used to govern retry attempts when an issue is encountered while sending events.
  * A simple usage can be `{ "maxRetries": 4 }`.
+ * @ignore
+ * @internal
  */
 export interface EventHubProducerOptions {
   /**
@@ -105,6 +107,7 @@ export interface SendBatchOptions extends OperationOptions {}
  * ```
  *
  * @internal
+ * @ignore
  */
 export interface SendOptions extends SendBatchOptions {
   /**
@@ -166,6 +169,8 @@ export interface CreateBatchOptions extends OperationOptions {
  *     trackLastEnqueuedEventProperties: false
  * }
  * ```
+ * @internal
+ * @ignore
  */
 export interface EventHubConsumerOptions {
   /**

--- a/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
+++ b/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
@@ -7,6 +7,8 @@ import { logger } from "./log";
 /**
  * Implements a load balancing algorithm for determining which consumers
  * own which partitions.
+ * @ignore
+ * @internal
  */
 export interface PartitionLoadBalancer {
   /**

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -55,6 +55,8 @@ export interface Checkpoint {
  * - Optionally override the `processError()` method to handle any error that might have occurred when processing the events.
  * - Optionally override the `initialize()` method to implement any set up related tasks you would want to carry out before starting to receive events from the partition
  * - Optionally override the `close()` method to implement any tear down or clean up tasks you would want to carry out.
+ * @internal
+ * @ignore
  */
 export class PartitionProcessor implements PartitionContext {
   private _lastEnqueuedEventProperties?: LastEnqueuedEventProperties;

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -15,6 +15,10 @@ import { Span, SpanKind, Link, CanonicalCode } from "@opentelemetry/types";
 import { extractSpanContextFromEventData } from "./diagnostics/instrumentEventData";
 import { ReceivedEventData } from "./eventData";
 
+/**
+ * @ignore
+ * @internal
+ */
 export class PartitionPump {
   private _eventHubClient: EventHubClient;
   private _partitionProcessor: PartitionProcessor;

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -8,6 +8,8 @@ import { logger, logErrorStackTrace } from "./log";
  * Describes the receive handler object that is returned from the receive() method with handlers.
  * The ReceiveHandler is used to stop receiving more messages.
  * @class ReceiveHandler
+ * @ignore
+ * @internal
  */
 export class ReceiveHandler {
   /**

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -26,22 +26,6 @@ import { EventPosition } from "./eventPosition";
 import "@azure/core-asynciterator-polyfill";
 
 /**
- * Options to pass when creating an async iteratable using the `getEventIterator()` method on the
- * `EventHubConsumer`.
- */
-export interface EventIteratorOptions {
-  /**
-   * Number of events to fetch at a time in the background
-   */
-  // prefetchCount?: number;
-  /**
-   * An implementation of the `AbortSignalLike` interface to signal the `EventIterator` to cancel the operation.
-   * For example, use the &commat;azure/abort-controller to create an `AbortSignal`.
-   */
-  abortSignal?: AbortSignalLike;
-}
-
-/**
  * A consumer is responsible for reading `EventData` from a specific Event Hub partition
  * in the context of a specific consumer group.
  * To create a consumer use the `createConsumer()` method on your `EventHubClient`.
@@ -59,6 +43,8 @@ export interface EventIteratorOptions {
  * The consumer can be used to receive messages in a batch using `receiveBatch()` or by registering handlers
  * by using `receive()` or via an async iterable got by using `getEventIterator()`
  * @class
+ * @ignore
+ * @internal
  */
 export class EventHubConsumer {
   private _baseConsumer?: EventHubReceiver;

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -31,6 +31,8 @@ import { getParentSpan } from "./util/operationOptions";
  *  - The event data will be evenly distributed among all available partitions.
  *
  * @class
+ * @internal
+ * @ignore
  */
 export class EventHubProducer {
   /**

--- a/sdk/eventhub/event-hubs/src/util/operationOptions.ts
+++ b/sdk/eventhub/event-hubs/src/util/operationOptions.ts
@@ -31,6 +31,10 @@ export interface OperationOptions extends TracingOptions {
   abortSignal?: AbortSignalLike;
 }
 
+/**
+ * @internal
+ * @ignore
+ */
 export function getParentSpan(
   options: Pick<OperationOptions, "tracingOptions">
 ): Span | SpanContext | undefined {

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/src/blobCheckpointStore.ts
@@ -280,6 +280,10 @@ type CheckpointMetadata = {
   [k in "sequencenumber" | "offset"]: string | undefined;
 };
 
+/**
+ * @ignore
+ * @internal
+ */
 export function parseIntOrThrow(
   blobName: string,
   fieldName: string,


### PR DESCRIPTION
I went through the list of exported package members vs what was being displayed in the github io docs.

This should remove all the members that aren't exported from the package's entry point.