### PR TITLE
[core-lro] Using await to test that pollUntilDone throws

### DIFF
--- a/sdk/core/core-lro/test/abort.test.ts
+++ b/sdk/core/core-lro/test/abort.test.ts
@@ -83,11 +83,7 @@ describe("Long Running Operations - working with abort signals", function() {
     const abortController = new AbortController();
     const poller = await client.startLRO();
 
-    // Testing subscriptions to the poll errors
-    let doneError: Error | undefined;
-    poller.pollUntilDone().catch((e) => {
-      doneError = e;
-    });
+    const donePromise = poller.pollUntilDone()
 
     await poller.poll();
     assert.equal(client.totalSentRequests, 2);
@@ -102,8 +98,14 @@ describe("Long Running Operations - working with abort signals", function() {
     } catch (e) {
       pollError = e;
     }
-
     assert.equal(pollError!.message, "The operation was aborted.");
+
+    let doneError: Error | undefined;
+    try {
+      await donePromise;
+    } catch (e) {
+      doneError = e;
+    }
     assert.equal(doneError!.message, "The operation was aborted.");
 
     assert.equal(client.totalSentRequests, 2);

--- a/sdk/core/core-lro/test/abort.test.ts
+++ b/sdk/core/core-lro/test/abort.test.ts
@@ -83,7 +83,7 @@ describe("Long Running Operations - working with abort signals", function() {
     const abortController = new AbortController();
     const poller = await client.startLRO();
 
-    const donePromise = poller.pollUntilDone()
+    const donePromise = poller.pollUntilDone();
 
     await poller.poll();
     assert.equal(client.totalSentRequests, 2);


### PR DESCRIPTION
Before this PR, the changed test passes using tslib 1.10.0, but not with tslib 1.11.0. This is due to the fact that tslib 1.11.0 includes a fix to the async scheduling generated by TypeScript https://github.com/microsoft/tslib/pull/70

To address this, this PR makes a slight change that properly awaits for the pollUntilDone method to finish before asserting the exception.