### PR TITLE
Disable publishing browser code coverage report

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -154,29 +154,13 @@ jobs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(PackagePath)/coverage/cobertura-coverage.xml'
 
-      - task: PublishCodeCoverageResults@1
-        displayName: 'Publish Browser Code Coverage to DevOps'
-        continueOnError: true
-        condition: and(succeededOrFailed(),eq(variables['TestType'], 'default'),eq(variables['PublishCodeCoverage'], true))
-        inputs:
-          codeCoverageTool: Cobertura
-          summaryFileLocation: '$(PackagePath)/coverage-browser/cobertura-coverage.xml'
-
       - task: PublishPipelineArtifact@1
-        displayName: 'Publish NodeJs CC result folder to DevOps'
-        continueOnError: true
-        condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),eq(variables['PublishCodeCoverage'], true))
-        inputs:
-          path: '$(PackagePath)/coverage'
-          artifact: NodeJsCCResult
-
-      - task: PublishPipelineArtifact@1
-        displayName: 'Publish Browser CC result folder to DevOps'
+        displayName: 'Publish Browser Code Coverage Report to DevOps'
         continueOnError: true
         condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
         inputs:
           path: '$(PackagePath)/coverage-browser'
-          artifact: BrowserCCResult
+          artifact: BrowserCodeCoverageReport
 
       # Unlink node_modules folders to significantly improve performance of subsequent tasks
       # which need to walk the directory tree (and are hardcoded to follow symlinks).

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -155,7 +155,7 @@ jobs:
           summaryFileLocation: '$(PackagePath)/coverage/cobertura-coverage.xml'
 
       - task: PublishPipelineArtifact@1
-        displayName: 'Publish Browser Code Coverage Report to DevOps'
+        displayName: 'Publish Browser Code Coverage Report Artifact'
         continueOnError: true
         condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
         inputs:

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -147,7 +147,7 @@ jobs:
         displayName: "Get package path"
 
       - task: PublishCodeCoverageResults@1
-        displayName: 'Publish Code Coverage to DevOps'
+        displayName: 'Publish NodeJs Code Coverage to DevOps'
         continueOnError: true
         condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),eq(variables['PublishCodeCoverage'], true))
         inputs:
@@ -155,12 +155,28 @@ jobs:
           summaryFileLocation: '$(PackagePath)/coverage/cobertura-coverage.xml'
 
       - task: PublishCodeCoverageResults@1
-        displayName: 'Publish Code Coverage to DevOps'
+        displayName: 'Publish Browser Code Coverage to DevOps'
         continueOnError: true
         condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
         inputs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(PackagePath)/coverage-browser/cobertura-coverage.xml'
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish NodeJs CC result folder to DevOps'
+        continueOnError: true
+        condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'),eq(variables['PublishCodeCoverage'], true))
+        inputs:
+          path: '$(PackagePath)/coverage'
+          artifact: NodeJsCCResult
+
+      - task: PublishPipelineArtifact@1
+        displayName: 'Publish Browser CC result folder to DevOps'
+        continueOnError: true
+        condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
+        inputs:
+          path: '$(PackagePath)/coverage-browser'
+          artifact: BrowserCCResult
 
       # Unlink node_modules folders to significantly improve performance of subsequent tasks
       # which need to walk the directory tree (and are hardcoded to follow symlinks).

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -157,7 +157,7 @@ jobs:
       - task: PublishCodeCoverageResults@1
         displayName: 'Publish Browser Code Coverage to DevOps'
         continueOnError: true
-        condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'),eq(variables['PublishCodeCoverage'], true))
+        condition: and(succeededOrFailed(),eq(variables['TestType'], 'default'),eq(variables['PublishCodeCoverage'], true))
         inputs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(PackagePath)/coverage-browser/cobertura-coverage.xml'


### PR DESCRIPTION
as Azure devops pipeline only supports publishing one set of code coverage result. Publishing for both NodeJs and
browser would result in one of the report overwrites the other.

Instead browser code coverage report are uploaded as an artifact.