### PR TITLE
Enable retry logging using azure logger

### DIFF
--- a/sdk/storage/storage-blob/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageRetryPolicy.ts
@@ -18,6 +18,7 @@ import {
 import { StorageRetryOptions } from "../StorageRetryPolicyFactory";
 import { URLConstants } from "../utils/constants";
 import { delay, setURLHost, setURLParameter } from "../utils/utils.common";
+import { logger } from "../log";
 
 /**
  * A factory method used to generated a RetryPolicy factory.
@@ -293,13 +294,21 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Comment/uncomment as necessary for releasing/debugging.
    *
    * @private
-   * @param {HttpPipelineLogLevel} _level
-   * @param {string} _message
+   * @param {HttpPipelineLogLevel} level
+   * @param {string} message
    * @memberof StorageRetryPolicy
    */
-  // tslint:disable-next-line:variable-name
-  private logf(_level: HttpPipelineLogLevel, _message: string) {
-    // this.log(_level, _message);
+  private logf(level: HttpPipelineLogLevel, message: string) {
+    switch (level) {
+      case HttpPipelineLogLevel.ERROR:
+        logger.error(message);
+        break;
+      case HttpPipelineLogLevel.WARNING:
+        logger.warning(message);
+        break;
+      case HttpPipelineLogLevel.INFO:
+        logger.info(message);
+    }
   }
 
   /**

--- a/sdk/storage/storage-blob/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-blob/src/policies/StorageRetryPolicy.ts
@@ -7,7 +7,6 @@ import {
   AbortSignalLike,
   BaseRequestPolicy,
   HttpOperationResponse,
-  HttpPipelineLogLevel,
   RequestPolicy,
   RequestPolicyFactory,
   RequestPolicyOptions,
@@ -184,8 +183,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 
     let response: HttpOperationResponse | undefined;
     try {
-      this.logf(
-        HttpPipelineLogLevel.INFO,
+      logger.info(
         `RetryPolicy: =====> Try=${attempt} ${isPrimaryRetry ? "Primary" : "Secondary"}`
       );
       response = await this._nextPolicy.sendRequest(newRequest);
@@ -195,8 +193,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 
       secondaryHas404 = secondaryHas404 || (!isPrimaryRetry && response.status === 404);
     } catch (err) {
-      this.logf(
-        HttpPipelineLogLevel.ERROR,
+      logger.error(
         `RetryPolicy: Caught error, message: ${err.message}, code: ${err.code}`
       );
       if (!this.shouldRetry(isPrimaryRetry, attempt, response, err)) {
@@ -226,8 +223,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     err?: RestError
   ): boolean {
     if (attempt >= this.retryOptions.maxTries!) {
-      this.logf(
-        HttpPipelineLogLevel.INFO,
+      logger.info(
         `RetryPolicy: Attempt(s) ${attempt} >= maxTries ${this.retryOptions
           .maxTries!}, no further try.`
       );
@@ -257,8 +253,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
               .toUpperCase()
               .includes(retriableError))
         ) {
-          this.logf(
-            HttpPipelineLogLevel.INFO,
+          logger.info(
             `RetryPolicy: Network error ${retriableError} found, will retry.`
           );
           return true;
@@ -272,14 +267,13 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     if (response || err) {
       const statusCode = response ? response.status : err ? err.statusCode : 0;
       if (!isPrimaryRetry && statusCode === 404) {
-        this.logf(HttpPipelineLogLevel.INFO, `RetryPolicy: Secondary access with 404, will retry.`);
+        logger.info(`RetryPolicy: Secondary access with 404, will retry.`);
         return true;
       }
 
       // Server internal error or server timeout
       if (statusCode === 503 || statusCode === 500) {
-        this.logf(
-          HttpPipelineLogLevel.INFO,
+        logger.info(
           `RetryPolicy: Will retry for status code ${statusCode}.`
         );
         return true;
@@ -287,28 +281,6 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     }
 
     return false;
-  }
-
-  /**
-   * This is to log for debugging purposes only.
-   * Comment/uncomment as necessary for releasing/debugging.
-   *
-   * @private
-   * @param {HttpPipelineLogLevel} level
-   * @param {string} message
-   * @memberof StorageRetryPolicy
-   */
-  private logf(level: HttpPipelineLogLevel, message: string) {
-    switch (level) {
-      case HttpPipelineLogLevel.ERROR:
-        logger.error(message);
-        break;
-      case HttpPipelineLogLevel.WARNING:
-        logger.warning(message);
-        break;
-      case HttpPipelineLogLevel.INFO:
-        logger.info(message);
-    }
   }
 
   /**
@@ -339,7 +311,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
       delayTimeInMs = Math.random() * 1000;
     }
 
-    this.logf(HttpPipelineLogLevel.INFO, `RetryPolicy: Delay for ${delayTimeInMs}ms`);
+    logger.info(`RetryPolicy: Delay for ${delayTimeInMs}ms`);
     return delay(delayTimeInMs, abortSignal, RETRY_ABORT_ERROR);
   }
 }

--- a/sdk/storage/storage-file-datalake/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-file-datalake/src/policies/StorageRetryPolicy.ts
@@ -16,6 +16,7 @@ import {
 import { StorageRetryOptions } from "../StorageRetryPolicyFactory";
 import { UrlConstants } from "../utils/constants";
 import { delay, setURLHost, setURLParameter } from "../utils/utils.common";
+import { logger } from "../log";
 
 /**
  * A factory method used to generated a RetryPolicy factory.
@@ -291,13 +292,21 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Comment/uncomment as necessary for releasing/debugging.
    *
    * @private
-   * @param {HttpPipelineLogLevel} _level
-   * @param {string} _message
+   * @param {HttpPipelineLogLevel} level
+   * @param {string} message
    * @memberof StorageRetryPolicy
    */
-  // tslint:disable-next-line:variable-name
-  private logf(_level: HttpPipelineLogLevel, _message: string) {
-    // this.log(_level, _message);
+  private logf(level: HttpPipelineLogLevel, message: string) {
+    switch (level) {
+      case HttpPipelineLogLevel.ERROR:
+        logger.error(message);
+        break;
+      case HttpPipelineLogLevel.WARNING:
+        logger.warning(message);
+        break;
+      case HttpPipelineLogLevel.INFO:
+        logger.info(message);
+    }
   }
 
   /**

--- a/sdk/storage/storage-file-share/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageRetryPolicy.ts
@@ -18,6 +18,7 @@ import { AbortError } from "@azure/abort-controller";
 import { StorageRetryOptions } from "../StorageRetryPolicyFactory";
 import { URLConstants } from "../utils/constants";
 import { delay, setURLParameter } from "../utils/utils.common";
+import { logger } from "../log";
 
 /**
  * A factory method used to generated a RetryPolicy factory.
@@ -287,9 +288,17 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * @param {string} message
    * @memberof StorageRetryPolicy
    */
-  // tslint:disable-next-line:variable-name
-  private logf(_level: HttpPipelineLogLevel, _message: string) {
-    // this.log(_level, _message);
+  private logf(level: HttpPipelineLogLevel, message: string) {
+    switch (level) {
+      case HttpPipelineLogLevel.ERROR:
+        logger.error(message);
+        break;
+      case HttpPipelineLogLevel.WARNING:
+        logger.warning(message);
+        break;
+      case HttpPipelineLogLevel.INFO:
+        logger.info(message);
+    }
   }
 
   /**

--- a/sdk/storage/storage-file-share/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-file-share/src/policies/StorageRetryPolicy.ts
@@ -5,7 +5,6 @@ import {
   AbortSignalLike,
   BaseRequestPolicy,
   HttpOperationResponse,
-  HttpPipelineLogLevel,
   RequestPolicy,
   RequestPolicyFactory,
   RequestPolicyOptions,
@@ -174,8 +173,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 
     let response: HttpOperationResponse | undefined;
     try {
-      this.logf(
-        HttpPipelineLogLevel.INFO,
+      logger.info(
         `RetryPolicy: =====> Try=${attempt} ${isPrimaryRetry ? "Primary" : "Secondary"}`
       );
       response = await this._nextPolicy.sendRequest(newRequest);
@@ -185,8 +183,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 
       secondaryHas404 = secondaryHas404 || (!isPrimaryRetry && response.status === 404);
     } catch (err) {
-      this.logf(
-        HttpPipelineLogLevel.ERROR,
+      logger.error(
         `RetryPolicy: Caught error, message: ${err.message}, code: ${err.code}`
       );
       if (!this.shouldRetry(isPrimaryRetry, attempt, response, err)) {
@@ -216,8 +213,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     err?: RestError
   ): boolean {
     if (attempt >= this.retryOptions.maxTries!) {
-      this.logf(
-        HttpPipelineLogLevel.INFO,
+      logger.info(
         `RetryPolicy: Attempt(s) ${attempt} >= maxTries ${this.retryOptions
           .maxTries!}, no further try.`
       );
@@ -247,8 +243,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
               .toUpperCase()
               .includes(retriableError))
         ) {
-          this.logf(
-            HttpPipelineLogLevel.INFO,
+          logger.info(
             `RetryPolicy: Network error ${retriableError} found, will retry.`
           );
           return true;
@@ -262,14 +257,13 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     if (response || err) {
       const statusCode = response ? response.status : err ? err.statusCode : 0;
       if (!isPrimaryRetry && statusCode === 404) {
-        this.logf(HttpPipelineLogLevel.INFO, `RetryPolicy: Secondary access with 404, will retry.`);
+        logger.info(`RetryPolicy: Secondary access with 404, will retry.`);
         return true;
       }
 
       // Server internal error or server timeout
       if (statusCode === 503 || statusCode === 500) {
-        this.logf(
-          HttpPipelineLogLevel.INFO,
+        logger.info(
           `RetryPolicy: Will retry for status code ${statusCode}.`
         );
         return true;
@@ -277,28 +271,6 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     }
 
     return false;
-  }
-
-  /**
-   * This is to log for debugging purposes only.
-   * Comment/uncomment as necessary for releasing/debugging.
-   *
-   * @private
-   * @param {HttpPipelineLogLevel} level
-   * @param {string} message
-   * @memberof StorageRetryPolicy
-   */
-  private logf(level: HttpPipelineLogLevel, message: string) {
-    switch (level) {
-      case HttpPipelineLogLevel.ERROR:
-        logger.error(message);
-        break;
-      case HttpPipelineLogLevel.WARNING:
-        logger.warning(message);
-        break;
-      case HttpPipelineLogLevel.INFO:
-        logger.info(message);
-    }
   }
 
   /**
@@ -330,7 +302,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
       delayTimeInMs = Math.random() * 1000;
     }
 
-    this.logf(HttpPipelineLogLevel.INFO, `RetryPolicy: Delay for ${delayTimeInMs}ms`);
+    logger.info(`RetryPolicy: Delay for ${delayTimeInMs}ms`);
     return delay(delayTimeInMs, abortSignal, RETRY_ABORT_ERROR);
   }
 }

--- a/sdk/storage/storage-queue/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/StorageRetryPolicy.ts
@@ -18,6 +18,7 @@ import {
 import { StorageRetryOptions } from "../StorageRetryPolicyFactory";
 import { URLConstants } from "../utils/constants";
 import { delay, setURLHost, setURLParameter } from "../utils/utils.common";
+import { logger } from "../log";
 
 /**
  * A factory method used to generated a RetryPolicy factory.
@@ -292,13 +293,21 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
    * Comment/uncomment as necessary for releasing/debugging.
    *
    * @private
-   * @param {HttpPipelineLogLevel} _level
-   * @param {string} _message
+   * @param {HttpPipelineLogLevel} level
+   * @param {string} message
    * @memberof StorageRetryPolicy
    */
-  // tslint:disable-next-line:variable-name
-  private logf(_level: HttpPipelineLogLevel, _message: string) {
-    // this.log(_level, _message);
+  private logf(level: HttpPipelineLogLevel, message: string) {
+    switch (level) {
+      case HttpPipelineLogLevel.ERROR:
+        logger.error(message);
+        break;
+      case HttpPipelineLogLevel.WARNING:
+        logger.warning(message);
+        break;
+      case HttpPipelineLogLevel.INFO:
+        logger.info(message);
+    }
   }
 
   /**

--- a/sdk/storage/storage-queue/src/policies/StorageRetryPolicy.ts
+++ b/sdk/storage/storage-queue/src/policies/StorageRetryPolicy.ts
@@ -7,7 +7,6 @@ import {
   AbortSignalLike,
   BaseRequestPolicy,
   HttpOperationResponse,
-  HttpPipelineLogLevel,
   RequestPolicy,
   RequestPolicyFactory,
   RequestPolicyOptions,
@@ -183,8 +182,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 
     let response: HttpOperationResponse | undefined;
     try {
-      this.logf(
-        HttpPipelineLogLevel.INFO,
+      logger.info(
         `RetryPolicy: =====> Try=${attempt} ${isPrimaryRetry ? "Primary" : "Secondary"}`
       );
       response = await this._nextPolicy.sendRequest(newRequest);
@@ -194,8 +192,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
 
       secondaryHas404 = secondaryHas404 || (!isPrimaryRetry && response.status === 404);
     } catch (err) {
-      this.logf(
-        HttpPipelineLogLevel.ERROR,
+      logger.error(
         `RetryPolicy: Caught error, message: ${err.message}, code: ${err.code}`
       );
       if (!this.shouldRetry(isPrimaryRetry, attempt, response, err)) {
@@ -225,8 +222,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     err?: RestError
   ): boolean {
     if (attempt >= this.retryOptions.maxTries!) {
-      this.logf(
-        HttpPipelineLogLevel.INFO,
+      logger.info(
         `RetryPolicy: Attempt(s) ${attempt} >= maxTries ${this.retryOptions
           .maxTries!}, no further try.`
       );
@@ -256,8 +252,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
               .toUpperCase()
               .includes(retriableError))
         ) {
-          this.logf(
-            HttpPipelineLogLevel.INFO,
+          logger.info(
             `RetryPolicy: Network error ${retriableError} found, will retry.`
           );
           return true;
@@ -271,14 +266,13 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     if (response || err) {
       const statusCode = response ? response.status : err ? err.statusCode : 0;
       if (!isPrimaryRetry && statusCode === 404) {
-        this.logf(HttpPipelineLogLevel.INFO, `RetryPolicy: Secondary access with 404, will retry.`);
+        logger.info(`RetryPolicy: Secondary access with 404, will retry.`);
         return true;
       }
 
       // Server internal error or server timeout
       if (statusCode === 503 || statusCode === 500) {
-        this.logf(
-          HttpPipelineLogLevel.INFO,
+        logger.info(
           `RetryPolicy: Will retry for status code ${statusCode}.`
         );
         return true;
@@ -286,28 +280,6 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
     }
 
     return false;
-  }
-
-  /**
-   * This is to log for debugging purposes only.
-   * Comment/uncomment as necessary for releasing/debugging.
-   *
-   * @private
-   * @param {HttpPipelineLogLevel} level
-   * @param {string} message
-   * @memberof StorageRetryPolicy
-   */
-  private logf(level: HttpPipelineLogLevel, message: string) {
-    switch (level) {
-      case HttpPipelineLogLevel.ERROR:
-        logger.error(message);
-        break;
-      case HttpPipelineLogLevel.WARNING:
-        logger.warning(message);
-        break;
-      case HttpPipelineLogLevel.INFO:
-        logger.info(message);
-    }
   }
 
   /**
@@ -338,7 +310,7 @@ export class StorageRetryPolicy extends BaseRequestPolicy {
       delayTimeInMs = Math.random() * 1000;
     }
 
-    this.logf(HttpPipelineLogLevel.INFO, `RetryPolicy: Delay for ${delayTimeInMs}ms`);
+    logger.info(`RetryPolicy: Delay for ${delayTimeInMs}ms`);
     return delay(delayTimeInMs, abortSignal, RETRY_ABORT_ERROR);
   }
 }


### PR DESCRIPTION
Currently there's no way to configure StorageRetryPolicy to log retries without changing the code. Furthermore, the commented code in current `logf` method relies on `RequestPolicyOptions.log()` method, which depends on `HttpPipelineLogger` argument passed to `RequestPolicy`'s constructor. But there's no option to configure the option when creating a `StorageRetryPolicyFactory` instance.

This change enables retry logging using the same azure logger that we use in other places in storage code. HtttpPipelineLogLevel has four levels: OFF, ERROR, WARNING, INFO, which maps nicely to azure logger's `error()/warning()/info()` methods.