### PR TITLE
[service-bus] disable atom-based client

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -15,8 +15,6 @@ import { HttpOperationResponse } from '@azure/core-http';
 import Long from 'long';
 import { MessagingError } from '@azure/amqp-common';
 import { MSITokenCredentials } from '@azure/ms-rest-nodeauth';
-import { ProxySettings } from '@azure/core-http';
-import { ServiceClient } from '@azure/core-http';
 import { TokenInfo } from '@azure/amqp-common';
 import { TokenProvider } from '@azure/amqp-common';
 import { TokenType } from '@azure/amqp-common';
@@ -48,26 +46,6 @@ export interface CorrelationFilter {
     userProperties?: any;
 }
 
-// @public
-export interface CreateQueueResponse extends QueueDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface CreateRuleResponse extends RuleDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface CreateSubscriptionResponse extends SubscriptionDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface CreateTopicResponse extends TopicDetails {
-    _response: HttpOperationResponse;
-}
-
 export { DataTransformer }
 
 // @public
@@ -80,78 +58,12 @@ export { DefaultDataTransformer }
 
 export { delay }
 
-// @public
-export interface DeleteQueueResponse {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface DeleteRuleResponse {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface DeleteSubscriptionResponse {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface DeleteTopicResponse {
-    _response: HttpOperationResponse;
-}
-
 export { Delivery }
 
 // @public
 export type EntityStatus = "Active" | "Creating" | "Deleting" | "ReceiveDisabled" | "SendDisabled" | "Disabled" | "Renaming" | "Restoring" | "Unknown";
 
-// @public
-export interface GetQueueResponse extends QueueDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface GetRuleResponse extends RuleDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface GetSubscriptionResponse extends SubscriptionDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface GetTopicResponse extends TopicDetails {
-    _response: HttpOperationResponse;
-}
-
 export { HttpOperationResponse }
-
-// @public
-export interface ListQueuesResponse extends Array<QueueDetails> {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface ListRequestOptions {
-    skip?: number;
-    top?: number;
-}
-
-// @public
-export interface ListRulesResponse extends Array<RuleDetails> {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface ListSubscriptionsResponse extends Array<SubscriptionDetails> {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface ListTopicsResponse extends Array<TopicDetails> {
-    _response: HttpOperationResponse;
-}
 
 // @public
 export type MessageCountDetails = {
@@ -248,11 +160,6 @@ export interface QueueOptions {
 }
 
 // @public
-export interface QueueResponse extends QueueDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
 export interface ReceivedMessageInfo extends SendableMessageInfo {
     readonly _amqpMessage: AmqpMessage;
     readonly deadLetterSource?: string;
@@ -309,11 +216,6 @@ export interface RuleOptions {
 }
 
 // @public
-export interface RuleResponse extends RuleDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
 export interface SendableMessageInfo {
     body: any;
     contentType?: string;
@@ -344,36 +246,6 @@ export class Sender {
     send(message: SendableMessageInfo): Promise<void>;
     sendBatch(messages: SendableMessageInfo[]): Promise<void>;
     }
-
-// @public
-export class ServiceBusAtomManagementClient extends ServiceClient {
-    constructor(connectionString: string, options?: ServiceBusAtomManagementClientOptions);
-    createQueue(queueName: string, queueOptions?: QueueOptions): Promise<CreateQueueResponse>;
-    createRule(topicName: string, subscriptionName: string, ruleName: string, ruleOptions?: RuleOptions): Promise<CreateRuleResponse>;
-    createSubscription(topicName: string, subscriptionName: string, subscriptionOptions?: SubscriptionOptions): Promise<CreateSubscriptionResponse>;
-    createTopic(topicName: string, topicOptions?: TopicOptions): Promise<CreateTopicResponse>;
-    deleteQueue(queueName: string): Promise<DeleteQueueResponse>;
-    deleteRule(topicName: string, subscriptionName: string, ruleName: string): Promise<DeleteRuleResponse>;
-    deleteSubscription(topicName: string, subscriptionName: string): Promise<DeleteSubscriptionResponse>;
-    deleteTopic(topicName: string): Promise<DeleteTopicResponse>;
-    getQueueDetails(queueName: string): Promise<GetQueueResponse>;
-    getRuleDetails(topicName: string, subscriptioName: string, ruleName: string): Promise<GetRuleResponse>;
-    getSubscriptionDetails(topicName: string, subscriptionName: string): Promise<GetSubscriptionResponse>;
-    getTopicDetails(topicName: string): Promise<GetTopicResponse>;
-    listQueues(listRequestOptions?: ListRequestOptions): Promise<ListQueuesResponse>;
-    listRules(topicName: string, subscriptionName: string, listRequestOptions?: ListRequestOptions): Promise<ListRulesResponse>;
-    listSubscriptions(topicName: string, listRequestOptions?: ListRequestOptions): Promise<ListSubscriptionsResponse>;
-    listTopics(listRequestOptions?: ListRequestOptions): Promise<ListTopicsResponse>;
-    updateQueue(queueName: string, queueOptions: QueueOptions): Promise<UpdateQueueResponse>;
-    updateRule(topicName: string, subscriptionName: string, ruleName: string, ruleOptions: RuleOptions): Promise<UpdateRuleResponse>;
-    updateSubscription(topicName: string, subscriptionName: string, subscriptionOptions: SubscriptionOptions): Promise<UpdateSubscriptionResponse>;
-    updateTopic(topicName: string, topicOptions: TopicOptions): Promise<UpdateTopicResponse>;
-}
-
-// @public
-export interface ServiceBusAtomManagementClientOptions {
-    proxySettings?: ProxySettings;
-}
 
 // @public
 export class ServiceBusClient {
@@ -547,11 +419,6 @@ export interface SubscriptionOptions {
     userMetadata?: string;
 }
 
-// @public
-export interface SubscriptionResponse extends SubscriptionDetails {
-    _response: HttpOperationResponse;
-}
-
 export { TokenInfo }
 
 export { TokenProvider }
@@ -610,31 +477,6 @@ export interface TopicOptions {
     status?: EntityStatus;
     supportOrdering?: boolean;
     userMetadata?: string;
-}
-
-// @public
-export interface TopicResponse extends TopicDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface UpdateQueueResponse extends QueueDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface UpdateRuleResponse extends RuleDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface UpdateSubscriptionResponse extends SubscriptionDetails {
-    _response: HttpOperationResponse;
-}
-
-// @public
-export interface UpdateTopicResponse extends TopicDetails {
-    _response: HttpOperationResponse;
 }
 
 export { WebSocketImpl }

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -39,36 +39,6 @@ export { Delivery, WebSocketImpl } from "rhea-promise";
 
 export { HttpOperationResponse } from "@azure/core-http";
 
-export {
-  ServiceBusAtomManagementClient,
-  ServiceBusAtomManagementClientOptions,
-  ListRequestOptions,
-  QueueResponse,
-  CreateQueueResponse,
-  GetQueueResponse,
-  ListQueuesResponse,
-  UpdateQueueResponse,
-  DeleteQueueResponse,
-  TopicResponse,
-  CreateTopicResponse,
-  GetTopicResponse,
-  ListTopicsResponse,
-  UpdateTopicResponse,
-  DeleteTopicResponse,
-  SubscriptionResponse,
-  CreateSubscriptionResponse,
-  GetSubscriptionResponse,
-  ListSubscriptionsResponse,
-  UpdateSubscriptionResponse,
-  DeleteSubscriptionResponse,
-  RuleResponse,
-  CreateRuleResponse,
-  GetRuleResponse,
-  ListRulesResponse,
-  UpdateRuleResponse,
-  DeleteRuleResponse
-} from "./serviceBusAtomManagementClient";
-
 export { QueueDetails, QueueOptions } from "./serializers/queueResourceSerializer";
 export { TopicDetails, TopicOptions } from "./serializers/topicResourceSerializer";
 export {

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-  ServiceBusAtomManagementClient,
-  QueueOptions,
-  TopicOptions,
-  SubscriptionOptions,
-  RuleOptions,
-  EntityStatus
-} from "../src";
+import { QueueOptions, TopicOptions, SubscriptionOptions, RuleOptions, EntityStatus } from "../src";
+import { ServiceBusAtomManagementClient } from "../src/serviceBusAtomManagementClient";
 
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";

--- a/sdk/servicebus/service-bus/test/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/managementUtils.ts
@@ -1,13 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import {
-  QueueOptions,
-  TopicOptions,
-  SubscriptionOptions,
-  ServiceBusAtomManagementClient,
-  delay
-} from "../../src";
+import { QueueOptions, TopicOptions, SubscriptionOptions, delay } from "../../src";
+import { ServiceBusAtomManagementClient } from "../../src/serviceBusAtomManagementClient";
 
 import { EnvVarNames, getEnvVars } from "./envVarUtils";
 


### PR DESCRIPTION
This removes the ATOM based service bus from the entry point since it is not yet ready for GA. This feature has not been shipped yet.