### PR TITLE
Improve RestError output in Node

### DIFF
--- a/sdk/core/core-http/lib/restError.ts
+++ b/sdk/core/core-http/lib/restError.ts
@@ -25,6 +25,7 @@ export class RestError extends Error {
     response?: HttpOperationResponse
   ) {
     super(message);
+    this.name = "RestError";
     this.code = code;
     this.statusCode = statusCode;
     this.request = request;
@@ -37,6 +38,6 @@ export class RestError extends Error {
    * Logging method for util.inspect in Node
    */
   [custom](): string {
-    return errorSanitizer.sanitize(this);
+    return `RestError: ${this.message} \n ${errorSanitizer.sanitize(this)}`;
   }
 }

--- a/sdk/core/core-http/lib/util/sanitizer.ts
+++ b/sdk/core/core-http/lib/util/sanitizer.ts
@@ -72,6 +72,14 @@ export class Sanitizer {
   }
 
   private replacer(key: string, value: unknown) {
+    // Ensure Errors include their interesting non-enumerable members
+    if (value instanceof Error) {
+      return {
+        ...value,
+        name: value.name,
+        message: value.message
+      };
+    }
     if (key === "_headersMap") {
       return this.sanitizeHeaders(key, value as {});
     } else if (key === "url") {


### PR DESCRIPTION
In #7173 we sanitized `RestError` for when it was output by Node to avoid leaking sensitive information.

Unfortunately, the way we did it uses JSON.stringify which respects if properties are enumerable or not, and all `Error` properties are non-enumerable by default.

This PR tries to fix things up a bit by:

- Giving `RestError` and appropriate `name` property.
- When serializing Errors, promoting `name` and `message` to being included.
- When emitting the output shape of `RestError`, including some preamble with the message, as Node normally does for errors.

I didn't include the `stack` property since the printing was very awkward. It included the message and didn't print the newlines correctly, so it was very hard to read, e.g.

```
  "stack": "RestError: The request is invalid. Details: actions : 0: Invalid document key: '4395$#%#$'. Keys can only contain letters, digits, underscore (_), dash (-), or equal sign (=). If the keys in your source data contain other characters, we recommend encoding them with a URL-safe version of Base64 before uploading them to your index. If that is not an option, you can add the 'allowUnsafeKeys' query string parameter to disable this check.\r\n\n    at new RestError (C:\\src\\azure-sdk-for-js\\sdk\\core\\core-http\\lib\\restError.ts:27:5)\n    at C:\\src\\azure-sdk-for-js\\sdk\\core\\core-http\\lib\\policies\\deserializationPolicy.ts:176:21\n    at processTicksAndRejections (internal/process/task_queues.js:93:5)"
```