### PR TITLE
require core-http version of ^1.0.3

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -42,6 +42,7 @@
    */
   "allowedAlternativeVersions": {
     "@azure/ms-rest-js": ["^2.0.0"],
+    "@azure/core-http": ["^1.0.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -42,7 +42,7 @@
    */
   "allowedAlternativeVersions": {
     "@azure/ms-rest-js": ["^2.0.0"],
-    "@azure/core-http": ["^1.0.0"],
+    "@azure/core-http": ["^1.0.3"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -100,7 +100,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
+    "@azure/core-http": "^1.0.3",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -96,7 +96,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
+    "@azure/core-http": "^1.0.3",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
+    "@azure/core-http": "^1.0.3",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -100,7 +100,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
+    "@azure/core-http": "^1.0.3",
     "@azure/core-paging": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
Increase minimum core-http version from 1.0.0 to 1.0.3 to incorporate important bug fixes.

One data-loss bug fixed in 1.0.3 is #6656

cc @jeremymeng 