### PR TITLE
[Recorder] nyc code coverage config for the recorder tests

### DIFF
--- a/sdk/test-utils/recorder/.nycrc
+++ b/sdk/test-utils/recorder/.nycrc
@@ -1,0 +1,17 @@
+{
+    "include": [
+      "dist-esm/src/**/*.js"
+    ],
+    "exclude": [
+      "**/*.d.ts"
+    ],
+    "reporter": [
+      "text-summary",
+      "html",
+      "cobertura"
+    ],
+    "exclude-after-remap":false,
+    "sourceMap": true,
+    "instrument": true,
+    "all": true
+  }


### PR DESCRIPTION
Code coverage report wasn't being generated, the reason being `.nycrc` config's absence.