### PR TITLE
DocWarden version lock-down.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -159,7 +159,7 @@ jobs:
 
       - script: |
           pip install setuptools wheel
-          pip install doc-warden
+          pip install doc-warden==$(DocWardenVersion)
           ward scan -d $(Build.SourcesDirectory) -c $(Build.SourcesDirectory)/.docsettings.yml
         displayName: "Verify Readmes"
 

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,4 +1,5 @@
 variables:
+  DocWardenVersion: '0.4.2'
   NodeVersion: "10.x"
   OSVmImage: "ubuntu-16.04"
   Agent.Source.Git.ShallowFetchDepth: 20


### PR DESCRIPTION
This PR adds the logic to lock down the version of doc-warden that is being used in the build pipeline. We are doing this because we want to be able to update the doc-warden package and we don't want a bug to blow up all the pipelines, instead, when we publish doc-warden we can flight usage of the new version with a PR by updating the version in the global variables.