### PR TITLE
Plumb ServiceDirectory parameter variable through release pipelines

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -16,5 +16,6 @@ stages:
   - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
     parameters:
       DependsOn: Build
+      ServiceDirectory: ${{parameters.ServiceDirectory}}
       Artifacts: ${{parameters.Artifacts}}
       ArtifactName: packages

--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -31,5 +31,6 @@ stages:
     - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
       parameters:
         DependsOn: Build
+        ServiceDirectory: ${{parameters.ServiceDirectory}}
         Artifacts: ${{parameters.Artifacts}}
         ArtifactName: packages


### PR DESCRIPTION
The problem here is that the ServiceDirectory parameter from the ci.yml wasn't fully plumbed through to the archetype-js-release.yml which never needed it until now.