### PR TITLE
Change default live tests pipeline timeout limit to 60 minutes

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -5,7 +5,7 @@ parameters:
   ResourceServiceDirectory: ""
   EnvVars: {}
   MaxParallel: 0
-  TimeoutInMinutes: 240
+  TimeoutInMinutes: 60
   Matrix:
     Linux_Node10:
       OSVmImage: "ubuntu-16.04"

--- a/sdk/eventhub/event-processor-host/tests.yml
+++ b/sdk/eventhub/event-processor-host/tests.yml
@@ -13,6 +13,7 @@ jobs:
     parameters:
       PackageName: "@azure/event-processor-host"
       ResourceServiceDirectory: eventhub
+      TimeoutInMinutes: 90
       # Remove Browser tests from matrix since they are currently a no-op
       Matrix:
         Linux_Node10:

--- a/sdk/servicebus/service-bus/tests.yml
+++ b/sdk/servicebus/service-bus/tests.yml
@@ -15,6 +15,7 @@ jobs:
     parameters:
       PackageName: "@azure/service-bus"
       ResourceServiceDirectory: servicebus
+      TimeoutInMinutes: 180
       # Use a more simple matrix because these tests run for a long time
       Matrix:
         Linux_Node10:

--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -13,7 +13,6 @@ jobs:
     parameters:
       PackageName: "@azure/storage-blob"
       ResourceServiceDirectory: storage
-      TimeoutInMinutes: 60
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/storage/storage-file-datalake/tests.yml
+++ b/sdk/storage/storage-file-datalake/tests.yml
@@ -12,4 +12,3 @@ jobs:
   - template: ../../../eng/pipelines/templates/jobs/archetype-sdk-integration.yml
     parameters:
       PackageName: "@azure/storage-file-datalake"
-      TimeoutInMinutes: 60

--- a/sdk/storage/storage-file-share/tests.yml
+++ b/sdk/storage/storage-file-share/tests.yml
@@ -13,7 +13,6 @@ jobs:
     parameters:
       PackageName: "@azure/storage-file-share"
       ResourceServiceDirectory: storage
-      TimeoutInMinutes: 60
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/storage/storage-queue/tests.yml
+++ b/sdk/storage/storage-queue/tests.yml
@@ -13,7 +13,6 @@ jobs:
     parameters:
       PackageName: "@azure/storage-queue"
       ResourceServiceDirectory: storage
-      TimeoutInMinutes: 60
       Matrix:
         Linux_Node8:
           OSVmImage: "ubuntu-16.04"


### PR DESCRIPTION
and override the parameter for service bus and event process host as their
normal passing builds take more time.