### PR TITLE
[event-hubs] Migration guide changes to point to motivation and additional differences

### DIFF
--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -7,9 +7,12 @@ For users new to the JavaScript SDK for Event Hubs, please see the [readme file 
 
 ## General changes
 
-Version 5 of the `@azure/event-hubs` package is a result of our efforts to create a client library that is user friendly and idiomatic to the JavaScript ecosystem. Apart from redesigns resulting from following the new [Azure SDK Design Guidelines for Typescript](https://azure.github.io/azure-sdk/typescript_introduction.html#design-principles), the latest version provides the below improvements:
-for providing a better out-of-the-box experience for JavaScript developers 
-across several areas:
+Version 5 of the `@azure/event-hubs` package is a result of our efforts to
+create a client library that is user-friendly and idiomatic to the JavaScript
+ecosystem.
+
+Apart from redesigns resulting from the new [Azure SDK Design Guidelines for Typescript](https://azure.github.io/azure-sdk/typescript_introduction.html#design-principles),
+the latest version improves on several areas from V2:
 
 ### Handling backpressure
 

--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -7,8 +7,9 @@ For users new to the JavaScript SDK for Event Hubs, please see the [readme file 
 
 ## General changes
 
-EventHubs v5 is a redesign that provides a better out-of-the-box experience 
-for developers across several areas:
+EventHubs v5 is a redesign that aligns with the new Azure SDK [guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html#design-principles)
+for providing a better out-of-the-box experience for JavaScript developers 
+across several areas:
 
 ### Handling backpressure
 
@@ -67,6 +68,7 @@ If you havent created any consumer groups explicitly, then use the name of the d
 | In v2                                          | Equivalent in v5                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
 | `EventHubClient.receive()` and `EventHubClient.receiveBatch()`                       | `EventHubConsumerClient.subscribe()`                               | [receiveEvents](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts) |
+| Consumer group was optional | Consumer group is mandatory | [receiveEvents](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts) |
 
 Other noteworthy changes:
 - Use the `options` parameter to the `subscribe()` method to specify starting position to receive events from.

--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -1,4 +1,4 @@
-# Migration Guide (EventHubs v2 to v5)
+# Guide to migrate from @azure/event-hubs v2 to v5
 
 This document is intended for users that are familiar with V2 of the JavaScript SDK for Event Hubs library (`@azure/event-hubs@2.x.x` & `@azure/event-processor-host@2.x.x`) and wish 
 to migrate their application to V5 of the same library.
@@ -68,7 +68,6 @@ If you havent created any consumer groups explicitly, then use the name of the d
 | In v2                                          | Equivalent in v5                                                 | Sample |
 |------------------------------------------------|------------------------------------------------------------------|--------|
 | `EventHubClient.receive()` and `EventHubClient.receiveBatch()`                       | `EventHubConsumerClient.subscribe()`                               | [receiveEvents](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts) |
-| Consumer group was optional | Consumer group is mandatory | [receiveEvents](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/samples/typescript/src/receiveEvents.ts) |
 
 Other noteworthy changes:
 - Use the `options` parameter to the `subscribe()` method to specify starting position to receive events from.

--- a/sdk/eventhub/event-hubs/migrationguide.md
+++ b/sdk/eventhub/event-hubs/migrationguide.md
@@ -7,7 +7,7 @@ For users new to the JavaScript SDK for Event Hubs, please see the [readme file 
 
 ## General changes
 
-EventHubs v5 is a redesign that aligns with the new Azure SDK [guidelines](https://azure.github.io/azure-sdk/typescript_introduction.html#design-principles)
+Version 5 of the `@azure/event-hubs` package is a result of our efforts to create a client library that is user friendly and idiomatic to the JavaScript ecosystem. Apart from redesigns resulting from following the new [Azure SDK Design Guidelines for Typescript](https://azure.github.io/azure-sdk/typescript_introduction.html#design-principles), the latest version provides the below improvements:
 for providing a better out-of-the-box experience for JavaScript developers 
 across several areas:
 


### PR DESCRIPTION
Fixes #6604

* Include a link to the Azure SDK for TypeScript guidelines
* Change title of doc to mention the actual package name