### PR TITLE
Remove subscriptionID from subscriptionclient init

### DIFF
--- a/sdk/subscription/arm-subscriptions/README.md
+++ b/sdk/subscription/arm-subscriptions/README.md
@@ -34,7 +34,7 @@ import { SubscriptionClient, SubscriptionModels, SubscriptionMappers } from "@az
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 
 msRestNodeAuth.interactiveLogin().then((creds) => {
-  const client = new SubscriptionClient(creds, subscriptionId);
+  const client = new SubscriptionClient(creds);
   const subscriptionId = "testsubscriptionId";
   client.subscriptions.listLocations(subscriptionId).then((result) => {
     console.log("The result is:");


### PR DESCRIPTION
it expects a userAgent as the second  param, and for that reason it throws the following error:

```
TypeError: Cannot create property 'userAgent' on string '<ID>'
```

We can omit this in the example.