### PR TITLE
[eventhubs-checkpointstore-blob] add sample for downleveling storage blob

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/downlevelContainerClient.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/downlevelContainerClient.js
@@ -1,0 +1,42 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how to extend the Storage Blob Container Client
+  to downlevel the API version used when communicating with the service.
+
+  This may be useful if the environment you are targetting supports an
+  older version of Storage Blob than is officially supported by the
+  @azure/storage-blob SDK.
+*/
+
+const { ContainerClient } = require("@azure/storage-blob");
+
+/**
+ * The DownlevelContainerClient overwrites the API version sent via the
+ * `x-ms-version` header to "2017-11-09".
+ */
+class DownlevelContainerClient extends ContainerClient {
+  constructor(connectionString, containerName, options) {
+    super(connectionString, containerName, options);
+
+    const storageVersionPolicy = {
+      create(nextPolicy) {
+        return {
+          async sendRequest(httpRequest) {
+            httpRequest.headers.set("x-ms-version", DownlevelContainerClient.API_VERSION);
+            const response = await nextPolicy.sendRequest(httpRequest);
+            return response;
+          }
+        };
+      }
+    };
+
+    const pipelineFactoriesCount = this.pipeline.factories.length;
+    // Set the storage version policy as the second to last so that the HTTP header
+    // is updated before the request is signed.
+    this.pipeline.factories.splice(pipelineFactoriesCount - 1, 0, storageVersionPolicy);
+  }
+}
+DownlevelContainerClient.API_VERSION = "2017-11-09";
+exports.DownlevelContainerClient = DownlevelContainerClient;

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/downlevelContainerClient.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/downlevelContainerClient.ts
@@ -1,0 +1,41 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how to extend the Storage Blob Container Client
+  to downlevel the API version used when communicating with the service.
+
+  This may be useful if the environment you are targetting supports an
+  older version of Storage Blob than is officially supported by the
+  @azure/storage-blob SDK.
+*/
+
+import { ContainerClient, StoragePipelineOptions, RequestPolicyFactory } from "@azure/storage-blob";
+
+/**
+ * The DownlevelContainerClient overwrites the API version sent via the
+ * `x-ms-version` header to "2017-11-09".
+ */
+export class DownlevelContainerClient extends ContainerClient {
+  private static API_VERSION = "2017-11-09";
+  constructor(connectionString: string, containerName: string, options?: StoragePipelineOptions) {
+    super(connectionString, containerName, options);
+
+    const storageVersionPolicy: RequestPolicyFactory = {
+      create(nextPolicy) {
+        return {
+          async sendRequest(httpRequest) {
+            httpRequest.headers.set("x-ms-version", DownlevelContainerClient.API_VERSION);
+            const response = await nextPolicy.sendRequest(httpRequest);
+            return response;
+          }
+        };
+      }
+    };
+
+    const pipelineFactoriesCount = this.pipeline.factories.length;
+    // Set the storage version policy as the second to last so that the HTTP header
+    // is updated before the request is signed.
+    this.pipeline.factories.splice(pipelineFactoriesCount - 1, 0, storageVersionPolicy);
+  }
+}

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/receiveEventsWithDownleveledStorage.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/receiveEventsWithDownleveledStorage.js
@@ -1,0 +1,88 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how to use the EventHubConsumerClient to process events from all partitions
+  of a consumer group in an Event Hubs instance, as well as checkpointing along the way.
+
+  This sample uses the `DownLevelContainerClient` to target an older version of the Storage Blob service.
+
+  Checkpointing using a durable store allows your application to be more resilient. When you restart
+  your application after a crash (or an intentional stop), your application can continue consuming
+  events from where it last checkpointed.
+  
+  If your Event Hub instance doesn't have any events, then please run "sendEvents.ts" sample
+  to populate it before running this sample.
+
+  If your Event Hub instance doesn't have any events, then please run "sendEvents.ts" from the event-hubs project
+  located here: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/samples/sendEvents.ts
+*/
+
+const { EventHubConsumerClient } = require("@azure/event-hubs");
+const { BlobCheckpointStore } = require("@azure/eventhubs-checkpointstore-blob");
+const { DownlevelContainerClient } = require("./downlevelContainerClient");
+
+const connectionString = "";
+const eventHubName = "";
+const storageConnectionString = "";
+const containerName = "";
+const consumerGroup = "";
+
+async function main() {
+  // This client will be used by our eventhubs-checkpointstore-blob, which
+  // persists any checkpoints from this session in Azure Storage.
+  const containerClient = new DownlevelContainerClient(storageConnectionString, containerName);
+
+  if (!containerClient.exists()) {
+    await containerClient.create();
+  }
+
+  const checkpointStore = new BlobCheckpointStore(containerClient);
+
+  const consumerClient = new EventHubConsumerClient(
+    consumerGroup,
+    connectionString,
+    eventHubName,
+    checkpointStore
+  );
+
+  const subscription = consumerClient.subscribe({
+    processEvents: async (events, context) => {
+      for (const event of events) {
+        console.log(
+          `Received event: '${event.body}' from partition: '${context.partitionId}' and consumer group: '${context.consumerGroup}'`
+        );
+      }
+
+      try {
+        // Save a checkpoint for the last event now that we've processed this batch.
+        await context.updateCheckpoint(events[events.length - 1]);
+      } catch (err) {
+        console.log(`Error when checkpointing on partition ${context.partitionId}: `, err);
+        throw err;
+      }
+
+      console.log(
+        `Successfully checkpointed event with sequence number: ${
+          events[events.length - 1].sequenceNumber
+        } from partition: 'partitionContext.partitionId'`
+      );
+    },
+    processError: async (err, context) => {
+      console.log(`Error : ${err}`);
+    }
+  });
+
+  // after 30 seconds, stop processing
+  await new Promise((resolve) => {
+    setTimeout(async () => {
+      await subscription.close();
+      await consumerClient.close();
+      resolve();
+    }, 30000);
+  });
+}
+
+main().catch((err) => {
+  console.log("Error occurred: ", err);
+});

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/samples/receiveEventsWithDownleveledStorage.ts
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/samples/receiveEventsWithDownleveledStorage.ts
@@ -1,0 +1,88 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how to use the EventHubConsumerClient to process events from all partitions
+  of a consumer group in an Event Hubs instance, as well as checkpointing along the way.
+
+
+
+  Checkpointing using a durable store allows your application to be more resilient. When you restart
+  your application after a crash (or an intentional stop), your application can continue consuming
+  events from where it last checkpointed.
+  
+  If your Event Hub instance doesn't have any events, then please run "sendEvents.ts" sample
+  to populate it before running this sample.
+
+  If your Event Hub instance doesn't have any events, then please run "sendEvents.ts" from the event-hubs project
+  located here: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/samples/sendEvents.ts
+*/
+
+import { EventHubConsumerClient, CheckpointStore } from "@azure/event-hubs";
+import { BlobCheckpointStore } from "@azure/eventhubs-checkpointstore-blob";
+import { DownlevelContainerClient } from "./downlevelContainerClient";
+
+const connectionString = "";
+const eventHubName = "";
+const storageConnectionString = "";
+const containerName = "";
+const consumerGroup = "";
+
+async function main() {
+  // This client will be used by our eventhubs-checkpointstore-blob, which
+  // persists any checkpoints from this session in Azure Storage.
+  const containerClient = new DownlevelContainerClient(storageConnectionString, containerName);
+
+  if (!containerClient.exists()) {
+    await containerClient.create();
+  }
+
+  const checkpointStore: CheckpointStore = new BlobCheckpointStore(containerClient);
+
+  const consumerClient = new EventHubConsumerClient(
+    consumerGroup,
+    connectionString,
+    eventHubName,
+    checkpointStore
+  );
+
+  const subscription = consumerClient.subscribe({
+    processEvents: async (events, context) => {
+      for (const event of events) {
+        console.log(
+          `Received event: '${event.body}' from partition: '${context.partitionId}' and consumer group: '${context.consumerGroup}'`
+        );
+      }
+
+      try {
+        // save a checkpoint for the last event now that we've processed this batch.
+        await context.updateCheckpoint(events[events.length - 1]);
+      } catch (err) {
+        console.log(`Error when checkpointing on partition ${context.partitionId}: `, err);
+        throw err;
+      }
+
+      console.log(
+        `Successfully checkpointed event with sequence number: ${
+          events[events.length - 1].sequenceNumber
+        } from partition: 'partitionContext.partitionId'`
+      );
+    },
+    processError: async (err, context) => {
+      console.log(`Error : ${err}`);
+    }
+  });
+
+  // after 30 seconds, stop processing
+  await new Promise((resolve) => {
+    setTimeout(async () => {
+      await subscription.close();
+      await consumerClient.close();
+      resolve();
+    }, 30000);
+  });
+}
+
+main().catch((err) => {
+  console.log("Error occurred: ", err);
+});


### PR DESCRIPTION
This adds a sample that illustrates how to downlevel the Storage Blob `ContainerClient` to target an older API version. This can be useful when running this code against an older version of the service.