### PR TITLE
[ai-text-analytics] Repo Documentation Fixes for Preview 3

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-preview.3 (Unreleased)
+## 1.0.0-preview.3 (2020-03-10)
 - [Breaking] Renamed `id` to `dataSourceEntityId` in the `LinkedEntity` type.
 - Added special handling for the string `"none"` as the `countryHint` parameter of the `TextAnalyticsClient.detectLanguage`. `"none"` is now treated the same as the empty string, and indicates that the default language detection model should be used.
 - [Breaking] Renamed `offset` to `graphemeOffset` and `length` to `graphemeLength` in fields of response objects as appropriate in order to make it clear that the offsets and lengths are in units of Unicode graphemes.

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -1,6 +1,6 @@
-# Azure TextAnalytics client library for JavaScript
+# Azure Text Analytics client library for JavaScript
 
-[Azure TextAnalytics](https://azure.microsoft.com/en-us/services/cognitive-services/text-analytics/) is a cloud-based service that provides advanced natural language processing over raw text, and includes six main functions:
+[Azure TextAnalytics](https://azure.microsoft.com/services/cognitive-services/text-analytics/) is a cloud-based service that provides advanced natural language processing over raw text, and includes six main functions:
 
 - Language Detection
 - Sentiment Analysis
@@ -19,7 +19,7 @@ Use the client library to:
 [Source code](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/textanalytics/ai-text-analytics/) |
 [Package (NPM)](https://www.npmjs.com/package/@azure/ai-text-analytics) |
 [API reference documentation](https://aka.ms/azsdk-js-textanalytics-ref-docs) |
-[Product documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/text-analytics/) |
+[Product documentation](https://docs.microsoft.com/azure/cognitive-services/text-analytics/) |
 [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/textanalytics/ai-text-analytics/samples)
 
 ## Getting started
@@ -39,29 +39,35 @@ If you use the Azure CLI, replace `<your-resource-group-name>` and `<your-resour
 az cognitiveservices account create --kind TextAnalytics --resource-group <your-resource-group-name> --name <your-resource-name>
 ```
 
-### 1. Install the `@azure/ai-text-analytics` package
+### Install the `@azure/ai-text-analytics` package
+
+Install the Azure Text Analytics client library for JavaScript with `npm`:
 
 ```bash
 npm install @azure/ai-text-analytics
 ```
 
-### 2. Create and authenticate a `TextAnalyticsClient`
+### Create and authenticate a `TextAnalyticsClient`
 
-TextAnalytics uses both AAD and API keys for authentication.
+To create a client object to access the Text Analytics API, you will need the `endpoint` of your Text Analytics resource and a `credential`. The Text Analytics client can use either Azure Active Directory credentials or an API key credential to authenticate.
+
+You can find the endpoint for your text analytics resource either in the [Azure Portal][azure_portal] or by using the [Azure CLI][azure_cli] snippet below:
+
+```bash
+az cognitiveservices account show --name <your-resource-name> --resource-group <your-resource-group-name> --query "endpoint"
+```
 
 #### Using an API Key
 
-Use the [Azure CLI][azure_cli] snippet below to get the API key from the Text Analytics resource.
+Use the [Azure Portal][azure_portal] to browse to your Text Analytics resource and retrieve an API key, or use the [Azure CLI][azure_cli] snippet below:
 
-**Note:** Sometimes the API key is referred to as a "subscription key" or "subscription API key".
+**Note:** Sometimes the API key is referred to as a "subscription key" or "subscription API key."
 
 ```PowerShell
 az cognitiveservices account keys list --resource-group <your-resource-group-name> --name <your-resource-name>
 ```
 
-Alternatively, you can get the endpoint and API key from the resource information in the [Azure Portal][azure_portal].
-
-Once you have an API key, you can use it as follows:
+Once you have an API key and endpoint, you can use it as follows:
 
 ```js
 const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
@@ -98,36 +104,298 @@ const client = new TextAnalyticsClient("<endpoint>", new DefaultAzureCredential(
 
 `TextAnalyticsClient` is the primary interface for developers using the Text Analytics client library. It provides asynchronous methods to access a specific use of Text Analytics, such as language detection or key phrase extraction.
 
-### Text Input
+### Input
 
-A **text input**, sometimes called a **document**, is a single unit of input to be analyzed by the predictive models in the Text Analytics service. Operations on `TextAnalyticsClient` take a collection of inputs to be analyzed as a batch.
+A **document** represents a single unit of input to be analyzed by the predictive models in the Text Analytics service. Operations on `TextAnalyticsClient` take a collection of inputs to be analyzed as a batch. The operation methods have overloads that allow the inputs to be represented as strings, or as objects with attached metadata.
 
-### Operation Result
+For example, each document can be passed as a string in an array, e.g.
 
-An operation result, such as `AnalyzeSentimentResult`, is the result of a Text Analytics operation, containing a prediction or predictions about a single text input. An operation's result type also may optionally include information about the input document and how it was processed.
+```typescript
+const documents = [
+  "I hated the movie. It was so slow!",
+  "The movie made it into my top ten favorites.",
+  "What a great movie!"
+];
+```
 
-### Operation Result Collection
+or, if you wish to pass in a per-item document `id` or `language`/`countryHint`, they can be given as a list of `TextDocumentInput` or `DetectLanguageInput` depending on the operation;
 
-An operation result collection, such as `AnalyzeSentimentResultCollection`, is a collection of operation results, where each corresponds to one of the text inputs provided in the input batch. A text input and its result will have the same index in the input and result collections. An operation result collection may optionally include information about the input batch and how it was processed.
+```javascript
+const textDocumentInputs = [
+  { id: "1", language: "en", text: "I hated the movie. It was so slow!" },
+  { id: "2", language: "en", text: "The movie made it into my top ten favorites." },
+  { id: "3", language: "en", text: "What a great movie!" },
+];
+```
 
-### Operation Overloads
+See [service limiations][data_limits] for the input, including document length limits, maximum batch size, and supported text encodings.
 
-For each supported operation, `TextAnalyticsClient` provides method overloads to take a batch of text inputs as strings or a batch of `DetectLanguageInput` or `TextDocumentInput` objects, depending on the operation. Overloads that take an object batches allows callers to give each document a unique ID, or indicate extra metadata such as the langauge the document is written in or the country of origin.
+### Return Value
+
+The return value corresponding to a single document is either a successful result or an error object. Each `TextAnalyticsClient` method returns a heterogeneous array of results and errors that correspond to the inputs by index. A text input and its result will have the same index in the input and result collections. The collection may also optionally include information about the input batch and how it was processed in the `statistics` field.
+
+An __result__, such as `AnalyzeSentimentResult`, is the result of a Text Analytics operation, containing a prediction or predictions about a single text input. An operation's result type also may optionally include information about the input document and how it was processed.
+
+The __error__ object, `TextAnalyticsErrorResult`, indicates that the service encountered an error while processing the document and contains information about the error.
+
+### Document Error Handling
+
+In the collection returned by an operation, errors are distinguished from successful responses by the presence of the `error` property, which contains the inner `TextAnalyticsError` object if an error was encountered. For successful result objects, this property is _always_ `undefined`.
+
+For example, to filter out all errors, you could use the following `filter`:
+
+```javascript
+const results = await client.analyzeSentiment(documents);
+const onlySuccessful = results.filter((result) => result.error === undefined);
+```
+
+__Note__: TypeScript users can benefit from better type-checking of result and error objects if `compilerOptions.strictNullChecks` is set to `true` in their `tsconfig.json` configuration. For example:
+
+```typescript
+const [result] = await client.analyzeSentiment(["Hello world!"]);
+
+if (result.error !== undefined) {
+  // In this if block, TypeScript will be sure that the type of `result` is
+  // `TextAnalyticsError` if compilerOptions.strictNullChecks is enabled in
+  // the tsconfig.json
+
+  console.log(result.error);
+}
+```
 
 ## Examples
 
-### Detect the language of an input string
+### Analyze Sentiment
 
-```js
-const [result] = await client.detectLanguage(["hello world"]);
-console.log(`Primary language detected as ${result.primaryLanguage.name}`);
+Analyze sentiment of text to determine if it is positive, negative, neutral, or mixed, including per-sentence sentiment analysis and confidence scores.
+
+```javascript
+const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
+
+const client = new TextAnalyticsClient(
+  "<endpoint>",
+  new TextAnalyticsApiKeyCredential("<API key>")
+);
+
+const documents = [
+  "I did not like the restaurant. The food was too spicy.",
+  "The restaurant was decorated beautifully. The atmosphere was unlike any other restaurant I've been to.",
+  "The food was yummy. :)"
+]
+
+async function main() {
+  const results = await client.analyzeSentiment(documents);
+
+  for (const result of results) {
+    if (result.error === undefined) {
+      console.log("Overall sentiment:", result.sentiment);
+      console.log("Scores:", result.confidenceScores); 
+    } else {
+      console.error("Encountered an error:", result.error);
+    }
+  }
+}
+
+main();
+```
+
+### Recognize Entities
+
+Rwecognize and categorize entities in text as people, places, organizations, dates/times, quantities, currencies, etc.
+
+The `language` parameter is optional. If it is not specified, the default English model will be used.
+
+```javascript
+const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
+
+const client = new TextAnalyticsClient(
+  "<endpoint>",
+  new TextAnalyticsApiKeyCredential("<API key>")
+);
+
+const documents = [
+  "Microsoft was founded by Bill Gates and Paul Allen.",
+  "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
+  "Jeff bought three dozen eggs because there was a 50% discount."
+];
+
+async function main() {
+  const results = await client.recognizeEntities(documents, "en");
+
+  for (const result of results) {
+    if (result.error === undefined) {
+      console.log(" -- Recognized entities for input", result.id, "--");
+      for (const entity of result.entities) {
+        console.log(entity.text, ":", entity.category, "(Score:", entity.score, ")");
+      }
+    } else {
+      console.error("Encountered an error:", result.error);
+    }
+  }
+}
+
+main();
+```
+
+### Recognize PII Entities
+
+There is a separate endpoint and operation for recognizing Personally Identifiable Information (PII) in text such as Social Security Numbers, bank account information, credit card numbers, etc. Its usage is very similar to the standard entity recognition above:
+
+```javascript
+const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
+
+const client = new TextAnalyticsClient(
+  "<endpoint>",
+  new TextAnalyticsApiKeyCredential("<API key>")
+);
+
+const documents = [
+  "The employee's SSN is 555-55-5555.",
+  "The employee's phone number is (555) 555-5555."
+];
+
+async function main() {
+  const results = await client.recognizePiiEntities(documents, "en");
+
+  for (const result of results) {
+    if (result.error === undefined) {
+      console.log(" -- Recognized PII entities for input", result.id, "--");
+      for (const entity of result.entities) {
+        console.log(entity.text, ":", entity.category, "(Score:", entity.score, ")");
+      }
+    } else {
+      console.error("Encountered an error:", result.error);
+    }
+  }
+}
+
+main();
+```
+
+### Recognize Linked Entities
+
+A "Linked" entity is one that exists in a knowledge base (such as Wikipedia). The `recognizeLinkedEntities` operation can disambiguate entities by determining which entry in a knowledge base they likely refer to (for example, in a piece of text, does the word "Mars" refer to the planet, or to the Roman god of war). Linked entities contain associated URLs to the knowledge base that provides the definition of the entity.
+
+```javascript
+const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
+
+const client = new TextAnalyticsClient(
+  "<endpoint>",
+  new TextAnalyticsApiKeyCredential("<API key>")
+);
+
+const documents = [
+  "Microsoft was founded by Bill Gates and Paul Allen.",
+  "Easter Island, a Chilean territory, is a remote volcanic island in Polynesia.",
+  "I use Azure Functions to develop my product."
+];
+
+async function main() {
+  const results = await client.recognizeLinkedEntities(documents, "en");
+
+  for (const result of results) {
+    if (result.error === undefined) {
+      console.log(" -- Recognized linked entities for input", result.id, "--");
+      for (const entity of result.entities) {
+        console.log(entity.name, "(URL:", entity.url, ", Source:", entity.dataSource, ")");
+        for (const match of entity.matches) {
+          console.log("  Occurrence:", "\"" + match.text + "\"", "(Score:", match.score, ")");
+        }
+      }
+    } else {
+      console.error("Encountered an error:", result.error);
+    }
+  }
+}
+
+main();
+```
+
+### Extract Key Phrases
+
+Key Phrase extraction identifies the main talking points in a document. For example, given input text "The food was delicious and there were wonderful staff", the service returns "food" and "wonderful staff".
+
+```javascript
+const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
+
+const client = new TextAnalyticsClient(
+  "<endpoint>",
+  new TextAnalyticsApiKeyCredential("<API key>")
+);
+
+const documents = [
+  "Redmond is a city in King County, Washington, United States, located 15 miles east of Seattle.",
+  "I need to take my cat to the veterinarian.",
+  "I will travel to South America in the summer."
+];
+
+async function main() {
+  const results = await client.extractKeyPhrases(documents, "en");
+
+  for (const result of results) {
+    if (result.error === undefined) {
+      console.log(" -- Extracted key phrases for input", result.id, "--");
+      console.log(result.keyPhrases)
+    } else {
+      console.error("Encountered an error:", result.error);
+    }
+  }
+}
+
+main();
+```
+
+### Detect Language
+
+Determine the language of a piece of text.
+
+The `countryHint` parameter is optional, but can assist the service in providing correct output if the country of origin is known. If it is not provided, or the value `"none"` is given, then a default model that does not assume a country of origin will be used.
+
+```javascript
+const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");
+
+const client = new TextAnalyticsClient(
+  "<endpoint>",
+  new TextAnalyticsApiKeyCredential("<API key>")
+);
+
+const documents = [
+  "This is written in English.",
+  "Il documento scritto in italiano.",
+  "Dies ist in englischer Sprache verfasst."
+];
+
+async function main() {
+  const results = await client.detectLanguage(documents, "none");
+
+  for (const result of results) {
+    const { primaryLanguage } = result;
+    if (result.error === undefined) {
+      console.log(
+        "Input #",
+        result.id,
+        "identified as",
+        primaryLanguage.name,
+        "( ISO6391:",
+        primaryLanguage.iso6391Name,
+        ", Score:",
+        primaryLanguage.score,
+        ")"
+      );
+    } else {
+      console.error("Encountered an error:", result.error);
+    }
+  }
+}
+
+main();
 ```
 
 ## Troubleshooting
 
 ### Enable logs
 
-You can set the following environment variable to get the debug logs when using this library.
+You can set the following environment variable to see debug logs when using this library.
 
 - Getting debug logs from the Azure TextAnalytics client library
 
@@ -168,6 +436,7 @@ If you'd like to contribute to this library, please read the [contributing guide
 [cognitive_resource]: https://docs.microsoft.com/en-us/azure/cognitive-services/cognitive-services-apis-create-account
 [azure_portal]: https://portal.azure.com
 [azure_identity]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity
-[cognitive_auth]: https://docs.microsoft.com/en-us/azure/cognitive-services/authentication
+[cognitive_auth]: https://docs.microsoft.com/azure/cognitive-services/authentication
 [register_aad_app]: https://docs.microsoft.com/azure/cognitive-services/authentication#assign-a-role-to-a-service-principal
 [defaultazurecredential]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential
+[data_limits]: https://docs.microsoft.com/azure/cognitive-services/text-analytics/overview#data-limits

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -201,7 +201,7 @@ main();
 
 ### Recognize Entities
 
-Rwecognize and categorize entities in text as people, places, organizations, dates/times, quantities, currencies, etc.
+Recognize and categorize entities in text as people, places, organizations, dates/times, quantities, currencies, etc.
 
 The `language` parameter is optional. If it is not specified, the default English model will be used.
 

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -349,7 +349,7 @@ main();
 
 Determine the language of a piece of text.
 
-The `countryHint` parameter is optional, but can assist the service in providing correct output if the country of origin is known. If it is not provided, or the value `"none"` is given, then a default model that does not assume a country of origin will be used.
+The `countryHint` parameter is optional, but can assist the service in providing correct output if the country of origin is known. If provided, it should be set to an ISO-3166 Alpha-2 two-letter country code (such as "us" for the United States or "jp" for Japan) or to the value `"none"`. If the parameter is not provided, or `"none"` is given, then a default US-based model will be used. The default model gives some extra weight to languages that are common in the USA, but is not the same as passing `"us"` for the `countryHint`. If you do not know the country of origin of the document, then the parameter `"none"` should be used or the parameter should be omitted entirely.
 
 ```javascript
 const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -349,7 +349,7 @@ main();
 
 Determine the language of a piece of text.
 
-The `countryHint` parameter is optional, but can assist the service in providing correct output if the country of origin is known. If provided, it should be set to an ISO-3166 Alpha-2 two-letter country code (such as "us" for the United States or "jp" for Japan) or to the value `"none"`. If the parameter is not provided, or `"none"` is given, then a default US-based model will be used. The default model gives some extra weight to languages that are common in the USA, but is not the same as passing `"us"` for the `countryHint`. If you do not know the country of origin of the document, then the parameter `"none"` should be used or the parameter should be omitted entirely.
+The `countryHint` parameter is optional, but can assist the service in providing correct output if the country of origin is known. If provided, it should be set to an ISO-3166 Alpha-2 two-letter country code (such as "us" for the United States or "jp" for Japan) or to the value `"none"`. If the parameter is not provided, then the default `"us"` (United States) model will be used. If you do not know the country of origin of the document, then the parameter `"none"` should be used, and the Text Analytics service will apply a model that is tuned for an unknown country of origin.
 
 ```javascript
 const { TextAnalyticsClient, TextAnalyticsApiKeyCredential } = require("@azure/ai-text-analytics");

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClient.ts
@@ -12,11 +12,11 @@ import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import * as Parameters from "./models/parameters";
-import { TextAnalyticsClientContext } from "./textAnalyticsClientContext";
+import { GeneratedClientContext } from "./generatedClientContext";
 
-class TextAnalyticsClient extends TextAnalyticsClientContext {
+class GeneratedClient extends GeneratedClientContext {
   /**
-   * Initializes a new instance of the TextAnalyticsClient class.
+   * Initializes a new instance of the GeneratedClient class.
    * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
    * https://westus.api.cognitive.microsoft.com).
    * @param credentials Subscription credentials which uniquely identify client subscription.
@@ -36,7 +36,7 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.EntitiesRecognitionGeneralResponse>
    */
-  entitiesRecognitionGeneral(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientEntitiesRecognitionGeneralOptionalParams): Promise<Models.EntitiesRecognitionGeneralResponse>;
+  entitiesRecognitionGeneral(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientEntitiesRecognitionGeneralOptionalParams): Promise<Models.EntitiesRecognitionGeneralResponse>;
   /**
    * @param input Collection of documents to analyze.
    * @param callback The callback
@@ -47,8 +47,8 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  entitiesRecognitionGeneral(input: Models.MultiLanguageBatchInput, options: Models.TextAnalyticsClientEntitiesRecognitionGeneralOptionalParams, callback: coreHttp.ServiceCallback<Models.EntitiesResult>): void;
-  entitiesRecognitionGeneral(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientEntitiesRecognitionGeneralOptionalParams | coreHttp.ServiceCallback<Models.EntitiesResult>, callback?: coreHttp.ServiceCallback<Models.EntitiesResult>): Promise<Models.EntitiesRecognitionGeneralResponse> {
+  entitiesRecognitionGeneral(input: Models.MultiLanguageBatchInput, options: Models.GeneratedClientEntitiesRecognitionGeneralOptionalParams, callback: coreHttp.ServiceCallback<Models.EntitiesResult>): void;
+  entitiesRecognitionGeneral(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientEntitiesRecognitionGeneralOptionalParams | coreHttp.ServiceCallback<Models.EntitiesResult>, callback?: coreHttp.ServiceCallback<Models.EntitiesResult>): Promise<Models.EntitiesRecognitionGeneralResponse> {
     return this.sendOperationRequest(
       {
         input,
@@ -69,7 +69,7 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.EntitiesRecognitionPiiResponse>
    */
-  entitiesRecognitionPii(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientEntitiesRecognitionPiiOptionalParams): Promise<Models.EntitiesRecognitionPiiResponse>;
+  entitiesRecognitionPii(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientEntitiesRecognitionPiiOptionalParams): Promise<Models.EntitiesRecognitionPiiResponse>;
   /**
    * @param input Collection of documents to analyze.
    * @param callback The callback
@@ -80,8 +80,8 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  entitiesRecognitionPii(input: Models.MultiLanguageBatchInput, options: Models.TextAnalyticsClientEntitiesRecognitionPiiOptionalParams, callback: coreHttp.ServiceCallback<Models.EntitiesResult>): void;
-  entitiesRecognitionPii(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientEntitiesRecognitionPiiOptionalParams | coreHttp.ServiceCallback<Models.EntitiesResult>, callback?: coreHttp.ServiceCallback<Models.EntitiesResult>): Promise<Models.EntitiesRecognitionPiiResponse> {
+  entitiesRecognitionPii(input: Models.MultiLanguageBatchInput, options: Models.GeneratedClientEntitiesRecognitionPiiOptionalParams, callback: coreHttp.ServiceCallback<Models.EntitiesResult>): void;
+  entitiesRecognitionPii(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientEntitiesRecognitionPiiOptionalParams | coreHttp.ServiceCallback<Models.EntitiesResult>, callback?: coreHttp.ServiceCallback<Models.EntitiesResult>): Promise<Models.EntitiesRecognitionPiiResponse> {
     return this.sendOperationRequest(
       {
         input,
@@ -100,7 +100,7 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.EntitiesLinkingResponse>
    */
-  entitiesLinking(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientEntitiesLinkingOptionalParams): Promise<Models.EntitiesLinkingResponse>;
+  entitiesLinking(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientEntitiesLinkingOptionalParams): Promise<Models.EntitiesLinkingResponse>;
   /**
    * @param input Collection of documents to analyze.
    * @param callback The callback
@@ -111,8 +111,8 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  entitiesLinking(input: Models.MultiLanguageBatchInput, options: Models.TextAnalyticsClientEntitiesLinkingOptionalParams, callback: coreHttp.ServiceCallback<Models.EntityLinkingResult>): void;
-  entitiesLinking(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientEntitiesLinkingOptionalParams | coreHttp.ServiceCallback<Models.EntityLinkingResult>, callback?: coreHttp.ServiceCallback<Models.EntityLinkingResult>): Promise<Models.EntitiesLinkingResponse> {
+  entitiesLinking(input: Models.MultiLanguageBatchInput, options: Models.GeneratedClientEntitiesLinkingOptionalParams, callback: coreHttp.ServiceCallback<Models.EntityLinkingResult>): void;
+  entitiesLinking(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientEntitiesLinkingOptionalParams | coreHttp.ServiceCallback<Models.EntityLinkingResult>, callback?: coreHttp.ServiceCallback<Models.EntityLinkingResult>): Promise<Models.EntitiesLinkingResponse> {
     return this.sendOperationRequest(
       {
         input,
@@ -132,7 +132,7 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.KeyPhrasesResponse>
    */
-  keyPhrases(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientKeyPhrasesOptionalParams): Promise<Models.KeyPhrasesResponse>;
+  keyPhrases(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientKeyPhrasesOptionalParams): Promise<Models.KeyPhrasesResponse>;
   /**
    * @param input Collection of documents to analyze. Documents can now contain a language field to
    * indicate the text language
@@ -145,8 +145,8 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  keyPhrases(input: Models.MultiLanguageBatchInput, options: Models.TextAnalyticsClientKeyPhrasesOptionalParams, callback: coreHttp.ServiceCallback<Models.KeyPhraseResult>): void;
-  keyPhrases(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientKeyPhrasesOptionalParams | coreHttp.ServiceCallback<Models.KeyPhraseResult>, callback?: coreHttp.ServiceCallback<Models.KeyPhraseResult>): Promise<Models.KeyPhrasesResponse> {
+  keyPhrases(input: Models.MultiLanguageBatchInput, options: Models.GeneratedClientKeyPhrasesOptionalParams, callback: coreHttp.ServiceCallback<Models.KeyPhraseResult>): void;
+  keyPhrases(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientKeyPhrasesOptionalParams | coreHttp.ServiceCallback<Models.KeyPhraseResult>, callback?: coreHttp.ServiceCallback<Models.KeyPhraseResult>): Promise<Models.KeyPhrasesResponse> {
     return this.sendOperationRequest(
       {
         input,
@@ -166,7 +166,7 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.LanguagesResponse>
    */
-  languages(input: Models.LanguageBatchInput, options?: Models.TextAnalyticsClientLanguagesOptionalParams): Promise<Models.LanguagesResponse>;
+  languages(input: Models.LanguageBatchInput, options?: Models.GeneratedClientLanguagesOptionalParams): Promise<Models.LanguagesResponse>;
   /**
    * @param input Collection of documents to analyze.
    * @param callback The callback
@@ -177,8 +177,8 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  languages(input: Models.LanguageBatchInput, options: Models.TextAnalyticsClientLanguagesOptionalParams, callback: coreHttp.ServiceCallback<Models.LanguageResult>): void;
-  languages(input: Models.LanguageBatchInput, options?: Models.TextAnalyticsClientLanguagesOptionalParams | coreHttp.ServiceCallback<Models.LanguageResult>, callback?: coreHttp.ServiceCallback<Models.LanguageResult>): Promise<Models.LanguagesResponse> {
+  languages(input: Models.LanguageBatchInput, options: Models.GeneratedClientLanguagesOptionalParams, callback: coreHttp.ServiceCallback<Models.LanguageResult>): void;
+  languages(input: Models.LanguageBatchInput, options?: Models.GeneratedClientLanguagesOptionalParams | coreHttp.ServiceCallback<Models.LanguageResult>, callback?: coreHttp.ServiceCallback<Models.LanguageResult>): Promise<Models.LanguagesResponse> {
     return this.sendOperationRequest(
       {
         input,
@@ -198,7 +198,7 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.SentimentResponse2>
    */
-  sentiment(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientSentimentOptionalParams): Promise<Models.SentimentResponse2>;
+  sentiment(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientSentimentOptionalParams): Promise<Models.SentimentResponse2>;
   /**
    * @param input Collection of documents to analyze.
    * @param callback The callback
@@ -209,8 +209,8 @@ class TextAnalyticsClient extends TextAnalyticsClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  sentiment(input: Models.MultiLanguageBatchInput, options: Models.TextAnalyticsClientSentimentOptionalParams, callback: coreHttp.ServiceCallback<Models.SentimentResponse>): void;
-  sentiment(input: Models.MultiLanguageBatchInput, options?: Models.TextAnalyticsClientSentimentOptionalParams | coreHttp.ServiceCallback<Models.SentimentResponse>, callback?: coreHttp.ServiceCallback<Models.SentimentResponse>): Promise<Models.SentimentResponse2> {
+  sentiment(input: Models.MultiLanguageBatchInput, options: Models.GeneratedClientSentimentOptionalParams, callback: coreHttp.ServiceCallback<Models.SentimentResponse>): void;
+  sentiment(input: Models.MultiLanguageBatchInput, options?: Models.GeneratedClientSentimentOptionalParams | coreHttp.ServiceCallback<Models.SentimentResponse>, callback?: coreHttp.ServiceCallback<Models.SentimentResponse>): Promise<Models.SentimentResponse2> {
     return this.sendOperationRequest(
       {
         input,
@@ -392,8 +392,8 @@ const sentimentOperationSpec: coreHttp.OperationSpec = {
 };
 
 export {
-  TextAnalyticsClient,
-  TextAnalyticsClientContext,
-  Models as TextAnalyticsModels,
-  Mappers as TextAnalyticsMappers
+  GeneratedClient,
+  GeneratedClientContext,
+  Models as GeneratedModels,
+  Mappers as GeneratedMappers
 };

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
@@ -13,12 +13,12 @@ import * as coreHttp from "@azure/core-http";
 const packageName = "@azure/ai-text-analytics";
 const packageVersion = "1.0.0-preview.3";
 
-export class TextAnalyticsClientContext extends coreHttp.ServiceClient {
+export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;
   credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials;
 
   /**
-   * Initializes a new instance of the TextAnalyticsClientContext class.
+   * Initializes a new instance of the GeneratedClientContext class.
    * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
    * https://westus.api.cognitive.microsoft.com).
    * @param credentials Subscription credentials which uniquely identify client subscription.

--- a/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/models/index.ts
@@ -505,7 +505,7 @@ export interface LanguageResult {
 /**
  * Optional Parameters.
  */
-export interface TextAnalyticsClientEntitiesRecognitionGeneralOptionalParams extends coreHttp.RequestOptionsBase {
+export interface GeneratedClientEntitiesRecognitionGeneralOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * (Optional) This value indicates which model will be used for scoring. If a model-version is
    * not specified, the API should default to the latest, non-preview version.
@@ -520,7 +520,7 @@ export interface TextAnalyticsClientEntitiesRecognitionGeneralOptionalParams ext
 /**
  * Optional Parameters.
  */
-export interface TextAnalyticsClientEntitiesRecognitionPiiOptionalParams extends coreHttp.RequestOptionsBase {
+export interface GeneratedClientEntitiesRecognitionPiiOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * (Optional) This value indicates which model will be used for scoring. If a model-version is
    * not specified, the API should default to the latest, non-preview version.
@@ -535,7 +535,7 @@ export interface TextAnalyticsClientEntitiesRecognitionPiiOptionalParams extends
 /**
  * Optional Parameters.
  */
-export interface TextAnalyticsClientEntitiesLinkingOptionalParams extends coreHttp.RequestOptionsBase {
+export interface GeneratedClientEntitiesLinkingOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * (Optional) This value indicates which model will be used for scoring. If a model-version is
    * not specified, the API should default to the latest, non-preview version.
@@ -550,7 +550,7 @@ export interface TextAnalyticsClientEntitiesLinkingOptionalParams extends coreHt
 /**
  * Optional Parameters.
  */
-export interface TextAnalyticsClientKeyPhrasesOptionalParams extends coreHttp.RequestOptionsBase {
+export interface GeneratedClientKeyPhrasesOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * (Optional) This value indicates which model will be used for scoring. If a model-version is
    * not specified, the API should default to the latest, non-preview version.
@@ -565,7 +565,7 @@ export interface TextAnalyticsClientKeyPhrasesOptionalParams extends coreHttp.Re
 /**
  * Optional Parameters.
  */
-export interface TextAnalyticsClientLanguagesOptionalParams extends coreHttp.RequestOptionsBase {
+export interface GeneratedClientLanguagesOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * (Optional) This value indicates which model will be used for scoring. If a model-version is
    * not specified, the API should default to the latest, non-preview version.
@@ -580,7 +580,7 @@ export interface TextAnalyticsClientLanguagesOptionalParams extends coreHttp.Req
 /**
  * Optional Parameters.
  */
-export interface TextAnalyticsClientSentimentOptionalParams extends coreHttp.RequestOptionsBase {
+export interface GeneratedClientSentimentOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * (Optional) This value indicates which model will be used for scoring. If a model-version is
    * not specified, the API should default to the latest, non-preview version.

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -13,7 +13,7 @@ import {
 } from "@azure/core-http";
 import { TokenCredential } from "@azure/identity";
 import { SDK_VERSION } from "./constants";
-import { TextAnalyticsClient as GeneratedClient } from "./generated/textAnalyticsClient";
+import { GeneratedClient } from "./generated/generatedClient";
 import { logger } from "./logger";
 import {
   LanguageInput as DetectLanguageInput,

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 package-name: "@azure/ai-text-analytics"
-title: TextAnalyticsClient
+title: GeneratedClient
 description: TextAnalytics Client
 generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION


### PR DESCRIPTION
This PR:
- adds more examples showing the usage of the library to the README
- brings the README key concepts in line with newer conceptual copy
- adds the release date to the CHANGELOG
- renames `TextAnalyticsClient` in `src/generated` to `GeneratedClient` in order to avoid a name collision in generated reference documentation