### PR TITLE
[ai-text-analytics] hotfix: use `"strict": true` in sample tsconfig

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/samples/typescript/tsconfig.json
+++ b/sdk/textanalytics/ai-text-analytics/samples/typescript/tsconfig.json
@@ -5,6 +5,9 @@
 
     "allowSyntheticDefaultImports": true,
 
+    "strict": true,
+    "alwaysStrict": true,
+
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
(CC @bterlson @xirzec )

While testing for the TA release, I discovered that our TA TypeScript samples have been broken for a little bit due to a bug in the tsconfig.

When we introduced the `error?: undefined` discriminant in `TextAnalyticsSuccess`, we needed to set "strict" in the sample tsconfig (specifically "strictNullChecks", because otherwise TSC can't use `null` or `undefined` as a discriminant, since they would be valid for all types.

Adding both "strict" and "alwaysStrict" will make the published tsconfig more similar to the one we use for builds.

This was a particularly strange one to debug.