### PR TITLE
[ai-text-analytics] API changes for Preview 3

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -2,19 +2,22 @@
 
 ## 1.0.0-preview.3 (Unreleased)
 - [Breaking] Renamed `id` to `dataSourceEntityId` in the `LinkedEntity` type.
+- Added special handling for the string `"none"` as the `countryHint` parameter of the `TextAnalyticsClient.detectLanguage`. `"none"` is now treated the same as the empty string, and indicates that the default language detection model should be used.
+- [Breaking] Renamed `offset` to `graphemeOffset` in fields of objects as appropriate in order to make it clear that the offsets are in units of Unicode graphemes.
+- [Breaking] Renamed `sentimentScores` on both `DocumentSentiment` and `SentenceSentiment` to `confidenceScores`, and renamed the type `SentimentScorePerLabel` back to `SentimentConfidenceScorePerLabel`.
 
 ## 1.0.0-preview.2 (2020-02-11)
 
-- Added support for rotating API keys via the `TextAnalyticsApiKeyCredential.updateKey` method. #6972
-- Added a discriminant type for `TextAnalyticsResult.error` to allow for easy differentiation between success and error types using `if (result.error) { ... }` in both TypeScript and JavaScript. #7046
-- [Breaking] Removed the `Entity` type and added new return types `CategorizedEntity` and `PiiEntity` for the `recognizeEntities` and `recognizePiiEntities` methods respectively. These types are equivalent to the previous `Entity` type. #7220
-- [Breaking] Removed the `detectedLanguages` property from `DetectLanguageResult`, as the service currently only returns one language. #7220
-- [Breaking] Renamed the `detectLanguages` method to `detectLanguage`, as the `detectedLanguages` property was removed from the `DetectLanguageResult` return type. #7220
-- [Breaking] Renamed `documentScores` and `sentenceScores` on the `DocumentSentiment` and `SentenceSentiment` types both to `sentimentScores`. #7220
-- [Breaking] Renamed `type` and `subtype` to `category` and `subcategory` respectively in the `CategorizedEntity` and `PiiEntity` types. #7220
-- [Breaking] Renamed `DocumentSentimentValue` and `SentenceSentimentValue` to `DocumentSentimentLabel` and `SentenceSentimentLabel` respectively. #7220
-- [Breaking] Renamed `SentimentConfidenceScorePerLabel` to `SentimentScorePerLabel`. #7220
-- [Breaking] Refactored `TextAnalyticsError` to flatten the error hierarchy and remove `innerError`. The new error model has properties for `code`, `message`, and an optional `target` only. The `code` property of `TextAnalyticsError` can now contain all of the codes from the previous `InnerErrorCodeValue` as well as those from the top-level `ErrorCodeValue`. #7276
+- Added support for rotating API keys via the `TextAnalyticsApiKeyCredential.updateKey` method.
+- Added a discriminant type for `TextAnalyticsResult.error` to allow for easy differentiation between success and error types using `if (result.error) { ... }` in both TypeScript and JavaScript.
+- [Breaking] Removed the `Entity` type and added new return types `CategorizedEntity` and `PiiEntity` for the `recognizeEntities` and `recognizePiiEntities` methods respectively. These types are equivalent to the previous `Entity` type.
+- [Breaking] Removed the `detectedLanguages` property from `DetectLanguageResult`, as the service currently only returns one language.
+- [Breaking] Renamed the `detectLanguages` method to `detectLanguage`, as the `detectedLanguages` property was removed from the `DetectLanguageResult` return type.
+- [Breaking] Renamed `documentScores` and `sentenceScores` on the `DocumentSentiment` and `SentenceSentiment` types both to `sentimentScores`.
+- [Breaking] Renamed `type` and `subtype` to `category` and `subcategory` respectively in the `CategorizedEntity` and `PiiEntity` types.
+- [Breaking] Renamed `DocumentSentimentValue` and `SentenceSentimentValue` to `DocumentSentimentLabel` and `SentenceSentimentLabel` respectively.
+- [Breaking] Renamed `SentimentConfidenceScorePerLabel` to `SentimentScorePerLabel`.
+- [Breaking] Refactored `TextAnalyticsError` to flatten the error hierarchy and remove `innerError`. The new error model has properties for `code`, `message`, and an optional `target` only. The `code` property of `TextAnalyticsError` can now contain all of the codes from the previous `InnerErrorCodeValue` as well as those from the top-level `ErrorCodeValue`.
 
 ## 1.0.0-preview.1 (2020-01-09)
 

--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.0.0-preview.3 (Unreleased)
-
+- [Breaking] Renamed `id` to `dataSourceEntityId` in the `LinkedEntity` type.
 
 ## 1.0.0-preview.2 (2020-02-11)
 

--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0-preview.3 (Unreleased)
 - [Breaking] Renamed `id` to `dataSourceEntityId` in the `LinkedEntity` type.
 - Added special handling for the string `"none"` as the `countryHint` parameter of the `TextAnalyticsClient.detectLanguage`. `"none"` is now treated the same as the empty string, and indicates that the default language detection model should be used.
-- [Breaking] Renamed `offset` to `graphemeOffset` in fields of objects as appropriate in order to make it clear that the offsets are in units of Unicode graphemes.
+- [Breaking] Renamed `offset` to `graphemeOffset` and `length` to `graphemeLength` in fields of response objects as appropriate in order to make it clear that the offsets and lengths are in units of Unicode graphemes.
 - [Breaking] Renamed `sentimentScores` on both `DocumentSentiment` and `SentenceSentiment` to `confidenceScores`, and renamed the type `SentimentScorePerLabel` back to `SentimentConfidenceScorePerLabel`.
 
 ## 1.0.0-preview.2 (2020-02-11)

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.json
@@ -1,0 +1,51 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 28 Feb 2020 23:51:09 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.10104.13 - WST ProdSlices",
+    "x-ms-request-id": "693152ae-d2e8-483b-bf50-a716890b8500"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/languages",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"1\",\"text\":\"I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!\",\"countryHint\":\"\"},{\"id\":\"2\",\"text\":\"Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle\",\"countryHint\":\"\"},{\"id\":\"3\",\"text\":\"I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.\",\"countryHint\":\"\"},{\"id\":\"4\",\"text\":\"I didn't like the last book I read at all.\",\"countryHint\":\"\"},{\"id\":\"5\",\"text\":\"Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.\",\"countryHint\":\"\"},{\"id\":\"6\",\"text\":\"La carretera estaba atascada. Había mucho tráfico el día de ayer.\",\"countryHint\":\"\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[{\"id\":\"1\",\"detectedLanguages\":[{\"name\":\"English\",\"iso6391Name\":\"en\",\"score\":1.0}]},{\"id\":\"2\",\"detectedLanguages\":[{\"name\":\"English\",\"iso6391Name\":\"en\",\"score\":1.0}]},{\"id\":\"3\",\"detectedLanguages\":[{\"name\":\"English\",\"iso6391Name\":\"en\",\"score\":1.0}]},{\"id\":\"4\",\"detectedLanguages\":[{\"name\":\"English\",\"iso6391Name\":\"en\",\"score\":1.0}]},{\"id\":\"5\",\"detectedLanguages\":[{\"name\":\"Spanish\",\"iso6391Name\":\"es\",\"score\":1.0}]},{\"id\":\"6\",\"detectedLanguages\":[{\"name\":\"Spanish\",\"iso6391Name\":\"es\",\"score\":1.0}]}],\"errors\":[],\"modelVersion\":\"2019-10-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "3c8af150-0669-40d7-b78a-f9e3fce00457",
+    "content-type": "application/json; charset=utf-8",
+    "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=6",
+    "date": "Fri, 28 Feb 2020 23:51:10 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "4"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "d56d1179ab04538c027b92c1e083e362"
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_string_input.json
+++ b/sdk/textanalytics/ai-text-analytics/recordings/browsers/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_string_input.json
@@ -1,0 +1,51 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":3599,\"ext_expires_in\":3599,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1417",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Fri, 28 Feb 2020 23:51:09 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.10104.13 - SAN ProdSlices",
+    "x-ms-request-id": "fbbb3371-88f9-4d59-8ffc-2c3de95de300"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://endpoint/text/analytics/v3.0-preview.1/languages",
+   "query": {},
+   "requestBody": "{\"documents\":[{\"id\":\"0\",\"text\":\"I use Azure Functions to develop my service.\",\"countryHint\":\"\"}]}",
+   "status": 200,
+   "response": "{\"documents\":[{\"id\":\"0\",\"detectedLanguages\":[{\"name\":\"English\",\"iso6391Name\":\"en\",\"score\":1.0}]}],\"errors\":[],\"modelVersion\":\"2019-10-01\"}",
+   "responseHeaders": {
+    "access-control-allow-origin": "*",
+    "access-control-expose-headers": "Operation-Location",
+    "apim-request-id": "68661d7b-c474-4a4f-b449-585e17066d24",
+    "content-type": "application/json; charset=utf-8",
+    "csp-billing-usage": "CognitiveServices.TextAnalytics.BatchScoring=1",
+    "date": "Fri, 28 Feb 2020 23:51:10 GMT",
+    "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+    "transfer-encoding": "chunked",
+    "x-content-type-options": "nosniff",
+    "x-envoy-upstream-service-time": "3"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "6bb71b1055c9adfaf9b7c302deae77f0"
+}

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_detectlanguageinput_input.js
@@ -1,0 +1,59 @@
+let nock = require('nock');
+
+module.exports.hash = "fac23089cd8c20684b1e16fb9b75e38c";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '12212c07-3b6f-4abf-b810-5b3676f00f01',
+  'x-ms-ests-server',
+  '2.1.10104.13 - SAN ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=Agg1gYJnBeRPjltof7Vl8_v0CyfMAQAAAGye69UOAAAA; expires=Sun, 29-Mar-2020 23:51:08 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Fri, 28 Feb 2020 23:51:07 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/languages', {"documents":[{"id":"1","text":"I had a wonderful trip to Seattle last week and even visited the Space Needle 2 times!","countryHint":""},{"id":"2","text":"Unfortunately, it rained during my entire trip to Seattle. I didn't even get to visit the Space Needle","countryHint":""},{"id":"3","text":"I went to see a movie on Saturday and it was perfectly average, nothing more or less than I expected.","countryHint":""},{"id":"4","text":"I didn't like the last book I read at all.","countryHint":""},{"id":"5","text":"Los caminos que llevan hasta Monte Rainier son espectaculares y hermosos.","countryHint":""},{"id":"6","text":"La carretera estaba atascada. Había mucho tráfico el día de ayer.","countryHint":""}]})
+  .reply(200, {"documents":[{"id":"1","detectedLanguages":[{"name":"English","iso6391Name":"en","score":1}]},{"id":"2","detectedLanguages":[{"name":"English","iso6391Name":"en","score":1}]},{"id":"3","detectedLanguages":[{"name":"English","iso6391Name":"en","score":1}]},{"id":"4","detectedLanguages":[{"name":"English","iso6391Name":"en","score":1}]},{"id":"5","detectedLanguages":[{"name":"Spanish","iso6391Name":"es","score":1}]},{"id":"6","detectedLanguages":[{"name":"Spanish","iso6391Name":"es","score":1}]}],"errors":[],"modelVersion":"2019-10-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'csp-billing-usage',
+  'CognitiveServices.TextAnalytics.BatchScoring=6',
+  'x-envoy-upstream-service-time',
+  '3',
+  'apim-request-id',
+  '3687ae63-0fed-4952-acbb-9f2c07a4b006',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 28 Feb 2020 23:51:07 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_string_input.js
+++ b/sdk/textanalytics/ai-text-analytics/recordings/node/aad_textanalyticsclient_detectlanguage/recording_client_accepts_none_country_hint_with_string_input.js
@@ -1,0 +1,59 @@
+let nock = require('nock');
+
+module.exports.hash = "05434aebc271891cd65b4fe50b254d3f";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fcognitiveservices.azure.com%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":3599,"ext_expires_in":3599,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  '79f7f077-f5e5-472d-85ef-201ff6858400',
+  'x-ms-ests-server',
+  '2.1.10104.13 - WST ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=AvMk9c85w21NndsU_YwTaun0CyfMAQAAAGue69UOAAAA; expires=Sun, 29-Mar-2020 23:51:08 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=corp; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estscorp; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Fri, 28 Feb 2020 23:51:07 GMT',
+  'Content-Length',
+  '1417'
+]);
+
+nock('https://endpoint:443', {"encodedQueryParams":true})
+  .post('/text/analytics/v3.0-preview.1/languages', {"documents":[{"id":"0","text":"I use Azure Functions to develop my service.","countryHint":""}]})
+  .reply(200, {"documents":[{"id":"0","detectedLanguages":[{"name":"English","iso6391Name":"en","score":1}]}],"errors":[],"modelVersion":"2019-10-01"}, [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'csp-billing-usage',
+  'CognitiveServices.TextAnalytics.BatchScoring=1',
+  'x-envoy-upstream-service-time',
+  '3',
+  'apim-request-id',
+  '82d661ae-5fe9-40dd-9fbd-9f9fb05d27b4',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains; preload',
+  'x-content-type-options',
+  'nosniff',
+  'Date',
+  'Fri, 28 Feb 2020 23:51:07 GMT'
+]);

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -117,7 +117,7 @@ export type InnerErrorCodeValue = 'InvalidParameterValue' | 'InvalidRequestBodyF
 // @public
 export interface LinkedEntity {
     dataSource: string;
-    id?: string;
+    dataSourceEntityId?: string;
     language: string;
     matches: Match[];
     name: string;

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -27,9 +27,9 @@ export interface AnalyzeSentimentResultCollection extends Array<AnalyzeSentiment
 
 // @public
 export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResult {
+    confidenceScores: SentimentConfidenceScorePerLabel;
     sentences: SentenceSentiment[];
     sentiment: DocumentSentimentLabel;
-    sentimentScores: SentimentScorePerLabel;
 }
 
 // @public
@@ -78,8 +78,8 @@ export type DocumentSentimentLabel = 'positive' | 'neutral' | 'negative' | 'mixe
 // @public
 export interface Entity {
     category: string;
+    graphemeOffset: number;
     length: number;
-    offset: number;
     score: number;
     subCategory?: string;
     text: string;
@@ -126,8 +126,8 @@ export interface LinkedEntity {
 
 // @public
 export interface Match {
+    graphemeOffset: number;
     length: number;
-    offset: number;
     score: number;
     text: string;
 }
@@ -198,10 +198,10 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
 
 // @public
 export interface SentenceSentiment {
+    confidenceScores: SentimentConfidenceScorePerLabel;
+    graphemeOffset: number;
     length: number;
-    offset: number;
     sentiment: SentenceSentimentLabel;
-    sentimentScores: SentimentScorePerLabel;
     warnings?: string[];
 }
 
@@ -209,7 +209,7 @@ export interface SentenceSentiment {
 export type SentenceSentimentLabel = 'positive' | 'neutral' | 'negative';
 
 // @public
-export interface SentimentScorePerLabel {
+export interface SentimentConfidenceScorePerLabel {
     // (undocumented)
     negative: number;
     // (undocumented)

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -78,8 +78,8 @@ export type DocumentSentimentLabel = 'positive' | 'neutral' | 'negative' | 'mixe
 // @public
 export interface Entity {
     category: string;
+    graphemeLength: number;
     graphemeOffset: number;
-    length: number;
     score: number;
     subCategory?: string;
     text: string;
@@ -126,8 +126,8 @@ export interface LinkedEntity {
 
 // @public
 export interface Match {
+    graphemeLength: number;
     graphemeOffset: number;
-    length: number;
     score: number;
     text: string;
 }
@@ -199,8 +199,8 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
 // @public
 export interface SentenceSentiment {
     confidenceScores: SentimentConfidenceScorePerLabel;
+    graphemeLength: number;
     graphemeOffset: number;
-    length: number;
     sentiment: SentenceSentimentLabel;
     warnings?: string[];
 }

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
@@ -12,7 +12,7 @@ import {
   TextAnalyticsError,
   DocumentSentimentLabel,
   SentenceSentiment,
-  SentimentScorePerLabel
+  SentimentConfidenceScorePerLabel
 } from "./generated/models";
 
 /**
@@ -33,7 +33,7 @@ export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResul
   /**
    * Document level sentiment confidence scores between 0 and 1 for each sentiment class.
    */
-  sentimentScores: SentimentScorePerLabel;
+  confidenceScores: SentimentConfidenceScorePerLabel;
   /**
    * The predicted sentiment for each sentence in the corresponding document.
    */
@@ -48,14 +48,14 @@ export type AnalyzeSentimentErrorResult = TextAnalyticsErrorResult;
 export function makeAnalyzeSentimentResult(
   id: string,
   sentiment: DocumentSentimentLabel,
-  sentimentScores: SentimentScorePerLabel,
+  confidenceScores: SentimentConfidenceScorePerLabel,
   sentences: SentenceSentiment[],
   statistics?: TextDocumentStatistics
 ): AnalyzeSentimentSuccessResult {
   return {
     ...makeTextAnalyticsSuccessResult(id, statistics),
     sentiment,
-    sentimentScores,
+    confidenceScores,
     sentences
   };
 }

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -337,7 +337,7 @@ export interface LinkedEntity {
   /**
    * Unique identifier of the recognized entity from the data source.
    */
-  id?: string;
+  dataSourceEntityId?: string;
   /**
    * URL for the entity's page from the data source.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -126,7 +126,7 @@ export interface TextDocumentStatistics {
  * Represents the confidence scores between 0 and 1 across all sentiment classes: positive,
  * neutral, negative.
  */
-export interface SentimentScorePerLabel {
+export interface SentimentConfidenceScorePerLabel {
   positive: number;
   neutral: number;
   negative: number;
@@ -144,7 +144,7 @@ export interface SentenceSentiment {
   /**
    * The sentiment confidence score between 0 and 1 for the sentence for all classes.
    */
-  sentimentScores: SentimentScorePerLabel;
+  confidenceScores: SentimentConfidenceScorePerLabel;
   /**
    * The sentence offset from the start of the document.
    */
@@ -176,7 +176,7 @@ export interface DocumentSentiment {
   /**
    * Document level sentiment confidence scores between 0 and 1 for each sentiment class.
    */
-  documentScores: SentimentScorePerLabel;
+  documentScores: SentimentConfidenceScorePerLabel;
   /**
    * Sentence level sentiment analysis.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -148,7 +148,7 @@ export interface SentenceSentiment {
   /**
    * The sentence offset from the start of the document.
    */
-  offset: number;
+  graphemeOffset: number;
   /**
    * The length of the sentence by Unicode standard.
    */
@@ -244,9 +244,9 @@ export interface Entity {
    */
   subCategory?: string;
   /**
-   * Start position (in Unicode characters) for the entity text.
+   * Start position (in Unicode graphemes) for the entity text.
    */
-  offset: number;
+  graphemeOffset: number;
   /**
    * Length (in Unicode characters) for the entity text.
    */
@@ -309,9 +309,9 @@ export interface Match {
    */
   text: string;
   /**
-   * Start position (in Unicode characters) for the entity match text.
+   * Start position (in Unicode graphemes) for the entity match text.
    */
-  offset: number;
+  graphemeOffset: number;
   /**
    * Length (in Unicode characters) for the entity match text.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -152,7 +152,7 @@ export interface SentenceSentiment {
   /**
    * The length of the sentence by Unicode standard.
    */
-  length: number;
+  graphemeLength: number;
   /**
    * The warnings generated for the sentence.
    */
@@ -248,9 +248,9 @@ export interface Entity {
    */
   graphemeOffset: number;
   /**
-   * Length (in Unicode characters) for the entity text.
+   * Length (in Unicode graphemes) for the entity text.
    */
-  length: number;
+  graphemeLength: number;
   /**
    * Confidence score between 0 and 1 of the extracted entity.
    */
@@ -313,9 +313,9 @@ export interface Match {
    */
   graphemeOffset: number;
   /**
-   * Length (in Unicode characters) for the entity match text.
+   * Length (in Unicode graphemes) for the entity match text.
    */
-  length: number;
+  graphemeLength: number;
 }
 
 /**

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -666,7 +666,7 @@ export const LinkedEntity: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      id: {
+      dataSourceEntityId: {
         serializedName: "id",
         type: {
           name: "String"

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -225,11 +225,11 @@ export const TextDocumentStatistics: coreHttp.CompositeMapper = {
   }
 };
 
-export const SentimentScorePerLabel: coreHttp.CompositeMapper = {
-  serializedName: "SentimentScorePerLabel",
+export const SentimentConfidenceScorePerLabel: coreHttp.CompositeMapper = {
+  serializedName: "SentimentConfidenceScorePerLabel",
   type: {
     name: "Composite",
-    className: "SentimentScorePerLabel",
+    className: "SentimentConfidenceScorePerLabel",
     modelProperties: {
       positive: {
         required: true,
@@ -274,12 +274,12 @@ export const SentenceSentiment: coreHttp.CompositeMapper = {
           ]
         }
       },
-      sentimentScores: {
+      confidenceScores: {
         required: true,
         serializedName: "sentenceScores",
         type: {
           name: "Composite",
-          className: "SentimentScorePerLabel"
+          className: "SentimentConfidenceScorePerLabel"
         }
       },
       graphemeOffset: {
@@ -349,7 +349,7 @@ export const DocumentSentiment: coreHttp.CompositeMapper = {
         serializedName: "documentScores",
         type: {
           name: "Composite",
-          className: "SentimentScorePerLabel"
+          className: "SentimentConfidenceScorePerLabel"
         }
       },
       sentenceSentiments: {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -289,7 +289,7 @@ export const SentenceSentiment: coreHttp.CompositeMapper = {
           name: "Number"
         }
       },
-      length: {
+      graphemeLength: {
         required: true,
         serializedName: "length",
         type: {
@@ -490,7 +490,7 @@ export const Entity: coreHttp.CompositeMapper = {
           name: "Number"
         }
       },
-      length: {
+      graphemeLength: {
         required: true,
         serializedName: "length",
         type: {
@@ -622,7 +622,7 @@ export const Match: coreHttp.CompositeMapper = {
           name: "Number"
         }
       },
-      length: {
+      graphemeLength: {
         required: true,
         serializedName: "length",
         type: {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -282,7 +282,7 @@ export const SentenceSentiment: coreHttp.CompositeMapper = {
           className: "SentimentScorePerLabel"
         }
       },
-      offset: {
+      graphemeOffset: {
         required: true,
         serializedName: "offset",
         type: {
@@ -483,7 +483,7 @@ export const Entity: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      offset: {
+      graphemeOffset: {
         required: true,
         serializedName: "offset",
         type: {
@@ -615,7 +615,7 @@ export const Match: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      offset: {
+      graphemeOffset: {
         required: true,
         serializedName: "offset",
         type: {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/textAnalyticsClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/textAnalyticsClientContext.ts
@@ -24,11 +24,7 @@ export class TextAnalyticsClientContext extends coreHttp.ServiceClient {
    * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    endpoint: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
+  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, endpoint: string, options?: coreHttp.ServiceClientOptions) {
     if (endpoint == undefined) {
       throw new Error("'endpoint' cannot be null.");
     }

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -63,7 +63,7 @@ export {
 export {
   DetectedLanguage,
   TextDocumentStatistics,
-  SentimentScorePerLabel,
+  SentimentConfidenceScorePerLabel,
   MultiLanguageInput as TextDocumentInput,
   LanguageInput as DetectLanguageInput,
   TextDocumentBatchStatistics,

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -202,8 +202,8 @@ export class TextAnalyticsClient {
    *   the input strings to assist the text analytics model in predicting
    *   the language they are written in.  If unspecified, this value will be
    *   set to the default country hint in `TextAnalyticsClientOptions`.
-   *   If set to an empty string, the service will apply a model where the
-   *   country is explicitly set to "None".
+   *   If set to an empty string, or the string "none", the service will apply a
+   *   model where the country is explicitly unset.
    *   The same country hint is applied to all strings in the input collection.
    * @param options Optional parameters for the operation.
    */
@@ -238,7 +238,11 @@ export class TextAnalyticsClient {
       realInputs = convertToDetectLanguageInput(inputs, countryHint);
       realOptions = options || {};
     } else {
-      realInputs = inputs;
+      // Replace "none" hints with ""
+      realInputs = inputs.map((input) => ({
+        ...input,
+        countryHint: input.countryHint === "none" ? "" : input.countryHint
+      }));
       realOptions = (countryHintOrOptions as DetectLanguageOptions) || {};
     }
 
@@ -686,6 +690,9 @@ function convertToDetectLanguageInput(
   inputs: string[],
   countryHint: string
 ): DetectLanguageInput[] {
+  if (countryHint === "none") {
+    countryHint = "";
+  }
   return inputs.map(
     (text: string, index): DetectLanguageInput => {
       return {

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -134,33 +134,14 @@ directive:
       $.subtype["x-ms-client-name"] = "subCategory";
 ```
 
-### Rename sentenceScores -> sentimentScores
+### Rename sentenceScores -> confidenceScores
 
 ```yaml
 directive:
   - from: swagger-document
     where: $.definitions.SentenceSentiment.properties.sentenceScores
     transform: >
-      $["x-ms-client-name"] = "sentimentScores";
-```
-
-### Rename SentimentConfidenceScorePerLabel -> SentimentScorePerLabel 
-
-```yaml
-directive:
-  - from: swagger-document
-    where: $.definitions
-    transform: >
-      if (!$.SentimentScorePerLabel) {
-          $.SentimentScorePerLabel = $.SentimentConfidenceScorePerLabel;
-          delete $.SentimentConfidenceScorePerLabel;
-      }
-  - from: swagger-document
-    where: $.definitions..properties[*]
-    transform: >
-      if ($["$ref"] && $["$ref"] === "#/definitions/SentimentConfidenceScorePerLabel") {
-          $["$ref"] = "#/definitions/SentimentScorePerLabel";
-      }
+      $["x-ms-client-name"] = "confidenceScores";
 ```
 
 ### Rename {Document,Sentence}SentimentValue -> Label 

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -197,3 +197,14 @@ directive:
       $["x-ms-client-name"] = "dataSourceEntityId";
 ```
 
+### Rename Entity/Match offset -> graphemeOffset
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions..properties.offset
+    transform: >
+      $["x-ms-client-name"] = "graphemeOffset";
+      $.description = $.description.replace("Unicode characters", "Unicode graphemes");
+```
+

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -187,5 +187,10 @@ directive:
     transform: >
       $["x-ms-client-name"] = "graphemeOffset";
       $.description = $.description.replace("Unicode characters", "Unicode graphemes");
+  - from: swagger-document
+    where: $.definitions..properties.length
+    transform: >
+      $["x-ms-client-name"] = "graphemeLength";
+      $.description = $.description.replace("Unicode characters", "Unicode graphemes");
 ```
 

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -187,3 +187,13 @@ directive:
       $.enum = $.enum.map((val) => val.charAt(0).toUpperCase() + val.slice(1));
 ```
 
+### Rename LinkedEntity id -> dataSourceEntityId
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.LinkedEntity.properties.id
+    transform: >
+      $["x-ms-client-name"] = "dataSourceEntityId";
+```
+

--- a/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
@@ -204,7 +204,7 @@ describe("RecognizeCategorizedEntitiesResultCollection", () => {
               text: "Microsoft",
               category: "Organization",
               graphemeOffset: 10,
-              length: 9,
+              graphemeLength: 9,
               score: 0.9989
             }
           ]
@@ -217,7 +217,7 @@ describe("RecognizeCategorizedEntitiesResultCollection", () => {
               category: "DateTime",
               subCategory: "DateRange",
               graphemeOffset: 34,
-              length: 9,
+              graphemeLength: 9,
               score: 0.8
             }
           ]
@@ -267,7 +267,7 @@ describe("RecognizePiiEntitiesResultCollection", () => {
               text: "(555) 555-5555",
               category: "US Phone Number",
               graphemeOffset: 10,
-              length: 9,
+              graphemeLength: 9,
               score: 0.9989
             }
           ]
@@ -280,7 +280,7 @@ describe("RecognizePiiEntitiesResultCollection", () => {
               category: "US Address",
               subCategory: "",
               graphemeOffset: 34,
-              length: 9,
+              graphemeLength: 9,
               score: 0.8
             }
           ]
@@ -332,7 +332,7 @@ describe("RecognizeLinkedEntitiesResultCollection", () => {
                 {
                   text: "Seattle",
                   graphemeOffset: 26,
-                  length: 7,
+                  graphemeLength: 7,
                   score: 0.15046201222847677
                 }
               ],
@@ -352,7 +352,7 @@ describe("RecognizeLinkedEntitiesResultCollection", () => {
                 {
                   text: "Microsoft",
                   graphemeOffset: 10,
-                  length: 9,
+                  graphemeLength: 9,
                   score: 0.1869365971673207
                 }
               ],

--- a/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
@@ -203,7 +203,7 @@ describe("RecognizeCategorizedEntitiesResultCollection", () => {
             {
               text: "Microsoft",
               category: "Organization",
-              offset: 10,
+              graphemeOffset: 10,
               length: 9,
               score: 0.9989
             }
@@ -216,7 +216,7 @@ describe("RecognizeCategorizedEntitiesResultCollection", () => {
               text: "last week",
               category: "DateTime",
               subCategory: "DateRange",
-              offset: 34,
+              graphemeOffset: 34,
               length: 9,
               score: 0.8
             }
@@ -266,7 +266,7 @@ describe("RecognizePiiEntitiesResultCollection", () => {
             {
               text: "(555) 555-5555",
               category: "US Phone Number",
-              offset: 10,
+              graphemeOffset: 10,
               length: 9,
               score: 0.9989
             }
@@ -279,7 +279,7 @@ describe("RecognizePiiEntitiesResultCollection", () => {
               text: "1234 Default Ln.",
               category: "US Address",
               subCategory: "",
-              offset: 34,
+              graphemeOffset: 34,
               length: 9,
               score: 0.8
             }
@@ -331,7 +331,7 @@ describe("RecognizeLinkedEntitiesResultCollection", () => {
               matches: [
                 {
                   text: "Seattle",
-                  offset: 26,
+                  graphemeOffset: 26,
                   length: 7,
                   score: 0.15046201222847677
                 }
@@ -351,7 +351,7 @@ describe("RecognizeLinkedEntitiesResultCollection", () => {
               matches: [
                 {
                   text: "Microsoft",
-                  offset: 10,
+                  graphemeOffset: 10,
                   length: 9,
                   score: 0.1869365971673207
                 }

--- a/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/collections.spec.ts
@@ -337,7 +337,7 @@ describe("RecognizeLinkedEntitiesResultCollection", () => {
                 }
               ],
               language: "en",
-              id: "Seattle",
+              dataSourceEntityId: "Seattle",
               url: "https://en.wikipedia.org/wiki/Seattle",
               dataSource: "Wikipedia"
             }
@@ -357,7 +357,7 @@ describe("RecognizeLinkedEntitiesResultCollection", () => {
                 }
               ],
               language: "en",
-              id: "Microsoft",
+              dataSourceEntityId: "Microsoft",
               url: "https://en.wikipedia.org/wiki/Microsoft",
               dataSource: "Wikipedia"
             }

--- a/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
@@ -6,7 +6,12 @@ import { assert } from "chai";
 import { Recorder } from "@azure/test-utils-recorder";
 
 import { createRecordedClient } from "./utils/recordedClient";
-import { TextAnalyticsClient, TextDocumentInput, DetectLanguageInput } from "../src/index";
+import {
+  TextAnalyticsClient,
+  TextDocumentInput,
+  DetectLanguageInput,
+  DetectLanguageSuccessResult
+} from "../src/index";
 import { isSuccess, assertAllSuccess } from "./utils/resultHelper";
 
 const testDataEn = [
@@ -121,6 +126,30 @@ describe("[AAD] TextAnalyticsClient", function() {
     it("client accepts a countryHint", async () => {
       const results = await client.detectLanguage(["impossible"], "fr");
       assert.equal(results.length, 1);
+      assertAllSuccess(results);
+    });
+
+    it('client accepts "none" country hint with string[] input', async () => {
+      const results = await client.detectLanguage(
+        ["I use Azure Functions to develop my service."],
+        "none"
+      );
+      assert.equal(results.length, 1);
+      assertAllSuccess(results);
+      const result = results[0] as DetectLanguageSuccessResult;
+      assert.equal(result.primaryLanguage.iso6391Name, "en");
+    });
+
+    it('client accepts "none" country hint with DetectLanguageInput[] input', async () => {
+      const results = await client.detectLanguage(
+        testDataEn.concat(testDataEs).map(
+          (input): DetectLanguageInput => ({
+            id: getId(),
+            countryHint: "none",
+            text: input
+          })
+        )
+      );
       assertAllSuccess(results);
     });
 


### PR DESCRIPTION
This is the set of renames and tweaks to APIs with changelog updates for preview.3 of TextAnalytics

- id -> dataSourceEntityId
- length, offset -> graphemeLength, graphemeOffset
- sentimentScores -> confidenceScores, SentimentScorePerLabel -> SentimentConfidenceScorePerLabel

I also
- Removed the PR numbers from the changelog, since they don't link correctly anyway and other packages don't have them.
- Re-recorded tests.