### PR TITLE
[Recorder] Bug Fix - Filter secrets from JSON

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2020-01-30
+
+- Fixed a bug where the replacements aren't properly filerted in the JSON recordings.
+
 ## 2020-01-29
 
 - Fixed a bug where the replacements provided aren't being replaced in the query-param parts of recordings, which is an expectation for playback. This caused a few test failures during playback for new recordings. More info [#7108](https://github.com/Azure/azure-sdk-for-js/issues/7108)

--- a/sdk/test-utils/recorder/src/baseRecorder.ts
+++ b/sdk/test-utils/recorder/src/baseRecorder.ts
@@ -16,7 +16,7 @@ import {
   ReplacementFunctions,
   ReplacementMap,
   filterSecretsFromStrings,
-  filterSecretsFromJSONContent
+  filterSecretsRecursivelyFromJSON
 } from "./utils";
 import { customConsoleLog } from "./customConsoleLog";
 
@@ -107,7 +107,7 @@ export abstract class BaseRecorder {
    */
   protected filterSecrets(content: any): any {
     const recordingFilterMethod =
-      typeof content === "string" ? filterSecretsFromStrings : filterSecretsFromJSONContent;
+      typeof content === "string" ? filterSecretsFromStrings : filterSecretsRecursivelyFromJSON;
     return recordingFilterMethod(content, replaceableVariables, replacements);
   }
 

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -165,14 +165,30 @@ export function filterSecretsFromStrings(
  * @param {ReplacementFunctions} replacements
  * @returns
  */
-export function filterSecretsFromJSONContent(
-  content: any,
+export function filterSecretsRecursivelyFromJSON(
+  recording: any,
   replaceableVariables: ReplacementMap,
   replacements: ReplacementFunctions
 ) {
-  return JSON.parse(
-    filterSecretsFromStrings(JSON.stringify(content), replaceableVariables, replacements)
-  );
+  let content = recording;
+  if (Array.isArray(content)) {
+    content = content.map((item) =>
+      filterSecretsRecursivelyFromJSON(item, replaceableVariables, replacements)
+    );
+  } else {
+    for (const i of Object.keys(content)) {
+      if (typeof content[i] === "string") {
+        content[i] = filterSecretsFromStrings(content[i], replaceableVariables, replacements);
+      } else if (content[i] !== null && typeof content[i] === "object") {
+        content[i] = filterSecretsRecursivelyFromJSON(
+          content[i],
+          replaceableVariables,
+          replacements
+        );
+      }
+    }
+  }
+  return content;
 }
 
 /**

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -166,29 +166,33 @@ export function filterSecretsFromStrings(
  * @returns
  */
 export function filterSecretsRecursivelyFromJSON(
-  recording: any,
+  content: any,
   replaceableVariables: ReplacementMap,
   replacements: ReplacementFunctions
 ) {
-  let content = recording;
-  if (Array.isArray(content)) {
-    content = content.map((item) =>
+  let updatedContent = content;
+  if (Array.isArray(updatedContent)) {
+    updatedContent = updatedContent.map((item) =>
       filterSecretsRecursivelyFromJSON(item, replaceableVariables, replacements)
     );
   } else {
-    for (const i of Object.keys(content)) {
-      if (typeof content[i] === "string") {
-        content[i] = filterSecretsFromStrings(content[i], replaceableVariables, replacements);
-      } else if (content[i] !== null && typeof content[i] === "object") {
-        content[i] = filterSecretsRecursivelyFromJSON(
-          content[i],
+    for (const i of Object.keys(updatedContent)) {
+      if (typeof updatedContent[i] === "string") {
+        updatedContent[i] = filterSecretsFromStrings(
+          updatedContent[i],
+          replaceableVariables,
+          replacements
+        );
+      } else if (updatedContent[i] !== null && typeof updatedContent[i] === "object") {
+        updatedContent[i] = filterSecretsRecursivelyFromJSON(
+          updatedContent[i],
           replaceableVariables,
           replacements
         );
       }
     }
   }
-  return content;
+  return updatedContent;
 }
 
 /**

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -171,11 +171,16 @@ export function filterSecretsRecursivelyFromJSON(
   replacements: ReplacementFunctions
 ) {
   let updatedContent = content;
-  if (Array.isArray(updatedContent)) {
+  if (typeof updatedContent === "string") {
+    // strings
+    updatedContent = filterSecretsFromStrings(updatedContent, replaceableVariables, replacements);
+  } else if (Array.isArray(updatedContent)) {
+    // arrays
     updatedContent = updatedContent.map((item) =>
       filterSecretsRecursivelyFromJSON(item, replaceableVariables, replacements)
     );
   } else {
+    // json objects
     for (const i of Object.keys(updatedContent)) {
       if (typeof updatedContent[i] === "string") {
         updatedContent[i] = filterSecretsFromStrings(
@@ -191,6 +196,10 @@ export function filterSecretsRecursivelyFromJSON(
         );
       }
     }
+    // last resort to capture any left over secrets
+    updatedContent = JSON.parse(
+      filterSecretsFromStrings(JSON.stringify(updatedContent), replaceableVariables, replacements)
+    );
   }
   return updatedContent;
 }

--- a/sdk/test-utils/recorder/test/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/utils.spec.ts
@@ -5,8 +5,8 @@ import {
   applyReplacementFunctions,
   encodeRFC3986,
   filterSecretsFromStrings,
-  filterSecretsFromJSONContent,
-  env
+  env,
+  filterSecretsRecursivelyFromJSON
 } from "../src/utils";
 import chai from "chai";
 const { expect } = chai;
@@ -210,7 +210,11 @@ ultramarine.com/url/PUBLIC
           }
         ]
       };
-      const updatedRecording = filterSecretsFromJSONContent(recording, replaceableVariables, []);
+      const updatedRecording = filterSecretsRecursivelyFromJSON(
+        recording,
+        replaceableVariables,
+        []
+      );
       expect(updatedRecording).to.deep.equal({
         recordings: [
           {


### PR DESCRIPTION
## Issue
- While the PR https://github.com/Azure/azure-sdk-for-js/pull/7119 fixed a bug where replacements of query-param parts of recordings aren't acted upon, it checked in with a regression.
  - The fix was to call filterSecrets method over the complete recording by converting the content from JSON to string with  `JSON.stringify`.
- The above introduced a new issue where `JSON.stringify` adds an escape character to the plain text strings present in the recordings and the callback functions with regex replacements weren't expecting the escape characters.
 Hence the callback functions failed to filter the recordings properly.
  - There are even more issues if we rely on `JSON.stringify`, if applied twice, it would add escape characters everywhere.

## Fix
- Instead of relying upon the `JSON.stringify`, came up with a new recursive method to filter JSON content.