### PR TITLE
[service-bus] track2 - fixing issues with the public surface (ServiceBusClient)

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -14,7 +14,6 @@ import { MessagingError } from '@azure/core-amqp';
 import { OperationOptions } from '@azure/core-auth';
 import { RetryOptions } from '@azure/core-amqp';
 import { TokenCredential } from '@azure/core-amqp';
-import { TokenCredential as TokenCredential_2 } from '@azure/core-auth';
 import { TokenType } from '@azure/core-amqp';
 import { WebSocketImpl } from 'rhea-promise';
 import { WebSocketOptions } from '@azure/core-amqp';
@@ -297,7 +296,7 @@ export interface Sender {
 // @public
 export class ServiceBusClient {
     constructor(connectionString: string, options?: ServiceBusClientOptions);
-    constructor(hostName: string, tokenCredential: TokenCredential_2, options?: ServiceBusClientOptions);
+    constructor(hostName: string, tokenCredential: TokenCredential, options?: ServiceBusClientOptions);
     close(): Promise<void>;
     getReceiver(queueName: string, receiveMode: "peekLock"): Receiver<ContextWithSettlement>;
     getReceiver(queueName: string, receiveMode: "receiveAndDelete"): Receiver<{}>;

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { QueueAuth, SubscriptionAuth } from "./models";
 import { ReceiveMode } from "./serviceBusMessage";
 import {
-  isTokenCredential,
   TokenCredential,
   ConnectionConfig,
   SharedKeyCredential,
@@ -96,74 +94,6 @@ export function getEntityNameFromConnectionString(connectionString: string): str
 }
 
 /**
- * Attempts to generically figure out what the entity path is from the grab bag of string parameters
- * we get in our constructors.
- *
- * @param auth Authentication information using connection strings or a TokenCredential.
- * @param options Options for the service bus client itself.
- * @internal
- * @ignore
- */
-export function createConnectionContext(
-  auth: QueueAuth | SubscriptionAuth,
-  options: ServiceBusClientOptions
-): { context: ConnectionContext; entityPath: string } {
-  if (hasTokenCredentialAndHost(auth)) {
-    let entityPath: string;
-
-    if (hasQueueName(auth)) {
-      entityPath = auth.queueName;
-    } else if (hasTopicName(auth) && hasSubscriptionName(auth)) {
-      entityPath = `${auth.topicName}/Subscriptions/${auth.subscriptionName}`;
-    } else {
-      throw new TypeError("Missing fields when using TokenCredential authentication");
-    }
-
-    return {
-      context: createConnectionContextForTokenCredential(auth.tokenCredential, auth.host, options),
-      entityPath: entityPath
-    };
-  } else if (hasQueueConnectionString(auth)) {
-    // connection string based authentication
-    const queueName = getEntityNameFromConnectionString(auth.queueConnectionString);
-
-    return {
-      context: createConnectionContextForConnectionString(auth.queueConnectionString, options),
-      entityPath: queueName
-    };
-  } else if (hasTopicConnectionString(auth)) {
-    const topicName = getEntityNameFromConnectionString(auth.topicConnectionString);
-
-    if (hasSubscriptionName(auth)) {
-      // topic (from connection string) + sub
-      return {
-        context: createConnectionContextForConnectionString(auth.topicConnectionString, options),
-        entityPath: `${topicName}/Subscriptions/${auth.subscriptionName as string}`
-      };
-    } else {
-      throw new TypeError("Missing subscription name, required as part of connecting to a topic");
-    }
-  } else if (hasConnectionString(auth)) {
-    let entityPath: string;
-
-    if (hasQueueName(auth)) {
-      entityPath = auth.queueName;
-    } else if (hasTopicName(auth) && hasSubscriptionName(auth)) {
-      entityPath = `${auth.topicName}/Subscriptions/${auth.subscriptionName}`;
-    } else {
-      throw new TypeError("Missing fields when using TokenCredential authentication");
-    }
-
-    return {
-      context: createConnectionContextForConnectionString(auth.connectionString, options),
-      entityPath: entityPath
-    };
-  } else {
-    throw new TypeError("Unhandled set of parameters");
-  }
-}
-
-/**
  * Temporary bit of conversion code until we can eliminate external usage of this
  * enum.
  * @param receiveMode
@@ -179,42 +109,4 @@ export function convertToInternalReceiveMode(
     case "receiveAndDelete":
       return ReceiveMode.receiveAndDelete;
   }
-}
-
-function hasHost(auth: any): auth is { host: string } {
-  return auth.host && typeof auth.host === "string";
-}
-
-function hasTokenCredentialAndHost(
-  auth: any
-): auth is { tokenCredential: TokenCredential; host: string } {
-  return isTokenCredential(auth.tokenCredential) && hasHost(auth);
-}
-
-function hasSubscriptionName(auth: any): auth is { subscriptionName: string } {
-  return auth.subscriptionName && typeof auth.subscriptionName === "string";
-}
-
-function hasQueueName(auth: any): auth is { queueName: string } {
-  return auth.queueName && typeof auth.queueName === "string";
-}
-
-function hasTopicName(auth: any): auth is { topicName: string } {
-  return auth.topicName && typeof auth.topicName === "string";
-}
-
-function hasQueueConnectionString(auth: any): auth is { queueConnectionString: string } {
-  return auth.queueConnectionString && typeof auth.queueConnectionString === "string";
-}
-
-function hasConnectionString(auth: any): auth is { connectionString: string } {
-  return auth.connectionString && typeof auth.connectionString === "string";
-}
-
-function hasTopicConnectionString(
-  auth: any
-): auth is {
-  topicConnectionString: string;
-} {
-  return auth.topicConnectionString && typeof auth.topicConnectionString === "string";
 }

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -52,8 +52,6 @@ export {
   ReceivedMessage,
   ContextWithSettlement,
   Session,
-  QueueAuth,
-  SubscriptionAuth,
   GetMessageIteratorOptions,
   ReceiveBatchOptions,
   SubscribeOptions,
@@ -62,8 +60,11 @@ export {
   ContextType,
   Closeable,
   MessageAndContext,
-  MessageIterator
+  MessageIterator,
+  GetSessionReceiverOptions
 } from "./models";
 
-export { Receiver } from "./receivers/receiver";
+export { Receiver, SubscriptionRuleManagement } from "./receivers/receiver";
 export { SessionReceiver } from "./receivers/sessionReceiver";
+export { Sender } from "./sender";
+export { ServiceBusClient } from "./serviceBusClient";

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import { ServiceBusMessage, DeadLetterOptions } from "./serviceBusMessage";
-import { TokenCredential } from "@azure/core-amqp";
 import { OperationOptions } from "@azure/core-auth";
 
 /**
@@ -153,61 +152,6 @@ export type ContextType<LockModeT> = LockModeT extends "peekLock"
   : LockModeT extends "receiveAndDelete"
   ? {}
   : never;
-
-/**
- * Authentication methods for queues.
- * TODO: consider inlining inside constructors
- */
-export type QueueAuth =
-  | {
-      /**
-       * A connection string that points to a service bus (ie: does not contain an EntityName value).
-       */
-      connectionString: string;
-      /**
-       * The name of the queue to connect to.
-       */
-      queueName: string;
-    }
-  | {
-      /**
-       * A connection string that points to a queue (contains EntityName=<queue-name>).
-       */
-      queueConnectionString: string;
-    }
-  | {
-      tokenCredential: TokenCredential;
-      host: string;
-      queueName: string;
-    };
-
-export function isQueueAuth(
-  possibleQueueAuth: QueueAuth | SubscriptionAuth
-): possibleQueueAuth is QueueAuth {
-  const queueAuth = possibleQueueAuth as any;
-  return queueAuth.queueName != null || queueAuth.queueConnectionString != null;
-}
-
-/**
- * Authentication methods for subscriptions.
- * TODO: consider inlining inside constructors
- */
-export type SubscriptionAuth =
-  | {
-      connectionString: string;
-      topicName: string;
-      subscriptionName: string;
-    }
-  | {
-      topicConnectionString: string;
-      subscriptionName: string;
-    }
-  | {
-      tokenCredential: TokenCredential;
-      host: string;
-      topicName: string;
-      subscriptionName: string;
-    };
 
 /**
  * Options when receiving a batch of messages from Service Bus.

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -223,9 +223,18 @@ export interface SubscriptionRuleManagement {
     filter: boolean | string | CorrelationFilter,
     sqlRuleActionExpression?: string
   ): Promise<void>;
+
+  /**
+   * @readonly
+   * @property The name of the default rule on the subscription.
+   */
   readonly defaultRuleName: string;
 }
 
+/**
+ * @internal
+ * @ignore
+ */
 export class ReceiverImpl<ContextT> implements Receiver<ContextT>, SubscriptionRuleManagement {
   /**
    * @property Describes the amqp connection context for the QueueClient.

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -111,6 +111,10 @@ export interface SessionReceiver<ContextT extends ContextWithSettlement | {}>
   setState(state: any): Promise<void>;
 }
 
+/**
+ * @internal
+ * @ignore
+ */
 export class SessionReceiverImpl<ContextT extends ContextWithSettlement | {}>
   implements SessionReceiver<ContextT> {
   public entityPath: string;

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -15,13 +15,102 @@ import {
 } from "./util/errors";
 
 /**
- * The Sender class can be used to send messages, schedule messages to be sent at a later time
+ * A Sender can be used to send messages, schedule messages to be sent at a later time
  * and cancel such scheduled messages.
- * Use the `createSender` function on the QueueClient or TopicClient to instantiate a Sender.
+ * Use the `createSender` function on the ServiceBusClient instantiate a Sender.
  * The Sender class is an abstraction over the underlying AMQP sender link.
- * @class Sender
  */
-export class Sender {
+export interface Sender {
+  /**
+   * Sends the given message after creating an AMQP Sender link if it doesnt already exists.
+   *
+   * To send a message to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
+   * and/or `partitionKey` properties respectively on the message.
+   *
+   * @param message - Message to send.
+   * @returns Promise<void>
+   * @throws Error if the underlying connection, client or sender is closed.
+   * @throws MessagingError if the service returns an error while sending messages to the service.
+   */
+  send(message: SendableMessageInfo): Promise<void>;
+
+  /**
+   * Sends the given messages in a single batch i.e. in a single AMQP message after creating an AMQP
+   * Sender link if it doesnt already exists.
+   *
+   * - To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
+   * and/or `partitionKey` properties respectively on the messages.
+   * - When doing so, all
+   * messages in the batch should have the same `sessionId` (if using sessions) and the same
+   * `parititionKey` (if using paritions).
+   *
+   * @param messages - An array of SendableMessageInfo objects to be sent in a Batch message.
+   * @return Promise<void>
+   * @throws Error if the underlying connection, client or sender is closed.
+   * @throws MessagingError if the service returns an error while sending messages to the service.
+   */
+  sendBatch(messages: SendableMessageInfo[]): Promise<void>;
+  /**
+   * @property Returns `true` if either the sender or the client that created it has been closed
+   * @readonly
+   */
+  isClosed: boolean;
+  /**
+   * Schedules given message to appear on Service Bus Queue/Subscription at a later time.
+   *
+   * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
+   * @param message - The message that needs to be scheduled.
+   * @returns Promise<Long> - The sequence number of the message that was scheduled.
+   * You will need the sequence number if you intend to cancel the scheduling of the message.
+   * Save the `Long` type as-is in your application without converting to number. Since JavaScript
+   * only supports 53 bit numbers, converting the `Long` to number will cause loss in precision.
+   * @throws Error if the underlying connection, client or sender is closed.
+   * @throws MessagingError if the service returns an error while scheduling a message.
+   */
+  scheduleMessage(scheduledEnqueueTimeUtc: Date, message: SendableMessageInfo): Promise<Long>;
+
+  /**
+   * Schedules given messages to appear on Service Bus Queue/Subscription at a later time.
+   *
+   * @param scheduledEnqueueTimeUtc - The UTC time at which the messages should be enqueued.
+   * @param messages - Array of Messages that need to be scheduled.
+   * @returns Promise<Long[]> - The sequence numbers of messages that were scheduled.
+   * You will need the sequence number if you intend to cancel the scheduling of the messages.
+   * Save the `Long` type as-is in your application without converting to number. Since JavaScript
+   * only supports 53 bit numbers, converting the `Long` to number will cause loss in precision.
+   * @throws Error if the underlying connection, client or sender is closed.
+   * @throws MessagingError if the service returns an error while scheduling messages.
+   */
+  scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: SendableMessageInfo[]): Promise<Long[]>;
+
+  /**
+   * Cancels a message that was scheduled to appear on a ServiceBus Queue/Subscription.
+   * @param sequenceNumber - The sequence number of the message to be cancelled.
+   * @returns Promise<void>
+   * @throws Error if the underlying connection, client or sender is closed.
+   * @throws MessagingError if the service returns an error while canceling a scheduled message.
+   */
+  cancelScheduledMessage(sequenceNumber: Long): Promise<void>;
+  /**
+   * Cancels multiple messages that were scheduled to appear on a ServiceBus Queue/Subscription.
+   * @param sequenceNumbers - An Array of sequence numbers of the messages to be cancelled.
+   * @returns Promise<void>
+   * @throws Error if the underlying connection, client or sender is closed.
+   * @throws MessagingError if the service returns an error while canceling scheduled messages.
+   */
+  cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void>;
+
+  /**
+   * Closes the underlying AMQP sender link.
+   * Once closed, the sender cannot be used for any further operations.
+   * Use the `createSender` function on the QueueClient or TopicClient to instantiate a new Sender
+   *
+   * @returns {Promise<void>}
+   */
+  close(): Promise<void>;
+}
+
+export class SenderImpl implements Sender {
   /**
    * @property Describes the amqp connection context for the Client.
    */
@@ -54,25 +143,10 @@ export class Sender {
     }
   }
 
-  /**
-   * @property Returns `true` if either the sender or the client that created it has been closed
-   * @readonly
-   */
   public get isClosed(): boolean {
     return this._isClosed || this._context.isClosed;
   }
 
-  /**
-   * Sends the given message after creating an AMQP Sender link if it doesnt already exists.
-   *
-   * To send a message to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
-   * and/or `partitionKey` properties respectively on the message.
-   *
-   * @param message - Message to send.
-   * @returns Promise<void>
-   * @throws Error if the underlying connection, client or sender is closed.
-   * @throws MessagingError if the service returns an error while sending messages to the service.
-   */
   async send(message: SendableMessageInfo): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "message", message);
@@ -80,21 +154,6 @@ export class Sender {
     return sender.send(message);
   }
 
-  /**
-   * Sends the given messages in a single batch i.e. in a single AMQP message after creating an AMQP
-   * Sender link if it doesnt already exists.
-   *
-   * - To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
-   * and/or `partitionKey` properties respectively on the messages.
-   * - When doing so, all
-   * messages in the batch should have the same `sessionId` (if using sessions) and the same
-   * `parititionKey` (if using paritions).
-   *
-   * @param messages - An array of SendableMessageInfo objects to be sent in a Batch message.
-   * @return Promise<void>
-   * @throws Error if the underlying connection, client or sender is closed.
-   * @throws MessagingError if the service returns an error while sending messages to the service.
-   */
   async sendBatch(messages: SendableMessageInfo[]): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "messages", messages);
@@ -137,18 +196,6 @@ export class Sender {
     return result[0];
   }
 
-  /**
-   * Schedules given messages to appear on Service Bus Queue/Subscription at a later time.
-   *
-   * @param scheduledEnqueueTimeUtc - The UTC time at which the messages should be enqueued.
-   * @param messages - Array of Messages that need to be scheduled.
-   * @returns Promise<Long[]> - The sequence numbers of messages that were scheduled.
-   * You will need the sequence number if you intend to cancel the scheduling of the messages.
-   * Save the `Long` type as-is in your application without converting to number. Since JavaScript
-   * only supports 53 bit numbers, converting the `Long` to number will cause loss in precision.
-   * @throws Error if the underlying connection, client or sender is closed.
-   * @throws MessagingError if the service returns an error while scheduling messages.
-   */
   async scheduleMessages(
     scheduledEnqueueTimeUtc: Date,
     messages: SendableMessageInfo[]
@@ -167,13 +214,6 @@ export class Sender {
     return this._context.managementClient!.scheduleMessages(scheduledEnqueueTimeUtc, messages);
   }
 
-  /**
-   * Cancels a message that was scheduled to appear on a ServiceBus Queue/Subscription.
-   * @param sequenceNumber - The sequence number of the message to be cancelled.
-   * @returns Promise<void>
-   * @throws Error if the underlying connection, client or sender is closed.
-   * @throws MessagingError if the service returns an error while canceling a scheduled message.
-   */
   async cancelScheduledMessage(sequenceNumber: Long): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
@@ -190,13 +230,6 @@ export class Sender {
     return this._context.managementClient!.cancelScheduledMessages([sequenceNumber]);
   }
 
-  /**
-   * Cancels multiple messages that were scheduled to appear on a ServiceBus Queue/Subscription.
-   * @param sequenceNumbers - An Array of sequence numbers of the messages to be cancelled.
-   * @returns Promise<void>
-   * @throws Error if the underlying connection, client or sender is closed.
-   * @throws MessagingError if the service returns an error while canceling scheduled messages.
-   */
   async cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
@@ -216,13 +249,6 @@ export class Sender {
     return this._context.managementClient!.cancelScheduledMessages(sequenceNumbers);
   }
 
-  /**
-   * Closes the underlying AMQP sender link.
-   * Once closed, the sender cannot be used for any further operations.
-   * Use the `createSender` function on the QueueClient or TopicClient to instantiate a new Sender
-   *
-   * @returns {Promise<void>}
-   */
   async close(): Promise<void> {
     try {
       this._isClosed = true;

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -11,11 +11,15 @@ import {
 import { ConnectionContext } from "./connectionContext";
 import { ClientEntityContext } from "./clientEntityContext";
 import { ClientType } from "./client";
-import { Sender } from "./sender";
+import { SenderImpl, Sender } from "./sender";
 import { GetSessionReceiverOptions, ContextWithSettlement } from "./models";
 import { Receiver, ReceiverImpl, SubscriptionRuleManagement } from "./receivers/receiver";
 import { SessionReceiver, SessionReceiverImpl } from "./receivers/sessionReceiver";
 
+/**
+ * A client that can create Sender instances for sending messages to queues and
+ * topics as well as Receiver instances to receive messages from queus and subscriptions.
+ */
 export class ServiceBusClient {
   private _connectionContext: ConnectionContext;
 
@@ -256,9 +260,14 @@ export class ServiceBusClient {
       `${queueOrTopicName}/${generate_uuid()}`
     );
 
-    return new Sender(clientEntityContext);
+    return new SenderImpl(clientEntityContext);
   }
 
+  /**
+   * Closes the underlying AMQP connection.
+   * NOTE: this will also disconnect any Receiver or Sender instances created from this
+   * instance.
+   */
   close(): Promise<void> {
     return ConnectionContext.close(this._connectionContext);
   }

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { generate_uuid } from "rhea-promise";
-import { isTokenCredential, TokenCredential } from "@azure/core-auth";
+import { isTokenCredential, TokenCredential } from "@azure/core-amqp";
 import {
   ServiceBusClientOptions,
   createConnectionContextForTokenCredential,

--- a/sdk/servicebus/service-bus/test/track2.samples.spec.ts
+++ b/sdk/servicebus/service-bus/test/track2.samples.spec.ts
@@ -6,10 +6,7 @@ import { delay, SendableMessageInfo } from "../src";
 import { TestClientType } from "./utils/testUtils";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import {
-  createConnectionContext,
-  getEntityNameFromConnectionString
-} from "../src/constructorHelpers";
+import { getEntityNameFromConnectionString } from "../src/constructorHelpers";
 import { createServiceBusClientForTests, ServiceBusClientForTests } from "./utils/testutils2";
 import { Sender } from "../src/sender";
 chai.use(chaiAsPromised);
@@ -425,61 +422,6 @@ describe("ConstructorHelpers for track 2", () => {
 
   const serviceBusConnectionString =
     "Endpoint=sb://host/;SharedAccessKeyName=queueall;SharedAccessKey=thesharedkey=";
-
-  const fakeTokenCredential = {
-    getToken: async () => null,
-    sentinel: "test token credential"
-  };
-
-  const badAuths = [
-    // missing required fields
-    { connectionString: serviceBusConnectionString },
-    { topicConnectionString: entityConnectionString },
-    { tokenCredential: fakeTokenCredential } as any,
-
-    // wrong types
-    { connectionString: 4, topicName: "myentity", subscriptionName: "mysubscription" },
-    {
-      connectionString: serviceBusConnectionString,
-      topicName: 4,
-      subscriptionName: "mysubscription"
-    },
-    { connectionString: serviceBusConnectionString, topicName: "myentity", subscriptionName: 4 },
-    { connectionString: "", topicName: "myentity", subscriptionName: "mysubscription" },
-    {
-      connectionString: serviceBusConnectionString,
-      topicName: "",
-      subscriptionName: "mysubscription"
-    },
-    { connectionString: serviceBusConnectionString, topicName: "myentity", subscriptionName: "" },
-    { connectionString: 4, queueName: "myentity" },
-    { connectionString: serviceBusConnectionString, queueName: 4 },
-    { queueConnectionString: 4 },
-    { queueConnectionString: "" },
-    { topicConnectionString: 4, subscriptionName: "mysubscription" },
-    { topicConnectionString: entityConnectionString, subscriptionName: 4 },
-    { topicConnectionString: "", subscriptionName: "mysubscription" },
-    { topicConnectionString: entityConnectionString, subscriptionName: "" },
-
-    // no entity name present for entity connection string types
-    {
-      topicConnectionString:
-        "Endpoint=sb://host/;SharedAccessKeyName=queueall;SharedAccessKey=thesharedkey=",
-      subscriptionName: "mysubscription"
-    },
-    {
-      queueConnectionString:
-        "Endpoint=sb://host/;SharedAccessKeyName=queueall;SharedAccessKey=thesharedkey="
-    }
-  ];
-
-  badAuths.forEach((badAuth) => {
-    it(`createConnectionContext - bad auth ${JSON.stringify(badAuth)}`, () => {
-      assert.throws(() => {
-        createConnectionContext(badAuth, {});
-      });
-    });
-  });
 
   it("getEntityNameFromConnectionString", () => {
     assert.equal("myentity", getEntityNameFromConnectionString(entityConnectionString));

--- a/sdk/servicebus/service-bus/test/track2.samples.spec.ts
+++ b/sdk/servicebus/service-bus/test/track2.samples.spec.ts
@@ -12,7 +12,7 @@ import { Sender } from "../src/sender";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
-describe("Sample scenarios for track 2", () => {
+describe("Sample scenarios for track 2 #RunInBrowser", () => {
   let serviceBusClient: ServiceBusClientForTests;
 
   before(async () => {

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -1,16 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Anything we expect to be available to users should come from this import
+// as a simple sanity check that we've exported things properly.
+import {
+  ServiceBusClient,
+  SessionReceiver,
+  Receiver,
+  SubscriptionRuleManagement,
+  GetSessionReceiverOptions
+} from "../../src";
+
 import { TestClientType, TestMessage } from "./testUtils";
 import { getEnvVars, EnvVarNames } from "./envVarUtils";
 import * as dotenv from "dotenv";
 import { recreateQueue, recreateTopic, recreateSubscription } from "./managementUtils";
-import { SessionReceiver } from "../../src/receivers/sessionReceiver";
-import { Receiver, SubscriptionRuleManagement } from "../../src/receivers/receiver";
-import { ServiceBusClient } from "../../src/serviceBusClient";
 import { ServiceBusClientOptions, ContextWithSettlement } from "../../src";
 import chai from "chai";
-import { GetSessionReceiverOptions } from "../../src/models";
 
 dotenv.config();
 const env = getEnvVars();


### PR DESCRIPTION
Public surface had some issues:
- `ServiceBusClient` wasn't exported from index.ts (and thus a few associated types were _also_ not properly exported)
- Some older code from preview 0.01 were still exported (QueueAuths, etc..). Those have been removed

I also changed over some tests to:
- Run in the browser
- Import some of the critical classes via `..\src` rather than by file, giving a _little_ extra check the critical types are exported properly.