### PR TITLE
[event-hubs] Introduce a random delay when starting the event processor loop 

### DIFF
--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -56,6 +56,15 @@ export interface CommonEventProcessorOptions  // make the 'maxBatchSize', 'maxWa
   loopIntervalInMs?: number;
 
   /**
+   * The # of milliseconds (as a non-inclusive upper-bound) to delay before
+   * starting the event processor loop.
+   *
+   * This allows us to mitigate potential lockstep issues with other event
+   * processors that are starting up at the same time.
+   */
+  initialLoopDelayMaxInMs?: number;
+
+  /**
    * A load balancer to use to find targets or a specific partition to target.
    */
   processingTarget?: PartitionLoadBalancer | string;


### PR DESCRIPTION
Add in a randomized delay when starting the event processor loop for the first time, to avoid processors running on the exact same cadence and getting into a deadlock.

Fixes #7017 