### PR TITLE
[amqp-common] Increase timeout from 10s to 60s to avoid `"$cbs" timeout`s

### DIFF
--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,4 +1,4 @@
-### 2020-03-13 1.0.0-preview.11
+### 2020-03-16 1.0.0-preview.11
 
 - Increase the default timeout for the authorization requests sent to the service from 10s to 60s to avoid frequent timeout errors during the CBS claim negotiation.
   Fixes [bug 7786](https://github.com/Azure/azure-sdk-for-js/issues/7786).

--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,3 +1,8 @@
+### 2020-03-13 1.0.0-preview.11
+
+- Increase the timeout for the requests sent to the service from 10s to 60s to avoid `"$cbs" timeout` during the CBS claim negotiation.
+  Fixes [bug 7786](https://github.com/Azure/azure-sdk-for-js/issues/7786).
+
 ### 2020-02-11 1.0.0-preview.10
 
 - Improves bundling support by updating `rhea` dependency and removing reference

--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,6 +1,6 @@
 ### 2020-03-13 1.0.0-preview.11
 
-- Increase the default timeout for the requests sent to the service from 10s to 60s to avoid `"$cbs" timeout` during the CBS claim negotiation.
+- Increase the default timeout for the authorization requests sent to the service from 10s to 60s to avoid frequent timeout errors during the CBS claim negotiation.
   Fixes [bug 7786](https://github.com/Azure/azure-sdk-for-js/issues/7786).
 
 ### 2020-02-11 1.0.0-preview.10

--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,6 +1,6 @@
 ### 2020-03-13 1.0.0-preview.11
 
-- Increase the timeout for the requests sent to the service from 10s to 60s to avoid `"$cbs" timeout` during the CBS claim negotiation.
+- Increase the default timeout for the requests sent to the service from 10s to 60s to avoid `"$cbs" timeout` during the CBS claim negotiation.
   Fixes [bug 7786](https://github.com/Azure/azure-sdk-for-js/issues/7786).
 
 ### 2020-02-11 1.0.0-preview.10

--- a/sdk/core/amqp-common/package.json
+++ b/sdk/core/amqp-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/amqp-common",
   "sdk-type": "client",
-  "version": "1.0.0-preview.10",
+  "version": "1.0.0-preview.11",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/amqp-common/src/requestResponseLink.ts
+++ b/sdk/core/amqp-common/src/requestResponseLink.ts
@@ -98,7 +98,7 @@ export class RequestResponseLink implements ReqResLink {
     if (!options) options = {};
 
     if (!options.timeoutInSeconds) {
-      options.timeoutInSeconds = 10;
+      options.timeoutInSeconds = Constants.defaultOperationTimeoutInSeconds;
     }
 
     let count: number = 0;


### PR DESCRIPTION
During the CBS claim negotiation, `"$cbs" time out` might occur in case the service is unavailable.
This PR attempts to update the timeout from 10s to 60s as per the recommendation from the service team.
This requires updating the `amqp-common` library with the fix (and publishing it to npm) and then updating service-bus track 1 library to use the latest `amqp-common` library.

Fixes part of https://github.com/Azure/azure-sdk-for-js/issues/7786