### PR TITLE
Convert core-http to use interfaces for requests

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,19 +1,21 @@
 # Release History
 
-## 1.0.5 (Unreleased)
+## 1.1.0 (Unreleased)
 
+- A new interface `WebResourceLike` was introduced to avoid a direct dependency on the class `WebResource` in public interfaces. `HttpHeadersLike` was also added to replace references to `HttpHeaders`. This should improve cross-version compatibility for core-http. [PR #7873](https://github.com/Azure/azure-sdk-for-js/pull/7873)
 
 ## 1.0.4 (2020-03-03)
 
 - When an operation times out based on the `timeout` configured in the `OperationRequestOptions`, it gets terminated with an error. In this update, the error that is thrown in browser for such cases is updated to match what is thrown in node i.e an `AbortError` is thrown instead of the previous `RestError`. [PR #7159](https://github.com/Azure/azure-sdk-for-js/pull/7159)
 - Support for username and password in the proxy url [PR #7211](https://github.com/Azure/azure-sdk-for-js/pull/7211)
-- Removed dependency on `lib.dom.d.ts` so TypeScript users no longer need `lib: ["dom"]` in their tsconfig.json file to use this library.  [PR #7500](https://github.com/Azure/azure-sdk-for-js/pull/7500)
+- Removed dependency on `lib.dom.d.ts` so TypeScript users no longer need `lib: ["dom"]` in their tsconfig.json file to use this library. [PR #7500](https://github.com/Azure/azure-sdk-for-js/pull/7500)
 
 ## 1.0.3 (2020-01-02)
+
 - Added `x-ms-useragent` to the list of allowed headers in request logs.
 - Fix issue of data being pushed twice when reporting progress ([PR #6427](https://github.com/Azure/azure-sdk-for-js/issues/6427))
 - Move `getDefaultProxySettings()` calls into `proxyPolicy` so that libraries that don't use the PipelineOptions or createDefaultRequestPolicyFactories from core-http can use this behavior without duplicating code. ([PR #6478](https://github.com/Azure/azure-sdk-for-js/issues/6478))
-- Fix tracingPolicy() to set standard span attributes ([PR #6565](https://github.com/Azure/azure-sdk-for-js/pull/6565)).  Now the following are set correctly for the spans
+- Fix tracingPolicy() to set standard span attributes ([PR #6565](https://github.com/Azure/azure-sdk-for-js/pull/6565)). Now the following are set correctly for the spans
   - `http.method`
   - `http.url`
   - `http.user_agent`

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -6,7 +6,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-for-js"
   },
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Isomorphic client Runtime for Typescript/node.js/browser javascript client libraries generated using AutoRest",
   "tags": [
     "isomorphic",

--- a/sdk/core/core-http/src/browserFetchHttpClient.ts
+++ b/sdk/core/core-http/src/browserFetchHttpClient.ts
@@ -3,10 +3,10 @@
 
 import { FetchHttpClient, CommonRequestInfo } from "./fetchHttpClient";
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { WebResource } from "./webResource";
+import { WebResourceLike } from "./webResource";
 
 export class BrowserFetchHttpClient extends FetchHttpClient {
-  prepareRequest(_httpRequest: WebResource): Promise<Partial<RequestInit>> {
+  prepareRequest(_httpRequest: WebResourceLike): Promise<Partial<RequestInit>> {
     return Promise.resolve({});
   }
 

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -5,6 +5,7 @@
 
 export {
   WebResource,
+  WebResourceLike,
   HttpRequestBody,
   RequestPrepareOptions,
   HttpMethods,
@@ -14,7 +15,7 @@ export {
 } from "./webResource";
 export { DefaultHttpClient } from "./defaultHttpClient";
 export { HttpClient } from "./httpClient";
-export { HttpHeaders } from "./httpHeaders";
+export { HttpHeaders, HttpHeadersLike } from "./httpHeaders";
 export { HttpOperationResponse, HttpResponse, RestResponse } from "./httpOperationResponse";
 export { HttpPipelineLogger } from "./httpPipelineLogger";
 export { HttpPipelineLogLevel } from "./httpPipelineLogLevel";

--- a/sdk/core/core-http/src/credentials/apiKeyCredentials.ts
+++ b/sdk/core/core-http/src/credentials/apiKeyCredentials.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { HttpHeaders } from "../httpHeaders";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { ServiceClientCredentials } from "./serviceClientCredentials";
 
 /**
@@ -50,10 +50,10 @@ export class ApiKeyCredentials implements ServiceClientCredentials {
   /**
    * Signs a request with the values provided in the inHeader and inQuery parameter.
    *
-   * @param {WebResource} webResource The WebResource to be signed.
-   * @returns {Promise<WebResource>} The signed request object.
+   * @param {WebResourceLike} webResource The WebResourceLike to be signed.
+   * @returns {Promise<WebResourceLike>} The signed request object.
    */
-  signRequest(webResource: WebResource): Promise<WebResource> {
+  signRequest(webResource: WebResourceLike): Promise<WebResourceLike> {
     if (!webResource) {
       return Promise.reject(
         new Error(`webResource cannot be null or undefined and must be of type "object".`)

--- a/sdk/core/core-http/src/credentials/basicAuthenticationCredentials.ts
+++ b/sdk/core/core-http/src/credentials/basicAuthenticationCredentials.ts
@@ -4,7 +4,7 @@
 import { HttpHeaders } from "../httpHeaders";
 import * as base64 from "../util/base64";
 import { Constants } from "../util/constants";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { ServiceClientCredentials } from "./serviceClientCredentials";
 const HeaderConstants = Constants.HeaderConstants;
 const DEFAULT_AUTHORIZATION_SCHEME = "Basic";
@@ -41,10 +41,10 @@ export class BasicAuthenticationCredentials implements ServiceClientCredentials 
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {WebResource} webResource The WebResource to be signed.
-   * @returns {Promise<WebResource>} The signed request object.
+   * @param {WebResourceLike} webResource The WebResourceLike to be signed.
+   * @returns {Promise<WebResourceLike>} The signed request object.
    */
-  signRequest(webResource: WebResource) {
+  signRequest(webResource: WebResourceLike) {
     const credentials = `${this.userName}:${this.password}`;
     const encodedCredentials = `${this.authorizationScheme} ${base64.encodeString(credentials)}`;
     if (!webResource.headers) webResource.headers = new HttpHeaders();

--- a/sdk/core/core-http/src/credentials/serviceClientCredentials.ts
+++ b/sdk/core/core-http/src/credentials/serviceClientCredentials.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 
 export interface ServiceClientCredentials {
   /**
    * Signs a request with the Authentication header.
    *
-   * @param {WebResource} webResource The WebResource/request to be signed.
-   * @returns {Promise<WebResource>} The signed request object;
+   * @param {WebResourceLike} webResource The WebResourceLike/request to be signed.
+   * @returns {Promise<WebResourceLike>} The signed request object;
    */
-  signRequest(webResource: WebResource): Promise<WebResource>;
+  signRequest(webResource: WebResourceLike): Promise<WebResourceLike>;
 }

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -5,9 +5,9 @@ import { AbortController, AbortError } from "@azure/abort-controller";
 import FormData from "form-data";
 
 import { HttpClient } from "./httpClient";
-import { TransferProgressEvent, WebResource } from "./webResource";
+import { TransferProgressEvent, WebResourceLike } from "./webResource";
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { HttpHeaders } from "./httpHeaders";
+import { HttpHeaders, HttpHeadersLike } from "./httpHeaders";
 import { RestError } from "./restError";
 import { Readable, Transform } from "stream";
 
@@ -34,10 +34,10 @@ export class ReportTransform extends Transform {
 }
 
 export abstract class FetchHttpClient implements HttpClient {
-  async sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse> {
+  async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
     if (!httpRequest && typeof httpRequest !== "object") {
       throw new Error(
-        "'httpRequest' (WebResource) cannot be null or undefined and must be of type object."
+        "'httpRequest' (WebResourceLike) cannot be null or undefined and must be of type object."
       );
     }
 
@@ -188,7 +188,7 @@ export abstract class FetchHttpClient implements HttpClient {
     }
   }
 
-  abstract async prepareRequest(httpRequest: WebResource): Promise<Partial<RequestInit>>;
+  abstract async prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>>;
   abstract async processRequest(operationResponse: HttpOperationResponse): Promise<void>;
   abstract async fetch(input: CommonRequestInfo, init?: RequestInit): Promise<Response>;
 }
@@ -197,7 +197,7 @@ function isReadableStream(body: any): body is Readable {
   return body && typeof body.pipe === "function";
 }
 
-export function parseHeaders(headers: Headers): HttpHeaders {
+export function parseHeaders(headers: Headers): HttpHeadersLike {
   const httpHeaders = new HttpHeaders();
 
   headers.forEach((value, key) => {

--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -28,10 +28,42 @@ export interface HttpHeader {
  */
 export type RawHttpHeaders = { [headerName: string]: string };
 
+export interface HttpHeadersLike {
+  set(headerName: string, headerValue: string | number): void;
+  get(headerName: string): string | undefined;
+  contains(headerName: string): boolean;
+  remove(headerName: string): boolean;
+  rawHeaders(): RawHttpHeaders;
+  headersArray(): HttpHeader[];
+  headerNames(): string[];
+  headerValues(): string[];
+  clone(): HttpHeadersLike;
+  toJson(): RawHttpHeaders;
+}
+
+export function isHttpHeadersLike(object?: object): object is HttpHeadersLike {
+  if (!object) {
+    return false;
+  }
+
+  const anyObj: any = object;
+  if (
+    typeof anyObj.rawHeaders === "function" &&
+    typeof anyObj.clone === "function" &&
+    typeof anyObj.get === "function" &&
+    typeof anyObj.set === "function" &&
+    typeof anyObj.contains === "function" &&
+    typeof anyObj.remove === "function"
+  ) {
+    return true;
+  }
+  return false;
+}
+
 /**
  * A collection of HTTP header key/value pairs.
  */
-export class HttpHeaders {
+export class HttpHeaders implements HttpHeadersLike {
   private readonly _headersMap: { [headerKey: string]: HttpHeader };
 
   constructor(rawHeaders?: RawHttpHeaders) {

--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -28,16 +28,57 @@ export interface HttpHeader {
  */
 export type RawHttpHeaders = { [headerName: string]: string };
 
+/**
+ * A collection of HTTP header key/value pairs.
+ */
 export interface HttpHeadersLike {
+  /**
+   * Set a header in this collection with the provided name and value. The name is
+   * case-insensitive.
+   * @param headerName The name of the header to set. This value is case-insensitive.
+   * @param headerValue The value of the header to set.
+   */
   set(headerName: string, headerValue: string | number): void;
+  /**
+   * Get the header value for the provided header name, or undefined if no header exists in this
+   * collection with the provided name.
+   * @param headerName The name of the header.
+   */
   get(headerName: string): string | undefined;
+  /**
+   * Get whether or not this header collection contains a header entry for the provided header name.
+   */
   contains(headerName: string): boolean;
+  /**
+   * Remove the header with the provided headerName. Return whether or not the header existed and
+   * was removed.
+   * @param headerName The name of the header to remove.
+   */
   remove(headerName: string): boolean;
+  /**
+   * Get the headers that are contained this collection as an object.
+   */
   rawHeaders(): RawHttpHeaders;
+  /**
+   * Get the headers that are contained in this collection as an array.
+   */
   headersArray(): HttpHeader[];
+  /**
+   * Get the header names that are contained in this collection.
+   */
   headerNames(): string[];
+  /**
+   * Get the header values that are contained in this collection.
+   */
   headerValues(): string[];
+  /**
+   * Create a deep clone/copy of this HttpHeaders collection.
+   */
   clone(): HttpHeadersLike;
+  /**
+   * Get the JSON object representation of this HTTP header collection.
+   * The result is the same as `rawHeaders()`.
+   */
   toJson(): RawHttpHeaders;
 }
 
@@ -152,7 +193,7 @@ export class HttpHeaders implements HttpHeadersLike {
   }
 
   /**
-   * Get the header names that are contained in this collection.
+   * Get the header values that are contained in this collection.
    */
   public headerValues(): string[] {
     const headerValues: string[] = [];

--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -82,19 +82,22 @@ export interface HttpHeadersLike {
   toJson(): RawHttpHeaders;
 }
 
-export function isHttpHeadersLike(object?: object): object is HttpHeadersLike {
-  if (!object) {
+export function isHttpHeadersLike(object?: any): object is HttpHeadersLike {
+  if (!object || typeof object !== "object") {
     return false;
   }
 
-  const anyObj: any = object;
   if (
-    typeof anyObj.rawHeaders === "function" &&
-    typeof anyObj.clone === "function" &&
-    typeof anyObj.get === "function" &&
-    typeof anyObj.set === "function" &&
-    typeof anyObj.contains === "function" &&
-    typeof anyObj.remove === "function"
+    typeof object.rawHeaders === "function" &&
+    typeof object.clone === "function" &&
+    typeof object.get === "function" &&
+    typeof object.set === "function" &&
+    typeof object.contains === "function" &&
+    typeof object.remove === "function" &&
+    typeof object.headersArray === "function" &&
+    typeof object.headerValues === "function" &&
+    typeof object.headerNames === "function" &&
+    typeof object.toJson === "function"
   ) {
     return true;
   }

--- a/sdk/core/core-http/src/httpOperationResponse.ts
+++ b/sdk/core/core-http/src/httpOperationResponse.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { WebResource } from "./webResource";
-import { HttpHeaders } from "./httpHeaders";
+import { WebResourceLike } from "./webResource";
+import { HttpHeadersLike } from "./httpHeaders";
 
 /**
  * The properties on an HTTP response which will always be present.
@@ -11,7 +11,7 @@ export interface HttpResponse {
   /**
    * The raw request
    */
-  request: WebResource;
+  request: WebResourceLike;
 
   /**
    * The HTTP response status (e.g. 200)
@@ -21,7 +21,7 @@ export interface HttpResponse {
   /**
    * The HTTP response headers.
    */
-  headers: HttpHeaders;
+  headers: HttpHeadersLike;
 }
 
 declare global {

--- a/sdk/core/core-http/src/nodeFetchHttpClient.ts
+++ b/sdk/core/core-http/src/nodeFetchHttpClient.ts
@@ -8,7 +8,7 @@ import "node-fetch";
 
 import { FetchHttpClient, CommonRequestInfo } from "./fetchHttpClient";
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { WebResource } from "./webResource";
+import { WebResourceLike } from "./webResource";
 import { createProxyAgent, ProxyAgent, isUrlHttps } from "./proxyAgent";
 
 interface GlobalWithFetch extends NodeJS.Global {
@@ -39,7 +39,7 @@ export class NodeFetchHttpClient extends FetchHttpClient {
 
   private readonly cookieJar = new tough.CookieJar(undefined, { looseMode: true });
 
-  private getOrCreateAgent(httpRequest: WebResource): http.Agent | https.Agent {
+  private getOrCreateAgent(httpRequest: WebResourceLike): http.Agent | https.Agent {
     const isHttps = isUrlHttps(httpRequest.url);
 
     // At the moment, proxy settings and keepAlive are mutually
@@ -91,7 +91,7 @@ export class NodeFetchHttpClient extends FetchHttpClient {
     return fetch(input, init);
   }
 
-  async prepareRequest(httpRequest: WebResource): Promise<Partial<RequestInit>> {
+  async prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>> {
     const requestInit: Partial<RequestInit & { agent?: any }> = {};
 
     if (this.cookieJar && !httpRequest.headers.get("Cookie")) {

--- a/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -11,7 +11,7 @@ import {
 import { Constants } from "../util/constants";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { HttpHeaders } from "../httpHeaders";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { AccessTokenCache, ExpiringAccessTokenCache } from "../credentials/accessTokenCache";
 
 /**
@@ -69,7 +69,7 @@ export class BearerTokenAuthenticationPolicy extends BaseRequestPolicy {
    * Applies the Bearer token to the request through the Authorization header.
    * @param webResource
    */
-  public async sendRequest(webResource: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(webResource: WebResourceLike): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
     const token = await this.getToken({
       abortSignal: webResource.abortSignal,

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -7,7 +7,7 @@ import { OperationSpec, isStreamOperation } from "../operationSpec";
 import { RestError } from "../restError";
 import { MapperType } from "../serializer";
 import { parseXML } from "../util/xml";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicy,
@@ -89,7 +89,7 @@ export class DeserializationPolicy extends BaseRequestPolicy {
       (deserializationContentTypes && deserializationContentTypes.xml) || defaultXmlContentTypes;
   }
 
-  public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy
       .sendRequest(request)
       .then((response: HttpOperationResponse) =>
@@ -102,7 +102,7 @@ function getOperationResponse(
   parsedResponse: HttpOperationResponse
 ): undefined | OperationResponse {
   let result: OperationResponse | undefined;
-  const request: WebResource = parsedResponse.request;
+  const request: WebResourceLike = parsedResponse.request;
   const operationSpec: OperationSpec | undefined = request.operationSpec;
   if (operationSpec) {
     const operationResponseGetter:

--- a/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicy,
@@ -87,7 +87,7 @@ export const DefaultRetryOptions: RetryOptions = {
   maxRetries: DEFAULT_CLIENT_RETRY_COUNT,
   retryDelayInMs: DEFAULT_CLIENT_RETRY_INTERVAL,
   maxRetryDelayInMs: DEFAULT_CLIENT_MAX_RETRY_INTERVAL
-}
+};
 
 /**
  * @class
@@ -134,7 +134,7 @@ export class ExponentialRetryPolicy extends BaseRequestPolicy {
       : DEFAULT_CLIENT_MAX_RETRY_INTERVAL;
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy
       .sendRequest(request.clone())
       .then((response) => retry(this, request, response))
@@ -211,17 +211,14 @@ function updateRetryData(
     Math.floor(Math.random() * (policy.retryInterval * 1.2 - policy.retryInterval * 0.8));
   incrementDelta *= boundedRandDelta;
 
-  retryData.retryInterval = Math.min(
-    incrementDelta,
-    policy.maxRetryInterval
-  );
+  retryData.retryInterval = Math.min(incrementDelta, policy.maxRetryInterval);
 
   return retryData;
 }
 
 function retry(
   policy: ExponentialRetryPolicy,
-  request: WebResource,
+  request: WebResourceLike,
   response?: HttpOperationResponse,
   retryData?: RetryData,
   requestError?: RetryError

--- a/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
+++ b/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicy,
@@ -29,7 +29,7 @@ export class GenerateClientRequestIdPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     if (!request.headers.contains(this._requestIdHeaderName)) {
       request.headers.set(this._requestIdHeaderName, request.requestId);
     }

--- a/sdk/core/core-http/src/policies/keepAlivePolicy.ts
+++ b/sdk/core/core-http/src/policies/keepAlivePolicy.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from './requestPolicy';
-import { WebResource } from '../webResource';
-import { HttpOperationResponse } from '../httpOperationResponse';
+import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from "./requestPolicy";
+import { WebResourceLike } from "../webResource";
+import { HttpOperationResponse } from "../httpOperationResponse";
 
 /**
  * Options for how HTTP connections should be maintained for future
@@ -19,7 +19,7 @@ export interface KeepAliveOptions {
 
 export const DefaultKeepAliveOptions: KeepAliveOptions = {
   enable: true
-}
+};
 
 export function keepAlivePolicy(keepAliveOptions?: KeepAliveOptions) {
   return {
@@ -51,11 +51,11 @@ export class KeepAlivePolicy extends BaseRequestPolicy {
   /**
    * Sends out request.
    *
-   * @param {WebResource} request
+   * @param {WebResourceLike} request
    * @returns {Promise<HttpOperationResponse>}
    * @memberof KeepAlivePolicy
    */
-  public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     request.keepAlive = this.keepAliveOptions.enable;
     return this._nextPolicy.sendRequest(request);
   }

--- a/sdk/core/core-http/src/policies/logPolicy.ts
+++ b/sdk/core/core-http/src/policies/logPolicy.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicy,
@@ -100,14 +100,14 @@ export class LogPolicy extends BaseRequestPolicy {
     this.sanitizer = new Sanitizer({ allowedHeaderNames, allowedQueryParameters });
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     if (!this.logger.enabled) return this._nextPolicy.sendRequest(request);
 
     this.logRequest(request);
     return this._nextPolicy.sendRequest(request).then((response) => this.logResponse(response));
   }
 
-  private logRequest(request: WebResource) {
+  private logRequest(request: WebResourceLike) {
     this.logger(`Request: ${this.sanitizer.sanitize(request)}`);
   }
 

--- a/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
@@ -9,7 +9,7 @@ import {
   RequestPolicyOptions
 } from "./requestPolicy";
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 
 const proxyNotSupportedInBrowser = new Error("ProxyPolicy is not supported in browser environment");
 
@@ -31,7 +31,7 @@ export class ProxyPolicy extends BaseRequestPolicy {
     throw proxyNotSupportedInBrowser;
   }
 
-  public sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(_request: WebResourceLike): Promise<HttpOperationResponse> {
     throw proxyNotSupportedInBrowser;
   }
 }

--- a/sdk/core/core-http/src/policies/proxyPolicy.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.ts
@@ -9,7 +9,7 @@ import {
 } from "./requestPolicy";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { ProxySettings } from "../serviceClient";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { Constants } from "../util/constants";
 import { URLBuilder } from "../url";
 
@@ -61,25 +61,27 @@ export function proxyPolicy(proxySettings?: ProxySettings): RequestPolicyFactory
   };
 }
 
-function extractAuthFromUrl(url: string) : { username?: string, password? : string, urlWithoutAuth: string } {
+function extractAuthFromUrl(
+  url: string
+): { username?: string; password?: string; urlWithoutAuth: string } {
   const atIndex = url.indexOf("@");
   if (atIndex === -1) {
-    return { urlWithoutAuth: url};
+    return { urlWithoutAuth: url };
   }
 
-  const schemeIndex = url.indexOf("://")
-  let authStart =  schemeIndex !== -1 ? schemeIndex + 3  : 0;
+  const schemeIndex = url.indexOf("://");
+  let authStart = schemeIndex !== -1 ? schemeIndex + 3 : 0;
   const auth = url.substring(authStart, atIndex);
   const colonIndex = auth.indexOf(":");
   const hasPassword = colonIndex !== -1;
-  const username = hasPassword ? auth.substring(0, colonIndex) : auth
+  const username = hasPassword ? auth.substring(0, colonIndex) : auth;
   const password = hasPassword ? auth.substring(colonIndex + 1) : undefined;
   const urlWithoutAuth = url.substring(0, authStart) + url.substring(atIndex + 1);
   return {
     username,
     password,
     urlWithoutAuth
-  }
+  };
 }
 
 export class ProxyPolicy extends BaseRequestPolicy {
@@ -94,7 +96,7 @@ export class ProxyPolicy extends BaseRequestPolicy {
     this.proxySettings = proxySettings;
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     if (!request.proxySettings) {
       request.proxySettings = this.proxySettings;
     }

--- a/sdk/core/core-http/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-http/src/policies/redirectPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { URLBuilder } from "../url";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicy,
@@ -30,7 +30,7 @@ export interface RedirectOptions {
 export const DefaultRedirectOptions: RedirectOptions = {
   handleRedirects: true,
   maxRetries: 20
-}
+};
 
 export function redirectPolicy(maximumRetries = 20): RequestPolicyFactory {
   return {
@@ -45,7 +45,7 @@ export class RedirectPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy
       .sendRequest(request)
       .then((response) => handleRedirect(this, response, 0));

--- a/sdk/core/core-http/src/policies/requestPolicy.ts
+++ b/sdk/core/core-http/src/policies/requestPolicy.ts
@@ -4,7 +4,7 @@
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { HttpPipelineLogger } from "../httpPipelineLogger";
 import { HttpPipelineLogLevel } from "../httpPipelineLogLevel";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 
 /**
  * Creates a new RequestPolicy per-request that uses the provided nextPolicy.
@@ -14,7 +14,7 @@ export type RequestPolicyFactory = {
 };
 
 export interface RequestPolicy {
-  sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse>;
+  sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse>;
 }
 
 export abstract class BaseRequestPolicy implements RequestPolicy {
@@ -23,7 +23,7 @@ export abstract class BaseRequestPolicy implements RequestPolicy {
     readonly _options: RequestPolicyOptions
   ) {}
 
-  public abstract sendRequest(webResource: WebResource): Promise<HttpOperationResponse>;
+  public abstract sendRequest(webResource: WebResourceLike): Promise<HttpOperationResponse>;
 
   /**
    * Get whether or not a log with the provided log level should be logged.

--- a/sdk/core/core-http/src/policies/rpRegistrationPolicy.ts
+++ b/sdk/core/core-http/src/policies/rpRegistrationPolicy.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicy,
@@ -27,7 +27,7 @@ export class RPRegistrationPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy
       .sendRequest(request.clone())
       .then((response) => registerIfNeeded(this, request, response));
@@ -36,7 +36,7 @@ export class RPRegistrationPolicy extends BaseRequestPolicy {
 
 function registerIfNeeded(
   policy: RPRegistrationPolicy,
-  request: WebResource,
+  request: WebResourceLike,
   response: HttpOperationResponse
 ): Promise<HttpOperationResponse> {
   if (response.status === 409) {
@@ -67,12 +67,15 @@ function registerIfNeeded(
 
 /**
  * Reuses the headers of the original request and url (if specified).
- * @param {WebResource} originalRequest The original request
+ * @param {WebResourceLike} originalRequest The original request
  * @param {boolean} reuseUrlToo Should the url from the original request be reused as well. Default false.
  * @returns {object} A new request object with desired headers.
  */
-function getRequestEssentials(originalRequest: WebResource, reuseUrlToo = false): WebResource {
-  const reqOptions: WebResource = originalRequest.clone();
+function getRequestEssentials(
+  originalRequest: WebResourceLike,
+  reuseUrlToo = false
+): WebResourceLike {
+  const reqOptions: WebResourceLike = originalRequest.clone();
   if (reuseUrlToo) {
     reqOptions.url = originalRequest.url;
   }
@@ -139,7 +142,7 @@ function extractSubscriptionUrl(url: string): string {
  * @param {RPRegistrationPolicy} policy The RPRegistrationPolicy this function is being called against.
  * @param {string} urlPrefix https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/
  * @param {string} provider The provider name to be registered.
- * @param {WebResource} originalRequest The original request sent by the user that returned a 409 response
+ * @param {WebResourceLike} originalRequest The original request sent by the user that returned a 409 response
  * with a message that the provider is not registered.
  * @param {registrationCallback} callback The callback that handles the RP registration
  */
@@ -147,7 +150,7 @@ function registerRP(
   policy: RPRegistrationPolicy,
   urlPrefix: string,
   provider: string,
-  originalRequest: WebResource
+  originalRequest: WebResourceLike
 ): Promise<boolean> {
   const postUrl = `${urlPrefix}providers/${provider}/register?api-version=2016-02-01`;
   const getUrl = `${urlPrefix}providers/${provider}?api-version=2016-02-01`;
@@ -168,14 +171,14 @@ function registerRP(
  * Polling will happen till the registrationState property of the response body is "Registered".
  * @param {RPRegistrationPolicy} policy The RPRegistrationPolicy this function is being called against.
  * @param {string} url The request url for polling
- * @param {WebResource} originalRequest The original request sent by the user that returned a 409 response
+ * @param {WebResourceLike} originalRequest The original request sent by the user that returned a 409 response
  * with a message that the provider is not registered.
  * @returns {Promise<boolean>} True if RP Registration is successful.
  */
 function getRegistrationStatus(
   policy: RPRegistrationPolicy,
   url: string,
-  originalRequest: WebResource
+  originalRequest: WebResourceLike
 ): Promise<boolean> {
   const reqOptions: any = getRequestEssentials(originalRequest);
   reqOptions.url = url;

--- a/sdk/core/core-http/src/policies/signingPolicy.ts
+++ b/sdk/core/core-http/src/policies/signingPolicy.ts
@@ -3,7 +3,7 @@
 
 import { ServiceClientCredentials } from "../credentials/serviceClientCredentials";
 import { HttpOperationResponse } from "../httpOperationResponse";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicyFactory,
@@ -30,11 +30,11 @@ export class SigningPolicy extends BaseRequestPolicy {
     super(nextPolicy, options);
   }
 
-  signRequest(request: WebResource): Promise<WebResource> {
+  signRequest(request: WebResourceLike): Promise<WebResourceLike> {
     return this.authenticationProvider.signRequest(request);
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this.signRequest(request).then((nextRequest) =>
       this._nextPolicy.sendRequest(nextRequest)
     );

--- a/sdk/core/core-http/src/policies/systemErrorRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/systemErrorRetryPolicy.ts
@@ -3,7 +3,7 @@
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import {
   BaseRequestPolicy,
   RequestPolicy,
@@ -85,7 +85,7 @@ export class SystemErrorRetryPolicy extends BaseRequestPolicy {
         : this.DEFAULT_CLIENT_MAX_RETRY_INTERVAL;
   }
 
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy
       .sendRequest(request.clone())
       .then((response) => retry(this, request, response));
@@ -155,7 +155,7 @@ function updateRetryData(
 
 function retry(
   policy: SystemErrorRetryPolicy,
-  request: WebResource,
+  request: WebResourceLike,
   operationResponse: HttpOperationResponse,
   retryData?: RetryData,
   err?: RetryError

--- a/sdk/core/core-http/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/throttlingRetryPolicy.ts
@@ -7,13 +7,13 @@ import {
   RequestPolicyOptions,
   RequestPolicyFactory
 } from "./requestPolicy";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { Constants } from "../util/constants";
 import { delay } from "../util/utils";
 
 type ResponseHandler = (
-  httpRequest: WebResource,
+  httpRequest: WebResourceLike,
   response: HttpOperationResponse
 ) => Promise<HttpOperationResponse>;
 const StatusCodes = Constants.HttpConstants.StatusCodes;
@@ -44,7 +44,7 @@ export class ThrottlingRetryPolicy extends BaseRequestPolicy {
     this._handleResponse = _handleResponse || this._defaultResponseHandler;
   }
 
-  public async sendRequest(httpRequest: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy.sendRequest(httpRequest.clone()).then((response) => {
       if (response.status !== StatusCodes.TooManyRequests) {
         return response;
@@ -55,7 +55,7 @@ export class ThrottlingRetryPolicy extends BaseRequestPolicy {
   }
 
   private async _defaultResponseHandler(
-    httpRequest: WebResource,
+    httpRequest: WebResourceLike,
     httpResponse: HttpOperationResponse
   ): Promise<HttpOperationResponse> {
     const retryAfterHeader: string | undefined = httpResponse.headers.get(

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -9,7 +9,7 @@ import {
   RequestPolicyOptions,
   BaseRequestPolicy
 } from "./requestPolicy";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { URLBuilder } from "../url";
 
@@ -37,7 +37,7 @@ export class TracingPolicy extends BaseRequestPolicy {
     this.userAgent = tracingOptions.userAgent;
   }
 
-  public async sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public async sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     if (!request.spanOptions || !request.spanOptions.parent) {
       return this._nextPolicy.sendRequest(request);
     }

--- a/sdk/core/core-http/src/policies/userAgentPolicy.ts
+++ b/sdk/core/core-http/src/policies/userAgentPolicy.ts
@@ -4,7 +4,7 @@
 import { HttpHeaders } from "../httpHeaders";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { Constants } from "../util/constants";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { getDefaultUserAgentKey, getPlatformSpecificData } from "./msRestUserAgentPolicy";
 import {
   BaseRequestPolicy,
@@ -82,12 +82,12 @@ export class UserAgentPolicy extends BaseRequestPolicy {
     super(_nextPolicy, _options);
   }
 
-  sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     this.addUserAgentHeader(request);
     return this._nextPolicy.sendRequest(request);
   }
 
-  addUserAgentHeader(request: WebResource): void {
+  addUserAgentHeader(request: WebResourceLike): void {
     if (!request.headers) {
       request.headers = new HttpHeaders();
     }

--- a/sdk/core/core-http/src/proxyAgent.ts
+++ b/sdk/core/core-http/src/proxyAgent.ts
@@ -7,24 +7,20 @@ import * as tunnel from "tunnel";
 
 import { ProxySettings } from "./serviceClient";
 import { URLBuilder } from "./url";
-import { HttpHeaders } from "./httpHeaders";
+import { HttpHeadersLike } from "./httpHeaders";
 
 export type ProxyAgent = { isHttps: boolean; agent: http.Agent | https.Agent };
 export function createProxyAgent(
   requestUrl: string,
   proxySettings: ProxySettings,
-  headers?: HttpHeaders
+  headers?: HttpHeadersLike
 ): ProxyAgent {
   const host = URLBuilder.parse(proxySettings.host).getHost() as string;
   if (!host) {
-    throw new Error(
-      "Expecting a non-empty host in proxy settings."
-    );
+    throw new Error("Expecting a non-empty host in proxy settings.");
   }
   if (!isValidPort(proxySettings.port)) {
-    throw new Error(
-      "Expecting a valid port number in the range of [0, 65535] in proxy settings."
-    );
+    throw new Error("Expecting a valid port number in the range of [0, 65535] in proxy settings.");
   }
   const tunnelOptions: tunnel.HttpsOverHttpsOptions = {
     proxy: {

--- a/sdk/core/core-http/src/restError.ts
+++ b/sdk/core/core-http/src/restError.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { HttpOperationResponse } from "./httpOperationResponse";
-import { WebResource } from "./webResource";
+import { WebResourceLike } from "./webResource";
 import { custom } from "./util/inspect";
 import { Sanitizer } from "./util/sanitizer";
 
@@ -14,14 +14,14 @@ export class RestError extends Error {
 
   code?: string;
   statusCode?: number;
-  request?: WebResource;
+  request?: WebResourceLike;
   response?: HttpOperationResponse;
   details?: unknown;
   constructor(
     message: string,
     code?: string,
     statusCode?: number,
-    request?: WebResource,
+    request?: WebResourceLike,
     response?: HttpOperationResponse
   ) {
     super(message);

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -41,7 +41,13 @@ import { CompositeMapper, DictionaryMapper, Mapper, MapperType, Serializer } fro
 import { URLBuilder } from "./url";
 import * as utils from "./util/utils";
 import { stringifyXML } from "./util/xml";
-import { RequestOptionsBase, RequestPrepareOptions, WebResource } from "./webResource";
+import {
+  RequestOptionsBase,
+  RequestPrepareOptions,
+  WebResource,
+  WebResourceLike,
+  isWebResourceLike
+} from "./webResource";
 import { OperationResponse } from "./operationResponse";
 import { ServiceCallback, isNode } from "./util/utils";
 import { proxyPolicy } from "./policies/proxyPolicy";
@@ -247,14 +253,14 @@ export class ServiceClient {
   /**
    * Send the provided httpRequest.
    */
-  sendRequest(options: RequestPrepareOptions | WebResource): Promise<HttpOperationResponse> {
+  sendRequest(options: RequestPrepareOptions | WebResourceLike): Promise<HttpOperationResponse> {
     if (options === null || options === undefined || typeof options !== "object") {
       throw new Error("options cannot be null or undefined and it must be of type object.");
     }
 
-    let httpRequest: WebResource;
+    let httpRequest: WebResourceLike;
     try {
-      if (options instanceof WebResource) {
+      if (isWebResourceLike(options)) {
         options.validateRequestProperties();
         httpRequest = options;
       } else {
@@ -293,7 +299,7 @@ export class ServiceClient {
       operationArguments.options = undefined;
     }
 
-    const httpRequest = new WebResource();
+    const httpRequest: WebResourceLike = new WebResource();
 
     let result: Promise<RestResponse>;
     try {
@@ -491,7 +497,7 @@ export class ServiceClient {
 
 export function serializeRequestBody(
   serviceClient: ServiceClient,
-  httpRequest: WebResource,
+  httpRequest: WebResourceLike,
   operationArguments: OperationArguments,
   operationSpec: OperationSpec
 ): void {

--- a/sdk/core/core-http/src/util/constants.ts
+++ b/sdk/core/core-http/src/util/constants.ts
@@ -7,7 +7,7 @@ export const Constants = {
    * @const
    * @type {string}
    */
-  coreHttpVersion: "1.0.5",
+  coreHttpVersion: "1.1.0",
 
   /**
    * Specifies HTTP.

--- a/sdk/core/core-http/src/util/utils.ts
+++ b/sdk/core/core-http/src/util/utils.ts
@@ -4,7 +4,7 @@
 import uuidv4 from "uuid/v4";
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { RestError } from "../restError";
-import { WebResource } from "../webResource";
+import { WebResourceLike } from "../webResource";
 import { Constants } from "./constants";
 
 const validUuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i;
@@ -63,11 +63,11 @@ export function stripResponse(response: HttpOperationResponse): any {
  * Returns a stripped version of the Http Request that does not contain the
  * Authorization header.
  *
- * @param {WebResource} request The Http Request object
+ * @param {WebResourceLike} request The Http Request object
  *
- * @return {WebResource} The stripped version of Http Request.
+ * @return {WebResourceLike} The stripped version of Http Request.
  */
-export function stripRequest(request: WebResource): WebResource {
+export function stripRequest(request: WebResourceLike): WebResourceLike {
   const strippedRequest = request.clone();
   if (strippedRequest.headers) {
     strippedRequest.headers.remove("authorization");
@@ -132,13 +132,13 @@ export interface ServiceCallback<TResult> {
    * A method that will be invoked as a callback to a service function.
    * @param {Error | RestError | null} err The error occurred if any, while executing the request; otherwise null.
    * @param {TResult} [result] The deserialized response body if an error did not occur.
-   * @param {WebResource} [request] The raw/actual request sent to the server if an error did not occur.
+   * @param {WebResourceLike} [request] The raw/actual request sent to the server if an error did not occur.
    * @param {HttpOperationResponse} [response] The raw/actual response from the server if an error did not occur.
    */
   (
     err: Error | RestError | null,
     result?: TResult,
-    request?: WebResource,
+    request?: WebResourceLike,
     response?: HttpOperationResponse
   ): void;
 }

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -38,30 +38,103 @@ export type TransferProgressEvent = {
 };
 
 export interface WebResourceLike {
+  /**
+   * The URL being accessed by the request.
+   */
   url: string;
+  /**
+   * The HTTP method to use when making the request.
+   */
   method: HttpMethods;
+  /**
+   * The HTTP body contents of the request.
+   */
   body?: any;
+  /**
+   * The HTTP headers to use when making the request.
+   */
   headers: HttpHeadersLike;
+  /**
+   * Whether or not the body of the HttpOperationResponse should be treated as a stream.
+   */
   streamResponseBody?: boolean;
+  /**
+   * Whether or not the HttpOperationResponse should be deserialized. If this is undefined, then the
+   * HttpOperationResponse should be deserialized.
+   */
   shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
+  /**
+   * A function that returns the proper OperationResponse for the given OperationSpec and
+   * HttpOperationResponse combination. If this is undefined, then a simple status code lookup will
+   * be used.
+   */
   operationResponseGetter?: (
     operationSpec: OperationSpec,
     response: HttpOperationResponse
   ) => undefined | OperationResponse;
   formData?: any;
+  /**
+   * A query string represented as an object.
+   */
   query?: { [key: string]: any };
+  /**
+   * Used to parse the response.
+   */
   operationSpec?: OperationSpec;
+  /**
+   * If credentials (cookies) should be sent along during an XHR.
+   */
   withCredentials: boolean;
+  /**
+   * The number of milliseconds a request can take before automatically being terminated.
+   * If the request is terminated, an `AbortError` is thrown.
+   */
   timeout: number;
+  /**
+   * Proxy configuration.
+   */
   proxySettings?: ProxySettings;
+  /**
+   * If the connection should be reused.
+   */
   keepAlive?: boolean;
+  /**
+   * A unique identifier for the request. Used for logging and tracing.
+   */
   requestId: string;
+
+  /**
+   * Used to abort the request later.
+   */
   abortSignal?: AbortSignalLike;
+
+  /**
+   * Callback which fires upon upload progress.
+   */
   onUploadProgress?: (progress: TransferProgressEvent) => void;
+
+  /** Callback which fires upon download progress. */
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
+
+  /**
+   * Options used to create a span when tracing is enabled.
+   */
   spanOptions?: SpanOptions;
+
+  /**
+   * Validates that the required properties such as method, url, headers["Content-Type"],
+   * headers["accept-language"] are defined. It will throw an error if one of the above
+   * mentioned properties are not defined.
+   */
   validateRequestProperties(): void;
+
+  /**
+   * Sets options on the request.
+   */
   prepare(options: RequestPrepareOptions): WebResourceLike;
+  /**
+   * Clone this request object.
+   */
   clone(): WebResourceLike;
 }
 

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -138,15 +138,18 @@ export interface WebResourceLike {
   clone(): WebResourceLike;
 }
 
-export function isWebResourceLike(object: object): object is WebResourceLike {
-  const anyObj: any = object;
+export function isWebResourceLike(object: any): object is WebResourceLike {
+  if (typeof object !== "object") {
+    return false;
+  }
   if (
-    typeof anyObj.url === "string" &&
-    typeof anyObj.method === "string" &&
-    typeof anyObj.headers === "object" &&
-    typeof anyObj.validateRequestProperties === "function" &&
-    typeof anyObj.prepare === "function" &&
-    typeof anyObj.clone === "function"
+    typeof object.url === "string" &&
+    typeof object.method === "string" &&
+    typeof object.headers === "object" &&
+    isHttpHeadersLike(object.headers) &&
+    typeof object.validateRequestProperties === "function" &&
+    typeof object.prepare === "function" &&
+    typeof object.clone === "function"
   ) {
     return true;
   }

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -88,7 +88,7 @@ export function isWebResourceLike(object: object): object is WebResourceLike {
  *
  * @constructor
  */
-export class WebResource {
+export class WebResource implements WebResourceLike {
   url: string;
   method: HttpMethods;
   body?: any;

--- a/sdk/core/core-http/src/xhrHttpClient.ts
+++ b/sdk/core/core-http/src/xhrHttpClient.ts
@@ -4,7 +4,7 @@
 import { AbortError } from "@azure/abort-controller";
 import { HttpClient } from "./httpClient";
 import { HttpHeaders } from "./httpHeaders";
-import { WebResource, TransferProgressEvent } from "./webResource";
+import { WebResourceLike, TransferProgressEvent } from "./webResource";
 import { HttpOperationResponse } from "./httpOperationResponse";
 import { RestError } from "./restError";
 
@@ -12,7 +12,7 @@ import { RestError } from "./restError";
  * A HttpClient implementation that uses XMLHttpRequest to send HTTP requests.
  */
 export class XhrHttpClient implements HttpClient {
-  public sendRequest(request: WebResource): Promise<HttpOperationResponse> {
+  public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     const xhr = new XMLHttpRequest();
 
     if (request.proxySettings) {
@@ -147,7 +147,7 @@ export function parseHeaders(xhr: XMLHttpRequest) {
 }
 
 function rejectOnTerminalEvent(
-  request: WebResource,
+  request: WebResourceLike,
   xhr: XMLHttpRequest,
   reject: (err: any) => void
 ) {


### PR DESCRIPTION
Since we have been bitten a couple times by `WebResource` being a concrete class instead of an interface on our public methods, I tried making an interface out of it and moving things over to use it. I had to do the same for the `HttpHeaders` class.

It was a little easier to accomplish than I expected, so I appreciate some extra eyes/feedback on the approach. :)