### PR TITLE
[ci] add synapse readme to exceptions list

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -83,6 +83,7 @@ known_content_issues:
   - ["sdk/storage/storage-file-datalake/test/README.md", "#1583"]
   - ["sdk/storage/storage-file-share/test/README.md", "#1583"]
   - ["sdk/storage/storage-queue/test/README.md", "#1583"]
+  - ["sdk/synapse/synapse/README.md", "#1583"]
   - ["sdk/template/template/README.md", "#1583"]
   - ["sdk/test-utils/recorder/README.md", "#1583"]
 


### PR DESCRIPTION
The nightly builds started failing after Synapse was merged to master due to its README not conforming to the expected format. This is a code-generated data-plane SDK, not one of our track2 SDKs that are added to the rush list.

