### PR TITLE
Remove webpack dependency from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "plugin-error": "^1.0.1",
     "prettier": "^1.16.4",
     "ts-node": "^7.0.1",
+    "tslib": "^1.10.0",
     "typescript": "^3.2.2",
     "yargs": "^11.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "prettier": "^1.16.4",
     "ts-node": "^7.0.1",
     "typescript": "^3.2.2",
-    "webpack": "^4.26.1",
     "yargs": "^11.0.0"
   },
   "engines": {


### PR DESCRIPTION
This has started breaking CI due to an outdated dependency, but I don't think the management libs actually use/need this.