### PR TITLE
Update for AzureCliCredential

### DIFF
--- a/sdk/identity/identity/src/client/azureCliCredentialClient.ts
+++ b/sdk/identity/identity/src/client/azureCliCredentialClient.ts
@@ -1,0 +1,26 @@
+import * as child_process from "child_process";
+
+interface CredentialClient {
+  getAzureCliAccessToken(resource: string): Promise<any>;
+}
+
+class AzureCliCredentialClient implements CredentialClient {
+  public getAzureCliAccessToken(resource: string) {
+    return new Promise((resolve, reject) => {
+      try {
+        child_process.exec(
+          `az account get-access-token --output json --resource ${resource}`,
+          (error, stdout, stderr) => {
+            resolve({ stdout: stdout, stderr: stderr });
+          }
+        );
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+}
+
+export interface AzureCliCredentialOptions {
+  azureCliCredentialClient?: CredentialClient;
+}

--- a/sdk/identity/identity/src/credentials/azureCliCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/azureCliCredential.browser.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+import { AccessToken, TokenCredential, GetTokenOptions } from "@azure/core-http";
+import { TokenCredentialOptions } from "../client/identityClient";
+
+const BrowserNotSupportedError = new Error("AzureCliCredential is not supported in the browser.");
+
+export class AzureCliCredential implements TokenCredential {
+  constructor(options?: TokenCredentialOptions) {
+    throw BrowserNotSupportedError;
+  }
+
+  getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null> {
+    throw BrowserNotSupportedError;
+  }
+}

--- a/sdk/identity/identity/src/credentials/azureCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureCliCredential.ts
@@ -64,7 +64,7 @@ export class AzureCliCredential implements TokenCredential {
               obj.stderr.match("az:(.*)not found") ||
               obj.stderr.startsWith("'az' is not recognized");
             if (isNotInstallError) {
-              throw new Error("Azure Cli not Installed");
+              throw new Error("Azure CLI not Installed");
             } else if (isLoginError) {
               throw new Error("Azure user is not logged in");
             }

--- a/sdk/identity/identity/src/credentials/azureCliCredential.ts
+++ b/sdk/identity/identity/src/credentials/azureCliCredential.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TokenCredential, GetTokenOptions, AccessToken } from "@azure/core-http";
+import { createSpan } from "../util/tracing";
+import { AuthenticationErrorName } from "../client/errors";
+import { CanonicalCode } from "@opentelemetry/types";
+import { logger } from "../util/logging";
+import {
+  CredentialClient,
+  AzureCliCredentialClient,
+  AzureCliCredentialOptions
+} from "../client/AzureCliCredentialClient";
+
+/**
+ * Provides the user access token and expire time
+ * with azure cli command "az account get-access-token" in powershell.
+ */
+export class AzureCliCredential implements TokenCredential {
+  private client: CredentialClient;
+  /**
+   * Creates an instance of the AzureCliCredential class.
+   *
+   * @param options Options for configuring the client which makes the authentication request.
+   */
+  constructor(options?: AzureCliCredentialOptions) {
+    if (options && options.azureCliCredentialClient) {
+      this.client = options.azureCliCredentialClient;
+    } else {
+      this.client = new AzureCliCredentialClient();
+    }
+  }
+
+  /**
+   * Authenticates with Azure Active Directory and returns an access token if
+   * successful.  If authentication cannot be performed at this time, this method may
+   * return null.  If an error occurs during authentication, an {@link AuthenticationError}
+   * containing failure details will be thrown.
+   *
+   * @param scopes The list of scopes for which the token will have access.
+   * @param options The options used to configure any requests this
+   *                TokenCredential implementation might make.
+   */
+  public async getToken(
+    scopes: string | string[],
+    options?: GetTokenOptions
+  ): Promise<AccessToken | null> {
+    const { span } = createSpan("AzureCliCredential-getToken", options);
+
+    return new Promise((resolve, reject) => {
+      let scope: string;
+      scope = typeof scopes === "string" ? scopes : scopes[0];
+      logger.info(`use the scope ${scope}`);
+      const resource = scope.replace(/\/.default$/, "");
+      let responseData = "";
+
+      const { span } = createSpan("AzureCliCredential-getToken", options);
+      this.client
+        .getAzureCliAccessToken(resource)
+        .then((obj: any) => {
+          if (obj.stderr) {
+            let isLoginError = obj.stderr.match("Please run 'az login' to setup account");
+            let isNotInstallError =
+              obj.stderr.match("az:(.*)not found") ||
+              obj.stderr.startsWith("'az' is not recognized");
+            if (isNotInstallError) {
+              throw new Error("Azure Cli not Installed");
+            } else if (isLoginError) {
+              throw new Error("Azure user is not logged in");
+            }
+            throw new Error(obj.stderr);
+          } else {
+            responseData = obj.stdout;
+            const response: { accessToken: string; expiresOn: string } = JSON.parse(responseData);
+            resolve({
+              token: response.accessToken,
+              expiresOnTimestamp: new Date(response.expiresOn).getTime()
+            });
+          }
+        })
+        .catch((err) => {
+          const code =
+            err.name === AuthenticationErrorName
+              ? CanonicalCode.UNAUTHENTICATED
+              : CanonicalCode.UNKNOWN;
+          span.setStatus({
+            code,
+            message: err.message
+          });
+          reject(err);
+        });
+    });
+  }
+}

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -5,6 +5,7 @@ import { TokenCredentialOptions } from "../client/identityClient";
 import { ChainedTokenCredential } from "./chainedTokenCredential";
 import { EnvironmentCredential } from "./environmentCredential";
 import { ManagedIdentityCredential } from "./managedIdentityCredential";
+import { AzureCliCredential } from "./azureCliCredential";
 
 /**
  * Provides a default {@link ChainedTokenCredential} configuration for
@@ -26,7 +27,8 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
   constructor(tokenCredentialOptions?: TokenCredentialOptions) {
     super(
       new EnvironmentCredential(tokenCredentialOptions),
-      new ManagedIdentityCredential(tokenCredentialOptions)
+      new ManagedIdentityCredential(tokenCredentialOptions),
+      new AzureCliCredential()
     );
   }
 }

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -7,6 +7,7 @@ import { DefaultAzureCredential } from "./credentials/defaultAzureCredential";
 export { ChainedTokenCredential } from "./credentials/chainedTokenCredential";
 export { TokenCredentialOptions } from "./client/identityClient";
 export { EnvironmentCredential } from "./credentials/environmentCredential";
+export { AzureCliCredential } from "./credentials/azureCliCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { InteractiveBrowserCredential } from "./credentials/interactiveBrowserCredential";

--- a/sdk/identity/identity/test/mockAzureCliCredentialClient.ts
+++ b/sdk/identity/identity/test/mockAzureCliCredentialClient.ts
@@ -1,0 +1,32 @@
+import {
+  CredentialClient,
+  AzureCliCredentialOptions
+} from "../src/client/AzureCliCredentialClient";
+
+interface MockCredentialClient {
+  stdout: string;
+  stderr: string;
+}
+
+export class MockAzureCliCredentialClientOptions implements AzureCliCredentialOptions {
+  azureCliCredentialClient?: CredentialClient;
+  constructor(mockClient: MockAzureCliCredentialClient) {
+    this.azureCliCredentialClient = mockClient;
+  }
+}
+
+export class MockAzureCliCredentialClient implements CredentialClient {
+  private stdout;
+  private stderr;
+
+  constructor(options?: MockCredentialClient) {
+    this.stdout = options.stdout;
+    this.stderr = options.stderr;
+  }
+
+  public getAzureCliAccessToken(resource: string) {
+    return new Promise((resolve) => {
+      resolve({ stdout: this.stdout, stderr: this.stderr });
+    });
+  }
+}

--- a/sdk/identity/identity/test/node/azureCliCredential.spec.ts
+++ b/sdk/identity/identity/test/node/azureCliCredential.spec.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import assert from "assert";
+import {
+  MockAzureCliCredentialClient,
+  MockAzureCliCredentialClientOptions
+} from "../mockAzureCliCredentialClient";
+import { AzureCliCredential } from "../../src/credentials/azureCliCredential";
+
+describe("AzureCliCredential", function() {
+  it("get access token without error", async function() {
+    var mockCliCredentialClient = new MockAzureCliCredentialClient({
+      stdout: '{"accessToken": "token","expiresOn": "01/01/1900 00:00:00 +00:00"}',
+      stderr: ""
+    });
+    let credential = new AzureCliCredential(
+      new MockAzureCliCredentialClientOptions(mockCliCredentialClient)
+    );
+    let actualToken = await credential.getToken("https://service/.default");
+    assert.equal(actualToken.token, "token");
+  });
+
+  it("get access token when azure cli not installed", async () => {
+    if (process.platform == "linux" || process.platform == "darwin") {
+      var mockCliCredentialClient = new MockAzureCliCredentialClient({
+        stdout: "",
+        stderr: "az: command not found"
+      });
+      let credential = new AzureCliCredential(
+        new MockAzureCliCredentialClientOptions(mockCliCredentialClient)
+      );
+
+      try {
+        await credential.getToken("https://service/.default");
+      } catch (error) {
+        assert.equal(error.message, "Azure CLI not Installed");
+      }
+    } else {
+      var mockCliCredentialClient = new MockAzureCliCredentialClient({
+        stdout: "",
+        stderr: "'az' is not recognized"
+      });
+      let credential = new AzureCliCredential(
+        new MockAzureCliCredentialClientOptions(mockCliCredentialClient)
+      );
+
+      try {
+        await credential.getToken("https://service/.default");
+      } catch (error) {
+        assert.equal(error.message, "Azure CLI not Installed");
+      }
+    }
+  });
+
+  it("get access token when azure cli not login in", async () => {
+    var mockCliCredentialClient = new MockAzureCliCredentialClient({
+      stdout: "",
+      stderr: "Please run 'az login' to setup account"
+    });
+    let credential = new AzureCliCredential(
+      new MockAzureCliCredentialClientOptions(mockCliCredentialClient)
+    );
+    try {
+      await credential.getToken("https://service/.default");
+    } catch (error) {
+      assert.equal(error.message, "Azure user is not logged in");
+    }
+  });
+
+  it("get access token when having other access token error", async () => {
+    var mockCliCredentialClient = new MockAzureCliCredentialClient({
+      stdout: "",
+      stderr: "mock other access token error"
+    });
+    let credential = new AzureCliCredential(
+      new MockAzureCliCredentialClientOptions(mockCliCredentialClient)
+    );
+    try {
+      await credential.getToken("https://service/.default");
+    } catch (error) {
+      assert.equal(error.message, "mock other access token error");
+    }
+  });
+});


### PR DESCRIPTION
## Purpose
1. Rename CliCredential to AzureCliCredential
2. Remove the "export" before the CredentialClient and AzureCliCredentialClient