### PR TITLE
[storage][test] sharing the cached default HttpClient

### DIFF
--- a/sdk/storage/storage-blob/test/utils/index.ts
+++ b/sdk/storage/storage-blob/test/utils/index.ts
@@ -51,12 +51,8 @@ export function getGenericBSU(
   } else {
     const credential = getGenericCredential(accountType) as StorageSharedKeyCredential;
 
-    const pipeline = newPipeline(credential, {
-      // Enable logger when debugging
-      // logger: new ConsoleHttpPipelineLogger(HttpPipelineLogLevel.INFO)
-    });
     const blobPrimaryURL = `https://${credential.accountName}${accountNameSuffix}.blob.core.windows.net/`;
-    return new BlobServiceClient(blobPrimaryURL, pipeline);
+    return new BlobServiceClient(blobPrimaryURL, credential);
   }
 }
 


### PR DESCRIPTION
Tests were using `newPipeline()` to create a pipeline then pass it to
the `BlobServiceClient` constructor.  `newPipeline()` was consider an
advanced usage (this can be debated) so we didn't try to offer a
HttpClient by default.

This change updates the blob tests to use the `BlobServiceClient`
directly so all clients can share the default HttpClient