### PR TITLE
Unlink dependencies even if build is cancelled

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -238,7 +238,7 @@ jobs:
         # which need to walk the directory tree (and are hardcoded to follow symlinks).
         - script: |
             node eng/tools/rush-runner.js unlink
-          condition: succeededOrFailed()
+          condition: always()
           displayName: "Unlink dependencies"
 
         # It's important for performance to pass "sdk" as "searchFolder" to avoid looking under root "node_modules".

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -236,8 +236,18 @@ jobs:
 
         # Unlink node_modules folders to significantly improve performance of subsequent tasks
         # which need to walk the directory tree (and are hardcoded to follow symlinks).
-        - script: |
-            node eng/tools/rush-runner.js unlink
+        # Retry for 30 seconds, since this command may fail with error "Another rush command is already
+        # running in this repository" if the previous rush command was killed.
+        - pwsh: |
+            for ($i=0; $i -lt 30; $i++) {
+              node eng/tools/rush-runner.js unlink
+              if ($lastexitcode -eq 0) {
+                break
+              }
+              else {
+                start-sleep 1
+              }
+            }
           condition: always()
           displayName: "Unlink dependencies"
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -135,7 +135,7 @@ jobs:
       # which need to walk the directory tree (and are hardcoded to follow symlinks).
       - script: |
           node eng/tools/rush-runner.js unlink
-        condition: succeededOrFailed()
+        condition: always()
         displayName: "Unlink dependencies"
 
       # It's important for performance to pass "sdk" as "searchFolder" to avoid looking under root "node_modules".

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -133,8 +133,18 @@ jobs:
 
       # Unlink node_modules folders to significantly improve performance of subsequent tasks
       # which need to walk the directory tree (and are hardcoded to follow symlinks).
-      - script: |
-          node eng/tools/rush-runner.js unlink
+      # Retry for 30 seconds, since this command may fail with error "Another rush command is already
+      # running in this repository" if the previous rush command was killed.
+      - pwsh: |
+          for ($i=0; $i -lt 30; $i++) {
+            node eng/tools/rush-runner.js unlink
+            if ($lastexitcode -eq 0) {
+              break
+            }
+            else {
+              start-sleep 1
+            }
+          }
         condition: always()
         displayName: "Unlink dependencies"
 


### PR DESCRIPTION
- Condition used for "unlink dependencies" and "PublishTestResults" should match

This PR will need a bit more work.  The `rush unlink` command fails with error "Another rush command is already running in this repository".  I think the issue is that the previous `rush test` command was killed when the job was cancelled, so we might need to either sleep a few seconds or somehow force the new rush command through (e.g. by deleting a lockfile).

Example: https://dev.azure.com/azure-sdk/public/_build/results?buildId=229792&view=logs&j=ba8c15a9-bc1f-5628-021b-e6d79d48e15f&t=ea8763a5-7b1c-546a-3b50-4594d764634e&l=28