### PR TITLE
[KeyVault] Live test browser fixes

### DIFF
--- a/sdk/keyvault/keyvault-certificates/test/mergeAndImport.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/mergeAndImport.test.ts
@@ -69,7 +69,8 @@ describe("Certificates client - merge and import certificates", () => {
     }
   });
 
-  // The signed csr will never be the same.
+  // The signed certificate will never be the same, so we can't play it back.
+  // This test is only designed to work on NodeJS, since we use child_process to interact with openssl.
   it("can merge a self signed certificate", async function() {
     recorder.skip(
       undefined,

--- a/sdk/keyvault/keyvault-certificates/test/mergeAndImport.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/mergeAndImport.test.ts
@@ -76,7 +76,7 @@ describe("Certificates client - merge and import certificates", () => {
       "The signed certificate will never be the same, so we can't play it back."
     );
     if (!isNode) {
-      // recorder.skip doesn't work on TEST_MODE=live
+      // recorder.skip is not meant for TEST_MODE=live
       return this.skip();
     }
     const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);

--- a/sdk/keyvault/keyvault-certificates/test/mergeAndImport.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/mergeAndImport.test.ts
@@ -75,6 +75,10 @@ describe("Certificates client - merge and import certificates", () => {
       undefined,
       "The signed certificate will never be the same, so we can't play it back."
     );
+    if (!isNode) {
+      // recorder.skip doesn't work on TEST_MODE=live
+      return this.skip();
+    }
     const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
 
     await client.beginCreateCertificate(

--- a/sdk/keyvault/keyvault-keys/test/crypto.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/crypto.test.ts
@@ -11,6 +11,7 @@ import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
 import { stringToUint8Array, uint8ArrayToString } from "./utils/crypto";
 import { isRecordMode, Recorder } from "@azure/test-utils-recorder";
+import { isNode } from "@azure/core-http";
 
 describe("CryptographyClient (all decrypts happen remotely)", () => {
   let client: KeyClient;
@@ -83,6 +84,10 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
 
   it("sign and verify with RS256", async function() {
     recorder.skip("browser", "Local encryption is only supported in NodeJS");
+    if (!isNode) {
+      // recorder.skip doesn't work on TEST_MODE=live
+      return this.skip();
+    }
     const signatureValue = this.test!.title;
     const hash = createHash("sha256");
     hash.update(signatureValue);

--- a/sdk/keyvault/keyvault-keys/test/crypto.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/crypto.test.ts
@@ -85,7 +85,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
   it("sign and verify with RS256", async function() {
     recorder.skip("browser", "Local encryption is only supported in NodeJS");
     if (!isNode) {
-      // recorder.skip doesn't work on TEST_MODE=live
+      // recorder.skip is not meant for TEST_MODE=live
       return this.skip();
     }
     const signatureValue = this.test!.title;

--- a/sdk/keyvault/keyvault-keys/test/crypto.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/crypto.test.ts
@@ -82,6 +82,7 @@ describe("CryptographyClient (all decrypts happen remotely)", () => {
     });
   }
 
+  // Local encryption is only supported in NodeJS.
   it("sign and verify with RS256", async function() {
     recorder.skip("browser", "Local encryption is only supported in NodeJS");
     if (!isNode) {


### PR DESCRIPTION
After merging the recorder.skip changes, the nightly builds highlighted that our browser live tests are now failing. This is due to the fact that some of these tests are not expected to ever run on the browser, and `recorder.skip` will not work if `TEST_MODE` is `live`.