### PR TITLE
[ai-text-analytics] User study feedback items

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/.eslintrc.json
+++ b/sdk/textanalytics/ai-text-analytics/.eslintrc.json
@@ -1,6 +1,9 @@
 {
-    "plugins": ["@azure/azure-sdk"],
-    "extends": ["../../.eslintrc.json", "plugin:@azure/azure-sdk/recommended"],
-    "ignorePatterns": ["src/generated/**/*.ts"]
+  "plugins": ["@azure/azure-sdk"],
+  "extends": ["../../.eslintrc.json", "plugin:@azure/azure-sdk/recommended"],
+  "ignorePatterns": ["src/generated/**/*.ts"],
+  "rules": {
+    "@typescript-eslint/no-empty-interface": "off"
   }
-  
+}
+

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -56,6 +56,9 @@ export interface DetectLanguageInput {
 }
 
 // @public
+export type DetectLanguageOptions = TextAnalyticsOperationOptions;
+
+// @public
 export type DetectLanguageResult = DetectLanguageSuccessResult | DetectLanguageErrorResult;
 
 // @public
@@ -63,9 +66,6 @@ export interface DetectLanguageResultCollection extends Array<DetectLanguageResu
     modelVersion: string;
     statistics?: TextDocumentBatchStatistics;
 }
-
-// @public
-export type DetectLanguagesOptions = TextAnalyticsOperationOptions;
 
 // @public
 export interface DetectLanguageSuccessResult extends TextAnalyticsSuccessResult {
@@ -240,8 +240,8 @@ export class TextAnalyticsClient {
     analyzeSentiment(inputs: TextDocumentInput[], options?: AnalyzeSentimentOptions): Promise<AnalyzeSentimentResultCollection>;
     defaultCountryHint: string;
     defaultLanguage: string;
-    detectLanguages(inputs: string[], countryHint?: string, options?: DetectLanguagesOptions): Promise<DetectLanguageResultCollection>;
-    detectLanguages(inputs: DetectLanguageInput[], options?: DetectLanguagesOptions): Promise<DetectLanguageResultCollection>;
+    detectLanguage(inputs: string[], countryHint?: string, options?: DetectLanguageOptions): Promise<DetectLanguageResultCollection>;
+    detectLanguage(inputs: DetectLanguageInput[], options?: DetectLanguageOptions): Promise<DetectLanguageResultCollection>;
     readonly endpointUrl: string;
     extractKeyPhrases(inputs: string[], language?: string, options?: ExtractKeyPhrasesOptions): Promise<ExtractKeyPhrasesResultCollection>;
     extractKeyPhrases(inputs: TextDocumentInput[], options?: ExtractKeyPhrasesOptions): Promise<ExtractKeyPhrasesResultCollection>;

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -69,7 +69,6 @@ export type DetectLanguagesOptions = TextAnalyticsOperationOptions;
 
 // @public
 export interface DetectLanguageSuccessResult extends TextAnalyticsSuccessResult {
-    readonly detectedLanguages: DetectedLanguage[];
     readonly primaryLanguage: DetectedLanguage;
 }
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -27,9 +27,9 @@ export interface AnalyzeSentimentResultCollection extends Array<AnalyzeSentiment
 
 // @public
 export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResult {
-    documentScores: SentimentConfidenceScorePerLabel;
     sentences: SentenceSentiment[];
     sentiment: DocumentSentimentValue;
+    sentimentScores: SentimentConfidenceScorePerLabel;
 }
 
 // @public
@@ -208,8 +208,8 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
 export interface SentenceSentiment {
     length: number;
     offset: number;
-    sentenceScores: SentimentConfidenceScorePerLabel;
     sentiment: SentenceSentimentValue;
+    sentimentScores: SentimentConfidenceScorePerLabel;
     warnings?: string[];
 }
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -33,6 +33,10 @@ export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResul
 }
 
 // @public
+export interface CategorizedEntity extends Entity {
+}
+
+// @public
 export interface DetectedLanguage {
     iso6391Name: string;
     name: string;
@@ -74,12 +78,12 @@ export type DocumentSentimentValue = 'positive' | 'neutral' | 'negative' | 'mixe
 
 // @public
 export interface Entity {
+    category: string;
     length: number;
     offset: number;
     score: number;
-    subtype?: string;
+    subCategory?: string;
     text: string;
-    type: string;
 }
 
 // @public
@@ -138,23 +142,27 @@ export interface Match {
 }
 
 // @public
-export type RecognizeEntitiesErrorResult = TextAnalyticsErrorResult;
+export interface PiiEntity extends Entity {
+}
 
 // @public
-export type RecognizeEntitiesOptions = TextAnalyticsOperationOptions;
+export type RecognizeCategorizedEntitiesErrorResult = TextAnalyticsErrorResult;
 
 // @public
-export type RecognizeEntitiesResult = RecognizeEntitiesSuccessResult | RecognizeEntitiesErrorResult;
+export type RecognizeCategorizedEntitiesOptions = TextAnalyticsOperationOptions;
 
 // @public
-export interface RecognizeEntitiesResultCollection extends Array<RecognizeEntitiesResult> {
+export type RecognizeCategorizedEntitiesResult = RecognizeCategorizedEntitiesSuccessResult | RecognizeCategorizedEntitiesErrorResult;
+
+// @public
+export interface RecognizeCategorizedEntitiesResultCollection extends Array<RecognizeCategorizedEntitiesResult> {
     modelVersion: string;
     statistics?: TextDocumentBatchStatistics;
 }
 
 // @public
-export interface RecognizeEntitiesSuccessResult extends TextAnalyticsSuccessResult {
-    readonly entities: Entity[];
+export interface RecognizeCategorizedEntitiesSuccessResult extends TextAnalyticsSuccessResult {
+    readonly entities: CategorizedEntity[];
 }
 
 // @public
@@ -178,7 +186,24 @@ export interface RecognizeLinkedEntitiesSuccessResult extends TextAnalyticsSucce
 }
 
 // @public
+export type RecognizePiiEntitiesErrorResult = TextAnalyticsErrorResult;
+
+// @public
 export type RecognizePiiEntitiesOptions = TextAnalyticsOperationOptions;
+
+// @public
+export type RecognizePiiEntitiesResult = RecognizePiiEntitiesSuccessResult | RecognizePiiEntitiesErrorResult;
+
+// @public
+export interface RecognizePiiEntitiesResultCollection extends Array<RecognizePiiEntitiesResult> {
+    modelVersion: string;
+    statistics?: TextDocumentBatchStatistics;
+}
+
+// @public
+export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessResult {
+    readonly entities: PiiEntity[];
+}
 
 // @public
 export interface SentenceSentiment {
@@ -221,12 +246,12 @@ export class TextAnalyticsClient {
     readonly endpointUrl: string;
     extractKeyPhrases(inputs: string[], language?: string, options?: ExtractKeyPhrasesOptions): Promise<ExtractKeyPhrasesResultCollection>;
     extractKeyPhrases(inputs: TextDocumentInput[], options?: ExtractKeyPhrasesOptions): Promise<ExtractKeyPhrasesResultCollection>;
-    recognizeEntities(inputs: string[], language?: string, options?: RecognizeEntitiesOptions): Promise<RecognizeEntitiesResultCollection>;
-    recognizeEntities(inputs: TextDocumentInput[], options?: RecognizeEntitiesOptions): Promise<RecognizeEntitiesResultCollection>;
+    recognizeCategorizedEntities(inputs: string[], language?: string, options?: RecognizeCategorizedEntitiesOptions): Promise<RecognizeCategorizedEntitiesResultCollection>;
+    recognizeCategorizedEntities(inputs: TextDocumentInput[], options?: RecognizeCategorizedEntitiesOptions): Promise<RecognizeCategorizedEntitiesResultCollection>;
     recognizeLinkedEntities(inputs: string[], language?: string, options?: RecognizeLinkedEntitiesOptions): Promise<RecognizeLinkedEntitiesResultCollection>;
     recognizeLinkedEntities(inputs: TextDocumentInput[], options?: RecognizeLinkedEntitiesOptions): Promise<RecognizeLinkedEntitiesResultCollection>;
-    recognizePiiEntities(inputs: string[], language?: string, options?: RecognizePiiEntitiesOptions): Promise<RecognizeEntitiesResultCollection>;
-    recognizePiiEntities(inputs: TextDocumentInput[], options?: RecognizePiiEntitiesOptions): Promise<RecognizeEntitiesResultCollection>;
+    recognizePiiEntities(inputs: string[], language?: string, options?: RecognizePiiEntitiesOptions): Promise<RecognizePiiEntitiesResultCollection>;
+    recognizePiiEntities(inputs: TextDocumentInput[], options?: RecognizePiiEntitiesOptions): Promise<RecognizePiiEntitiesResultCollection>;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
@@ -33,7 +33,7 @@ export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResul
   /**
    * Document level sentiment confidence scores between 0 and 1 for each sentiment class.
    */
-  documentScores: SentimentConfidenceScorePerLabel;
+  sentimentScores: SentimentConfidenceScorePerLabel;
   /**
    * The predicted sentiment for each sentence in the corresponding document.
    */
@@ -43,19 +43,19 @@ export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResul
 /**
  * An error result from the analyze sentiment operation on a single document.
  */
-export type AnalyzeSentimentErrorResult = TextAnalyticsErrorResult
+export type AnalyzeSentimentErrorResult = TextAnalyticsErrorResult;
 
 export function makeAnalyzeSentimentResult(
   id: string,
   sentiment: DocumentSentimentValue,
-  documentScores: SentimentConfidenceScorePerLabel,
+  sentimentScores: SentimentConfidenceScorePerLabel,
   sentences: SentenceSentiment[],
   statistics?: TextDocumentStatistics
 ): AnalyzeSentimentSuccessResult {
   return {
     ...makeTextAnalysisResult(id, statistics),
     sentiment,
-    documentScores,
+    sentimentScores,
     sentences
   };
 }

--- a/sdk/textanalytics/ai-text-analytics/src/detectLanguageResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/detectLanguageResult.ts
@@ -20,10 +20,6 @@ export type DetectLanguageResult = DetectLanguageSuccessResult | DetectLanguageE
  */
 export interface DetectLanguageSuccessResult extends TextAnalyticsSuccessResult {
   /**
-   * All detected languages in the document.
-   */
-  readonly detectedLanguages: DetectedLanguage[];
-  /**
    * The top detected language by confidence score.
    */
   readonly primaryLanguage: DetectedLanguage;
@@ -32,7 +28,7 @@ export interface DetectLanguageSuccessResult extends TextAnalyticsSuccessResult 
 /**
  * An error result from the detect languge operation on a single document.
  */
-export type DetectLanguageErrorResult = TextAnalyticsErrorResult
+export type DetectLanguageErrorResult = TextAnalyticsErrorResult;
 
 export function makeDetectLanguageResult(
   id: string,
@@ -41,7 +37,6 @@ export function makeDetectLanguageResult(
 ): DetectLanguageSuccessResult {
   return {
     ...makeTextAnalysisResult(id, statistics),
-    detectedLanguages,
     primaryLanguage: primaryLanguage(detectedLanguages)
   };
 }

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -144,7 +144,7 @@ export interface SentenceSentiment {
   /**
    * The sentiment confidence score between 0 and 1 for the sentence for all classes.
    */
-  sentenceScores: SentimentConfidenceScorePerLabel;
+  sentimentScores: SentimentConfidenceScorePerLabel;
   /**
    * The sentence offset from the start of the document.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -238,11 +238,11 @@ export interface Entity {
   /**
    * Entity type, such as Person/Location/Org/SSN etc
    */
-  type: string;
+  category: string;
   /**
    * Entity sub type, such as Age/Year/TimeRange etc
    */
-  subtype?: string;
+  subCategory?: string;
   /**
    * Start position (in Unicode characters) for the entity text.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -470,14 +470,14 @@ export const Entity: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      type: {
+      category: {
         required: true,
         serializedName: "type",
         type: {
           name: "String"
         }
       },
-      subtype: {
+      subCategory: {
         serializedName: "subtype",
         type: {
           name: "String"

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -274,7 +274,7 @@ export const SentenceSentiment: coreHttp.CompositeMapper = {
           ]
         }
       },
-      sentenceScores: {
+      sentimentScores: {
         required: true,
         serializedName: "sentenceScores",
         type: {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/textAnalyticsClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/textAnalyticsClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "@azure/ai-text-analytics";
-const packageVersion = "1.0.0-preview.1";
+const packageVersion = "1.0.0-preview.2";
 
 export class TextAnalyticsClientContext extends coreHttp.ServiceClient {
   endpoint: string;
@@ -24,11 +24,7 @@ export class TextAnalyticsClientContext extends coreHttp.ServiceClient {
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    endpoint: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
+  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, endpoint: string, options?: coreHttp.ServiceClientOptions) {
     if (endpoint == undefined) {
       throw new Error("'endpoint' cannot be null.");
     }

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -4,7 +4,7 @@
 export {
   TextAnalyticsClient,
   TextAnalyticsClientOptions,
-  DetectLanguagesOptions,
+  DetectLanguageOptions,
   RecognizeCategorizedEntitiesOptions,
   AnalyzeSentimentOptions,
   ExtractKeyPhrasesOptions,

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -5,7 +5,7 @@ export {
   TextAnalyticsClient,
   TextAnalyticsClientOptions,
   DetectLanguagesOptions,
-  RecognizeEntitiesOptions,
+  RecognizeCategorizedEntitiesOptions,
   AnalyzeSentimentOptions,
   ExtractKeyPhrasesOptions,
   RecognizePiiEntitiesOptions,
@@ -20,11 +20,19 @@ export {
 } from "./detectLanguageResult";
 export { DetectLanguageResultCollection } from "./detectLanguageResultCollection";
 export {
-  RecognizeEntitiesResult,
-  RecognizeEntitiesErrorResult,
-  RecognizeEntitiesSuccessResult
-} from "./recognizeEntitiesResult";
-export { RecognizeEntitiesResultCollection } from "./recognizeEntitiesResultCollection";
+  CategorizedEntity,
+  RecognizeCategorizedEntitiesResult,
+  RecognizeCategorizedEntitiesErrorResult,
+  RecognizeCategorizedEntitiesSuccessResult
+} from "./recognizeCategorizedEntitiesResult";
+export { RecognizeCategorizedEntitiesResultCollection } from "./recognizeCategorizedEntitiesResultCollection";
+export {
+  PiiEntity,
+  RecognizePiiEntitiesResult,
+  RecognizePiiEntitiesErrorResult,
+  RecognizePiiEntitiesSuccessResult
+} from "./recognizePiiEntitiesResult";
+export { RecognizePiiEntitiesResultCollection } from "./recognizePiiEntitiesResultCollection";
 export {
   AnalyzeSentimentResult,
   AnalyzeSentimentErrorResult,

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResult.ts
@@ -10,40 +10,48 @@ import {
 import { Entity, TextDocumentStatistics, TextAnalyticsError } from "./generated/models";
 
 /**
+ * An entity from text analysis with information about its categorical
+ * classification.
+ */
+export interface CategorizedEntity extends Entity {}
+
+/**
  * The result of the recognize entities operation on a single document.
  */
-export type RecognizeEntitiesResult = RecognizeEntitiesSuccessResult | RecognizeEntitiesErrorResult;
+export type RecognizeCategorizedEntitiesResult =
+  | RecognizeCategorizedEntitiesSuccessResult
+  | RecognizeCategorizedEntitiesErrorResult;
 
 /**
  * The result of the recognize entities operation on a single document, containing the collection of
  * `Entity` objects identified in that document.
  */
-export interface RecognizeEntitiesSuccessResult extends TextAnalyticsSuccessResult {
+export interface RecognizeCategorizedEntitiesSuccessResult extends TextAnalyticsSuccessResult {
   /**
    * The collection of entities identified in the input document.
    */
-  readonly entities: Entity[];
+  readonly entities: CategorizedEntity[];
 }
 
 /**
  * An error result from the recognize entities operation on a single document.
  */
-export type RecognizeEntitiesErrorResult = TextAnalyticsErrorResult
+export type RecognizeCategorizedEntitiesErrorResult = TextAnalyticsErrorResult;
 
-export function makeRecognizeEntitiesResult(
+export function makeRecognizeCategorizedEntitiesResult(
   id: string,
-  entities: Entity[],
+  entities: CategorizedEntity[],
   statistics?: TextDocumentStatistics
-): RecognizeEntitiesSuccessResult {
+): RecognizeCategorizedEntitiesSuccessResult {
   return {
     ...makeTextAnalysisResult(id, statistics),
     entities
   };
 }
 
-export function makeRecognizeEntitiesErrorResult(
+export function makeRecognizeCategorizedEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError
-): RecognizeEntitiesErrorResult {
+): RecognizeCategorizedEntitiesErrorResult {
   return makeTextAnalysisErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResultCollection.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResultCollection.ts
@@ -8,17 +8,18 @@ import {
   MultiLanguageInput
 } from "./generated/models";
 import {
-  RecognizeEntitiesResult,
-  makeRecognizeEntitiesResult,
-  makeRecognizeEntitiesErrorResult
-} from "./recognizeEntitiesResult";
+  RecognizeCategorizedEntitiesResult,
+  makeRecognizeCategorizedEntitiesResult,
+  makeRecognizeCategorizedEntitiesErrorResult
+} from "./recognizeCategorizedEntitiesResult";
 import { sortByPreviousIdOrder } from "./util";
 
 /**
- * Collection of `RecognizeEntitiesResult` objects corresponding to a batch of input documents, and
+ * Collection of `RecognizeCategorizedEntitiesResult` objects corresponding to a batch of input documents, and
  * annotated with information about the batch operation.
  */
-export interface RecognizeEntitiesResultCollection extends Array<RecognizeEntitiesResult> {
+export interface RecognizeCategorizedEntitiesResultCollection
+  extends Array<RecognizeCategorizedEntitiesResult> {
   /**
    * Statistics about the input document batch and how it was processed
    * by the service. This property will have a value when includeStatistics is set to true
@@ -32,23 +33,27 @@ export interface RecognizeEntitiesResultCollection extends Array<RecognizeEntiti
   modelVersion: string;
 }
 
-export function makeRecognizeEntitiesResultCollection(
+export function makeRecognizeCategorizedEntitiesResultCollection(
   input: MultiLanguageInput[],
   documents: DocumentEntities[],
   errors: DocumentError[],
   modelVersion: string,
   statistics?: TextDocumentBatchStatistics
-): RecognizeEntitiesResultCollection {
+): RecognizeCategorizedEntitiesResultCollection {
   const unsortedResult = documents
     .map(
-      (document): RecognizeEntitiesResult => {
-        return makeRecognizeEntitiesResult(document.id, document.entities, document.statistics);
+      (document): RecognizeCategorizedEntitiesResult => {
+        return makeRecognizeCategorizedEntitiesResult(
+          document.id,
+          document.entities,
+          document.statistics
+        );
       }
     )
     .concat(
       errors.map(
-        (error): RecognizeEntitiesResult => {
-          return makeRecognizeEntitiesErrorResult(error.id, error.error);
+        (error): RecognizeCategorizedEntitiesResult => {
+          return makeRecognizeCategorizedEntitiesErrorResult(error.id, error.error);
         }
       )
     );

--- a/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResult.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  makeTextAnalysisResult,
+  TextAnalyticsSuccessResult,
+  TextAnalyticsErrorResult,
+  makeTextAnalysisErrorResult
+} from "./textAnalyticsResult";
+import { Entity, TextDocumentStatistics, TextAnalyticsError } from "./generated/models";
+
+/**
+ * An entity from PII recognition with information about the kind of PII
+ * encountered.
+ */
+export interface PiiEntity extends Entity {}
+
+/**
+ * The result of the recognize entities operation on a single document.
+ */
+export type RecognizePiiEntitiesResult =
+  | RecognizePiiEntitiesSuccessResult
+  | RecognizePiiEntitiesErrorResult;
+
+/**
+ * The result of the recognize entities operation on a single document, containing the collection of
+ * `Entity` objects identified in that document.
+ */
+export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessResult {
+  /**
+   * The collection of entities identified in the input document.
+   */
+  readonly entities: PiiEntity[];
+}
+
+/**
+ * An error result from the recognize entities operation on a single document.
+ */
+export type RecognizePiiEntitiesErrorResult = TextAnalyticsErrorResult;
+
+export function makeRecognizePiiEntitiesResult(
+  id: string,
+  entities: PiiEntity[],
+  statistics?: TextDocumentStatistics
+): RecognizePiiEntitiesSuccessResult {
+  return {
+    ...makeTextAnalysisResult(id, statistics),
+    entities
+  };
+}
+
+export function makeRecognizePiiEntitiesErrorResult(
+  id: string,
+  error: TextAnalyticsError
+): RecognizePiiEntitiesErrorResult {
+  return makeTextAnalysisErrorResult(id, error);
+}

--- a/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResultCollection.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResultCollection.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  TextDocumentBatchStatistics,
+  DocumentError,
+  DocumentEntities,
+  MultiLanguageInput
+} from "./generated/models";
+import {
+  RecognizePiiEntitiesResult,
+  makeRecognizePiiEntitiesResult,
+  makeRecognizePiiEntitiesErrorResult
+} from "./recognizePiiEntitiesResult";
+import { sortByPreviousIdOrder } from "./util";
+
+/**
+ * Collection of `RecognizePiiEntitiesResult` objects corresponding to a batch of input documents, and
+ * annotated with information about the batch operation.
+ */
+export interface RecognizePiiEntitiesResultCollection extends Array<RecognizePiiEntitiesResult> {
+  /**
+   * Statistics about the input document batch and how it was processed
+   * by the service. This property will have a value when includeStatistics is set to true
+   * in the client call.
+   */
+  statistics?: TextDocumentBatchStatistics;
+  /**
+   * The version of the text analytics model used by this operation on this
+   * batch of input documents.
+   */
+  modelVersion: string;
+}
+
+export function makeRecognizePiiEntitiesResultCollection(
+  input: MultiLanguageInput[],
+  documents: DocumentEntities[],
+  errors: DocumentError[],
+  modelVersion: string,
+  statistics?: TextDocumentBatchStatistics
+): RecognizePiiEntitiesResultCollection {
+  const unsortedResult = documents
+    .map(
+      (document): RecognizePiiEntitiesResult => {
+        return makeRecognizePiiEntitiesResult(document.id, document.entities, document.statistics);
+      }
+    )
+    .concat(
+      errors.map(
+        (error): RecognizePiiEntitiesResult => {
+          return makeRecognizePiiEntitiesErrorResult(error.id, error.error);
+        }
+      )
+    );
+  const result = sortByPreviousIdOrder(input, unsortedResult);
+  return Object.assign(result, {
+    statistics,
+    modelVersion
+  });
+}

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -24,9 +24,13 @@ import {
   makeDetectLanguageResultCollection
 } from "./detectLanguageResultCollection";
 import {
-  RecognizeEntitiesResultCollection,
-  makeRecognizeEntitiesResultCollection
-} from "./recognizeEntitiesResultCollection";
+  RecognizeCategorizedEntitiesResultCollection,
+  makeRecognizeCategorizedEntitiesResultCollection
+} from "./recognizeCategorizedEntitiesResultCollection";
+import {
+  RecognizePiiEntitiesResultCollection,
+  makeRecognizePiiEntitiesResultCollection
+} from "./recognizePiiEntitiesResultCollection";
 import {
   AnalyzeSentimentResultCollection,
   makeAnalyzeSentimentResultCollection
@@ -80,32 +84,32 @@ export interface TextAnalyticsOperationOptions extends OperationOptions {
 /**
  * Options for the detect languages operation.
  */
-export type DetectLanguagesOptions = TextAnalyticsOperationOptions
+export type DetectLanguagesOptions = TextAnalyticsOperationOptions;
 
 /**
  * Options for the recognize entities operation.
  */
-export type RecognizeEntitiesOptions = TextAnalyticsOperationOptions
+export type RecognizeCategorizedEntitiesOptions = TextAnalyticsOperationOptions;
 
 /**
  * Options for the analyze sentiment operation.
  */
-export type AnalyzeSentimentOptions = TextAnalyticsOperationOptions
+export type AnalyzeSentimentOptions = TextAnalyticsOperationOptions;
 
 /**
  * Options for the extract key phrases operation.
  */
-export type ExtractKeyPhrasesOptions = TextAnalyticsOperationOptions
+export type ExtractKeyPhrasesOptions = TextAnalyticsOperationOptions;
 
 /**
  * Options for the recognize linked entities operation.
  */
-export type RecognizeLinkedEntitiesOptions = TextAnalyticsOperationOptions
+export type RecognizeLinkedEntitiesOptions = TextAnalyticsOperationOptions;
 
 /**
  * Options for the recognize PII entities operation.
  */
-export type RecognizePiiEntitiesOptions = TextAnalyticsOperationOptions
+export type RecognizePiiEntitiesOptions = TextAnalyticsOperationOptions;
 
 /**
  * Client class for interacting with Azure Text Analytics.
@@ -285,11 +289,11 @@ export class TextAnalyticsClient {
         where the lanuage is explicitly set to "None".
    * @param options Optional parameters for the operation.
    */
-  public async recognizeEntities(
+  public async recognizeCategorizedEntities(
     inputs: string[],
     language?: string,
-    options?: RecognizeEntitiesOptions
-  ): Promise<RecognizeEntitiesResultCollection>;
+    options?: RecognizeCategorizedEntitiesOptions
+  ): Promise<RecognizeCategorizedEntitiesResultCollection>;
   /**
    * Runs a predictive model to identify a collection of named entities
    * in the passed-in input documents, and categorize those entities into types
@@ -301,16 +305,16 @@ export class TextAnalyticsClient {
    * @param inputs The input documents to analyze.
    * @param options Optional parameters for the operation.
    */
-  public async recognizeEntities(
+  public async recognizeCategorizedEntities(
     inputs: TextDocumentInput[],
-    options?: RecognizeEntitiesOptions
-  ): Promise<RecognizeEntitiesResultCollection>;
-  public async recognizeEntities(
+    options?: RecognizeCategorizedEntitiesOptions
+  ): Promise<RecognizeCategorizedEntitiesResultCollection>;
+  public async recognizeCategorizedEntities(
     inputs: string[] | TextDocumentInput[],
-    languageOrOptions?: string | RecognizeEntitiesOptions,
-    options?: RecognizeEntitiesOptions
-  ): Promise<RecognizeEntitiesResultCollection> {
-    let realOptions: RecognizeEntitiesOptions;
+    languageOrOptions?: string | RecognizeCategorizedEntitiesOptions,
+    options?: RecognizeCategorizedEntitiesOptions
+  ): Promise<RecognizeCategorizedEntitiesResultCollection> {
+    let realOptions: RecognizeCategorizedEntitiesOptions;
     let realInputs: TextDocumentInput[];
 
     if (isStringArray(inputs)) {
@@ -319,7 +323,7 @@ export class TextAnalyticsClient {
       realOptions = options || {};
     } else {
       realInputs = inputs;
-      realOptions = (languageOrOptions as RecognizeEntitiesOptions) || {};
+      realOptions = (languageOrOptions as RecognizeCategorizedEntitiesOptions) || {};
     }
 
     const { span, updatedOptions: finalOptions } = createSpan(
@@ -335,7 +339,7 @@ export class TextAnalyticsClient {
         operationOptionsToRequestOptionsBase(finalOptions)
       );
 
-      return makeRecognizeEntitiesResultCollection(
+      return makeRecognizeCategorizedEntitiesResultCollection(
         realInputs,
         result.documents,
         result.errors,
@@ -530,7 +534,7 @@ export class TextAnalyticsClient {
     inputs: string[],
     language?: string,
     options?: RecognizePiiEntitiesOptions
-  ): Promise<RecognizeEntitiesResultCollection>;
+  ): Promise<RecognizePiiEntitiesResultCollection>;
   /**
    * Runs a predictive model to identify a collection of entities containing
    * personally identifiable information found in the passed-in input documents,
@@ -544,12 +548,12 @@ export class TextAnalyticsClient {
   public async recognizePiiEntities(
     inputs: TextDocumentInput[],
     options?: RecognizePiiEntitiesOptions
-  ): Promise<RecognizeEntitiesResultCollection>;
+  ): Promise<RecognizePiiEntitiesResultCollection>;
   public async recognizePiiEntities(
     inputs: string[] | TextDocumentInput[],
     languageOrOptions?: string | RecognizePiiEntitiesOptions,
     options?: RecognizePiiEntitiesOptions
-  ): Promise<RecognizeEntitiesResultCollection> {
+  ): Promise<RecognizePiiEntitiesResultCollection> {
     let realOptions: RecognizePiiEntitiesOptions;
     let realInputs: TextDocumentInput[];
 
@@ -575,7 +579,7 @@ export class TextAnalyticsClient {
         operationOptionsToRequestOptionsBase(finalOptions)
       );
 
-      return makeRecognizeEntitiesResultCollection(
+      return makeRecognizePiiEntitiesResultCollection(
         realInputs,
         result.documents,
         result.errors,

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -84,7 +84,7 @@ export interface TextAnalyticsOperationOptions extends OperationOptions {
 /**
  * Options for the detect languages operation.
  */
-export type DetectLanguagesOptions = TextAnalyticsOperationOptions;
+export type DetectLanguageOptions = TextAnalyticsOperationOptions;
 
 /**
  * Options for the recognize entities operation.
@@ -207,10 +207,10 @@ export class TextAnalyticsClient {
    *   The same country hint is applied to all strings in the input collection.
    * @param options Optional parameters for the operation.
    */
-  public async detectLanguages(
+  public async detectLanguage(
     inputs: string[],
     countryHint?: string,
-    options?: DetectLanguagesOptions
+    options?: DetectLanguageOptions
   ): Promise<DetectLanguageResultCollection>;
   /**
    * Runs a predictive model to determine the language that the passed-in
@@ -221,16 +221,16 @@ export class TextAnalyticsClient {
    * @param inputs A collection of input documents to analyze.
    * @param options Optional parameters for the operation.
    */
-  public async detectLanguages(
+  public async detectLanguage(
     inputs: DetectLanguageInput[],
-    options?: DetectLanguagesOptions
+    options?: DetectLanguageOptions
   ): Promise<DetectLanguageResultCollection>;
-  public async detectLanguages(
+  public async detectLanguage(
     inputs: string[] | DetectLanguageInput[],
-    countryHintOrOptions?: string | DetectLanguagesOptions,
-    options?: DetectLanguagesOptions
+    countryHintOrOptions?: string | DetectLanguageOptions,
+    options?: DetectLanguageOptions
   ): Promise<DetectLanguageResultCollection> {
-    let realOptions: DetectLanguagesOptions;
+    let realOptions: DetectLanguageOptions;
     let realInputs: DetectLanguageInput[];
 
     if (isStringArray(inputs)) {
@@ -239,7 +239,7 @@ export class TextAnalyticsClient {
       realOptions = options || {};
     } else {
       realInputs = inputs;
-      realOptions = (countryHintOrOptions as DetectLanguagesOptions) || {};
+      realOptions = (countryHintOrOptions as DetectLanguageOptions) || {};
     }
 
     const { span, updatedOptions: finalOptions } = createSpan(

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -122,3 +122,15 @@ directive:
         $["x-ms-client-name"] = "includeStatistics";
       }
 ```
+
+### Rename type, subtype -> category, subCategory
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.Entity.properties
+    transform: >
+      $.type["x-ms-client-name"] = "category";
+      $.subtype["x-ms-client-name"] = "subCategory";
+```
+

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -134,3 +134,13 @@ directive:
       $.subtype["x-ms-client-name"] = "subCategory";
 ```
 
+### Rename sentenceScores -> sentimentScores
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.SentenceSentiment.properties.sentenceScores
+    transform: >
+      $["x-ms-client-name"] = "sentimentScores";
+```
+

--- a/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
@@ -6,8 +6,9 @@ import { makeAnalyzeSentimentResultCollection } from "../src/analyzeSentimentRes
 import { makeDetectLanguageResultCollection } from "../src/detectLanguageResultCollection";
 import { makeExtractKeyPhrasesResultCollection } from "../src/extractKeyPhrasesResultCollection";
 import { makeRecognizeLinkedEntitiesResultCollection } from "../src/recognizeLinkedEntitiesResultCollection";
-import { makeRecognizeEntitiesResultCollection } from "../src/recognizeEntitiesResultCollection";
+import { makeRecognizeCategorizedEntitiesResultCollection } from "../src/recognizeCategorizedEntitiesResultCollection";
 import { LanguageInput, MultiLanguageInput } from "../src/generated/models";
+import { makeRecognizePiiEntitiesResultCollection } from "../src/recognizePiiEntitiesResultCollection";
 
 describe("SentimentResultCollection", () => {
   it("merges items in order", () => {
@@ -176,7 +177,7 @@ describe("ExtractKeyPhrasesResultCollection", () => {
   });
 });
 
-describe("RecognizeEntitiesResultCollection", () => {
+describe("RecognizeCategorizedEntitiesResultCollection", () => {
   it("merges items in order", () => {
     const input: MultiLanguageInput[] = [
       {
@@ -192,7 +193,7 @@ describe("RecognizeEntitiesResultCollection", () => {
         text: "test3"
       }
     ];
-    const result = makeRecognizeEntitiesResultCollection(
+    const result = makeRecognizeCategorizedEntitiesResultCollection(
       input,
       [
         {
@@ -200,7 +201,7 @@ describe("RecognizeEntitiesResultCollection", () => {
           entities: [
             {
               text: "Microsoft",
-              type: "Organization",
+              category: "Organization",
               offset: 10,
               length: 9,
               score: 0.9989
@@ -212,8 +213,71 @@ describe("RecognizeEntitiesResultCollection", () => {
           entities: [
             {
               text: "last week",
-              type: "DateTime",
-              subtype: "DateRange",
+              category: "DateTime",
+              subCategory: "DateRange",
+              offset: 34,
+              length: 9,
+              score: 0.8
+            }
+          ]
+        }
+      ],
+      [
+        {
+          id: "B",
+          error: {
+            code: "internalServerError",
+            message: "test error"
+          }
+        }
+      ],
+      ""
+    );
+
+    const inputOrder = input.map((item) => item.id);
+    const outputOrder = result.map((item) => item.id);
+    assert.deepEqual(inputOrder, outputOrder);
+  });
+});
+
+describe("RecognizePiiEntitiesResultCollection", () => {
+  it("merges items in order", () => {
+    const input: MultiLanguageInput[] = [
+      {
+        id: "A",
+        text: "test"
+      },
+      {
+        id: "B",
+        text: "test2"
+      },
+      {
+        id: "C",
+        text: "test3"
+      }
+    ];
+    const result = makeRecognizePiiEntitiesResultCollection(
+      input,
+      [
+        {
+          id: "A",
+          entities: [
+            {
+              text: "(555) 555-5555",
+              category: "US Phone Number",
+              offset: 10,
+              length: 9,
+              score: 0.9989
+            }
+          ]
+        },
+        {
+          id: "C",
+          entities: [
+            {
+              text: "1234 Default Ln.",
+              category: "US Address",
+              subCategory: "",
               offset: 34,
               length: 9,
               score: 0.8


### PR DESCRIPTION
This PR implements the changes discussed as part of the Text Analytics user-study feedback.

- Rename `type` and `subtype` to `category` and `subCategory` in the Entity model
- Rename recognizeEntities to recognizeCategorizedEntities
  - alias both `CategorizedEntity` and `PiiEntity` to `Entity` using a blank `extends`
  - added boilerplate implementations of Result Collection objects for PiiEntity
- Remove the `detectedLanguages` property from `DetectLanguagesResult` -- we may add it back later if the service supports multiple languages
  - rename `detectLanguages` and its friends (options types) to `detectLanguage`
- Rename `documentScores` and `sentenceScores` to `sentimentScores`

I also copied the unit-test for `makeRecognizeEntitiesResponseCollection` to both `makeRecognizeCategorizedEntitiesResponseCollection`
 and `makeRecognizePiiEntitiesResponseCollection`.