### PR TITLE
Quick fix for core's CI.yml

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -41,7 +41,7 @@ pr:
 stages:
   - template: ../../eng/pipelines/templates/stages/archetype-sdk-client.yml
     parameters:
-      ServiceDirectory: "core"
+      ServiceDirectory: core
       Artifacts:
         - name: azure-abort-controller
           safeName: azureabortcontroller


### PR DESCRIPTION
The sdk/core/ci.yml file had unnecessary quotes around the ServiceDirectory entry. It is the only ci.yml file in the repo with the quotes.