### PR TITLE
[event-hubs] add security_token to management apis

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 5.0.2 (Unreleased)
 
+- Fixes an issue that caused `getPartitionIds`, `getEventHubProperties`,
+  and `getPartitionProperties` to throw an error when run against an
+  Event Hub in Azure Stack.
+  ([PR #7463](https://github.com/Azure/azure-sdk-for-js/pull/7463))
 
 ## 5.0.1 (2020-02-11)
 

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -141,7 +141,9 @@ export class ManagementClient extends LinkEntity {
   async getSecurityToken() {
     if (this._context.tokenCredential instanceof SharedKeyCredential) {
       // the security_token has the $management address removed from the end of the audience
+      // expected audience: sb://fully.qualified.namespace/event-hub-name/$management
       const audienceParts = this.audience.split("/");
+      // for management links, address should be '$management'
       if (audienceParts[audienceParts.length - 1] === this.address) {
         audienceParts.pop();
       }


### PR DESCRIPTION
Adds the security_token field for management apis in event hubs. Java and .NET already do this.

While testing event-hubs in Azure Stack we observed that the management APIs would throw unauthorized errors if the security_token wasn't present.