### PR TITLE
[Cosmos] Fix bug in QueryIterator for non-item resources

### DIFF
--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -142,9 +142,7 @@ export class QueryIterator<T> {
     let response: Response<any>;
     try {
       response = await this.queryExecutionContext.fetchMore();
-      console.log(response);
     } catch (error) {
-      console.log(error);
       if (this.needsQueryPlan(error)) {
         await this.createPipelinedExecutionContext();
         try {

--- a/sdk/cosmosdb/cosmos/src/queryIterator.ts
+++ b/sdk/cosmosdb/cosmos/src/queryIterator.ts
@@ -142,7 +142,9 @@ export class QueryIterator<T> {
     let response: Response<any>;
     try {
       response = await this.queryExecutionContext.fetchMore();
+      console.log(response);
     } catch (error) {
+      console.log(error);
       if (this.needsQueryPlan(error)) {
         await this.createPipelinedExecutionContext();
         try {
@@ -256,7 +258,7 @@ export class QueryIterator<T> {
     return this.initPromise;
   }
   private async _init() {
-    if (this.options.forceQueryPlan === true) {
+    if (this.options.forceQueryPlan === true && this.resourceType === ResourceType.item) {
       await this.createPipelinedExecutionContext();
     }
     this.isInitialized = true;

--- a/sdk/cosmosdb/cosmos/test/functional/conflict.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/conflict.spec.ts
@@ -11,11 +11,17 @@ describe.only("Conflicts", function() {
 
   describe("Query conflicts", function() {
     it("query conflicts", async function() {
-      // create database
       const container = await getTestContainer("conflicts");
-
       const { resources } = await container.conflicts.query("SELECT * from C").fetchNext();
-
+      assert.equal(resources.length, 0);
+    });
+    it("query conflicts with forceQueryPlan", async function() {
+      // TODO. Remove! This test is to prevent regression on a bug where a query plan was being fetched for non-item resources
+      // Ideally QueryIterator for item gets its own type instead of shared amongst all resources
+      const container = await getTestContainer("conflicts");
+      const { resources } = await container.conflicts
+        .query("SELECT * from C", { forceQueryPlan: true })
+        .fetchNext();
       assert.equal(resources.length, 0);
     });
   });

--- a/sdk/cosmosdb/cosmos/test/functional/conflict.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/conflict.spec.ts
@@ -3,7 +3,7 @@
 import assert from "assert";
 import { removeAllDatabases, getTestContainer } from "../common/TestHelpers";
 
-describe.only("Conflicts", function() {
+describe("Conflicts", function() {
   this.timeout(process.env.MOCHA_TIMEOUT || 10000);
   beforeEach(async function() {
     await removeAllDatabases();

--- a/sdk/cosmosdb/cosmos/test/functional/conflict.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/conflict.spec.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import assert from "assert";
+import { removeAllDatabases, getTestContainer } from "../common/TestHelpers";
+
+describe.only("Conflicts", function() {
+  this.timeout(process.env.MOCHA_TIMEOUT || 10000);
+  beforeEach(async function() {
+    await removeAllDatabases();
+  });
+
+  describe("Query conflicts", function() {
+    it("query conflicts", async function() {
+      // create database
+      const container = await getTestContainer("conflicts");
+
+      const { resources } = await container.conflicts.query("SELECT * from C").fetchNext();
+
+      assert.equal(resources.length, 0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes a bug where if you accidentally passed `forceQueryPlan` to a non-item resource it would throw an error. Long term we should split up the QueryIterator