### PR TITLE
[ai-text-analytics] Rename type for SentimentConfidenceScores

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [Breaking] Renamed `id` to `dataSourceEntityId` in the `LinkedEntity` type.
 - Added special handling for the string `"none"` as the `countryHint` parameter of the `TextAnalyticsClient.detectLanguage`. `"none"` is now treated the same as the empty string, and indicates that the default language detection model should be used.
 - [Breaking] Renamed `offset` to `graphemeOffset` and `length` to `graphemeLength` in fields of response objects as appropriate in order to make it clear that the offsets and lengths are in units of Unicode graphemes.
-- [Breaking] Renamed `sentimentScores` on both `DocumentSentiment` and `SentenceSentiment` to `confidenceScores`, and renamed the type `SentimentScorePerLabel` back to `SentimentConfidenceScorePerLabel`.
+- [Breaking] Renamed `sentimentScores` on both `DocumentSentiment` and `SentenceSentiment` to `confidenceScores`, and renamed the type `SentimentScorePerLabel` to `SentimentConfidenceScores`.
 
 ## 1.0.0-preview.2 (2020-02-11)
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -27,7 +27,7 @@ export interface AnalyzeSentimentResultCollection extends Array<AnalyzeSentiment
 
 // @public
 export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResult {
-    confidenceScores: SentimentConfidenceScorePerLabel;
+    confidenceScores: SentimentConfidenceScores;
     sentences: SentenceSentiment[];
     sentiment: DocumentSentimentLabel;
 }
@@ -198,7 +198,7 @@ export interface RecognizePiiEntitiesSuccessResult extends TextAnalyticsSuccessR
 
 // @public
 export interface SentenceSentiment {
-    confidenceScores: SentimentConfidenceScorePerLabel;
+    confidenceScores: SentimentConfidenceScores;
     graphemeLength: number;
     graphemeOffset: number;
     sentiment: SentenceSentimentLabel;
@@ -209,7 +209,7 @@ export interface SentenceSentiment {
 export type SentenceSentimentLabel = 'positive' | 'neutral' | 'negative';
 
 // @public
-export interface SentimentConfidenceScorePerLabel {
+export interface SentimentConfidenceScores {
     // (undocumented)
     negative: number;
     // (undocumented)

--- a/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/analyzeSentimentResult.ts
@@ -12,7 +12,7 @@ import {
   TextAnalyticsError,
   DocumentSentimentLabel,
   SentenceSentiment,
-  SentimentConfidenceScorePerLabel
+  SentimentConfidenceScores
 } from "./generated/models";
 
 /**
@@ -33,7 +33,7 @@ export interface AnalyzeSentimentSuccessResult extends TextAnalyticsSuccessResul
   /**
    * Document level sentiment confidence scores between 0 and 1 for each sentiment class.
    */
-  confidenceScores: SentimentConfidenceScorePerLabel;
+  confidenceScores: SentimentConfidenceScores;
   /**
    * The predicted sentiment for each sentence in the corresponding document.
    */
@@ -48,7 +48,7 @@ export type AnalyzeSentimentErrorResult = TextAnalyticsErrorResult;
 export function makeAnalyzeSentimentResult(
   id: string,
   sentiment: DocumentSentimentLabel,
-  confidenceScores: SentimentConfidenceScorePerLabel,
+  confidenceScores: SentimentConfidenceScores,
   sentences: SentenceSentiment[],
   statistics?: TextDocumentStatistics
 ): AnalyzeSentimentSuccessResult {

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -126,7 +126,7 @@ export interface TextDocumentStatistics {
  * Represents the confidence scores between 0 and 1 across all sentiment classes: positive,
  * neutral, negative.
  */
-export interface SentimentConfidenceScorePerLabel {
+export interface SentimentConfidenceScores {
   positive: number;
   neutral: number;
   negative: number;
@@ -144,7 +144,7 @@ export interface SentenceSentiment {
   /**
    * The sentiment confidence score between 0 and 1 for the sentence for all classes.
    */
-  confidenceScores: SentimentConfidenceScorePerLabel;
+  confidenceScores: SentimentConfidenceScores;
   /**
    * The sentence offset from the start of the document.
    */
@@ -176,7 +176,7 @@ export interface DocumentSentiment {
   /**
    * Document level sentiment confidence scores between 0 and 1 for each sentiment class.
    */
-  documentScores: SentimentConfidenceScorePerLabel;
+  documentScores: SentimentConfidenceScores;
   /**
    * Sentence level sentiment analysis.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -225,11 +225,11 @@ export const TextDocumentStatistics: coreHttp.CompositeMapper = {
   }
 };
 
-export const SentimentConfidenceScorePerLabel: coreHttp.CompositeMapper = {
-  serializedName: "SentimentConfidenceScorePerLabel",
+export const SentimentConfidenceScores: coreHttp.CompositeMapper = {
+  serializedName: "SentimentConfidenceScores",
   type: {
     name: "Composite",
-    className: "SentimentConfidenceScorePerLabel",
+    className: "SentimentConfidenceScores",
     modelProperties: {
       positive: {
         required: true,
@@ -279,7 +279,7 @@ export const SentenceSentiment: coreHttp.CompositeMapper = {
         serializedName: "sentenceScores",
         type: {
           name: "Composite",
-          className: "SentimentConfidenceScorePerLabel"
+          className: "SentimentConfidenceScores"
         }
       },
       graphemeOffset: {
@@ -349,7 +349,7 @@ export const DocumentSentiment: coreHttp.CompositeMapper = {
         serializedName: "documentScores",
         type: {
           name: "Composite",
-          className: "SentimentConfidenceScorePerLabel"
+          className: "SentimentConfidenceScores"
         }
       },
       sentenceSentiments: {

--- a/sdk/textanalytics/ai-text-analytics/src/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/index.ts
@@ -63,7 +63,7 @@ export {
 export {
   DetectedLanguage,
   TextDocumentStatistics,
-  SentimentConfidenceScorePerLabel,
+  SentimentConfidenceScores,
   MultiLanguageInput as TextDocumentInput,
   LanguageInput as DetectLanguageInput,
   TextDocumentBatchStatistics,

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -194,3 +194,22 @@ directive:
       $.description = $.description.replace("Unicode characters", "Unicode graphemes");
 ```
 
+### Rename SentimentConfidenceScorePerLabel -> SentimentConfidenceScores
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions
+    transform: >
+      if (!$.SentimentConfidenceScores) {
+          $.SentimentConfidenceScores = $.SentimentConfidenceScorePerLabel;
+          delete $.SentimentConfidenceScorePerLabel;
+      }
+  - from: swagger-document
+    where: $.definitions..properties[*]
+    transform: >
+      if ($["$ref"] && $["$ref"] === "#/definitions/SentimentConfidenceScorePerLabel") {
+          $["$ref"] = "#/definitions/SentimentConfidenceScores";
+      }
+```
+


### PR DESCRIPTION
This changes the type name from SentimentConfidenceScorePerLabel to SentimentConfidenceScores to align with a rename in Java and .NET.