### PR TITLE
[Storage] increase live test timeout limits

### DIFF
--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -130,7 +130,7 @@ module.exports = function(config) {
     // how many browser should be started simultaneous
     concurrency: 1,
 
-    browserNoActivityTimeout: 600000,
+    browserNoActivityTimeout: 1200000,
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -46,7 +46,7 @@
     "execute:samples": "npm run build:samples && npm run execute:js-samples && npm run execute:ts-samples",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000  dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 300000  dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.old.json src test samples --ext .ts --fix",
     "lint": "eslint -c ../../.eslintrc.old.json src test samples --ext .ts -f html -o storage-blob-lintReport.html || exit 0",

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -22,7 +22,7 @@ describe("Highlevel", () => {
   let tempFileLarge: string;
   let tempFileLargeLength: number;
   const tempFolderPath = "temp";
-  const timeoutForLargeFileUploadingTest = 10 * 60 * 1000;
+  const timeoutForLargeFileUploadingTest = 20 * 60 * 1000;
 
   let recorder: Recorder;
 

--- a/sdk/storage/storage-blob/tests.yml
+++ b/sdk/storage/storage-blob/tests.yml
@@ -13,6 +13,7 @@ jobs:
     parameters:
       PackageName: "@azure/storage-blob"
       ResourceServiceDirectory: storage
+      TimeoutInMinutes: 90
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/sdk/storage/storage-file-share/karma.conf.js
+++ b/sdk/storage/storage-file-share/karma.conf.js
@@ -121,7 +121,7 @@ module.exports = function(config) {
     // how many browser should be started simultaneous
     concurrency: 1,
 
-    browserNoActivityTimeout: 600000,
+    browserNoActivityTimeout: 1200000,
     browserDisconnectTimeout: 10000,
     browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -45,7 +45,7 @@
     "execute:samples": "npm run build:samples && npm run execute:js-samples && npm run execute:ts-samples",
     "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
-    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 120000  dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
+    "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter mocha-multi --reporter-options spec=-,mocha-junit-reporter=- --full-trace -t 300000  dist-esm/test/*.spec.js dist-esm/test/node/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint -c ../../.eslintrc.old.json src test samples --ext .ts --fix",
     "lint": "eslint -c ../../.eslintrc.old.json src test samples --ext .ts -f html -o storage-file-share-lintReport.html || exit 0",

--- a/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
@@ -25,7 +25,7 @@ describe("FileClient Node.js only", () => {
   let fileName: string;
   let fileClient: ShareFileClient;
   const content = "Hello World";
-  const timeoutForLargeFileUploadingTest = 10 * 60 * 1000;
+  const timeoutForLargeFileUploadingTest = 20 * 60 * 1000;
 
   let recorder: Recorder;
 

--- a/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/highlevel.node.spec.ts
@@ -23,7 +23,7 @@ describe("Highlevel Node.js only", () => {
   let tempFileLarge: string;
   let tempFileLargeLength: number;
   const tempFolderPath = "temp";
-  const timeoutForLargeFileUploadingTest = 10 * 60 * 1000;
+  const timeoutForLargeFileUploadingTest = 20 * 60 * 1000;
 
   let recorder: Recorder;
 

--- a/sdk/storage/storage-file-share/tests.yml
+++ b/sdk/storage/storage-file-share/tests.yml
@@ -13,6 +13,7 @@ jobs:
     parameters:
       PackageName: "@azure/storage-file-share"
       ResourceServiceDirectory: storage
+      TimeoutInMinutes: 90
       EnvVars:
         AZURE_CLIENT_ID: $(aad-azure-sdk-test-client-id)
         AZURE_TENANT_ID: $(aad-azure-sdk-test-tenant-id)


### PR DESCRIPTION
- double the time for large data tests to 20 minutes. We have seen them passing
closer to 10-minute mark.

- increase global mocha timeout to 5 minutes

- increase pipeline time out for blob and file-share to 90 minutes.