### PR TITLE
[core-http] Fix the error inconsistency of requestOptions.timeout - node vs browser

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.4 (Unreleased)
 
-- Fixed the error thrown when a request is terminated with `OperationRequestOptions.timeout` in browsers. An abort error is thrown with the message - "The operation was aborted." if the request is terminated. [PR #7159](https://github.com/Azure/azure-sdk-for-js/pull/7159)
+- Updated the error thrown when a request is terminated with `OperationRequestOptions.timeout` in browsers. An abort error is thrown with the message - "The operation was aborted." if the request is terminated. [PR #7159](https://github.com/Azure/azure-sdk-for-js/pull/7159)
 - Fixed an issue where `error.code` and `error.message` are not assigned for `StorageError` instances. ([PR #7107](https://github.com/Azure/azure-sdk-for-js/pull/7107))
 
 ## 1.0.3 (2020-01-02)

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## 1.0.4 (Unreleased)
 
+- Fixed the error thrown when a request is terminated with `OperationRequestOptions.timeout` in browsers. An abort error is thrown with the message - "The operation was aborted." if the request is terminated. [PR #7159](https://github.com/Azure/azure-sdk-for-js/pull/7159)
+
 ## 1.0.3 (2020-01-02)
+
 - Added `x-ms-useragent` to the list of allowed headers in request logs.
 - Fix issue of data being pushed twice when reporting progress ([PR #6427](https://github.com/Azure/azure-sdk-for-js/issues/6427))
 - Move `getDefaultProxySettings()` calls into `proxyPolicy` so that libraries that don't use the PipelineOptions or createDefaultRequestPolicyFactories from core-http can use this behavior without duplicating code. ([PR #6478](https://github.com/Azure/azure-sdk-for-js/issues/6478))
-- Fix tracingPolicy() to set standard span attributes ([PR #6565](https://github.com/Azure/azure-sdk-for-js/pull/6565)).  Now the following are set correctly for the spans
+- Fix tracingPolicy() to set standard span attributes ([PR #6565](https://github.com/Azure/azure-sdk-for-js/pull/6565)). Now the following are set correctly for the spans
   - `http.method`
   - `http.url`
   - `http.user_agent`

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.4 (Unreleased)
 
-- Updated the error thrown when a request is terminated with `OperationRequestOptions.timeout` in browsers. An abort error is thrown with the message - "The operation was aborted." if the request is terminated. [PR #7159](https://github.com/Azure/azure-sdk-for-js/pull/7159)
+- When an operation times out based on the `timeout` configured in the `OperationRequestOptions`, it gets terminated with an error. In this update, the error that is thrown in browser for such cases is updated to match what is thrown in node i.e an `AbortError` is thrown instead of the previous `RestError`. [PR #7159](https://github.com/Azure/azure-sdk-for-js/pull/7159)
 - Fixed an issue where `error.code` and `error.message` are not assigned for `StorageError` instances. ([PR #7107](https://github.com/Azure/azure-sdk-for-js/pull/7107))
 
 ## 1.0.3 (2020-01-02)

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -503,6 +503,7 @@ export interface RequestOptionsBase {
 
   /**
    * The number of milliseconds a request can take before automatically being terminated.
+   * If the request is terminated, an abort error is thrown with the message - "The operation was aborted."
    */
   timeout?: number;
 

--- a/sdk/core/core-http/lib/webResource.ts
+++ b/sdk/core/core-http/lib/webResource.ts
@@ -503,7 +503,7 @@ export interface RequestOptionsBase {
 
   /**
    * The number of milliseconds a request can take before automatically being terminated.
-   * If the request is terminated, an abort error is thrown with the message - "The operation was aborted."
+   * If the request is terminated, an `AbortError` is thrown.
    */
   timeout?: number;
 

--- a/sdk/core/core-http/lib/xhrHttpClient.ts
+++ b/sdk/core/core-http/lib/xhrHttpClient.ts
@@ -161,15 +161,7 @@ function rejectOnTerminalEvent(
       )
     )
   );
-  xhr.addEventListener("abort", () => reject(new AbortError("The operation was aborted.")));
-  xhr.addEventListener("timeout", () =>
-    reject(
-      new RestError(
-        `timeout of ${xhr.timeout}ms exceeded`,
-        RestError.REQUEST_SEND_ERROR,
-        undefined,
-        request
-      )
-    )
-  );
+  const abortError = new AbortError("The operation was aborted.");
+  xhr.addEventListener("abort", () => reject(abortError));
+  xhr.addEventListener("timeout", () => reject(abortError));
 }


### PR DESCRIPTION
Issue - https://github.com/Azure/azure-sdk-for-js/issues/5747

### Notes
https://github.com/Azure/azure-sdk-for-js/issues/5747#issuecomment-580012332
`requestOptions timeout` test is failing in the browser while it succeeds in node.
The test expects AbortError to be thrown.
Upon some digging through the internals of it in core-http, found this..
In node, we do a setTimeout with abort().
![image](https://user-images.githubusercontent.com/10452642/73406679-dd6d7380-42ab-11ea-8cd3-9cff80bc4472.png)
In browser, we are throwing a new error instead of the AbortError - This is the only difference and the reason for test failure.
![image](https://user-images.githubusercontent.com/10452642/73406689-e3fbeb00-42ab-11ea-9e7b-1048687dfdeb.png)

### Fix
Updated the `core-http` timeout to throw abort error instead just as suggested by the reviewers.