### PR TITLE
[Cosmos] Rollup - throw errors if circular dependencies are present

### DIFF
--- a/sdk/cosmosdb/cosmos/rollup.config.js
+++ b/sdk/cosmosdb/cosmos/rollup.config.js
@@ -30,6 +30,12 @@ export default [
         semaphore: "semaphore"
       }
     },
-    plugins: [resolve()]
+    plugins: [resolve()],
+    onwarn(warning, warn) {
+      if (warning.code === "CIRCULAR_DEPENDENCY") {
+        throw new Error(warning.message);
+      }
+      warn(warning);
+    }
   }
 ];


### PR DESCRIPTION
As @southpolesteve suggested a long time ago.. this PR is to update the rollup config to make it throw errors if circular dependencies are present instead of warnings. 
All the existing circular dependencies have been fixed in https://github.com/Azure/azure-sdk-for-js/pull/5256 and https://github.com/Azure/azure-sdk-for-js/pull/5374. This PR is to make sure we don't regress and introduce new circular dependencies.
