### PR TITLE
Dependency report data.js to exclude external dependencies by default

### DIFF
--- a/eng/tools/analyze-deps/index.js
+++ b/eng/tools/analyze-deps/index.js
@@ -292,7 +292,8 @@ const main = async () => {
     for (const pkgId of Object.keys(dumpData)) {
       resolveRushPackageDeps(dumpData, internalPackages, pnpmLock, pkgId);
     }
-    await writeFile(args.dump, "const data = " + JSON.stringify(dumpData) + ";");
+    const internalDep = dumpData.filter(d => d.type === 'internal');
+    await writeFile(args.dump, "const data = " + JSON.stringify(internalDep) + ";");
   }
 };
 


### PR DESCRIPTION
This is to allow dependency graph data.js to have only the internal dependencies by default. If external dependencies are required, they can be generated using the `--external` flag