### PR TITLE
Pinning to Typedoc 0.16.x until further investigation

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -108,22 +108,7 @@ jobs:
           artifactName: packages
           path: $(Build.ArtifactStagingDirectory)
 
-      - script: |
-          npm i -g typedoc
-        displayName: "Install typedoc"
-
-      - script: |
-          npm install
-        workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/generate-doc
-        displayName: "Install tool dependencies"
-
-      - pwsh: |
-          node $(Build.SourcesDirectory)/eng/tools/generate-doc/index.js --dgOp "dg" -i "inc" --inc "${{parameters.ServiceDirectory}}"
-        displayName: "Run Typedoc Docs"
-
-      - pwsh: |
-          $(Build.SourcesDirectory)/eng/tools/compress-subfolders.ps1 "$(Build.SourcesDirectory)/docGen" "$(Build.ArtifactStagingDirectory)/Documentation"
-        displayName: "Generate Typedoc Docs"
+      - template: ../steps/generate-doc.yml
 
       - task: PublishPipelineArtifact@1
         condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -109,6 +109,8 @@ jobs:
           path: $(Build.ArtifactStagingDirectory)
 
       - template: ../steps/generate-doc.yml
+        parameters:
+          ServiceDirectory: ${{parameters.ServiceDirectory}}
 
       - task: PublishPipelineArtifact@1
         condition: succeededOrFailed()

--- a/eng/pipelines/templates/steps/generate-doc.yml
+++ b/eng/pipelines/templates/steps/generate-doc.yml
@@ -1,0 +1,17 @@
+steps:
+  - script: |
+      npm i -g typedoc typescript
+    displayName: "Install typedoc & typescript"
+
+  - script: |
+      npm install
+    workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/generate-doc
+    displayName: "Install tool dependencies"
+
+  - pwsh: |
+      node $(Build.SourcesDirectory)/eng/tools/generate-doc/index.js --dgOp "dg" -i "inc" --inc "${{parameters.ServiceDirectory}}"
+    displayName: "Run Typedoc Docs"
+
+  - pwsh: |
+      $(Build.SourcesDirectory)/eng/tools/compress-subfolders.ps1 "$(Build.SourcesDirectory)/docGen" "$(Build.ArtifactStagingDirectory)/Documentation"
+    displayName: "Generate Typedoc Docs"

--- a/eng/pipelines/templates/steps/generate-doc.yml
+++ b/eng/pipelines/templates/steps/generate-doc.yml
@@ -1,7 +1,7 @@
 steps:
   - script: |
-      npm i -g typedoc typescript
-    displayName: "Install typedoc & typescript"
+      npm i -g typedoc@0.16.x
+    displayName: "Install typedoc"
 
   - script: |
       npm install

--- a/eng/pipelines/templates/steps/generate-doc.yml
+++ b/eng/pipelines/templates/steps/generate-doc.yml
@@ -1,3 +1,6 @@
+parameters:
+  ServiceDirectory: not-specified
+
 steps:
   - script: |
       npm i -g typedoc@0.16.x


### PR DESCRIPTION
Cancelled original plan - 
- Typedoc 0.17.0 requires TS 3.8.3 as peer dependency 
- We need to global install Typedoc since we run the Typedoc command, that is why we need to global install TS  in this PR


----Change in plans ------
Typedoc 0.17.0 is exposing internal variables while generating docs. So will pin to 0.16.x for now until further investigation. 
- moving generate doc steps into separate pipeline for sanity purpose