### PR TITLE
[Service Bus] Encoding the message.body in the scheduleMessages method

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 2.0.0-preview.1 (Unreleased)
 
-- Fixes [bug 6816](https://github.com/Azure/azure-sdk-for-js/issues/6816) affecting messages sent using the `scheduleMessage()` and `scheduleMessages()` methods. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372)
+### Breaking Changes
+
+- Fixes [bug 6816](https://github.com/Azure/azure-sdk-for-js/issues/6816) affecting messages sent using the `scheduleMessage()` and `scheduleMessages()` methods. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
+  - Users on version-`1.x.x` of `@azure/service-bus` library had to rely on the workaround of encoding the message body with `DefaultDataTransformer` before calling `scheduleMessage()`/`scheduleMessages()` methods. The workaround is no longer needed since the bug has been fixed here starting from version-`2.0.0-preview.1`. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
 
 ## 1.1.3 (2020-02-11)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 2.0.0-preview.1 (#ToBeReleased)
+## 2.0.0-preview.1 (Unreleased)
 
 - Fixes [bug 6816](https://github.com/Azure/azure-sdk-for-js/issues/6816) affecting messages sent using the `scheduleMessage()` and `scheduleMessages()` methods. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Changes
 
 - Fixes [bug 6816](https://github.com/Azure/azure-sdk-for-js/issues/6816) affecting messages sent using the `scheduleMessage()` and `scheduleMessages()` methods. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
-  - Users on version-`1.x.x` of `@azure/service-bus` library had to rely on the workaround of encoding the message body with `DefaultDataTransformer` before calling `scheduleMessage()`/`scheduleMessages()` methods. The workaround is no longer needed since the bug has been fixed here starting from version-`2.0.0-preview.1`. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
+  - Users on version-`1.x.x` of `@azure/service-bus` library had to rely on the [workaround of encoding the message body with `DefaultDataTransformer`](https://github.com/Azure/azure-sdk-for-js/pull/6983) before calling `scheduleMessage()`/`scheduleMessages()` methods. The workaround is no longer needed since the bug has been fixed here starting from version-`2.0.0-preview.1`. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
 
 ## 1.1.3 (2020-02-11)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 2.0.0-preview.1 (#ToBeReleased)
+
+- Fixes [bug 6816](https://github.com/Azure/azure-sdk-for-js/issues/6816) affecting messages sent using the `scheduleMessage()` and `scheduleMessages()` methods. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372)
+
 ## 1.1.3 (2020-02-11)
 
 - Fixes issue where the promise returned by `receiveMessages` would sometimes fail to settle when the underlying connection

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -543,6 +543,7 @@ export class ManagementClient extends LinkEntity {
       if (!item.messageId) item.messageId = generate_uuid();
       item.scheduledEnqueueTimeUtc = scheduledEnqueueTimeUtc;
       const amqpMessage = toAmqpMessage(item);
+      amqpMessage.body = this._context.namespace.dataTransformer.encode(amqpMessage.body);
 
       try {
         const entry: any = {

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -7,7 +7,6 @@
 export { ServiceBusClient, ServiceBusClientOptions } from "./serviceBusClient";
 export {
   TokenType,
-  DefaultDataTransformer,
   TokenCredential,
   DataTransformer,
   delay,

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -108,17 +108,6 @@ export class Sender {
   /**
    * Schedules given message to appear on Service Bus Queue/Subscription at a later time.
    *
-   * Please note that you need to explicitly encode the message body if you intend to receive the message using a tool or library other than this library.
-   * For example:
-   *  1. Import DefaultDataTransformer and instantiate.
-   *      ```js
-   *        const dt = new DefaultDataTransformer();
-   *      ```
-   *  2. Use the `encode` method on the transformer to encode the message body before calling the scheduleMessage() method
-   *      ```js
-   *        message.body = dt.encode(message.body);
-   *      ```
-   *
    * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
    * @param message - The message that needs to be scheduled.
    * @returns Promise<Long> - The sequence number of the message that was scheduled.
@@ -150,17 +139,6 @@ export class Sender {
 
   /**
    * Schedules given messages to appear on Service Bus Queue/Subscription at a later time.
-   *
-   * Please note that you need to explicitly encode the message body if you intend to receive the message using a tool or library other than this library.
-   * For example:
-   *  1. Import DefaultDataTransformer and instantiate.
-   *      ```js
-   *        const dt = new DefaultDataTransformer();
-   *      ```
-   *  2. Use the `encode` method on the transformer to encode the message body before calling the scheduleMessage() method
-   *      ```js
-   *        message.body = dt.encode(message.body);
-   *      ```
    *
    * @param scheduledEnqueueTimeUtc - The UTC time at which the messages should be enqueued.
    * @param messages - Array of Messages that need to be scheduled.


### PR DESCRIPTION

**Bug**
- Send a message with `scheduleMessage()` method from the SDK.
- Receive the message through the Azure Function Triggers or [Service Bus Explorer](https://github.com/paolosalvatori/ServiceBusExplorer), the received message is `undefined` or corrupted.
(the same is not the case when received the message with `Receiver.registerMessageHandler` from the sdk, which is the reason why the bug wasn't discovered till now)

**Fix**
- Encoding the message would fix the above issues.
- dataTransformer.encode() on the message body just like the sendBatch()
- removing the workaround that was added #6983 


**User Issue** - #6816 
**More info** - https://github.com/Azure/azure-sdk-for-js/issues/6816#issuecomment-574461068
