### PR TITLE
Remove bundled browser file from browser mapping

### DIFF
--- a/sdk/core/core-lro/package.json
+++ b/sdk/core/core-lro/package.json
@@ -38,7 +38,6 @@
     "README.md"
   ],
   "browser": {
-    "./dist/index.js": "./browser/azure-core-lro.min.js",
     "os": false,
     "process": false
   },

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -6,7 +6,6 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/logger.js",
   "browser": {
-    "./dist/index.js": "./dist-browser/logger.js",
     "./dist-esm/src/log.js": "./dist-esm/src/log.browser.js",
     "process": false
   },

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -20,9 +20,6 @@
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",
   "types": "./typings/eventhubs-checkpointstore-blob.d.ts",
-  "browser": {
-    "./dist/index.js": "./dist-browser/index.js"
-  },
   "engine": {
     "node": ">=8.0.0"
   },

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -30,7 +30,6 @@
   },
   "files": [
     "dist/",
-    "dist-browser/",
     "dist-esm/src/",
     "src/",
     "typings/service-bus.d.ts",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -19,7 +19,6 @@
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {
-    "./dist/index.js": "./dist-browser/service-bus.js",
     "./dist-esm/src/util/crypto.js": "./dist-esm/src/util/crypto.browser.js",
     "./dist-esm/src/util/parseUrl.js": "./dist-esm/src/util/parseUrl.browser.js",
     "buffer": "buffer",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -38,7 +38,6 @@
   },
   "files": [
     "dist/",
-    "dist-browser/*.js*",
     "dist-esm/src/",
     "src/",
     "types/azure-template.d.ts"

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -7,7 +7,6 @@
   "module": "dist-esm/src/index.js",
   "browser": {
     "stream": "./node_modules/stream-browserify/index.js",
-    "./dist/index.js": "./dist-browser/index.js",
     "./dist-esm/src/print.js": "./dist-esm/src/print.browser.js"
   },
   "types": "types/azure-template.d.ts",

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
   "browser": {
-    "dist/index.js": "./dist-browser/azure-test-utils-recorder.js"
   },
   "types": "./typings/src/index.d.ts",
   "scripts": {

--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -34,7 +34,6 @@
   },
   "files": [
     "dist/",
-    "dist-browser/*.js*",
     "dist-esm/src/",
     "src/",
     "typings/src"

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -14,9 +14,6 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
-  "browser": {
-    "./dist/index.js": "./dist-browser/index.js"
-  },
   "types": "./types/ai-text-analytics.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics",
   "repository": {


### PR DESCRIPTION
It is not recommended to map rolled-up files in the browser section. This change
removes them.