### PR TITLE
[Event Hubs] Code coverage in browsers - leftovers

### DIFF
--- a/sdk/eventhub/event-hubs/karma.conf.js
+++ b/sdk/eventhub/event-hubs/karma.conf.js
@@ -56,7 +56,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ["mocha", "coverage", "remap-coverage", "junit"],
+    reporters: ["mocha", "coverage", "karma-remap-istanbul", "junit"],
 
     coverageReporter: {
       // specify a common output directory


### PR DESCRIPTION
@jeremymeng found that I missed updating remap-coverage meant for karma-remap-coverage for event hubs in the PR - https://github.com/Azure/azure-sdk-for-js/pull/7496