### PR TITLE
[KeyVault] Seems like this line isn't needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,3 @@ sdk/cosmosdb/cosmos/lib
 
 # autorest generated files
 swagger/*.json
-
-# library-specific ignores
-sdk/keyvault/*/src/**/*.js


### PR DESCRIPTION
What script generates these files? Once I remove this line, after I run `rushx build` in these three packages, no untracked files appear on the tree.

Fixes #7370