### PR TITLE
[Service Bus] Remove lingering artifacts for management apis

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -8,7 +8,6 @@ import { AmqpMessage } from '@azure/core-amqp';
 import { DataTransformer } from '@azure/core-amqp';
 import { delay } from '@azure/core-amqp';
 import { Delivery } from 'rhea-promise';
-import { HttpOperationResponse } from '@azure/core-http';
 import Long from 'long';
 import { MessagingError } from '@azure/core-amqp';
 import { OperationOptions } from '@azure/core-auth';
@@ -17,18 +16,6 @@ import { TokenCredential } from '@azure/core-amqp';
 import { TokenType } from '@azure/core-amqp';
 import { WebSocketImpl } from 'rhea-promise';
 import { WebSocketOptions } from '@azure/core-amqp';
-
-// @public
-export type AuthorizationRule = {
-    claimType: string;
-    claimValue: string;
-    rights: {
-        accessRights?: string[];
-    };
-    keyName: string;
-    primaryKey?: string;
-    secondaryKey?: string;
-};
 
 // @public
 export interface CorrelationFilter {
@@ -56,9 +43,6 @@ export { delay }
 export { Delivery }
 
 // @public
-export type EntityStatus = "Active" | "Creating" | "Deleting" | "ReceiveDisabled" | "SendDisabled" | "Disabled" | "Renaming" | "Restoring" | "Unknown";
-
-// @public
 export interface GetMessageIteratorOptions extends OperationOptions, WaitTimeOptions {
 }
 
@@ -67,17 +51,6 @@ export interface GetSessionReceiverOptions extends OperationOptions {
     maxSessionAutoRenewLockDurationInSeconds?: number;
     sessionId?: string;
 }
-
-export { HttpOperationResponse }
-
-// @public
-export type MessageCountDetails = {
-    activeMessageCount: number;
-    deadLetterMessageCount: number;
-    scheduledMessageCount: number;
-    transferMessageCount: number;
-    transferDeadLetterMessageCount: number;
-};
 
 // @public
 export interface MessageHandlerOptions {
@@ -93,57 +66,6 @@ export interface MessageHandlers<ReceivedMessageT> {
 }
 
 export { MessagingError }
-
-// @public
-export interface QueueDetails {
-    accessedOn?: string;
-    authorizationRules?: AuthorizationRule[];
-    autoDeleteOnIdle: string;
-    createdOn?: string;
-    deadLetteringOnMessageExpiration: boolean;
-    defaultMessageTtl: string;
-    duplicateDetectionHistoryTimeWindow: string;
-    enableBatchedOperations: boolean;
-    enableExpress?: boolean;
-    enablePartitioning: boolean;
-    entityAvailabilityStatus?: string;
-    forwardDeadLetteredMessagesTo?: string;
-    forwardTo?: string;
-    isAnonymousAccessible?: boolean;
-    lockDuration: string;
-    maxDeliveryCount: number;
-    maxSizeInMegabytes: number;
-    messageCount?: number;
-    messageCountDetails?: MessageCountDetails;
-    queueName: string;
-    requiresDuplicateDetection: boolean;
-    requiresSession: boolean;
-    sizeInBytes?: number;
-    status?: EntityStatus;
-    supportOrdering?: boolean;
-    updatedOn?: string;
-    userMetadata?: string;
-}
-
-// @public
-export interface QueueOptions {
-    authorizationRules?: AuthorizationRule[];
-    autoDeleteOnIdle?: string;
-    deadLetteringOnMessageExpiration?: boolean;
-    defaultMessageTtl?: string;
-    duplicateDetectionHistoryTimeWindow?: string;
-    enableBatchedOperations?: boolean;
-    enablePartitioning?: boolean;
-    forwardDeadLetteredMessagesTo?: string;
-    forwardTo?: string;
-    lockDuration?: string;
-    maxDeliveryCount?: number;
-    maxSizeInMegabytes?: number;
-    requiresDuplicateDetection?: boolean;
-    requiresSession?: boolean;
-    status?: EntityStatus;
-    userMetadata?: string;
-}
 
 // @public
 export interface ReceiveBatchOptions extends OperationOptions, WaitTimeOptions {
@@ -207,22 +129,6 @@ export interface RuleDescription {
     action?: string;
     filter?: string | CorrelationFilter;
     name: string;
-}
-
-// @public
-export interface RuleDetails {
-    action?: SqlAction;
-    createdOn: string;
-    filter?: SqlFilter | CorrelationFilter;
-    ruleName: string;
-    subscriptionName: string;
-    topicName: string;
-}
-
-// @public
-export interface RuleOptions {
-    action?: SqlAction;
-    filter?: SqlFilter | CorrelationFilter;
 }
 
 // @public
@@ -305,69 +211,7 @@ export interface SessionReceiverOptions {
 }
 
 // @public
-export type SqlAction = SqlFilter;
-
-// @public
-export interface SqlFilter {
-    compatibilityLevel?: number;
-    requiresPreprocessing?: boolean;
-    sqlExpression?: string;
-    sqlParameters?: SqlParameter[];
-}
-
-// @public
-export type SqlParameter = {
-    key: string;
-    value: string | number;
-    type: string;
-};
-
-// @public
 export interface SubscribeOptions extends OperationOptions, MessageHandlerOptions {
-}
-
-// @public
-export interface SubscriptionDetails {
-    accessedOn?: string;
-    autoDeleteOnIdle: string;
-    createdOn: string;
-    deadLetteringOnFilterEvaluationExceptions: boolean;
-    deadLetteringOnMessageExpiration: boolean;
-    defaultMessageTtl?: string;
-    defaultRuleDescription?: any;
-    enableBatchedOperations: boolean;
-    enablePartitioning?: boolean;
-    entityAvailabilityStatus: string;
-    forwardDeadLetteredMessagesTo?: string;
-    forwardTo?: string;
-    lockDuration: string;
-    maxDeliveryCount: number;
-    maxSizeInMegabytes?: number;
-    messageCount: number;
-    messageCountDetails?: MessageCountDetails;
-    requiresSession: boolean;
-    sizeInBytes?: number;
-    status?: EntityStatus;
-    subscriptionName: string;
-    topicName: string;
-    updatedOn: string;
-    userMetadata?: string;
-}
-
-// @public
-export interface SubscriptionOptions {
-    autoDeleteOnIdle?: string;
-    deadLetteringOnFilterEvaluationExceptions?: boolean;
-    deadLetteringOnMessageExpiration?: boolean;
-    defaultMessageTtl?: string;
-    enableBatchedOperations?: boolean;
-    forwardDeadLetteredMessagesTo?: string;
-    forwardTo?: string;
-    lockDuration?: string;
-    maxDeliveryCount?: number;
-    requiresSession?: boolean;
-    status?: EntityStatus;
-    userMetadata?: string;
 }
 
 // @public
@@ -381,51 +225,6 @@ export interface SubscriptionRuleManagement {
 export { TokenCredential }
 
 export { TokenType }
-
-// @public
-export interface TopicDetails {
-    accessedOn?: string;
-    authorizationRules?: AuthorizationRule[];
-    autoDeleteOnIdle?: string;
-    createdOn?: string;
-    defaultMessageTtl: string;
-    duplicateDetectionHistoryTimeWindow: string;
-    enableBatchedOperations: boolean;
-    enableExpress?: boolean;
-    enablePartitioning: boolean;
-    enableSubscriptionPartitioning?: boolean;
-    entityAvailabilityStatus?: string;
-    filteringMessagesBeforePublishing?: boolean;
-    isAnonymousAccessible?: boolean;
-    isExpress?: boolean;
-    maxDeliveryCount?: number;
-    maxSizeInMegabytes: number;
-    messageCount?: number;
-    messageCountDetails?: MessageCountDetails;
-    requiresDuplicateDetection: boolean;
-    sizeInBytes?: number;
-    status?: EntityStatus;
-    subscriptionCount?: number;
-    supportOrdering: boolean;
-    topicName: string;
-    updatedOn?: string;
-    userMetadata?: string;
-}
-
-// @public
-export interface TopicOptions {
-    authorizationRules?: AuthorizationRule[];
-    autoDeleteOnIdle?: string;
-    defaultMessageTtl?: string;
-    duplicateDetectionHistoryTimeWindow?: string;
-    enableBatchedOperations?: boolean;
-    enablePartitioning?: boolean;
-    maxSizeInMegabytes?: number;
-    requiresDuplicateDetection?: boolean;
-    status?: EntityStatus;
-    supportOrdering?: boolean;
-    userMetadata?: string;
-}
 
 // @public
 export interface WaitTimeOptions {

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -28,24 +28,6 @@ export {
 } from "./serviceBusMessage";
 export { Delivery, WebSocketImpl } from "rhea-promise";
 
-export { HttpOperationResponse } from "@azure/core-http";
-
-export { QueueDetails, QueueOptions } from "./serializers/queueResourceSerializer";
-export { TopicDetails, TopicOptions } from "./serializers/topicResourceSerializer";
-export {
-  SubscriptionDetails,
-  SubscriptionOptions
-} from "./serializers/subscriptionResourceSerializer";
-export {
-  RuleDetails,
-  RuleOptions,
-  SqlFilter,
-  SqlParameter,
-  SqlAction
-} from "./serializers/ruleResourceSerializer";
-
-export { MessageCountDetails, AuthorizationRule, EntityStatus } from "./util/utils";
-
 export {
   GetMessageIteratorOptions,
   GetSessionReceiverOptions,

--- a/sdk/servicebus/service-bus/test/atomManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/atomManagement.spec.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { QueueOptions, TopicOptions, SubscriptionOptions, RuleOptions, EntityStatus } from "../src";
+import { QueueOptions } from "../src/serializers/queueResourceSerializer";
+import { TopicOptions } from "../src/serializers/topicResourceSerializer";
+import { SubscriptionOptions } from "../src/serializers/subscriptionResourceSerializer";
+import { RuleOptions } from "../src/serializers/ruleResourceSerializer";
+import { EntityStatus } from "../src/util/utils";
 import { ServiceBusAtomManagementClient } from "../src/serviceBusAtomManagementClient";
 
 import chai from "chai";

--- a/sdk/servicebus/service-bus/test/utils/managementUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/managementUtils.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { QueueOptions, TopicOptions, SubscriptionOptions, delay } from "../../src";
+import { delay } from "../../src";
+import { QueueOptions } from "../../src/serializers/queueResourceSerializer";
+import { TopicOptions } from "../../src/serializers/topicResourceSerializer";
+import { SubscriptionOptions } from "../../src/serializers/subscriptionResourceSerializer";
 import { ServiceBusAtomManagementClient } from "../../src/serviceBusAtomManagementClient";
 
 import { EnvVarNames, getEnvVars } from "./envVarUtils";


### PR DESCRIPTION
`ServiceBusAtomManagementClient` is not exposed by the Service Bus public facing apis at the moment. Removing all other related interfaces and classes to keep the public surface clean

