### PR TITLE
add script to set CORS rules for storage queue testing

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -3,7 +3,7 @@ parameters:
   PreIntegrationSteps: ""
   PostIntegrationSteps: ""
   ResourceServiceDirectory: ""
-  EnvVars: []
+  EnvVars: {}
   MaxParallel: 0
   Matrix:
     Linux_Node10:

--- a/sdk/storage/storage-queue/tests.yml
+++ b/sdk/storage/storage-queue/tests.yml
@@ -13,10 +13,6 @@ jobs:
     parameters:
       PackageName: "@azure/storage-queue"
       ResourceServiceDirectory: storage
-      EnvVars:
-        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
-        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
-        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
       Matrix:
         Linux_Node8:
           OSVmImage: "ubuntu-16.04"

--- a/sdk/storage/storage-queue/tests.yml
+++ b/sdk/storage/storage-queue/tests.yml
@@ -9,6 +9,64 @@ resources:
       name: Azure/azure-sdk-tools
       endpoint: azure
 jobs:
-  - template: ../archetype-sdk-tests-storage.yml
+  - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
     parameters:
       PackageName: "@azure/storage-queue"
+      ResourceServiceDirectory: storage
+      EnvVars:
+        AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+        AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
+        AZURE_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+      Matrix:
+        Linux_Node8:
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "8.x"
+          TestType: "node"
+        Linux_Node10:
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "10.x"
+          TestType: "node"
+        Linux_Node12:
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "12.x"
+          TestType: "node"
+        Windows_Node8:
+          OSVmImage: "windows-2019"
+          NodeVersion: "8.x"
+          TestType: "node"
+        Windows_Node10:
+          OSVmImage: "windows-2019"
+          NodeVersion: "10.x"
+          TestType: "node"
+        Windows_Node12:
+          OSVmImage: "windows-2019"
+          NodeVersion: "12.x"
+          TestType: "node"
+        macOS_Node8:
+          OSVmImage: "macOS-10.13"
+          NodeVersion: "8.x"
+          TestType: "node"
+        macOS_Node10:
+          OSVmImage: "macOS-10.13"
+          NodeVersion: "10.x"
+          TestType: "node"
+        macOS_Node12:
+          OSVmImage: "macOS-10.13"
+          NodeVersion: "12.x"
+          TestType: "node"
+        Browser_Linux_Node10:
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "10.x"
+          TestType: "browser"
+        Browser_Windows_Node10:
+          OSVmImage: "windows-2019"
+          NodeVersion: "10.x"
+          TestType: "browser"
+        Browser_macOS_Node10:
+          OSVmImage: "macOS-10.13"
+          NodeVersion: "10.x"
+          TestType: "browser"
+        Linux_Sample10:
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "10.x"
+          TestType: "sample"

--- a/sdk/storage/test-resources-post.ps1
+++ b/sdk/storage/test-resources-post.ps1
@@ -28,8 +28,7 @@ $corsRules = (@{
       'MERGE',
       'POST',
       'OPTIONS',
-      'PUT',
-      'PATCH');
+      'PUT');
     ExposedHeaders  = @('*');
   })
 

--- a/sdk/storage/test-resources-post.ps1
+++ b/sdk/storage/test-resources-post.ps1
@@ -2,6 +2,9 @@
 # Licensed under the MIT License.
 
 # This script is used to set up CORS rules for queues after storage account creation by New-TestResources.ps1
+# There are no documented approaches to specifying CORS rules using ARM, this is a workaround until
+# support for setting CORS rules is added to ARM for Queues
+
 # It is invoked by the https://github.com/Azure/azure-sdk-for-js/blob/master/eng/New-TestResources.ps1
 # script after the ARM template, defined in https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/test-resources.json,
 # is finished being deployed. The ARM template is responsible for creating the Storage accounts needed for live tests.

--- a/sdk/storage/test-resources-post.ps1
+++ b/sdk/storage/test-resources-post.ps1
@@ -13,7 +13,7 @@ param (
   [string] $TestApplicationSecret
 )
 
-$storageAccountName = $DeploymentOutputs['STORAGE_ACCOUNT_NAME']
+$storageAccountName = $DeploymentOutputs['ACCOUNT_NAME']
 $context = New-AzStorageContext -StorageAccountName $storageAccountName
 
 # https://docs.microsoft.com/en-us/powershell/module/az.storage/set-azstoragecorsrule?view=azps-3.3.0

--- a/sdk/storage/test-resources-post.ps1
+++ b/sdk/storage/test-resources-post.ps1
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# This script is used to set up CORS rules for queues after storage account creation by New-TestResources.ps1
+# It is invoked by the https://github.com/Azure/azure-sdk-for-js/blob/master/eng/New-TestResources.ps1
+# script after the ARM template, defined in https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/test-resources.json,
+# is finished being deployed. The ARM template is responsible for creating the Storage accounts needed for live tests.
+
+param (
+  [hashtable] $DeploymentOutputs,
+  [string] $TenantId,
+  [string] $TestApplicationId,
+  [string] $TestApplicationSecret
+)
+
+$storageAccountName = $DeploymentOutputs['STORAGE_ACCOUNT_NAME']
+$context = New-AzStorageContext -StorageAccountName $storageAccountName
+
+# https://docs.microsoft.com/en-us/powershell/module/az.storage/set-azstoragecorsrule?view=azps-3.3.0
+$corsRules = (@{
+    AllowedHeaders  = @('*');
+    AllowedOrigins  = @('*');
+    MaxAgeInSeconds = 86400;
+    AllowedMethods  = @(
+      'DELETE',
+      'GET',
+      'HEAD',
+      'MERGE',
+      'POST',
+      'OPTIONS',
+      'PUT',
+      'PATCH');
+    ExposedHeaders  = @('*');
+  })
+
+Set-AzStorageCORSRule -ServiceType 'Queue' -CorsRules $corsRules -Context $context
+
+Write-Verbose "CORS rule set for $storageAccountName"

--- a/sdk/storage/test-resources.json
+++ b/sdk/storage/test-resources.json
@@ -13,6 +13,25 @@
       "metadata": {
         "description": "The client OID to grant access to test resources."
       }
+    },
+    "tenantId": {
+      "type": "string",
+      "defaultValue": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+      "metadata": {
+        "description": "The tenant ID to which the application and resources belong."
+      }
+    },
+    "testApplicationId": {
+      "type": "string",
+      "metadata": {
+        "description": "The application client ID used to run tests."
+      }
+    },
+    "testApplicationSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "The application client secret used to run tests."
+      }
     }
   },
   "variables": {
@@ -221,7 +240,7 @@
     }
   ],
   "outputs": {
-    "STORAGE_ACCOUNT_NAME": {
+    "ACCOUNT_NAME": {
       "type": "string",
       "value": "[variables('accountName')]"
     },
@@ -229,17 +248,29 @@
       "type": "string",
       "value": "[variables('datalakeAccountName')]"
     },
-    "STORAGE_ACCOUNT_KEY": {
+    "ACCOUNT_KEY": {
       "type": "string",
       "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('accountName')), variables('storageApiVersion')).keys[0].value]"
     },
-    "STORAGE_ACCOUNT_SAS": {
+    "ACCOUNT_SAS": {
       "type": "string",
       "value": "[concat('?', listAccountSas(variables('accountNameTidy'), variables('storageApiVersion'), variables('accountSasProperties')).accountSasToken)]"
     },
     "STORAGE_CONNECTION_STRING": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('accountName'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('accountName')), variables('storageApiVersion')).keys[0].value, ';EndpointSuffix=', 'core.windows.net')]"
+    },
+    "AZURE_TENANT_ID": {
+      "type": "string",
+      "value": "[parameters('tenantId')]"
+    },
+    "AZURE_CLIENT_ID": {
+      "type": "string",
+      "value": "[parameters('testApplicationId')]"
+    },
+    "AZURE_CLIENT_SECRET": {
+      "type": "string",
+      "value": "[parameters('testApplicationSecret')]"
     }
   }
 }


### PR DESCRIPTION
Unlike Blob and File storage, there are no documented approaches to specifying CORS rules using ARM. This uses a feature of the resource provisioner to run a powershell [command](https://docs.microsoft.com/en-us/powershell/module/az.storage/set-azstoragecorsrule?view=azps-3.3.0) that will set CORS rules for queues. 