### PR TITLE
[Storage][Blob] add md5 and crc headers for copy blob from URL 

### DIFF
--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -739,6 +739,13 @@ export interface BlobSyncCopyFromURLOptions extends CommonOptions {
    * @memberof BlobSyncCopyFromURLOptions
    */
   sourceConditions?: ModifiedAccessConditions;
+  /**
+   * Specify the md5 calculated for the range of bytes that must be read from the copy source.
+   * 
+   * @type {Uint8Array}
+   * @memberof BlobSyncCopyFromURLOptions
+   */
+  sourceContentMD5?: Uint8Array;
 }
 
 /**
@@ -1675,6 +1682,7 @@ export class BlobClient extends StorageClient {
           sourceIfNoneMatch: options.sourceConditions.ifNoneMatch,
           sourceIfUnmodifiedSince: options.sourceConditions.ifUnmodifiedSince
         },
+        sourceContentMD5: options.sourceContentMD5,
         spanOptions
       });
     } catch (e) {


### PR DESCRIPTION
The change in swagger was added to 2019-02-02 but we didn't pick it up and re-generate.
Do this in Jul19 release once and for all.