### PR TITLE
[core-http] Refactor deserialze method for simplicity

### DIFF
--- a/sdk/core/core-http/lib/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/deserializationPolicy.ts
@@ -140,140 +140,131 @@ export function deserializeResponseBody(
   response: HttpOperationResponse
 ): Promise<HttpOperationResponse> {
   return parse(jsonContentTypes, xmlContentTypes, response).then((parsedResponse) => {
-    const shouldDeserialize: boolean = shouldDeserializeResponse(parsedResponse);
-    if (shouldDeserialize) {
-      const operationSpec: OperationSpec | undefined = parsedResponse.request.operationSpec;
-      if (operationSpec && operationSpec.responses) {
-        const statusCode: number = parsedResponse.status;
+    const shouldDeserialize = shouldDeserializeResponse(parsedResponse);
+    if (!shouldDeserialize) {
+      return parsedResponse;
+    }
 
-        const expectedStatusCodes: string[] = Object.keys(operationSpec.responses);
+    const operationSpec = parsedResponse.request.operationSpec;
+    if (!operationSpec || !operationSpec.responses) {
+      return parsedResponse;
+    }
 
-        const hasNoExpectedStatusCodes: boolean =
-          expectedStatusCodes.length === 0 ||
-          (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default");
+    const responseSpec = getOperationResponse(parsedResponse);
+    const statusCode = parsedResponse.status;
+    const expectedStatusCodes = Object.keys(operationSpec.responses);
+    const hasNoExpectedStatusCodes =
+      expectedStatusCodes.length === 0 ||
+      (expectedStatusCodes.length === 1 && expectedStatusCodes[0] === "default");
+    const isExpectedStatusCode: boolean = hasNoExpectedStatusCodes
+      ? 200 <= statusCode && statusCode < 300
+      : !!responseSpec;
 
-        const responseSpec: OperationResponse | undefined = getOperationResponse(parsedResponse);
+    // There is no operation response spec for current status code.
+    // So, treat it as an error case and use the default response spec to deserialize the response.
+    if (!isExpectedStatusCode) {
+      const defaultResponseSpec = operationSpec.responses.default;
+      if (!defaultResponseSpec) {
+        return parsedResponse;
+      }
 
-        const isExpectedStatusCode: boolean = hasNoExpectedStatusCodes
-          ? 200 <= statusCode && statusCode < 300
-          : !!responseSpec;
-        if (!isExpectedStatusCode) {
-          const defaultResponseSpec: OperationResponse = operationSpec.responses.default;
-          if (defaultResponseSpec) {
-            const initialErrorMessage: string = isStreamOperation(operationSpec)
-              ? `Unexpected status code: ${statusCode}`
-              : (parsedResponse.bodyAsText as string);
+      const defaultBodyMapper = defaultResponseSpec.bodyMapper;
+      const defaultHeadersMapper = defaultResponseSpec.headersMapper;
+      const parsedBody = parsedResponse.parsedBody;
+      const parsedHeaders = parsedResponse.parsedHeaders;
 
-            const error = new RestError(
-              initialErrorMessage,
-              undefined,
-              statusCode,
-              parsedResponse.request,
-              parsedResponse
-            );
+      const initialErrorMessage = isStreamOperation(operationSpec)
+        ? `Unexpected status code: ${statusCode}`
+        : (parsedResponse.bodyAsText as string);
 
-            let parsedErrorResponse: { [key: string]: any } = parsedResponse.parsedBody;
-            try {
-              if (parsedErrorResponse) {
-                const defaultResponseBodyMapper: Mapper | undefined =
-                  defaultResponseSpec.bodyMapper;
-                if (
-                  defaultResponseBodyMapper &&
-                  defaultResponseBodyMapper.serializedName === "CloudError"
-                ) {
-                  if (parsedErrorResponse.error) {
-                    parsedErrorResponse = parsedErrorResponse.error;
-                  }
-                  if (parsedErrorResponse.code) {
-                    error.code = parsedErrorResponse.code;
-                  }
-                  if (parsedErrorResponse.message) {
-                    error.message = parsedErrorResponse.message;
-                  }
-                } else {
-                  let internalError: any = parsedErrorResponse;
-                  if (parsedErrorResponse.error) {
-                    internalError = parsedErrorResponse.error;
-                  }
+      const error = new RestError(
+        initialErrorMessage,
+        undefined,
+        statusCode,
+        parsedResponse.request,
+        parsedResponse
+      );
 
-                  error.code = internalError.code;
-                  if (internalError.message) {
-                    error.message = internalError.message;
-                  }
-                }
-
-                if (defaultResponseBodyMapper) {
-                  let valueToDeserialize: any = parsedErrorResponse;
-                  if (
-                    operationSpec.isXML &&
-                    defaultResponseBodyMapper.type.name === MapperType.Sequence
-                  ) {
-                    valueToDeserialize =
-                      typeof parsedErrorResponse === "object"
-                        ? parsedErrorResponse[defaultResponseBodyMapper.xmlElementName!]
-                        : [];
-                  }
-                  error.response!.parsedBody = operationSpec.serializer.deserialize(
-                    defaultResponseBodyMapper,
-                    valueToDeserialize,
-                    "error.response.parsedBody"
-                  );
-                }
-              }
-
-              if (parsedResponse.headers && defaultResponseSpec.headersMapper) {
-                error.response!.parsedHeaders = operationSpec.serializer.deserialize(
-                  defaultResponseSpec.headersMapper,
-                  parsedResponse.headers.rawHeaders(),
-                  "operationRes.parsedHeaders"
-                );
-              }
-            } catch (defaultError) {
-              error.message = `Error \"${defaultError.message}\" occurred in deserializing the responseBody - \"${parsedResponse.bodyAsText}\" for the default response.`;
-            }
-            return Promise.reject(error);
+      try {
+        // If error response has a body, try to extract error code & message from it
+        // Then try to deserialize it using default body mapper
+        if (parsedBody) {
+          const internalError: any = parsedBody.error || parsedBody;
+          error.code = internalError.code;
+          if (internalError.message) {
+            error.message = internalError.message;
           }
-        } else if (responseSpec) {
-          if (responseSpec.bodyMapper) {
-            let valueToDeserialize: any = parsedResponse.parsedBody;
-            if (operationSpec.isXML && responseSpec.bodyMapper.type.name === MapperType.Sequence) {
+
+          if (defaultBodyMapper) {
+            let valueToDeserialize: any = parsedBody;
+            if (operationSpec.isXML && defaultBodyMapper.type.name === MapperType.Sequence) {
               valueToDeserialize =
-                typeof valueToDeserialize === "object"
-                  ? valueToDeserialize[responseSpec.bodyMapper.xmlElementName!]
-                  : [];
+                typeof parsedBody === "object" ? parsedBody[defaultBodyMapper.xmlElementName!] : [];
             }
-            try {
-              parsedResponse.parsedBody = operationSpec.serializer.deserialize(
-                responseSpec.bodyMapper,
-                valueToDeserialize,
-                "operationRes.parsedBody"
-              );
-            } catch (error) {
-              const restError = new RestError(
-                `Error ${error} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`,
-                undefined,
-                parsedResponse.status,
-                parsedResponse.request,
-                parsedResponse
-              );
-              return Promise.reject(restError);
-            }
-          } else if (operationSpec.httpMethod === "HEAD") {
-            // head methods never have a body, but we return a boolean to indicate presence/absence of the resource
-            parsedResponse.parsedBody = response.status >= 200 && response.status < 300;
-          }
-
-          if (responseSpec.headersMapper) {
-            parsedResponse.parsedHeaders = operationSpec.serializer.deserialize(
-              responseSpec.headersMapper,
-              parsedResponse.headers.rawHeaders(),
-              "operationRes.parsedHeaders"
+            error.response!.parsedBody = operationSpec.serializer.deserialize(
+              defaultBodyMapper,
+              valueToDeserialize,
+              "error.response.parsedBody"
             );
           }
         }
+
+        // If error response has headers, try to deserialize it using default header mapper
+        if (parsedHeaders && defaultHeadersMapper) {
+          error.response!.parsedHeaders = operationSpec.serializer.deserialize(
+            defaultHeadersMapper,
+            parsedHeaders.rawHeaders(),
+            "operationRes.parsedHeaders"
+          );
+        }
+      } catch (defaultError) {
+        error.message = `Error \"${defaultError.message}\" occurred in deserializing the responseBody - \"${parsedResponse.bodyAsText}\" for the default response.`;
+      }
+      return Promise.reject(error);
+    }
+
+    // An operation response spec does exist for current status code, so
+    // use it to deserialize the response.
+    if (responseSpec) {
+      if (responseSpec.bodyMapper) {
+        let valueToDeserialize: any = parsedResponse.parsedBody;
+        if (operationSpec.isXML && responseSpec.bodyMapper.type.name === MapperType.Sequence) {
+          valueToDeserialize =
+            typeof valueToDeserialize === "object"
+              ? valueToDeserialize[responseSpec.bodyMapper.xmlElementName!]
+              : [];
+        }
+        try {
+          parsedResponse.parsedBody = operationSpec.serializer.deserialize(
+            responseSpec.bodyMapper,
+            valueToDeserialize,
+            "operationRes.parsedBody"
+          );
+        } catch (error) {
+          const restError = new RestError(
+            `Error ${error} occurred in deserializing the responseBody - ${parsedResponse.bodyAsText}`,
+            undefined,
+            parsedResponse.status,
+            parsedResponse.request,
+            parsedResponse
+          );
+          return Promise.reject(restError);
+        }
+      } else if (operationSpec.httpMethod === "HEAD") {
+        // head methods never have a body, but we return a boolean to indicate presence/absence of the resource
+        parsedResponse.parsedBody = response.status >= 200 && response.status < 300;
+      }
+
+      if (responseSpec.headersMapper) {
+        parsedResponse.parsedHeaders = operationSpec.serializer.deserialize(
+          responseSpec.headersMapper,
+          parsedResponse.headers.rawHeaders(),
+          "operationRes.parsedHeaders"
+        );
       }
     }
-    return Promise.resolve(parsedResponse);
+
+    return parsedResponse;
   });
 }
 

--- a/sdk/core/core-http/lib/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/deserializationPolicy.ts
@@ -169,7 +169,7 @@ export function deserializeResponseBody(
       const defaultBodyMapper = defaultResponseSpec.bodyMapper;
       const defaultHeadersMapper = defaultResponseSpec.headersMapper;
       const parsedBody = parsedResponse.parsedBody;
-      const parsedHeaders = parsedResponse.parsedHeaders;
+      const parsedHeaders = parsedResponse.headers;
 
       const initialErrorMessage = isStreamOperation(operationSpec)
         ? `Unexpected status code: ${parsedResponse.status}`

--- a/sdk/core/core-http/lib/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/lib/policies/deserializationPolicy.ts
@@ -168,8 +168,6 @@ export function deserializeResponseBody(
 
       const defaultBodyMapper = defaultResponseSpec.bodyMapper;
       const defaultHeadersMapper = defaultResponseSpec.headersMapper;
-      const parsedBody = parsedResponse.parsedBody;
-      const parsedHeaders = parsedResponse.headers;
 
       const initialErrorMessage = isStreamOperation(operationSpec)
         ? `Unexpected status code: ${parsedResponse.status}`
@@ -186,7 +184,8 @@ export function deserializeResponseBody(
       try {
         // If error response has a body, try to extract error code & message from it
         // Then try to deserialize it using default body mapper
-        if (parsedBody) {
+        if (parsedResponse.parsedBody) {
+          const parsedBody = parsedResponse.parsedBody;
           const internalError: any = parsedBody.error || parsedBody;
           error.code = internalError.code;
           if (internalError.message) {
@@ -208,10 +207,10 @@ export function deserializeResponseBody(
         }
 
         // If error response has headers, try to deserialize it using default header mapper
-        if (parsedHeaders && defaultHeadersMapper) {
+        if (parsedResponse.headers && defaultHeadersMapper) {
           error.response!.parsedHeaders = operationSpec.serializer.deserialize(
             defaultHeadersMapper,
-            parsedHeaders.rawHeaders(),
+            parsedResponse.headers.rawHeaders(),
             "operationRes.parsedHeaders"
           );
         }


### PR DESCRIPTION
This PR refactors the `deserializeResponseBody()` function with the below intentions
- Remove the code path for `CloudError`. This is dead code and we do not support a generic `CloudError` anymore. It was for an intermediate phase where Swagger Spec did support it, but @sarangan12 has confirmed that no existing swagger specs use it anymore
- Remove type declarations when it can be inferred by the assigned value
- Flip `if` checks to support early exit
- Add comments
Tip to review: Use the `Hide white space changes` setting to reduce the noise in the diff