### PR TITLE
[event-hubs] Fixing bug in load balancing algorithm with even numbers of processors.

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 5.0.1 (TBD)
+
+- Fixed a potential issue with deadlock where greedy consumers could
+  starve out other consumers, preventing us from properly balancing.
+
 ## 5.0.0 (2020-01-09)
 
 - This release marks the general availability of the `@azure/event-hubs` package.

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
+++ b/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
@@ -256,7 +256,7 @@ export class FairPartitionLoadBalancer implements PartitionLoadBalancer {
     const numberOfEventProcessorsWithAdditionalPartition =
       partitionsToAdd.length % ownerPartitionMap.size;
 
-    const possibleExtraPartition = numberOfEventProcessorsWithAdditionalPartition != 0 ? 1 : 0;
+    const possibleExtraPartition = numberOfEventProcessorsWithAdditionalPartition !== 0 ? 1 : 0;
 
     logger.verbose(
       `[${ourOwnerId}] Expected minimum number of partitions per event processor: ${minPartitionsPerEventProcessor}, 

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,5 +6,5 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.0.0"
+  version: "5.0.1"
 };

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -1134,7 +1134,7 @@ describe("Event Processor", function(): void {
       processorByName[`processor-2`].start();
 
       await loopUntil({
-        name: "Processors have reached equilibium",
+        name: "Processors are balanced",
         maxTimes: 60,
         timeBetweenRunsMs: 1000,
         until: async () => {

--- a/sdk/eventhub/event-hubs/test/loadBalancer.spec.ts
+++ b/sdk/eventhub/event-hubs/test/loadBalancer.spec.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { GreedyPartitionLoadBalancer } from "../src/partitionLoadBalancer";
+import {
+  GreedyPartitionLoadBalancer,
+  FairPartitionLoadBalancer
+} from "../src/partitionLoadBalancer";
 import { PartitionOwnership } from "../src/eventProcessor";
 
 describe("PartitionLoadBalancer", () => {
@@ -49,5 +52,195 @@ describe("PartitionLoadBalancer", () => {
 
       lb.loadBalance("ownerId", m, ["1", "2", "3"]).should.deep.eq(["1", "2", "3"]);
     });
+  });
+
+  describe("FairPartitionLoadBalancer", () => {
+    const lb = new FairPartitionLoadBalancer(1000 * 60);
+
+    it("odd number of partitions per processor", () => {
+      const allPartitions = ["0", "1", "2"];
+
+      // at this point 'a' has it's fair share of partitions (there are 3 total)
+      // and it's okay to have 1 extra.
+      let partitionsToOwn = lb.loadBalance(
+        "a",
+        createOwnershipMap({
+          "1": "b",
+          "2": "a",
+          "3": "a"
+        }),
+        allPartitions
+      );
+      partitionsToOwn.sort();
+      partitionsToOwn.should.be.deep.equal(
+        ["2", "3"],
+        "we've gotten our fair share, shouldn't claim anything new"
+      );
+
+      // now the other side of this is when we're fighting for the ownership of an
+      // extra partition
+      partitionsToOwn = lb.loadBalance(
+        "a",
+        createOwnershipMap({
+          "1": "b",
+          "2": "a"
+        }),
+        allPartitions
+      );
+      partitionsToOwn.sort();
+      partitionsToOwn.should.be.deep.equal(
+        ["0", "2"],
+        "we had our minimum fair share (1) but there's still one extra (uneven number of partitions per processor) and we should snag it"
+      );
+    });
+
+    it("even number of partitions per processor", () => {
+      const allPartitions = ["0", "1", "2", "3"];
+
+      // at this point 'a' has it's fair share of partitions (there are 4 total)
+      // so it'll stop claiming additional partitions.
+      let partitionsToOwn = lb.loadBalance(
+        "a",
+        createOwnershipMap({
+          "1": "b",
+          "2": "a",
+          "3": "a"
+        }),
+        allPartitions
+      );
+      partitionsToOwn.sort();
+      partitionsToOwn.should.be.deep.equal(
+        ["2", "3"],
+        "we've gotten our fair share, shouldn't claim anything new"
+      );
+
+      partitionsToOwn = lb.loadBalance(
+        "a",
+        createOwnershipMap({
+          "0": "b",
+          "1": "b",
+          "2": "a",
+          "3": "a"
+        }),
+        allPartitions
+      );
+      partitionsToOwn.sort();
+      partitionsToOwn.should.be.deep.equal(["2", "3"], "load is balanced, won't grab any more.");
+    });
+
+    // when there are no freely available partitions (partitions that have either expired or are literally unowned)
+    // we'll need to steal from an existing processor.
+    // This can happen in a few ways:
+    // 1. we were simply racing against other processors
+    // 2. we're coming in later after all partitions have been allocated (ie, scaling out)
+    // 3. timing issues, death of a processor, etc...
+    it("stealing", () => {
+      // something like this could happen if 'a' were just the only processor
+      // and now we're spinning up 'b'
+      let partitionsToOwn = lb.loadBalance(
+        "b",
+        createOwnershipMap({
+          "0": "a",
+          "1": "a",
+          "2": "a"
+        }),
+        ["0", "1", "2"]
+      );
+      partitionsToOwn.sort();
+      // we'll attempt to steal a partition from 'a'.
+      partitionsToOwn.length.should.equal(
+        1,
+        "stealing with an odd number of partitions per processor"
+      );
+
+      // and now the same case as above, but with an even number of partitions per processor.
+      partitionsToOwn = lb.loadBalance(
+        "b",
+        createOwnershipMap({
+          "0": "a",
+          "1": "a",
+          "2": "a",
+          "3": "a"
+        }),
+        ["0", "1", "2", "3"]
+      );
+      partitionsToOwn.sort();
+      // we'll attempt to steal a partition from 'a'.
+      partitionsToOwn.length.should.equal(
+        1,
+        "stealing with an even number of partitions per processor"
+      );
+    });
+
+    it("general cases", () => {
+      const allPartitions = ["0", "1", "2", "3"];
+
+      // in the presence of no owners we claim a random partition
+      let partitionsToOwn = lb.loadBalance("a", createOwnershipMap({}), allPartitions);
+      partitionsToOwn.length.should.be.equal(1, "nothing is owned, claim one");
+
+      // if there are other owners we should claim up to #partitions/#owners
+      partitionsToOwn = lb.loadBalance(
+        "a",
+        createOwnershipMap({
+          "1": "b",
+          "3": "a"
+        }),
+        allPartitions
+      );
+      partitionsToOwn.length.should.be.equal(2, "1 and 1 with another owner, should claim one");
+      // better not try to claim 'b's partition when there are unowned partitions
+      partitionsToOwn.filter((p) => p === "1").length.should.equal(0);
+
+      // 'b' should claim the last unowned partition
+      partitionsToOwn = lb.loadBalance(
+        "b",
+        createOwnershipMap({
+          "1": "b",
+          "2": "a",
+          "3": "a"
+        }),
+        allPartitions
+      );
+      partitionsToOwn.sort();
+      partitionsToOwn.should.be.deep.equal(["0", "1"], "b grabbed the last available partition");
+
+      // we're at equilibrium - processors now only grab the partitions that they own
+      partitionsToOwn = lb.loadBalance(
+        "b",
+        createOwnershipMap({
+          "0": "b",
+          "1": "a",
+          "2": "b",
+          "3": "a"
+        }),
+        allPartitions
+      );
+      partitionsToOwn.sort();
+      partitionsToOwn.should.be.deep.equal(
+        ["0", "2"],
+        "equilibrium: b only grabbed it's already owned partitions"
+      );
+    });
+
+    function createOwnershipMap(
+      partitionToOwner: Record<string, string>
+    ): Map<string, PartitionOwnership> {
+      const ownershipMap = new Map<string, PartitionOwnership>();
+
+      for (const partitionId in partitionToOwner) {
+        ownershipMap.set(partitionId, {
+          consumerGroup: "$Default",
+          eventHubName: "eventhubname1",
+          fullyQualifiedNamespace: "fqdn",
+          ownerId: partitionToOwner[partitionId],
+          partitionId: partitionId,
+          etag: "etag",
+          lastModifiedTimeInMs: Date.now()
+        });
+      }
+
+      return ownershipMap;
+    }
   });
 });

--- a/sdk/eventhub/event-hubs/test/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/utils/testUtils.ts
@@ -29,9 +29,7 @@ function getEnvVarValue(name: string): string | undefined {
 
 export function getEnvVars(): { [key in EnvVarKeys]: any } {
   return {
-    [EnvVarKeys.EVENTHUB_CONNECTION_STRING]: getEnvVarValue(
-      EnvVarKeys.EVENTHUB_CONNECTION_STRING
-    ),
+    [EnvVarKeys.EVENTHUB_CONNECTION_STRING]: getEnvVarValue(EnvVarKeys.EVENTHUB_CONNECTION_STRING),
     [EnvVarKeys.EVENTHUB_NAME]: getEnvVarValue(EnvVarKeys.EVENTHUB_NAME),
     [EnvVarKeys.IOTHUB_EH_COMPATIBLE_CONNECTION_STRING]: getEnvVarValue(
       EnvVarKeys.IOTHUB_EH_COMPATIBLE_CONNECTION_STRING
@@ -47,6 +45,7 @@ export async function loopUntil(args: {
   timeBetweenRunsMs: number;
   maxTimes: number;
   until: () => Promise<boolean>;
+  errorMessageFn?: () => string;
 }): Promise<void> {
   for (let i = 0; i < args.maxTimes + 1; ++i) {
     const finished = await args.until();
@@ -59,5 +58,7 @@ export async function loopUntil(args: {
     await delay(args.timeBetweenRunsMs);
   }
 
-  throw new Error(`Waited way too long for ${args.name}`);
+  throw new Error(
+    `Waited way too long for ${args.name}: ${args.errorMessageFn ? args.errorMessageFn() : ""}`
+  );
 }


### PR DESCRIPTION
This "fixes" the problem we're seeing in #6439.

Our code was always assuming that we were allowed an "extra" partition, even
when the partitions would be evenly divisible by the number of processors.

This PR changes that to take into account whether or not we really do want to
have an extra partition.

NOTE: there is still a possibility of deadlock if a new processor comes online and
can't claim it's first partition. This is logged in issue #6945.