### PR TITLE
[storage][test] set larger timeout for fileclient test

### DIFF
--- a/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
@@ -27,6 +27,7 @@ describe("FileClient Node.js only", () => {
   let fileName: string;
   let fileClient: ShareFileClient;
   const content = "Hello World";
+  const timeoutForLargeFileUploadingTest = 10 * 60 * 1000;
 
   let recorder: Recorder;
 
@@ -68,7 +69,7 @@ describe("FileClient Node.js only", () => {
 
     fs.unlinkSync(downloadedFile);
     assert.ok(downloadedData.equals(uploadedData));
-  });
+  }).timeout(timeoutForLargeFileUploadingTest);
 
   it("upload with buffer and default parameters", async () => {
     const body: string = recorder.getUniqueName("randomstring");


### PR DESCRIPTION
which uploads 257 MB data.

Previous change in PR #6950 only covers high level tests.