### PR TITLE
[ai-text-analytics] added note to readme about roles

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -79,7 +79,7 @@ or other credential providers provided with the Azure SDK, please install the `@
 npm install @azure/identity
 ```
 
-You will also need to [register a new AAD application][register_aad_app] and grant access to Text Analytics by assigning the `"Cognitive Services User"` role to your service principal (note: other roles such as `"Owner"` will not grant the necessary permissions, only `"Cognitive Services User"` or `"Cognitive Services Contributor"` will suffice to run the examples and the sample code).
+You will also need to [register a new AAD application][register_aad_app] and grant access to Text Analytics by assigning the `"Cognitive Services User"` role to your service principal (note: other roles such as `"Owner"` will not grant the necessary permissions, only `"Cognitive Services User"` will suffice to run the examples and the sample code).
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
 

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -79,7 +79,7 @@ or other credential providers provided with the Azure SDK, please install the `@
 npm install @azure/identity
 ```
 
-You will also need to [register a new AAD application][register_aad_app] and grant access to Text Analytics by assigning the `"Cognitive Services User"` role to your service principal.
+You will also need to [register a new AAD application][register_aad_app] and grant access to Text Analytics by assigning the `"Cognitive Services User"` role to your service principal (note: other roles such as `"Owner"` will not grant the necessary permissions, only `"Cognitive Services User"` or `"Cognitive Services Contributor"` will suffice to run the examples and the sample code).
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
 


### PR DESCRIPTION
Through experimenting with the samples I found out (and confirmed with @xirzec) that unlike several other services the `Owner` role in AAD does not grant access to read/write the API in Cognitive Services. The `Cognitive Services {User,Contributor,Data Reader}` roles are required. For testing I usually create a resource and assign an SP to be an owner of that resource, so I spent some time today debugging why that wasn't working for our token RBAC samples. 

We figure it would be good to add a callout that mentions this for users messing with the samples.