### PR TITLE
[KeyVault] Fixed typo on the ARM template

### DIFF
--- a/sdk/keyvault/test-resources.json
+++ b/sdk/keyvault/test-resources.json
@@ -15,7 +15,7 @@
         "description": "The tenant ID to which the application and resources belong."
       }
     },
-    "testApplicationOid": {
+    "testApplicationId": {
       "type": "string",
       "metadata": {
         "description": "The application client ID used to run tests."
@@ -41,7 +41,7 @@
         "accessPolicies": [
           {
             "tenantId": "[parameters('tenantId')]",
-            "objectId": "[parameters('testApplicationOid')]",
+            "objectId": "[parameters('testApplicationId')]",
             "permissions": {
               "keys": [
                 "backup",


### PR DESCRIPTION
I believe the parameter `testApplicationId` should be `testApplicationOid`. Am I missing something?