### PR TITLE
Change copy source from GitHub to Blob

### DIFF
--- a/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
@@ -153,7 +153,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     );
 
     const poller1 = await newBlobClient.beginCopyFromURL(
-      "https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/README.md",
+      blobClient.url,
       testPollerProperties
     );
 
@@ -162,7 +162,7 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     const state = poller1.toString();
 
     const poller2 = await newBlobClient.beginCopyFromURL(
-      "https://raw.githubusercontent.com/Azure/azure-sdk-for-js/master/README.md",
+      blobClient.url,
       {
         resumeFrom: state,
         ...testPollerProperties


### PR DESCRIPTION
- Copy from GitHub recently started failing, perhaps due to service change