### PR TITLE
Smoke Tests: correct location for globals.yml

### DIFF
--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -13,7 +13,7 @@ jobs:
       vmImage: $(OSVmImage)
 
     variables:
-      - template: ./templates/variables/globals.yml
+      - template: ../../eng/pipelines/templates/variables/globals.yml
 
     steps:
       - task: NodeTool@0
@@ -30,7 +30,7 @@ jobs:
       - task: Npm@1
         inputs:
           command: custom
-          customCommand: 'list --depth=0'
+          customCommand: "list --depth=0"
           workingDir: common/smoke-test/
         displayName: List packages installed from the feed
 
@@ -38,7 +38,7 @@ jobs:
       - task: Npm@1
         inputs:
           command: custom
-          customCommand: 'install -g typescript'
+          customCommand: "install -g typescript"
         displayName: Install TypeScript
         condition: and(succeeded(), contains(variables['OSVmImage'], 'macos'))
 


### PR DESCRIPTION
Moving the smoke tests yml file is difficult to test without having the pipeline in `master`.. When the original PR merged it was using a yml file which pointed to the wrong location for the globals.yml. This PR fixes that. 