### PR TITLE
[service-bus] Remove samples frontmatter and reference old version in README

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -9,6 +9,12 @@ Use the client library for Azure Service Bus in your Node.js application to
 
 [Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus) | [Package (npm)](https://www.npmjs.com/package/@azure/service-bus) | [API Reference Documentation](https://docs.microsoft.com/en-us/javascript/api/%40azure/service-bus/) | [Product documentation](https://azure.microsoft.com/en-us/services/service-bus/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples)
 
+**NOTE**: If you are using version 1.1.x or lower, then please use the below links instead
+
+[Source code for v1.1.3](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.3/sdk/servicebus/service-bus) |
+[Package for v1.1.3 (npm)](https://www.npmjs.com/package/@azure/service-bus/v/1.1.3) |
+[Samples for v1.1.3](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.3/sdk/servicebus/service-bus/samples)
+
 ## Getting Started
 
 ### Install the package

--- a/sdk/servicebus/service-bus/samples/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples/javascript/README.md
@@ -1,13 +1,3 @@
----
-page_type: sample
-languages:
-  - javascript
-products:
-  - azure
-  - azure-service-bus
-urlFragment: service-bus-javascript
----
-
 # Azure Service Bus client library samples for JavaScript
 
 These sample programs show how to use the JavaScript client libraries for Azure Service Bus in some common scenarios.

--- a/sdk/servicebus/service-bus/samples/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples/typescript/README.md
@@ -1,13 +1,3 @@
----
-page_type: sample
-languages:
-  - typescript
-products:
-  - azure
-  - azure-service-bus
-urlFragment: service-bus-typescript
----
-
 # Azure Service Bus client library samples for TypeScript
 
 These sample programs show how to use the TypeScript client libraries for Azure Service Bus in some common scenarios.


### PR DESCRIPTION
This PR removes the YAML frontmatter from our samples so that 2.0.0-preview.1 samples don't overwrite the working samples on docs.microsoft.com.

It also references the older samples, source, and NPM package through stable links in the README similar to Event Hubs.