### PR TITLE
[storage][sample]fix sample debug in launch.json

### DIFF
--- a/sdk/storage/storage-blob/.vscode/launch.json
+++ b/sdk/storage/storage-blob/.vscode/launch.json
@@ -15,9 +15,9 @@
       "type": "node",
       "request": "launch",
       "name": "Debug Typescript Samples",
-      "program": "${workspaceFolder}/samples/typescript/basic.ts",
-      "preLaunchTask": "npm: build:ts-samples",
-      "outFiles": ["${workspaceFolder}/dist-esm/samples/typescript/*.js"]
+      "program": "${workspaceFolder}/samples/typescript/src/basic.ts",
+      "preLaunchTask": "npm: build:samples",
+      "outFiles": ["${workspaceFolder}/samples/typescript/dist/samples/typescript/src/*.js"]
     },
     {
       "type": "node",


### PR DESCRIPTION
The debug config for "Debug Typescript Samples" is broken by PR #6496.
azure-sdk-for-js/sdk/storage/storage-blob/.vscode/launch.json
```
    {
      "type": "node",
      "request": "launch",
      "name": "Debug Typescript Samples",
      "program": "${workspaceFolder}/samples/typescript/basic.ts",
      "preLaunchTask": "npm: build:ts-samples",
      "outFiles": ["${workspaceFolder}/dist-esm/samples/typescript/*.js"]
    },
```
1. The generated JavaScript files are now under the ${workspaceFolder}/samples/typescript/dist/samples/typescript/src/ directory.
2. The `npm build:ts-samples` command is removed.

I haven't figured out the perfect fix for the `preLaunchTask` since `build:prep-samples` will delete the main function of each individual sample file.
