### PR TITLE
[event-hubs] Fix broken/outdated links

### DIFF
--- a/sdk/eventhub/event-hubs/README.md
+++ b/sdk/eventhub/event-hubs/README.md
@@ -5,8 +5,8 @@ Azure Event Hubs is a highly scalable publish-subscribe service that can ingest 
 The Azure Event Hubs client library allows you to send and receive events in your Node.js application.
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs) |
-[Package (npm)](https://www.npmjs.com/package/@azure/event-hubs/v/next) |
-[API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/event-hubs/?view=azure-node-preview) |
+[Package (npm)](https://www.npmjs.com/package/@azure/event-hubs) |
+[API Reference Documentation](https://docs.microsoft.com/javascript/api/@azure/event-hubs) |
 [Product documentation](https://azure.microsoft.com/en-us/services/event-hubs/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs/samples)
 


### PR DESCRIPTION
EventHubs is GA so we can fix some of the links to just point to the current package.