### PR TITLE
[storage][test] fetch next page until non-empty result array

### DIFF
--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_undelete.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_undelete.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003455152806224",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
    "query": {
     "restype": "container"
    },
@@ -10,98 +10,99 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:31 GMT",
+    "content-length": "0",
+    "date": "Fri, 21 Feb 2020 01:24:06 GMT",
+    "etag": "\"0x8D7B66CBE88E848\"",
+    "last-modified": "Fri, 21 Feb 2020 01:24:06 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "etag": "\"0x8D7475784D2C4DE\"",
-    "x-ms-request-id": "215f1059-201e-0080-0e40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "6e25d806-25a7-4a8a-a7bb-e7b510f6f52a",
-    "content-length": "0"
+    "x-ms-client-request-id": "bf6ad9ca-0bd6-4a26-91a0-e045b77c94f9",
+    "x-ms-request-id": "04e05e2b-201e-005b-5d55-e8663e000000",
+    "x-ms-version": "2019-02-02"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003455152806224/blob157003455159603531",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081/blob158224824671508312",
    "query": {},
    "requestBody": "Hello World",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "x-ms-content-crc64": "YeJLfssylmU=",
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
-    "last-modified": "Wed, 02 Oct 2019 16:42:31 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "content-length": "0",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "etag": "\"0x8D7475784E1E932\"",
-    "x-ms-request-id": "215f10a0-201e-0080-4340-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "d0f178ce-e97e-4ebd-93e3-fa90193af00c",
+    "date": "Fri, 21 Feb 2020 01:24:06 GMT",
+    "etag": "\"0x8D7B66CBEE395E7\"",
+    "last-modified": "Fri, 21 Feb 2020 01:24:07 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "9c2acef0-075c-400f-aeaa-148f23a8b076",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "04e05ffb-201e-005b-0e55-e8663e000000",
     "x-ms-request-server-encrypted": "true",
-    "content-length": "0"
+    "x-ms-version": "2019-02-02"
    }
   },
   {
    "method": "GET",
    "url": "https://fakestorageaccount.blob.core.windows.net/",
    "query": {
-    "comp": "properties",
-    "restype": "service"
+    "restype": "service",
+    "comp": "properties"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>5</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>3</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>4</Days></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>DELETE,GET,HEAD,MERGE,POST,OPTIONS,PUT</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>5</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>3</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>4</Days></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>DELETE,GET,HEAD,MERGE,POST,OPTIONS,PUT,PATCH</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
+    "content-type": "application/xml",
+    "date": "Fri, 21 Feb 2020 01:24:07 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f10f3-201e-0080-7b40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "a53b2715-7d3c-4ca2-bd54-cae23e8a6ffd"
+    "x-ms-client-request-id": "0095d87f-969b-45e8-a5e7-2fb3cb07ce99",
+    "x-ms-request-id": "04e06183-201e-005b-7755-e8663e000000",
+    "x-ms-version": "2019-02-02"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003455152806224/blob157003455159603531",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081/blob158224824671508312",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
+    "content-length": "0",
+    "date": "Fri, 21 Feb 2020 01:24:08 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b19e4da3-13c8-4692-ac74-17371e07d97e",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "215f112f-201e-0080-2740-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "29807c07-cfb7-479a-bba1-eca4f7655d22",
-    "content-length": "0"
+    "x-ms-request-id": "04e06321-201e-005b-7255-e8663e000000",
+    "x-ms-version": "2019-02-02"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003455152806224",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
    "query": {
-    "comp": "list",
+    "maxresults": "1",
     "include": "deleted",
-    "restype": "container"
+    "restype": "container",
+    "comp": "list"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003455152806224\"><Blobs><Blob><Name>blob157003455159603531</Name><Deleted>true</Deleted><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:31 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:31 GMT</Last-Modified><Etag>0x8D7475784E1E932</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>YeJLfssylmU=</Content-CRC64><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Wed, 02 Oct 2019 16:42:31 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays><TagCount>0</TagCount></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224824523309081\"><MaxResults>1</MaxResults><Blobs><Blob><Name>blob158224824671508312</Name><Deleted>true</Deleted><Properties><Creation-Time>Fri, 21 Feb 2020 01:24:07 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:24:07 GMT</Last-Modified><Etag>0x8D7B66CBEE395E7</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Fri, 21 Feb 2020 01:24:08 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
+    "content-type": "application/xml",
+    "date": "Fri, 21 Feb 2020 01:24:08 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f116f-201e-0080-5640-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "f80623b8-30e6-4d8c-8540-522dc240b6a1"
+    "x-ms-client-request-id": "982eed10-dfb6-4497-b900-b7f4427960c7",
+    "x-ms-request-id": "04e064b0-201e-005b-6455-e8663e000000",
+    "x-ms-version": "2019-02-02"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003455152806224/blob157003455159603531",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081/blob158224824671508312",
    "query": {
     "comp": "undelete"
    },
@@ -109,38 +110,38 @@
    "status": 200,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
+    "content-length": "0",
+    "date": "Fri, 21 Feb 2020 01:24:09 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f11a9-201e-0080-0440-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "95cc47b1-d61f-4759-97fa-750a272806ad",
-    "content-length": "0"
+    "x-ms-client-request-id": "e841edde-f7b6-41df-ae08-8e997a24d0c0",
+    "x-ms-request-id": "04e066a7-201e-005b-3f55-e8663e000000",
+    "x-ms-version": "2019-02-02"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003455152806224",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
    "query": {
-    "comp": "list",
     "include": "deleted",
-    "restype": "container"
+    "restype": "container",
+    "comp": "list"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container157003455152806224\"><Blobs><Blob><Name>blob157003455159603531</Name><Properties><Creation-Time>Wed, 02 Oct 2019 16:42:31 GMT</Creation-Time><Last-Modified>Wed, 02 Oct 2019 16:42:31 GMT</Last-Modified><Etag>0x8D7475784E1E932</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>YeJLfssylmU=</Content-CRC64><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224824523309081\"><Blobs><Blob><Name>blob158224824671508312</Name><Properties><Creation-Time>Fri, 21 Feb 2020 01:24:07 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:24:07 GMT</Last-Modified><Etag>0x8D7B66CBEE395E7</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
+    "content-type": "application/xml",
+    "date": "Fri, 21 Feb 2020 01:24:09 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "content-type": "application/xml",
-    "x-ms-request-id": "215f12a6-201e-0080-4f40-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "94e7c09d-98c5-4b4a-8ad4-413817a326f0"
+    "x-ms-client-request-id": "7bb4a9b0-be37-4508-bfc7-8f635e449a0c",
+    "x-ms-request-id": "04e06877-201e-005b-6755-e8663e000000",
+    "x-ms-version": "2019-02-02"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container157003455152806224",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
    "query": {
     "restype": "container"
    },
@@ -148,17 +149,20 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "date": "Wed, 02 Oct 2019 16:42:31 GMT",
+    "content-length": "0",
+    "date": "Fri, 21 Feb 2020 01:24:10 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-request-id": "215f12ef-201e-0080-0740-7993dc000000",
-    "x-ms-version": "2019-02-02",
-    "x-ms-client-request-id": "8f6d9672-4d4f-464a-a8e7-03d224c90578",
-    "content-length": "0"
+    "x-ms-client-request-id": "b53b190a-1dd0-49f0-a1ad-0424eef6ae0a",
+    "x-ms-request-id": "04e06b0d-201e-005b-5755-e8663e000000",
+    "x-ms-version": "2019-02-02"
    }
   }
  ],
  "uniqueTestInfo": {
-  "container": "container157003455152806224",
-  "blob": "blob157003455159603531"
+  "uniqueName": {
+   "container": "container158224824523309081",
+   "blob": "blob158224824671508312"
+  },
+  "newDate": {}
  }
 }

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_undelete.js
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_undelete.js
@@ -1,44 +1,46 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"container":"container156816831286504419","blob":"blob156816831328601618"}
+module.exports.testInfo = {"uniqueName":{"container":"container158224819242602498","blob":"blob158224819384806465"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816831286504419')
+  .put('/container158224819242602498')
   .query(true)
-  .reply(201, "", [ 'Content-Length',
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:18:33 GMT',
+  'Fri, 21 Feb 2020 01:23:13 GMT',
   'ETag',
-  '"0x8D7365E5847DDBB"',
+  '"0x8D7B66C9F05446C"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'a2732e95-b01e-0046-4847-68b86a000000',
+  '16a15905-f01e-0048-4755-e84232000000',
   'x-ms-client-request-id',
-  'bad946b5-b354-45e0-a071-5d07f3e128f8',
+  '0701b4e0-e23c-4571-b062-a811c675cc23',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 11 Sep 2019 02:18:32 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:12 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816831286504419/blob156816831328601618', "Hello World")
-  .reply(201, "", [ 'Content-Length',
+  .put('/container158224819242602498/blob158224819384806465', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Wed, 11 Sep 2019 02:18:33 GMT',
+  'Fri, 21 Feb 2020 01:23:14 GMT',
   'ETag',
-  '"0x8D7365E58882022"',
+  '"0x8D7B66C9FB99A69"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd89830b7-f01e-0063-0847-6820d9000000',
+  'f1569be6-a01e-0008-2155-e8450a000000',
   'x-ms-client-request-id',
-  'dcb3b43b-ccc2-4a71-93d1-71062465744b',
+  '1d217bd0-430b-4927-92e8-c9e983188d6e',
   'x-ms-version',
   '2019-02-02',
   'x-ms-content-crc64',
@@ -46,22 +48,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Wed, 11 Sep 2019 02:18:33 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:14 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
   .get('/')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>5</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>3</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>4</Days></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>DELETE,GET,HEAD,MERGE,POST,OPTIONS,PUT,PATCH</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>5</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>3</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>4</Days></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>DELETE,GET,HEAD,MERGE,POST,OPTIONS,PUT,PATCH</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '53c20123-f01e-002c-2847-68e4c1000000',
+  '1206a6c6-601e-0017-1555-e8f60e000000',
   'x-ms-client-request-id',
-  '4be7fc49-e80c-4779-8dce-a87578efe8f8',
+  'a54eeccd-225e-4712-8fc2-a0ecd57f1cca',
   'x-ms-version',
   '2019-02-02',
   'Access-Control-Expose-Headers',
@@ -69,40 +72,42 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:18:33 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:15 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816831286504419/blob156816831328601618')
-  .reply(202, "", [ 'Content-Length',
+  .delete('/container158224819242602498/blob158224819384806465')
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f194c243-301e-0057-0547-688f71000000',
+  '4317385a-801e-0052-2355-e823ed000000',
   'x-ms-client-request-id',
-  '80d44106-f768-4144-99c5-73a4ea96ef08',
+  '74edeedb-f29f-4143-bc94-24d1ce31e039',
   'x-ms-version',
   '2019-02-02',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Wed, 11 Sep 2019 02:18:34 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:16 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816831286504419')
+  .get('/container158224819242602498')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816831286504419\"><Blobs><Blob><Name>blob156816831328601618</Name><Deleted>true</Deleted><Properties><Creation-Time>Wed, 11 Sep 2019 02:18:33 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:18:33 GMT</Last-Modified><Etag>0x8D7365E58882022</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>YeJLfssylmU=</Content-CRC64><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Wed, 11 Sep 2019 02:18:34 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays><TagCount>0</TagCount></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224819242602498\"><MaxResults>1</MaxResults><Blobs><Blob><Name>blob158224819384806465</Name><Deleted>true</Deleted><Properties><Creation-Time>Fri, 21 Feb 2020 01:23:14 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:23:14 GMT</Last-Modified><Etag>0x8D7B66C9FB99A69</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Fri, 21 Feb 2020 01:23:17 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '95f288db-401e-0053-3b47-687af3000000',
+  '16a15f77-f01e-0048-0455-e84232000000',
   'x-ms-client-request-id',
-  '0c5e8149-946d-42d2-8faa-6cf7ab3ea37f',
+  '9ee5fb28-702d-4320-9897-bb38ddd5bf82',
   'x-ms-version',
   '2019-02-02',
   'Access-Control-Expose-Headers',
@@ -110,39 +115,41 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:18:33 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:16 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container156816831286504419/blob156816831328601618')
+  .put('/container158224819242602498/blob158224819384806465')
   .query(true)
-  .reply(200, "", [ 'Content-Length',
+  .reply(200, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'dd4a3461-901e-0037-5547-68ca53000000',
+  '4317393f-801e-0052-7755-e823ed000000',
   'x-ms-client-request-id',
-  '5df8535a-377f-40bd-895d-f70fbc2934c8',
+  '9b5fb2c2-879c-4747-88cb-05d2adbde60e',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 11 Sep 2019 02:18:35 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:16 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container156816831286504419')
+  .get('/container158224819242602498')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container156816831286504419\"><Blobs><Blob><Name>blob156816831328601618</Name><Properties><Creation-Time>Wed, 11 Sep 2019 02:18:33 GMT</Creation-Time><Last-Modified>Wed, 11 Sep 2019 02:18:33 GMT</Last-Modified><Etag>0x8D7365E58882022</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64>YeJLfssylmU=</Content-CRC64><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Cool</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted><TagCount>0</TagCount></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [ 'Transfer-Encoding',
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224819242602498\"><Blobs><Blob><Name>blob158224819384806465</Name><Properties><Creation-Time>Fri, 21 Feb 2020 01:23:14 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:23:14 GMT</Last-Modified><Etag>0x8D7B66C9FB99A69</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
   'chunked',
   'Content-Type',
   'application/xml',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1b9eaa18-e01e-0033-2547-683fd1000000',
+  '16a16073-f01e-0048-6355-e84232000000',
   'x-ms-client-request-id',
-  'd2bf7dce-3204-431d-b42b-28f2c99d3974',
+  '7231eea9-7bf1-40a0-a359-811726cc6404',
   'x-ms-version',
   '2019-02-02',
   'Access-Control-Expose-Headers',
@@ -150,22 +157,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Wed, 11 Sep 2019 02:18:35 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:17 GMT'
+]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container156816831286504419')
+  .delete('/container158224819242602498')
   .query(true)
-  .reply(202, "", [ 'Content-Length',
+  .reply(202, "", [
+  'Content-Length',
   '0',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '9a00b814-701e-005b-3e47-686180000000',
+  '16a16113-f01e-0048-7355-e84232000000',
   'x-ms-client-request-id',
-  'cb0ee6c2-9226-41ca-a48f-342c231d280b',
+  '500e08dc-9fa1-487c-91d0-3ca0ac351314',
   'x-ms-version',
   '2019-02-02',
   'Date',
-  'Wed, 11 Sep 2019 02:18:35 GMT' ]);
-
+  'Fri, 21 Feb 2020 01:23:17 GMT'
+]);

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -19,9 +19,10 @@ import {
   BlobServiceClient
 } from "../src";
 import { Test_CPK_INFO } from "./utils/constants";
+import { setLogLevel } from '@azure/logger';
 dotenv.config({ path: "../.env" });
 
-describe("BlobClient", () => {
+describe.only("BlobClient", () => {
   let blobServiceClient: BlobServiceClient;
   let containerName: string;
   let containerClient: ContainerClient;
@@ -29,6 +30,8 @@ describe("BlobClient", () => {
   let blobClient: BlobClient;
   let blockBlobClient: BlockBlobClient;
   const content = "Hello World";
+
+  setLogLevel("info");
 
   let recorder: any;
 

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -243,6 +243,7 @@ describe("BlobClient", () => {
       });
       await delay(15 * 1000);
       properties = await blobServiceClient.getProperties();
+      assert.ok(properties.deleteRetentionPolicy!.enabled, "deleteRetentionPolicy should be enabled.");
     }
 
     await blobClient.delete();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -234,16 +234,16 @@ describe("BlobClient", () => {
 
   it.only("undelete", async () => {
     let properties = await blobServiceClient.getProperties();
-    while (!properties.deleteRetentionPolicy!.enabled) {
+    if (!properties.deleteRetentionPolicy!.enabled) {
       await blobServiceClient.setProperties({
         deleteRetentionPolicy: {
           days: 7,
           enabled: true
         }
       });
-      await delay(15 * 1000);
+      // await delay(15 * 1000);
       properties = await blobServiceClient.getProperties();
-      assert.ok(properties.deleteRetentionPolicy!.enabled, "deleteRetentionPolicy should be enabled.");
+      assert.ok(properties.deleteRetentionPolicy!.enabled, "deleteRetentionPolicy should be enabled immediately.");
     }
 
     await blobClient.delete();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -252,7 +252,8 @@ describe.only("BlobClient", () => {
     let res = await iter.next();
     let result = res.value;
     while (!res.done) {
-      if (!!result && !!result.segment && !!result.segment.blobItems) {
+      if (!!result && !!result.segment && !!result.segment.blobItems &&
+        result.segment.blobItems.length > 0) {
         break;
       }
       res = await iter.next();
@@ -270,7 +271,7 @@ describe.only("BlobClient", () => {
     assert.equal(
       result.segment.blobItems.length,
       1,
-      `Expect result.segmetn.blobItems.length === 1 but got ${result.segment.blobItems.length}.`
+      `Expect result.segment.blobItems.length === 1 but got ${result.segment.blobItems.length}.`
     );
 
     assert.ok(
@@ -291,7 +292,8 @@ describe.only("BlobClient", () => {
     res = await iter2.next();
     result = res.value;
     while (!res.done) {
-      if (!!result && !!result.segment && !!result.segment.blobItems) {
+      if (!!result && !!result.segment && !!result.segment.blobItems &&
+        result.segment.blobItems.length > 0) {
         break;
       }
       res = await iter2.next();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -21,9 +21,6 @@ import {
 import { Test_CPK_INFO } from "./utils/constants";
 dotenv.config({ path: "../.env" });
 
-import { setLogLevel } from '@azure/logger';
-setLogLevel("info");
-
 describe("BlobClient", () => {
   let blobServiceClient: BlobServiceClient;
   let containerName: string;
@@ -232,7 +229,7 @@ describe("BlobClient", () => {
     assert.ok(result3.segment.blobItems![0].snapshot || result3.segment.blobItems![1].snapshot);
   });
 
-  it.only("undelete", async () => {
+  it("undelete", async () => {
     let properties = await blobServiceClient.getProperties();
     if (!properties.deleteRetentionPolicy!.enabled) {
       await blobServiceClient.setProperties({
@@ -243,7 +240,7 @@ describe("BlobClient", () => {
       });
       // await delay(15 * 1000);
       properties = await blobServiceClient.getProperties();
-      assert.ok(properties.deleteRetentionPolicy!.enabled, "deleteRetentionPolicy should be enabled immediately.");
+      assert.ok(properties.deleteRetentionPolicy!.enabled, "deleteRetentionPolicy should be enabled.");
     }
 
     await blobClient.delete();
@@ -256,14 +253,12 @@ describe("BlobClient", () => {
 
     let res = await iter.next();
     let result = res.value;
-    console.log(res);
     while (!res.done) {
       if (!!result && !!result.segment && !!result.segment.blobItems &&
         result.segment.blobItems.length > 0) {
         break;
       }
       res = await iter.next();
-      console.log(res);
       result = res.value;
     }
 

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -243,7 +243,7 @@ describe("BlobClient", () => {
 
     await blobClient.delete();
 
-    const iter = await containerClient
+    const iter = containerClient
       .listBlobsFlat({
         includeDeleted: true
       })
@@ -251,12 +251,14 @@ describe("BlobClient", () => {
 
     let res = await iter.next();
     let result = res.value;
-    while (!result.segment.blobItems && !res.done) {
+    while (!res.done && result.segment && !result.segment.blobItems) {
       console.log(`result.segment.blobItems ${result.segment.blobItems}`);
       console.log(`res.done ${res.done}`);
       res = await iter.next();
       result = res.value;
     }
+
+    assert.ok(result.segment, "Expect valid segment response");
 
     assert.ok(
       result.segment.blobItems,
@@ -266,7 +268,7 @@ describe("BlobClient", () => {
 
     await blobClient.undelete();
 
-    const iter2 = await containerClient
+    const iter2 = containerClient
       .listBlobsFlat({
         includeDeleted: true
       })
@@ -274,12 +276,14 @@ describe("BlobClient", () => {
 
     res = await iter2.next();
     result = res.value;
-    while (!result.segment.blobItems && !res.done) {
+    while (!res.done && result.segment && !result.segment.blobItems) {
       console.log(`result.segment.blobItems ${result.segment.blobItems}`);
       console.log(`res.done ${res.done}`);
       res = await iter2.next();
       result = res.value;
     }
+
+    assert.ok(result.segment, "Expect valid segment response");
 
     assert.ok(result.segment.blobItems, "Expect non empty result from list blobs().");
     assert.ok(

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -233,8 +233,8 @@ describe("BlobClient", () => {
   });
 
   it.only("undelete", async () => {
-    const properties = await blobServiceClient.getProperties();
-    if (!properties.deleteRetentionPolicy!.enabled) {
+    let properties = await blobServiceClient.getProperties();
+    while (!properties.deleteRetentionPolicy!.enabled) {
       await blobServiceClient.setProperties({
         deleteRetentionPolicy: {
           days: 7,
@@ -242,6 +242,7 @@ describe("BlobClient", () => {
         }
       });
       await delay(15 * 1000);
+      properties = await blobServiceClient.getProperties();
     }
 
     await blobClient.delete();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -254,12 +254,14 @@ describe("BlobClient", () => {
 
     let res = await iter.next();
     let result = res.value;
+    console.log(res);
     while (!res.done) {
       if (!!result && !!result.segment && !!result.segment.blobItems &&
         result.segment.blobItems.length > 0) {
         break;
       }
       res = await iter.next();
+      console.log(res);
       result = res.value;
     }
 

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -251,13 +251,15 @@ describe.only("BlobClient", () => {
 
     let res = await iter.next();
     let result = res.value;
-    while (!res.done && (!result.segment.blobItems || result.segment.blobItems.length === 0)) {
-      console.log(`result.segment.blobItems ${result.segment.blobItems} ${result.segment.blobItems.length}`);
-      console.log(`res.done ${res.done}`);
+    while (!res.done) {
+      if (!!result && !!result.segment && !!result.segment.blobItems) {
+        break;
+      }
       res = await iter.next();
       result = res.value;
     }
 
+    assert.ok(result, "Expect valid iterator value");
     assert.ok(result.segment, "Expect valid segment response");
 
     assert.ok(
@@ -288,13 +290,15 @@ describe.only("BlobClient", () => {
 
     res = await iter2.next();
     result = res.value;
-    while (!res.done && (!result.segment.blobItems || result.segment.blobItems.length === 0)) {
-      console.log(`result.segment.blobItems ${result.segment.blobItems} ${result.segment.blobItems.length}`);
-      console.log(`res.done ${res.done}`);
+    while (!res.done) {
+      if (!!result && !!result.segment && !!result.segment.blobItems) {
+        break;
+      }
       res = await iter2.next();
       result = res.value;
     }
 
+    assert.ok(result, "Expect valid iterator value");
     assert.ok(result.segment, "Expect valid segment response");
 
     assert.ok(result.segment.blobItems, "Expect non empty result from list blobs().");

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -19,7 +19,6 @@ import {
   BlobServiceClient
 } from "../src";
 import { Test_CPK_INFO } from "./utils/constants";
-import { setLogLevel } from '@azure/logger';
 dotenv.config({ path: "../.env" });
 
 describe.only("BlobClient", () => {
@@ -30,8 +29,6 @@ describe.only("BlobClient", () => {
   let blobClient: BlobClient;
   let blockBlobClient: BlockBlobClient;
   const content = "Hello World";
-
-  setLogLevel("info");
 
   let recorder: any;
 
@@ -265,8 +262,20 @@ describe.only("BlobClient", () => {
 
     assert.ok(
       result.segment.blobItems,
-      "Expect non empty result from list blobs({ includeDeleted: true })."
+      "Expect non empty result from list blobs({ includeDeleted: true }) with page size of 1."
     );
+
+    assert.equal(
+      result.segment.blobItems.length,
+      1,
+      "Expect one element in result array from list blobs({ includeDeleted: true }) with page size of 1."
+    );
+
+    assert.ok(
+      result.segment.blobItems![0],
+      "Expect a valid element in result array from list blobs({ includeDeleted: true }) with page size of 1."
+    );
+
     assert.ok(result.segment.blobItems![0].deleted, "Expect that the blob is marked for deletion");
 
     await blobClient.undelete();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -21,7 +21,10 @@ import {
 import { Test_CPK_INFO } from "./utils/constants";
 dotenv.config({ path: "../.env" });
 
-describe.only("BlobClient", () => {
+import { setLogLevel } from '@azure/logger';
+setLogLevel("info");
+
+describe("BlobClient", () => {
   let blobServiceClient: BlobServiceClient;
   let containerName: string;
   let containerClient: ContainerClient;
@@ -32,7 +35,7 @@ describe.only("BlobClient", () => {
 
   let recorder: any;
 
-  beforeEach(async function() {
+  beforeEach(async function () {
     recorder = record(this, recorderEnvSetup);
     blobServiceClient = getBSU();
     containerName = recorder.getUniqueName("container");
@@ -44,7 +47,7 @@ describe.only("BlobClient", () => {
     await blockBlobClient.upload(content, content.length);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await containerClient.delete();
     recorder.stop();
   });
@@ -229,7 +232,7 @@ describe.only("BlobClient", () => {
     assert.ok(result3.segment.blobItems![0].snapshot || result3.segment.blobItems![1].snapshot);
   });
 
-  it("undelete", async () => {
+  it.only("undelete", async () => {
     const properties = await blobServiceClient.getProperties();
     if (!properties.deleteRetentionPolicy!.enabled) {
       await blobServiceClient.setProperties({

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -251,8 +251,8 @@ describe.only("BlobClient", () => {
 
     let res = await iter.next();
     let result = res.value;
-    while (!res.done && result.segment && !result.segment.blobItems) {
-      console.log(`result.segment.blobItems ${result.segment.blobItems}`);
+    while (!res.done && (!result.segment.blobItems || result.segment.blobItems.length === 0)) {
+      console.log(`result.segment.blobItems ${result.segment.blobItems} ${result.segment.blobItems.length}`);
       console.log(`res.done ${res.done}`);
       res = await iter.next();
       result = res.value;
@@ -268,7 +268,7 @@ describe.only("BlobClient", () => {
     assert.equal(
       result.segment.blobItems.length,
       1,
-      "Expect one element in result array from list blobs({ includeDeleted: true }) with page size of 1."
+      `Expect result.segmetn.blobItems.length === 1 but got ${result.segment.blobItems.length}.`
     );
 
     assert.ok(
@@ -288,8 +288,8 @@ describe.only("BlobClient", () => {
 
     res = await iter2.next();
     result = res.value;
-    while (!res.done && result.segment && !result.segment.blobItems) {
-      console.log(`result.segment.blobItems ${result.segment.blobItems}`);
+    while (!res.done && (!result.segment.blobItems || result.segment.blobItems.length === 0)) {
+      console.log(`result.segment.blobItems ${result.segment.blobItems} ${result.segment.blobItems.length}`);
       console.log(`res.done ${res.done}`);
       res = await iter2.next();
       result = res.value;

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -252,10 +252,16 @@ describe("BlobClient", () => {
     let res = await iter.next();
     let result = res.value;
     while (!result.segment.blobItems && !res.done) {
+      console.log(`result.segment.blobItems ${result.segment.blobItems}`);
+      console.log(`res.done ${res.done}`);
       res = await iter.next();
       result = res.value;
     }
 
+    assert.ok(
+      result.segment.blobItems,
+      "Expect non empty result from list blobs({ includeDeleted: true })."
+    );
     assert.ok(result.segment.blobItems![0].deleted, "Expect that the blob is marked for deletion");
 
     await blobClient.undelete();
@@ -267,14 +273,17 @@ describe("BlobClient", () => {
       .byPage();
 
     res = await iter2.next();
-    let result2 = res.value;
-    while (!result2.segment.blobItems && !res.done) {
+    result = res.value;
+    while (!result.segment.blobItems && !res.done) {
+      console.log(`result.segment.blobItems ${result.segment.blobItems}`);
+      console.log(`res.done ${res.done}`);
       res = await iter2.next();
-      result2 = res.value;
+      result = res.value;
     }
 
+    assert.ok(result.segment.blobItems, "Expect non empty result from list blobs().");
     assert.ok(
-      !result2.segment.blobItems![0].deleted,
+      !result.segment.blobItems![0].deleted,
       "Expect that the blob is NOT marked for deletion"
     );
   });

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -187,45 +187,6 @@ describe("BlobClient Node.js only", () => {
     assert.ok(result3.segment.blobItems![0].snapshot || result3.segment.blobItems![1].snapshot);
   });
 
-  it("undelete", async () => {
-    const properties = await blobServiceClient.getProperties();
-    if (!properties.deleteRetentionPolicy!.enabled) {
-      await blobServiceClient.setProperties({
-        deleteRetentionPolicy: {
-          days: 7,
-          enabled: true
-        }
-      });
-      await delay(15 * 1000);
-    }
-
-    await blobClient.delete();
-
-    const result = (
-      await containerClient
-        .listBlobsFlat({
-          includeDeleted: true
-        })
-        .byPage()
-        .next()
-    ).value;
-
-    assert.ok(result.segment.blobItems![0].deleted);
-
-    await blobClient.undelete();
-
-    const result2 = (
-      await containerClient
-        .listBlobsFlat({
-          includeDeleted: true
-        })
-        .byPage()
-        .next()
-    ).value;
-
-    assert.ok(!result2.segment.blobItems![0].deleted);
-  });
-
   it("syncCopyFromURL", async () => {
     const newBlobClient = containerClient.getBlobClient(recorder.getUniqueName("copiedblob"));
 


### PR DESCRIPTION
The service may return a segment with a valid continuation token, but
with empty result array. In this case we need to keep getting next
page until we have a non-empty result array.

Remove the duplicate "BlobClient Node.js only undelete" test