### PR TITLE
[core-http] support username and password in proxy url string

### DIFF
--- a/sdk/core/core-http/lib/policies/proxyPolicy.ts
+++ b/sdk/core/core-http/lib/policies/proxyPolicy.ts
@@ -41,8 +41,9 @@ export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | unde
 
   const { username, password, urlWithoutAuth } = extractAuthFromUrl(proxyUrl);
   const parsedUrl = URLBuilder.parse(urlWithoutAuth);
+  const schema = parsedUrl.getScheme() ? parsedUrl.getScheme() + "://" : "";
   return {
-    host: parsedUrl.getScheme() + "://" + parsedUrl.getHost(),
+    host: schema + parsedUrl.getHost(),
     port: Number.parseInt(parsedUrl.getPort() || "80"),
     username,
     password

--- a/sdk/core/core-http/lib/policies/proxyPolicy.ts
+++ b/sdk/core/core-http/lib/policies/proxyPolicy.ts
@@ -39,10 +39,13 @@ export function getDefaultProxySettings(proxyUrl?: string): ProxySettings | unde
     }
   }
 
-  const parsedUrl = URLBuilder.parse(proxyUrl);
+  const { username, password, urlWithoutAuth } = extractAuthFromUrl(proxyUrl);
+  const parsedUrl = URLBuilder.parse(urlWithoutAuth);
   return {
     host: parsedUrl.getScheme() + "://" + parsedUrl.getHost(),
-    port: Number.parseInt(parsedUrl.getPort() || "80")
+    port: Number.parseInt(parsedUrl.getPort() || "80"),
+    username,
+    password
   };
 }
 
@@ -55,6 +58,27 @@ export function proxyPolicy(proxySettings?: ProxySettings): RequestPolicyFactory
       return new ProxyPolicy(nextPolicy, options, proxySettings!);
     }
   };
+}
+
+function extractAuthFromUrl(url: string) : { username?: string, password? : string, urlWithoutAuth: string } {
+  const atIndex = url.indexOf("@");
+  if (atIndex === -1) {
+    return { urlWithoutAuth: url};
+  }
+
+  const schemeIndex = url.indexOf("://")
+  let authStart =  schemeIndex !== -1 ? schemeIndex + 3  : 0;
+  const auth = url.substring(authStart, atIndex);
+  const colonIndex = auth.indexOf(":");
+  const hasPassword = colonIndex !== -1;
+  const username = hasPassword ? auth.substring(0, colonIndex) : auth
+  const password = hasPassword ? auth.substring(colonIndex + 1) : undefined;
+  const urlWithoutAuth = url.substring(0, authStart) + url.substring(atIndex + 1);
+  return {
+    username,
+    password,
+    urlWithoutAuth
+  }
 }
 
 export class ProxyPolicy extends BaseRequestPolicy {

--- a/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
+++ b/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
@@ -91,15 +91,16 @@ describe("getDefaultProxySettings", () => {
     });
 
     [
-      { proxyUrl: "prot://user:pass@proxy.microsoft.com", username: "user", password: "pass" },
-      { proxyUrl: "prot://user@proxy.microsoft.com", username: "user", password: undefined },
-      { proxyUrl: "prot://:pass@proxy.microsoft.com", username: undefined, password: "pass" },
-      { proxyUrl: "prot://proxy.microsoft.com", username: undefined, password: undefined }
+      { proxyUrl: "prot://user:pass@proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: "user", password: "pass" },
+      { proxyUrl: "prot://user@proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: "user", password: undefined },
+      { proxyUrl: "prot://:pass@proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: undefined, password: "pass" },
+      { proxyUrl: "prot://proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: undefined, password: undefined },
+      { proxyUrl: "user:pass@proxy.microsoft.com", proxyUrlWithoutAuth: "proxy.microsoft.com", username: "user", password: "pass" },
+      { proxyUrl: "proxy.microsoft.com", proxyUrlWithoutAuth: "proxy.microsoft.com", username: undefined, password: undefined }
     ].forEach((testCase) => {
       it(`should return settings with passed proxyUrl : ${testCase.proxyUrl}`, () => {
-        const proxyUrlWithoutAuth = "prot://proxy.microsoft.com";
         const proxySettings: ProxySettings = getDefaultProxySettings(testCase.proxyUrl)!;
-        proxySettings.host.should.equal(proxyUrlWithoutAuth);
+        proxySettings.host.should.equal(testCase.proxyUrlWithoutAuth);
         if (testCase.username) {
           proxySettings.username!.should.equal(testCase.username);
         }

--- a/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
+++ b/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
@@ -90,6 +90,25 @@ describe("getDefaultProxySettings", () => {
       proxySettings.port.should.equal(port);
     });
 
+    [
+      { proxyUrl: "prot://user:pass@proxy.microsoft.com", username: "user", password: "pass" },
+      { proxyUrl: "prot://user@proxy.microsoft.com", username: "user", password: undefined },
+      { proxyUrl: "prot://:pass@proxy.microsoft.com", username: undefined, password: "pass" },
+      { proxyUrl: "prot://proxy.microsoft.com", username: undefined, password: undefined }
+    ].forEach((testCase) => {
+      it.only(`should return settings with passed proxyUrl : ${testCase.proxyUrl}`, () => {
+        const proxyUrlWithoutAuth = "prot://proxy.microsoft.com";
+        const proxySettings: ProxySettings = getDefaultProxySettings(testCase.proxyUrl)!;
+        proxySettings.host.should.equal(proxyUrlWithoutAuth);
+        if (testCase.username) {
+          proxySettings.username!.should.equal(testCase.username);
+        }
+        if (testCase.password) {
+          proxySettings.password!.should.equal(testCase.password);
+        }
+      })
+    });
+
     describe("with loadEnvironmentProxyValue", () => {
       beforeEach(() => {
         delete process.env[Constants.HTTP_PROXY];

--- a/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
+++ b/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
@@ -96,7 +96,7 @@ describe("getDefaultProxySettings", () => {
       { proxyUrl: "prot://:pass@proxy.microsoft.com", username: undefined, password: "pass" },
       { proxyUrl: "prot://proxy.microsoft.com", username: undefined, password: undefined }
     ].forEach((testCase) => {
-      it.only(`should return settings with passed proxyUrl : ${testCase.proxyUrl}`, () => {
+      it(`should return settings with passed proxyUrl : ${testCase.proxyUrl}`, () => {
         const proxyUrlWithoutAuth = "prot://proxy.microsoft.com";
         const proxySettings: ProxySettings = getDefaultProxySettings(testCase.proxyUrl)!;
         proxySettings.host.should.equal(proxyUrlWithoutAuth);


### PR DESCRIPTION
by extracting then removing them from the url and parse the updated
url as URLBuilder doesn't support them.

For #5011 