### PR TITLE
[Cosmos] Normalize when selecting preferredLocation endpoints

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Release History
 
-## 3.6.1 (Unreleased)
+## 3.6.1 (2020-2-11)
 
+- BUG FIX: Normalize location names when selecting endpoint. Allows passing of normalized endpoint names
 
 ## 3.6.0 (2020-2-10)
 

--- a/sdk/cosmosdb/cosmos/src/globalEndpointManager.ts
+++ b/sdk/cosmosdb/cosmos/src/globalEndpointManager.ts
@@ -127,7 +127,9 @@ export class GlobalEndpointManager {
     if (this.preferredLocations && this.preferredLocations.length > 0) {
       for (const preferredLocation of this.preferredLocations) {
         location = locations.find(
-          (loc) => loc.unavailable !== true && loc.name === preferredLocation
+          (loc) =>
+            loc.unavailable !== true &&
+            normalizeEndpoint(loc.name) === normalizeEndpoint(preferredLocation)
         );
         if (location) {
           break;
@@ -257,4 +259,11 @@ export class GlobalEndpointManager {
 
     return null;
   }
+}
+
+function normalizeEndpoint(endpoint: string) {
+  return endpoint
+    .split(" ")
+    .join("")
+    .toLowerCase();
 }

--- a/sdk/cosmosdb/cosmos/test/functional/globalEndpointManager.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/globalEndpointManager.spec.ts
@@ -71,5 +71,30 @@ describe("GlobalEndpointManager", function() {
         "https://test-eastus2.documents.azure.com:443/"
       );
     });
+    it("should allow you to pass a normalized preferred location", async function() {
+      const gem = new GlobalEndpointManager(
+        {
+          endpoint: "https://test.documents.azure.com:443/",
+          key: masterKey,
+          connectionPolicy: {
+            enableEndpointDiscovery: true,
+            preferredLocations: ["eastus2", "West US 2"]
+          }
+        },
+        async (opts: RequestOptions) => {
+          const response: ResourceResponse<DatabaseAccount> = new ResourceResponse(
+            new DatabaseAccount(databaseAccountBody, headers),
+            headers,
+            200
+          );
+          return response;
+        }
+      );
+
+      assert.equal(
+        await gem.resolveServiceEndpoint(ResourceType.item, OperationType.Read),
+        "https://test-eastus2.documents.azure.com:443/"
+      );
+    });
   });
 });


### PR DESCRIPTION
Currently, you can only pass the full name: "East US 2"
This PR allows passing the full name OR a normalized URL name: "eastus2"