### PR TITLE
[event-hubs] receiver redirect

### DIFF
--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -145,9 +145,9 @@ export module ConnectionContextBase {
     const connectionOptions: ConnectionOptions = {
       transport: Constants.TLS,
       host: parameters.config.host,
-      hostname: parameters.config.host,
+      hostname: parameters.config.hostname ?? parameters.config.host,
       username: parameters.config.sharedAccessKeyName,
-      port: 5671,
+      port: parameters.config.port ?? 5671,
       reconnect: false,
       properties: {
         product: parameters.connectionProperties.product,

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -32,6 +32,14 @@ export interface ConnectionConfig {
    */
   host: string;
   /**
+   * @property {string} hostname - The hostname "<yournamespace>.servicebus.windows.net".
+   */
+  hostname?: string;
+  /**
+   * The port number.
+   */
+  port?: number;
+  /**
    * @property {string} connectionString - The connection string.
    */
   connectionString: string;

--- a/sdk/eventhub/event-hubs/src/EventHubClientManager.ts
+++ b/sdk/eventhub/event-hubs/src/EventHubClientManager.ts
@@ -1,0 +1,300 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+  GetPartitionPropertiesOptions,
+  GetEventHubPropertiesOptions,
+  GetPartitionIdsOptions,
+  EventHubConsumerClientOptions
+} from "./models/public";
+import { TokenCredential } from "@azure/identity";
+import {
+  isTokenCredential,
+  parseConnectionString,
+  EventHubConnectionStringModel,
+  EventHubConnectionConfig,
+  SharedKeyCredential,
+  ConnectionConfig
+} from "@azure/core-amqp";
+import { ConnectionContext, ConnectionContextOptions } from "./connectionContext";
+import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
+import { EventHubProperties } from "./managementClient";
+import { EventHubProducerOptions } from "./models/private";
+import { EventHubProducer } from "./sender";
+import { EventPosition } from "./eventPosition";
+import { EventHubConsumerOptions } from "./impl/eventHubClient";
+import { EventHubConsumer } from "./receiver";
+
+// Should have the same public API as EventHubClient
+export class EventHubClientManager {
+  public static readonly defaultConsumerGroupName = "$default";
+  public readonly eventHubName: string;
+  public readonly fullyQualifiedNamespace: string;
+
+  private readonly _clientOptions: ConnectionContextOptions;
+  private readonly _connectionConfig: EventHubConnectionConfig;
+  private readonly _credential: SharedKeyCredential | TokenCredential;
+  private readonly _redirectEnabled: boolean = false;
+  private readonly _coreConnectionContext: ConnectionContext;
+  private readonly _hostConnectionContextMap: Map<string, ConnectionContext> = new Map();
+
+  private readonly _connectionProvider = ({
+    host,
+    hostname,
+    port,
+    address
+  }: {
+    hostname: string;
+    host: string;
+    port: number;
+    address: string;
+  }): ConnectionContext => {
+    if (hostname === "") {
+      return this._coreConnectionContext;
+    }
+
+    const key = `${host}:${port}`;
+
+    // Check if a connection already exists.
+    let connectionContext = this._hostConnectionContextMap.get(key);
+    if (connectionContext) {
+      return connectionContext;
+    }
+
+    const config = EventHubConnectionConfig.createFromConnectionConfig({
+      ...this._connectionConfig,
+      host,
+      hostname,
+      port
+    });
+    config.getReceiverAddress = (partitionId: string, consumerGroup?: string) => {
+      return address;
+    };
+    (config as any).name = address;
+    connectionContext = ConnectionContext.create(config, this._credential, this._clientOptions);
+
+    this._hostConnectionContextMap.set(key, connectionContext);
+    return connectionContext;
+  };
+
+  constructor(connectionString: string, options?: EventHubConsumerClientOptions);
+  constructor(
+    connectionString: string,
+    eventHubName: string,
+    options?: EventHubConsumerClientOptions
+  );
+  constructor(
+    host: string,
+    eventHubName: string,
+    credential: TokenCredential,
+    options?: EventHubConsumerClientOptions
+  );
+  constructor(
+    hostOrConnectionString: string,
+    eventHubNameOrOptions?: string | EventHubConsumerClientOptions,
+    credentialOrOptions?: TokenCredential | EventHubConsumerClientOptions,
+    options?: EventHubConsumerClientOptions
+  ) {
+    let config: EventHubConnectionConfig;
+    let credential: TokenCredential | SharedKeyCredential;
+
+    if (!isTokenCredential(credentialOrOptions)) {
+      const connectionString = hostOrConnectionString;
+      const connectionStringProps = parseConnectionString<EventHubConnectionStringModel>(
+        connectionString
+      );
+      if (!connectionStringProps.EntityPath && typeof eventHubNameOrOptions !== "string") {
+        throw new TypeError(
+          `Either provide "eventHubName" or the "connectionString" must contain "EntityPath=<your-event-hub-name>".`
+        );
+      }
+
+      if (
+        connectionStringProps.EntityPath &&
+        typeof eventHubNameOrOptions === "string" &&
+        connectionStringProps.EntityPath !== eventHubNameOrOptions
+      ) {
+        throw new TypeError(
+          `The entity path "${connectionStringProps.EntityPath}" in the connectionString does not match with the provided eventHubName "${eventHubNameOrOptions}".`
+        );
+      }
+
+      if (typeof eventHubNameOrOptions !== "string") {
+        config = EventHubConnectionConfig.create(connectionString);
+        options = eventHubNameOrOptions;
+      } else {
+        config = EventHubConnectionConfig.create(connectionString, eventHubNameOrOptions);
+        options = credentialOrOptions;
+      }
+
+      credential = new SharedKeyCredential(config.sharedAccessKeyName, config.sharedAccessKey);
+    } else {
+      const eventHubName = eventHubNameOrOptions;
+      let host = hostOrConnectionString;
+      credential = credentialOrOptions;
+      if (!eventHubName) {
+        throw new TypeError(`"eventHubName" is missing.`);
+      }
+      if (!host.endsWith("/")) {
+        host += "/";
+      }
+      const connectionString = `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;SharedAccessKey=defaultKeyValue;EntityPath=${eventHubName}`;
+      config = EventHubConnectionConfig.create(connectionString);
+    }
+
+    ConnectionConfig.validate(config);
+
+    if (options?.enableRedirects) {
+      this._redirectEnabled = options.enableRedirects;
+    }
+    this._clientOptions = options ?? {};
+    this._connectionConfig = config;
+    this._credential = credential;
+    this.eventHubName = config.entityPath;
+    this.fullyQualifiedNamespace = config.host;
+    this._coreConnectionContext = ConnectionContext.create(
+      this._connectionConfig,
+      this._credential,
+      this._clientOptions
+    );
+  }
+
+  createConsumer(
+    consumerGroup: string,
+    partitionId: string,
+    eventPosition: EventPosition,
+    options: EventHubConsumerOptions = {}
+  ): EventHubConsumer {
+    if (!options.retryOptions) {
+      options.retryOptions = this._clientOptions.retryOptions;
+    }
+
+    // Always use the core context for receiver APIs
+    const connectionContext = this._coreConnectionContext;
+    throwErrorIfConnectionClosed(connectionContext);
+    throwTypeErrorIfParameterMissing(
+      connectionContext.connectionId,
+      "createConsumer",
+      "consumerGroup",
+      consumerGroup
+    );
+    throwTypeErrorIfParameterMissing(
+      connectionContext.connectionId,
+      "createConsumer",
+      "partitionId",
+      partitionId
+    );
+    throwTypeErrorIfParameterMissing(
+      connectionContext.connectionId,
+      "createConsumer",
+      "eventPosition",
+      eventPosition
+    );
+    // ensure partition id is a string
+    partitionId = String(partitionId);
+
+    const redirectSettings: EventHubConsumerOptions["redirectSettings"] = {
+      enabled: this._redirectEnabled,
+      connectionProvider: this._redirectEnabled ? this._connectionProvider : undefined
+    };
+
+    return new EventHubConsumer(connectionContext, consumerGroup, partitionId, eventPosition, {
+      ...options,
+      redirectSettings
+    });
+  }
+
+  createProducer(options: EventHubProducerOptions = {}): EventHubProducer {
+    if (!options.retryOptions) {
+      options.retryOptions = this._clientOptions.retryOptions;
+    }
+
+    // Always use the core context for sender APIs
+    const connectionContext = this._coreConnectionContext;
+    throwErrorIfConnectionClosed(connectionContext);
+    return new EventHubProducer(
+      this.eventHubName,
+      this._connectionConfig.endpoint,
+      this._coreConnectionContext,
+      options
+    );
+  }
+
+  async getPartitionIds(options: GetPartitionIdsOptions = {}): Promise<Array<string>> {
+    // Always use the core context for management APIs
+    const connectionContext = this._coreConnectionContext;
+    throwErrorIfConnectionClosed(connectionContext);
+
+    const runtimeInfo = await this.getProperties(options);
+    return runtimeInfo.partitionIds;
+  }
+
+  getProperties(options: GetEventHubPropertiesOptions = {}): Promise<EventHubProperties> {
+    // Always use the core context for management APIs
+    const connectionContext = this._coreConnectionContext;
+    throwErrorIfConnectionClosed(connectionContext);
+
+    const managementSession = connectionContext.managementSession;
+    if (!managementSession) {
+      throw new Error(`Unable to create a management session for the connection.`);
+    }
+
+    return managementSession.getHubRuntimeInformation({
+      retryOptions: this._clientOptions.retryOptions,
+      abortSignal: options.abortSignal
+    });
+  }
+
+  getPartitionProperties(partitionId: string, options: GetPartitionPropertiesOptions = {}) {
+    // Always use the core context for management APIs
+    const connectionContext = this._coreConnectionContext;
+    throwErrorIfConnectionClosed(connectionContext);
+    throwTypeErrorIfParameterMissing(
+      connectionContext.connectionId,
+      "getPartitionProperties",
+      "partitionId",
+      partitionId
+    );
+
+    // ensure partition id is a string
+    partitionId = String(partitionId);
+    const managementSession = connectionContext.managementSession;
+    if (!managementSession) {
+      throw new Error(`Unable to create a management session for the connection.`);
+    }
+
+    return managementSession.getPartitionProperties(partitionId, {
+      retryOptions: this._clientOptions.retryOptions,
+      abortSignal: options.abortSignal
+    });
+  }
+
+  async close(): Promise<void> {
+    return this._close(this._coreConnectionContext);
+  }
+
+  private async _close(context: ConnectionContext): Promise<void> {
+    try {
+      if (!context.connection.isOpen()) {
+        return;
+      }
+      // close all senders
+      for (const senderName of Object.keys(context.senders)) {
+        await context.senders[senderName].close();
+      }
+      // close all receievers
+      for (const receiverName of Object.keys(context.receivers)) {
+        await context.receivers[receiverName].close();
+      }
+      // close cbs session
+      await context.cbsSession.close();
+      // close management session
+      await context.managementSession?.close();
+      await context.connection.close();
+      context.wasConnectionCloseCalled = true;
+    } catch (err) {
+      err = err instanceof Error ? err : JSON.stringify(err);
+      throw err;
+    }
+  }
+}

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { EventHubClient } from "./impl/eventHubClient";
+import { EventHubClientManager as EventHubClient } from "./EventHubClientManager";
 import {
   EventHubClientOptions,
   GetPartitionPropertiesOptions,
   GetEventHubPropertiesOptions,
-  GetPartitionIdsOptions
+  GetPartitionIdsOptions,
+  EventHubConsumerClientOptions
 } from "./models/public";
 import { InMemoryCheckpointStore } from "./inMemoryCheckpointStore";
 import { EventProcessor, CheckpointStore, FullEventProcessorOptions } from "./eventProcessor";
@@ -119,7 +120,7 @@ export class EventHubConsumerClient {
     consumerGroup: string,
     connectionString: string,
     checkpointStore: CheckpointStore,
-    options?: EventHubClientOptions
+    options?: EventHubConsumerClientOptions
   ); // #1.1
   /**
    * @constructor
@@ -140,7 +141,7 @@ export class EventHubConsumerClient {
     consumerGroup: string,
     connectionString: string,
     eventHubName: string,
-    options?: EventHubClientOptions
+    options?: EventHubConsumerClientOptions
   ); // #2
   /**
    * @constructor
@@ -165,7 +166,7 @@ export class EventHubConsumerClient {
     connectionString: string,
     eventHubName: string,
     checkpointStore: CheckpointStore,
-    options?: EventHubClientOptions
+    options?: EventHubConsumerClientOptions
   ); // #2.1
   /**
    * @constructor
@@ -188,7 +189,7 @@ export class EventHubConsumerClient {
     fullyQualifiedNamespace: string,
     eventHubName: string,
     credential: TokenCredential,
-    options?: EventHubClientOptions
+    options?: EventHubConsumerClientOptions
   ); // #3
   /**
    * @constructor
@@ -215,24 +216,27 @@ export class EventHubConsumerClient {
     eventHubName: string,
     credential: TokenCredential,
     checkpointStore: CheckpointStore,
-    options?: EventHubClientOptions
+    options?: EventHubConsumerClientOptions
   ); // #3.1
   constructor(
     private _consumerGroup: string,
     connectionStringOrFullyQualifiedNamespace2: string,
-    checkpointStoreOrEventHubNameOrOptions3?: CheckpointStore | EventHubClientOptions | string,
+    checkpointStoreOrEventHubNameOrOptions3?:
+      | CheckpointStore
+      | EventHubConsumerClientOptions
+      | string,
     checkpointStoreOrCredentialOrOptions4?:
       | CheckpointStore
-      | EventHubClientOptions
+      | EventHubConsumerClientOptions
       | TokenCredential,
-    checkpointStoreOrOptions5?: CheckpointStore | EventHubClientOptions,
-    options6?: EventHubClientOptions
+    checkpointStoreOrOptions5?: CheckpointStore | EventHubConsumerClientOptions,
+    options6?: EventHubConsumerClientOptions
   ) {
     if (isTokenCredential(checkpointStoreOrCredentialOrOptions4)) {
       // #3 or 3.1
       logger.info("Creating EventHubConsumerClient with TokenCredential.");
 
-      let eventHubClientOptions: EventHubClientOptions | undefined;
+      let eventHubClientOptions: EventHubConsumerClientOptions | undefined;
 
       if (isCheckpointStore(checkpointStoreOrOptions5)) {
         // 3.1
@@ -516,7 +520,7 @@ export class EventHubConsumerClient {
   ) {
     return new EventProcessor(
       consumerGroup,
-      eventHubClient,
+      eventHubClient as any,
       subscriptionEventHandlers,
       checkpointStore,
       options

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -3,7 +3,7 @@
 
 import { isTokenCredential, TokenCredential } from "@azure/core-amqp";
 import { EventDataBatch } from "./eventDataBatch";
-import { EventHubClient } from "./impl/eventHubClient";
+import { EventHubClientManager as EventHubClient } from "./EventHubClientManager";
 import { EventHubProperties, PartitionProperties } from "./managementClient";
 import { EventHubProducer } from "./sender";
 import {

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -601,6 +601,11 @@ export class EventHubReceiver extends LinkEntity {
         options.onSessionClose || ((context: EventContext) => this._onAmqpSessionClose(context))
     };
 
+    const desiredCapabilities: string[] = [];
+    if (this.options.redirectSettings?.enabled) {
+      desiredCapabilities.push("amqp:link:redirect");
+    }
+
     if (typeof this.ownerLevel === "number") {
       rcvrOptions.properties = {
         [Constants.attachEpoch]: types.wrap_long(this.ownerLevel)
@@ -608,9 +613,12 @@ export class EventHubReceiver extends LinkEntity {
     }
 
     if (this.options.trackLastEnqueuedEventProperties) {
-      rcvrOptions.desired_capabilities = Constants.enableReceiverRuntimeMetricName;
+      desiredCapabilities.push(Constants.enableReceiverRuntimeMetricName);
     }
 
+    if (desiredCapabilities.length) {
+      rcvrOptions.desired_capabilities = desiredCapabilities;
+    }
     const eventPosition = options.eventPosition || this.eventPosition;
     if (eventPosition) {
       // Set filter on the receiver if event position is specified.

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -79,6 +79,16 @@ export interface EventHubConsumerOptions {
    * against periodically making requests for partition properties using the Event Hub client.
    */
   trackLastEnqueuedEventProperties?: boolean;
+
+  redirectSettings?: {
+    enabled: boolean;
+    connectionProvider?: (props: {
+      hostname: string;
+      host: string;
+      port: number;
+      address: string;
+    }) => ConnectionContext;
+  };
 }
 
 /**

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -174,7 +174,11 @@ export class LinkEntity {
       this.address
     );
     await defaultLock.acquire(this._context.negotiateClaimLock, () => {
-      return this._context.cbsSession.negotiateClaim(this.audience, tokenObject, tokenType);
+      return this._context.cbsSession.negotiateClaim(
+        (this._context.config as any).name || this.audience,
+        tokenObject,
+        tokenType
+      ); //
     });
     logger.verbose(
       "[%s] Negotiated claim for %s '%s' with with address: %s",

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -113,6 +113,10 @@ export interface EventHubClientOptions {
   userAgent?: string;
 }
 
+export interface EventHubConsumerClientOptions extends EventHubClientOptions {
+  enableRedirects?: boolean;
+}
+
 /**
  * Options to configure the `createBatch` method on the `EventHubProducerClient`.
  * - `partitionKey`  : A value that is hashed to produce a partition assignment.

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -3,6 +3,7 @@
 
 import { logger, logErrorStackTrace } from "../log";
 import { ConnectionContext } from "../connectionContext";
+import { MessagingError } from "@azure/core-amqp";
 
 /**
  * @internal
@@ -43,4 +44,8 @@ export function throwTypeErrorIfParameterMissing(
     logErrorStackTrace(error);
     throw error;
   }
+}
+
+export function isMessagingError(err: any): err is MessagingError {
+  return err && err.name === "MessagingError";
 }


### PR DESCRIPTION
This is a prototype for supporting receiver redirect in Event Hubs.

This requires allowing a single client to manage multiple connections. The EventHubClientManager was added to support this. The goal was to make it API compatible with EventHubClient so that the two could eventually be merged.

## Background
Event Hubs supports amqp redirect on receiver links. When the `amqp:link:redirect` desired capability is added to the amqp receiver link the service will send a `LinkRedirectError` when the receiver link is created.

The LinkRedirectError contains the hostname, port, and address that should be used for creating a new connection/link to the service.

It's important to keep in mind that traditionally, a single connection managed multiple receiver links. However, it is possible (likely?) that different receiver links on the same connection will be given different redirect info in their respective LinkRedirectErrors. In this case, a new connection will need to be made for each hostname/port/address trio.

## Implementation
TL;DR
The `EventHubClientManager` has a `core` connection, and creates additional connections mapped to a partition id as needed (determined by LinkRedirectErrors).

### Walkthrough Example
1. User creates a client with redirect enabled.
2. User calls client.subscribe to start receiving events.
3. The subscription asks for partition ids.
   - The EventHubClientManager (used under the hood) creates a `core` connection based on the initial info passed to the `EventHubConsumerClient`.
   - `core` connection is used to get partition ids.
4. The subscription creates a receiver.
5. The receiver attempts to receive messages
   - `core` connection is used to create receiver link.
   - `receiver link` gets a `LinkRedirectError`.
   - receiver asks EventHubClientManager for a new connection given details in the LinkRedirectError.
   - `receiver link` is created from the new connection
   - receiver starts receiving messages

### Multi-connection support
A customer should be able to use a single EventHubConsumerClient with redirect enabled. This necessitates changing the 1 client = 1 connection to allowing 1 client = many connections.

The `EventHubClientManager` handles managing multiple connections. It contains one `core` connection that is responsible for calling $management calls for getting partitionIds. The `core` connection is also used to create a receiver link if an existing connection doesn't already exist for the partition the receiver link is being created for.

When a LinkRedirectError is encountered, the underlying receiver gets a new connection from the `EventHubClientManager` and creates a receiver link again.

### Auth changes
When creating the cbs connection and negotiating the claim, the `name` in `applicationProperties` should be the `address` returned by the LinkRedirectError. This will look different than the `address` typically used without receiver redirect.

## TODO
- [ ] Retry instantly when encountering a LinkRedirectError rather than apply the retry delay.
- [ ] Ensure redirect feature is documented to explain that multiple connections are used.
- [ ] Ensure redirect feature calls out that additional ports may need to be allowed in firewall rules. 
- [ ] Ensure all connections are closed when closing the client.
- [ ] Ensure force:closed errors cause a new redirect to occur.