### PR TITLE
[storage] Fix typings support for TypeScript 3.1

### DIFF
--- a/sdk/storage/storage-blob/api-extractor.json
+++ b/sdk/storage/storage-blob/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "typings/src/index.d.ts",
+  "mainEntryPointFilePath": "typings/latest/src/index.d.ts",
   "docModel": {
     "enabled": false
   },
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./typings/storage-blob.d.ts"
+    "publicTrimmedFilePath": "./typings/latest/storage-blob.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -16,18 +16,26 @@
     "os": false,
     "process": false
   },
-  "types": "./typings/src/index.d.ts",
+  "types": "./typings/latest/src/index.d.ts",
+  "typesVersions": {
+    "<3.6": {
+      "*": [
+        "./typings/3.1/src/index.d.ts"
+      ]
+    }
+  },
   "engine": {
     "node": ">=8.0.0"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.1.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
-    "build:es6": "tsc -p tsconfig.json",
+    "build:es6": "tsc -p tsconfig.json && npm run build:types",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",
     "build:prep-samples": "node ../../../common/scripts/prep-samples.js && cd samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
+    "build:types": "downlevel-dts typings/latest typings/3.1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-test typings temp browser/*.js* browser/*.zip statistics.html coverage coverage-browser .nyc_output *.tgz *.log test*.xml TEST*.xml",
@@ -58,7 +66,8 @@
     "dist-esm/src/",
     "LICENSE",
     "src/",
-    "typings/src",
+    "typings/latest/src",
+    "typings/3.1/src",
     "tsconfig.json"
   ],
   "repository": {
@@ -113,6 +122,7 @@
     "assert": "^1.4.1",
     "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
+    "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/storage/storage-blob/tsconfig.json
+++ b/sdk/storage/storage-blob/tsconfig.json
@@ -15,7 +15,7 @@
     "declaration": true,
     "declarationMap": true,
     "importHelpers": true,
-    "declarationDir": "./typings",
+    "declarationDir": "./typings/latest",
     "lib": ["dom", "es5", "es6", "es7", "esnext"],
     "esModuleInterop": true
   },

--- a/sdk/storage/storage-file-datalake/api-extractor.json
+++ b/sdk/storage/storage-file-datalake/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "typings/src/index.d.ts",
+  "mainEntryPointFilePath": "typings/latest/src/index.d.ts",
   "docModel": {
     "enabled": false
   },
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./typings/storage-datalake.d.ts"
+    "publicTrimmedFilePath": "./typings/latest/storage-datalake.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -5,7 +5,14 @@
   "sdk-type": "client",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
-  "types": "./typings/src/index.d.ts",
+  "types": "./typings/latest/src/index.d.ts",
+  "typesVersions": {
+    "<3.6": {
+      "*": [
+        "./typings/3.1/src/index.d.ts"
+      ]
+    }
+  },
   "browser": {
     "./dist-esm/src/index.js": "./dist-esm/src/index.browser.js",
     "./dist-esm/src/credentials/StorageSharedKeyCredential.js": "./dist-esm/src/credentials/StorageSharedKeyCredential.browser.js",
@@ -21,11 +28,12 @@
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:autorest": "autorest ./swagger/README.md --typescript --use=@microsoft.azure/autorest.typescript@5.0.1",
-    "build:es6": "tsc -p tsconfig.json",
+    "build:es6": "tsc -p tsconfig.json && npm run build:types",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:js-samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:ts-samples": "npm run clean && cd samples && tsc -p . ",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
+    "build:types": "downlevel-dts typings/latest typings/3.1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-test typings temp browser/*.js* browser/*.zip statistics.html coverage coverage-browser .nyc_output *.tgz *.log test*.xml TEST*.xml",
@@ -52,7 +60,8 @@
     "dist-esm/src/",
     "LICENSE",
     "src/",
-    "typings/src",
+    "typings/latest/src",
+    "typings/3.1/src",
     "tsconfig.json"
   ],
   "sideEffects": false,
@@ -114,6 +123,7 @@
     "assert": "^1.4.1",
     "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
+    "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/storage/storage-file-datalake/tsconfig.json
+++ b/sdk/storage/storage-file-datalake/tsconfig.json
@@ -15,7 +15,7 @@
     "declaration": true,
     "declarationMap": true,
     "importHelpers": true,
-    "declarationDir": "./typings",
+    "declarationDir": "./typings/latest",
     "lib": ["dom", "es5", "es6", "es7", "esnext"],
     "esModuleInterop": true
   },

--- a/sdk/storage/storage-file-share/api-extractor.json
+++ b/sdk/storage/storage-file-share/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "typings/src/index.d.ts",
+  "mainEntryPointFilePath": "typings/latest/src/index.d.ts",
   "docModel": {
     "enabled": false
   },
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./typings/storage-file-share.d.ts"
+    "publicTrimmedFilePath": "./typings/latest/storage-file-share.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -15,18 +15,26 @@
     "os": false,
     "process": false
   },
-  "types": "./typings/src/index.d.ts",
+  "types": "./typings/latest/src/index.d.ts",
+  "typesVersions": {
+    "<3.6": {
+      "*": [
+        "./typings/3.1/src/index.d.ts"
+      ]
+    }
+  },
   "engine": {
     "node": ">=8.0.0"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.1.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
-    "build:es6": "tsc -p tsconfig.json",
+    "build:es6": "tsc -p tsconfig.json && npm run build:types",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",
     "build:prep-samples": "node ../../../common/scripts/prep-samples.js && cd samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
+    "build:types": "downlevel-dts typings/latest typings/3.1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-test typings temp browser/*.js* browser/*.zip statistics.html coverage coverage-browser .nyc_output *.tgz *.log test*.xml TEST*.xml",
@@ -57,7 +65,8 @@
     "dist-esm/src/",
     "LICENSE",
     "src/",
-    "typings/src",
+    "typings/latest/src",
+    "typings/3.1/src",
     "tsconfig.json"
   ],
   "repository": {
@@ -116,6 +125,7 @@
     "assert": "^1.4.1",
     "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
+    "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/storage/storage-file-share/review/storage-file-share.api.md
+++ b/sdk/storage/storage-file-share/review/storage-file-share.api.md
@@ -1186,9 +1186,9 @@ export class ShareLeaseClient {
     acquireLease(duration?: number, options?: LeaseOperationOptions): Promise<LeaseOperationResponse>;
     breakLease(options?: LeaseOperationOptions): Promise<LeaseOperationResponse>;
     changeLease(proposedLeaseId: string, options?: LeaseOperationOptions): Promise<LeaseOperationResponse>;
-    readonly leaseId: string;
+    get leaseId(): string;
     releaseLease(options?: LeaseOperationOptions): Promise<LeaseOperationResponse>;
-    readonly url: string;
+    get url(): string;
     }
 
 // @public

--- a/sdk/storage/storage-file-share/tsconfig.json
+++ b/sdk/storage/storage-file-share/tsconfig.json
@@ -15,7 +15,7 @@
     "declaration": true,
     "declarationMap": true,
     "importHelpers": true,
-    "declarationDir": "./typings",
+    "declarationDir": "./typings/latest",
     "lib": ["dom", "es5", "es6", "es7", "esnext"],
     "esModuleInterop": true
   },

--- a/sdk/storage/storage-queue/api-extractor.json
+++ b/sdk/storage/storage-queue/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "typings/src/index.d.ts",
+  "mainEntryPointFilePath": "typings/latest/src/index.d.ts",
   "docModel": {
     "enabled": false
   },
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./typings/storage-queue.d.ts"
+    "publicTrimmedFilePath": "./typings/latest/storage-queue.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -12,18 +12,26 @@
     "os": false,
     "process": false
   },
-  "types": "./typings/src/index.d.ts",
+  "types": "./typings/latest/src/index.d.ts",
+  "typesVersions": {
+    "<3.6": {
+      "*": [
+        "./typings/3.1/src/index.d.ts"
+      ]
+    }
+  },
   "engines": {
     "node": ">=8.0.0"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.0.3 --use=@microsoft.azure/autorest.typescript@5.0.1",
-    "build:es6": "tsc -p tsconfig.json",
+    "build:es6": "tsc -p tsconfig.json && npm run build:types",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",
     "build:prep-samples": "node ../../../common/scripts/prep-samples.js && cd samples && tsc",
     "build:test": "npm run build:es6 && rollup -c rollup.test.config.js 2>&1",
+    "build:types": "downlevel-dts typings/latest typings/3.1",
     "build": "npm run build:es6 && npm run build:nodebrowser && api-extractor run --local",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm dist-test typings temp browser/*.js* browser/*.zip statistics.html coverage coverage-browser .nyc_output *.tgz *.log test*.xml TEST*.xml",
@@ -54,7 +62,8 @@
     "dist-esm/src/",
     "LICENSE",
     "src/",
-    "typings/src",
+    "typings/latest/src",
+    "typings/3.1/src",
     "tsconfig.json"
   ],
   "repository": {
@@ -113,6 +122,7 @@
     "assert": "^1.4.1",
     "cross-env": "^6.0.3",
     "dotenv": "^8.2.0",
+    "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/storage/storage-queue/tsconfig.json
+++ b/sdk/storage/storage-queue/tsconfig.json
@@ -15,7 +15,7 @@
     "declaration": true,
     "declarationMap": true,
     "importHelpers": true,
-    "declarationDir": "./typings",
+    "declarationDir": "./typings/latest",
     "lib": ["dom", "es5", "es6", "es7", "esnext"],
     "esModuleInterop": true
   },


### PR DESCRIPTION
Since TypeScript 3.7 introduced an incompatible change to their typings files, we have to generate a downlevel version that works with 3.1 -> 3.5.

Fixes #7296