### PR TITLE
[Storage] Fix logic bugs in streamToBuffer2()

### DIFF
--- a/sdk/storage/storage-blob/src/utils/utils.node.ts
+++ b/sdk/storage/storage-blob/src/utils/utils.node.ts
@@ -82,11 +82,6 @@ export async function streamToBuffer2(
 
   return new Promise<number>((resolve, reject) => {
     stream.on("readable", () => {
-      if (pos >= bufferSize) {
-        reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
-        return;
-      }
-
       let chunk = stream.read();
       if (!chunk) {
         return;
@@ -95,11 +90,13 @@ export async function streamToBuffer2(
         chunk = Buffer.from(chunk, encoding);
       }
 
-      // How much data needed in this chunk
-      const chunkLength = pos + chunk.length > bufferSize ? bufferSize - pos : chunk.length;
+      if (pos + chunk.length > bufferSize) {
+        reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
+        return;
+      }
 
-      buffer.fill(chunk.slice(0, chunkLength), pos, pos + chunkLength);
-      pos += chunkLength;
+      buffer.fill(chunk, pos, pos + chunk.length);
+      pos += chunk.length;
     });
 
     stream.on("end", () => {

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -234,9 +234,10 @@ describe("Utility Helpers Node.js only", () => {
 
   describe.only("streamToBuffer2", () => {
     class TestReadableStream extends Readable {
+      private readonly _buffer: Buffer;
+      private readonly _bytesPerRead: number;
+
       private _numBytesSent = 0;
-      private _buffer: Buffer;
-      private _bytesPerRead: number;
 
       constructor(buffer: Buffer, bytesPerRead: number, opts?: ReadableOptions) {
         super(opts);

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -300,6 +300,10 @@ describe("Utility Helpers Node.js only", () => {
       it(test.title, async () => {
         const inputBuffer = randomBytes(test.streamLength);
 
+        // TestReadableStream and PassThrough seem to have slightly different behavior at the end of the stream.
+        // With TestReadableStream, the last call to read() will return null.  However, with PassThrough
+        // the last call to read() returns the last bytes, and there is never a call which returns null.
+        // I'm not sure why this behavior is different, but streamToBuffer2() should support both.
         let readStream: Readable;
         if (test.streamType == "test") {
           readStream = new TestReadableStream(inputBuffer, test.bytesPerRead!);

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import { randomBytes } from "crypto";
 import * as dotenv from "dotenv";
 import * as fs from "fs";
 import * as path from "path";
@@ -284,7 +285,7 @@ describe("Utility Helpers Node.js only", () => {
 
     tests.forEach(function (test) {
       it(test.title, async () => {
-        const inputBuffer = Buffer.alloc(test.streamLength, 1);
+        const inputBuffer = randomBytes(test.streamLength);
         const readStream = new TestReadableStream(inputBuffer, test.bytesPerRead);
         const outputBuffer = Buffer.alloc(test.bufferLength);
 

--- a/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/utils.node.ts
@@ -83,11 +83,6 @@ export async function streamToBuffer2(
 
   return new Promise<number>((resolve, reject) => {
     stream.on("readable", () => {
-      if (pos >= bufferSize) {
-        reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
-        return;
-      }
-
       let chunk = stream.read();
       if (!chunk) {
         return;
@@ -96,11 +91,13 @@ export async function streamToBuffer2(
         chunk = Buffer.from(chunk, encoding);
       }
 
-      // How much data needed in this chunk
-      const chunkLength = pos + chunk.length > bufferSize ? bufferSize - pos : chunk.length;
+      if (pos + chunk.length > bufferSize) {
+        reject(new Error(`Stream exceeds buffer size. Buffer size: ${bufferSize}`));
+        return;
+      }
 
-      buffer.fill(chunk.slice(0, chunkLength), pos, pos + chunkLength);
-      pos += chunkLength;
+      buffer.fill(chunk, pos, pos + chunk.length);
+      pos += chunk.length;
     });
 
     stream.on("end", () => {
@@ -182,4 +179,4 @@ export async function readStreamToLocalFile(
  *
  * Promisified version of fs.stat().
  */
-export const fsStat = util.promisify(isNode ? fs.stat : function stat() {});
+export const fsStat = util.promisify(isNode ? fs.stat : function stat() { });


### PR DESCRIPTION
The utility function `streamToBuffer2()` had two logic bugs:

1. If `pos == bufferSize`, and the next call to `stream.read()` would return null, the method should succeed rather than fail.  This is covered by the test cases where `streamType == test` and `buffer.length == stream.length`.

https://github.com/Azure/azure-sdk-for-js/blob/9da9f89ae29e2c233b8fc6530c2667eb95c40d52/sdk/storage/storage-blob/src/utils/utils.node.ts#L86-L94

2. If the last chunk exceeded the remaining size in the buffer, it would be sliced and the method would succeed, however it should throw since the buffer was too small.  This is covered by the test cases where `buffer.length < stream.length`.

https://github.com/Azure/azure-sdk-for-js/blob/9da9f89ae29e2c233b8fc6530c2667eb95c40d52/sdk/storage/storage-blob/src/utils/utils.node.ts#L99-L102

The tests use two different readable streams.  `TestReadableStream` and `PassThrough` raise events slightly differently.  `PassThrough` only raises the `readable` event once, while `TestReadableStream` raises it multiple times:

```
[passthrough] on(readable)
[passthrough] read(): 1024
[passthrough] read(): null
[passthrough] end

[test] on(readable)
[test] read(): 1024
[test] read(): null
[test] on(readable)
[test] read(): null
[test] end
```

I'm not sure why this behavior is different, but `streamToBuffer2()` should support both.

- Fixes #7077
