### PR TITLE
Genericize PageSettings in PagedAsyncIterableIterator

### DIFF
--- a/sdk/core/core-paging/CHANGELOG.md
+++ b/sdk/core/core-paging/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Release History
 
-## 1.0.1 (Unreleased)
+## 1.1.0 (Unreleased)
+
+- Added new generic argument to `PagedAsyncIterableIterator` for custom `PageSettings` for services that have complex continuation parameters or no maxPageSize.
 
 ## 1.0.0 (2019-10-29)
 

--- a/sdk/core/core-paging/CHANGELOG.md
+++ b/sdk/core/core-paging/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0 (Unreleased)
 
-- Added new generic argument to `PagedAsyncIterableIterator` for custom `PageSettings` for services that have complex continuation parameters or no maxPageSize.
+- Added new generic argument to `PagedAsyncIterableIterator` for custom `PageSettings` for services that use client-driven paging or other paging patterns.
 
 ## 1.0.0 (2019-10-29)
 

--- a/sdk/core/core-paging/package.json
+++ b/sdk/core/core-paging/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/Azure/azure-sdk-for-js"
   },
   "sdk-type": "client",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Core types for paging async iterable iterators",
   "tags": [
     "microsoft",

--- a/sdk/core/core-paging/types/corePaging.d.ts
+++ b/sdk/core/core-paging/types/corePaging.d.ts
@@ -14,10 +14,10 @@ export interface PageSettings {
   maxPageSize?: number;
 }
 /**
-* @interface
-* An interface that allows async iterable iteration both to completion and by page.
-*/
-export interface PagedAsyncIterableIterator<T, PageT = never> {
+ * @interface
+ * An interface that allows async iterable iteration both to completion and by page.
+ */
+export interface PagedAsyncIterableIterator<T, PageT = never, PageSettingsT = PageSettings> {
   /**
    * @member {Promise} [next] The next method, part of the iteration protocol
    */
@@ -32,5 +32,5 @@ export interface PagedAsyncIterableIterator<T, PageT = never> {
   /**
    * @member {Function} [byPage] Return an AsyncIterableIterator that works a page at a time
    */
-  byPage: (settings?: PageSettings) => AsyncIterableIterator<PageT extends never ? T[] : PageT>;
+  byPage: (settings?: PageSettingsT) => AsyncIterableIterator<PageT extends never ? T[] : PageT>;
 }


### PR DESCRIPTION
Currently `PageSettings` was locked to a specific shape, but there are services like Cognitive Search that do not support `maxPageSize` and have complex continuation logic (i.e. here's the object bag of request options to change for the next page.)

This PR genericizes the page settings so that a service client can specify what options are interesting to a paged request.