### PR TITLE
[core-http] work around issue where body not set due to incorrect operationSpec

### DIFF
--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -452,6 +452,13 @@ export class ServiceClient {
         httpRequest.streamResponseBody = isStreamOperation(operationSpec);
       }
 
+      // Workaround to pass in body directly via operation arguments in cases
+      // where operationSpec is not generated correctly thus body is not set
+      // as expected.
+      if (httpRequest.body == undefined && (options as any).body) {
+        httpRequest.body = (options as any).body;
+      }
+
       let rawResponse: HttpOperationResponse;
       let sendRequestError;
       try {


### PR DESCRIPTION
In the case of api endpoint consuming multiple content-types, autorest codegen
doesn't generate proper code to serialize body yet, the http request body is not
set as expected. This change work around it by setting it using the value from
options.