### PR TITLE
[core-amqp] prepare for 1.1.0 release

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.2 (Unreleased)
+## 1.1.0 (2020-02-28)
 
 - Exports `WebSocketOptions` interface to configure the channelling of the AMQP connection over Web Sockets. [PR 7368](https://github.com/Azure/azure-sdk-for-js/pull/7368)
 

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/core-amqp",
   "sdk-type": "client",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^1.0.2",
+    "@azure/core-amqp": "^1.1.0",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/identity": "^1.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -75,7 +75,7 @@
     ]
   },
   "dependencies": {
-    "@azure/core-amqp": "^1.0.2",
+    "@azure/core-amqp": "^1.1.0",
     "@azure/core-http": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "@types/is-buffer": "^2.0.0",


### PR DESCRIPTION
Updated core-amqp to 1.1.0 from 1.0.2 because exporting `WebSocketOptions` is considered a feature, not a bug fix.

Also updated event-hubs and service-bus to depend on this version of core-amqp.

For background info, WebSocketOptions used to be exported from event-hubs, but is now exported from core-amqp so service-bus can reference them as well. Boths ervice-bus and event-hubs will re-export WebSocketOptions.