### PR TITLE
[Storage][test] set larger timeout when uploading 257 MB

### DIFF
--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -77,7 +77,7 @@ describe("Highlevel", () => {
 
     fs.unlinkSync(downloadedFile);
     assert.ok(downloadedData.equals(uploadedData));
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("uploadFile should success when blob < BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -205,7 +205,7 @@ describe("Highlevel", () => {
     assert.ok(uploadedBuffer.equals(downloadedBuffer));
 
     fs.unlinkSync(downloadFilePath);
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("uploadStream should success for tiny buffers", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -253,7 +253,7 @@ describe("Highlevel", () => {
       }
     });
     assert.ok(eventTriggered);
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadToBuffer should success - without passing the buffer", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -268,7 +268,7 @@ describe("Highlevel", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadToBuffer should throw error if the count(size provided in bytes) is too large", async () => {
     let error;
@@ -297,7 +297,7 @@ describe("Highlevel", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadBlobToBuffer should success when downloading a range inside blob", async () => {
     await blockBlobClient.upload("aaaabbbb", 8);
@@ -349,7 +349,7 @@ describe("Highlevel", () => {
     } catch (err) {
       assert.equal(err.name, "AbortError");
     }
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadToBuffer should update progress event", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -77,7 +77,7 @@ describe("Highlevel", () => {
 
     fs.unlinkSync(downloadedFile);
     assert.ok(downloadedData.equals(uploadedData));
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("uploadFile should success when blob < BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -205,7 +205,7 @@ describe("Highlevel", () => {
     assert.ok(uploadedBuffer.equals(downloadedBuffer));
 
     fs.unlinkSync(downloadFilePath);
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("uploadStream should success for tiny buffers", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -253,7 +253,7 @@ describe("Highlevel", () => {
       }
     });
     assert.ok(eventTriggered);
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadToBuffer should success - without passing the buffer", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -268,7 +268,7 @@ describe("Highlevel", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadToBuffer should throw error if the count(size provided in bytes) is too large", async () => {
     let error;
@@ -297,7 +297,7 @@ describe("Highlevel", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadBlobToBuffer should success when downloading a range inside blob", async () => {
     await blockBlobClient.upload("aaaabbbb", 8);
@@ -349,7 +349,7 @@ describe("Highlevel", () => {
     } catch (err) {
       assert.equal(err.name, "AbortError");
     }
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadToBuffer should update progress event", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");

--- a/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
@@ -76,7 +76,7 @@ describe("Highlevel Node.js only", () => {
 
     fs.unlinkSync(downloadedFile);
     assert.ok(downloadedData.equals(uploadedData));
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("uploadFile should success for small data", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -187,7 +187,7 @@ describe("Highlevel Node.js only", () => {
     assert.ok(uploadedBuffer.equals(downloadedBuffer));
 
     fs.unlinkSync(downloadFilePath);
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("uploadStream should abort", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -216,7 +216,7 @@ describe("Highlevel Node.js only", () => {
       }
     });
     assert.ok(eventTriggered);
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadToBuffer should success", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -231,7 +231,7 @@ describe("Highlevel Node.js only", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadToBuffer should succeed - without passing the buffer", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -245,7 +245,7 @@ describe("Highlevel Node.js only", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadToBuffer should throw an error if the count (size in bytes) is too large", async () => {
     let error;
@@ -317,7 +317,7 @@ describe("Highlevel Node.js only", () => {
     } catch (err) {
       assert.equal(err.name, "AbortError");
     }
-  });
+  }).timeout(3 * 60 * 1000);
 
   it("downloadToBuffer should update progress event", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");

--- a/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
@@ -76,7 +76,7 @@ describe("Highlevel Node.js only", () => {
 
     fs.unlinkSync(downloadedFile);
     assert.ok(downloadedData.equals(uploadedData));
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("uploadFile should success for small data", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -187,7 +187,7 @@ describe("Highlevel Node.js only", () => {
     assert.ok(uploadedBuffer.equals(downloadedBuffer));
 
     fs.unlinkSync(downloadFilePath);
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("uploadStream should abort", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -216,7 +216,7 @@ describe("Highlevel Node.js only", () => {
       }
     });
     assert.ok(eventTriggered);
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadToBuffer should success", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -231,7 +231,7 @@ describe("Highlevel Node.js only", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadToBuffer should succeed - without passing the buffer", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");
@@ -245,7 +245,7 @@ describe("Highlevel Node.js only", () => {
 
     const localFileContent = fs.readFileSync(tempFileLarge);
     assert.ok(localFileContent.equals(buf));
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadToBuffer should throw an error if the count (size in bytes) is too large", async () => {
     let error;
@@ -317,7 +317,7 @@ describe("Highlevel Node.js only", () => {
     } catch (err) {
       assert.equal(err.name, "AbortError");
     }
-  }).timeout(3 * 60 * 1000);
+  }).timeout(10 * 60 * 1000);
 
   it("downloadToBuffer should update progress event", async () => {
     recorder.skip("node", "Temp file - recorder doesn't support saving the file");


### PR DESCRIPTION
The duration of these tests normally is below 100 seconds but
occasionally goes over 2 minutes which is the timeout we specified
for mocha tests. We have seen from storage account logs that downloading
257 MB blob can take over 7 minutes.

This change increases the timeout value of these individual test cases 
to 10 minutes which hopefully should be large enough even for slow network.