### PR TITLE
Add request/response back to deserialization error

### DIFF
--- a/sdk/core/core-http/lib/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/deserializationPolicy.ts
@@ -262,7 +262,11 @@ export function deserializeResponseBody(
               );
             } catch (error) {
               const restError = new RestError(
-                `Error ${error} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`
+                `Error ${error} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`,
+                undefined,
+                parsedResponse.status,
+                parsedResponse.request,
+                parsedResponse
               );
               return Promise.reject(restError);
             }


### PR DESCRIPTION
In PR #7173 we removed some sanitization logic, but accidentally also removed setting the response and request on RestError.