### PR TITLE
Shorten timout for storage live tests to 60 minutes

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -5,6 +5,7 @@ parameters:
   ResourceServiceDirectory: ""
   EnvVars: {}
   MaxParallel: 0
+  TimeoutInMinutes: 240
   Matrix:
     Linux_Node10:
       OSVmImage: "ubuntu-16.04"
@@ -48,7 +49,7 @@ jobs:
     pool:
       vmImage: "$(OSVmImage)"
 
-    timeoutInMinutes: 240
+    timeoutInMinutes: ${{ parameters.TimeoutInMinutes }}
 
     steps:
       - template: ../steps/common.yml

--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -13,6 +13,7 @@ jobs:
     parameters:
       PackageName: "@azure/storage-blob"
       ResourceServiceDirectory: storage
+      TimeoutInMinutes: 60
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/storage/storage-file-datalake/tests.yml
+++ b/sdk/storage/storage-file-datalake/tests.yml
@@ -9,6 +9,7 @@ resources:
       name: Azure/azure-sdk-tools
       endpoint: azure
 jobs:
-  - template: ../archetype-sdk-tests-storage.yml
+  - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
     parameters:
       PackageName: "@azure/storage-file-datalake"
+      TimeoutInMinutes: 60

--- a/sdk/storage/storage-file-share/tests.yml
+++ b/sdk/storage/storage-file-share/tests.yml
@@ -13,6 +13,7 @@ jobs:
     parameters:
       PackageName: "@azure/storage-file-share"
       ResourceServiceDirectory: storage
+      TimeoutInMinutes: 60
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/storage/storage-queue/tests.yml
+++ b/sdk/storage/storage-queue/tests.yml
@@ -13,6 +13,7 @@ jobs:
     parameters:
       PackageName: "@azure/storage-queue"
       ResourceServiceDirectory: storage
+      TimeoutInMinutes: 60
       Matrix:
         Linux_Node8:
           OSVmImage: "ubuntu-16.04"


### PR DESCRIPTION
Even in the case of test timing out the build should be finished under one hour.
Shortening the timeout to 60 minutes so we are not wasting build agent resource.