### PR TITLE
[Recorder] Bug Fix - Verify for `sdk` folder and `rush.json` file along with the `package.json`

### DIFF
--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -300,7 +300,11 @@ export function findRecordingsFolderPath(filePath: string): string {
   try {
     // While loop to find the `recordings` folder
     while (!fs.existsSync(path.resolve(currentPath, "recordings/"))) {
-      if (fs.existsSync(path.resolve(currentPath, "package.json"))) {
+      if (
+        fs.existsSync(path.resolve(currentPath, "package.json")) &&
+        fs.existsSync(path.resolve(currentPath, "..", "..", "sdk/")) &&
+        fs.existsSync(path.resolve(currentPath, "..", "..", "..", "rush.json"))
+      ) {
         // package.json of the SDK is found but not the `recordings` folder
         // which is supposed to be present at the same level as package.json
         throw new Error(`'recordings' folder is not found at ${currentPath}`);


### PR DESCRIPTION
### Issue

@sadasant came up with the issue, error is as follows.
```
 1) Keys client - create, read, update and delete operations                                                                                                                                        
       "before each" hook for "can create a key with requestOptions timeout":                                                                                                                        
     Error: Unable to locate the 'recordings' folder anywhere in the hierarchy of the file path /home/vsonline/workspace/sdk/keyvault/keyvault-keys/dist-esm/test/CRUD.test.js                       
 Error: 'recordings' folder is not found at /home/vsonline/workspace/sdk/keyvault/keyvault-keys/dist-esm 
```
- Recorder was relying on the package.json as a limit in the hierarchy to find the recordings folder
- But keyvault-keys package is verifying the package.json in the tests, which adds a package.json copy in the dist-esm folder.
- In that case, Recorder before hitting the keyvault-keys/package.json, it looks at dist-esm/package.json and spits an error saying the recordings folder is not found.

### Fix
Other than just checking for package.json..
Additional checks are added to confirm that the package.json we come across, is for sure located at `sdk/service/service-sdk`.
- Additional checks - `sdk` folder and `rush.json` at the root.