### PR TITLE
Make ResourceResponse.resource optional

### DIFF
--- a/sdk/cosmosdb/cosmos/review/cosmos.api.md
+++ b/sdk/cosmosdb/cosmos/review/cosmos.api.md
@@ -966,7 +966,7 @@ export interface Resource {
 
 // @public (undocumented)
 export class ResourceResponse<TResource> {
-    constructor(resource: TResource, headers: CosmosHeaders_2, statusCode: StatusCode, substatus?: SubStatusCode);
+    constructor(resource: TResource | undefined, headers: CosmosHeaders_2, statusCode: StatusCode, substatus?: SubStatusCode);
     // (undocumented)
     get activityId(): string;
     // (undocumented)
@@ -976,7 +976,7 @@ export class ResourceResponse<TResource> {
     // (undocumented)
     get requestCharge(): number;
     // (undocumented)
-    readonly resource: TResource;
+    readonly resource: TResource | undefined;
     // Warning: (ae-forgotten-export) The symbol "StatusCode" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
+++ b/sdk/cosmosdb/cosmos/src/request/ResourceResponse.ts
@@ -6,11 +6,11 @@ import { StatusCode, SubStatusCode } from "./StatusCodes";
 
 export class ResourceResponse<TResource> {
   constructor(
-    public readonly resource: TResource,
+    public readonly resource: TResource | undefined,
     public readonly headers: CosmosHeaders,
     public readonly statusCode: StatusCode,
     public readonly substatus?: SubStatusCode
-  ) {}
+  ) { }
   public get requestCharge(): number {
     return Number(this.headers[Constants.HttpHeaders.RequestCharge]) || 0;
   }


### PR DESCRIPTION
Currently the types indicate resource will never be undefined but that
is not the case when nothing is returned from a query in Cosmos. This
fix causes API to break in a sense that it may result in compile errors
however these compile errors may be masking bugs when the consumer is
using strict null checking.

Fixes #7819