### PR TITLE
[app-configuration] Updated documentation to reflect that key/label filters have changed

### DIFF
--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.0.1 (2002-02-17)
+
+- The underlying filter behavior has changed for `listConfigurationSettings` and `listRevisions`.
+  Inline documentation has been revised to accomodate it.
+
 ## 1.0.0 (2020-01-06)
 
 This release marks the general availability of the `@azure/app-configuration` package.
@@ -21,7 +26,7 @@ This release marks the general availability of the `@azure/app-configuration` pa
 ## 1.0.0-preview.10 (2019-12-10)
 
 
-- Specifying filters for listConfigurationSettings() or listRevisions() is 
+- Specifying filters for listConfigurationSettings() or listRevisions() is
   now done with the `keyFilter` or `labelFilter` strings rather than `keys`
   and `labels` as they were previously.
 - Fixed issue [#6408](https://github.com/Azure/azure-sdk-for-js/issues/6408) where

--- a/sdk/appconfiguration/app-configuration/CHANGELOG.md
+++ b/sdk/appconfiguration/app-configuration/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.1 (2002-02-17)
+## 1.0.1 (2020-02-19)
 
 - The underlying filter behavior has changed for `listConfigurationSettings` and `listRevisions`.
   Inline documentation has been revised to accomodate it.

--- a/sdk/appconfiguration/app-configuration/src/models.ts
+++ b/sdk/appconfiguration/app-configuration/src/models.ts
@@ -243,8 +243,6 @@ export interface ListSettingsOptions extends OptionalFields {
    *    | omitted or * | Matches any key                       |
    *    | abc          | Matches a key named abc               |
    *    | abc*         | Matches key names that start with abc |
-   *    | *abc         | Matches key names that end with abc   |
-   *    | *abc*        | Matches key names that contain abc    |
    * 
    * These characters are reserved and must be prefixed with backslash in order 
    * to be specified: * or \ or ,
@@ -263,8 +261,6 @@ export interface ListSettingsOptions extends OptionalFields {
    *    | %00          | Matches any key without a label                   |
    *    | prod         | Matches a key with label named prod               |
    *    | prod*        | Matches key with label names that start with prod |
-   *    | *prod        | Matches key with label names that end with prod   |
-   *    | *prod*       | Matches key with label names that contain prod    |
    * 
    * These characters are reserved and must be prefixed with backslash in order 
    * to be specified: * or \ or ,

--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -501,7 +501,7 @@ describe("AppConfigurationClient", () => {
     it("label wildcards", async () => {
       // query with a direct label match
       let byLabelIterator = client.listConfigurationSettings({
-        labelFilter: "*" + uniqueLabel.substring(1)
+        labelFilter: uniqueLabel.substring(0, uniqueLabel.length - 1) + "*"
       });
       const byLabelSettings = await toSortedArray(byLabelIterator);
 
@@ -549,7 +549,10 @@ describe("AppConfigurationClient", () => {
 
     it("key wildcards", async () => {
       // query with a key wildcard
-      let byKeyIterator = client.listConfigurationSettings({ keyFilter: `*istConfigSettingA-${now}` });
+      const keyFilter = `listConfigSettingA-${now}`;
+      let byKeyIterator = client.listConfigurationSettings({
+        keyFilter: keyFilter.substring(0, keyFilter.length - 1) + '*'
+      });
       const byKeySettings = await toSortedArray(byKeyIterator);
 
       assertEqualSettings(
@@ -705,7 +708,7 @@ describe("AppConfigurationClient", () => {
 
     it("label wildcards", async () => {
       const revisionsWithLabelIterator = await client.listRevisions({
-        labelFilter: "*" + labelA.substring(1)
+        labelFilter: labelA.substring(0, labelA.length - 1) + "*"
       });
       const revisions = await toSortedArray(revisionsWithLabelIterator);
 
@@ -735,7 +738,7 @@ describe("AppConfigurationClient", () => {
 
     it("key wildcards", async () => {
       const revisionsWithKeyIterator = await client.listRevisions({
-        keyFilter: "*" + key.substring(1)
+        keyFilter: key.substring(0, key.length - 1) + "*"
       });
       const revisions = await toSortedArray(revisionsWithKeyIterator);
 


### PR DESCRIPTION
AppConfig has tightened the rules on where wildcards can be used within filter strings for labels and keys. AppConfig is pre-GA so changes like this should not be considered "breaking".

This PR alters the JSDoc comments to reflect that change.