### PR TITLE
[ai-text-analytics] Unify TA error model

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_analyzesentiment/recording_service_returns_an_error_for_an_empty_document.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_analyzesentiment/recording_service_returns_an_error_for_an_empty_document.json
@@ -1,0 +1,50 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:22 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.9987.16 - WST ProdSlices",
+    "x-ms-request-id": "fc65c9ce-af61-458c-a243-46f1f91f3400"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/sentiment",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!\",\"language\":\"en\"},{\"id\":\"1\",\"text\":\"\",\"language\":\"en\"},{\"id\":\"2\",\"text\":\"Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle\",\"language\":\"en\"},{\"id\":\"3\",\"text\":\"I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.\",\"language\":\"en\"},{\"id\":\"4\",\"text\":\"I didn't like the last book I read at all.\",\"language\":\"en\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[{\"id\":\"0\",\"sentiment\":\"positive\",\"documentScores\":{\"positive\":0.99,\"neutral\":0.01,\"negative\":0.0},\"sentences\":[{\"sentiment\":\"positive\",\"sentenceScores\":{\"positive\":0.99,\"neutral\":0.01,\"negative\":0.0},\"offset\":0,\"length\":86}]},{\"id\":\"2\",\"sentiment\":\"negative\",\"documentScores\":{\"positive\":0.0,\"neutral\":0.0,\"negative\":1.0},\"sentences\":[{\"sentiment\":\"negative\",\"sentenceScores\":{\"positive\":0.0,\"neutral\":0.0,\"negative\":1.0},\"offset\":0,\"length\":58},{\"sentiment\":\"neutral\",\"sentenceScores\":{\"positive\":0.01,\"neutral\":0.7,\"negative\":0.29},\"offset\":59,\"length\":43}]},{\"id\":\"3\",\"sentiment\":\"positive\",\"documentScores\":{\"positive\":1.0,\"neutral\":0.0,\"negative\":0.0},\"sentences\":[{\"sentiment\":\"positive\",\"sentenceScores\":{\"positive\":1.0,\"neutral\":0.0,\"negative\":0.0},\"offset\":0,\"length\":101}]},{\"id\":\"4\",\"sentiment\":\"negative\",\"documentScores\":{\"positive\":0.01,\"neutral\":0.03,\"negative\":0.96},\"sentences\":[{\"sentiment\":\"negative\",\"sentenceScores\":{\"positive\":0.01,\"neutral\":0.03,\"negative\":0.96},\"offset\":0,\"length\":42}]}],\"errors\":[{\"id\":\"1\",\"error\":{\"code\":\"InvalidArgument\",\"message\":\"Invalid document in request.\",\"innerError\":{\"code\":\"InvalidDocument\",\"message\":\"Document text is empty.\"}}}],\"modelVersion\":\"2019-10-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "f5f5a21d-98e6-49bd-a5d9-905cebfd5bab",
+    "content-type": "application/json; charset=utf-8",
+    "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=4",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "111"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ }
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_analyzesentiment/recording_service_returns_error_for_invalid_language.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_analyzesentiment/recording_service_returns_error_for_invalid_language.json
@@ -1,0 +1,49 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:22 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.9987.16 - WST ProdSlices",
+    "x-ms-request-id": "7dcad05a-7d99-4eb8-b7ce-d8dae3823500"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/sentiment",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"Hello world!\",\"language\":\"notalanguage\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[],\"errors\":[{\"id\":\"0\",\"error\":{\"code\":\"InvalidArgument\",\"message\":\"Invalid Language Code.\",\"innerError\":{\"code\":\"UnsupportedLanguageCode\",\"message\":\"Supplied language not supported. Pass in one of: de,en,es,fr,it,ja,ko,nl,pt-PT,zh-Hans,zh-Hant\"}}}],\"modelVersion\":\"2019-10-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "70cc3528-2802-4b0f-87d5-d056e6413f96",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "4"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ }
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_detectlanguage/recording_service_errors_on_invalid_country_hint.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_detectlanguage/recording_service_errors_on_invalid_country_hint.json
@@ -1,0 +1,50 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.9987.16 - WST ProdSlices",
+    "x-ms-request-id": "02579615-a650-447f-81e9-4a74a8b53700"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/languages",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"hello\",\"countryHint\":\"invalidcountry\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[],\"errors\":[{\"id\":\"0\",\"error\":{\"code\":\"InvalidArgument\",\"message\":\"Invalid Country Hint.\",\"innerError\":{\"code\":\"InvalidCountryHint\",\"message\":\"Country hint is not valid. Please specify an ISO 3166-1 alpha-2 two letter country code.\"}}}],\"modelVersion\":\"2019-10-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "0d694cef-8bd7-45bf-ac27-48c8edcdb1d4",
+    "content-type": "application/json; charset=utf-8",
+    "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=0",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "3"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ }
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_extractkeyphrases/recording_service_errors_on_unsupported_language.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_extractkeyphrases/recording_service_errors_on_unsupported_language.json
@@ -1,0 +1,50 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.9987.14 - SAN ProdSlices",
+    "x-ms-request-id": "914780c5-e0af-48b9-a267-88c9361a8a00"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/keyPhrases",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"This is some text, but it doesn't matter.\",\"language\":\"notalanguage\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[],\"errors\":[{\"id\":\"0\",\"error\":{\"code\":\"InvalidArgument\",\"message\":\"Invalid Language Code.\",\"innerError\":{\"code\":\"UnsupportedLanguageCode\",\"message\":\"Supplied language not supported. Pass in one of: da,de,en,es,fi,fr,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv\"}}}],\"modelVersion\":\"2019-10-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "2b4884ff-8db5-4521-8d80-cf43e50f704b",
+    "content-type": "application/json; charset=utf-8",
+    "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=0",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "22"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ }
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_recognizeentities/recording_service_errors_on_unsupported_language.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_recognizeentities/recording_service_errors_on_unsupported_language.json
@@ -1,0 +1,49 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.9987.16 - WST ProdSlices",
+    "x-ms-request-id": "863a500b-a5ff-4b03-be12-42020f863300"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/entities/recognition/general",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"This is some text, but it doesn't matter.\",\"language\":\"notalanguage\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[],\"errors\":[{\"id\":\"0\",\"error\":{\"code\":\"InvalidArgument\",\"message\":\"Invalid Language Code.\",\"innerError\":{\"code\":\"UnsupportedLanguageCode\",\"message\":\"Supplied language not supported. Pass in one of: ar,cs,da,de,en,es,fi,fr,hu,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv,tr,zh-Hans\"}}}],\"modelVersion\":\"2020-02-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "aa58de43-b2e6-4408-92c8-2aec99c394a2",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "2"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ }
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_recognizelinkedentities/recording_service_errors_on_unsupported_language.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_recognizelinkedentities/recording_service_errors_on_unsupported_language.json
@@ -1,0 +1,49 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.9987.14 - SAN ProdSlices",
+    "x-ms-request-id": "e5ce71fb-f038-4bf8-9c7c-abcf3fc74300"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/entities/linking",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"This is some text, but it doesn't matter.\",\"language\":\"notalanguage\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[],\"errors\":[{\"id\":\"0\",\"error\":{\"code\":\"InvalidArgument\",\"message\":\"Invalid Language Code.\",\"innerError\":{\"code\":\"UnsupportedLanguageCode\",\"message\":\"Supplied language not supported. Pass in one of: en,es\"}}}],\"modelVersion\":\"2020-02-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "abcaa353-009d-471a-8c0a-228e661dcab3",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:24 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "3"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ }
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_recognizepiientities/recording_service_errors_on_unsupported_language.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_recognizepiientities/recording_service_errors_on_unsupported_language.json
@@ -1,0 +1,49 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:23 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.9987.16 - WST ProdSlices",
+    "x-ms-request-id": "7dcad05a-7d99-4eb8-b7ce-d8da13833500"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/entities/recognition/pii",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"This is some text, but it doesn't matter.\",\"language\":\"notalanguage\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[],\"errors\":[{\"id\":\"0\",\"error\":{\"code\":\"InvalidArgument\",\"message\":\"Invalid Language Code.\",\"innerError\":{\"code\":\"UnsupportedLanguageCode\",\"message\":\"Supplied language not supported. Pass in one of: en\"}}}],\"modelVersion\":\"2020-02-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "e3550312-391c-40d2-8937-1a498ffa8555",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Thu, 06 Feb 2020 23:49:24 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "3"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ }
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_analyzesentiment/recording_service_returns_an_error_for_an_empty_document.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_analyzesentiment/recording_service_returns_an_error_for_an_empty_document.js
@@ -1,0 +1,57 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '7f0480ee-70c5-43a7-b271-8c73e2788c00',
+  'x-ms-ests-server',
+  '2.1.9987.14 - SAN ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=Aqw9zXY9gJJCnz6hmvCZFST0CyfMAQAAAP-cztUOAAAA; expires=Sat, 07-Mar-2020 23:49:19 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:19 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/sentiment', {"documents":[{"id":"0","text":"I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!","language":"en"},{"id":"1","text":"","language":"en"},{"id":"2","text":"Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle","language":"en"},{"id":"3","text":"I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.","language":"en"},{"id":"4","text":"I didn't like the last book I read at all.","language":"en"}]})
+  .reply(200, {"documents":[{"id":"0","sentiment":"positive","documentScores":{"positive":0.99,"neutral":0.01,"negative":0},"sentences":[{"sentiment":"positive","sentenceScores":{"positive":0.99,"neutral":0.01,"negative":0},"offset":0,"length":86}]},{"id":"2","sentiment":"negative","documentScores":{"positive":0,"neutral":0,"negative":1},"sentences":[{"sentiment":"negative","sentenceScores":{"positive":0,"neutral":0,"negative":1},"offset":0,"length":58},{"sentiment":"neutral","sentenceScores":{"positive":0.01,"neutral":0.7,"negative":0.29},"offset":59,"length":43}]},{"id":"3","sentiment":"positive","documentScores":{"positive":1,"neutral":0,"negative":0},"sentences":[{"sentiment":"positive","sentenceScores":{"positive":1,"neutral":0,"negative":0},"offset":0,"length":101}]},{"id":"4","sentiment":"negative","documentScores":{"positive":0.01,"neutral":0.03,"negative":0.96},"sentences":[{"sentiment":"negative","sentenceScores":{"positive":0.01,"neutral":0.03,"negative":0.96},"offset":0,"length":42}]}],"errors":[{"id":"1","error":{"code":"InvalidArgument","message":"Invalid document in request.","innerError":{"code":"InvalidDocument","message":"Document text is empty."}}}],"modelVersion":"2019-10-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'csp-billing-usage',
+  'CognitiveServices.TextAnalytics.BatchScoring=4',
+  'x-envoy-upstream-service-time',
+  '117',
+  'apim-request-id',
+  'ea3ae3c5-a99f-4bc0-93ca-168ecd20ad2d',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:19 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_analyzesentiment/recording_service_returns_error_for_invalid_language.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_analyzesentiment/recording_service_returns_error_for_invalid_language.js
@@ -1,0 +1,55 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '182c1c08-935c-465a-96df-e9c940059600',
+  'x-ms-ests-server',
+  '2.1.9987.14 - SAN ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=AsZDUUqF_glNimNhKtg1vnD0CyfMAQAAAP-cztUOAAAA; expires=Sat, 07-Mar-2020 23:49:19 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:18 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/sentiment', {"documents":[{"id":"0","text":"Hello world!","language":"notalanguage"}]})
+  .reply(200, {"documents":[],"errors":[{"id":"0","error":{"code":"InvalidArgument","message":"Invalid Language Code.","innerError":{"code":"UnsupportedLanguageCode","message":"Supplied language not supported. Pass in one of: de,en,es,fr,it,ja,ko,nl,pt-PT,zh-Hans,zh-Hant"}}}],"modelVersion":"2019-10-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '3',
+  'apim-request-id',
+  '55dee208-f7a2-490a-ba08-7626b278637e',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:19 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_detectlanguage/recording_service_errors_on_invalid_country_hint.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_detectlanguage/recording_service_errors_on_invalid_country_hint.js
@@ -1,0 +1,57 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '863a500b-a5ff-4b03-be12-420266853300',
+  'x-ms-ests-server',
+  '2.1.9987.16 - WST ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=AuG666ngVytCmUvwPh9Q2i_0CyfMAQAAAP-cztUOAAAA; expires=Sat, 07-Mar-2020 23:49:20 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:19 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/languages', {"documents":[{"id":"0","text":"hello","countryHint":"invalidcountry"}]})
+  .reply(200, {"documents":[],"errors":[{"id":"0","error":{"code":"InvalidArgument","message":"Invalid Country Hint.","innerError":{"code":"InvalidCountryHint","message":"Country hint is not valid. Please specify an ISO 3166-1 alpha-2 two letter country code."}}}],"modelVersion":"2019-10-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'csp-billing-usage',
+  'CognitiveServices.TextAnalytics.BatchScoring=0',
+  'x-envoy-upstream-service-time',
+  '4',
+  'apim-request-id',
+  '49813230-7cf9-4bcc-900c-fb49efce756e',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:19 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_extractkeyphrases/recording_service_errors_on_unsupported_language.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_extractkeyphrases/recording_service_errors_on_unsupported_language.js
@@ -1,0 +1,57 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '7f0480ee-70c5-43a7-b271-8c7357798c00',
+  'x-ms-ests-server',
+  '2.1.9987.14 - SAN ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=ArWxb3FMikhFkgl4P-yigaD0CyfMAQAAAACdztUOAAAA; expires=Sat, 07-Mar-2020 23:49:20 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:20 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/keyPhrases', {"documents":[{"id":"0","text":"This is some text, but it doesn't matter.","language":"notalanguage"}]})
+  .reply(200, {"documents":[],"errors":[{"id":"0","error":{"code":"InvalidArgument","message":"Invalid Language Code.","innerError":{"code":"UnsupportedLanguageCode","message":"Supplied language not supported. Pass in one of: da,de,en,es,fi,fr,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv"}}}],"modelVersion":"2019-10-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'csp-billing-usage',
+  'CognitiveServices.TextAnalytics.BatchScoring=0',
+  'x-envoy-upstream-service-time',
+  '30',
+  'apim-request-id',
+  '9999228c-a034-4d17-bb56-ef7f56bd43e5',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:20 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_recognizeentities/recording_service_errors_on_unsupported_language.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_recognizeentities/recording_service_errors_on_unsupported_language.js
@@ -1,0 +1,55 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '6fb02ad4-1265-4616-984c-19188bca9300',
+  'x-ms-ests-server',
+  '2.1.9987.14 - SAN ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=Aj-mvp-DValNv7JDW0ob_ef0CyfMAQAAAACdztUOAAAA; expires=Sat, 07-Mar-2020 23:49:20 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:19 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/entities/recognition/general', {"documents":[{"id":"0","text":"This is some text, but it doesn't matter.","language":"notalanguage"}]})
+  .reply(200, {"documents":[],"errors":[{"id":"0","error":{"code":"InvalidArgument","message":"Invalid Language Code.","innerError":{"code":"UnsupportedLanguageCode","message":"Supplied language not supported. Pass in one of: ar,cs,da,de,en,es,fi,fr,hu,it,ja,ko,nl,no,pl,pt-BR,pt-PT,ru,sv,tr,zh-Hans"}}}],"modelVersion":"2020-02-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '7',
+  'apim-request-id',
+  'e4a2f9de-8143-4ea8-8b35-fe35a319965e',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:19 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_recognizelinkedentities/recording_service_errors_on_unsupported_language.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_recognizelinkedentities/recording_service_errors_on_unsupported_language.js
@@ -1,0 +1,55 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '182c1c08-935c-465a-96df-e9c919069600',
+  'x-ms-ests-server',
+  '2.1.9987.14 - SAN ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=Aj7KTnTKfMVBt4i9puu9B2D0CyfMAQAAAAGdztUOAAAA; expires=Sat, 07-Mar-2020 23:49:21 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:21 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/entities/linking', {"documents":[{"id":"0","text":"This is some text, but it doesn't matter.","language":"notalanguage"}]})
+  .reply(200, {"documents":[],"errors":[{"id":"0","error":{"code":"InvalidArgument","message":"Invalid Language Code.","innerError":{"code":"UnsupportedLanguageCode","message":"Supplied language not supported. Pass in one of: en,es"}}}],"modelVersion":"2020-02-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '4',
+  'apim-request-id',
+  '31c23057-1b0f-41fa-8477-8f4b8c2575cb',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:21 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_recognizepiientities/recording_service_errors_on_unsupported_language.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_recognizepiientities/recording_service_errors_on_unsupported_language.js
@@ -1,0 +1,55 @@
+let nock = require('nock');
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '10de7e13-9ac2-44fb-b210-91eb2d659200',
+  'x-ms-ests-server',
+  '2.1.9987.14 - SAN ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=ArR-Bas2Y1lFg_TBrmwGkEz0CyfMAQAAAACdztUOAAAA; expires=Sat, 07-Mar-2020 23:49:21 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:21 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/entities/recognition/pii', {"documents":[{"id":"0","text":"This is some text, but it doesn't matter.","language":"notalanguage"}]})
+  .reply(200, {"documents":[],"errors":[{"id":"0","error":{"code":"InvalidArgument","message":"Invalid Language Code.","innerError":{"code":"UnsupportedLanguageCode","message":"Supplied language not supported. Pass in one of: en"}}}],"modelVersion":"2020-02-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'x-envoy-upstream-service-time',
+  '3',
+  'apim-request-id',
+  '1405e34a-69c6-40b8-baa7-7ffe9f47f385',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Thu, 06 Feb 2020 23:49:21 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -86,7 +86,10 @@ export interface Entity {
 }
 
 // @public
-export type ErrorCode = "InvalidRequest" | "InvalidArgument" | "InternalServerError" | "ServiceUnavailable" | "InvalidParameterValue" | "InvalidRequestBodyFormat" | "EmptyRequest" | "MissingInputRecords" | "InvalidDocument" | "ModelVersionIncorrect" | "InvalidDocumentBatch" | "UnsupportedLanguageCode" | "InvalidCountryHint";
+export type ErrorCode = ErrorCodeValue | InnerErrorCodeValue;
+
+// @public
+export type ErrorCodeValue = 'InvalidRequest' | 'InvalidArgument' | 'InternalServerError' | 'ServiceUnavailable';
 
 // @public
 export type ExtractKeyPhrasesErrorResult = TextAnalyticsErrorResult;
@@ -107,6 +110,9 @@ export interface ExtractKeyPhrasesResultCollection extends Array<ExtractKeyPhras
 export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResult {
     keyPhrases: string[];
 }
+
+// @public
+export type InnerErrorCodeValue = 'InvalidParameterValue' | 'InvalidRequestBodyFormat' | 'EmptyRequest' | 'MissingInputRecords' | 'InvalidDocument' | 'ModelVersionIncorrect' | 'InvalidDocumentBatch' | 'UnsupportedLanguageCode' | 'InvalidCountryHint';
 
 // @public
 export interface LinkedEntity {

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -86,7 +86,7 @@ export interface Entity {
 }
 
 // @public
-export type ErrorCodeValue = 'invalidRequest' | 'invalidArgument' | 'internalServerError' | 'serviceUnavailable';
+export type ErrorCode = "InvalidRequest" | "InvalidArgument" | "InternalServerError" | "ServiceUnavailable" | "InvalidParameterValue" | "InvalidRequestBodyFormat" | "EmptyRequest" | "MissingInputRecords" | "InvalidDocument" | "ModelVersionIncorrect" | "InvalidDocumentBatch" | "UnsupportedLanguageCode" | "InvalidCountryHint";
 
 // @public
 export type ExtractKeyPhrasesErrorResult = TextAnalyticsErrorResult;
@@ -107,20 +107,6 @@ export interface ExtractKeyPhrasesResultCollection extends Array<ExtractKeyPhras
 export interface ExtractKeyPhrasesSuccessResult extends TextAnalyticsSuccessResult {
     keyPhrases: string[];
 }
-
-// @public
-export interface InnerError {
-    code: InnerErrorCodeValue;
-    details?: {
-        [propertyName: string]: string;
-    };
-    innerError?: InnerError;
-    message: string;
-    target?: string;
-}
-
-// @public
-export type InnerErrorCodeValue = 'invalidParameterValue' | 'invalidRequestBodyFormat' | 'emptyRequest' | 'missingInputRecords' | 'invalidDocument' | 'modelVersionIncorrect' | 'invalidDocumentBatch' | 'unsupportedLanguageCode' | 'invalidCountryHint';
 
 // @public
 export interface LinkedEntity {
@@ -261,11 +247,9 @@ export interface TextAnalyticsClientOptions extends PipelineOptions {
 
 // @public
 export interface TextAnalyticsError {
-    code: ErrorCodeValue;
-    details?: TextAnalyticsError[];
-    innerError?: InnerError;
-    message: string;
-    target?: string;
+    readonly code: ErrorCode;
+    readonly message: string;
+    readonly target?: string;
 }
 
 // @public

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  makeTextAnalysisResult,
+  makeTextAnalyticsSuccessResult,
   TextAnalyticsSuccessResult,
   TextAnalyticsErrorResult,
-  makeTextAnalysisErrorResult
+  makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
 import {
   TextDocumentStatistics,
@@ -53,7 +53,7 @@ export function makeAnalyzeSentimentResult(
   statistics?: TextDocumentStatistics
 ): AnalyzeSentimentSuccessResult {
   return {
-    ...makeTextAnalysisResult(id, statistics),
+    ...makeTextAnalyticsSuccessResult(id, statistics),
     sentiment,
     sentimentScores,
     sentences
@@ -64,5 +64,5 @@ export function makeAnalyzeSentimentErrorResult(
   id: string,
   error: TextAnalyticsError
 ): AnalyzeSentimentErrorResult {
-  return makeTextAnalysisErrorResult(id, error);
+  return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/detectLanguageResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/detectLanguageResult.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  makeTextAnalysisResult,
+  makeTextAnalyticsSuccessResult,
   TextAnalyticsSuccessResult,
   TextAnalyticsErrorResult,
-  makeTextAnalysisErrorResult
+  makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
 import { DetectedLanguage, TextDocumentStatistics, TextAnalyticsError } from "./generated/models";
 
@@ -36,7 +36,7 @@ export function makeDetectLanguageResult(
   statistics?: TextDocumentStatistics
 ): DetectLanguageSuccessResult {
   return {
-    ...makeTextAnalysisResult(id, statistics),
+    ...makeTextAnalyticsSuccessResult(id, statistics),
     primaryLanguage: primaryLanguage(detectedLanguages)
   };
 }
@@ -45,7 +45,7 @@ export function makeDetectLanguageErrorResult(
   id: string,
   error: TextAnalyticsError
 ): DetectLanguageErrorResult {
-  return makeTextAnalysisErrorResult(id, error);
+  return makeTextAnalyticsErrorResult(id, error);
 }
 
 function primaryLanguage(languages: DetectedLanguage[]): DetectedLanguage {

--- a/sdk/textanalytics/ai-text-analytics/src/extractKeyPhrasesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/extractKeyPhrasesResult.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  makeTextAnalysisResult,
+  makeTextAnalyticsSuccessResult,
   TextAnalyticsSuccessResult,
   TextAnalyticsErrorResult,
-  makeTextAnalysisErrorResult
+  makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
 import { TextDocumentStatistics, TextAnalyticsError } from "./generated/models";
 
@@ -37,7 +37,7 @@ export function makeExtractKeyPhrasesResult(
   statistics?: TextDocumentStatistics
 ): ExtractKeyPhrasesSuccessResult {
   return {
-    ...makeTextAnalysisResult(id, statistics),
+    ...makeTextAnalyticsSuccessResult(id, statistics),
     keyPhrases
   };
 }
@@ -46,5 +46,5 @@ export function makeExtractKeyPhrasesErrorResult(
   id: string,
   error: TextAnalyticsError
 ): ExtractKeyPhrasesErrorResult {
-  return makeTextAnalysisErrorResult(id, error);
+  return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -43,9 +43,9 @@ export interface MultiLanguageBatchInput {
  */
 export interface InnerError {
   /**
-   * Error code. Possible values include: 'invalidParameterValue', 'invalidRequestBodyFormat',
-   * 'emptyRequest', 'missingInputRecords', 'invalidDocument', 'modelVersionIncorrect',
-   * 'invalidDocumentBatch', 'unsupportedLanguageCode', 'invalidCountryHint'
+   * Error code. Possible values include: 'InvalidParameterValue', 'InvalidRequestBodyFormat',
+   * 'EmptyRequest', 'MissingInputRecords', 'InvalidDocument', 'ModelVersionIncorrect',
+   * 'InvalidDocumentBatch', 'UnsupportedLanguageCode', 'InvalidCountryHint'
    */
   code: InnerErrorCodeValue;
   /**
@@ -71,8 +71,8 @@ export interface InnerError {
  */
 export interface TextAnalyticsError {
   /**
-   * Error code. Possible values include: 'invalidRequest', 'invalidArgument',
-   * 'internalServerError', 'serviceUnavailable'
+   * Error code. Possible values include: 'InvalidRequest', 'InvalidArgument',
+   * 'InternalServerError', 'ServiceUnavailable'
    */
   code: ErrorCodeValue;
   /**
@@ -594,22 +594,22 @@ export interface TextAnalyticsClientSentimentOptionalParams extends coreHttp.Req
 
 /**
  * Defines values for ErrorCodeValue.
- * Possible values include: 'invalidRequest', 'invalidArgument', 'internalServerError',
- * 'serviceUnavailable'
+ * Possible values include: 'InvalidRequest', 'InvalidArgument', 'InternalServerError',
+ * 'ServiceUnavailable'
  * @readonly
  * @enum {string}
  */
-export type ErrorCodeValue = 'invalidRequest' | 'invalidArgument' | 'internalServerError' | 'serviceUnavailable';
+export type ErrorCodeValue = 'InvalidRequest' | 'InvalidArgument' | 'InternalServerError' | 'ServiceUnavailable';
 
 /**
  * Defines values for InnerErrorCodeValue.
- * Possible values include: 'invalidParameterValue', 'invalidRequestBodyFormat', 'emptyRequest',
- * 'missingInputRecords', 'invalidDocument', 'modelVersionIncorrect', 'invalidDocumentBatch',
- * 'unsupportedLanguageCode', 'invalidCountryHint'
+ * Possible values include: 'InvalidParameterValue', 'InvalidRequestBodyFormat', 'EmptyRequest',
+ * 'MissingInputRecords', 'InvalidDocument', 'ModelVersionIncorrect', 'InvalidDocumentBatch',
+ * 'UnsupportedLanguageCode', 'InvalidCountryHint'
  * @readonly
  * @enum {string}
  */
-export type InnerErrorCodeValue = 'invalidParameterValue' | 'invalidRequestBodyFormat' | 'emptyRequest' | 'missingInputRecords' | 'invalidDocument' | 'modelVersionIncorrect' | 'invalidDocumentBatch' | 'unsupportedLanguageCode' | 'invalidCountryHint';
+export type InnerErrorCodeValue = 'InvalidParameterValue' | 'InvalidRequestBodyFormat' | 'EmptyRequest' | 'MissingInputRecords' | 'InvalidDocument' | 'ModelVersionIncorrect' | 'InvalidDocumentBatch' | 'UnsupportedLanguageCode' | 'InvalidCountryHint';
 
 /**
  * Defines values for DocumentSentimentLabel.

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -74,15 +74,15 @@ export const InnerError: coreHttp.CompositeMapper = {
         type: {
           name: "Enum",
           allowedValues: [
-            "invalidParameterValue",
-            "invalidRequestBodyFormat",
-            "emptyRequest",
-            "missingInputRecords",
-            "invalidDocument",
-            "modelVersionIncorrect",
-            "invalidDocumentBatch",
-            "unsupportedLanguageCode",
-            "invalidCountryHint"
+            "InvalidParameterValue",
+            "InvalidRequestBodyFormat",
+            "EmptyRequest",
+            "MissingInputRecords",
+            "InvalidDocument",
+            "ModelVersionIncorrect",
+            "InvalidDocumentBatch",
+            "UnsupportedLanguageCode",
+            "InvalidCountryHint"
           ]
         }
       },
@@ -133,10 +133,10 @@ export const TextAnalyticsError: coreHttp.CompositeMapper = {
         type: {
           name: "Enum",
           allowedValues: [
-            "invalidRequest",
-            "invalidArgument",
-            "internalServerError",
-            "serviceUnavailable"
+            "InvalidRequest",
+            "InvalidArgument",
+            "InternalServerError",
+            "ServiceUnavailable"
           ]
         }
       },

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -71,6 +71,8 @@ export {
   SentenceSentiment,
   DocumentSentimentLabel,
   SentenceSentimentLabel,
+  ErrorCodeValue,
+  InnerErrorCodeValue,
   LinkedEntity,
   Match
 } from "./generated/models";

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -53,6 +53,8 @@ export {
 export { RecognizeLinkedEntitiesResultCollection } from "./recognizeLinkedEntitiesResultCollection";
 export {
   TextAnalyticsResult,
+  ErrorCode,
+  TextAnalyticsError,
   TextAnalyticsErrorResult,
   TextAnalyticsSuccessResult
 } from "./textAnalyticsResult";
@@ -64,11 +66,7 @@ export {
   SentimentScorePerLabel,
   MultiLanguageInput as TextDocumentInput,
   LanguageInput as DetectLanguageInput,
-  TextAnalyticsError,
   TextDocumentBatchStatistics,
-  InnerErrorCodeValue,
-  ErrorCodeValue,
-  InnerError,
   Entity,
   SentenceSentiment,
   DocumentSentimentLabel,

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeCategorizedEntitiesResult.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  makeTextAnalysisResult,
+  makeTextAnalyticsSuccessResult,
   TextAnalyticsSuccessResult,
   TextAnalyticsErrorResult,
-  makeTextAnalysisErrorResult
+  makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
 import { Entity, TextDocumentStatistics, TextAnalyticsError } from "./generated/models";
 
@@ -44,7 +44,7 @@ export function makeRecognizeCategorizedEntitiesResult(
   statistics?: TextDocumentStatistics
 ): RecognizeCategorizedEntitiesSuccessResult {
   return {
-    ...makeTextAnalysisResult(id, statistics),
+    ...makeTextAnalyticsSuccessResult(id, statistics),
     entities
   };
 }
@@ -53,5 +53,5 @@ export function makeRecognizeCategorizedEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError
 ): RecognizeCategorizedEntitiesErrorResult {
-  return makeTextAnalysisErrorResult(id, error);
+  return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/recognizeLinkedEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizeLinkedEntitiesResult.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  makeTextAnalysisResult,
+  makeTextAnalyticsSuccessResult,
   TextAnalyticsSuccessResult,
   TextAnalyticsErrorResult,
-  makeTextAnalysisErrorResult
+  makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
 import { TextDocumentStatistics, TextAnalyticsError, LinkedEntity } from "./generated/models";
 
@@ -38,7 +38,7 @@ export function makeRecognizeLinkedEntitiesResult(
   statistics?: TextDocumentStatistics
 ): RecognizeLinkedEntitiesSuccessResult {
   return {
-    ...makeTextAnalysisResult(id, statistics),
+    ...makeTextAnalyticsSuccessResult(id, statistics),
     entities
   };
 }
@@ -47,5 +47,5 @@ export function makeRecognizeLinkedEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError
 ): RecognizeLinkedEntitiesErrorResult {
-  return makeTextAnalysisErrorResult(id, error);
+  return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/recognizePiiEntitiesResult.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import {
-  makeTextAnalysisResult,
+  makeTextAnalyticsSuccessResult,
   TextAnalyticsSuccessResult,
   TextAnalyticsErrorResult,
-  makeTextAnalysisErrorResult
+  makeTextAnalyticsErrorResult
 } from "./textAnalyticsResult";
 import { Entity, TextDocumentStatistics, TextAnalyticsError } from "./generated/models";
 
@@ -44,7 +44,7 @@ export function makeRecognizePiiEntitiesResult(
   statistics?: TextDocumentStatistics
 ): RecognizePiiEntitiesSuccessResult {
   return {
-    ...makeTextAnalysisResult(id, statistics),
+    ...makeTextAnalyticsSuccessResult(id, statistics),
     entities
   };
 }
@@ -53,5 +53,5 @@ export function makeRecognizePiiEntitiesErrorResult(
   id: string,
   error: TextAnalyticsError
 ): RecognizePiiEntitiesErrorResult {
-  return makeTextAnalysisErrorResult(id, error);
+  return makeTextAnalyticsErrorResult(id, error);
 }

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsResult.ts
@@ -4,7 +4,9 @@
 import {
   TextDocumentStatistics,
   TextAnalyticsError as GeneratedTextAnalyticsErrorModel,
-  InnerError
+  InnerError,
+  ErrorCodeValue,
+  InnerErrorCodeValue
 } from "./generated/models";
 
 /**
@@ -16,36 +18,9 @@ export type TextAnalyticsResult = TextAnalyticsSuccessResult | TextAnalyticsErro
  * An Error Code returned from the Text Analytics service. Possible
  * values include:
  *
- * - 'InvalidRequest'
- * - 'InvalidArgument'
- * - 'InternalServerError'
- * - 'ServiceUnavailable'
- * - 'InvalidParameterValue'
- * - 'InvalidRequestBodyFormat'
- * - 'EmptyRequest'
- * - 'MissingInputRecords'
- * - 'InvalidDocument'
- * - 'ModelVersionIncorrect'
- * - 'InvalidDocumentBatch'
- * - 'UnsupportedLanguageCode'
- * - 'InvalidCountryHint'
- *
  * For more information about the error, see the `message` property of the associated error.
  */
-export type ErrorCode =
-  | "InvalidRequest"
-  | "InvalidArgument"
-  | "InternalServerError"
-  | "ServiceUnavailable"
-  | "InvalidParameterValue"
-  | "InvalidRequestBodyFormat"
-  | "EmptyRequest"
-  | "MissingInputRecords"
-  | "InvalidDocument"
-  | "ModelVersionIncorrect"
-  | "InvalidDocumentBatch"
-  | "UnsupportedLanguageCode"
-  | "InvalidCountryHint";
+export type ErrorCode = ErrorCodeValue | InnerErrorCodeValue;
 
 /**
  * Type describing an error from the Text Analytics service
@@ -118,11 +93,7 @@ function intoTextAnalyticsError(
   }
 
   return {
-    // 2020-02-06
-    // Cast is necessary for now as swagger generated model
-    // does not align with the actual results produced by the
-    // TA service in terms of casing.
-    code: errorModel.code as ErrorCode,
+    code: errorModel.code,
     message: errorModel.message,
     target: errorModel.target
   };

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -177,3 +177,13 @@ directive:
       $["x-ms-enum"].name = "SentenceSentimentLabel";
 ```
 
+### Fix capitalization of Code enum values
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions..properties.code
+    transform: >
+      $.enum = $.enum.map((val) => val.charAt(0).toUpperCase() + val.slice(1));
+```
+

--- a/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
@@ -55,7 +55,7 @@ describe("SentimentResultCollection", () => {
         {
           id: "B",
           error: {
-            code: "internalServerError",
+            code: "InternalServerError",
             message: "test error"
           }
         }
@@ -118,7 +118,7 @@ describe("DetectLanguageResultCollection", () => {
         {
           id: "B",
           error: {
-            code: "internalServerError",
+            code: "InternalServerError",
             message: "test error"
           }
         }
@@ -164,7 +164,7 @@ describe("ExtractKeyPhrasesResultCollection", () => {
         {
           id: "B",
           error: {
-            code: "internalServerError",
+            code: "InternalServerError",
             message: "test error"
           }
         }
@@ -227,7 +227,7 @@ describe("RecognizeCategorizedEntitiesResultCollection", () => {
         {
           id: "B",
           error: {
-            code: "internalServerError",
+            code: "InternalServerError",
             message: "test error"
           }
         }
@@ -290,7 +290,7 @@ describe("RecognizePiiEntitiesResultCollection", () => {
         {
           id: "B",
           error: {
-            code: "internalServerError",
+            code: "InternalServerError",
             message: "test error"
           }
         }
@@ -368,7 +368,7 @@ describe("RecognizeLinkedEntitiesResultCollection", () => {
         {
           id: "B",
           error: {
-            code: "internalServerError",
+            code: "InternalServerError",
             message: "test error"
           }
         }

--- a/sdk/textanalytics/ai-text-analytics/test/error.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/error.spec.ts
@@ -4,19 +4,11 @@
 import { assert } from "chai";
 
 import { makeTextAnalyticsErrorResult } from "../src/textAnalyticsResult";
-import { ErrorCodeValue, InnerErrorCodeValue } from "../src/generated/models";
-
-/**
- * Works around an issue with the swagger models and casing
- */
-function cap<T extends ErrorCodeValue | InnerErrorCodeValue>(code: T): T {
-  return (code.charAt(0).toUpperCase() + code.slice(1)) as T;
-}
 
 describe("makeTextAnalyticsErrorResult", function() {
   it("single-layer error is transposed", () => {
     const result = makeTextAnalyticsErrorResult("1", {
-      code: cap("serviceUnavailable"),
+      code: "ServiceUnavailable",
       message: "internal server error",
       details: []
     });
@@ -33,10 +25,10 @@ describe("makeTextAnalyticsErrorResult", function() {
 
   it("innerError must take precedence", () => {
     const result = makeTextAnalyticsErrorResult("2", {
-      code: cap("invalidRequest"),
+      code: "InvalidRequest",
       message: "This is an error message",
       innerError: {
-        code: cap("missingInputRecords"),
+        code: "MissingInputRecords",
         message: "This is a deeper error message",
         target: "a target"
       }

--- a/sdk/textanalytics/ai-text-analytics/test/error.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/error.spec.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+
+import { makeTextAnalyticsErrorResult } from "../src/textAnalyticsResult";
+import { ErrorCodeValue, InnerErrorCodeValue } from "../src/generated/models";
+
+/**
+ * Works around an issue with the swagger models and casing
+ */
+function cap<T extends ErrorCodeValue | InnerErrorCodeValue>(code: T): T {
+  return (code.charAt(0).toUpperCase() + code.slice(1)) as T;
+}
+
+describe("makeTextAnalyticsErrorResult", function() {
+  it("single-layer error is transposed", () => {
+    const result = makeTextAnalyticsErrorResult("1", {
+      code: cap("serviceUnavailable"),
+      message: "internal server error",
+      details: []
+    });
+
+    assert.deepEqual(result, {
+      id: "1",
+      error: {
+        code: "ServiceUnavailable",
+        message: "internal server error",
+        target: undefined
+      }
+    });
+  });
+
+  it("innerError must take precedence", () => {
+    const result = makeTextAnalyticsErrorResult("2", {
+      code: cap("invalidRequest"),
+      message: "This is an error message",
+      innerError: {
+        code: cap("missingInputRecords"),
+        message: "This is a deeper error message",
+        target: "a target"
+      }
+    });
+
+    assert.deepEqual(result, {
+      id: "2",
+      error: {
+        code: "MissingInputRecords",
+        message: "This is a deeper error message",
+        target: "a target"
+      }
+    });
+  });
+});

--- a/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
@@ -59,6 +59,31 @@ describe("[AAD] TextAnalyticsClient", function() {
       assertAllSuccess(results);
     });
 
+    it("service returns error for invalid language", async () => {
+      const [result] = await client.analyzeSentiment(["Hello world!"], "notalanguage");
+      if (result.error === undefined) {
+        assert.fail("Expected an error from the service.");
+        return;
+      }
+      assert.equal(result.error.code, "UnsupportedLanguageCode");
+    });
+
+    it("service returns an error for an empty document", async () => {
+      const data = [...testDataEn];
+      data.splice(1, 0, "");
+      const results = await client.analyzeSentiment(data);
+      const errorResult = results[1];
+      if (errorResult.error === undefined) {
+        assert.fail("Expected an error from the service");
+        return;
+      }
+      assert.equal(
+        results.filter((result) => result.error === undefined).length,
+        testDataEn.length
+      );
+      assert.equal(errorResult.error.code, "InvalidDocument");
+    });
+
     it("client accepts TextDocumentInput[]", async () => {
       const enInputs = testDataEn.map(
         (text): TextDocumentInput => ({
@@ -99,9 +124,14 @@ describe("[AAD] TextAnalyticsClient", function() {
       assertAllSuccess(results);
     });
 
-    it("client produces an error on invalid country hint", async () => {
+    it("service errors on invalid country hint", async () => {
       const [result] = await client.detectLanguage(["hello"], "invalidcountry");
-      assert.ok((result as any).error !== undefined);
+      if (result.error === undefined) {
+        assert.fail("Expected an error from the service");
+        return;
+      }
+
+      assert.equal(result.error.code, "InvalidCountryHint");
     });
 
     it("client accepts mixed-country DetectLanguageInput[]", async () => {
@@ -143,6 +173,20 @@ describe("[AAD] TextAnalyticsClient", function() {
       assertAllSuccess(results);
     });
 
+    it("service errors on unsupported language", async () => {
+      const [result] = await client.recognizeEntities(
+        ["This is some text, but it doesn't matter."],
+        "notalanguage"
+      );
+
+      if (result.error === undefined) {
+        assert.fail("Expected an error from the service");
+        return;
+      }
+
+      assert.equal(result.error.code, "UnsupportedLanguageCode");
+    });
+
     it("client accepts mixed-language TextDocumentInput[]", async () => {
       const enInputs = testDataEn.map(
         (text): TextDocumentInput => ({
@@ -181,6 +225,20 @@ describe("[AAD] TextAnalyticsClient", function() {
       const results = await client.extractKeyPhrases(testDataEn, "en");
       assert.equal(results.length, testDataEn.length);
       assertAllSuccess(results);
+    });
+
+    it("service errors on unsupported language", async () => {
+      const [result] = await client.extractKeyPhrases(
+        ["This is some text, but it doesn't matter."],
+        "notalanguage"
+      );
+
+      if (result.error === undefined) {
+        assert.fail("Expected an error from the service");
+        return;
+      }
+
+      assert.equal(result.error.code, "UnsupportedLanguageCode");
     });
 
     it("client accepts mixed-language TextDocumentInput[]", async () => {
@@ -236,6 +294,20 @@ describe("[AAD] TextAnalyticsClient", function() {
       }
     });
 
+    it("service errors on unsupported language", async () => {
+      const [result] = await client.recognizePiiEntities(
+        ["This is some text, but it doesn't matter."],
+        "notalanguage"
+      );
+
+      if (result.error === undefined) {
+        assert.fail("Expected an error from the service");
+        return;
+      }
+
+      assert.equal(result.error.code, "UnsupportedLanguageCode");
+    });
+
     it("client accepts mixed-language TextDocumentInput[]", async () => {
       const enInputs = testDataEn.map(
         (text): TextDocumentInput => ({
@@ -275,6 +347,20 @@ describe("[AAD] TextAnalyticsClient", function() {
       const results = await client.recognizeLinkedEntities(testDataEn, "en");
       assert.equal(results.length, testDataEn.length);
       assertAllSuccess(results);
+    });
+
+    it("service errors on unsupported language", async () => {
+      const [result] = await client.recognizeLinkedEntities(
+        ["This is some text, but it doesn't matter."],
+        "notalanguage"
+      );
+
+      if (result.error === undefined) {
+        assert.fail("Expected an error from the service");
+        return;
+      }
+
+      assert.equal(result.error.code, "UnsupportedLanguageCode");
     });
 
     it("client accepts mixed-language TextDocumentInput[]", async () => {


### PR DESCRIPTION
This PR adds a convenience layer to the text analytics error model that flattens out the `innerError` hierarchy, since TA only supports one nested inner error.

Effectively, we are swallowing the generated TextAnalyticsError and InnerError and replacing them with a single TextAnalyticsError that is not generated.

We override the ErrorCode enum because there is a discrepancy between the string literals specified in the swagger and the string literals that we observe during testing. The new model has only `code`, `message`, and an optional `target` (though I couldn't find a scenario in which I could make the service return anything other than `target: undefined`.

I also fixed a couple of typos (makeTextAnalysisResult -> makeTextAnalyticsSuccessResult and makeTextAnalysisErrorResult -> makeTextAnalyticsErrorResult).