### PR TITLE
Make JS Release Stage Public

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -120,7 +120,7 @@ stages:
                           npm install
                         displayName: Install versioning tool dependencies
                       - bash: |
-                          node ../../../tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
+                          node ./eng/tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
                         displayName: Increment package version
                       - template: ../../../common/pipelines/templates/steps/create-pull-request.yml
                         parameters:

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -54,7 +54,7 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      - checkout: azure-sdk-tools
+                      - checkout: self
                       - script: |
                           export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-*.tgz`
                           echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
@@ -64,7 +64,7 @@ stages:
                         displayName: 'Publish to npmjs.org'
                         inputs:
                           targetType: filePath
-                          filePath: 'scripts/powershell/publish-to-npm.ps1'
+                          filePath: "eng/tools/publish-to-npm.ps1"
                           arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag $(Tag) -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
                           pwsh: true
 
@@ -138,7 +138,7 @@ stages:
       pool:
         vmImage: ubuntu-16.04
       steps:
-        - checkout: azure-sdk-tools
+        - checkout: self
         - download: current
           artifact: ${{parameters.ArtifactName}}
           timeoutInMinutes: 5
@@ -152,5 +152,5 @@ stages:
               displayName: "Publish_${{artifact.safeName}} to npmjs.org"
               inputs:
                 targetType: filePath
-                filePath: "scripts/powershell/publish-to-npm.ps1"
+                filePath: "eng/tools/publish-to-npm.ps1"
                 arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag "dev" -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -120,7 +120,7 @@ stages:
                           npm install
                         displayName: Install versioning tool dependencies
                       - bash: |
-                          node ./eng/tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
+                          node ../../../tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
                         displayName: Increment package version
                       - template: ../../../common/pipelines/templates/steps/create-pull-request.yml
                         parameters:

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -73,6 +73,7 @@ stages:
               displayName: Publish Docs to GitHubIO Blob Storage
               condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
               environment: githubio
+              dependsOn: PublishPackage
 
               pool:
                 vmImage: windows-2019
@@ -107,6 +108,7 @@ stages:
               displayName: "Update Package Version"
               condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
               environment: github
+              dependsOn: PublishPackage
 
               pool:
                 vmImage: ubuntu-16.04

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -108,7 +108,6 @@ stages:
               displayName: "Update Package Version"
               condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
               environment: github
-              dependsOn: PublishPackage
 
               pool:
                 vmImage: ubuntu-16.04

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -108,6 +108,7 @@ stages:
               displayName: "Update Package Version"
               condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
               environment: github
+              dependsOn: PublishPackage
 
               pool:
                 vmImage: ubuntu-16.04

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -1,0 +1,158 @@
+parameters:
+  Artifacts: []
+  ArtifactName: 'not-specified'
+  DependsOn: Build
+  Registry: 'https://registry.npmjs.org/'
+  DocArtifact: 'documentation'
+
+stages:
+  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+    - ${{ each artifact in parameters.Artifacts }}:
+      - stage: Release_${{artifact.safeName}}
+        displayName: 'Release: ${{artifact.name}}'
+        dependsOn: ${{parameters.DependsOn}}
+        condition: and(succeeded(), ne(variables['SetDevVersion'], 'true'), ne(variables['Skip.Release'], 'true'), ne(variables['Build.Repository.Name'], 'Azure/azure-sdk-for-js-pr'))
+        jobs:
+          - deployment: TagRepository
+            displayName: "Create release tag"
+            condition: ne(variables['Skip.TagRepository'], 'true')
+            environment: github
+
+            pool:
+              vmImage: ubuntu-16.04
+
+            strategy:
+              runOnce:
+                deploy:
+                  steps:
+                    - checkout: none
+                    - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                    - pwsh: |
+                        Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}
+                        New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
+                        Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/${{artifact.safeName}}
+                        Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
+                      displayName: Stage artifacts
+                    - pwsh: |
+                        $(Pipeline.Workspace)/azure-sdk-build-tools/scripts/create-tags-and-git-release.ps1 -artifactLocation $(Pipeline.Workspace)/${{artifact.safeName}} -packageRepository Npm -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Name) -workingDirectory $(System.DefaultWorkingDirectory)
+                      displayName: 'Verify Package Tags and Create Git Releases'
+                      env:
+                        GH_TOKEN: $(azuresdk-github-pat)
+
+          - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
+            - deployment: PublishPackage
+              displayName: "Publish to npmjs"
+              condition: and(succeeded(), ne(variables['Skip.PublishPackage'], 'true'))
+              environment: npm
+              dependsOn: TagRepository
+
+              pool:
+                vmImage: ubuntu-16.04
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - script: |
+                          export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-*.tgz`
+                          echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
+                        displayName: Detecting package archive
+
+                      - task: PowerShell@2
+                        displayName: 'Publish to npmjs.org'
+                        inputs:
+                          targetType: filePath
+                          filePath: '$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/publish-to-npm.ps1'
+                          arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag $(Tag) -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
+                          pwsh: true
+
+          - ${{if ne(artifact.options.skipPublishDocs, 'true')}}:
+            - deployment: PublishDocs
+              displayName: Publish Docs to GitHubIO Blob Storage
+              condition: and(succeeded(), ne(variables['Skip.PublishDocs'], 'true'))
+              environment: githubio
+
+              pool:
+                vmImage: windows-2019
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: none
+                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - pwsh: |
+                          $transformedArtifact = "${{artifact.name}}".Replace("azure-", "")
+                          $artifactLocation = "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/$($transformedArtifact).zip"
+                          New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
+                          New-Item -Type Directory -Name ${{parameters.DocArtifact}} -Path $(Pipeline.Workspace)/${{artifact.safeName}}
+                          Copy-Item  $artifactLocation $(Pipeline.Workspace)/${{artifact.safeName}}/${{parameters.DocArtifact}}
+                        displayName: Stage artifacts
+                      - pwsh: |
+                          Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
+                        workingDirectory: $(Pipeline.Workspace)
+                        displayName: Output Visible Artifacts
+                      - template: ../../tools/generic-blob-upload/publish-blobs.yml
+                        parameters:
+                          FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
+                          BlobSASKey: '$(azure-sdk-docs-prod-sas)'
+                          BlobName: '$(azure-sdk-docs-prod-blob-name)'
+                          TargetLanguage: 'javascript'
+                          # we override the regular script path because we have cloned the build tools repo as a separate artifact.
+                          ScriptPath: '$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/copy-docs-to-blobstorage.ps1'
+
+          - ${{if ne(artifact.options.skipUpdatePackageVersion, 'true')}}:
+            - deployment: UpdatePackageVersion
+              displayName: "Update Package Version"
+              condition: and(succeeded(), ne(variables['Skip.UpdatePackageVersion'], 'true'))
+              environment: github
+
+              pool:
+                vmImage: ubuntu-16.04
+
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                      - checkout: self
+                      - bash: |
+                          npm install
+                        displayName: Install versioning tool dependencies
+                      - bash: |
+                          node ./eng/tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
+                        displayName: Increment package version
+                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - template: ../steps/create-pull-request.yml
+                        parameters:
+                          RepoName: azure-sdk-for-js
+                          PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
+                          CommitMsg: "Increment package version after release of ${{ artifact.name }}"
+                          PRTitle: "Increment version for ${{ parameters.ServiceDirectory }} releases"
+
+  - stage: Integration
+    dependsOn: ${{parameters.DependsOn}}
+    jobs:
+    - job: PublishPackages
+      condition: or(eq(variables['SetDevVersion'], 'true'), and(eq(variables['Build.Reason'],'Schedule'), eq(variables['System.TeamProject'], 'internal')))
+      displayName: Publish package to daily feed
+      pool:
+        vmImage: ubuntu-16.04
+      steps:
+        - checkout: none
+        - template: ../../tools/clone-buildtools/clone-buildtools.yml
+        - download: current
+          artifact: ${{parameters.ArtifactName}}
+          timeoutInMinutes: 5
+        - ${{ each artifact in parameters.Artifacts }}:
+            - script: |
+                export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-*-dev*.tgz`
+                echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
+              displayName: Detecting package archive_${{artifact.safeName}}
+
+            - task: PowerShell@2
+              displayName: "Publish_${{artifact.safeName}} to npmjs.org"
+              inputs:
+                targetType: filePath
+                filePath: "$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/publish-to-npm.ps1"
+                arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag "dev" -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -25,19 +25,20 @@ stages:
               runOnce:
                 deploy:
                   steps:
-                    - checkout: none
-                    - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                    - checkout: self
                     - pwsh: |
                         Get-ChildItem $(Pipeline.Workspace)/${{parameters.ArtifactName}}
                         New-Item -Type Directory -Name ${{artifact.safeName}} -Path $(Pipeline.Workspace)
                         Copy-Item $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-[0-9]*.[0-9]*.[0-9]* $(Pipeline.Workspace)/${{artifact.safeName}}
                         Get-ChildItem $(Pipeline.Workspace)/${{artifact.safeName}}
                       displayName: Stage artifacts
-                    - pwsh: |
-                        $(Pipeline.Workspace)/azure-sdk-build-tools/scripts/create-tags-and-git-release.ps1 -artifactLocation $(Pipeline.Workspace)/${{artifact.safeName}} -packageRepository Npm -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Name) -workingDirectory $(System.DefaultWorkingDirectory)
-                      displayName: 'Verify Package Tags and Create Git Releases'
-                      env:
-                        GH_TOKEN: $(azuresdk-github-pat)
+                    - template: ../../../common/pipelines/templates/steps/create-tags-and-git-release.yml
+                      parameters:
+                        ArtifactLocation: $(Pipeline.Workspace)/${{artifact.safeName}}
+                        PackageRepository: Npm
+                        ReleaseSha: $(Build.SourceVersion)
+                        RepoId: Azure/azure-sdk-for-js
+                        WorkingDirectory: $(System.DefaultWorkingDirectory)
 
           - ${{if ne(artifact.options.skipPublishPackage, 'true')}}:
             - deployment: PublishPackage
@@ -53,7 +54,7 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - checkout: azure-sdk-tools
                       - script: |
                           export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/${{parameters.ArtifactName}}/${{artifact.name}}-*.tgz`
                           echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
@@ -63,7 +64,7 @@ stages:
                         displayName: 'Publish to npmjs.org'
                         inputs:
                           targetType: filePath
-                          filePath: '$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/publish-to-npm.ps1'
+                          filePath: 'scripts/powershell/publish-to-npm.ps1'
                           arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag $(Tag) -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'
                           pwsh: true
 
@@ -80,8 +81,7 @@ stages:
                 runOnce:
                   deploy:
                     steps:
-                      - checkout: none
-                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
+                      - checkout: self
                       - pwsh: |
                           $transformedArtifact = "${{artifact.name}}".Replace("azure-", "")
                           $artifactLocation = "$(Pipeline.Workspace)/${{parameters.DocArtifact}}/$($transformedArtifact).zip"
@@ -93,14 +93,14 @@ stages:
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)
                         displayName: Output Visible Artifacts
-                      - template: ../../tools/generic-blob-upload/publish-blobs.yml
+                      - template: ../../../common/pipelines/templates/steps/publish-blobs.yml
                         parameters:
                           FolderForUpload: '$(Pipeline.Workspace)/${{artifact.safeName}}'
                           BlobSASKey: '$(azure-sdk-docs-prod-sas)'
                           BlobName: '$(azure-sdk-docs-prod-blob-name)'
                           TargetLanguage: 'javascript'
                           # we override the regular script path because we have cloned the build tools repo as a separate artifact.
-                          ScriptPath: '$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/copy-docs-to-blobstorage.ps1'
+                          ScriptPath: 'eng/common/scripts/copy-docs-to-blobstorage.ps1'
 
           - ${{if ne(artifact.options.skipUpdatePackageVersion, 'true')}}:
             - deployment: UpdatePackageVersion
@@ -122,8 +122,7 @@ stages:
                       - bash: |
                           node ./eng/tools/versioning/increment.js --artifact-name ${{ artifact.name }} --repo-root .
                         displayName: Increment package version
-                      - template: ../../tools/clone-buildtools/clone-buildtools.yml
-                      - template: ../steps/create-pull-request.yml
+                      - template: ../../../common/pipelines/templates/steps/create-pull-request.yml
                         parameters:
                           RepoName: azure-sdk-for-js
                           PRBranchName: increment-package-version-${{ parameters.ServiceDirectory }}-$(Build.BuildId)
@@ -139,8 +138,7 @@ stages:
       pool:
         vmImage: ubuntu-16.04
       steps:
-        - checkout: none
-        - template: ../../tools/clone-buildtools/clone-buildtools.yml
+        - checkout: azure-sdk-tools
         - download: current
           artifact: ${{parameters.ArtifactName}}
           timeoutInMinutes: 5
@@ -154,5 +152,5 @@ stages:
               displayName: "Publish_${{artifact.safeName}} to npmjs.org"
               inputs:
                 targetType: filePath
-                filePath: "$(Pipeline.Workspace)/azure-sdk-build-tools/scripts/publish-to-npm.ps1"
+                filePath: "scripts/powershell/publish-to-npm.ps1"
                 arguments: '-pathToArtifacts $(Package.Archive) -accessLevel "public" -tag "dev" -additionalTag "$(AdditionalTag)" -registry ${{parameters.Registry}} -npmToken $(azure-sdk-npm-token)'

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -13,7 +13,7 @@ stages:
 
 # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
 - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq(parameters.IncludeRelease,true))}}:
-  - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
+  - template: archetype-js-release.yml
     parameters:
       DependsOn: Build
       ServiceDirectory: ${{parameters.ServiceDirectory}}

--- a/eng/tools/publish-to-npm.ps1
+++ b/eng/tools/publish-to-npm.ps1
@@ -1,0 +1,142 @@
+param (
+  $pathToArtifacts,
+  $accessLevel,
+  $tag,
+  $additionalTag="",
+  $registry,
+  $npmToken,
+  $filterArg="",
+  $basicDeployment=$false
+)
+
+function replaceText($oldText,$newText,$filePath){
+    $content = Get-Content -Path $filePath
+    $newContent = $content -replace $oldText,$newText
+    if((-join $newContent) -ne (-join $content)){
+        Set-Content -Path $filePath -Value $newContent
+        Write-Host "replaceText [$oldText] [$newText] [$filePath]"
+    }
+}
+
+function updateContents($dirName, $version){
+    foreach ($md in $(dir $dirName -r -i *.md)){
+        replaceText "https://github.com/Azure/azure-sdk-for-js/tree/[^/]*" "" $md.Fullname
+    }
+    foreach ($file in $(dir $dirName -r -i *.js,*.ts,*.json)){
+        replaceText $version "VERSION_REMOVED" $file.Fullname
+    }
+}
+
+function extractPackage($package) {
+    $packageDir = Split-Path $package
+    $extractPackageDir = Join-Path $packageDir $package.BaseName
+    $devDir = "${extractPackageDir}-toPublishDev"
+    $lastDevDirTgz = "${extractPackageDir}-lastDevTgz"
+    $lastDevDir = "${extractPackageDir}-lastDev"
+    New-Item -ItemType "directory" -Path $devDir | out-null
+    pushd $devDir
+    tar -xzf $package.FullName
+    $json = Get-Content "./package/package.json" | Out-String | ConvertFrom-Json
+    $name = $json.name
+    $devVersion = $json.version
+    popd
+    $publish = $true
+    if ($tag -eq "dev")
+    {
+        mkdir $lastDevDirTgz
+        pushd $lastDevDirTgz
+        #npm pack downloads targz from npm
+        npm pack $name@dev | out-null
+        if($LastExitCode -eq 0){
+            $q = dir $lastDevDirTgz -r -i *.tgz
+            popd
+            New-Item -ItemType "directory" -Path $lastDevDir | out-null
+            pushd $lastDevDir
+            tar -xzf $q.Fullname
+            $lastDevJson = Get-Content "./package/package.json" | Out-String | ConvertFrom-Json
+            $lastDevVersion = $lastDevJson.version
+            popd
+            updateContents $devDir $devVersion
+            updateContents $lastDevDir $lastDevVersion
+            $publish = containsProductCodeDiff $devDir $lastDevDir
+        }
+    }
+
+    return new-object PSObject -Property @{
+        Project = $json;
+        TarGz = $package;
+        Publish = $publish
+    }
+}
+
+function containsProductCodeDiff($currentDevPackage,$lastDevPackage) {
+    $diffFile = "Change.diff"
+    git diff --output=$diffFile --exit-code $lastDevPackage $currentDevPackage
+    Write-Host "Exit code for git diff = $LastExitCode"
+    if($LastExitCode -ne 0) {
+        Write-Host "There were differences in the two packages - saved in $diffFile"
+        Write-Host "Contents of $diffFile"
+        Get-Content -Path $diffFile | % { Write-Host $_ }
+        return $true
+    }
+    return $false
+}
+
+try {
+    $regAuth=$registry.replace("https:","")
+    $filterPackageList= $filterArg -split "," | % { return $_.trim() }
+    $packageList = @()
+    #We need to run the npm pack before we set NPM_TOKEN in npmrc so that the npmrc file is in default (empty) state
+    foreach ($p in $(dir $pathToArtifacts -r -i *.tgz)) {
+        foreach($filterItem in $filterPackageList) {
+            if($p.BaseName.contains($filterItem)) {
+                $packageList += extractPackage $p
+            }
+        }
+    }
+
+    if(!$basicDeployment) {
+        Write-Host "Choosing AuthToken Deployment"
+        $env:NPM_TOKEN=$npmToken
+        npm config set $regAuth`:_authToken=`$`{NPM_TOKEN`}
+    }
+    else {
+        Write-Host "Choosing BasicAuth Deployment"
+        npm config set $regAuth`:username=pat_will_be_used
+        npm config set $regAuth`:_password=$npmToken
+        npm config set $regAuth`:email=not_set
+    }
+
+    foreach ($p in $packageList) {
+        if($p.Publish) {
+            Write-Host "npm publish $($p.TarGz) --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag"
+            npm publish $p.TarGz --access=$accessLevel --registry=$registry --always-auth=true --tag=$tag
+            if ($LastExitCode -ne 0) {
+                Write-Host "npm publish failed with exit code $LastExitCode"
+                exit 1
+            }
+            $addTagCheck = 0
+            if(($additionalTag) -and ($additionalTag -ne $tag)) {
+                $nameAndVersion = $p.Project.name + "@" + $p.Project.version
+                Write-Host "npm dist-tag add $($nameAndVersion) $additionalTag"
+                npm dist-tag add $nameAndVersion $additionalTag
+                $addTagCheck = $LastExitCode
+            }
+            if ($addTagCheck -ne 0) {
+                Write-Host "npm dist-tag add failed with exit code $addTagCheck"
+                exit 1
+            }
+        }
+        else{
+            Write-Host "Skipping package publish $($p.TarGz)"
+        }
+    }
+}
+finally
+{
+    npm config delete $regAuth`:_authToken
+    npm config delete $regAuth`:_password
+    npm config delete $regAuth`:email
+    npm config delete $regAuth`:username
+    $env:NPM_TOKEN=""
+}

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -11,6 +11,7 @@ resources:
       type: github
       name: Azure/azure-sdk-tools
       endpoint: azure
+      ref: refs/heads/MakingToolsOpenSource
 
 trigger:
   branches:

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Release History
 
-## 1.0.5 (Unreleased)
+## 1.0.6 (2020-03-26)
+- Test Release Pipeline
 
+## 1.0.5 (2020-03-25)
+- Test Release Pipeline
 
-## 1.0.4 (Unreleased)
+## 1.0.4 (2020-03-245
+- Test Release Pipeline
 
-
-## 1.0.3 (Unreleased)
-
+## 1.0.3 (2020-03-24)
+- Test Release Pipeline
 
 ## 1.0.2 (2020-03-24)
 - Test Release Pipeline

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.3 (Unreleased)
+
+
 ## 1.0.2 (2020-03-24)
 - Test Release Pipeline
 

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Release History
 
+## 1.0.2 (2020-03-24)
+- Test Release Pipeline
+
+
 ## 1.0.1 (2020-03-24)
 - Test Release Pipeline

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Release History
+
+## 1.0.1 (2020-03-24)
+- Test Release Pipeline

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.4 (Unreleased)
+
+
 ## 1.0.3 (Unreleased)
 
 

--- a/sdk/template/template/CHANGELOG.md
+++ b/sdk/template/template/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.0.5 (Unreleased)
+
+
 ## 1.0.4 (Unreleased)
 
 

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/template",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Template Library with typescript type definitions for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",


### PR DESCRIPTION
Move archetype-js-release.yml into the public repo.
Add dependsOn: PublishPackage for PublishDocs and UpdatePackageVersion deployments.

This PR Depends on https://github.com/Azure/azure-sdk-tools/pull/439