### PR TITLE
[ai-text-analytics] characterCount -> graphemeCount

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added special handling for the string `"none"` as the `countryHint` parameter of the `TextAnalyticsClient.detectLanguage`. `"none"` is now treated the same as the empty string, and indicates that the default language detection model should be used.
 - [Breaking] Renamed `offset` to `graphemeOffset` and `length` to `graphemeLength` in fields of response objects as appropriate in order to make it clear that the offsets and lengths are in units of Unicode graphemes.
 - [Breaking] Renamed `sentimentScores` on both `DocumentSentiment` and `SentenceSentiment` to `confidenceScores`, and renamed the type `SentimentScorePerLabel` to `SentimentConfidenceScores`.
+- [Breaking] Renamed `characterCount` to `graphemeCount` in the `DocumentStatistics` interface, to align with the change to using `grapheme` in the lengths/offsets of response objects.
 
 ## 1.0.0-preview.2 (2020-02-11)
 

--- a/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
+++ b/sdk/textanalytics/ai-text-analytics/review/ai-text-analytics.api.md
@@ -297,7 +297,7 @@ export interface TextDocumentInput {
 
 // @public
 export interface TextDocumentStatistics {
-    characterCount: number;
+    graphemeCount: number;
     transactionCount: number;
 }
 

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -115,7 +115,7 @@ export interface TextDocumentStatistics {
   /**
    * Number of text elements recognized in the document.
    */
-  characterCount: number;
+  graphemeCount: number;
   /**
    * Number of transactions for the document.
    */

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/mappers.ts
@@ -207,7 +207,7 @@ export const TextDocumentStatistics: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "TextDocumentStatistics",
     modelProperties: {
-      characterCount: {
+      graphemeCount: {
         required: true,
         serializedName: "charactersCount",
         type: {

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -30,7 +30,7 @@ directive:
   - from: swagger-document
     where: $.definitions.DocumentStatistics.properties.charactersCount
     transform: >
-      $["x-ms-client-name"] = "characterCount";
+      $["x-ms-client-name"] = "graphemeCount";
 ```
 
 ```yaml


### PR DESCRIPTION
Rename `characterCount` to `graphemeCount` in DocumentStatistics for consistency with use of "grapheme" in response objects.