### PR TITLE
[Storage] fix unused import warning in node test rollup

### DIFF
--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -64,8 +64,8 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // entry point is every test file
-    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js"];
-    baseConfig.plugins.unshift(multiEntry({ exports: false }));
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js", "dist-esm/src/index.js"];
+    baseConfig.plugins.unshift(multiEntry());
 
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";

--- a/sdk/storage/storage-file-datalake/rollup.base.config.js
+++ b/sdk/storage/storage-file-datalake/rollup.base.config.js
@@ -79,8 +79,8 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // entry point is every test file
-    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js"];
-    baseConfig.plugins.unshift(multiEntry({ exports: false }));
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js", "dist-esm/src/index.js"];
+    baseConfig.plugins.unshift(multiEntry());
 
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";

--- a/sdk/storage/storage-file-share/rollup.base.config.js
+++ b/sdk/storage/storage-file-share/rollup.base.config.js
@@ -64,8 +64,8 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // entry point is every test file
-    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js"];
-    baseConfig.plugins.unshift(multiEntry({ exports: false }));
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js", "dist-esm/src/index.js"];
+    baseConfig.plugins.unshift(multiEntry());
 
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";

--- a/sdk/storage/storage-queue/rollup.base.config.js
+++ b/sdk/storage/storage-queue/rollup.base.config.js
@@ -56,8 +56,8 @@ export function nodeConfig(test = false) {
 
   if (test) {
     // entry point is every test file
-    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js"];
-    baseConfig.plugins.unshift(multiEntry({ exports: false }));
+    baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/node/*.spec.js", "dist-esm/src/index.js"];
+    baseConfig.plugins.unshift(multiEntry());
 
     // different output file
     baseConfig.output.file = "dist-test/index.node.js";


### PR DESCRIPTION
There were types that are imported then re-exported for easy consumption by our
library users. Some of these types triggered rollup warnings like

(!) Unused external imports
RequestPolicyOptions,WebResource imported from external module '@azure/core-http' but never used

Unlike other re-exported things, RequestPolicyOptions is used nowhere in the
library. For a non-test build, this isn't an issue because rollup properly
detects that its re-exported from index.js. For tests, because we're using
multi-entry with exports: false, rollup sees a module with no exports and so all
of a sudden RPO is no longer re-exported and is thus unused.

This change does the following as suggested by @bterlson:

- Add the index file to the input list for tests, and
- Remove the exports: false option for multi-entry

This results in a bundle which exports everything index.js does from top-level
and includes all the test collateral.
