### PR TITLE
[Storage] align with documentation guide

### DIFF
--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -39,7 +39,7 @@ Azure Storage supports several ways to authenticate. In order to interact with t
 
 #### Azure Active Directory
 
- The Azure Blob Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. Please see the [README for `@azure/identity`](/sdk/identity/identity/README.md) for more details and samples to get you started.
+The Azure Blob Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. Please see the [README for `@azure/identity`](/sdk/identity/identity/README.md) for more details and samples to get you started.
 
 ### Compatibility
 
@@ -176,7 +176,7 @@ The `BlobServiceClient` requires an URL to the blob service and an access creden
 
   [Note - Above steps are only for Node.js]
 
-#### with StorageSharedKeyCredential
+#### with `StorageSharedKeyCredential`
 
 Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (The account-name and account-key can be obtained from the azure portal.)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -32,7 +32,7 @@ npm install @azure/storage-blob
 
 ### Authenticate the client
 
-Azure Storage supports several ways to authenticate. In order to interact with the Azure Blob Storage service you'll need to create an instance of a Storage client - `BlobServiceClient`, `ContainerClient`, or `BlobClient` for example. See [samples for creating `BlobServiceClient`](#create-the-blob-service-client) to learn more about authentication.
+Azure Storage supports several ways to authenticate. In order to interact with the Azure Blob Storage service you'll need to create an instance of a Storage client - `BlobServiceClient`, `ContainerClient`, or `BlobClient` for example. See [samples for creating the `BlobServiceClient`](#create-the-blob-service-client) to learn more about authentication.
 - [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
 - [Shared Key](#with-storagesharedkeycredential)
 - [Shared access signatures](#with-sas-token)
@@ -178,7 +178,7 @@ Use the constructor to create a instance of `BlobServiceClient`.
 
 #### with StorageSharedKeyCredential
 
-Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
+Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (The account-name and account-key can be obtained from the azure portal.)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
 
   ```javascript
@@ -198,6 +198,7 @@ Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCre
   ```
 
 #### with SAS Token
+
 Also, You can instantiate a `BlobServiceClient` with a shared access signatures (SAS). You can get the SAS token from the Azure Portal or generate one using `generateAccountSASQueryParameters()`.
 
 ```javascript

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -32,7 +32,7 @@ npm install @azure/storage-blob
 
 ### Authenticate the client
 
-Azure Storage supports several ways to authenticate. In order to interact with the Storage Service you'll need to create an instance of a Storage client - `BlobServiceClient`, `ContainerClient`, or `BlobClient` for example. See [samples for creating `BlobServiceClient`](#create-the-blob-service-client) to learn more about authentication.
+Azure Storage supports several ways to authenticate. In order to interact with the Azure Blob Storage service you'll need to create an instance of a Storage client - `BlobServiceClient`, `ContainerClient`, or `BlobClient` for example. See [samples for creating `BlobServiceClient`](#create-the-blob-service-client) to learn more about authentication.
 - [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
 - [Shared Key](#with-storagesharedkeycredential)
 - [Shared access signatures](#with-sas-token)
@@ -138,6 +138,7 @@ const { BlobServiceClient, StorageSharedKeyCredential } = require("@azure/storag
 Use the constructor to create a instance of `BlobServiceClient`.
 
 #### with `DefaultAzureCredential` from `@azure/identity` package
+
 **Recommended way to instantiate a `BlobServiceClient`**
 
   Setup : Reference - Authorize access to blobs and queues with Azure Active Directory from a client application - https://docs.microsoft.com/azure/storage/common/storage-auth-aad-app
@@ -176,7 +177,8 @@ Use the constructor to create a instance of `BlobServiceClient`.
   [Note - Above steps are only for Node.js]
 
 #### with StorageSharedKeyCredential
- Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
+
+Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
 
   ```javascript
@@ -208,6 +210,7 @@ const blobServiceClient = new BlobServiceClient(
   `https://${account}.blob.core.windows.net${sas}`
 );
 ```
+
 ### Create a new container
 
 Use `BlobServiceClient.getContainerClient()` to get a container client instance then create a new container resource.

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -135,7 +135,7 @@ const { BlobServiceClient, StorageSharedKeyCredential } = require("@azure/storag
 
 ### Create the blob service client
 
-Use the constructor to create a instance of `BlobServiceClient`.
+The `BlobServiceClient` requires an URL to the blob service and an access credential. It also optionally accepts some settings in the `options` parameter.
 
 #### with `DefaultAzureCredential` from `@azure/identity` package
 

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -18,26 +18,11 @@ Use the client libararies in this package to:
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-blob/samples) |
 [Azure Storage Blob REST APIs](https://docs.microsoft.com/rest/api/storageservices/blob-service-rest-api)
 
-## Key concepts
-
-Blob storage is designed for:
-
-- Serving images or documents directly to a browser.
-- Storing files for distributed access.
-- Streaming video and audio.
-- Writing to log files.
-- Storing data for backup and restore, disaster recovery, and archiving.
-- Storing data for analysis by an on-premises or Azure-hosted service.
-
-Blob storage offers three types of resources:
-
-- The _storage account_ used via `BlobServiceClient`
-- A _container_ in the storage account used via `ContainerClient`
-- A _blob_ in a container used via `BlobClient`
-
 ## Getting started
 
 **Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a [Storage Account](https://docs.microsoft.com/azure/storage/blobs/storage-quickstart-blobs-portal) to use this package. If you are using this package in a Node.js application, then Node.js version 8.0.0 or higher is required.
+
+### Install the package
 
 The preferred way to install the Azure Storage Blob client library for JavaScript is to use the npm package manager. Type the following into a terminal window:
 
@@ -45,9 +30,16 @@ The preferred way to install the Azure Storage Blob client library for JavaScrip
 npm install @azure/storage-blob
 ```
 
-### Authenticating with Azure Active Directory
+### Authenticate the client
 
-The Azure Blob Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. The [README for `@azure/identity`](/sdk/identity/identity/README.md) provides more details and samples to get you started.
+Azure Storage supports several ways to authenticate. In order to interact with the Storage Service you'll need to create an instance of a Storage client - `BlobServiceClient`, `ContainerClient`, or `BlobClient` for example. See [samples for creating `BlobServiceClient`](#create-the-blob-service-client) to learn more about authentication.
+- [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
+- [Shared Key](#with-storagesharedkeycredential)
+- [Shared access signatures](#with-sas-token)
+
+#### Azure Active Directory
+
+ The Azure Blob Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. Please see the [README for `@azure/identity`](/sdk/identity/identity/README.md) for more details and samples to get you started.
 
 ### Compatibility
 
@@ -108,6 +100,23 @@ For example, you can create following CORS settings for debugging. But please cu
 - Exposed headers: \*
 - Maximum age (seconds): 86400
 
+## Key concepts
+
+Blob storage is designed for:
+
+- Serving images or documents directly to a browser.
+- Storing files for distributed access.
+- Streaming video and audio.
+- Writing to log files.
+- Storing data for backup and restore, disaster recovery, and archiving.
+- Storing data for analysis by an on-premises or Azure-hosted service.
+
+Blob storage offers three types of resources:
+
+- The _storage account_ used via `BlobServiceClient`
+- A _container_ in the storage account used via `ContainerClient`
+- A _blob_ in a container used via `BlobClient`
+
 ## Examples
 
 ### Import the package
@@ -128,7 +137,8 @@ const { BlobServiceClient, StorageSharedKeyCredential } = require("@azure/storag
 
 Use the constructor to create a instance of `BlobServiceClient`.
 
-- **Recommended way to instantiate a `BlobServiceClient` - with `DefaultAzureCredential` from `@azure/identity` package**
+#### with `DefaultAzureCredential` from `@azure/identity` package
+**Recommended way to instantiate a `BlobServiceClient`**
 
   Setup : Reference - Authorize access to blobs and queues with Azure Active Directory from a client application - https://docs.microsoft.com/azure/storage/common/storage-auth-aad-app
 
@@ -165,7 +175,8 @@ Use the constructor to create a instance of `BlobServiceClient`.
 
   [Note - Above steps are only for Node.js]
 
-- Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
+#### with StorageSharedKeyCredential
+ Alternatively, you instantiate a `BlobServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
 
   ```javascript
@@ -184,6 +195,19 @@ Use the constructor to create a instance of `BlobServiceClient`.
   );
   ```
 
+#### with SAS Token
+Also, You can instantiate a `BlobServiceClient` with a shared access signatures (SAS). You can get the SAS token from the Azure Portal or generate one using `generateAccountSASQueryParameters()`.
+
+```javascript
+const { BlobServiceClient } = require("@azure/storage-blob");
+
+const account = "<account name>";
+const sas = "<service Shared Access Signature Token>";
+
+const blobServiceClient = new BlobServiceClient(
+  `https://${account}.blob.core.windows.net${sas}`
+);
+```
 ### Create a new container
 
 Use `BlobServiceClient.getContainerClient()` to get a container client instance then create a new container resource.

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -190,7 +190,7 @@ The `DataLakeServiceClient` requires an URL to the data lake service and an acce
 
   [Note - Above steps are only for Node.js]
 
-#### with StorageSharedKeyCredential
+#### with `StorageSharedKeyCredential`
 
 Alternatively, you instantiate a `DataLakeServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (The account-name and account-key can be obtained from the azure portal.)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -98,7 +98,7 @@ For example, you can create following CORS settings for debugging. But please cu
 
 Azure Data Lake Storage Gen2 was designed to:
 
-- Service multiple petabytes of information while sustaining hundreds of gigabits of throughput
+- Serve multiple petabytes of information while sustaining hundreds of gigabits of throughput
 - Allow you to easily manage massive amounts of data
 
 Key Features of DataLake Storage Gen2 include:

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -147,7 +147,7 @@ const { DataLakeServiceClient, StorageSharedKeyCredential } = require("@azure/st
 
 ### Create the data lake service client
 
-Use the constructor to create a instance of `DataLakeServiceClient`.
+The `DataLakeServiceClient` requires an URL to the data lake service and an access credential. It also optionally accepts some settings in the `options` parameter.
 
 #### with `DefaultAzureCredential` from `@azure/identity` package
 

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -15,44 +15,11 @@ Use the client libraries in this package to:
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-datalake/samples) |
 [Azure Storage Data Lake REST APIs](https://docs.microsoft.com/en-us/rest/api/storageservices/data-lake-storage-gen2)
 
-## Key concepts
-
-Azure Data Lake Storage Gen2 was designed to:
-
-- Service multiple petabytes of information while sustaining hundreds of gigabits of throughput
-- Allow you to easily manage massive amounts of data
-
-Key Features of DataLake Storage Gen2 include:
-
-- Hadoop compatible access
-- A super set of POSIX permissions
-- Cost effective in terms of low-cost storage capacity and transactions
-- Optimized driver for big data analytics
-
-A fundamental part of Data Lake Storage Gen2 is the addition of a hierarchical namespace to Blob storage. The hierarchical namespace organizes objects/files into a hierarchy of directories for efficient data access.
-
-In the past, cloud-based analytics had to compromise in areas of performance, management, and security. Data Lake Storage Gen2 addresses each of these aspects in the following ways:
-- Performance is optimized because you do not need to copy or transform data as a prerequisite for analysis. The hierarchical namespace greatly improves the performance of directory management operations, which improves overall job performance.
-- Management is easier because you can organize and manipulate files through directories and subdirectories.
-- Security is enforceable because you can define POSIX permissions on directories or individual files.
-- Cost effectiveness is made possible as Data Lake Storage Gen2 is built on top of the low-cost Azure Blob storage. The additional features further lower the total cost of ownership for running big data analytics on Azure.
-
-Data lake storage offers three types of resources:
-
-- The _storage account_ used via `DataLakeServiceClient`
-- A _file system_ in the storage account used via `DataLakeFileSystemClient`
-- A _path_ in a file system used via `DataLakeDirectoryClient` or `DataLakeFileClient`
-
-|Azure DataLake Gen2 	      | Blob       |
-| --------------------------| ---------- |
-|Filesystem                 | Container  | 
-|Path (File or Directory)   | Blob       |
-
-> Note: This client library does not support hierarchical namespace (HNS) disabled storage accounts.
-
 ## Getting started
 
 **Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a [Storage Account](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-quickstart-create-account?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json#create-an-account-using-the-azure-portal) to use this package. If you are using this package in a Node.js application, then Node.js version 8.0.0 or higher is required.
+
+### Install the package
 
 The preferred way to install the Azure Storage Data Lake client library for JavaScript is to use the npm package manager. Type the following into a terminal window:
 
@@ -60,9 +27,17 @@ The preferred way to install the Azure Storage Data Lake client library for Java
 npm install @azure/storage-file-datalake
 ```
 
-### Authenticating with Azure Active Directory
+### Authenticate the client
 
-The Azure Data Lake Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. The [README for `@azure/identity`](/sdk/identity/identity/README.md) provides more details and samples to get you started.
+Azure Storage supports several ways to authenticate. In order to interact with the Azure Data Lake Storage service you'll need to create an instance of a Storage client - `DataLakeServiceClient`, `DataLakeFileSystemClient`, or `DataLakePathClient` for example. See [Create the data lake service client](#create-the-data-lake-service-client) to learn more about authentication.
+
+- [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
+- [Shared Key](#with-storagesharedkeycredential)
+- [Shared access signatures](#with-sas-token)
+
+#### Azure Active Directory
+
+The Azure Data Lake Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. Please see the [README for `@azure/identity`](/sdk/identity/identity/README.md) for more details and samples to get you started.
 
 ### Compatibility
 
@@ -119,6 +94,41 @@ For example, you can create following CORS settings for debugging. But please cu
 
 > Notice: Data Lake currently shares CORS settings for blob service.
 
+## Key concepts
+
+Azure Data Lake Storage Gen2 was designed to:
+
+- Service multiple petabytes of information while sustaining hundreds of gigabits of throughput
+- Allow you to easily manage massive amounts of data
+
+Key Features of DataLake Storage Gen2 include:
+
+- Hadoop compatible access
+- A super set of POSIX permissions
+- Cost effective in terms of low-cost storage capacity and transactions
+- Optimized driver for big data analytics
+
+A fundamental part of Data Lake Storage Gen2 is the addition of a hierarchical namespace to Blob storage. The hierarchical namespace organizes objects/files into a hierarchy of directories for efficient data access.
+
+In the past, cloud-based analytics had to compromise in areas of performance, management, and security. Data Lake Storage Gen2 addresses each of these aspects in the following ways:
+- Performance is optimized because you do not need to copy or transform data as a prerequisite for analysis. The hierarchical namespace greatly improves the performance of directory management operations, which improves overall job performance.
+- Management is easier because you can organize and manipulate files through directories and subdirectories.
+- Security is enforceable because you can define POSIX permissions on directories or individual files.
+- Cost effectiveness is made possible as Data Lake Storage Gen2 is built on top of the low-cost Azure Blob storage. The additional features further lower the total cost of ownership for running big data analytics on Azure.
+
+Data lake storage offers three types of resources:
+
+- The _storage account_ used via `DataLakeServiceClient`
+- A _file system_ in the storage account used via `DataLakeFileSystemClient`
+- A _path_ in a file system used via `DataLakeDirectoryClient` or `DataLakeFileClient`
+
+|Azure DataLake Gen2 	      | Blob       |
+| --------------------------| ---------- |
+|Filesystem                 | Container  | 
+|Path (File or Directory)   | Blob       |
+
+> Note: This client library does not support hierarchical namespace (HNS) disabled storage accounts.
+
 ## Examples
 
 ### Import the package
@@ -139,7 +149,9 @@ const { DataLakeServiceClient, StorageSharedKeyCredential } = require("@azure/st
 
 Use the constructor to create a instance of `DataLakeServiceClient`.
 
-- **Recommended way to instantiate a `DataLakeServiceClient` - with `DefaultAzureCredential` from `@azure/identity` package**
+#### with `DefaultAzureCredential` from `@azure/identity` package
+
+**Recommended way to instantiate a `DataLakeServiceClient`**
 
 > Notice. Azure Data Lake currently reuses blob related roles like "Storage Blob Data Owner" during following AAD OAuth authentication.
 
@@ -178,7 +190,9 @@ Use the constructor to create a instance of `DataLakeServiceClient`.
 
   [Note - Above steps are only for Node.js]
 
-- Alternatively, you instantiate a `DataLakeServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
+#### with StorageSharedKeyCredential
+
+Alternatively, you instantiate a `DataLakeServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
 
   ```javascript
@@ -196,6 +210,20 @@ Use the constructor to create a instance of `DataLakeServiceClient`.
     sharedKeyCredential
   );
   ```
+
+#### with SAS Token
+
+Also, You can instantiate a `DataLakeServiceClient` with a shared access signatures (SAS). You can get the SAS token from the Azure Portal or generate one using `generateAccountSASQueryParameters()`.
+
+```javascript
+const { DataLakeServiceClient } = require("@azure/storage-file-datalake");
+
+const account = "<account name>";
+const sas = "<service Shared Access Signature Token>";
+const serviceClientWithSAS = new DataLakeServiceClient(
+  `https://${account}.dfs.core.windows.net${sas}`
+);
+```
 
 ### Create a new file system
 

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -116,7 +116,7 @@ In the past, cloud-based analytics had to compromise in areas of performance, ma
 - Security is enforceable because you can define POSIX permissions on directories or individual files.
 - Cost effectiveness is made possible as Data Lake Storage Gen2 is built on top of the low-cost Azure Blob storage. The additional features further lower the total cost of ownership for running big data analytics on Azure.
 
-Data lake storage offers three types of resources:
+Data Lake storage offers three types of resources:
 
 - The _storage account_ used via `DataLakeServiceClient`
 - A _file system_ in the storage account used via `DataLakeFileSystemClient`

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -29,7 +29,7 @@ npm install @azure/storage-file-datalake
 
 ### Authenticate the client
 
-Azure Storage supports several ways to authenticate. In order to interact with the Azure Data Lake Storage service you'll need to create an instance of a Storage client - `DataLakeServiceClient`, `DataLakeFileSystemClient`, or `DataLakePathClient` for example. See [Create the data lake service client](#create-the-data-lake-service-client) to learn more about authentication.
+Azure Storage supports several ways to authenticate. In order to interact with the Azure Data Lake Storage service you'll need to create an instance of a Storage client - `DataLakeServiceClient`, `DataLakeFileSystemClient`, or `DataLakePathClient` for example. See [samples for creating the `DataLakeServiceClient`](#create-the-data-lake-service-client) to learn more about authentication.
 
 - [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
 - [Shared Key](#with-storagesharedkeycredential)
@@ -192,7 +192,7 @@ Use the constructor to create a instance of `DataLakeServiceClient`.
 
 #### with StorageSharedKeyCredential
 
-Alternatively, you instantiate a `DataLakeServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
+Alternatively, you instantiate a `DataLakeServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (The account-name and account-key can be obtained from the azure portal.)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
 
   ```javascript

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -127,7 +127,7 @@ Data lake storage offers three types of resources:
 |Filesystem                 | Container  | 
 |Path (File or Directory)   | Blob       |
 
-> Note: This client library does not support hierarchical namespace (HNS) disabled storage accounts.
+> Note: This client library only supports storage accounts with hierarchical namespace (HNS) enabled.
 
 ## Examples
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -129,7 +129,7 @@ const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/stora
 
 The `ShareServiceClient` requires an URL to the file share service and an access credential. It also optionally accepts some settings in the `options` parameter.
 
-#### with StorageSharedKeyCredential
+#### with `StorageSharedKeyCredential`
 
 Pass in a `StorageSharedKeyCredential` with your account name and account key. (The account-name and account-key can be obtained from the azure portal.)
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -22,15 +22,6 @@ Use the client libraries in this package to:
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-file-share/samples) |
 [Azure Storage File REST APIs](https://docs.microsoft.com/rest/api/storageservices/file-service-rest-api)
 
-## Key concepts
-
-The following components and their corresponding client libraries make up the Azure Storage File Share service:
-
-- The storage account itself, represented by a `ShareServiceClient`
-- A file share within the storage account, represented by a `ShareClient`
-- An optional hierarchy of directories within the file share, represented by `ShareDirectoryClient` instances
-- A file within the file share, which may be up to 1 TiB in size, represented by a `ShareFileClient`
-
 ## Getting started
 
 **Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a [Storage Account](https://docs.microsoft.com/azure/storage/files/storage-how-to-use-files-portal) to use this package. If you are using this package in a Node.js application, then Node.js version 8.0.0 or higher is required.
@@ -42,6 +33,13 @@ The preferred way to install the Azure File Storage client library for JavaScrip
 ```bash
 npm install @azure/storage-file-share
 ```
+
+### Authenticate the client
+
+Azure Storage supports several ways to authenticate. In order to interact with the Azure Storage File Share service you'll need to create an instance of a Storage client - `ShareServiceClient`, `ShareClient`, or `ShareDirectoryClient` for example. See [samples for creating the `ShareServiceClient`](#create-the-share-service-client) to learn more about authentication.
+
+- [Shared Key](#with-storagesharedkeycredential)
+- [Shared access signatures](#with-sas-token)
 
 ### Compatibility
 
@@ -102,6 +100,15 @@ For example, you can create following CORS settings for debugging. But please cu
 - Exposed headers: \*
 - Maximum age (seconds): 86400
 
+## Key concepts
+
+The following components and their corresponding client libraries make up the Azure Storage File Share service:
+
+- The storage account itself, represented by a `ShareServiceClient`
+- A file share within the storage account, represented by a `ShareClient`
+- An optional hierarchy of directories within the file share, represented by `ShareDirectoryClient` instances
+- A file within the file share, which may be up to 1 TiB in size, represented by a `ShareFileClient`
+
 ## Examples
 
 ### Import the package
@@ -120,7 +127,11 @@ const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/stora
 
 ### Create the share service client
 
-Use the constructor to create a instance of `ShareServiceClient`. It needs to authenticate with the Azure service, so pass in a `StorageSharedKeyCredential` with your account and key.
+Use the constructor to create a instance of `ShareServiceClient`. It needs to authenticate with the Azure service.
+
+#### with StorageSharedKeyCredential
+
+Pass in a `StorageSharedKeyCredential` with your account name and account key. (The account-name and account-key can be obtained from the azure portal.)
 
 ```javascript
 const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/storage-file-share");
@@ -136,6 +147,21 @@ const serviceClient = new ShareServiceClient(
   // When using AnonymousCredential, following url should include a valid SAS
   `https://${account}.file.core.windows.net`,
   credential
+);
+```
+
+#### with SAS Token
+
+Also, You can instantiate a `ShareServiceClient` with a shared access signatures (SAS). You can get the SAS token from the Azure Portal or generate one using `generateAccountSASQueryParameters()`.
+
+```javascript
+const { ShareServiceClient } = require("@azure/storage-file-share");
+
+const account = "<account name>";
+const sas = "<service Shared Access Signature Token>";
+
+const serviceClientWithSAS = new ShareServiceClient(
+  `https://${account}.file.core.windows.net${sas}`,
 );
 ```
 

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -104,10 +104,10 @@ For example, you can create following CORS settings for debugging. But please cu
 
 The following components and their corresponding client libraries make up the Azure Storage File Share service:
 
-- The storage account itself, represented by a `ShareServiceClient`
-- A file share within the storage account, represented by a `ShareClient`
-- An optional hierarchy of directories within the file share, represented by `ShareDirectoryClient` instances
-- A file within the file share, which may be up to 1 TiB in size, represented by a `ShareFileClient`
+- The _storage account_ itself, represented by a `ShareServiceClient`
+- A _file share_ within the storage account, represented by a `ShareClient`
+- An optional _hierarchy of directories_ within the file share, represented by `ShareDirectoryClient` instances
+- A _file_ within the file share, which may be up to 1 TiB in size, represented by a `ShareFileClient`
 
 ## Examples
 
@@ -127,7 +127,7 @@ const { ShareServiceClient, StorageSharedKeyCredential } = require("@azure/stora
 
 ### Create the share service client
 
-Use the constructor to create a instance of `ShareServiceClient`. It needs to authenticate with the Azure service.
+The `ShareServiceClient` requires an URL to the file share service and an access credential. It also optionally accepts some settings in the `options` parameter.
 
 #### with StorageSharedKeyCredential
 

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -16,16 +16,6 @@ Use the client libraries in this package to:
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/storage/storage-queue/samples) |
 [Azure Storage Queue REST APIs](https://docs.microsoft.com/rest/api/storageservices/queue-service-rest-api)
 
-## Key concepts
-
-A Queue is a data store within an Azure Storage Queue service account for sending/receiving messages
-between connected clients.
-
-Key data types in our library related to these services are:
-
-- A `QueueServiceClient` represents a connection (via a URL) to a given storage account in the Azure Storage Queue service and provides APIs for manipulating its queues. It is authenticated to the service and can be used to create `QueueClient` objects, as well as create, delete, list queues from the service.
-- A `QueueClient` represents a single queue in the storage acccount. It can be used to manipulate the queue's messages, for example to send, receive, and peek messages in the queue.
-
 ## Getting started
 
 **Prerequisites**: You must have an [Azure subscription](https://azure.microsoft.com/free/) and a [Storage Account](https://docs.microsoft.com/azure/storage/queues/storage-quickstart-queues-portal) to use this package. If you are using this package in a Node.js application, then Node.js version 8.0.0 or higher is required.
@@ -38,9 +28,17 @@ The preferred way to install the Azure Storage Queue client library for JavaScri
 npm install @azure/storage-queue
 ```
 
-### Authenticating with Azure Active Directory
+### Authenticate the client
 
-The Azure Queue Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. The [README for `@azure/identity`](/sdk/identity/identity/README.md) provides more details and samples to get you started.
+Azure Storage supports several ways to authenticate. In order to interact with the Storage Service you'll need to create an instance of a Storage client - `QueueServiceClient` or `QueueClient` for example. See [Create the queue service client](#create-the-queue-service-client) to learn more about authentication.
+
+- [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
+- [Shared Key](#with-storagesharedkeycredential)
+- [Shared access signatures](#with-sas-token)
+
+#### Azure Active Directory
+
+The Azure Queue Storage service supports the use of Azure Active Directory to authenticate requests to its APIs. The [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) package provides a variety of credential types that your application can use to do this. Please see the [README for `@azure/identity`](/sdk/identity/identity/README.md) for more details and samples to get you started.
 
 ### Compatibility
 
@@ -91,6 +89,16 @@ For example, you can create following CORS settings for debugging. But please cu
 - Exposed headers: \*
 - Maximum age (seconds): 86400
 
+## Key concepts
+
+A Queue is a data store within an Azure Storage Queue service account for sending/receiving messages
+between connected clients.
+
+Key data types in our library related to these services are:
+
+- A `QueueServiceClient` represents a connection (via a URL) to a given storage account in the Azure Storage Queue service and provides APIs for manipulating its queues. It is authenticated to the service and can be used to create `QueueClient` objects, as well as create, delete, list queues from the service.
+- A `QueueClient` represents a single queue in the storage acccount. It can be used to manipulate the queue's messages, for example to send, receive, and peek messages in the queue.
+
 ## Examples
 
 ### Import the package
@@ -112,7 +120,9 @@ const { QueueServiceClient, StorageSharedKeyCredential } = require("@azure/stora
 The `QueueServiceClient` requires a URL to the queue service and an access credential. It also
 optionally accepts some settings in the `options` parameter.
 
-- **Recommended way to instantiate a `QueueServiceClient` - with `DefaultAzureCredential` from `@azure/identity` package**
+#### with `DefaultAzureCredential` from `@azure/identity` package
+
+- **Recommended way to instantiate a `QueueServiceClient`**
 
   Setup : Reference - Authorize access to blobs and queues with Azure Active Directory from a client application - https://docs.microsoft.com/azure/storage/common/storage-auth-aad-app
 
@@ -146,7 +156,9 @@ optionally accepts some settings in the `options` parameter.
 
   [Note - Above steps are only for Node.js]
 
-- Alternatively, you instantiate a `QueueServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
+#### with StorageSharedKeyCredential
+
+Alternatively, you instantiate a `QueueServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
 
   ```javascript
@@ -169,6 +181,18 @@ optionally accepts some settings in the `options` parameter.
     }
   );
   ```
+
+#### with SAS Token
+Also, You can instantiate a `QueueServiceClient` with a shared access signatures (SAS). You can get the SAS token from the Azure Portal or generate one using `generateAccountSASQueryParameters()`.
+
+```javascript
+const { QueueServiceClient } = require("@azure/storage-queue");
+const account = "<account name>";
+const sas = "<service Shared Access Signature Token>";
+const   const queueServiceClient = new QueueServiceClient(
+    `https://${account}.queue.core.windows.net${sas}`,
+);
+```
 
 ### List queues in this account
 

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -96,8 +96,8 @@ between connected clients.
 
 Key data types in our library related to these services are:
 
-- A `QueueServiceClient` represents a connection (via a URL) to a given storage account in the Azure Storage Queue service and provides APIs for manipulating its queues. It is authenticated to the service and can be used to create `QueueClient` objects, as well as create, delete, list queues from the service.
-- A `QueueClient` represents a single queue in the storage acccount. It can be used to manipulate the queue's messages, for example to send, receive, and peek messages in the queue.
+- A `QueueServiceClient` represents a connection (via a URL) to a given _storage account_ in the Azure Storage Queue service and provides APIs for manipulating its queues. It is authenticated to the service and can be used to create `QueueClient` objects, as well as create, delete, list queues from the service.
+- A `QueueClient` represents a single _queue_ in the storage acccount. It can be used to manipulate the queue's messages, for example to send, receive, and peek messages in the queue.
 
 ## Examples
 
@@ -117,8 +117,7 @@ const { QueueServiceClient, StorageSharedKeyCredential } = require("@azure/stora
 
 ### Create the queue service client
 
-The `QueueServiceClient` requires a URL to the queue service and an access credential. It also
-optionally accepts some settings in the `options` parameter.
+The `QueueServiceClient` requires an URL to the queue service and an access credential. It also optionally accepts some settings in the `options` parameter.
 
 #### with `DefaultAzureCredential` from `@azure/identity` package
 

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -30,7 +30,7 @@ npm install @azure/storage-queue
 
 ### Authenticate the client
 
-Azure Storage supports several ways to authenticate. In order to interact with the Azure Queue Storage service you'll need to create an instance of a Storage client - `QueueServiceClient` or `QueueClient` for example. See [Create the queue service client](#create-the-queue-service-client) to learn more about authentication.
+Azure Storage supports several ways to authenticate. In order to interact with the Azure Queue Storage service you'll need to create an instance of a Storage client - `QueueServiceClient` or `QueueClient` for example. See [samples for creating the `QueueServiceClient`](#create-the-queue-service-client) to learn more about authentication.
 
 - [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
 - [Shared Key](#with-storagesharedkeycredential)
@@ -158,7 +158,7 @@ optionally accepts some settings in the `options` parameter.
 
 #### with StorageSharedKeyCredential
 
-Alternatively, you instantiate a `QueueServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (account-name and account-key can be obtained from the azure portal)
+Alternatively, you instantiate a `QueueServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (The account-name and account-key can be obtained from the azure portal.)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
 
   ```javascript
@@ -183,6 +183,7 @@ Alternatively, you instantiate a `QueueServiceClient` with a `StorageSharedKeyCr
   ```
 
 #### with SAS Token
+
 Also, You can instantiate a `QueueServiceClient` with a shared access signatures (SAS). You can get the SAS token from the Azure Portal or generate one using `generateAccountSASQueryParameters()`.
 
 ```javascript

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -155,7 +155,7 @@ The `QueueServiceClient` requires an URL to the queue service and an access cred
 
   [Note - Above steps are only for Node.js]
 
-#### with StorageSharedKeyCredential
+#### with `StorageSharedKeyCredential`
 
 Alternatively, you instantiate a `QueueServiceClient` with a `StorageSharedKeyCredential` by passing account-name and account-key as arguments. (The account-name and account-key can be obtained from the azure portal.)
   [ONLY AVAILABLE IN NODE.JS RUNTIME]
@@ -189,7 +189,7 @@ Also, You can instantiate a `QueueServiceClient` with a shared access signatures
 const { QueueServiceClient } = require("@azure/storage-queue");
 const account = "<account name>";
 const sas = "<service Shared Access Signature Token>";
-const   const queueServiceClient = new QueueServiceClient(
+const queueServiceClient = new QueueServiceClient(
     `https://${account}.queue.core.windows.net${sas}`,
 );
 ```

--- a/sdk/storage/storage-queue/README.md
+++ b/sdk/storage/storage-queue/README.md
@@ -30,7 +30,7 @@ npm install @azure/storage-queue
 
 ### Authenticate the client
 
-Azure Storage supports several ways to authenticate. In order to interact with the Storage Service you'll need to create an instance of a Storage client - `QueueServiceClient` or `QueueClient` for example. See [Create the queue service client](#create-the-queue-service-client) to learn more about authentication.
+Azure Storage supports several ways to authenticate. In order to interact with the Azure Queue Storage service you'll need to create an instance of a Storage client - `QueueServiceClient` or `QueueClient` for example. See [Create the queue service client](#create-the-queue-service-client) to learn more about authentication.
 
 - [Azure Active Directory](#with-defaultazurecredential-from-azureidentity-package)
 - [Shared Key](#with-storagesharedkeycredential)
@@ -122,7 +122,7 @@ optionally accepts some settings in the `options` parameter.
 
 #### with `DefaultAzureCredential` from `@azure/identity` package
 
-- **Recommended way to instantiate a `QueueServiceClient`**
+**Recommended way to instantiate a `QueueServiceClient`**
 
   Setup : Reference - Authorize access to blobs and queues with Azure Active Directory from a client application - https://docs.microsoft.com/azure/storage/common/storage-auth-aad-app
 


### PR DESCRIPTION
Fix documentation issues to align with the [documentation guide](http://aka.ms/jointhesdk/docs)


**TODO**

- README: add `Authenticate the client` section
  - [x] blob 
  - [x] file-share
  - [x] queue
  - [x] file-datalake
  

