### PR TITLE
[storage][blob] blob versioning

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -69,6 +69,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ZRPkQuzFuT3H/XK81dHVSjCfmfgiPMpJWBZWCEkZAogysZEtO3ydwzIXn95KsRWLJzfoT9m9TYwccSB5Brs+bg==
+  /@azure/core-asynciterator-polyfill/1.0.0:
+    dev: false
+    resolution:
+      integrity: sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==
   /@azure/core-auth/1.1.1:
     dependencies:
       '@azure/abort-controller': 1.0.1
@@ -78,6 +82,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-9Sgl5tFu9s1UKghJUx1VK72CiShSeHbubaaE1xkK/xRc6CU11nU3aEFZBJxWNqBQoR1KmOk53mOQEz4haVLo6w==
+  /@azure/core-auth/1.1.2:
+    dependencies:
+      '@azure/abort-controller': 1.0.1
+      '@azure/core-tracing': 1.0.0-preview.8
+      '@opentelemetry/api': 0.6.1
+      tslib: 1.11.1
+    dev: false
+    resolution:
+      integrity: sha512-IUbP/f3v96dpHgXUwsAjUwDzjlUjawyUhWhGKKB6Qxy+iqppC/pVBPyc6kdpyTe7H30HN+4H3f0lar7Wp9Hx6A==
   /@azure/core-http/1.1.0:
     dependencies:
       '@azure/abort-controller': 1.0.1
@@ -99,6 +112,41 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2H9AU5PxOSpRggWvOwDOSjJ6+Vym7r8nkdm0PQVGXPiyHjhrR/pvYqi5fHKPYDQQL4hm0eQy7LsT0dRIfdeztw==
+  /@azure/core-http/1.1.3:
+    dependencies:
+      '@azure/abort-controller': 1.0.1
+      '@azure/core-auth': 1.1.2
+      '@azure/core-tracing': 1.0.0-preview.8
+      '@azure/logger': 1.0.0
+      '@opentelemetry/api': 0.6.1
+      '@types/node-fetch': 2.5.5
+      '@types/tunnel': 0.0.1
+      form-data: 3.0.0
+      node-fetch: 2.6.0
+      process: 0.11.10
+      tough-cookie: 4.0.0
+      tslib: 1.11.1
+      tunnel: 0.0.6
+      uuid: 8.1.0
+      xml2js: 0.4.23
+    dev: false
+    resolution:
+      integrity: sha512-GysW3+BRVV4L9cs3GsuCbnlyibrQU6hh5mcJ7hlnk7tdUBzWybUvJ8/P/nHX49PgwRmi81pD5v1ht2jF0IzxAQ==
+  /@azure/core-lro/1.0.2:
+    dependencies:
+      '@azure/abort-controller': 1.0.1
+      '@azure/core-http': 1.1.3
+      events: 3.1.0
+      tslib: 1.11.1
+    dev: false
+    resolution:
+      integrity: sha512-Yr0JD7GKryOmbcb5wHCQoQ4KCcH5QJWRNorofid+UvudLaxnbCfvKh/cUfQsGUqRjO9L/Bw4X7FP824DcHdMxw==
+  /@azure/core-paging/1.1.1:
+    dependencies:
+      '@azure/core-asynciterator-polyfill': 1.0.0
+    dev: false
+    resolution:
+      integrity: sha512-hqEJBEGKan4YdOaL9ZG/GRG6PXaFd/Wb3SSjQW4LWotZzgl6xqG00h6wmkrpd2NNkbBkD1erLHBO3lPHApv+iQ==
   /@azure/core-tracing/1.0.0-preview.7:
     dependencies:
       '@opencensus/web-types': 0.0.7
@@ -182,6 +230,20 @@ packages:
     dev: false
     resolution:
       integrity: sha512-aFHRw/IHhg3I9ZJW+Va4L+sCirFHMVIu6B7lFdL5mGLfG3xC5vDIdd957LRXFgy2OiKFRUC0QaKknd0YCsQIqA==
+  /@azure/storage-blob/12.1.2:
+    dependencies:
+      '@azure/abort-controller': 1.0.1
+      '@azure/core-http': 1.1.3
+      '@azure/core-lro': 1.0.2
+      '@azure/core-paging': 1.1.1
+      '@azure/core-tracing': 1.0.0-preview.8
+      '@azure/logger': 1.0.0
+      '@opentelemetry/api': 0.6.1
+      events: 3.1.0
+      tslib: 1.11.1
+    dev: false
+    resolution:
+      integrity: sha512-PCHgG4r3xLt5FaFj+uiMqrRpuzD3TD17cvxCeA1JKK2bJEf8b07H3QRLQVf0DM1MmvYY8FgQagkWZTp+jr9yew==
   /@babel/code-frame/7.8.3:
     dependencies:
       '@babel/highlight': 7.9.0
@@ -6741,14 +6803,14 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-WIeWa7WCpFA6QetST301ARgVphM=
-  /ts-loader/6.2.2_typescript@3.8.3:
+  /ts-loader/6.2.2_typescript@3.9.5:
     dependencies:
       chalk: 2.4.2
       enhanced-resolve: 4.1.1
       loader-utils: 1.4.0
       micromatch: 4.0.2
       semver: 6.3.0
-      typescript: 3.8.3
+      typescript: 3.9.5
     dev: false
     engines:
       node: '>=8.6'
@@ -7838,7 +7900,7 @@ packages:
       shx: 0.3.2
       sinon: 9.0.2
       tough-cookie: 4.0.0
-      ts-loader: 6.2.2_typescript@3.8.3
+      ts-loader: 6.2.2_typescript@3.9.5
       ts-node: 8.8.2_typescript@3.9.5
       tslib: 2.0.0
       tunnel: 0.0.6
@@ -8257,6 +8319,7 @@ packages:
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
     dependencies:
+      '@azure/storage-blob': 12.1.2
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.1_rollup@1.32.1
@@ -8316,7 +8379,7 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-WeR08au7K0lgwkV/nQjy3NP/6dOrJ9YBd2C4fPnaW01kDV65CeAwtbNbDRR0gqfzGZYi62Q3gFEdfzsuJjL2Wg==
+      integrity: sha512-a2VkvB0VXuppKkDffruxfSgqSFzDSxaY0eIrKr6mLVXE2dhmttnQUqt/v8Rhfam0e9YQZ78STghOi9eyO3/oKg==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -8838,6 +8901,7 @@ packages:
   'file:projects/storage-file-datalake.tgz':
     dependencies:
       '@azure/core-tracing': 1.0.0-preview.8
+      '@azure/storage-blob': 12.1.2
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@opentelemetry/types': 0.2.0
@@ -8902,7 +8966,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-+5A/p1Sz5BnPMXppQ+6CGY6vD+UtG0X93WoPzcmUjX4zlbtPZ1GGut1tEMMqoVtVO6DrbTWAfG1RqcZeQ4NnWw==
+      integrity: sha512-9YgvSq/ORVPAudkZMd4jODocqIlewuS9my9J33Ewh3ShqucfhS0LkQ7F4j06Fdd+G6q33n9/olBm8YiBV1i2BQ==
       tarball: 'file:projects/storage-file-datalake.tgz'
     version: 0.0.0
   'file:projects/storage-file-share.tgz':

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 12.2.0 (2020.06)
 
 - Supported quick query. Added a new API `BlockBlobClient.query()`.
+- Added support for blob versioning.
 
 ## 12.1.2 (2020.05)
 

--- a/sdk/storage/storage-blob/CHANGELOG.md
+++ b/sdk/storage/storage-blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 12.2.0 (2020.06)
+## 12.2.0-preview.1 (2020.06)
 
 - Supported quick query. Added a new API `BlockBlobClient.query()`.
 - Added support for blob versioning.

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -65,7 +65,8 @@ module.exports = function(config) {
       "MD_ACCOUNT_NAME",
       "MD_ACCOUNT_SAS",
       "ENCRYPTION_SCOPE_1",
-      "ENCRYPTION_SCOPE_2"
+      "ENCRYPTION_SCOPE_2",
+      "BLOB_VERSIONING_ENABLED",
     ],
 
     // test results reporter to use

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.1.2",
+  "version": "12.2.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob/src/index.js",
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.1.2 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.2.0",
+  "version": "12.2.0-preview.1",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/storage-blob/src/index.js",
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0-preview.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_asynchorous_copy_return_versionid.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_asynchorous_copy_return_versionid.json
@@ -1,0 +1,124 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881615108136",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:15 GMT",
+    "etag": "\"0x8D7CBCD976713A6\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "58b39517-753d-4506-8d6e-69d01f624de1",
+    "x-ms-request-id": "30564bfa-d01e-0037-36b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881615108136/blob158459881663707143",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:16 GMT",
+    "etag": "\"0x8D7CBCD97B15B2A\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:16 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "deb01af6-44d6-4843-b20d-38bdcb47b783",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "30564c9f-d01e-0037-51b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:16.9931562Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881615108136/blob158459881663707143",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:16 GMT",
+    "etag": "\"0x8D7CBCD97D760AA\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "729b19ce-6243-4800-b95f-8138cc233cb7",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "30564d14-d01e-0037-39b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:17.2433338Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881615108136/copiedblob158459881736905963",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:16 GMT",
+    "etag": "\"0x8D7CBCD9822F660\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "bbbdb833-5f2d-4cd7-9839-bdddd2f8e143",
+    "x-ms-copy-id": "ae72f090-1922-4a3d-a29d-6fabfef52e3b",
+    "x-ms-copy-status": "success",
+    "x-ms-request-id": "30564dda-d01e-0037-6eb6-fd086e000000",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:17.7386873Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881615108136",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:17 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "4fa4ff2d-cac3-4679-b968-c36c1c88f304",
+    "x-ms-request-id": "30564e93-d01e-0037-19b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459881615108136",
+   "blob": "blob158459881663707143",
+   "copiedblob": "copiedblob158459881736905963"
+  },
+  "newDate": {}
+ },
+ "hash": "3e5c80ac78e807a57279f678364a502a"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_blob_create_return_versionid.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_blob_create_return_versionid.json
@@ -1,0 +1,146 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881068704010",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:10 GMT",
+    "etag": "\"0x8D7CBCD9424E847\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:11 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "54f6f202-7dcb-429e-b25f-814682fe39d2",
+    "x-ms-request-id": "3056432a-d01e-0037-1bb6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881068704010/blob158459881116905984",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:10 GMT",
+    "etag": "\"0x8D7CBCD9470B39F\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:11 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "a9950ac3-2ef4-4275-b152-59e477b0bc87",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "3056442f-d01e-0037-59b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:11.5362719Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881068704010/blob158459881116905984",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:10 GMT",
+    "etag": "\"0x8D7CBCD949643CD\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:11 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "42940c9c-ba53-4556-aaef-7f8223ff0dc1",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "30564496-d01e-0037-32b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:11.7834461Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881068704010/appendblob158459881193700671",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:11 GMT",
+    "etag": "\"0x8D7CBCD94E3D5AC\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:12 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5be0b593-a370-492a-8cf8-2ac7328b56ae",
+    "x-ms-request-id": "30564577-d01e-0037-69b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:12.2918081Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881068704010/pageblob158459881242305319",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:11 GMT",
+    "etag": "\"0x8D7CBCD9536E6D1\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:12 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "a8a69856-650d-447e-8dae-53faef56a6ed",
+    "x-ms-request-id": "30564662-d01e-0037-31b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:12.8361958Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881068704010",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:12 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "9212afac-d8c2-4b86-91a9-b6e3beef2c7e",
+    "x-ms-request-id": "30564724-d01e-0037-54b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459881068704010",
+   "blob": "blob158459881116905984",
+   "appendblob": "appendblob158459881193700671",
+   "pageblob": "pageblob158459881242305319"
+  },
+  "newDate": {}
+ },
+ "hash": "6ff8fe801dcbf1a372d61468348d38ff"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_delete_a_snapshot.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_delete_a_snapshot.json
@@ -1,0 +1,196 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:56 GMT",
+    "etag": "\"0x8D7CBCD8BC2A63D\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:56 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "02a8bd62-08c6-419d-ad3b-75334803b2c9",
+    "x-ms-request-id": "d85c813b-201e-0041-01b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364/blob158459879710201125",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "etag": "\"0x8D7CBCD8C0BCDB5\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e0260587-09c4-41b6-9e48-531cb77a0b90",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c8249-201e-0041-62b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:57.4532533Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364/blob158459879710201125",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "etag": "\"0x8D7CBCD8C333304\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "152a35ac-dda5-417d-ba02-5f032c3c0014",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c82a9-201e-0041-39b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:57.7124372Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364/blob158459879710201125",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "comp": "snapshot"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "etag": "\"0x8D7CBCD8C333304\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "6ea0fcc2-f318-42a1-8137-19eac872e78b",
+    "x-ms-request-id": "d85c83d9-201e-0041-32b6-fd8226000000",
+    "x-ms-request-server-encrypted": "false",
+    "x-ms-snapshot": "2020-03-19T06:19:58.2007844Z",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:58.2017844Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364/blob158459879710201125",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "snapshot": "2020-03-19T06:19:58.2007844Z"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:58 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "23702850-aa66-4cc8-a787-be09b5476ff1",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "d85c84cd-201e-0041-7fb6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364/blob158459879710201125",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "snapshot": "2020-03-19T06:19:58.2007844Z"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 19 Mar 2020 06:19:58 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "bd3f7388-50c4-4d48-8004-efb6d36a9436",
+    "x-ms-error-code": "BlobNotFound",
+    "x-ms-request-id": "d85c85fa-201e-0041-04b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364/blob158459879710201125",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "content-type": "application/octet-stream",
+    "date": "Thu, 19 Mar 2020 06:19:59 GMT",
+    "etag": "\"0x8D7CBCD8C333304\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-access-tier": "Hot",
+    "x-ms-access-tier-inferred": "true",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "89d79e7d-7ac6-4965-af69-1f10078a21d9",
+    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:57 GMT",
+    "x-ms-is-current-version": "true",
+    "x-ms-lease-state": "available",
+    "x-ms-lease-status": "unlocked",
+    "x-ms-request-id": "d85c8711-201e-0041-77b6-fd8226000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:58.2017844Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879661206364",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:59 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "66be119a-18cf-420e-be0c-2240fdb1f79f",
+    "x-ms-request-id": "d85c8837-201e-0041-7bb6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459879661206364",
+   "blob": "blob158459879710201125"
+  },
+  "newDate": {}
+ },
+ "hash": "fa5324b30c133d0ec62344e1923ea2b7"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_delete_a_version.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_delete_a_version.json
@@ -1,0 +1,121 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879093306077",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:50 GMT",
+    "etag": "\"0x8D7CBCD885FA3A0\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:51 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "0bc7ba75-bd9a-40bb-a23f-c2b86bd43857",
+    "x-ms-request-id": "d85c73cc-201e-0041-03b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879093306077/blob158459879142408129",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:19:51 GMT",
+    "etag": "\"0x8D7CBCD88AA2AD5\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:51 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "0ce54f6c-3e8f-46e0-b45b-fc5f67544d60",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c7534-201e-0041-53b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:51.7802197Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879093306077/blob158459879142408129",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:51 GMT",
+    "etag": "\"0x8D7CBCD88D168FA\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:52 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "4868aa99-26dc-483f-a319-2918a3a8e696",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c75e9-201e-0041-79b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:52.0394020Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879093306077/blob158459879142408129",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:19:51.7802197Z"
+   },
+   "requestBody": null,
+   "status": 403,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>OperationNotAllowedOnAutomaticSnapshot</Code><Message>The specified operation is not allowed on version.\nRequestId:d85c7740-201e-0041-2db6-fd8226000000\nTime:2020-03-19T06:19:52.5676992Z</Message></Error>",
+   "responseHeaders": {
+    "content-length": "257",
+    "content-type": "application/xml",
+    "date": "Thu, 19 Mar 2020 06:19:52 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "3e94c185-1c84-42dd-be11-a276d2996023",
+    "x-ms-error-code": "OperationNotAllowedOnAutomaticSnapshot",
+    "x-ms-request-id": "d85c7740-201e-0041-2db6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879093306077",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:52 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "bca420c1-6c2b-4e88-9de7-0d2cd2cb33d9",
+    "x-ms-request-id": "d85c7840-201e-0041-19b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459879093306077",
+   "blob": "blob158459879142408129"
+  },
+  "newDate": {}
+ },
+ "hash": "d263dc6e0d99350c3775dc96bbaf37de"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleteblobs_should_work_for_batch_delete.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleteblobs_should_work_for_batch_delete.json
@@ -1,0 +1,81 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879319605712",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:53 GMT",
+    "etag": "\"0x8D7CBCD89B6BF7C\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:53 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "d5a4e550-f76d-4eaa-a4ef-cf53f1d2597f",
+    "x-ms-request-id": "d85c79fe-201e-0041-39b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879319605712/blob158459879366602194",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:19:53 GMT",
+    "etag": "\"0x8D7CBCD8A000DD9\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:54 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5dd4d0b8-94fa-4a33-a28b-0adaab37b73b",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c7b50-201e-0041-78b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:54.0218098Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879319605712/blob158459879366602194",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:53 GMT",
+    "etag": "\"0x8D7CBCD8A246559\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:54 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "6aca827b-5864-4f3c-a5d7-a59940c02af2",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c7c0a-201e-0041-21b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:54.2609794Z"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459879319605712",
+   "blob": "blob158459879366602194"
+  },
+  "newDate": {}
+ },
+ "hash": "af27cae29f2417e05856465e122ed57d"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_a_blob_that_has_snapshots_needs_deletesnapshots_option.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_a_blob_that_has_snapshots_needs_deletesnapshots_option.json
@@ -1,0 +1,202 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:00 GMT",
+    "etag": "\"0x8D7CBCD8DF492BE\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:00 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "7e0341fc-e706-4274-99ee-4e327b78872a",
+    "x-ms-request-id": "d85c8938-201e-0041-63b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807/blob158459880079005200",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:00 GMT",
+    "etag": "\"0x8D7CBCD8E420097\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:01 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "1eef727e-788f-4815-aa3f-cf19a030c379",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c8a27-201e-0041-34b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:01.1638935Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807/blob158459880079005200",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:01 GMT",
+    "etag": "\"0x8D7CBCD8E674293\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:01 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "4cc0058f-faf4-4a0b-839f-6cff5250ad47",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c8aaf-201e-0041-2db6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:01.4090659Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807/blob158459880079005200",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "comp": "snapshot"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:01 GMT",
+    "etag": "\"0x8D7CBCD8E674293\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:01 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "586c73ad-1235-42ca-8f0b-f42a92444392",
+    "x-ms-request-id": "d85c8ba8-201e-0041-12b6-fd8226000000",
+    "x-ms-request-server-encrypted": "false",
+    "x-ms-snapshot": "2020-03-19T06:20:01.9054165Z",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:01.9064165Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807/blob158459880079005200",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 409,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>SnapshotsPresent</Code><Message>This operation is not permitted because the blob has snapshots.\nRequestId:d85c8cfb-201e-0041-43b6-fd8226000000\nTime:2020-03-19T06:20:02.3976916Z</Message></Error>",
+   "responseHeaders": {
+    "content-length": "248",
+    "content-type": "application/xml",
+    "date": "Thu, 19 Mar 2020 06:20:02 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "a0b5f09f-f906-4048-87d3-4cdbf47675dc",
+    "x-ms-error-code": "SnapshotsPresent",
+    "x-ms-request-id": "d85c8cfb-201e-0041-43b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807/blob158459880079005200",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:02 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "62b4e3e5-1736-46a4-9a9b-c1f1a2524e2f",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "d85c8eb8-201e-0041-5bb6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807/blob158459880079005200",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "snapshot": "2020-03-19T06:20:01.9054165Z"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 19 Mar 2020 06:20:02 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "4371eea4-30d6-431e-b16d-46f6a8b2326e",
+    "x-ms-error-code": "BlobNotFound",
+    "x-ms-request-id": "3056358f-d01e-0037-3ab6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807/blob158459880079005200",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 19 Mar 2020 06:20:02 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "4d9beb14-b18b-43a6-8150-2aee269556ec",
+    "x-ms-error-code": "BlobNotFound",
+    "x-ms-request-id": "305636a3-d01e-0037-3ab6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880030109807",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:03 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "2832260a-256d-4976-b382-92b8c18ada8c",
+    "x-ms-request-id": "305637ee-d01e-0037-70b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459880030109807",
+   "blob": "blob158459880079005200"
+  },
+  "newDate": {}
+ },
+ "hash": "741141415d860b5903327a103230e775"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_a_blob_with_both_deletesnapshots_and_versionid_option_should_fail.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_a_blob_with_both_deletesnapshots_and_versionid_option_should_fail.json
@@ -1,0 +1,154 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511704469003843",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7D084310E5545\"",
+    "last-modified": "Wed, 25 Mar 2020 06:17:27 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "29c1801d-fded-47f7-831c-f3abf2370d6f",
+    "x-ms-request-id": "47f40d11-701e-000e-326d-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511704469003843/blob158511704637103330",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "etag": "\"0x8D7D08431547049\"",
+    "last-modified": "Wed, 25 Mar 2020 06:17:27 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "425838ab-06ee-44e6-854a-9b8ad4665446",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "47f40d3d-701e-000e-576d-02ac8e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T06:17:27.8102366Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511704469003843/blob158511704637103330",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "etag": "\"0x8D7D08431796444\"",
+    "last-modified": "Wed, 25 Mar 2020 06:17:28 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "14e86c47-149a-4504-92d0-4bcf1da3e33a",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "47f40d51-701e-000e-666d-02ac8e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T06:17:28.0524116Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511704469003843/blob158511704637103330",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "comp": "snapshot"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7D08431796444\"",
+    "last-modified": "Wed, 25 Mar 2020 06:17:28 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b2a5648a-35b5-4818-a26a-efed33e9ce5a",
+    "x-ms-request-id": "47f40d68-701e-000e-796d-02ac8e000000",
+    "x-ms-request-server-encrypted": "false",
+    "x-ms-snapshot": "2020-03-25T06:17:28.5447662Z",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T06:17:28.5457662Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511704469003843/blob158511704637103330",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-25T06:17:27.8102366Z"
+   },
+   "requestBody": null,
+   "status": 400,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>InvalidQueryParameterValue</Code><Message>Value for one of the query parameters specified in the request URI is invalid.\nRequestId:47f40d8f-701e-000e-1c6d-02ac8e000000\nTime:2020-03-25T06:17:29.0750153Z</Message><QueryParameterName>versionid</QueryParameterName><QueryParameterValue>2020-03-25T06:17:27.8102366Z</QueryParameterValue><Reason>This operation is only allowed on the root blob. Version id should not be provided.</Reason></Error>",
+   "responseHeaders": {
+    "content-length": "494",
+    "content-type": "application/xml",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e68295c6-48e0-43b5-8441-7680fbb3c2e1",
+    "x-ms-error-code": "InvalidQueryParameterValue",
+    "x-ms-request-id": "47f40d8f-701e-000e-1c6d-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511704469003843/blob158511704637103330",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-25T06:17:28.0524116Z"
+   },
+   "requestBody": null,
+   "status": 400,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>InvalidQueryParameterValue</Code><Message>Value for one of the query parameters specified in the request URI is invalid.\nRequestId:47f40dd8-701e-000e-556d-02ac8e000000\nTime:2020-03-25T06:17:29.8595747Z</Message><QueryParameterName>versionid</QueryParameterName><QueryParameterValue>2020-03-25T06:17:28.0524116Z</QueryParameterValue><Reason>This operation is only allowed on the root blob. Version id should not be provided.</Reason></Error>",
+   "responseHeaders": {
+    "content-length": "494",
+    "content-type": "application/xml",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "c12b3dba-d019-4f57-b3d1-c181c9bbb1cf",
+    "x-ms-error-code": "InvalidQueryParameterValue",
+    "x-ms-request-id": "47f40dd8-701e-000e-556d-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511704469003843",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "be790e2b-ef87-4769-a195-a4a517029c9f",
+    "x-ms-request-id": "47f40dfd-701e-000e-716d-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158511704469003843",
+   "blob": "blob158511704637103330"
+  },
+  "newDate": {}
+ },
+ "hash": "ce17be22ef0017e51e781f06fd9b37ec"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_a_versioned_blob_without_extra_parameters_should_succeed.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_a_versioned_blob_without_extra_parameters_should_succeed.json
@@ -1,0 +1,168 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880443801883",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:03 GMT",
+    "etag": "\"0x8D7CBCD90717055\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:04 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5835af13-3e08-4e3e-85c9-222f7456f8ca",
+    "x-ms-request-id": "305638fe-d01e-0037-63b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880443801883/blob158459880500206880",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:04 GMT",
+    "etag": "\"0x8D7CBCD90C59E39\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:05 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b5d15f9d-4abc-4fc2-9ab8-7ffb93e11cbc",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "30563a09-d01e-0037-5db6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:05.3818937Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880443801883/blob158459880500206880",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:04 GMT",
+    "etag": "\"0x8D7CBCD90EBCACE\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:05 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "0a553a3b-cb48-4199-9d20-be6c7bd3d158",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "30563a65-d01e-0037-31b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:05.6340723Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880443801883/blob158459880500206880",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:05 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "282f6a70-5d56-4d80-8725-7db8f1dfdee6",
+    "x-ms-delete-type-permanent": "false",
+    "x-ms-request-id": "30563b5d-d01e-0037-19b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880443801883/blob158459880500206880",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "",
+   "responseHeaders": {
+    "date": "Thu, 19 Mar 2020 06:20:05 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "905d9652-a979-411c-9761-e85a6fdc9d23",
+    "x-ms-error-code": "BlobNotFound",
+    "x-ms-request-id": "30563c5a-d01e-0037-0ab6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880443801883/blob158459880500206880",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:20:05.3818937Z"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "11",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "content-type": "application/octet-stream",
+    "date": "Thu, 19 Mar 2020 06:20:06 GMT",
+    "etag": "\"0x8D7CBCD90C59E39\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:05 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-access-tier": "Hot",
+    "x-ms-access-tier-inferred": "true",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "7eee92af-f9b9-4f84-8f06-e2c52d33fa05",
+    "x-ms-creation-time": "Thu, 19 Mar 2020 06:20:05 GMT",
+    "x-ms-request-id": "30563d79-d01e-0037-0fb6-fd086e000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:05.3818937Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880443801883",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:07 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "2e06e094-8c8c-4065-ba44-545c97e98ebc",
+    "x-ms-request-id": "30563ef6-d01e-0037-6db6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459880443801883",
+   "blob": "blob158459880500206880"
+  },
+  "newDate": {}
+ },
+ "hash": "30c758c59a537f6a51dbe1847a8881eb"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_root_blob_with_versionid_should_fail.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_deleting_root_blob_with_versionid_should_fail.json
@@ -1,0 +1,121 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879439802511",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:54 GMT",
+    "etag": "\"0x8D7CBCD8A6F348C\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:54 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "f520e22b-8d7e-4a1f-b98a-066256f19959",
+    "x-ms-request-id": "d85c7cd6-201e-0041-55b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879439802511/blob158459879487700392",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:19:54 GMT",
+    "etag": "\"0x8D7CBCD8AB96D84\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:55 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "d71385b6-4a68-4d0e-ac02-b1938685f782",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c7ddd-201e-0041-35b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:55.2366750Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879439802511/blob158459879487700392",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:55 GMT",
+    "etag": "\"0x8D7CBCD8ADF24D7\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:55 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b777caf1-cae0-421c-a694-f5e22b697b6e",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c7e71-201e-0041-39b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:55.4848508Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879439802511/blob158459879487700392",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:19:55.2366750Z"
+   },
+   "requestBody": null,
+   "status": 403,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>OperationNotAllowedOnAutomaticSnapshot</Code><Message>The specified operation is not allowed on version.\nRequestId:d85c7f59-201e-0041-7bb6-fd8226000000\nTime:2020-03-19T06:19:55.9751208Z</Message></Error>",
+   "responseHeaders": {
+    "content-length": "257",
+    "content-type": "application/xml",
+    "date": "Thu, 19 Mar 2020 06:19:55 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "d8ff42df-638e-4b77-ae36-59dc977355fb",
+    "x-ms-error-code": "OperationNotAllowedOnAutomaticSnapshot",
+    "x-ms-request-id": "d85c7f59-201e-0041-7bb6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459879439802511",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:56 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "3c77946d-01bf-4ddc-9e86-3523ae903be9",
+    "x-ms-request-id": "d85c8048-201e-0041-2db6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459879439802511",
+   "blob": "blob158459879487700392"
+  },
+  "newDate": {}
+ },
+ "hash": "8c6ce79a5f98d1097bf341c30058f4ca"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_download_a_blob_version.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_download_a_blob_version.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158472286918903504",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
     "restype": "container"
@@ -12,18 +12,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 19 Mar 2020 06:19:44 GMT",
-    "etag": "\"0x8D7CBCD846946A8\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:44 GMT",
+    "date": "Fri, 20 Mar 2020 16:47:50 GMT",
+    "etag": "\"0x8D7CCEE6D6DE606\"",
+    "last-modified": "Fri, 20 Mar 2020 16:47:50 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b4492630-92f7-4d2a-a9c1-84705599ef87",
-    "x-ms-request-id": "d85c6725-201e-0041-60b6-fd8226000000",
+    "x-ms-client-request-id": "470423fe-dd5b-4284-8e55-c5a0fb2424da",
+    "x-ms-request-id": "0f286783-701e-0011-75d7-fe4076000000",
     "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158472286918903504/blob158472287073207995",
    "query": {
     "sip": "0.0.0.0-255.255.255.255"
    },
@@ -33,21 +33,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "date": "Thu, 19 Mar 2020 06:19:44 GMT",
-    "etag": "\"0x8D7CBCD84B5A2CA\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "date": "Fri, 20 Mar 2020 16:47:50 GMT",
+    "etag": "\"0x8D7CCEE6DB97A18\"",
+    "last-modified": "Fri, 20 Mar 2020 16:47:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "3c029e74-401f-4f24-af9d-5db56c5075ad",
+    "x-ms-client-request-id": "f0379dcf-d8f6-486d-a3e2-53828622319e",
     "x-ms-content-crc64": "YeJLfssylmU=",
-    "x-ms-request-id": "d85c67fb-201e-0041-1ab6-fd8226000000",
+    "x-ms-request-id": "0f286a17-701e-0011-72d7-fe4076000000",
     "x-ms-request-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:45.1444938Z"
+    "x-ms-version-id": "2020-03-20T16:47:51.1369240Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158472286918903504/blob158472287073207995",
    "query": {
     "sip": "0.0.0.0-255.255.255.255"
    },
@@ -57,24 +57,24 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 19 Mar 2020 06:19:45 GMT",
-    "etag": "\"0x8D7CBCD84DC92D6\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "date": "Fri, 20 Mar 2020 16:47:51 GMT",
+    "etag": "\"0x8D7CCEE6DE4144A\"",
+    "last-modified": "Fri, 20 Mar 2020 16:47:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "43a4542e-a150-4639-b346-793c0410ee90",
+    "x-ms-client-request-id": "8214dd11-6eb6-432a-b053-c48687d25149",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d85c6862-201e-0041-6fb6-fd8226000000",
+    "x-ms-request-id": "0f286b88-701e-0011-56d7-fe4076000000",
     "x-ms-request-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:45.4006758Z"
+    "x-ms-version-id": "2020-03-20T16:47:51.4181236Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158472286918903504/blob158472287073207995",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
-    "versionid": "2020-03-19T06:19:45.1444938Z"
+    "versionid": "2020-03-20T16:47:51.1369240Z"
    },
    "requestBody": null,
    "status": 200,
@@ -84,25 +84,25 @@
     "content-length": "11",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
     "content-type": "application/octet-stream",
-    "date": "Thu, 19 Mar 2020 06:19:45 GMT",
-    "etag": "\"0x8D7CBCD84B5A2CA\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "date": "Fri, 20 Mar 2020 16:47:51 GMT",
+    "etag": "\"0x8D7CCEE6DB97A18\"",
+    "last-modified": "Fri, 20 Mar 2020 16:47:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "5e87a0c1-084a-44c2-b5bb-805f8fba18a7",
-    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:45 GMT",
-    "x-ms-request-id": "d85c6910-201e-0041-09b6-fd8226000000",
+    "x-ms-client-request-id": "b89738ae-eff5-43d0-acf6-6e6f99bda17e",
+    "x-ms-creation-time": "Fri, 20 Mar 2020 16:47:51 GMT",
+    "x-ms-request-id": "0f286df3-701e-0011-22d7-fe4076000000",
     "x-ms-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:45.1444938Z"
+    "x-ms-version-id": "2020-03-20T16:47:51.1369240Z"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158472286918903504/blob158472287073207995",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
-    "versionid": "2020-03-19T06:19:45.4006758Z"
+    "versionid": "2020-03-20T16:47:51.4181236Z"
    },
    "requestBody": null,
    "status": 200,
@@ -112,23 +112,23 @@
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
     "content-type": "application/octet-stream",
-    "date": "Thu, 19 Mar 2020 06:19:46 GMT",
-    "etag": "\"0x8D7CBCD84DC92D6\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "date": "Fri, 20 Mar 2020 16:47:52 GMT",
+    "etag": "\"0x8D7CCEE6DE4144A\"",
+    "last-modified": "Fri, 20 Mar 2020 16:47:51 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "d3feabb3-67ef-45aa-8a22-efd579dbfc25",
-    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "x-ms-client-request-id": "fc9f47f1-9561-4148-9b38-dbba2ceb96d9",
+    "x-ms-creation-time": "Fri, 20 Mar 2020 16:47:51 GMT",
     "x-ms-is-current-version": "true",
-    "x-ms-request-id": "d85c6a02-201e-0041-54b6-fd8226000000",
+    "x-ms-request-id": "0f287085-701e-0011-12d7-fe4076000000",
     "x-ms-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:45.4006758Z"
+    "x-ms-version-id": "2020-03-20T16:47:51.4181236Z"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158472286918903504",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
     "restype": "container"
@@ -138,20 +138,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 19 Mar 2020 06:19:46 GMT",
+    "date": "Fri, 20 Mar 2020 16:47:52 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "5296bdf6-7f4b-46e5-8889-01f4bf72780e",
-    "x-ms-request-id": "d85c6aa6-201e-0041-63b6-fd8226000000",
+    "x-ms-client-request-id": "50b75a6e-bd17-4861-adc9-92f02236f773",
+    "x-ms-request-id": "0f287296-701e-0011-0ed7-fe4076000000",
     "x-ms-version": "2019-12-12"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container158459878429101895",
-   "blob": "blob158459878477306095"
+   "container": "container158472286918903504",
+   "blob": "blob158472287073207995"
   },
   "newDate": {}
  },
- "hash": "d161a91364c1a8e1bbe859605811063d"
+ "hash": "8c7cb69114d7e5abeea0690257bb1fe1"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_download_a_blob_version.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_download_a_blob_version.json
@@ -1,0 +1,157 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:44 GMT",
+    "etag": "\"0x8D7CBCD846946A8\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:44 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b4492630-92f7-4d2a-a9c1-84705599ef87",
+    "x-ms-request-id": "d85c6725-201e-0041-60b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:19:44 GMT",
+    "etag": "\"0x8D7CBCD84B5A2CA\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "3c029e74-401f-4f24-af9d-5db56c5075ad",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c67fb-201e-0041-1ab6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:45.1444938Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "etag": "\"0x8D7CBCD84DC92D6\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "43a4542e-a150-4639-b346-793c0410ee90",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c6862-201e-0041-6fb6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:45.4006758Z"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:19:45.1444938Z"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "Hello World",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "11",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "content-type": "application/octet-stream",
+    "date": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "etag": "\"0x8D7CBCD84B5A2CA\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "5e87a0c1-084a-44c2-b5bb-805f8fba18a7",
+    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "x-ms-request-id": "d85c6910-201e-0041-09b6-fd8226000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:45.1444938Z"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895/blob158459878477306095",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:19:45.4006758Z"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "content-type": "application/octet-stream",
+    "date": "Thu, 19 Mar 2020 06:19:46 GMT",
+    "etag": "\"0x8D7CBCD84DC92D6\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "d3feabb3-67ef-45aa-8a22-efd579dbfc25",
+    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:45 GMT",
+    "x-ms-is-current-version": "true",
+    "x-ms-request-id": "d85c6a02-201e-0041-54b6-fd8226000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:45.4006758Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878429101895",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:46 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5296bdf6-7f4b-46e5-8889-01f4bf72780e",
+    "x-ms-request-id": "d85c6aa6-201e-0041-63b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459878429101895",
+   "blob": "blob158459878477306095"
+  },
+  "newDate": {}
+ },
+ "hash": "d161a91364c1a8e1bbe859605811063d"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_downloadtobuffer_with_cpk.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_downloadtobuffer_with_cpk.json
@@ -1,0 +1,116 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511872811209823",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7D088247799F1\"",
+    "last-modified": "Wed, 25 Mar 2020 06:45:44 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "a230ec0b-5bc5-4873-9740-1d8dbd9304d2",
+    "x-ms-request-id": "47f60f3c-701e-000e-3471-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511872811209823/blob158511874330506488",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "etag": "\"0x8D7D08824D7A94E\"",
+    "last-modified": "Wed, 25 Mar 2020 06:45:44 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "bb8f97a8-b03f-4699-be5c-106b9b6450d5",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "47f60f94-701e-000e-0571-02ac8e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T06:45:44.8457550Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511872811209823/blob158511874330506488",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "etag": "\"0x8D7D088251028EC\"",
+    "last-modified": "Wed, 25 Mar 2020 06:45:45 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "22d5561c-ff2c-4c51-bbcc-7756f42d25e2",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "47f60fbe-701e-000e-2c71-02ac8e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T06:45:45.2180241Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511872811209823/blobCPK158511874487009760",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "etag": "\"0x8D7D088261BD6C2\"",
+    "last-modified": "Wed, 25 Mar 2020 06:45:46 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "1ee340f9-586a-40ac-993b-306ef51680ac",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-encryption-key-sha256": "3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=",
+    "x-ms-request-id": "47f610a7-701e-000e-7971-02ac8e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T06:45:46.9702850Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158511872811209823",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ae301404-f7a7-4e7c-81ca-27bf05c75cda",
+    "x-ms-request-id": "47f61146-701e-000e-0171-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158511872811209823",
+   "blob": "blob158511874330506488",
+   "blobCPK": "blobCPK158511874487009760"
+  },
+  "newDate": {}
+ },
+ "hash": "2fb68ec85232c1b9404e9963df18ac77"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_exists_with_condition.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_exists_with_condition.json
@@ -1,0 +1,161 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512301909503157",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7D09219D81EA6\"",
+    "last-modified": "Wed, 25 Mar 2020 07:57:01 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "7174a0c7-7be3-45f2-9d3f-245388ae79b9",
+    "x-ms-request-id": "f8e41ec4-201e-0003-727a-02645a000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512301909503157/blob158512302033505426",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "etag": "\"0x8D7D0921A1FEEA0\"",
+    "last-modified": "Wed, 25 Mar 2020 07:57:01 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "fbb0996d-c2d3-4c08-81f9-2ed1d917bc35",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "f8e41ef2-201e-0003-0f7a-02645a000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T07:57:01.8327486Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512301909503157/blob158512302033505426",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "etag": "\"0x8D7D0921A488CA6\"",
+    "last-modified": "Wed, 25 Mar 2020 07:57:02 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "85b19e67-41ad-4ed5-b86d-7c55cc5a08fa",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "f8e41f01-201e-0003-197a-02645a000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T07:57:02.0989366Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512301909503157/blob158512302033505426",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "comp": "lease"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7D0921A488CA6\"",
+    "last-modified": "Wed, 25 Mar 2020 07:57:02 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ebe24411-7cc5-4609-ad28-2450cbffd76c",
+    "x-ms-lease-id": "4b230bff-45b2-4066-96c9-73b168dcd5e9",
+    "x-ms-request-id": "f8e41f17-201e-0003-287a-02645a000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512301909503157/blob158512302033505426",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "content-type": "application/octet-stream",
+    "etag": "\"0x8D7D0921A488CA6\"",
+    "last-modified": "Wed, 25 Mar 2020 07:57:02 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-access-tier": "Hot",
+    "x-ms-access-tier-inferred": "true",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "3af91d62-023f-4b6a-90bc-bbe8b489fd65",
+    "x-ms-creation-time": "Wed, 25 Mar 2020 07:57:02 GMT",
+    "x-ms-is-current-version": "true",
+    "x-ms-lease-duration": "fixed",
+    "x-ms-lease-state": "leased",
+    "x-ms-lease-status": "locked",
+    "x-ms-request-id": "f8e41f2f-201e-0003-3b7a-02645a000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T07:57:02.0989366Z"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512301909503157/blob158512302033505426",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 412,
+   "response": "",
+   "responseHeaders": {
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "9fc238c7-c865-492d-96cc-3980f44ff1ec",
+    "x-ms-error-code": "LeaseIdMismatchWithBlobOperation",
+    "x-ms-request-id": "f8e41f50-201e-0003-567a-02645a000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512301909503157",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "751deaf5-5be4-47f5-aa75-288e52c30f22",
+    "x-ms-request-id": "f8e41f74-201e-0003-6f7a-02645a000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158512301909503157",
+   "blob": "blob158512302033505426"
+  },
+  "newDate": {}
+ },
+ "hash": "0df9bab16aeb65eddebd0664087c46bb"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_get_properties_of_a_blob_version.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_get_properties_of_a_blob_version.json
@@ -1,0 +1,160 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:48 GMT",
+    "etag": "\"0x8D7CBCD86C44669\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:48 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "1902343e-bb27-466d-8d56-f8dc925ed83f",
+    "x-ms-request-id": "d85c6ddb-201e-0041-29b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:19:48 GMT",
+    "etag": "\"0x8D7CBCD870F1BA4\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b109dcf3-3666-4ae2-8683-b6ba43f43f7f",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c6ec4-201e-0041-7bb6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:49.0863012Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "etag": "\"0x8D7CBCD8734D2F2\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "dd94c1e9-5725-4a5f-9ac1-01106c27dc72",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c6f5b-201e-0041-80b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:49.3344770Z"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:19:49.0863012Z"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "11",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "content-type": "application/octet-stream",
+    "date": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "etag": "\"0x8D7CBCD870F1BA4\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-access-tier": "Hot",
+    "x-ms-access-tier-inferred": "true",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "cbd34c44-dcda-48b3-a0ec-c28ec1c18861",
+    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "x-ms-request-id": "d85c702b-201e-0041-3fb6-fd8226000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:49.0863012Z"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:19:49.0863012Z"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "11",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "content-type": "application/octet-stream",
+    "date": "Thu, 19 Mar 2020 06:19:50 GMT",
+    "etag": "\"0x8D7CBCD870F1BA4\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-access-tier": "Hot",
+    "x-ms-access-tier-inferred": "true",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "5e0ad884-bcdb-4dad-aaac-75a1e59332f5",
+    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "x-ms-request-id": "d85c715c-201e-0041-48b6-fd8226000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:49.0863012Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:50 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "2e4e24b0-b6bc-415a-bea6-6dd3c5bd8d7c",
+    "x-ms-request-id": "d85c7274-201e-0041-41b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459878824805307",
+   "blob": "blob158459878872507918"
+  },
+  "newDate": {}
+ },
+ "hash": "5292f75e716bc191ec25e1e4ae02273c"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_get_properties_of_a_blob_version.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_get_properties_of_a_blob_version.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
     "restype": "container"
@@ -11,19 +11,17 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
-    "date": "Fri, 20 Mar 2020 15:25:54 GMT",
-    "etag": "\"0x8D7CCE2FB9AD613\"",
-    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7D09742E9DD2A\"",
+    "last-modified": "Wed, 25 Mar 2020 08:33:57 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "8be9db72-42fe-4500-9332-01124dc38a01",
-    "x-ms-request-id": "65bd79d2-601e-0022-7ccb-fe1fdd000000",
+    "x-ms-client-request-id": "fb1b9427-5a48-4af2-b38c-3bc0082f1499",
+    "x-ms-request-id": "47fde939-701e-000e-0880-02ac8e000000",
     "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137/blob158512523676806270",
    "query": {
     "sip": "0.0.0.0-255.255.255.255"
    },
@@ -31,23 +29,21 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "date": "Fri, 20 Mar 2020 15:25:55 GMT",
-    "etag": "\"0x8D7CCE2FBE9F0E7\"",
-    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7D097433D626E\"",
+    "last-modified": "Wed, 25 Mar 2020 08:33:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "c4360265-ceba-4c47-b2f1-16c648b5405c",
+    "x-ms-client-request-id": "4ac07cb5-f634-4485-8b81-fceabb939d08",
     "x-ms-content-crc64": "YeJLfssylmU=",
-    "x-ms-request-id": "65bd7a64-601e-0022-75cb-fe1fdd000000",
+    "x-ms-request-id": "47fde96d-701e-000e-3180-02ac8e000000",
     "x-ms-request-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-20T15:25:55.7302503Z"
+    "x-ms-version-id": "2020-03-25T08:33:58.2949998Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137/blob158512523676806270",
    "query": {
     "sip": "0.0.0.0-255.255.255.255"
    },
@@ -55,26 +51,24 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Fri, 20 Mar 2020 15:25:55 GMT",
-    "etag": "\"0x8D7CCE2FC11CB82\"",
-    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7D09743669CEF\"",
+    "last-modified": "Wed, 25 Mar 2020 08:33:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "6f70d718-0a7d-47a4-a1f1-d4e83116366c",
+    "x-ms-client-request-id": "6cf367a1-4485-4944-b202-5ca140892227",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "65bd7ab3-601e-0022-3bcb-fe1fdd000000",
+    "x-ms-request-id": "47fde995-701e-000e-4f80-02ac8e000000",
     "x-ms-request-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-20T15:25:55.9924370Z"
+    "x-ms-version-id": "2020-03-25T08:33:58.5661951Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137/blob158512523676806270",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
-    "versionid": "2020-03-20T15:25:55.7302503Z"
+    "versionid": "2020-03-25T08:33:58.2949998Z"
    },
    "requestBody": null,
    "status": 200,
@@ -84,24 +78,23 @@
     "content-length": "11",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
     "content-type": "application/octet-stream",
-    "date": "Fri, 20 Mar 2020 15:25:55 GMT",
-    "etag": "\"0x8D7CCE2FBE9F0E7\"",
-    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7D097433D626E\"",
+    "last-modified": "Wed, 25 Mar 2020 08:33:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "c0d36877-c217-498f-aa77-0a071c1a24e2",
-    "x-ms-creation-time": "Fri, 20 Mar 2020 15:25:55 GMT",
-    "x-ms-request-id": "65bd7b6c-601e-0022-5acb-fe1fdd000000",
+    "x-ms-client-request-id": "67e15c74-f971-47b4-a3f9-6aecb5c39cb3",
+    "x-ms-creation-time": "Wed, 25 Mar 2020 08:33:58 GMT",
+    "x-ms-request-id": "47fdea18-701e-000e-3780-02ac8e000000",
     "x-ms-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-20T15:25:55.7302503Z"
+    "x-ms-version-id": "2020-03-25T08:33:58.2949998Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137/blob158512523676806270",
    "query": {
     "sip": "0.0.0.0-255.255.255.255"
    },
@@ -113,27 +106,26 @@
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
     "content-type": "application/octet-stream",
-    "date": "Fri, 20 Mar 2020 15:25:56 GMT",
-    "etag": "\"0x8D7CCE2FC11CB82\"",
-    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7D09743669CEF\"",
+    "last-modified": "Wed, 25 Mar 2020 08:33:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "4c274cea-7b77-4b78-b7a6-b83c1ccb5bd1",
-    "x-ms-creation-time": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "x-ms-client-request-id": "6bc67fa6-bca2-48b4-b3d1-5811aa296ff9",
+    "x-ms-creation-time": "Wed, 25 Mar 2020 08:33:58 GMT",
     "x-ms-is-current-version": "true",
     "x-ms-lease-state": "available",
     "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "65bd7bfa-601e-0022-54cb-fe1fdd000000",
+    "x-ms-request-id": "47fdea62-701e-000e-7c80-02ac8e000000",
     "x-ms-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-20T15:25:55.9924370Z"
+    "x-ms-version-id": "2020-03-25T08:33:58.5661951Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137/blob158512523676806270",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
     "comp": "snapshot"
@@ -142,44 +134,42 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
-    "date": "Fri, 20 Mar 2020 15:25:56 GMT",
-    "etag": "\"0x8D7CCE2FC11CB82\"",
-    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7D09743669CEF\"",
+    "last-modified": "Wed, 25 Mar 2020 08:33:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "cb16d8b1-e5ee-4469-8633-64894c4319c1",
-    "x-ms-request-id": "65bd7ca0-601e-0022-5ecb-fe1fdd000000",
+    "x-ms-client-request-id": "3f47c5e8-8c80-423d-aeca-a65f3cfc2404",
+    "x-ms-request-id": "47fdeaac-701e-000e-3680-02ac8e000000",
     "x-ms-request-server-encrypted": "false",
-    "x-ms-snapshot": "2020-03-20T15:25:57.4714902Z",
+    "x-ms-snapshot": "2020-03-25T08:34:01.1310480Z",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-20T15:25:57.4724902Z"
+    "x-ms-version-id": "2020-03-25T08:34:01.1320480Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137/blob158512523676806270",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
-    "snapshot": "2020-03-20T15:25:57.4714902Z",
-    "versionid": "2020-03-20T15:25:55.7302503Z"
+    "versionid": "2020-03-25T08:33:58.2949998Z",
+    "snapshot": "2020-03-25T08:34:01.1310480Z"
    },
    "requestBody": null,
    "status": 400,
    "response": "",
    "responseHeaders": {
-    "date": "Fri, 20 Mar 2020 15:25:57 GMT",
+    "date": "Wed, 25 Mar 2020 08:34:00 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-error-code": "MutuallyExclusiveQueryParameters",
-    "x-ms-request-id": "65bd7d33-601e-0022-5bcb-fe1fdd000000",
+    "x-ms-request-id": "47fdeaed-701e-000e-6b80-02ac8e000000",
     "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137/blob158512523676806270",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
-    "versionid": "2020-03-20T15:25:55.7302503Z"
+    "versionid": "2020-03-25T08:33:58.2949998Z"
    },
    "requestBody": null,
    "status": 200,
@@ -189,24 +179,23 @@
     "content-length": "11",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
     "content-type": "application/octet-stream",
-    "date": "Fri, 20 Mar 2020 15:25:57 GMT",
-    "etag": "\"0x8D7CCE2FBE9F0E7\"",
-    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7D097433D626E\"",
+    "last-modified": "Wed, 25 Mar 2020 08:33:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "87adbb65-3c6b-4405-bfa9-f8a90d25f903",
-    "x-ms-creation-time": "Fri, 20 Mar 2020 15:25:55 GMT",
-    "x-ms-request-id": "65bd7dd9-601e-0022-69cb-fe1fdd000000",
+    "x-ms-client-request-id": "68ae6024-c444-4aca-a8f1-16abb38e9e00",
+    "x-ms-creation-time": "Wed, 25 Mar 2020 08:33:58 GMT",
+    "x-ms-request-id": "47fdeb1e-701e-000e-1280-02ac8e000000",
     "x-ms-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-20T15:25:55.7302503Z"
+    "x-ms-version-id": "2020-03-25T08:33:58.2949998Z"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512523509207137",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
     "restype": "container"
@@ -215,21 +204,19 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
-    "date": "Fri, 20 Mar 2020 15:25:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "50f15aea-6c9c-4d7e-bb55-c772453e2ada",
-    "x-ms-request-id": "65bd7e53-601e-0022-5ecb-fe1fdd000000",
+    "x-ms-client-request-id": "0f7832d8-f465-48f0-a87f-1cf317f48934",
+    "x-ms-request-id": "47fdeb38-701e-000e-2c80-02ac8e000000",
     "x-ms-version": "2019-12-12"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container158471795384003858",
-   "blob": "blob158471795532705991"
+   "container": "container158512523509207137",
+   "blob": "blob158512523676806270"
   },
   "newDate": {}
  },
- "hash": "32ce29e84172f2f728a06ea7a01075cf"
+ "hash": "dd2960a3038af12a4eb5df52621b2ac6"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_get_properties_of_a_blob_version.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_get_properties_of_a_blob_version.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
     "restype": "container"
@@ -12,18 +12,18 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 19 Mar 2020 06:19:48 GMT",
-    "etag": "\"0x8D7CBCD86C44669\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:48 GMT",
+    "date": "Fri, 20 Mar 2020 15:25:54 GMT",
+    "etag": "\"0x8D7CCE2FB9AD613\"",
+    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "1902343e-bb27-466d-8d56-f8dc925ed83f",
-    "x-ms-request-id": "d85c6ddb-201e-0041-29b6-fd8226000000",
+    "x-ms-client-request-id": "8be9db72-42fe-4500-9332-01124dc38a01",
+    "x-ms-request-id": "65bd79d2-601e-0022-7ccb-fe1fdd000000",
     "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
    "query": {
     "sip": "0.0.0.0-255.255.255.255"
    },
@@ -33,21 +33,21 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "date": "Thu, 19 Mar 2020 06:19:48 GMT",
-    "etag": "\"0x8D7CBCD870F1BA4\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "date": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7CCE2FBE9F0E7\"",
+    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b109dcf3-3666-4ae2-8683-b6ba43f43f7f",
+    "x-ms-client-request-id": "c4360265-ceba-4c47-b2f1-16c648b5405c",
     "x-ms-content-crc64": "YeJLfssylmU=",
-    "x-ms-request-id": "d85c6ec4-201e-0041-7bb6-fd8226000000",
+    "x-ms-request-id": "65bd7a64-601e-0022-75cb-fe1fdd000000",
     "x-ms-request-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:49.0863012Z"
+    "x-ms-version-id": "2020-03-20T15:25:55.7302503Z"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
    "query": {
     "sip": "0.0.0.0-255.255.255.255"
    },
@@ -57,24 +57,24 @@
    "responseHeaders": {
     "content-length": "0",
     "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 19 Mar 2020 06:19:49 GMT",
-    "etag": "\"0x8D7CBCD8734D2F2\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "date": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7CCE2FC11CB82\"",
+    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "dd94c1e9-5725-4a5f-9ac1-01106c27dc72",
+    "x-ms-client-request-id": "6f70d718-0a7d-47a4-a1f1-d4e83116366c",
     "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "d85c6f5b-201e-0041-80b6-fd8226000000",
+    "x-ms-request-id": "65bd7ab3-601e-0022-3bcb-fe1fdd000000",
     "x-ms-request-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:49.3344770Z"
+    "x-ms-version-id": "2020-03-20T15:25:55.9924370Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
-    "versionid": "2020-03-19T06:19:49.0863012Z"
+    "versionid": "2020-03-20T15:25:55.7302503Z"
    },
    "requestBody": null,
    "status": 200,
@@ -84,27 +84,102 @@
     "content-length": "11",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
     "content-type": "application/octet-stream",
-    "date": "Thu, 19 Mar 2020 06:19:49 GMT",
-    "etag": "\"0x8D7CBCD870F1BA4\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "date": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "etag": "\"0x8D7CCE2FBE9F0E7\"",
+    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "cbd34c44-dcda-48b3-a0ec-c28ec1c18861",
-    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:49 GMT",
-    "x-ms-request-id": "d85c702b-201e-0041-3fb6-fd8226000000",
+    "x-ms-client-request-id": "c0d36877-c217-498f-aa77-0a071c1a24e2",
+    "x-ms-creation-time": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "x-ms-request-id": "65bd7b6c-601e-0022-5acb-fe1fdd000000",
     "x-ms-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:49.0863012Z"
+    "x-ms-version-id": "2020-03-20T15:25:55.7302503Z"
    }
   },
   {
    "method": "HEAD",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307/blob158459878872507918",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "content-type": "application/octet-stream",
+    "date": "Fri, 20 Mar 2020 15:25:56 GMT",
+    "etag": "\"0x8D7CCE2FC11CB82\"",
+    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-access-tier": "Hot",
+    "x-ms-access-tier-inferred": "true",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "4c274cea-7b77-4b78-b7a6-b83c1ccb5bd1",
+    "x-ms-creation-time": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "x-ms-is-current-version": "true",
+    "x-ms-lease-state": "available",
+    "x-ms-lease-status": "unlocked",
+    "x-ms-request-id": "65bd7bfa-601e-0022-54cb-fe1fdd000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-20T15:25:55.9924370Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
-    "versionid": "2020-03-19T06:19:49.0863012Z"
+    "comp": "snapshot"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Fri, 20 Mar 2020 15:25:56 GMT",
+    "etag": "\"0x8D7CCE2FC11CB82\"",
+    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "cb16d8b1-e5ee-4469-8633-64894c4319c1",
+    "x-ms-request-id": "65bd7ca0-601e-0022-5ecb-fe1fdd000000",
+    "x-ms-request-server-encrypted": "false",
+    "x-ms-snapshot": "2020-03-20T15:25:57.4714902Z",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-20T15:25:57.4724902Z"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "snapshot": "2020-03-20T15:25:57.4714902Z",
+    "versionid": "2020-03-20T15:25:55.7302503Z"
+   },
+   "requestBody": null,
+   "status": 400,
+   "response": "",
+   "responseHeaders": {
+    "date": "Fri, 20 Mar 2020 15:25:57 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-error-code": "MutuallyExclusiveQueryParameters",
+    "x-ms-request-id": "65bd7d33-601e-0022-5bcb-fe1fdd000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858/blob158471795532705991",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-20T15:25:55.7302503Z"
    },
    "requestBody": null,
    "status": 200,
@@ -114,24 +189,24 @@
     "content-length": "11",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
     "content-type": "application/octet-stream",
-    "date": "Thu, 19 Mar 2020 06:19:50 GMT",
-    "etag": "\"0x8D7CBCD870F1BA4\"",
-    "last-modified": "Thu, 19 Mar 2020 06:19:49 GMT",
+    "date": "Fri, 20 Mar 2020 15:25:57 GMT",
+    "etag": "\"0x8D7CCE2FBE9F0E7\"",
+    "last-modified": "Fri, 20 Mar 2020 15:25:55 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "x-ms-access-tier": "Hot",
     "x-ms-access-tier-inferred": "true",
     "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "5e0ad884-bcdb-4dad-aaac-75a1e59332f5",
-    "x-ms-creation-time": "Thu, 19 Mar 2020 06:19:49 GMT",
-    "x-ms-request-id": "d85c715c-201e-0041-48b6-fd8226000000",
+    "x-ms-client-request-id": "87adbb65-3c6b-4405-bfa9-f8a90d25f903",
+    "x-ms-creation-time": "Fri, 20 Mar 2020 15:25:55 GMT",
+    "x-ms-request-id": "65bd7dd9-601e-0022-69cb-fe1fdd000000",
     "x-ms-server-encrypted": "true",
     "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:19:49.0863012Z"
+    "x-ms-version-id": "2020-03-20T15:25:55.7302503Z"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459878824805307",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158471795384003858",
    "query": {
     "sip": "0.0.0.0-255.255.255.255",
     "restype": "container"
@@ -141,20 +216,20 @@
    "response": "",
    "responseHeaders": {
     "content-length": "0",
-    "date": "Thu, 19 Mar 2020 06:19:50 GMT",
+    "date": "Fri, 20 Mar 2020 15:25:58 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "2e4e24b0-b6bc-415a-bea6-6dd3c5bd8d7c",
-    "x-ms-request-id": "d85c7274-201e-0041-41b6-fd8226000000",
+    "x-ms-client-request-id": "50f15aea-6c9c-4d7e-bb55-c772453e2ada",
+    "x-ms-request-id": "65bd7e53-601e-0022-5ecb-fe1fdd000000",
     "x-ms-version": "2019-12-12"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container158459878824805307",
-   "blob": "blob158459878872507918"
+   "container": "container158471795384003858",
+   "blob": "blob158471795532705991"
   },
   "newDate": {}
  },
- "hash": "5292f75e716bc191ec25e1e4ae02273c"
+ "hash": "32ce29e84172f2f728a06ea7a01075cf"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_list_blobs_include_versions.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_list_blobs_include_versions.json
@@ -1,0 +1,172 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459877968401121",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:40 GMT",
+    "etag": "\"0x8D7CBCD8248C2B3\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:41 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "c0a590f0-a3d5-4fe9-ab6d-3b0f9d1ce13f",
+    "x-ms-request-id": "d85c6074-201e-0041-40b6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459877968401121/blob158459878121002897",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:19:41 GMT",
+    "etag": "\"0x8D7CBCD82956D12\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:41 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "de4fe410-a87f-4093-8434-11b73d19c914",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "d85c61ca-201e-0041-63b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:41.5779602Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459877968401121/blob158459878121002897",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:41 GMT",
+    "etag": "\"0x8D7CBCD82C2519B\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:41 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "2e305bc5-546e-45fb-b434-eba2377f5ded",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c626c-201e-0041-73b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:41.8731691Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459877968401121/blockblob%2F0158459878200208375",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:42 GMT",
+    "etag": "\"0x8D7CBCD830DE736\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:42 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "1f1dd490-7efb-47c9-8a66-be04a8869cbf",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c6378-201e-0041-4eb6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:42.3675190Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459877968401121/blockblob%2F1158459878249300647",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:19:42 GMT",
+    "etag": "\"0x8D7CBCD8357F5EB\"",
+    "last-modified": "Thu, 19 Mar 2020 06:19:42 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "dde44d40-ee08-424a-ad4d-eeff2c736f22",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "d85c6419-201e-0041-58b6-fd8226000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:19:42.8528619Z"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459877968401121",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "include": "versions",
+    "restype": "container",
+    "comp": "list"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158459877968401121\"><Blobs><Blob><Name>blob158459878121002897</Name><VersionId>2020-03-19T06:19:41.5779602Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:19:41 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:19:41 GMT</Last-Modified><Etag>0x8D7CBCD82956D12</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459878121002897</Name><VersionId>2020-03-19T06:19:41.8731691Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:19:41 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:19:41 GMT</Last-Modified><Etag>0x8D7CBCD82C2519B</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/0158459878200208375</Name><VersionId>2020-03-19T06:19:42.3675190Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:19:42 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:19:42 GMT</Last-Modified><Etag>0x8D7CBCD830DE736</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/1158459878249300647</Name><VersionId>2020-03-19T06:19:42.8528619Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:19:42 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:19:42 GMT</Last-Modified><Etag>0x8D7CBCD8357F5EB</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "responseHeaders": {
+    "content-type": "application/xml",
+    "date": "Thu, 19 Mar 2020 06:19:43 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "9a060e01-91c7-4dca-a56a-8f15d574418c",
+    "x-ms-request-id": "d85c6505-201e-0041-1ab6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459877968401121",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:19:43 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e4926de4-d977-4721-8989-4065e215b1cf",
+    "x-ms-request-id": "d85c664b-201e-0041-2db6-fd8226000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459877968401121",
+   "blob": "blob158459878121002897",
+   "blockblob/0": "blockblob/0158459878200208375",
+   "blockblob/1": "blockblob/1158459878249300647"
+  },
+  "newDate": {}
+ },
+ "hash": "1da2f2af412dda9265ceab4931cfb577"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
@@ -1,0 +1,120 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:07 GMT",
+    "etag": "\"0x8D7CBCD92B0A373\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:08 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ed978f31-55d7-42ef-a809-6301184c8b69",
+    "x-ms-request-id": "30563f9d-d01e-0037-0ab6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027/blob158459880874506787",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:08 GMT",
+    "etag": "\"0x8D7CBCD92FEB7E7\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:09 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "8f8cee93-b42a-4f8f-8850-7c5e2b402c49",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "3056406b-d01e-0037-45b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:09.1115495Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027/blob158459880874506787",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:08 GMT",
+    "etag": "\"0x8D7CBCD9324964F\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:09 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "2ba79777-149a-42fc-83a1-7c12bfb1db37",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "305640c4-d01e-0037-17b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:09.3607263Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027/blob158459880874506787",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 400,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>CannotVerifyCopySource</Code><Message>One of the query parameters specified in the request URI is not supported.\nRequestId:30564172-d01e-0037-34b6-fd086e000000\nTime:2020-03-19T06:20:09.8727329Z</Message></Error>",
+   "responseHeaders": {
+    "content-length": "265",
+    "content-type": "application/xml",
+    "date": "Thu, 19 Mar 2020 06:20:08 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ab124acd-24b1-4ac8-9873-4c26f12defcf",
+    "x-ms-error-code": "CannotVerifyCopySource",
+    "x-ms-request-id": "30564172-d01e-0037-34b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:09 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "3967d3d8-2433-49da-bcd2-cc77b29360aa",
+    "x-ms-request-id": "3056422c-d01e-0037-53b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459880823404027",
+   "blob": "blob158459880874506787"
+  },
+  "newDate": {}
+ },
+ "hash": "c1ddd7168a1d89fb72d78e78735c9a36"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
@@ -1,196 +1,167 @@
 {
-  "recordings": [
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "restype": "container"
-      },
-      "requestBody": null,
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "etag": "\"0x8D7CCAF96D4FFB8\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:01 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "71afe7c1-f395-4d12-b902-c99a5d8908db",
-        "x-ms-request-id": "382c2cdf-601e-0012-0a98-fefeee000000",
-        "x-ms-version": "2019-12-12"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": "Hello World",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "etag": "\"0x8D7CCAF971EAF63\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "91069504-a5f9-485d-9f70-5b9baf371225",
-        "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "382c2cf9-601e-0012-1c98-fefeee000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": "",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "etag": "\"0x8D7CCAF974306FF\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0446d7c8-e287-4c8c-94bd-e7e5710cc9f3",
-        "x-ms-content-crc64": "AAAAAAAAAAA=",
-        "x-ms-request-id": "382c2d03-601e-0012-2698-fefeee000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:02.5319951Z"
-      }
-    },
-    {
-      "method": "HEAD",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "versionid": "2020-03-20T09:18:02.2928227Z"
-      },
-      "requestBody": null,
-      "status": 200,
-      "response": "",
-      "responseHeaders": {
-        "accept-ranges": "bytes",
-        "content-length": "11",
-        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "content-type": "application/octet-stream",
-        "etag": "\"0x8D7CCAF971EAF63\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-access-tier": "Hot",
-        "x-ms-access-tier-inferred": "true",
-        "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "059b718f-636a-4081-9587-d46a3dcc31c9",
-        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "x-ms-request-id": "382c2d21-601e-0012-3d98-fefeee000000",
-        "x-ms-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": null,
-      "status": 202,
-      "response": "",
-      "responseHeaders": {
-        "etag": "\"0x8D7CCAF97DCF295\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "dafb4ee7-4266-476c-ab94-0393e517dad2",
-        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
-        "x-ms-copy-status": "success",
-        "x-ms-request-id": "382c2d3a-601e-0012-5198-fefeee000000",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
-      }
-    },
-    {
-      "method": "GET",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "include": "versions",
-        "restype": "container",
-        "comp": "list"
-      },
-      "requestBody": null,
-      "status": 200,
-      "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158469588020807188\"><Blobs><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.2928227Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF971EAF63</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.5319951Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF974306FF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:03.5417279Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:03 GMT</Last-Modified><Etag>0x8D7CCAF97DCF295</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
-      "responseHeaders": {
-        "content-type": "application/xml",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b4c29f64-b2a0-47f3-ab1a-9047d3ae6ea6",
-        "x-ms-request-id": "382c2d59-601e-0012-6998-fefeee000000",
-        "x-ms-version": "2019-12-12"
-      }
-    },
-    {
-      "method": "GET",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": null,
-      "status": 200,
-      "response": "Hello World",
-      "responseHeaders": {
-        "accept-ranges": "bytes",
-        "content-length": "11",
-        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "content-type": "application/octet-stream",
-        "etag": "\"0x8D7CCAF97DCF295\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "76a56e9b-e83a-4a72-8299-f45339a49595",
-        "x-ms-copy-completion-time": "Fri, 20 Mar 2020 09:18:03 GMT",
-        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
-        "x-ms-copy-progress": "11/11",
-        "x-ms-copy-source": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686?sv=2019-10-10&ss=btqf&srt=sco&spr=https%2Chttp&st=2020-03-20T09%3A00%3A00Z&se=2022-12-15T09%3A05%3A00Z&sip=0.0.0.0-255.255.255.255&sp=rwdxlacup&versionid=2020-03-20T09:18:02.2928227Z",
-        "x-ms-copy-status": "success",
-        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "x-ms-is-current-version": "true",
-        "x-ms-lease-state": "available",
-        "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "382c2d8d-601e-0012-1098-fefeee000000",
-        "x-ms-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
-      }
-    },
-    {
-      "method": "DELETE",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "restype": "container"
-      },
-      "requestBody": null,
-      "status": 202,
-      "response": "",
-      "responseHeaders": {
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "de051cfe-a985-4575-b9c8-399fbd78cd44",
-        "x-ms-request-id": "382c2d9d-601e-0012-1e98-fefeee000000",
-        "x-ms-version": "2019-12-12"
-      }
-    }
-  ],
-  "uniqueTestInfo": {
-    "uniqueName": {
-      "container": "container158469588020807188",
-      "blob": "blob158469588188607686"
-    },
-    "newDate": {}
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7CFA131B4BBD1\"",
+    "last-modified": "Tue, 24 Mar 2020 03:12:32 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b501cc0e-4f28-44ee-a8da-fc97b26c0011",
+    "x-ms-request-id": "f7f5c097-201e-0003-488a-01645a000000",
+    "x-ms-version": "2019-12-12"
+   }
   },
-  "hash": "d904b79863031a84c2093a63c68fce79"
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "etag": "\"0x8D7CFA131FEA31B\"",
+    "last-modified": "Tue, 24 Mar 2020 03:12:33 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "67e456de-813e-4f15-af28-5b21949895ad",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "f7f5c176-201e-0003-258a-01645a000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-24T03:12:33.1670299Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "etag": "\"0x8D7CFA1322E2064\"",
+    "last-modified": "Tue, 24 Mar 2020 03:12:33 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "93fa6096-c851-4d41-aded-e1245893f23f",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "f7f5c1e1-201e-0003-0d8a-01645a000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-24T03:12:33.4792564Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7CFA132843F7D\"",
+    "last-modified": "Tue, 24 Mar 2020 03:12:34 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "958d13ba-8865-4b76-8745-f1130736b262",
+    "x-ms-copy-id": "e860501f-ea27-43c2-a625-920f73a80a86",
+    "x-ms-copy-status": "success",
+    "x-ms-request-id": "f7f5c324-201e-0003-508a-01645a000000",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-24T03:12:34.0446626Z"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "include": "versions",
+    "restype": "container",
+    "comp": "list"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.preprod.core.windows.net/\" ContainerName=\"container158501954955601499\"><Blobs><Blob><Name>blob158501955278801412</Name><VersionId>2020-03-24T03:12:33.1670299Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:12:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:12:33 GMT</Last-Modified><Etag>0x8D7CFA131FEA31B</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501955278801412</Name><VersionId>2020-03-24T03:12:33.4792564Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:12:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:12:33 GMT</Last-Modified><Etag>0x8D7CFA1322E2064</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501955278801412</Name><VersionId>2020-03-24T03:12:34.0446626Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Tue, 24 Mar 2020 03:12:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:12:34 GMT</Last-Modified><Etag>0x8D7CFA132843F7D</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "responseHeaders": {
+    "content-type": "application/xml",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "49854405-6f13-4626-83ee-592ad18b2e43",
+    "x-ms-request-id": "f7f5c3f9-201e-0003-1a8a-01645a000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "Hello World",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "11",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "content-type": "application/octet-stream",
+    "etag": "\"0x8D7CFA132843F7D\"",
+    "last-modified": "Tue, 24 Mar 2020 03:12:34 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "4214978d-cc24-4303-93c1-617a6bfd43b7",
+    "x-ms-copy-completion-time": "Tue, 24 Mar 2020 03:12:34 GMT",
+    "x-ms-copy-id": "e860501f-ea27-43c2-a625-920f73a80a86",
+    "x-ms-copy-progress": "11/11",
+    "x-ms-copy-source": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412?sv=2019-10-10&ss=btqf&srt=sco&spr=https%2Chttp&st=2020-03-20T09%3A00%3A00Z&se=2022-12-15T09%3A05%3A00Z&sip=0.0.0.0-255.255.255.255&sp=rwdxlacup&versionid=2020-03-24T03:12:33.1670299Z",
+    "x-ms-copy-status": "success",
+    "x-ms-creation-time": "Tue, 24 Mar 2020 03:12:33 GMT",
+    "x-ms-is-current-version": "true",
+    "x-ms-lease-state": "available",
+    "x-ms-lease-status": "unlocked",
+    "x-ms-request-id": "f7f5c5db-201e-0003-7a8a-01645a000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-24T03:12:34.0446626Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "5b51d86f-ba60-45a9-a0e1-eeee685b629b",
+    "x-ms-request-id": "f7f5c652-201e-0003-708a-01645a000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158501954955601499",
+   "blob": "blob158501955278801412"
+  },
+  "newDate": {}
+ },
+ "hash": "54fda11a7b7b7495916f55430107b1ab"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
@@ -1,120 +1,196 @@
 {
- "recordings": [
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255",
-    "restype": "container"
-   },
-   "requestBody": null,
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "content-length": "0",
-    "date": "Thu, 19 Mar 2020 06:20:07 GMT",
-    "etag": "\"0x8D7CBCD92B0A373\"",
-    "last-modified": "Thu, 19 Mar 2020 06:20:08 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "ed978f31-55d7-42ef-a809-6301184c8b69",
-    "x-ms-request-id": "30563f9d-d01e-0037-0ab6-fd086e000000",
-    "x-ms-version": "2019-12-12"
-   }
+  "recordings": [
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "restype": "container"
+      },
+      "requestBody": null,
+      "status": 201,
+      "response": "",
+      "responseHeaders": {
+        "etag": "\"0x8D7CCAF96D4FFB8\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:01 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "71afe7c1-f395-4d12-b902-c99a5d8908db",
+        "x-ms-request-id": "382c2cdf-601e-0012-0a98-fefeee000000",
+        "x-ms-version": "2019-12-12"
+      }
+    },
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": "Hello World",
+      "status": 201,
+      "response": "",
+      "responseHeaders": {
+        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+        "etag": "\"0x8D7CCAF971EAF63\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "91069504-a5f9-485d-9f70-5b9baf371225",
+        "x-ms-content-crc64": "YeJLfssylmU=",
+        "x-ms-request-id": "382c2cf9-601e-0012-1c98-fefeee000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
+      }
+    },
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": "",
+      "status": 201,
+      "response": "",
+      "responseHeaders": {
+        "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "etag": "\"0x8D7CCAF974306FF\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "0446d7c8-e287-4c8c-94bd-e7e5710cc9f3",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "382c2d03-601e-0012-2698-fefeee000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:02.5319951Z"
+      }
+    },
+    {
+      "method": "HEAD",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "versionid": "2020-03-20T09:18:02.2928227Z"
+      },
+      "requestBody": null,
+      "status": 200,
+      "response": "",
+      "responseHeaders": {
+        "accept-ranges": "bytes",
+        "content-length": "11",
+        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+        "content-type": "application/octet-stream",
+        "etag": "\"0x8D7CCAF971EAF63\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "059b718f-636a-4081-9587-d46a3dcc31c9",
+        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "x-ms-request-id": "382c2d21-601e-0012-3d98-fefeee000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
+      }
+    },
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": null,
+      "status": 202,
+      "response": "",
+      "responseHeaders": {
+        "etag": "\"0x8D7CCAF97DCF295\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "dafb4ee7-4266-476c-ab94-0393e517dad2",
+        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
+        "x-ms-copy-status": "success",
+        "x-ms-request-id": "382c2d3a-601e-0012-5198-fefeee000000",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
+      }
+    },
+    {
+      "method": "GET",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "include": "versions",
+        "restype": "container",
+        "comp": "list"
+      },
+      "requestBody": null,
+      "status": 200,
+      "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158469588020807188\"><Blobs><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.2928227Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF971EAF63</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.5319951Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF974306FF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:03.5417279Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:03 GMT</Last-Modified><Etag>0x8D7CCAF97DCF295</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+      "responseHeaders": {
+        "content-type": "application/xml",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "b4c29f64-b2a0-47f3-ab1a-9047d3ae6ea6",
+        "x-ms-request-id": "382c2d59-601e-0012-6998-fefeee000000",
+        "x-ms-version": "2019-12-12"
+      }
+    },
+    {
+      "method": "GET",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": null,
+      "status": 200,
+      "response": "Hello World",
+      "responseHeaders": {
+        "accept-ranges": "bytes",
+        "content-length": "11",
+        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+        "content-type": "application/octet-stream",
+        "etag": "\"0x8D7CCAF97DCF295\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "76a56e9b-e83a-4a72-8299-f45339a49595",
+        "x-ms-copy-completion-time": "Fri, 20 Mar 2020 09:18:03 GMT",
+        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
+        "x-ms-copy-progress": "11/11",
+        "x-ms-copy-source": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686?sv=2019-10-10&ss=btqf&srt=sco&spr=https%2Chttp&st=2020-03-20T09%3A00%3A00Z&se=2022-12-15T09%3A05%3A00Z&sip=0.0.0.0-255.255.255.255&sp=rwdxlacup&versionid=2020-03-20T09:18:02.2928227Z",
+        "x-ms-copy-status": "success",
+        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "382c2d8d-601e-0012-1098-fefeee000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
+      }
+    },
+    {
+      "method": "DELETE",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "restype": "container"
+      },
+      "requestBody": null,
+      "status": 202,
+      "response": "",
+      "responseHeaders": {
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "de051cfe-a985-4575-b9c8-399fbd78cd44",
+        "x-ms-request-id": "382c2d9d-601e-0012-1e98-fefeee000000",
+        "x-ms-version": "2019-12-12"
+      }
+    }
+  ],
+  "uniqueTestInfo": {
+    "uniqueName": {
+      "container": "container158469588020807188",
+      "blob": "blob158469588188607686"
+    },
+    "newDate": {}
   },
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027/blob158459880874506787",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255"
-   },
-   "requestBody": "Hello World",
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "content-length": "0",
-    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "date": "Thu, 19 Mar 2020 06:20:08 GMT",
-    "etag": "\"0x8D7CBCD92FEB7E7\"",
-    "last-modified": "Thu, 19 Mar 2020 06:20:09 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "8f8cee93-b42a-4f8f-8850-7c5e2b402c49",
-    "x-ms-content-crc64": "YeJLfssylmU=",
-    "x-ms-request-id": "3056406b-d01e-0037-45b6-fd086e000000",
-    "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:20:09.1115495Z"
-   }
-  },
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027/blob158459880874506787",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255"
-   },
-   "requestBody": "",
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "content-length": "0",
-    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "date": "Thu, 19 Mar 2020 06:20:08 GMT",
-    "etag": "\"0x8D7CBCD9324964F\"",
-    "last-modified": "Thu, 19 Mar 2020 06:20:09 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "2ba79777-149a-42fc-83a1-7c12bfb1db37",
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "305640c4-d01e-0037-17b6-fd086e000000",
-    "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-19T06:20:09.3607263Z"
-   }
-  },
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027/blob158459880874506787",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255"
-   },
-   "requestBody": null,
-   "status": 400,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>CannotVerifyCopySource</Code><Message>One of the query parameters specified in the request URI is not supported.\nRequestId:30564172-d01e-0037-34b6-fd086e000000\nTime:2020-03-19T06:20:09.8727329Z</Message></Error>",
-   "responseHeaders": {
-    "content-length": "265",
-    "content-type": "application/xml",
-    "date": "Thu, 19 Mar 2020 06:20:08 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "ab124acd-24b1-4ac8-9873-4c26f12defcf",
-    "x-ms-error-code": "CannotVerifyCopySource",
-    "x-ms-request-id": "30564172-d01e-0037-34b6-fd086e000000",
-    "x-ms-version": "2019-12-12"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158459880823404027",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255",
-    "restype": "container"
-   },
-   "requestBody": null,
-   "status": 202,
-   "response": "",
-   "responseHeaders": {
-    "content-length": "0",
-    "date": "Thu, 19 Mar 2020 06:20:09 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "3967d3d8-2433-49da-bcd2-cc77b29360aa",
-    "x-ms-request-id": "3056422c-d01e-0037-53b6-fd086e000000",
-    "x-ms-version": "2019-12-12"
-   }
-  }
- ],
- "uniqueTestInfo": {
-  "uniqueName": {
-   "container": "container158459880823404027",
-   "blob": "blob158459880874506787"
-  },
-  "newDate": {}
- },
- "hash": "c1ddd7168a1d89fb72d78e78735c9a36"
+  "hash": "d904b79863031a84c2093a63c68fce79"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
@@ -1,167 +1,196 @@
 {
- "recordings": [
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255",
-    "restype": "container"
-   },
-   "requestBody": null,
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "etag": "\"0x8D7CFA131B4BBD1\"",
-    "last-modified": "Tue, 24 Mar 2020 03:12:32 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b501cc0e-4f28-44ee-a8da-fc97b26c0011",
-    "x-ms-request-id": "f7f5c097-201e-0003-488a-01645a000000",
-    "x-ms-version": "2019-12-12"
-   }
+  "recordings": [
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "restype": "container"
+      },
+      "requestBody": null,
+      "status": 201,
+      "response": "",
+      "responseHeaders": {
+        "etag": "\"0x8D7CCAF96D4FFB8\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:01 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "71afe7c1-f395-4d12-b902-c99a5d8908db",
+        "x-ms-request-id": "382c2cdf-601e-0012-0a98-fefeee000000",
+        "x-ms-version": "2019-12-12"
+      }
+    },
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": "Hello World",
+      "status": 201,
+      "response": "",
+      "responseHeaders": {
+        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+        "etag": "\"0x8D7CCAF971EAF63\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "91069504-a5f9-485d-9f70-5b9baf371225",
+        "x-ms-content-crc64": "YeJLfssylmU=",
+        "x-ms-request-id": "382c2cf9-601e-0012-1c98-fefeee000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
+      }
+    },
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": "",
+      "status": 201,
+      "response": "",
+      "responseHeaders": {
+        "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+        "etag": "\"0x8D7CCAF974306FF\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "0446d7c8-e287-4c8c-94bd-e7e5710cc9f3",
+        "x-ms-content-crc64": "AAAAAAAAAAA=",
+        "x-ms-request-id": "382c2d03-601e-0012-2698-fefeee000000",
+        "x-ms-request-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:02.5319951Z"
+      }
+    },
+    {
+      "method": "HEAD",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "versionid": "2020-03-20T09:18:02.2928227Z"
+      },
+      "requestBody": null,
+      "status": 200,
+      "response": "",
+      "responseHeaders": {
+        "accept-ranges": "bytes",
+        "content-length": "11",
+        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+        "content-type": "application/octet-stream",
+        "etag": "\"0x8D7CCAF971EAF63\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-access-tier": "Hot",
+        "x-ms-access-tier-inferred": "true",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "059b718f-636a-4081-9587-d46a3dcc31c9",
+        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "x-ms-request-id": "382c2d21-601e-0012-3d98-fefeee000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
+      }
+    },
+    {
+      "method": "PUT",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": null,
+      "status": 202,
+      "response": "",
+      "responseHeaders": {
+        "etag": "\"0x8D7CCAF97DCF295\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "dafb4ee7-4266-476c-ab94-0393e517dad2",
+        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
+        "x-ms-copy-status": "success",
+        "x-ms-request-id": "382c2d3a-601e-0012-5198-fefeee000000",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
+      }
+    },
+    {
+      "method": "GET",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "include": "versions",
+        "restype": "container",
+        "comp": "list"
+      },
+      "requestBody": null,
+      "status": 200,
+      "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158469588020807188\"><Blobs><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.2928227Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF971EAF63</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.5319951Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF974306FF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:03.5417279Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:03 GMT</Last-Modified><Etag>0x8D7CCAF97DCF295</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+      "responseHeaders": {
+        "content-type": "application/xml",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "b4c29f64-b2a0-47f3-ab1a-9047d3ae6ea6",
+        "x-ms-request-id": "382c2d59-601e-0012-6998-fefeee000000",
+        "x-ms-version": "2019-12-12"
+      }
+    },
+    {
+      "method": "GET",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255"
+      },
+      "requestBody": null,
+      "status": 200,
+      "response": "Hello World",
+      "responseHeaders": {
+        "accept-ranges": "bytes",
+        "content-length": "11",
+        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+        "content-type": "application/octet-stream",
+        "etag": "\"0x8D7CCAF97DCF295\"",
+        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-blob-type": "BlockBlob",
+        "x-ms-client-request-id": "76a56e9b-e83a-4a72-8299-f45339a49595",
+        "x-ms-copy-completion-time": "Fri, 20 Mar 2020 09:18:03 GMT",
+        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
+        "x-ms-copy-progress": "11/11",
+        "x-ms-copy-source": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686?sv=2019-10-10&ss=btqf&srt=sco&spr=https%2Chttp&st=2020-03-20T09%3A00%3A00Z&se=2022-12-15T09%3A05%3A00Z&sip=0.0.0.0-255.255.255.255&sp=rwdxlacup&versionid=2020-03-20T09:18:02.2928227Z",
+        "x-ms-copy-status": "success",
+        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
+        "x-ms-is-current-version": "true",
+        "x-ms-lease-state": "available",
+        "x-ms-lease-status": "unlocked",
+        "x-ms-request-id": "382c2d8d-601e-0012-1098-fefeee000000",
+        "x-ms-server-encrypted": "true",
+        "x-ms-version": "2019-12-12",
+        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
+      }
+    },
+    {
+      "method": "DELETE",
+      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
+      "query": {
+        "sip": "0.0.0.0-255.255.255.255",
+        "restype": "container"
+      },
+      "requestBody": null,
+      "status": 202,
+      "response": "",
+      "responseHeaders": {
+        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+        "x-ms-client-request-id": "de051cfe-a985-4575-b9c8-399fbd78cd44",
+        "x-ms-request-id": "382c2d9d-601e-0012-1e98-fefeee000000",
+        "x-ms-version": "2019-12-12"
+      }
+    }
+  ],
+  "uniqueTestInfo": {
+    "uniqueName": {
+      "container": "container158469588020807188",
+      "blob": "blob158469588188607686"
+    },
+    "newDate": {}
   },
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255"
-   },
-   "requestBody": "Hello World",
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "etag": "\"0x8D7CFA131FEA31B\"",
-    "last-modified": "Tue, 24 Mar 2020 03:12:33 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "67e456de-813e-4f15-af28-5b21949895ad",
-    "x-ms-content-crc64": "YeJLfssylmU=",
-    "x-ms-request-id": "f7f5c176-201e-0003-258a-01645a000000",
-    "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-24T03:12:33.1670299Z"
-   }
-  },
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255"
-   },
-   "requestBody": "",
-   "status": 201,
-   "response": "",
-   "responseHeaders": {
-    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-    "etag": "\"0x8D7CFA1322E2064\"",
-    "last-modified": "Tue, 24 Mar 2020 03:12:33 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "93fa6096-c851-4d41-aded-e1245893f23f",
-    "x-ms-content-crc64": "AAAAAAAAAAA=",
-    "x-ms-request-id": "f7f5c1e1-201e-0003-0d8a-01645a000000",
-    "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-24T03:12:33.4792564Z"
-   }
-  },
-  {
-   "method": "PUT",
-   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255"
-   },
-   "requestBody": null,
-   "status": 202,
-   "response": "",
-   "responseHeaders": {
-    "etag": "\"0x8D7CFA132843F7D\"",
-    "last-modified": "Tue, 24 Mar 2020 03:12:34 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "958d13ba-8865-4b76-8745-f1130736b262",
-    "x-ms-copy-id": "e860501f-ea27-43c2-a625-920f73a80a86",
-    "x-ms-copy-status": "success",
-    "x-ms-request-id": "f7f5c324-201e-0003-508a-01645a000000",
-    "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-24T03:12:34.0446626Z"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255",
-    "include": "versions",
-    "restype": "container",
-    "comp": "list"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.preprod.core.windows.net/\" ContainerName=\"container158501954955601499\"><Blobs><Blob><Name>blob158501955278801412</Name><VersionId>2020-03-24T03:12:33.1670299Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:12:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:12:33 GMT</Last-Modified><Etag>0x8D7CFA131FEA31B</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501955278801412</Name><VersionId>2020-03-24T03:12:33.4792564Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:12:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:12:33 GMT</Last-Modified><Etag>0x8D7CFA1322E2064</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501955278801412</Name><VersionId>2020-03-24T03:12:34.0446626Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Tue, 24 Mar 2020 03:12:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:12:34 GMT</Last-Modified><Etag>0x8D7CFA132843F7D</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
-   "responseHeaders": {
-    "content-type": "application/xml",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "49854405-6f13-4626-83ee-592ad18b2e43",
-    "x-ms-request-id": "f7f5c3f9-201e-0003-1a8a-01645a000000",
-    "x-ms-version": "2019-12-12"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255"
-   },
-   "requestBody": null,
-   "status": 200,
-   "response": "Hello World",
-   "responseHeaders": {
-    "accept-ranges": "bytes",
-    "content-length": "11",
-    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "content-type": "application/octet-stream",
-    "etag": "\"0x8D7CFA132843F7D\"",
-    "last-modified": "Tue, 24 Mar 2020 03:12:34 GMT",
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-blob-type": "BlockBlob",
-    "x-ms-client-request-id": "4214978d-cc24-4303-93c1-617a6bfd43b7",
-    "x-ms-copy-completion-time": "Tue, 24 Mar 2020 03:12:34 GMT",
-    "x-ms-copy-id": "e860501f-ea27-43c2-a625-920f73a80a86",
-    "x-ms-copy-progress": "11/11",
-    "x-ms-copy-source": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499/blob158501955278801412?sv=2019-10-10&ss=btqf&srt=sco&spr=https%2Chttp&st=2020-03-20T09%3A00%3A00Z&se=2022-12-15T09%3A05%3A00Z&sip=0.0.0.0-255.255.255.255&sp=rwdxlacup&versionid=2020-03-24T03:12:33.1670299Z",
-    "x-ms-copy-status": "success",
-    "x-ms-creation-time": "Tue, 24 Mar 2020 03:12:33 GMT",
-    "x-ms-is-current-version": "true",
-    "x-ms-lease-state": "available",
-    "x-ms-lease-status": "unlocked",
-    "x-ms-request-id": "f7f5c5db-201e-0003-7a8a-01645a000000",
-    "x-ms-server-encrypted": "true",
-    "x-ms-version": "2019-12-12",
-    "x-ms-version-id": "2020-03-24T03:12:34.0446626Z"
-   }
-  },
-  {
-   "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.preprod.core.windows.net/container158501954955601499",
-   "query": {
-    "sip": "0.0.0.0-255.255.255.255",
-    "restype": "container"
-   },
-   "requestBody": null,
-   "status": 202,
-   "response": "",
-   "responseHeaders": {
-    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "5b51d86f-ba60-45a9-a0e1-eeee685b629b",
-    "x-ms-request-id": "f7f5c652-201e-0003-708a-01645a000000",
-    "x-ms-version": "2019-12-12"
-   }
-  }
- ],
- "uniqueTestInfo": {
-  "uniqueName": {
-   "container": "container158501954955601499",
-   "blob": "blob158501955278801412"
-  },
-  "newDate": {}
- },
- "hash": "54fda11a7b7b7495916f55430107b1ab"
+  "hash": "d904b79863031a84c2093a63c68fce79"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_promote_a_version_as_the_copy_source.json
@@ -1,196 +1,196 @@
 {
-  "recordings": [
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "restype": "container"
-      },
-      "requestBody": null,
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "etag": "\"0x8D7CCAF96D4FFB8\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:01 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "71afe7c1-f395-4d12-b902-c99a5d8908db",
-        "x-ms-request-id": "382c2cdf-601e-0012-0a98-fefeee000000",
-        "x-ms-version": "2019-12-12"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": "Hello World",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "etag": "\"0x8D7CCAF971EAF63\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "91069504-a5f9-485d-9f70-5b9baf371225",
-        "x-ms-content-crc64": "YeJLfssylmU=",
-        "x-ms-request-id": "382c2cf9-601e-0012-1c98-fefeee000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": "",
-      "status": 201,
-      "response": "",
-      "responseHeaders": {
-        "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
-        "etag": "\"0x8D7CCAF974306FF\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "0446d7c8-e287-4c8c-94bd-e7e5710cc9f3",
-        "x-ms-content-crc64": "AAAAAAAAAAA=",
-        "x-ms-request-id": "382c2d03-601e-0012-2698-fefeee000000",
-        "x-ms-request-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:02.5319951Z"
-      }
-    },
-    {
-      "method": "HEAD",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "versionid": "2020-03-20T09:18:02.2928227Z"
-      },
-      "requestBody": null,
-      "status": 200,
-      "response": "",
-      "responseHeaders": {
-        "accept-ranges": "bytes",
-        "content-length": "11",
-        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "content-type": "application/octet-stream",
-        "etag": "\"0x8D7CCAF971EAF63\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-access-tier": "Hot",
-        "x-ms-access-tier-inferred": "true",
-        "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "059b718f-636a-4081-9587-d46a3dcc31c9",
-        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "x-ms-request-id": "382c2d21-601e-0012-3d98-fefeee000000",
-        "x-ms-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:02.2928227Z"
-      }
-    },
-    {
-      "method": "PUT",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": null,
-      "status": 202,
-      "response": "",
-      "responseHeaders": {
-        "etag": "\"0x8D7CCAF97DCF295\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "dafb4ee7-4266-476c-ab94-0393e517dad2",
-        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
-        "x-ms-copy-status": "success",
-        "x-ms-request-id": "382c2d3a-601e-0012-5198-fefeee000000",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
-      }
-    },
-    {
-      "method": "GET",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "include": "versions",
-        "restype": "container",
-        "comp": "list"
-      },
-      "requestBody": null,
-      "status": 200,
-      "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158469588020807188\"><Blobs><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.2928227Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF971EAF63</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:02.5319951Z</VersionId><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:02 GMT</Last-Modified><Etag>0x8D7CCAF974306FF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158469588188607686</Name><VersionId>2020-03-20T09:18:03.5417279Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Fri, 20 Mar 2020 09:18:02 GMT</Creation-Time><Last-Modified>Fri, 20 Mar 2020 09:18:03 GMT</Last-Modified><Etag>0x8D7CCAF97DCF295</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
-      "responseHeaders": {
-        "content-type": "application/xml",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "b4c29f64-b2a0-47f3-ab1a-9047d3ae6ea6",
-        "x-ms-request-id": "382c2d59-601e-0012-6998-fefeee000000",
-        "x-ms-version": "2019-12-12"
-      }
-    },
-    {
-      "method": "GET",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255"
-      },
-      "requestBody": null,
-      "status": 200,
-      "response": "Hello World",
-      "responseHeaders": {
-        "accept-ranges": "bytes",
-        "content-length": "11",
-        "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-        "content-type": "application/octet-stream",
-        "etag": "\"0x8D7CCAF97DCF295\"",
-        "last-modified": "Fri, 20 Mar 2020 09:18:03 GMT",
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-blob-type": "BlockBlob",
-        "x-ms-client-request-id": "76a56e9b-e83a-4a72-8299-f45339a49595",
-        "x-ms-copy-completion-time": "Fri, 20 Mar 2020 09:18:03 GMT",
-        "x-ms-copy-id": "6bb78fff-afe4-483b-a13e-71190407f7ac",
-        "x-ms-copy-progress": "11/11",
-        "x-ms-copy-source": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188/blob158469588188607686?sv=2019-10-10&ss=btqf&srt=sco&spr=https%2Chttp&st=2020-03-20T09%3A00%3A00Z&se=2022-12-15T09%3A05%3A00Z&sip=0.0.0.0-255.255.255.255&sp=rwdxlacup&versionid=2020-03-20T09:18:02.2928227Z",
-        "x-ms-copy-status": "success",
-        "x-ms-creation-time": "Fri, 20 Mar 2020 09:18:02 GMT",
-        "x-ms-is-current-version": "true",
-        "x-ms-lease-state": "available",
-        "x-ms-lease-status": "unlocked",
-        "x-ms-request-id": "382c2d8d-601e-0012-1098-fefeee000000",
-        "x-ms-server-encrypted": "true",
-        "x-ms-version": "2019-12-12",
-        "x-ms-version-id": "2020-03-20T09:18:03.5417279Z"
-      }
-    },
-    {
-      "method": "DELETE",
-      "url": "https://fakestorageaccount.blob.core.windows.net/container158469588020807188",
-      "query": {
-        "sip": "0.0.0.0-255.255.255.255",
-        "restype": "container"
-      },
-      "requestBody": null,
-      "status": 202,
-      "response": "",
-      "responseHeaders": {
-        "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-        "x-ms-client-request-id": "de051cfe-a985-4575-b9c8-399fbd78cd44",
-        "x-ms-request-id": "382c2d9d-601e-0012-1e98-fefeee000000",
-        "x-ms-version": "2019-12-12"
-      }
-    }
-  ],
-  "uniqueTestInfo": {
-    "uniqueName": {
-      "container": "container158469588020807188",
-      "blob": "blob158469588188607686"
-    },
-    "newDate": {}
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7D09746355BD9\"",
+    "last-modified": "Wed, 25 Mar 2020 08:34:03 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "83e91efc-1970-4c4a-9051-8a0b32bb2ea2",
+    "x-ms-request-id": "47fdeb5a-701e-000e-4880-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
   },
-  "hash": "d904b79863031a84c2093a63c68fce79"
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034/blob158512524270507574",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "etag": "\"0x8D7D09746D22F56\"",
+    "last-modified": "Wed, 25 Mar 2020 08:34:04 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "35ab7485-b603-4c7b-9708-5182f162b8f5",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "47fdebbd-701e-000e-1b80-02ac8e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T08:34:04.3033430Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034/blob158512524270507574",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "etag": "\"0x8D7D0974701374A\"",
+    "last-modified": "Wed, 25 Mar 2020 08:34:04 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "8222e39c-8c11-42b8-b051-fe1e57098230",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "47fdebe0-701e-000e-3d80-02ac8e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T08:34:04.6125658Z"
+   }
+  },
+  {
+   "method": "HEAD",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034/blob158512524270507574",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-25T08:34:04.3033430Z"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "11",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "content-type": "application/octet-stream",
+    "etag": "\"0x8D7D09746D22F56\"",
+    "last-modified": "Wed, 25 Mar 2020 08:34:04 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-access-tier": "Hot",
+    "x-ms-access-tier-inferred": "true",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "28aa44a4-b20a-4309-b40d-eae457ffb625",
+    "x-ms-creation-time": "Wed, 25 Mar 2020 08:34:04 GMT",
+    "x-ms-request-id": "47fdec09-701e-000e-6080-02ac8e000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T08:34:04.3033430Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034/blob158512524270507574",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "etag": "\"0x8D7D09747A49A66\"",
+    "last-modified": "Wed, 25 Mar 2020 08:34:05 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "df1e0dea-7ea9-4b52-aa4e-a2c6ed33c204",
+    "x-ms-copy-id": "aa69ab9a-f625-44b5-86cc-8107b0357b47",
+    "x-ms-copy-status": "success",
+    "x-ms-request-id": "47fdec34-701e-000e-0680-02ac8e000000",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T08:34:05.6843403Z"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "include": "versions",
+    "restype": "container",
+    "comp": "list"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158512524174808034\"><Blobs><Blob><Name>blob158512524270507574</Name><VersionId>2020-03-25T08:34:04.3033430Z</VersionId><Properties><Creation-Time>Wed, 25 Mar 2020 08:34:04 GMT</Creation-Time><Last-Modified>Wed, 25 Mar 2020 08:34:04 GMT</Last-Modified><Etag>0x8D7D09746D22F56</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158512524270507574</Name><VersionId>2020-03-25T08:34:04.6125658Z</VersionId><Properties><Creation-Time>Wed, 25 Mar 2020 08:34:04 GMT</Creation-Time><Last-Modified>Wed, 25 Mar 2020 08:34:04 GMT</Last-Modified><Etag>0x8D7D0974701374A</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158512524270507574</Name><VersionId>2020-03-25T08:34:05.6843403Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 25 Mar 2020 08:34:04 GMT</Creation-Time><Last-Modified>Wed, 25 Mar 2020 08:34:05 GMT</Last-Modified><Etag>0x8D7D09747A49A66</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "responseHeaders": {
+    "content-type": "application/xml",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "4d2a6bd4-c84c-467a-8cf1-ece72d23a02d",
+    "x-ms-request-id": "47fdec69-701e-000e-3880-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034/blob158512524270507574",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "Hello World",
+   "responseHeaders": {
+    "accept-ranges": "bytes",
+    "content-length": "11",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "content-type": "application/octet-stream",
+    "etag": "\"0x8D7D09747A49A66\"",
+    "last-modified": "Wed, 25 Mar 2020 08:34:05 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-blob-type": "BlockBlob",
+    "x-ms-client-request-id": "48c4e9ed-b6f9-433e-9c73-909b1169bf6a",
+    "x-ms-copy-completion-time": "Wed, 25 Mar 2020 08:34:05 GMT",
+    "x-ms-copy-id": "aa69ab9a-f625-44b5-86cc-8107b0357b47",
+    "x-ms-copy-progress": "11/11",
+    "x-ms-copy-source": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034/blob158512524270507574?sv=2019-10-10&ss=btqf&srt=sco&spr=https%2Chttp&st=2020-03-20T09%3A00%3A00Z&se=2022-12-15T09%3A05%3A00Z&sip=0.0.0.0-255.255.255.255&sp=rwdxlacup&versionid=2020-03-25T08:34:04.3033430Z",
+    "x-ms-copy-status": "success",
+    "x-ms-creation-time": "Wed, 25 Mar 2020 08:34:04 GMT",
+    "x-ms-is-current-version": "true",
+    "x-ms-lease-state": "available",
+    "x-ms-lease-status": "unlocked",
+    "x-ms-request-id": "47fdecbf-701e-000e-0480-02ac8e000000",
+    "x-ms-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-25T08:34:05.6843403Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158512524174808034",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "8f6735b3-27a7-4552-a5bc-818b351d7699",
+    "x-ms-request-id": "47fded10-701e-000e-5080-02ac8e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158512524174808034",
+   "blob": "blob158512524270507574"
+  },
+  "newDate": {}
+ },
+ "hash": "638077f3701ea504dd68739c992ec307"
 }

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_setmetadata.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_setmetadata.json
@@ -1,0 +1,123 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881838601962",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:17 GMT",
+    "etag": "\"0x8D7CBCD98BB2091\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:18 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "254a5406-549d-4b79-9ef6-9f6c45d5bf59",
+    "x-ms-request-id": "30564f34-d01e-0037-2bb6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881838601962/blob158459881886105715",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:18 GMT",
+    "etag": "\"0x8D7CBCD9903BB5A\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:19 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "0c24c0c8-b77f-412c-a1de-b37f6ddcaaa0",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "30564ff0-d01e-0037-55b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:19.2107354Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881838601962/blob158459881886105715",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:18 GMT",
+    "etag": "\"0x8D7CBCD992999C2\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:19 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "e040398f-32a5-490c-bd3b-cb9f75faeb25",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "3056505b-d01e-0037-36b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:19.4609131Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881838601962/blob158459881886105715",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "comp": "metadata"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:19 GMT",
+    "etag": "\"0x8D7CBCD9972E51E\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:19 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "c12c9c26-0ed0-4f4e-bd91-edcbeda84636",
+    "x-ms-request-id": "30565129-d01e-0037-7ab6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:19.9402542Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881838601962",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:19 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "6cfb6192-5ce5-4e07-b66f-29b3a6a1c5ff",
+    "x-ms-request-id": "30565236-d01e-0037-6eb6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459881838601962",
+   "blob": "blob158459881886105715"
+  },
+  "newDate": {}
+ },
+ "hash": "707b5201201727b785455ac69d6a0da0"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_undelete_a_softdeleted_version.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_undelete_a_softdeleted_version.json
@@ -1,0 +1,142 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459882055502672",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:20 GMT",
+    "etag": "\"0x8D7CBCD9A06EEA3\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:20 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "2aed0192-7a23-408f-96fa-096e4609528e",
+    "x-ms-request-id": "305652dd-d01e-0037-09b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459882055502672/blob158459882104501497",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:20 GMT",
+    "etag": "\"0x8D7CBCD9A513882\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:21 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "fb1e24bd-fc4c-48ba-a688-852f39642db9",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "305653be-d01e-0037-57b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:21.3962882Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459882055502672/blob158459882104501497",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:20 GMT",
+    "etag": "\"0x8D7CBCD9A75DE22\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:21 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "37728b64-4f21-4c84-8c95-95218cff1ab2",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "30565420-d01e-0037-30b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:21.6374578Z"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://fakestorageaccount.blob.core.windows.net/",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "service",
+    "comp": "properties"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>GET,PUT,POST,HEAD,DELETE,MERGE,OPTIONS,PATCH</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>",
+   "responseHeaders": {
+    "content-type": "application/xml",
+    "date": "Thu, 19 Mar 2020 06:20:21 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "f2281506-e6e8-4678-82c7-c274024b2085",
+    "x-ms-request-id": "305654ea-d01e-0037-67b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459882055502672/blob158459882104501497",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "versionid": "2020-03-19T06:20:21.3962882Z"
+   },
+   "requestBody": null,
+   "status": 403,
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>OperationNotAllowedOnAutomaticSnapshot</Code><Message>The specified operation is not allowed on version.\nRequestId:30565582-d01e-0037-77b6-fd086e000000\nTime:2020-03-19T06:20:22.7757319Z</Message></Error>",
+   "responseHeaders": {
+    "content-length": "257",
+    "content-type": "application/xml",
+    "date": "Thu, 19 Mar 2020 06:20:21 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "ec8a9f82-3076-4709-9189-ad6910cb0f2f",
+    "x-ms-error-code": "OperationNotAllowedOnAutomaticSnapshot",
+    "x-ms-request-id": "30565582-d01e-0037-77b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459882055502672",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:22 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "a35dac7f-d094-428b-8ea9-350dfec73203",
+    "x-ms-request-id": "30565684-d01e-0037-65b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459882055502672",
+   "blob": "blob158459882104501497"
+  },
+  "newDate": {}
+ },
+ "hash": "532f15900a07a42923319f706bbc6e06"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_upload_block_blob_return_versionid.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blob_versioning/recording_upload_block_blob_return_versionid.json
@@ -1,0 +1,148 @@
+{
+ "recordings": [
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881347506266",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:13 GMT",
+    "etag": "\"0x8D7CBCD95D6DD62\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:13 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "a2cd532a-b1de-43fd-bda1-1ab722c1766a",
+    "x-ms-request-id": "305647e2-d01e-0037-01b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881347506266/blob158459881423702452",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:13 GMT",
+    "etag": "\"0x8D7CBCD964CA822\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:14 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "3306fa29-fd56-40ce-a669-28412165788c",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "3056494b-d01e-0037-42b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:14.6564923Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881347506266/blob158459881423702452",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "1B2M2Y8AsgTpgAmY7PhCfg==",
+    "date": "Thu, 19 Mar 2020 06:20:14 GMT",
+    "etag": "\"0x8D7CBCD967E2167\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:14 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "6dbb512a-6f3a-4541-925b-0b315983192a",
+    "x-ms-content-crc64": "AAAAAAAAAAA=",
+    "x-ms-request-id": "305649aa-d01e-0037-1bb6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:14.9817232Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881347506266/blob158459881423702452",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:14 GMT",
+    "etag": "\"0x8D7CBCD96A2C715\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:15 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "b7ed4cea-f7c3-46e7-a0d0-3ce8678bf744",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "30564a11-d01e-0037-79b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:15.2208943Z"
+   }
+  },
+  {
+   "method": "PUT",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881347506266/blob158459881423702452",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255"
+   },
+   "requestBody": "Hello World",
+   "status": 201,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
+    "date": "Thu, 19 Mar 2020 06:20:14 GMT",
+    "etag": "\"0x8D7CBCD96CFD2BE\"",
+    "last-modified": "Thu, 19 Mar 2020 06:20:15 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "9eddb025-ef53-4752-8962-b480860fa7f7",
+    "x-ms-content-crc64": "YeJLfssylmU=",
+    "x-ms-request-id": "30564a75-d01e-0037-52b6-fd086e000000",
+    "x-ms-request-server-encrypted": "true",
+    "x-ms-version": "2019-12-12",
+    "x-ms-version-id": "2020-03-19T06:20:15.5161038Z"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158459881347506266",
+   "query": {
+    "sip": "0.0.0.0-255.255.255.255",
+    "restype": "container"
+   },
+   "requestBody": null,
+   "status": 202,
+   "response": "",
+   "responseHeaders": {
+    "content-length": "0",
+    "date": "Thu, 19 Mar 2020 06:20:15 GMT",
+    "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
+    "x-ms-client-request-id": "58c792f0-4c42-4e8e-b3ca-5038152c3b70",
+    "x-ms-request-id": "30564b3d-d01e-0037-08b6-fd086e000000",
+    "x-ms-version": "2019-12-12"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {
+   "container": "container158459881347506266",
+   "blob": "blob158459881423702452"
+  },
+  "newDate": {}
+ },
+ "hash": "603c7ef07e53e865d736dbd3d3ec4290"
+}

--- a/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_undelete.json
+++ b/sdk/storage/storage-blob/recordings/browsers/blobclient/recording_undelete.json
@@ -2,7 +2,7 @@
  "recordings": [
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158501883196502913",
    "query": {
     "restype": "container"
    },
@@ -10,35 +10,35 @@
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
-    "date": "Fri, 21 Feb 2020 01:24:06 GMT",
-    "etag": "\"0x8D7B66CBE88E848\"",
-    "last-modified": "Fri, 21 Feb 2020 01:24:06 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:32 GMT",
+    "etag": "\"0x8D7CF9F84D998D9\"",
+    "last-modified": "Tue, 24 Mar 2020 03:00:33 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "bf6ad9ca-0bd6-4a26-91a0-e045b77c94f9",
-    "x-ms-request-id": "04e05e2b-201e-005b-5d55-e8663e000000",
-    "x-ms-version": "2019-02-02"
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "5e37e0a1-2dec-45de-9cec-d47b4bef440f",
+    "x-ms-request-id": "681a670c-c01e-0016-3e88-0128a1000000",
+    "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081/blob158224824671508312",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158501883196502913/blob158501883327901608",
    "query": {},
    "requestBody": "Hello World",
    "status": 201,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
     "content-md5": "sQqNsWTgdUEFt6mb5y4/5Q==",
-    "date": "Fri, 21 Feb 2020 01:24:06 GMT",
-    "etag": "\"0x8D7B66CBEE395E7\"",
-    "last-modified": "Fri, 21 Feb 2020 01:24:07 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:33 GMT",
+    "etag": "\"0x8D7CF9F85227D9F\"",
+    "last-modified": "Tue, 24 Mar 2020 03:00:33 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "9c2acef0-075c-400f-aeaa-148f23a8b076",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "d78071ef-9904-4c65-a690-ca26faaafbc4",
     "x-ms-content-crc64": "YeJLfssylmU=",
-    "x-ms-request-id": "04e05ffb-201e-005b-0e55-e8663e000000",
+    "x-ms-request-id": "681a6743-c01e-0016-6488-0128a1000000",
     "x-ms-request-server-encrypted": "true",
-    "x-ms-version": "2019-02-02"
+    "x-ms-version": "2019-12-12"
    }
   },
   {
@@ -50,59 +50,59 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>5</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>3</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>4</Days></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>DELETE,GET,HEAD,MERGE,POST,OPTIONS,PUT,PATCH</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>PATCH,PUT,OPTIONS,POST,MERGE,HEAD,GET,DELETE</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><AutomaticSnapshotPolicy><Enabled>false</Enabled></AutomaticSnapshotPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Fri, 21 Feb 2020 01:24:07 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:33 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "0095d87f-969b-45e8-a5e7-2fb3cb07ce99",
-    "x-ms-request-id": "04e06183-201e-005b-7755-e8663e000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "f27dc6c8-b785-4090-a02e-bf84f041ed44",
+    "x-ms-request-id": "681a6796-c01e-0016-1788-0128a1000000",
+    "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081/blob158224824671508312",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158501883196502913/blob158501883327901608",
    "query": {},
    "requestBody": null,
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
-    "date": "Fri, 21 Feb 2020 01:24:08 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:34 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b19e4da3-13c8-4692-ac74-17371e07d97e",
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "ba7cd3cc-2a67-4484-8ac4-1461a8448f36",
     "x-ms-delete-type-permanent": "false",
-    "x-ms-request-id": "04e06321-201e-005b-7255-e8663e000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-request-id": "681a67e2-c01e-0016-4b88-0128a1000000",
+    "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158501883196502913",
    "query": {
     "maxresults": "1",
-    "include": "deleted",
+    "include": "deleted,versions",
     "restype": "container",
     "comp": "list"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224824523309081\"><MaxResults>1</MaxResults><Blobs><Blob><Name>blob158224824671508312</Name><Deleted>true</Deleted><Properties><Creation-Time>Fri, 21 Feb 2020 01:24:07 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:24:07 GMT</Last-Modified><Etag>0x8D7B66CBEE395E7</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Fri, 21 Feb 2020 01:24:08 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158501883196502913\"><MaxResults>1</MaxResults><Blobs><Blob><Name>blob158501883327901608</Name><Deleted>true</Deleted><Properties><Creation-Time>Tue, 24 Mar 2020 03:00:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:00:33 GMT</Last-Modified><Etag>0x8D7CF9F85227D9F</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Tue, 24 Mar 2020 03:00:34 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Fri, 21 Feb 2020 01:24:08 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:34 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "982eed10-dfb6-4497-b900-b7f4427960c7",
-    "x-ms-request-id": "04e064b0-201e-005b-6455-e8663e000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "335575ab-7333-4bd2-bfcc-46c7127b38b7",
+    "x-ms-request-id": "681a6828-c01e-0016-7688-0128a1000000",
+    "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "PUT",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081/blob158224824671508312",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158501883196502913/blob158501883327901608",
    "query": {
     "comp": "undelete"
    },
@@ -110,38 +110,38 @@
    "status": 200,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
-    "date": "Fri, 21 Feb 2020 01:24:09 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:35 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "e841edde-f7b6-41df-ae08-8e997a24d0c0",
-    "x-ms-request-id": "04e066a7-201e-005b-3f55-e8663e000000",
-    "x-ms-version": "2019-02-02"
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "1ce86e16-572a-48f7-8c52-c7174883d339",
+    "x-ms-request-id": "681a6871-c01e-0016-2088-0128a1000000",
+    "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "GET",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158501883196502913",
    "query": {
-    "include": "deleted",
+    "include": "deleted,versions",
     "restype": "container",
     "comp": "list"
    },
    "requestBody": null,
    "status": 200,
-   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224824523309081\"><Blobs><Blob><Name>blob158224824671508312</Name><Properties><Creation-Time>Fri, 21 Feb 2020 01:24:07 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:24:07 GMT</Last-Modified><Etag>0x8D7B66CBEE395E7</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
+   "response": "<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158501883196502913\"><Blobs><Blob><Name>blob158501883327901608</Name><Properties><Creation-Time>Tue, 24 Mar 2020 03:00:33 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:00:33 GMT</Last-Modified><Etag>0x8D7CF9F85227D9F</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>",
    "responseHeaders": {
     "content-type": "application/xml",
-    "date": "Fri, 21 Feb 2020 01:24:09 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:35 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
     "transfer-encoding": "chunked",
-    "x-ms-client-request-id": "7bb4a9b0-be37-4508-bfc7-8f635e449a0c",
-    "x-ms-request-id": "04e06877-201e-005b-6755-e8663e000000",
-    "x-ms-version": "2019-02-02"
+    "x-ms-client-request-id": "e3425de5-cd19-4700-95b7-65324f83ac7e",
+    "x-ms-request-id": "681a68b3-c01e-0016-4d88-0128a1000000",
+    "x-ms-version": "2019-12-12"
    }
   },
   {
    "method": "DELETE",
-   "url": "https://fakestorageaccount.blob.core.windows.net/container158224824523309081",
+   "url": "https://fakestorageaccount.blob.core.windows.net/container158501883196502913",
    "query": {
     "restype": "container"
    },
@@ -149,20 +149,21 @@
    "status": 202,
    "response": "",
    "responseHeaders": {
-    "content-length": "0",
-    "date": "Fri, 21 Feb 2020 01:24:10 GMT",
+    "date": "Tue, 24 Mar 2020 03:00:36 GMT",
     "server": "Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0",
-    "x-ms-client-request-id": "b53b190a-1dd0-49f0-a1ad-0424eef6ae0a",
-    "x-ms-request-id": "04e06b0d-201e-005b-5755-e8663e000000",
-    "x-ms-version": "2019-02-02"
+    "transfer-encoding": "chunked",
+    "x-ms-client-request-id": "b0330c72-d807-4a84-bae3-d81d4ba6e65a",
+    "x-ms-request-id": "681a68f7-c01e-0016-7688-0128a1000000",
+    "x-ms-version": "2019-12-12"
    }
   }
  ],
  "uniqueTestInfo": {
   "uniqueName": {
-   "container": "container158224824523309081",
-   "blob": "blob158224824671508312"
+   "container": "container158501883196502913",
+   "blob": "blob158501883327901608"
   },
   "newDate": {}
- }
+ },
+ "hash": "9955cdc24f7740b2a708b4ab74d2601f"
 }

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_asynchorous_copy_return_versionid.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_asynchorous_copy_return_versionid.js
@@ -1,0 +1,130 @@
+let nock = require('nock');
+
+module.exports.hash = "e398b7bcabf21c191b9670bc84a4fc30";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459901672706413","blob":"blob158459901696704278","copiedblob":"copiedblob158459901745702616"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901672706413')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:36 GMT',
+  'ETag',
+  '"0x8D7CBCE0ECFF5AA"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b9026-701e-005c-1eb6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'f104b9b5-248d-4a04-ad6d-43cd54288c1d',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:36 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901672706413/blob158459901696704278', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:37 GMT',
+  'ETag',
+  '"0x8D7CBCE0EF52E44"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e55d1-b01e-0088-29b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '26737cca-f85e-439f-8570-3ec7b029cc2b',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:37.0865220Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:36 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901672706413/blob158459901696704278')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:37 GMT',
+  'ETag',
+  '"0x8D7CBCE0F1AE597"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b90ea-701e-005c-46b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'db1cbd1e-f99e-4038-bdc8-aa6bbe4fb89b',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:37.3356992Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:36 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901672706413/copiedblob158459901745702616')
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:37 GMT',
+  'ETag',
+  '"0x8D7CBCE0F409CE5"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e568d-b01e-0088-47b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'c72b3194-a8cf-4d4d-8d2b-2102e19ff48b',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:37.5818746Z',
+  'x-ms-copy-id',
+  '6b333786-1dd4-452d-8ed5-e6a48eb7c838',
+  'x-ms-copy-status',
+  'success',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:37 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459901672706413')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b91bc-701e-005c-06b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '8307f037-3e1e-4daa-b706-5132be449766',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:37 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_blob_create_return_versionid.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_blob_create_return_versionid.js
@@ -1,0 +1,153 @@
+let nock = require('nock');
+
+module.exports.hash = "451c6fd62c81383c6e0cce46649063e6";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459901405902088","blob":"blob158459901430407722","appendblob":"appendblob158459901478704253","pageblob":"pageblob158459901502809947"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901405902088')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:34 GMT',
+  'ETag',
+  '"0x8D7CBCE0D395269"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e51d6-b01e-0088-23b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'a860ac66-29b6-44a1-8fed-9444239e0645',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:33 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901405902088/blob158459901430407722', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:34 GMT',
+  'ETag',
+  '"0x8D7CBCE0D5E8CEE"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8b95-701e-005c-79b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '758156ed-19ca-4cbc-90ac-d3233809b027',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:34.4226312Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:34 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901405902088/blob158459901430407722')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:34 GMT',
+  'ETag',
+  '"0x8D7CBCE0D83A7E4"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e526b-b01e-0088-25b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '983e5e09-80f1-4347-aeed-2f9aaef9eabc',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:34.6658036Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:34 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901405902088/appendblob158459901478704253')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:34 GMT',
+  'ETag',
+  '"0x8D7CBCE0DA89BC1"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8c3b-701e-005c-0eb6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'f74f7cb5-8987-4250-a54a-a8b48ba25e63',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:34.9069761Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:34 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901405902088/pageblob158459901502809947')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:35 GMT',
+  'ETag',
+  '"0x8D7CBCE0DCD6884"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5321-b01e-0088-46b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'c030965b-1792-4fe5-8ac7-aa7d620bd50e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:35.1481476Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:34 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459901405902088')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8d21-701e-005c-5ab6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'c1122fe5-8e67-403e-ada5-0d683341ca80',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:34 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_delete_a_snapshot.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_delete_a_snapshot.js
@@ -1,0 +1,224 @@
+let nock = require('nock');
+
+module.exports.hash = "58513e0c39f37daceede07e04a9062d7";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459900517006636","blob":"blob158459900541003605"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900517006636')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:25 GMT',
+  'ETag',
+  '"0x8D7CBCE07EC9D40"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e45b1-b01e-0088-58b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '733d2bdc-1c46-4c6b-ad25-f1bab95a4d28',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:25 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900517006636/blob158459900541003605', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:25 GMT',
+  'ETag',
+  '"0x8D7CBCE08131040"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4604-b01e-0088-1bb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '9f2600f8-24c8-4777-add7-c4d4cd828891',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:25.5393109Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:25 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900517006636/blob158459900541003605')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:25 GMT',
+  'ETag',
+  '"0x8D7CBCE0838EEA8"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4655-b01e-0088-57b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '4a619f85-b558-43fe-9b50-9e19f35c80dc',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:25.7884877Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:25 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900517006636/blob158459900541003605')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:25 GMT',
+  'ETag',
+  '"0x8D7CBCE0838EEA8"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e46a6-b01e-0088-1cb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '94b6e56b-1a4e-4534-8e00-0853c2edb25e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:26.0416662Z',
+  'x-ms-snapshot',
+  '2020-03-19T06:23:26.0406662Z',
+  'x-ms-request-server-encrypted',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:25 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900517006636/blob158459900541003605')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4731-b01e-0088-7ab6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '2dd68f98-6cc4-42e3-bd25-5c2aa3a24021',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:26 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900517006636/blob158459900541003605')
+  .query(true)
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4777-b01e-0088-36b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '414f3441-c5c8-423f-9969-321199850025',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:26 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900517006636/blob158459900541003605')
+  .reply(200, "", [
+  'Content-Length',
+  '0',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:25 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE0838EEA8"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e47cc-b01e-0088-7bb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'eb986bff-0e1e-488c-9dd3-022426430a14',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:26.0416662Z',
+  'x-ms-is-current-version',
+  'true',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:25 GMT',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:26 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900517006636')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4835-b01e-0088-55b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'c48eb5cb-477d-4c21-9e81-6eeee53c9525',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:26 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_delete_a_version.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_delete_a_version.js
@@ -1,0 +1,196 @@
+let nock = require('nock');
+
+module.exports.hash = "bc4dd729c5dd87bf12319e80d8e8545f";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459900100501054","blob":"blob158459900124500587"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900100501054')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:21 GMT',
+  'ETag',
+  '"0x8D7CBCE05713E93"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4071-b01e-0088-52b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '012c13e8-7b4d-4c9d-b8a2-da8647837ae1',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:20 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900100501054/blob158459900124500587', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:21 GMT',
+  'ETag',
+  '"0x8D7CBCE0596C6CE"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e40ac-b01e-0088-05b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '0d5ef65f-c510-4533-89ad-4118a25df3ee',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:21.3693415Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:21 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900100501054/blob158459900124500587')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:21 GMT',
+  'ETag',
+  '"0x8D7CBCE05BB9395"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e40ed-b01e-0088-3eb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'fadba3a7-65e3-4a84-9fc4-408e67a95bfb',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:21.6115130Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:21 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900100501054/blob158459900124500587')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4139-b01e-0088-02b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '24727022-163f-487e-8ea4-a0097c6b54d8',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:21 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900100501054/blob158459900124500587')
+  .query(true)
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4189-b01e-0088-4ab6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'af9eca93-5e39-46f9-8485-14c012b27d62',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:21 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900100501054/blob158459900124500587')
+  .reply(200, "", [
+  'Content-Length',
+  '0',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:21 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE05BB9395"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e41da-b01e-0088-08b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '4529a963-a613-4f64-8563-55c56314ccf8',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:21.6115130Z',
+  'x-ms-is-current-version',
+  'true',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:21 GMT',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:22 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900100501054')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4227-b01e-0088-4bb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'edf24965-6935-4388-bd93-2a2b50cd9da6',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:22 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleteblobs_should_work_for_batch_delete.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleteblobs_should_work_for_batch_delete.js
@@ -1,0 +1,85 @@
+let nock = require('nock');
+
+module.exports.hash = "6f6a281fc76eb2011a24cc4f8e8e5fd5";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459900270600707","blob":"blob158459900294706388"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900270600707')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:22 GMT',
+  'ETag',
+  '"0x8D7CBCE0674D411"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4286-b01e-0088-1ab6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '2fcf3631-70a9-4f23-a03d-6d0a46ee940d',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:22 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900270600707/blob158459900294706388', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:23 GMT',
+  'ETag',
+  '"0x8D7CBCE069A354C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e42c7-b01e-0088-55b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '30e1ee1b-1578-4702-a037-00e61e37c0a5',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:23.0685516Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:22 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900270600707/blob158459900294706388')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:23 GMT',
+  'ETag',
+  '"0x8D7CBCE06BF503D"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4338-b01e-0088-39b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'abef7945-21b5-4064-9ea3-68cc2ca62275',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:23.3127245Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:23 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_a_blob_that_has_snapshots_needs_deletesnapshots_option.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_a_blob_that_has_snapshots_needs_deletesnapshots_option.js
@@ -1,0 +1,218 @@
+let nock = require('nock');
+
+module.exports.hash = "db1d48bb3945806dc2f8f8b03ffa17a5";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459900716901393","blob":"blob158459900741801925"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900716901393')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:27 GMT',
+  'ETag',
+  '"0x8D7CBCE091E28E7"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e48a8-b01e-0088-33b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '32d1dc49-1081-42ce-ba6a-d845d7bf3b07',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:27 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900716901393/blob158459900741801925', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:27 GMT',
+  'ETag',
+  '"0x8D7CBCE0945110B"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4906-b01e-0088-03b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '11e5478c-a4eb-4fcc-9f4c-969ae0b21b8b',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:27.5437323Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:27 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900716901393/blob158459900741801925')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:27 GMT',
+  'ETag',
+  '"0x8D7CBCE096A04E8"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e494c-b01e-0088-3cb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'd5666cfb-1d22-4a2e-83a8-b3a12aafc77d',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:27.7869048Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:27 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900716901393/blob158459900741801925')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:27 GMT',
+  'ETag',
+  '"0x8D7CBCE096A04E8"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4995-b01e-0088-7db6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'd33a297c-129c-4de1-8322-a932e0497a39',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:28.0310773Z',
+  'x-ms-snapshot',
+  '2020-03-19T06:23:28.0300773Z',
+  'x-ms-request-server-encrypted',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:27 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900716901393/blob158459900741801925')
+  .reply(409, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>SnapshotsPresent</Code><Message>This operation is not permitted because the blob has snapshots.\nRequestId:775e4a07-b01e-0088-53b6-fd3fcb000000\nTime:2020-03-19T06:23:28.3044745Z</Message></Error>", [
+  'Content-Length',
+  '248',
+  'Content-Type',
+  'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4a07-b01e-0088-53b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '062856c8-f552-4d70-8aa1-78291df3cc05',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'SnapshotsPresent',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:28 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900716901393/blob158459900741801925')
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4a64-b01e-0088-23b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '209597c0-ca18-47f0-b6c8-54ff2de516d4',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:28 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900716901393/blob158459900741801925')
+  .query(true)
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b83b1-701e-005c-0db6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '15fccdb4-c158-4bfa-ba60-e5e9646e5a78',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:28 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900716901393/blob158459900741801925')
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4be3-b01e-0088-63b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '7d3f7598-4b5a-45b6-a03e-97ee76c6c8ea',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:29 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900716901393')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8478-701e-005c-34b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'b37b4b1a-0c0a-4abf-904c-9fb9345b2489',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:29 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_a_blob_with_both_deletesnapshots_and_versionid_option_should_fail.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_a_blob_with_both_deletesnapshots_and_versionid_option_should_fail.js
@@ -1,0 +1,175 @@
+let nock = require('nock');
+
+module.exports.hash = "225342bc54f257faee0103248ddc59dd";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158511669236805116","blob":"blob158511669646200888"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511669236805116')
+  .query(true)
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:11:36 GMT',
+  'ETag',
+  '"0x8D7D08360141C11"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5866e7db-301e-000f-566c-02f352000000',
+  'x-ms-client-request-id',
+  'b7c3b932-dcd6-4e44-8cd6-e64865a984f0',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Wed, 25 Mar 2020 06:11:36 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511669236805116/blob158511669646200888', "Hello World")
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:11:37 GMT',
+  'ETag',
+  '"0x8D7D08360A37E50"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5866e856-301e-000f-446c-02f352000000',
+  'x-ms-client-request-id',
+  'c042277d-609f-414b-a596-e6034624a489',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-25T06:11:37.6845161Z',
+  'Date',
+  'Wed, 25 Mar 2020 06:11:37 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511669236805116/blob158511669646200888')
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:11:40 GMT',
+  'ETag',
+  '"0x8D7D083627119AE"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5866e90f-301e-000f-6b6c-02f352000000',
+  'x-ms-client-request-id',
+  '5e503553-0e09-45be-9b31-feb74f0c8777',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-25T06:11:40.7097022Z',
+  'Date',
+  'Wed, 25 Mar 2020 06:11:40 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511669236805116/blob158511669646200888')
+  .query(true)
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:11:40 GMT',
+  'ETag',
+  '"0x8D7D083627119AE"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5866e920-301e-000f-786c-02f352000000',
+  'x-ms-client-request-id',
+  '3587b8b4-f8d1-4ec9-9d35-49570198205e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-25T06:11:41.0089164Z',
+  'x-ms-snapshot',
+  '2020-03-25T06:11:41.0079164Z',
+  'x-ms-request-server-encrypted',
+  'false',
+  'Date',
+  'Wed, 25 Mar 2020 06:11:40 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158511669236805116/blob158511669646200888')
+  .query(true)
+  .reply(400, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>InvalidQueryParameterValue</Code><Message>Value for one of the query parameters specified in the request URI is invalid.\nRequestId:5866e932-301e-000f-066c-02f352000000\nTime:2020-03-25T06:11:41.2891209Z</Message><QueryParameterName>versionid</QueryParameterName><QueryParameterValue>2020-03-25T06:11:37.6845161Z</QueryParameterValue><Reason>This operation is only allowed on the root blob. Version id should not be provided.</Reason></Error>", [
+  'Content-Length',
+  '494',
+  'Content-Type',
+  'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5866e932-301e-000f-066c-02f352000000',
+  'x-ms-client-request-id',
+  'c399a343-f3f5-47d0-aa1a-efa9f8374633',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'InvalidQueryParameterValue',
+  'Date',
+  'Wed, 25 Mar 2020 06:11:40 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158511669236805116/blob158511669646200888')
+  .query(true)
+  .reply(400, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>InvalidQueryParameterValue</Code><Message>Value for one of the query parameters specified in the request URI is invalid.\nRequestId:5866e94f-301e-000f-186c-02f352000000\nTime:2020-03-25T06:11:41.5833335Z</Message><QueryParameterName>versionid</QueryParameterName><QueryParameterValue>2020-03-25T06:11:40.7097022Z</QueryParameterValue><Reason>This operation is only allowed on the root blob. Version id should not be provided.</Reason></Error>", [
+  'Content-Length',
+  '494',
+  'Content-Type',
+  'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5866e94f-301e-000f-186c-02f352000000',
+  'x-ms-client-request-id',
+  'eb7f104d-7dde-4a87-816f-af32f6db306e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'InvalidQueryParameterValue',
+  'Date',
+  'Wed, 25 Mar 2020 06:11:41 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158511669236805116')
+  .query(true)
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '5866e963-301e-000f-286c-02f352000000',
+  'x-ms-client-request-id',
+  'c69694de-4765-4d24-be1e-4643fdd46a73',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Wed, 25 Mar 2020 06:11:41 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_a_versioned_blob_without_extra_parameters_should_succeed.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_a_versioned_blob_without_extra_parameters_should_succeed.js
@@ -1,0 +1,189 @@
+let nock = require('nock');
+
+module.exports.hash = "20cc456e0374a6511f10ecd16ac23b06";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459900995505704","blob":"blob158459901037808615"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900995505704')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:30 GMT',
+  'ETag',
+  '"0x8D7CBCE0AD6D774"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4cad-b01e-0088-12b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '47ab8233-939f-46dc-8aa2-a7c1b7baff32',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:29 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900995505704/blob158459901037808615', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:30 GMT',
+  'ETag',
+  '"0x8D7CBCE0B09A8D3"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b85a5-701e-005c-3ab6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'ab1ac37f-58a5-4a0d-8c4c-ae0a311d511f',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:30.5098451Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:30 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900995505704/blob158459901037808615')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:30 GMT',
+  'ETag',
+  '"0x8D7CBCE0B35A2D3"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4d77-b01e-0088-3bb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'dd9287b1-14a9-4a53-8e07-5c21d74cf7a9',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:30.7990499Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:30 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900995505704/blob158459901037808615')
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b86a4-701e-005c-21b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '7cd3e246-d1a6-41cf-9794-bbb62c114655',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:30 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900995505704/blob158459901037808615')
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4e35-b01e-0088-5ab6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'dfd6e2bf-290f-4999-80d1-6a2a8abf084e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:31 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900995505704/blob158459901037808615')
+  .query(true)
+  .reply(200, "", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:30 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE0B09A8D3"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b876c-701e-005c-4bb6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '84080d34-0e6a-4c81-9345-2a2e0b25fafd',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:30.5098451Z',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:30 GMT',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:31 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900995505704')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4ede-b01e-0088-75b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'ed1929cd-3e70-4f8d-829e-818718b4ba3d',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:31 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_root_blob_with_versionid_should_fail.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_deleting_root_blob_with_versionid_should_fail.js
@@ -1,0 +1,169 @@
+let nock = require('nock');
+
+module.exports.hash = "00606a4db118fe0be9eb18e940c81596";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459900344007763","blob":"blob158459900368205915"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900344007763')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:23 GMT',
+  'ETag',
+  '"0x8D7CBCE06E49A27"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4376-b01e-0088-74b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '52958440-1031-4149-b4e2-62f1dcab9218',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:23 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900344007763/blob158459900368205915', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:23 GMT',
+  'ETag',
+  '"0x8D7CBCE070A499B"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e43c9-b01e-0088-3fb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '656dd5ea-d17a-4f3b-9b11-c13340c88056',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:23.8030747Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:23 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459900344007763/blob158459900368205915')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:24 GMT',
+  'ETag',
+  '"0x8D7CBCE072F8BA6"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e43fd-b01e-0088-6eb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '8ae99738-81b7-4576-ad37-b699dd6f1ec3',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:24.0482486Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:23 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900344007763/blob158459900368205915')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4455-b01e-0088-39b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'ce88d01f-e99a-46a7-b6ff-a93fd39412c9',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:24 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459900344007763/blob158459900368205915')
+  .query(true)
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e44a0-b01e-0088-78b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '2759b383-a2a9-4ce9-ad54-4066fb7720b7',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:24 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900344007763/blob158459900368205915')
+  .query(true)
+  .reply(403, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>OperationNotAllowedOnRootBlob</Code><Message>The specified operation is not allowed on root blob.\nRequestId:775e44df-b01e-0088-2bb6-fd3fcb000000\nTime:2020-03-19T06:23:24.8029861Z</Message></Error>", [
+  'Content-Length',
+  '250',
+  'Content-Type',
+  'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e44df-b01e-0088-2bb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '8e07f3fd-dab5-48b7-b43a-9ba13112a491',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'OperationNotAllowedOnRootBlob',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:24 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459900344007763')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4537-b01e-0088-75b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'e6b488d4-b0b5-40b9-b99b-5a6924d71501',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:24 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_download_a_blob_version.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_download_a_blob_version.js
@@ -1,48 +1,48 @@
 let nock = require('nock');
 
-module.exports.hash = "14cd8d7d4719c90f047013bf0b362ab3";
+module.exports.hash = "ee99fdab9f827965e4e47d0a2601ab44";
 
-module.exports.testInfo = {"uniqueName":{"container":"container158459899682603969","blob":"blob158459899706506390"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container158472280465409921","blob":"blob158472280609502441"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459899682603969')
+  .put('/container158472280465409921')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:16 GMT',
+  'Fri, 20 Mar 2020 16:46:45 GMT',
   'ETag',
-  '"0x8D7CBCE02F36EB9"',
+  '"0x8D7CCEE46E331F1"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3b03-b01e-0088-34b6-fd3fcb000000',
+  'c1a967b8-101e-0017-01d7-fe73c9000000',
   'x-ms-client-request-id',
-  '9f53a13f-8b77-4d1e-b43e-08062e3c7e2c',
+  'f721189a-d6ef-4df6-9fe6-2b21a1307c52',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:16 GMT'
+  'Fri, 20 Mar 2020 16:46:45 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459899682603969/blob158459899706506390', "Hello World")
+  .put('/container158472280465409921/blob158472280609502441', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:46 GMT',
   'ETag',
-  '"0x8D7CBCE031944A6"',
+  '"0x8D7CCEE472896F8"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3b75-b01e-0088-0cb6-fd3fcb000000',
+  'c1a96a28-101e-0017-52d7-fe73c9000000',
   'x-ms-client-request-id',
-  '57b8615a-c595-4102-9350-4c81ac2e41f8',
+  '8a4c75f1-19dc-47f3-8381-f222ddb3abe0',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -50,28 +50,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:17.1903654Z',
+  '2020-03-20T16:46:46.4339704Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:17 GMT'
+  'Fri, 20 Mar 2020 16:46:45 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459899682603969/blob158459899706506390')
+  .put('/container158472280465409921/blob158472280609502441')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:47 GMT',
   'ETag',
-  '"0x8D7CBCE033D9C26"',
+  '"0x8D7CCEE4784352E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3ba8-b01e-0088-3bb6-fd3fcb000000',
+  'c1a96d02-101e-0017-15d7-fe73c9000000',
   'x-ms-client-request-id',
-  'fd165d94-759f-4e75-91b8-aa878d80d658',
+  'd71eaff1-7630-4231-bbe0-b454c62a09e9',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -79,13 +79,13 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:17.4295350Z',
+  '2020-03-20T16:46:47.0363987Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:17 GMT'
+  'Fri, 20 Mar 2020 16:46:46 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158459899682603969/blob158459899706506390')
+  .get('/container158472280465409921/blob158472280609502441')
   .query(true)
   .reply(200, "Hello World", [
   'Content-Length',
@@ -95,23 +95,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:46 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE031944A6"',
+  '"0x8D7CCEE472896F8"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3bee-b01e-0088-79b6-fd3fcb000000',
+  'c1a96ff6-101e-0017-6bd7-fe73c9000000',
   'x-ms-client-request-id',
-  'eb8342c3-7ec5-46e8-aca3-d0a0630380c1',
+  'c6eaa16f-2569-42f8-9e9d-3f5a9d988993',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:17.1903654Z',
+  '2020-03-20T16:46:46.4339704Z',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:46 GMT',
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-server-encrypted',
@@ -121,11 +121,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:17 GMT'
+  'Fri, 20 Mar 2020 16:46:46 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158459899682603969/blob158459899706506390')
+  .get('/container158472280465409921/blob158472280609502441')
   .query(true)
   .reply(200, "", [
   'Content-Length',
@@ -135,25 +135,25 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:47 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE033D9C26"',
+  '"0x8D7CCEE4784352E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3c2d-b01e-0088-2fb6-fd3fcb000000',
+  'c1a971c9-101e-0017-2cd7-fe73c9000000',
   'x-ms-client-request-id',
-  '10fb02c8-bf66-4be5-bfef-b7f5ea6ca9c5',
+  'd90e48e3-ddab-434e-b534-8221de450a60',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:17.4295350Z',
+  '2020-03-20T16:46:47.0363987Z',
   'x-ms-is-current-version',
   'true',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:47 GMT',
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-server-encrypted',
@@ -163,11 +163,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:17 GMT'
+  'Fri, 20 Mar 2020 16:46:47 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158459899682603969/blob158459899706506390')
+  .head('/container158472280465409921/blob158472280609502441')
   .query(true)
   .reply(200, "", [
   'Content-Length',
@@ -177,23 +177,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:46 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE031944A6"',
+  '"0x8D7CCEE472896F8"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3c7a-b01e-0088-75b6-fd3fcb000000',
+  'c1a9736b-101e-0017-34d7-fe73c9000000',
   'x-ms-client-request-id',
-  '5db15ebf-43c7-40ca-8024-490585102ad3',
+  'f071747b-cb9d-4732-80ac-c32e733cf8fc',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:17.1903654Z',
+  '2020-03-20T16:46:46.4339704Z',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:46 GMT',
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-server-encrypted',
@@ -207,11 +207,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:17 GMT'
+  'Fri, 20 Mar 2020 16:46:47 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158459899682603969/blob158459899706506390')
+  .get('/container158472280465409921/blob158472280609502441')
   .query(true)
   .reply(206, "Hello World", [
   'Content-Length',
@@ -221,23 +221,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-Range',
   'bytes 0-10/11',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:46 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE031944A6"',
+  '"0x8D7CCEE472896F8"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3cc1-b01e-0088-38b6-fd3fcb000000',
+  'c1a97501-101e-0017-3cd7-fe73c9000000',
   'x-ms-client-request-id',
-  '58e8105e-358e-4f32-ad02-95e5f567a9a6',
+  'a08075b3-d079-412c-98b3-7b22caedaeaf',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:17.1903654Z',
+  '2020-03-20T16:46:46.4339704Z',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Fri, 20 Mar 2020 16:46:46 GMT',
   'x-ms-blob-content-md5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'x-ms-blob-type',
@@ -249,11 +249,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:18 GMT'
+  'Fri, 20 Mar 2020 16:46:47 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158459899682603969')
+  .delete('/container158472280465409921')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -261,11 +261,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3d17-b01e-0088-03b6-fd3fcb000000',
+  'c1a97758-101e-0017-7cd7-fe73c9000000',
   'x-ms-client-request-id',
-  'a419de47-975b-4fa2-b87f-b57421f28c89',
+  '4b1fa8c1-90b0-4fc0-8035-176a2ff695c0',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:18 GMT'
+  'Fri, 20 Mar 2020 16:46:48 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_download_a_blob_version.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_download_a_blob_version.js
@@ -1,0 +1,271 @@
+let nock = require('nock');
+
+module.exports.hash = "14cd8d7d4719c90f047013bf0b362ab3";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459899682603969","blob":"blob158459899706506390"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899682603969')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:16 GMT',
+  'ETag',
+  '"0x8D7CBCE02F36EB9"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3b03-b01e-0088-34b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '9f53a13f-8b77-4d1e-b43e-08062e3c7e2c',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:16 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899682603969/blob158459899706506390', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'ETag',
+  '"0x8D7CBCE031944A6"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3b75-b01e-0088-0cb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '57b8615a-c595-4102-9350-4c81ac2e41f8',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:17.1903654Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:17 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899682603969/blob158459899706506390')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'ETag',
+  '"0x8D7CBCE033D9C26"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3ba8-b01e-0088-3bb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'fd165d94-759f-4e75-91b8-aa878d80d658',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:17.4295350Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:17 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158459899682603969/blob158459899706506390')
+  .query(true)
+  .reply(200, "Hello World", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE031944A6"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3bee-b01e-0088-79b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'eb8342c3-7ec5-46e8-aca3-d0a0630380c1',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:17.1903654Z',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:17 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158459899682603969/blob158459899706506390')
+  .query(true)
+  .reply(200, "", [
+  'Content-Length',
+  '0',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE033D9C26"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3c2d-b01e-0088-2fb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '10fb02c8-bf66-4be5-bfef-b7f5ea6ca9c5',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:17.4295350Z',
+  'x-ms-is-current-version',
+  'true',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:17 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459899682603969/blob158459899706506390')
+  .query(true)
+  .reply(200, "", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE031944A6"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3c7a-b01e-0088-75b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '5db15ebf-43c7-40ca-8024-490585102ad3',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:17.1903654Z',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:17 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158459899682603969/blob158459899706506390')
+  .query(true)
+  .reply(206, "Hello World", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-Range',
+  'bytes 0-10/11',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE031944A6"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3cc1-b01e-0088-38b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '58e8105e-358e-4f32-ad02-95e5f567a9a6',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:17.1903654Z',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:17 GMT',
+  'x-ms-blob-content-md5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-blob-content-md5,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:18 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459899682603969')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3d17-b01e-0088-03b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'a419de47-975b-4fa2-b87f-b57421f28c89',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:18 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_download_a_version_to_file.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_download_a_version_to_file.js
@@ -1,0 +1,85 @@
+let nock = require('nock');
+
+module.exports.hash = "e9055ad5397c8ec5665db9c18d047954";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459899877900136","blob":"blob158459899902709938"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899877900136')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:18 GMT',
+  'ETag',
+  '"0x8D7CBCE041EB7AC"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3d66-b01e-0088-48b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '8b492f6a-109d-48a4-be7f-de83a7176c59',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:18 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899877900136/blob158459899902709938', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'ETag',
+  '"0x8D7CBCE0444186F"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3dc9-b01e-0088-18b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'e0308c97-cc85-4d30-866d-efc534a26504',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:19.1487599Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:18 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899877900136/blob158459899902709938')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'ETag',
+  '"0x8D7CBCE0468BE1D"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3e17-b01e-0088-5eb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '06319605-3027-420a-b74f-51dd7426d856',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:19.3899309Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:19 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_downloadtobuffer_with_cpk.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_downloadtobuffer_with_cpk.js
@@ -1,0 +1,257 @@
+let nock = require('nock');
+
+module.exports.hash = "084794f83c7ea813a5b667148ee3ceda";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158511863727805139","blob":"blob158511864171607121","blobCPK":"blobCPK158511864234403164"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511863727805139')
+  .query(true)
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:44:02 GMT',
+  'ETag',
+  '"0x8D7D087E7EC2675"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d77b-e01e-000c-5870-021236000000',
+  'x-ms-client-request-id',
+  '52904539-8bc9-452c-9424-7cf890acd8c7',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:02 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511863727805139/blob158511864171607121', "Hello World")
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:44:02 GMT',
+  'ETag',
+  '"0x8D7D087E81B3632"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d792-e01e-000c-6970-021236000000',
+  'x-ms-client-request-id',
+  'c82c4a86-3585-4953-9e56-f4976538b47b',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-25T06:44:02.9474354Z',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:02 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511863727805139/blob158511864171607121')
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:44:03 GMT',
+  'ETag',
+  '"0x8D7D087E84C3A47"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d79c-e01e-000c-7170-021236000000',
+  'x-ms-client-request-id',
+  '47be5b35-a63e-4250-afb4-ddcd4ba846f4',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-25T06:44:03.2706668Z',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:02 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158511863727805139/blobCPK158511864234403164', "Hello World")
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:44:03 GMT',
+  'ETag',
+  '"0x8D7D087E87C0590"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d7a4-e01e-000c-7870-021236000000',
+  'x-ms-client-request-id',
+  'aa8ea488-884a-4e53-b958-b557c9359b3b',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-encryption-key-sha256',
+  '3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=',
+  'x-ms-version-id',
+  '2020-03-25T06:44:03.5818896Z',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:03 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158511863727805139/blobCPK158511864234403164')
+  .reply(200, "", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:44:03 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7D087E87C0590"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d7ae-e01e-000c-8070-021236000000',
+  'x-ms-client-request-id',
+  'c5354194-7dfe-4845-9459-108112f4b9bf',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-25T06:44:03.5818896Z',
+  'x-ms-is-current-version',
+  'true',
+  'x-ms-creation-time',
+  'Wed, 25 Mar 2020 06:44:03 GMT',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-encryption-key-sha256',
+  '3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:03 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158511863727805139/blobCPK158511864234403164')
+  .reply(206, "Hello World", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-Range',
+  'bytes 0-10/11',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 06:44:03 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7D087E87C0590"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d7b6-e01e-000c-0870-021236000000',
+  'x-ms-client-request-id',
+  '90c8af3a-8188-4362-8e3d-2387357bab52',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-25T06:44:03.5818896Z',
+  'x-ms-is-current-version',
+  'true',
+  'x-ms-creation-time',
+  'Wed, 25 Mar 2020 06:44:03 GMT',
+  'x-ms-blob-content-md5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-encryption-key-sha256',
+  '3QFFFpRA5+XANHqwwbT4yXDmrT/2JaLt/FKHjzhOdoE=',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,x-ms-blob-content-md5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-encryption-key-sha256,Accept-Ranges',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:03 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158511863727805139/blobCPK158511864234403164')
+  .reply(409, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d7d0-e01e-000c-1b70-021236000000',
+  'x-ms-client-request-id',
+  '04e6330a-0216-4ed6-a89e-29dfd9527d07',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobUsesCustomerSpecifiedEncryption',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:04 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158511863727805139')
+  .query(true)
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '40e5d7de-e01e-000c-2670-021236000000',
+  'x-ms-client-request-id',
+  '0a8f9fc5-2e6e-4c63-8547-ea8e35eef7d6',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Wed, 25 Mar 2020 06:44:04 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_exists_with_condition.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_exists_with_condition.js
@@ -1,0 +1,201 @@
+let nock = require('nock');
+
+module.exports.hash = "d5502ae98d701eb6230929f447f1bdc5";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158512295881100501","blob":"blob158512296170809417"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158512295881100501')
+  .query(true)
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 07:56:02 GMT',
+  'ETag',
+  '"0x8D7D091F6DA00D7"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '330ba4a0-201e-0013-5c7a-02a132000000',
+  'x-ms-client-request-id',
+  '6f233a93-fa4e-4999-8bdd-db6405c8998c',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Wed, 25 Mar 2020 07:56:02 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158512295881100501/blob158512296170809417', "Hello World")
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 07:56:02 GMT',
+  'ETag',
+  '"0x8D7D091F70D2060"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '330ba4b5-201e-0013-6c7a-02a132000000',
+  'x-ms-client-request-id',
+  '3680d8e6-2f9e-4276-849c-5dc418ea6fc2',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-25T07:56:02.9882464Z',
+  'Date',
+  'Wed, 25 Mar 2020 07:56:02 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158512295881100501/blob158512296170809417')
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 07:56:03 GMT',
+  'ETag',
+  '"0x8D7D091F7915CF4"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '330ba4dd-201e-0013-057a-02a132000000',
+  'x-ms-client-request-id',
+  'e6f5aafe-db1c-4404-9a21-d804da614024',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-25T07:56:03.8558724Z',
+  'Date',
+  'Wed, 25 Mar 2020 07:56:03 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158512295881100501/blob158512296170809417')
+  .query(true)
+  .reply(201, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 07:56:03 GMT',
+  'ETag',
+  '"0x8D7D091F7915CF4"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '330ba4f2-201e-0013-167a-02a132000000',
+  'x-ms-client-request-id',
+  '8e835a85-93b9-4d53-aa8d-660407e9dedc',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-lease-id',
+  '1443bc5a-2884-4b3a-be7f-755f1f124cd8',
+  'Date',
+  'Wed, 25 Mar 2020 07:56:04 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158512295881100501/blob158512296170809417')
+  .reply(200, "", [
+  'Content-Length',
+  '0',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 07:56:03 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7D091F7915CF4"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '330ba52d-201e-0013-3e7a-02a132000000',
+  'x-ms-client-request-id',
+  '95a75445-7a98-4e0d-86ba-f9989febb0b5',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-25T07:56:03.8558724Z',
+  'x-ms-is-current-version',
+  'true',
+  'x-ms-creation-time',
+  'Wed, 25 Mar 2020 07:56:03 GMT',
+  'x-ms-lease-status',
+  'locked',
+  'x-ms-lease-state',
+  'leased',
+  'x-ms-lease-duration',
+  'fixed',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-lease-duration,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Wed, 25 Mar 2020 07:56:04 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158512295881100501/blob158512296170809417')
+  .reply(412, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '330ba544-201e-0013-537a-02a132000000',
+  'x-ms-client-request-id',
+  'a3073ea9-526d-4f53-bc2c-4128920e2a9d',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'LeaseIdMismatchWithBlobOperation',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Wed, 25 Mar 2020 07:56:05 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158512295881100501')
+  .query(true)
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '330ba54d-201e-0013-5a7a-02a132000000',
+  'x-ms-client-request-id',
+  '351a13e6-49fd-4b6e-82e1-36788bea9181',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Wed, 25 Mar 2020 07:56:05 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_get_properties_of_a_blob_version.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_get_properties_of_a_blob_version.js
@@ -1,48 +1,48 @@
 let nock = require('nock');
 
-module.exports.hash = "9824a6daab12292957d73406d9ba3de9";
+module.exports.hash = "84c88658e9a89e757a1f61ac8797856b";
 
-module.exports.testInfo = {"uniqueName":{"container":"container158459463331705281","blob":"blob158459463355705972","copiedblob":"copiedblob158459463380103159"},"newDate":{"undefined":"2020-03-19T05:10:33.801Z"}}
+module.exports.testInfo = {"uniqueName":{"container":"container158459899952303081","blob":"blob158459899978308099"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459463331705281')
+  .put('/container158459899952303081')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 19 Mar 2020 05:10:33 GMT',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
   'ETag',
-  '"0x8D7CBC3DA171971"',
+  '"0x8D7CBCE0490A101"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd838c3b2-201e-0041-40ac-fd8226000000',
+  '775e3e61-b01e-0088-1cb6-fd3fcb000000',
   'x-ms-client-request-id',
-  '79599e27-c9f2-4b4c-ad70-f54fd43e2353',
+  '22810aae-eb7d-4ce1-98dc-9ea3f7b2a4dc',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 05:10:32 GMT'
+  'Thu, 19 Mar 2020 06:23:19 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459463331705281/blob158459463355705972', "Hello World")
+  .put('/container158459899952303081/blob158459899978308099', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 05:10:33 GMT',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
   'ETag',
-  '"0x8D7CBC3DA3BF48A"',
+  '"0x8D7CBCE04B84C30"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '15fd09ff-d01e-0018-62ac-fd05a5000000',
+  '775e3eba-b01e-0088-61b6-fd3fcb000000',
   'x-ms-client-request-id',
-  'f1ef1af5-d5e3-4509-9466-0c900aea590f',
+  '351c69c3-85ef-409b-8ff9-ae6c1bb350eb',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -50,42 +50,43 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T05:10:33.6648095Z',
+  '2020-03-19T06:23:19.9103024Z',
   'Date',
-  'Thu, 19 Mar 2020 05:10:33 GMT'
+  'Thu, 19 Mar 2020 06:23:19 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459463331705281/copiedblob158459463380103159')
-  .reply(202, "", [
+  .put('/container158459899952303081/blob158459899978308099')
+  .reply(201, "", [
   'Content-Length',
   '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 05:10:34 GMT',
+  'Thu, 19 Mar 2020 06:23:20 GMT',
   'ETag',
-  '"0x8D7CBC3DA970F42"',
+  '"0x8D7CBCE04DD6722"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd838c492-201e-0041-14ac-fd8226000000',
+  '775e3f2a-b01e-0088-3cb6-fd3fcb000000',
   'x-ms-client-request-id',
-  '9f78df14-8b4b-406f-8cf9-157d8140c204',
+  'c3616c06-818a-4b61-87ce-00aa8c1843c9',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
-  'YeJLfssylmU=',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
   'x-ms-version-id',
-  '2020-03-19T05:10:34.2652371Z',
-  'x-ms-copy-id',
-  'cad1df54-bfae-4f8d-877c-6ac60f2e696b',
-  'x-ms-copy-status',
-  'success',
+  '2020-03-19T06:23:20.1544754Z',
   'Date',
-  'Thu, 19 Mar 2020 05:10:33 GMT'
+  'Thu, 19 Mar 2020 06:23:19 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158459463331705281/blob158459463355705972')
+  .head('/container158459899952303081/blob158459899978308099')
+  .query(true)
   .reply(200, "", [
   'Content-Length',
   '11',
@@ -94,29 +95,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 05:10:33 GMT',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBC3DA3BF48A"',
+  '"0x8D7CBCE04B84C30"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '15fd0b6b-d01e-0018-19ac-fd05a5000000',
+  '775e3f7d-b01e-0088-01b6-fd3fcb000000',
   'x-ms-client-request-id',
-  '85d4ae99-dce6-4bf7-911b-7847d7e80c64',
+  '729609f5-408f-485b-9045-75fd2a8b8fe3',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T05:10:33.6648095Z',
-  'x-ms-is-current-version',
-  'true',
+  '2020-03-19T06:23:19.9103024Z',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 05:10:33 GMT',
-  'x-ms-lease-status',
-  'unlocked',
-  'x-ms-lease-state',
-  'available',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-server-encrypted',
@@ -125,12 +120,17 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Hot',
   'x-ms-access-tier-inferred',
   'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Thu, 19 Mar 2020 05:10:34 GMT'
+  'Thu, 19 Mar 2020 06:23:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158459463331705281/copiedblob158459463380103159')
+  .head('/container158459899952303081/blob158459899978308099')
+  .query(true)
   .reply(200, "", [
   'Content-Length',
   '11',
@@ -139,53 +139,41 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 05:10:34 GMT',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBC3DA970F42"',
+  '"0x8D7CBCE04B84C30"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'd838c61d-201e-0041-7aac-fd8226000000',
+  '775e3fc3-b01e-0088-3eb6-fd3fcb000000',
   'x-ms-client-request-id',
-  'b22bc58c-f504-4546-a28e-06bcd59e998d',
+  '303063aa-d9d2-409d-8d6a-aca71c79d456',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T05:10:34.2652371Z',
-  'x-ms-is-current-version',
-  'true',
+  '2020-03-19T06:23:19.9103024Z',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 05:10:34 GMT',
-  'x-ms-lease-status',
-  'unlocked',
-  'x-ms-lease-state',
-  'available',
+  'Thu, 19 Mar 2020 06:23:19 GMT',
   'x-ms-blob-type',
   'BlockBlob',
-  'x-ms-copy-id',
-  'cad1df54-bfae-4f8d-877c-6ac60f2e696b',
-  'x-ms-copy-source',
-  'https://fakestorageaccount.blob.core.windows.net/container158459463331705281/blob158459463355705972?sv=2019-07-07&se=2020-03-20T05%3A10%3A33Z&sr=b&sp=racwd&sig=XAxbUEG26%2FCXtFlj2cVNjQ%2B%2F%2FlGjapB%2Ft7y8S6TEt6A%3D',
-  'x-ms-copy-status',
-  'success',
-  'x-ms-copy-progress',
-  '11/11',
-  'x-ms-copy-completion-time',
-  'Thu, 19 Mar 2020 05:10:34 GMT',
   'x-ms-server-encrypted',
   'true',
   'x-ms-access-tier',
   'Hot',
   'x-ms-access-tier-inferred',
   'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Thu, 19 Mar 2020 05:10:33 GMT'
+  'Thu, 19 Mar 2020 06:23:20 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158459463331705281')
+  .delete('/container158459899952303081')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -193,11 +181,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '15fd0c0d-d01e-0018-29ac-fd05a5000000',
+  '775e400d-b01e-0088-7cb6-fd3fcb000000',
   'x-ms-client-request-id',
-  '7e0cd9e5-2b41-46df-9d71-414718729662',
+  '973d505e-6782-4519-bb09-d837ea71499e',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 05:10:34 GMT'
+  'Thu, 19 Mar 2020 06:23:20 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_get_properties_of_a_blob_version.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_get_properties_of_a_blob_version.js
@@ -1,48 +1,48 @@
 let nock = require('nock');
 
-module.exports.hash = "84c88658e9a89e757a1f61ac8797856b";
+module.exports.hash = "4b24b4a1e11b442fc2043f109ef51019";
 
-module.exports.testInfo = {"uniqueName":{"container":"container158459899952303081","blob":"blob158459899978308099"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container158471766140306365","blob":"blob158471766287009243"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459899952303081')
+  .put('/container158471766140306365')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'Fri, 20 Mar 2020 15:21:02 GMT',
   'ETag',
-  '"0x8D7CBCE0490A101"',
+  '"0x8D7CCE24D48E710"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3e61-b01e-0088-1cb6-fd3fcb000000',
+  'b2c208eb-401e-0057-54cb-fe74f1000000',
   'x-ms-client-request-id',
-  '22810aae-eb7d-4ce1-98dc-9ea3f7b2a4dc',
+  '805351b3-3f19-42f5-b79b-4293254d9ebe',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:19 GMT'
+  'Fri, 20 Mar 2020 15:21:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459899952303081/blob158459899978308099', "Hello World")
+  .put('/container158471766140306365/blob158471766287009243', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'Fri, 20 Mar 2020 15:21:03 GMT',
   'ETag',
-  '"0x8D7CBCE04B84C30"',
+  '"0x8D7CCE24D7741B3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3eba-b01e-0088-61b6-fd3fcb000000',
+  'b2c20932-401e-0057-14cb-fe74f1000000',
   'x-ms-client-request-id',
-  '351c69c3-85ef-409b-8ff9-ae6c1bb350eb',
+  '6a6b94d9-8132-43ff-803d-81a3ed938dce',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -50,28 +50,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:19.9103024Z',
+  '2020-03-20T15:21:03.0550963Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:19 GMT'
+  'Fri, 20 Mar 2020 15:21:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459899952303081/blob158459899978308099')
+  .put('/container158471766140306365/blob158471766287009243')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:20 GMT',
+  'Fri, 20 Mar 2020 15:21:03 GMT',
   'ETag',
-  '"0x8D7CBCE04DD6722"',
+  '"0x8D7CCE24DA18DBC"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3f2a-b01e-0088-3cb6-fd3fcb000000',
+  'b2c209b3-401e-0057-07cb-fe74f1000000',
   'x-ms-client-request-id',
-  'c3616c06-818a-4b61-87ce-00aa8c1843c9',
+  '2aa94c82-1371-4d31-9142-a3c1edbb75cb',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -79,13 +79,13 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:20.1544754Z',
+  '2020-03-20T15:21:03.3342944Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:19 GMT'
+  'Fri, 20 Mar 2020 15:21:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158459899952303081/blob158459899978308099')
+  .head('/container158471766140306365/blob158471766287009243')
   .query(true)
   .reply(200, "", [
   'Content-Length',
@@ -95,23 +95,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'Fri, 20 Mar 2020 15:21:03 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE04B84C30"',
+  '"0x8D7CCE24D7741B3"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3f7d-b01e-0088-01b6-fd3fcb000000',
+  'b2c209f9-401e-0057-46cb-fe74f1000000',
   'x-ms-client-request-id',
-  '729609f5-408f-485b-9045-75fd2a8b8fe3',
+  'c2338de4-c8cc-4603-a1cd-8d1b7a7a6059',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:19.9103024Z',
+  '2020-03-20T15:21:03.0550963Z',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'Fri, 20 Mar 2020 15:21:03 GMT',
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-server-encrypted',
@@ -125,37 +125,42 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:20 GMT'
+  'Fri, 20 Mar 2020 15:21:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158459899952303081/blob158459899978308099')
-  .query(true)
+  .head('/container158471766140306365/blob158471766287009243')
   .reply(200, "", [
   'Content-Length',
-  '11',
+  '0',
   'Content-Type',
   'application/octet-stream',
   'Content-MD5',
-  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'Fri, 20 Mar 2020 15:21:03 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE04B84C30"',
+  '"0x8D7CCE24DA18DBC"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e3fc3-b01e-0088-3eb6-fd3fcb000000',
+  'b2c20a48-401e-0057-0ecb-fe74f1000000',
   'x-ms-client-request-id',
-  '303063aa-d9d2-409d-8d6a-aca71c79d456',
+  '246a414f-85a1-42d0-a0de-95aefff02718',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:19.9103024Z',
+  '2020-03-20T15:21:03.3342944Z',
+  'x-ms-is-current-version',
+  'true',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:19 GMT',
+  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-server-encrypted',
@@ -165,15 +170,61 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:20 GMT'
+  'Fri, 20 Mar 2020 15:21:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158459899952303081')
+  .put('/container158471766140306365/blob158471766287009243')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'ETag',
+  '"0x8D7CCE24DA18DBC"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b2c20aa8-401e-0057-67cb-fe74f1000000',
+  'x-ms-client-request-id',
+  '85240d4c-8b59-42b5-aeef-7c730363375e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-20T15:21:04.1798954Z',
+  'x-ms-snapshot',
+  '2020-03-20T15:21:04.1788954Z',
+  'x-ms-request-server-encrypted',
+  'false',
+  'Date',
+  'Fri, 20 Mar 2020 15:21:03 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158471766140306365/blob158471766287009243')
+  .query(true)
+  .reply(400, "", [
+  'Vary',
+  'Origin',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-error-code',
+  'MutuallyExclusiveQueryParameters',
+  'x-ms-request-id',
+  'b2c20ae3-401e-0057-1dcb-fe74f1000000',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Fri, 20 Mar 2020 15:21:04 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158471766140306365')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -181,11 +232,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e400d-b01e-0088-7cb6-fd3fcb000000',
+  '76774d81-801e-0077-0acb-fe0f56000000',
   'x-ms-client-request-id',
-  '973d505e-6782-4519-bb09-d837ea71499e',
+  '66d2806b-755f-4825-ae9e-a10e82716a22',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:20 GMT'
+  'Fri, 20 Mar 2020 15:21:05 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_get_properties_of_a_blob_version.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_get_properties_of_a_blob_version.js
@@ -1,48 +1,48 @@
 let nock = require('nock');
 
-module.exports.hash = "4b24b4a1e11b442fc2043f109ef51019";
+module.exports.hash = "60bf506b341e62b4b649aa4832f73b66";
 
-module.exports.testInfo = {"uniqueName":{"container":"container158471766140306365","blob":"blob158471766287009243"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container158512474743806447","blob":"blob158512474989600217"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158471766140306365')
+  .put('/container158512474743806447')
   .query(true)
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Last-Modified',
-  'Fri, 20 Mar 2020 15:21:02 GMT',
+  'Wed, 25 Mar 2020 08:25:50 GMT',
   'ETag',
-  '"0x8D7CCE24D48E710"',
+  '"0x8D7D09620A60950"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b2c208eb-401e-0057-54cb-fe74f1000000',
+  '47fd4f0a-701e-000e-137e-02ac8e000000',
   'x-ms-client-request-id',
-  '805351b3-3f19-42f5-b79b-4293254d9ebe',
+  'ed1d73c7-9b36-47b4-924f-fb64f597f951',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Fri, 20 Mar 2020 15:21:02 GMT'
+  'Wed, 25 Mar 2020 08:25:50 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158471766140306365/blob158471766287009243', "Hello World")
+  .put('/container158512474743806447/blob158512474989600217', "Hello World")
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
   'ETag',
-  '"0x8D7CCE24D7741B3"',
+  '"0x8D7D09620E8A521"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b2c20932-401e-0057-14cb-fe74f1000000',
+  '47fd4f1b-701e-000e-1d7e-02ac8e000000',
   'x-ms-client-request-id',
-  '6a6b94d9-8132-43ff-803d-81a3ed938dce',
+  '8bbe2f00-a4cd-47d6-9cce-d11644859808',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -50,28 +50,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-20T15:21:03.0550963Z',
+  '2020-03-25T08:25:51.2003873Z',
   'Date',
-  'Fri, 20 Mar 2020 15:21:02 GMT'
+  'Wed, 25 Mar 2020 08:25:50 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158471766140306365/blob158471766287009243')
+  .put('/container158512474743806447/blob158512474989600217')
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
   'ETag',
-  '"0x8D7CCE24DA18DBC"',
+  '"0x8D7D09621203A2F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b2c209b3-401e-0057-07cb-fe74f1000000',
+  '47fd4f30-701e-000e-2c7e-02ac8e000000',
   'x-ms-client-request-id',
-  '2aa94c82-1371-4d31-9142-a3c1edbb75cb',
+  '47a2baa3-c93f-400a-9094-25b8d369d2bd',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -79,13 +79,13 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-20T15:21:03.3342944Z',
+  '2020-03-25T08:25:51.5656511Z',
   'Date',
-  'Fri, 20 Mar 2020 15:21:03 GMT'
+  'Wed, 25 Mar 2020 08:25:51 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158471766140306365/blob158471766287009243')
+  .head('/container158512474743806447/blob158512474989600217')
   .query(true)
   .reply(200, "", [
   'Content-Length',
@@ -95,23 +95,23 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CCE24D7741B3"',
+  '"0x8D7D09620E8A521"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b2c209f9-401e-0057-46cb-fe74f1000000',
+  '47fd4f4d-701e-000e-467e-02ac8e000000',
   'x-ms-client-request-id',
-  'c2338de4-c8cc-4603-a1cd-8d1b7a7a6059',
+  'f7c0e9e6-b916-4012-bf26-5c448ad93b6a',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-20T15:21:03.0550963Z',
+  '2020-03-25T08:25:51.2003873Z',
   'x-ms-creation-time',
-  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-server-encrypted',
@@ -121,15 +121,15 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Fri, 20 Mar 2020 15:21:03 GMT'
+  'Wed, 25 Mar 2020 08:25:52 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158471766140306365/blob158471766287009243')
+  .head('/container158512474743806447/blob158512474989600217')
   .reply(200, "", [
   'Content-Length',
   '0',
@@ -138,25 +138,25 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CCE24DA18DBC"',
+  '"0x8D7D09621203A2F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b2c20a48-401e-0057-0ecb-fe74f1000000',
+  '47fd4f5c-701e-000e-507e-02ac8e000000',
   'x-ms-client-request-id',
-  '246a414f-85a1-42d0-a0de-95aefff02718',
+  '3ec25096-10d0-4fc2-ba73-bc6f922120bd',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-20T15:21:03.3342944Z',
+  '2020-03-25T08:25:51.5656511Z',
   'x-ms-is-current-version',
   'true',
   'x-ms-creation-time',
-  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -170,43 +170,43 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-access-tier-inferred',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Fri, 20 Mar 2020 15:21:03 GMT'
+  'Wed, 25 Mar 2020 08:25:52 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158471766140306365/blob158471766287009243')
+  .put('/container158512474743806447/blob158512474989600217')
   .query(true)
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Last-Modified',
-  'Fri, 20 Mar 2020 15:21:03 GMT',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
   'ETag',
-  '"0x8D7CCE24DA18DBC"',
+  '"0x8D7D09621203A2F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b2c20aa8-401e-0057-67cb-fe74f1000000',
+  '47fd4f66-701e-000e-597e-02ac8e000000',
   'x-ms-client-request-id',
-  '85240d4c-8b59-42b5-aeef-7c730363375e',
+  '69edbe4a-ff52-4654-b134-e8c4d2e36fda',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-20T15:21:04.1798954Z',
+  '2020-03-25T08:25:53.1958278Z',
   'x-ms-snapshot',
-  '2020-03-20T15:21:04.1788954Z',
+  '2020-03-25T08:25:53.1948278Z',
   'x-ms-request-server-encrypted',
   'false',
   'Date',
-  'Fri, 20 Mar 2020 15:21:03 GMT'
+  'Wed, 25 Mar 2020 08:25:52 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .head('/container158471766140306365/blob158471766287009243')
+  .head('/container158512474743806447/blob158512474989600217')
   .query(true)
   .reply(400, "", [
   'Vary',
@@ -216,27 +216,71 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-error-code',
   'MutuallyExclusiveQueryParameters',
   'x-ms-request-id',
-  'b2c20ae3-401e-0057-1dcb-fe74f1000000',
+  '47fd4f79-701e-000e-697e-02ac8e000000',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Fri, 20 Mar 2020 15:21:04 GMT'
+  'Wed, 25 Mar 2020 08:25:53 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158471766140306365')
+  .head('/container158512474743806447/blob158512474989600217')
   .query(true)
-  .reply(202, "", [
+  .reply(200, "", [
   'Content-Length',
-  '0',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7D09620E8A521"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '76774d81-801e-0077-0acb-fe0f56000000',
+  'ddad7bd5-501e-0009-2d7f-02c0ed000000',
   'x-ms-client-request-id',
-  '66d2806b-755f-4825-ae9e-a10e82716a22',
+  'da4fadde-551c-418a-9324-a6708c8ced59',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-25T08:25:51.2003873Z',
+  'x-ms-creation-time',
+  'Wed, 25 Mar 2020 08:25:51 GMT',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Wed, 25 Mar 2020 08:26:00 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158512474743806447')
+  .query(true)
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'ddad7bfb-501e-0009-417f-02c0ed000000',
+  'x-ms-client-request-id',
+  'db180d6f-d167-4972-992e-0a218470ce2b',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Fri, 20 Mar 2020 15:21:05 GMT'
+  'Wed, 25 Mar 2020 08:26:00 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_list_blobs_include_versions.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_list_blobs_include_versions.js
@@ -1,0 +1,185 @@
+let nock = require('nock');
+
+module.exports.hash = "7343055b916de5458c6b21755c23322a";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459899364508652","blob":"blob158459899502904787","blockblob/0":"blockblob/0158459899553202352","blockblob/1":"blockblob/1158459899578203015"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899364508652')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:14 GMT',
+  'ETag',
+  '"0x8D7CBCE01BB2B15"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3887-b01e-0088-1ab6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'd1646155-1755-4762-b3b0-34cf56e413c5',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:14 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899364508652/blob158459899502904787', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:15 GMT',
+  'ETag',
+  '"0x8D7CBCE01E2FD54"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e38e8-b01e-0088-69b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'bad7c8e8-a31b-4aeb-b14f-43fbaa1d612f',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:15.1569236Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:14 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899364508652/blob158459899502904787')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:15 GMT',
+  'ETag',
+  '"0x8D7CBCE0208DBBB"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3934-b01e-0088-2bb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'ae4e39e0-5cfe-419a-9fc9-1e2c382fd708',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:15.4071008Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:15 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899364508652/blockblob%2F0158459899553202352')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:15 GMT',
+  'ETag',
+  '"0x8D7CBCE022F7D94"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e397c-b01e-0088-6ab6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'b6ce1ec0-95b4-41fe-9ca7-1056ea961fc9',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:15.6582804Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:15 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459899364508652/blockblob%2F1158459899578203015')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:15 GMT',
+  'ETag',
+  '"0x8D7CBCE02566D9F"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e39b7-b01e-0088-1eb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '63adf972-aa1b-4e83-b143-0add9508ac57',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:15.9144628Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:15 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158459899364508652')
+  .query(true)
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158459899364508652\"><Blobs><Blob><Name>blob158459899502904787</Name><VersionId>2020-03-19T06:23:15.1569236Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:15 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:15 GMT</Last-Modified><Etag>0x8D7CBCE01E2FD54</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459899502904787</Name><VersionId>2020-03-19T06:23:15.4071008Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:15 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:15 GMT</Last-Modified><Etag>0x8D7CBCE0208DBBB</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/0158459899553202352</Name><VersionId>2020-03-19T06:23:15.6582804Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:15 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:15 GMT</Last-Modified><Etag>0x8D7CBCE022F7D94</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blockblob/1158459899578203015</Name><VersionId>2020-03-19T06:23:15.9144628Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:15 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:15 GMT</Last-Modified><Etag>0x8D7CBCE02566D9F</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3a22-b01e-0088-77b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '9678c27f-7c17-4ac4-8c42-c113eac1de8e',
+  'x-ms-version',
+  '2019-12-12',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:15 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459899364508652')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e3ad2-b01e-0088-08b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '8b9c1686-d29a-46e0-9805-b415a7a2b3f8',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:16 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
@@ -1,48 +1,48 @@
 let nock = require('nock');
 
-module.exports.hash = "318de628af223ea365a07e3ad594193f";
+module.exports.hash = "982c4e2fe5d1d00d124d98f61bc8882d";
 
-module.exports.testInfo = {"uniqueName":{"container":"container158459901204501613","blob":"blob158459901228504616"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container158501909382406507","blob":"blob158501909509404786"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613')
+  .put('/container158501909382406507')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Tue, 24 Mar 2020 03:04:54 GMT',
   'ETag',
-  '"0x8D7CBCE0C057E0C"',
+  '"0x8D7CFA020E65FD9"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b8833-701e-005c-7ab6-fd8f9a000000',
+  'ab083b9f-e01e-0071-2888-013ce9000000',
   'x-ms-client-request-id',
-  'fec91be5-af38-46f3-af2f-8c0eaee74b9b',
+  '441b4d68-2936-443d-a30b-563fc126e1c0',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:31 GMT'
+  'Tue, 24 Mar 2020 03:04:54 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613/blob158459901228504616', "Hello World")
+  .put('/container158501909382406507/blob158501909509404786', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Tue, 24 Mar 2020 03:04:55 GMT',
   'ETag',
-  '"0x8D7CBCE0C2D2841"',
+  '"0x8D7CFA0210E2C33"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e4f99-b01e-0088-1cb6-fd3fcb000000',
+  'ab083c8d-e01e-0071-7e88-013ce9000000',
   'x-ms-client-request-id',
-  '2bb400d7-8bf1-4757-abdb-20a06a6b1741',
+  '41a25d68-7c85-4e98-adcd-d9e4701fc8dc',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -50,28 +50,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.4202049Z',
+  '2020-03-24T03:04:55.2508467Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Tue, 24 Mar 2020 03:04:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613/blob158459901228504616')
+  .put('/container158501909382406507/blob158501909509404786')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Tue, 24 Mar 2020 03:04:55 GMT',
   'ETag',
-  '"0x8D7CBCE0C521C1E"',
+  '"0x8D7CFA021362DDF"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b88f3-701e-005c-22b6-fd8f9a000000',
+  'ab083d58-e01e-0071-4288-013ce9000000',
   'x-ms-client-request-id',
-  'a73acf78-0ce8-4d18-bc4e-169eb7ead072',
+  'f1114793-2574-41a1-b572-3d5e55ba5271',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -79,42 +79,42 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.6633774Z',
+  '2020-03-24T03:04:55.5140335Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Tue, 24 Mar 2020 03:04:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613/blob158459901228504616')
+  .put('/container158501909382406507/blob158501909509404786')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Tue, 24 Mar 2020 03:04:55 GMT',
   'ETag',
-  '"0x8D7CBCE0C78E510"',
+  '"0x8D7CFA021703433"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e5027-b01e-0088-20b6-fd3fcb000000',
+  'ab083e2d-e01e-0071-0f88-013ce9000000',
   'x-ms-client-request-id',
-  '9dce2e27-bce4-4749-b74d-7b3dc9939512',
+  'd08164f5-b6ee-4544-822b-4652015cc113',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.9185593Z',
+  '2020-03-24T03:04:55.8963057Z',
   'x-ms-copy-id',
-  '97284516-417d-4e6a-b0fe-5bc0437d8040',
+  'f2388049-749b-4c08-b423-1739983768bb',
   'x-ms-copy-status',
   'success',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Tue, 24 Mar 2020 03:04:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158459901204501613')
+  .get('/container158501909382406507')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158459901204501613\"><Blobs><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.4202049Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C2D2841</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.6633774Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C521C1E</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.9185593Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C78E510</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158501909382406507\"><Blobs><Blob><Name>blob158501909509404786</Name><VersionId>2020-03-24T03:04:55.2508467Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:04:55 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:04:55 GMT</Last-Modified><Etag>0x8D7CFA0210E2C33</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501909509404786</Name><VersionId>2020-03-24T03:04:55.5140335Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:04:55 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:04:55 GMT</Last-Modified><Etag>0x8D7CFA021362DDF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501909509404786</Name><VersionId>2020-03-24T03:04:55.8963057Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Tue, 24 Mar 2020 03:04:55 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:04:55 GMT</Last-Modified><Etag>0x8D7CFA021703433</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -122,9 +122,9 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b89bc-701e-005c-55b6-fd8f9a000000',
+  'ab083f7a-e01e-0071-5188-013ce9000000',
   'x-ms-client-request-id',
-  'a41f74df-3d58-4194-8c7a-a386c49cd8c1',
+  'd77fc088-f8bb-4d32-bd16-6d04e2b2206c',
   'x-ms-version',
   '2019-12-12',
   'Access-Control-Expose-Headers',
@@ -132,11 +132,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Tue, 24 Mar 2020 03:04:55 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158459901204501613/blob158459901228504616')
+  .get('/container158501909382406507/blob158501909509404786')
   .reply(200, "Hello World", [
   'Content-Length',
   '11',
@@ -145,25 +145,25 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Tue, 24 Mar 2020 03:04:55 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE0C78E510"',
+  '"0x8D7CFA021703433"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e5125-b01e-0088-05b6-fd3fcb000000',
+  'ab08411f-e01e-0071-6788-013ce9000000',
   'x-ms-client-request-id',
-  'ba1dbb23-fb70-4fa3-844f-499ffdff82d8',
+  'a405b072-6e56-4b89-8887-80617eef19ae',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.9185593Z',
+  '2020-03-24T03:04:55.8963057Z',
   'x-ms-is-current-version',
   'true',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Tue, 24 Mar 2020 03:04:55 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -171,15 +171,15 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-copy-id',
-  '97284516-417d-4e6a-b0fe-5bc0437d8040',
+  'f2388049-749b-4c08-b423-1739983768bb',
   'x-ms-copy-source',
-  'https://fakestorageaccount.blob.core.windows.net/container158459901204501613/blob158459901228504616?versionId=2020-03-19T06:23:32.4202049Z',
+  'https://fakestorageaccount.blob.core.windows.net/container158501909382406507/blob158501909509404786?versionid=2020-03-24T03:04:55.2508467Z',
   'x-ms-copy-status',
   'success',
   'x-ms-copy-progress',
   '11/11',
   'x-ms-copy-completion-time',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Tue, 24 Mar 2020 03:04:55 GMT',
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
@@ -187,11 +187,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:33 GMT'
+  'Tue, 24 Mar 2020 03:04:56 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158459901204501613')
+  .delete('/container158501909382406507')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -199,11 +199,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b8acb-701e-005c-42b6-fd8f9a000000',
+  'ab0841f4-e01e-0071-3188-013ce9000000',
   'x-ms-client-request-id',
-  'ef3c8759-2f91-4526-8253-db0095100b06',
+  'b0054ba7-6176-4f34-bc92-9d2c6e5d6325',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:33 GMT'
+  'Tue, 24 Mar 2020 03:04:56 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
@@ -1,0 +1,209 @@
+let nock = require('nock');
+
+module.exports.hash = "318de628af223ea365a07e3ad594193f";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459901204501613","blob":"blob158459901228504616"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901204501613')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'ETag',
+  '"0x8D7CBCE0C057E0C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8833-701e-005c-7ab6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'fec91be5-af38-46f3-af2f-8c0eaee74b9b',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:31 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901204501613/blob158459901228504616', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'ETag',
+  '"0x8D7CBCE0C2D2841"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e4f99-b01e-0088-1cb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '2bb400d7-8bf1-4757-abdb-20a06a6b1741',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:32.4202049Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:32 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901204501613/blob158459901228504616')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'ETag',
+  '"0x8D7CBCE0C521C1E"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b88f3-701e-005c-22b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'a73acf78-0ce8-4d18-bc4e-169eb7ead072',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:32.6633774Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:32 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901204501613/blob158459901228504616')
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'ETag',
+  '"0x8D7CBCE0C78E510"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5027-b01e-0088-20b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '9dce2e27-bce4-4749-b74d-7b3dc9939512',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:32.9185593Z',
+  'x-ms-copy-id',
+  '97284516-417d-4e6a-b0fe-5bc0437d8040',
+  'x-ms-copy-status',
+  'success',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:32 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158459901204501613')
+  .query(true)
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158459901204501613\"><Blobs><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.4202049Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C2D2841</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.6633774Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C521C1E</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.9185593Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C78E510</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b89bc-701e-005c-55b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'a41f74df-3d58-4194-8c7a-a386c49cd8c1',
+  'x-ms-version',
+  '2019-12-12',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:32 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158459901204501613/blob158459901228504616')
+  .reply(200, "Hello World", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE0C78E510"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5125-b01e-0088-05b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'ba1dbb23-fb70-4fa3-844f-499ffdff82d8',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:32.9185593Z',
+  'x-ms-is-current-version',
+  'true',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-copy-id',
+  '97284516-417d-4e6a-b0fe-5bc0437d8040',
+  'x-ms-copy-source',
+  'https://fakestorageaccount.blob.core.windows.net/container158459901204501613/blob158459901228504616?versionId=2020-03-19T06:23:32.4202049Z',
+  'x-ms-copy-status',
+  'success',
+  'x-ms-copy-progress',
+  '11/11',
+  'x-ms-copy-completion-time',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'x-ms-server-encrypted',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-copy-id,x-ms-copy-source,x-ms-copy-status,x-ms-copy-progress,x-ms-copy-completion-time,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:33 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459901204501613')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8acb-701e-005c-42b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'ef3c8759-2f91-4526-8253-db0095100b06',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:33 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
@@ -1,48 +1,48 @@
 let nock = require('nock');
 
-module.exports.hash = "982c4e2fe5d1d00d124d98f61bc8882d";
+module.exports.hash = "318de628af223ea365a07e3ad594193f";
 
-module.exports.testInfo = {"uniqueName":{"container":"container158501909382406507","blob":"blob158501909509404786"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container158459901204501613","blob":"blob158459901228504616"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158501909382406507')
+  .put('/container158459901204501613')
   .query(true)
   .reply(201, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 24 Mar 2020 03:04:54 GMT',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
   'ETag',
-  '"0x8D7CFA020E65FD9"',
+  '"0x8D7CBCE0C057E0C"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ab083b9f-e01e-0071-2888-013ce9000000',
+  'b42b8833-701e-005c-7ab6-fd8f9a000000',
   'x-ms-client-request-id',
-  '441b4d68-2936-443d-a30b-563fc126e1c0',
+  'fec91be5-af38-46f3-af2f-8c0eaee74b9b',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Tue, 24 Mar 2020 03:04:54 GMT'
+  'Thu, 19 Mar 2020 06:23:31 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158501909382406507/blob158501909509404786', "Hello World")
+  .put('/container158459901204501613/blob158459901228504616', "Hello World")
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Tue, 24 Mar 2020 03:04:55 GMT',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
   'ETag',
-  '"0x8D7CFA0210E2C33"',
+  '"0x8D7CBCE0C2D2841"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ab083c8d-e01e-0071-7e88-013ce9000000',
+  '775e4f99-b01e-0088-1cb6-fd3fcb000000',
   'x-ms-client-request-id',
-  '41a25d68-7c85-4e98-adcd-d9e4701fc8dc',
+  '2bb400d7-8bf1-4757-abdb-20a06a6b1741',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -50,28 +50,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-24T03:04:55.2508467Z',
+  '2020-03-19T06:23:32.4202049Z',
   'Date',
-  'Tue, 24 Mar 2020 03:04:55 GMT'
+  'Thu, 19 Mar 2020 06:23:32 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158501909382406507/blob158501909509404786')
+  .put('/container158459901204501613/blob158459901228504616')
   .reply(201, "", [
   'Content-Length',
   '0',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Tue, 24 Mar 2020 03:04:55 GMT',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
   'ETag',
-  '"0x8D7CFA021362DDF"',
+  '"0x8D7CBCE0C521C1E"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ab083d58-e01e-0071-4288-013ce9000000',
+  'b42b88f3-701e-005c-22b6-fd8f9a000000',
   'x-ms-client-request-id',
-  'f1114793-2574-41a1-b572-3d5e55ba5271',
+  'a73acf78-0ce8-4d18-bc4e-169eb7ead072',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -79,42 +79,42 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-24T03:04:55.5140335Z',
+  '2020-03-19T06:23:32.6633774Z',
   'Date',
-  'Tue, 24 Mar 2020 03:04:55 GMT'
+  'Thu, 19 Mar 2020 06:23:32 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158501909382406507/blob158501909509404786')
+  .put('/container158459901204501613/blob158459901228504616')
   .reply(202, "", [
   'Content-Length',
   '0',
   'Last-Modified',
-  'Tue, 24 Mar 2020 03:04:55 GMT',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
   'ETag',
-  '"0x8D7CFA021703433"',
+  '"0x8D7CBCE0C78E510"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ab083e2d-e01e-0071-0f88-013ce9000000',
+  '775e5027-b01e-0088-20b6-fd3fcb000000',
   'x-ms-client-request-id',
-  'd08164f5-b6ee-4544-822b-4652015cc113',
+  '9dce2e27-bce4-4749-b74d-7b3dc9939512',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-24T03:04:55.8963057Z',
+  '2020-03-19T06:23:32.9185593Z',
   'x-ms-copy-id',
-  'f2388049-749b-4c08-b423-1739983768bb',
+  '97284516-417d-4e6a-b0fe-5bc0437d8040',
   'x-ms-copy-status',
   'success',
   'Date',
-  'Tue, 24 Mar 2020 03:04:55 GMT'
+  'Thu, 19 Mar 2020 06:23:32 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158501909382406507')
+  .get('/container158459901204501613')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158501909382406507\"><Blobs><Blob><Name>blob158501909509404786</Name><VersionId>2020-03-24T03:04:55.2508467Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:04:55 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:04:55 GMT</Last-Modified><Etag>0x8D7CFA0210E2C33</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501909509404786</Name><VersionId>2020-03-24T03:04:55.5140335Z</VersionId><Properties><Creation-Time>Tue, 24 Mar 2020 03:04:55 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:04:55 GMT</Last-Modified><Etag>0x8D7CFA021362DDF</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158501909509404786</Name><VersionId>2020-03-24T03:04:55.8963057Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Tue, 24 Mar 2020 03:04:55 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 03:04:55 GMT</Last-Modified><Etag>0x8D7CFA021703433</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158459901204501613\"><Blobs><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.4202049Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C2D2841</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.6633774Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C521C1E</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.9185593Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C78E510</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -122,9 +122,9 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ab083f7a-e01e-0071-5188-013ce9000000',
+  'b42b89bc-701e-005c-55b6-fd8f9a000000',
   'x-ms-client-request-id',
-  'd77fc088-f8bb-4d32-bd16-6d04e2b2206c',
+  'a41f74df-3d58-4194-8c7a-a386c49cd8c1',
   'x-ms-version',
   '2019-12-12',
   'Access-Control-Expose-Headers',
@@ -132,11 +132,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 24 Mar 2020 03:04:55 GMT'
+  'Thu, 19 Mar 2020 06:23:32 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158501909382406507/blob158501909509404786')
+  .get('/container158459901204501613/blob158459901228504616')
   .reply(200, "Hello World", [
   'Content-Length',
   '11',
@@ -145,25 +145,25 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Tue, 24 Mar 2020 03:04:55 GMT',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CFA021703433"',
+  '"0x8D7CBCE0C78E510"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ab08411f-e01e-0071-6788-013ce9000000',
+  '775e5125-b01e-0088-05b6-fd3fcb000000',
   'x-ms-client-request-id',
-  'a405b072-6e56-4b89-8887-80617eef19ae',
+  'ba1dbb23-fb70-4fa3-844f-499ffdff82d8',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-24T03:04:55.8963057Z',
+  '2020-03-19T06:23:32.9185593Z',
   'x-ms-is-current-version',
   'true',
   'x-ms-creation-time',
-  'Tue, 24 Mar 2020 03:04:55 GMT',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -171,15 +171,15 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-copy-id',
-  'f2388049-749b-4c08-b423-1739983768bb',
+  '97284516-417d-4e6a-b0fe-5bc0437d8040',
   'x-ms-copy-source',
-  'https://fakestorageaccount.blob.core.windows.net/container158501909382406507/blob158501909509404786?versionid=2020-03-24T03:04:55.2508467Z',
+  'https://fakestorageaccount.blob.core.windows.net/container158459901204501613/blob158459901228504616?versionId=2020-03-19T06:23:32.4202049Z',
   'x-ms-copy-status',
   'success',
   'x-ms-copy-progress',
   '11/11',
   'x-ms-copy-completion-time',
-  'Tue, 24 Mar 2020 03:04:55 GMT',
+  'Thu, 19 Mar 2020 06:23:32 GMT',
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
@@ -187,11 +187,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Tue, 24 Mar 2020 03:04:56 GMT'
+  'Thu, 19 Mar 2020 06:23:33 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158501909382406507')
+  .delete('/container158459901204501613')
   .query(true)
   .reply(202, "", [
   'Content-Length',
@@ -199,11 +199,11 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'ab0841f4-e01e-0071-3188-013ce9000000',
+  'b42b8acb-701e-005c-42b6-fd8f9a000000',
   'x-ms-client-request-id',
-  'b0054ba7-6176-4f34-bc92-9d2c6e5d6325',
+  'ef3c8759-2f91-4526-8253-db0095100b06',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Tue, 24 Mar 2020 03:04:56 GMT'
+  'Thu, 19 Mar 2020 06:23:33 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_promote_a_version_as_the_copy_source.js
@@ -1,48 +1,48 @@
 let nock = require('nock');
 
-module.exports.hash = "318de628af223ea365a07e3ad594193f";
+module.exports.hash = "6792f50664e5657867a58bb56c5c68c9";
 
-module.exports.testInfo = {"uniqueName":{"container":"container158459901204501613","blob":"blob158459901228504616"},"newDate":{}}
+module.exports.testInfo = {"uniqueName":{"container":"container158512476074705738","blob":"blob158512476253303108"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613')
+  .put('/container158512476074705738')
   .query(true)
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Wed, 25 Mar 2020 08:26:02 GMT',
   'ETag',
-  '"0x8D7CBCE0C057E0C"',
+  '"0x8D7D0962760746D"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b8833-701e-005c-7ab6-fd8f9a000000',
+  'ddad7c1e-501e-0009-5d7f-02c0ed000000',
   'x-ms-client-request-id',
-  'fec91be5-af38-46f3-af2f-8c0eaee74b9b',
+  'be8fd281-b1d3-4920-847b-4516b190e157',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:31 GMT'
+  'Wed, 25 Mar 2020 08:26:01 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613/blob158459901228504616', "Hello World")
+  .put('/container158512476074705738/blob158512476253303108', "Hello World")
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Wed, 25 Mar 2020 08:26:03 GMT',
   'ETag',
-  '"0x8D7CBCE0C2D2841"',
+  '"0x8D7D096286E527B"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e4f99-b01e-0088-1cb6-fd3fcb000000',
+  'ddad7c80-501e-0009-307f-02c0ed000000',
   'x-ms-client-request-id',
-  '2bb400d7-8bf1-4757-abdb-20a06a6b1741',
+  '06e1fd49-1491-4074-a7c9-6e4be98f6acf',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -50,28 +50,28 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.4202049Z',
+  '2020-03-25T08:26:03.8215043Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Wed, 25 Mar 2020 08:26:02 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613/blob158459901228504616')
+  .put('/container158512476074705738/blob158512476253303108')
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Content-MD5',
   '1B2M2Y8AsgTpgAmY7PhCfg==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Wed, 25 Mar 2020 08:26:04 GMT',
   'ETag',
-  '"0x8D7CBCE0C521C1E"',
+  '"0x8D7D0962897DB0D"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b88f3-701e-005c-22b6-fd8f9a000000',
+  'ddad7c9a-501e-0009-437f-02c0ed000000',
   'x-ms-client-request-id',
-  'a73acf78-0ce8-4d18-bc4e-169eb7ead072',
+  '6d6d3c8e-fa42-4c7a-8f08-f69974a38566',
   'x-ms-version',
   '2019-12-12',
   'x-ms-content-crc64',
@@ -79,42 +79,86 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-request-server-encrypted',
   'true',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.6633774Z',
+  '2020-03-25T08:26:04.0946994Z',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Wed, 25 Mar 2020 08:26:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158459901204501613/blob158459901228504616')
-  .reply(202, "", [
+  .head('/container158512476074705738/blob158512476253303108')
+  .query(true)
+  .reply(200, "", [
   'Content-Length',
-  '0',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Wed, 25 Mar 2020 08:26:03 GMT',
+  'Accept-Ranges',
+  'bytes',
   'ETag',
-  '"0x8D7CBCE0C78E510"',
+  '"0x8D7D096286E527B"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e5027-b01e-0088-20b6-fd3fcb000000',
+  'ddad7cac-501e-0009-517f-02c0ed000000',
   'x-ms-client-request-id',
-  '9dce2e27-bce4-4749-b74d-7b3dc9939512',
+  '0519cdf0-dafd-4295-b470-e969820536d3',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.9185593Z',
-  'x-ms-copy-id',
-  '97284516-417d-4e6a-b0fe-5bc0437d8040',
-  'x-ms-copy-status',
-  'success',
+  '2020-03-25T08:26:03.8215043Z',
+  'x-ms-creation-time',
+  'Wed, 25 Mar 2020 08:26:03 GMT',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges',
+  'Access-Control-Allow-Origin',
+  '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Wed, 25 Mar 2020 08:26:03 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158459901204501613')
+  .put('/container158512476074705738/blob158512476253303108')
+  .reply(202, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Last-Modified',
+  'Wed, 25 Mar 2020 08:26:04 GMT',
+  'ETag',
+  '"0x8D7D09628ECC160"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'ddad7cbb-501e-0009-5c7f-02c0ed000000',
+  'x-ms-client-request-id',
+  '3dd5a71a-42d6-4ffb-b156-1008f143b666',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-25T08:26:04.6510986Z',
+  'x-ms-copy-id',
+  '08dbc451-7517-44a9-8665-051330711f5e',
+  'x-ms-copy-status',
+  'success',
+  'Date',
+  'Wed, 25 Mar 2020 08:26:03 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158512476074705738')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158459901204501613\"><Blobs><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.4202049Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C2D2841</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.6633774Z</VersionId><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C521C1E</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158459901228504616</Name><VersionId>2020-03-19T06:23:32.9185593Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Thu, 19 Mar 2020 06:23:32 GMT</Creation-Time><Last-Modified>Thu, 19 Mar 2020 06:23:32 GMT</Last-Modified><Etag>0x8D7CBCE0C78E510</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158512476074705738\"><Blobs><Blob><Name>blob158512476253303108</Name><VersionId>2020-03-25T08:26:03.8215043Z</VersionId><Properties><Creation-Time>Wed, 25 Mar 2020 08:26:03 GMT</Creation-Time><Last-Modified>Wed, 25 Mar 2020 08:26:03 GMT</Last-Modified><Etag>0x8D7D096286E527B</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158512476253303108</Name><VersionId>2020-03-25T08:26:04.0946994Z</VersionId><Properties><Creation-Time>Wed, 25 Mar 2020 08:26:04 GMT</Creation-Time><Last-Modified>Wed, 25 Mar 2020 08:26:04 GMT</Last-Modified><Etag>0x8D7D0962897DB0D</Etag><Content-Length>0</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>1B2M2Y8AsgTpgAmY7PhCfg==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><ServerEncrypted>true</ServerEncrypted></Properties></Blob><Blob><Name>blob158512476253303108</Name><VersionId>2020-03-25T08:26:04.6510986Z</VersionId><IsCurrentVersion>true</IsCurrentVersion><Properties><Creation-Time>Wed, 25 Mar 2020 08:26:04 GMT</Creation-Time><Last-Modified>Wed, 25 Mar 2020 08:26:04 GMT</Last-Modified><Etag>0x8D7D09628ECC160</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -122,21 +166,21 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b89bc-701e-005c-55b6-fd8f9a000000',
+  'ddad7cd4-501e-0009-727f-02c0ed000000',
   'x-ms-client-request-id',
-  'a41f74df-3d58-4194-8c7a-a386c49cd8c1',
+  'c7d8bfe4-c607-4008-89a6-feb23ed3c16b',
   'x-ms-version',
   '2019-12-12',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:32 GMT'
+  'Wed, 25 Mar 2020 08:26:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158459901204501613/blob158459901228504616')
+  .get('/container158512476074705738/blob158512476253303108')
   .reply(200, "Hello World", [
   'Content-Length',
   '11',
@@ -145,25 +189,25 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Wed, 25 Mar 2020 08:26:04 GMT',
   'Accept-Ranges',
   'bytes',
   'ETag',
-  '"0x8D7CBCE0C78E510"',
+  '"0x8D7D09628ECC160"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '775e5125-b01e-0088-05b6-fd3fcb000000',
+  'ddad7ce6-501e-0009-027f-02c0ed000000',
   'x-ms-client-request-id',
-  'ba1dbb23-fb70-4fa3-844f-499ffdff82d8',
+  'd0c78850-4260-4c7a-ab05-7864ff569c73',
   'x-ms-version',
   '2019-12-12',
   'x-ms-version-id',
-  '2020-03-19T06:23:32.9185593Z',
+  '2020-03-25T08:26:04.6510986Z',
   'x-ms-is-current-version',
   'true',
   'x-ms-creation-time',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Wed, 25 Mar 2020 08:26:04 GMT',
   'x-ms-lease-status',
   'unlocked',
   'x-ms-lease-state',
@@ -171,39 +215,39 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'x-ms-blob-type',
   'BlockBlob',
   'x-ms-copy-id',
-  '97284516-417d-4e6a-b0fe-5bc0437d8040',
+  '08dbc451-7517-44a9-8665-051330711f5e',
   'x-ms-copy-source',
-  'https://fakestorageaccount.blob.core.windows.net/container158459901204501613/blob158459901228504616?versionId=2020-03-19T06:23:32.4202049Z',
+  'https://fakestorageaccount.blob.core.windows.net/container158512476074705738/blob158512476253303108?versionid=2020-03-25T08:26:03.8215043Z',
   'x-ms-copy-status',
   'success',
   'x-ms-copy-progress',
   '11/11',
   'x-ms-copy-completion-time',
-  'Thu, 19 Mar 2020 06:23:32 GMT',
+  'Wed, 25 Mar 2020 08:26:04 GMT',
   'x-ms-server-encrypted',
   'true',
   'Access-Control-Expose-Headers',
-  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-copy-id,x-ms-copy-source,x-ms-copy-status,x-ms-copy-progress,x-ms-copy-completion-time,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,x-ms-is-current-version,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-copy-id,x-ms-copy-source,x-ms-copy-status,x-ms-copy-progress,x-ms-copy-completion-time,x-ms-server-encrypted,Accept-Ranges',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Thu, 19 Mar 2020 06:23:33 GMT'
+  'Wed, 25 Mar 2020 08:26:04 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158459901204501613')
+  .delete('/container158512476074705738')
   .query(true)
   .reply(202, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'b42b8acb-701e-005c-42b6-fd8f9a000000',
+  'ddad7d30-501e-0009-3b7f-02c0ed000000',
   'x-ms-client-request-id',
-  'ef3c8759-2f91-4526-8253-db0095100b06',
+  '96872254-6a83-4c72-8062-f3a3b5e064aa',
   'x-ms-version',
   '2019-12-12',
   'Date',
-  'Thu, 19 Mar 2020 06:23:33 GMT'
+  'Wed, 25 Mar 2020 08:26:06 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_setmetadata.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_setmetadata.js
@@ -1,0 +1,129 @@
+let nock = require('nock');
+
+module.exports.hash = "a02a4136be7d42cb6fdb315eddbb2f95";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459901794700068","blob":"blob158459901818509666"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901794700068')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:38 GMT',
+  'ETag',
+  '"0x8D7CBCE0F8A3DB9"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e572c-b01e-0088-56b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '953ac2d3-5d0c-4fc8-a850-3db4276e5312',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:37 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901794700068/blob158459901818509666', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:38 GMT',
+  'ETag',
+  '"0x8D7CBCE0FAEDC1E"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b92e1-701e-005c-1ab6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '15a4bfcf-2827-4ab2-9202-1012c2f2690e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:38.3033886Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:37 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901794700068/blob158459901818509666')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:38 GMT',
+  'ETag',
+  '"0x8D7CBCE0FD4453E"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e57e3-b01e-0088-72b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'c7004baa-9f8c-4bcd-888e-431485e195b9',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:38.5505639Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:38 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901794700068/blob158459901818509666')
+  .query(true)
+  .reply(200, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:38 GMT',
+  'ETag',
+  '"0x8D7CBCE0FF96034"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b93ae-701e-005c-54b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '5d243375-ca2b-4ff9-ae2c-f9d8ef438db9',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:38.7927364Z',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:38 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459901794700068')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e588b-b01e-0088-07b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '8d6a2723-0a7d-4e33-9465-5230221b28c2',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:38 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_undelete_a_softdeleted_version.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_undelete_a_softdeleted_version.js
@@ -1,0 +1,233 @@
+let nock = require('nock');
+
+module.exports.hash = "467dd77f82dae27b49ab3ff9f7eb4d1a";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459901915803807","blob":"blob158459901939705184"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901915803807')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:39 GMT',
+  'ETag',
+  '"0x8D7CBCE10432A33"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b94ce-701e-005c-53b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '300e06a0-b983-42d9-b330-86596cdb2022',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:38 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901915803807/blob158459901939705184', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:39 GMT',
+  'ETag',
+  '"0x8D7CBCE1067ED9C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5946-b01e-0088-32b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '9e78241f-9eba-471d-8130-53b7fb76acb1',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:39.5162524Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:39 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901915803807/blob158459901939705184')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:39 GMT',
+  'ETag',
+  '"0x8D7CBCE108C6C31"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b95c3-701e-005c-2fb6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '1c1821c9-3067-436f-b5e3-beab2f687a58',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:39.7574234Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:39 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/')
+  .query(true)
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>GET,PUT,POST,HEAD,DELETE,MERGE,OPTIONS,PATCH</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>", [
+  'Transfer-Encoding',
+  'chunked',
+  'Content-Type',
+  'application/xml',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5a0c-b01e-0088-5ab6-fd3fcb000000',
+  'x-ms-client-request-id',
+  'c3196b37-e0a2-40fb-974b-13e6643510f0',
+  'x-ms-version',
+  '2019-12-12',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:39 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459901915803807/blob158459901939705184')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b9705-701e-005c-4bb6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'bd04df20-1404-45e0-adec-a5d6a690f58f',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:39 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459901915803807/blob158459901939705184')
+  .query(true)
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5b01-b01e-0088-1eb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '97cdc424-d74f-4c65-8b6b-f87d28e12a5d',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:40 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901915803807/blob158459901939705184')
+  .query(true)
+  .reply(200, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b97c8-701e-005c-63b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '8d18edf6-a68f-4ecc-bfa6-2a51d2293d89',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:40 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158459901915803807/blob158459901939705184')
+  .query(true)
+  .reply(200, "", [
+  'Content-Length',
+  '11',
+  'Content-Type',
+  'application/octet-stream',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:39 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7CBCE1067ED9C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5bb6-b01e-0088-2fb6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '622f9da6-5247-47ba-b205-5bb7b8926bb8',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-version-id',
+  '2020-03-19T06:23:39.5162524Z',
+  'x-ms-creation-time',
+  'Thu, 19 Mar 2020 06:23:39 GMT',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Hot',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-version-id,Content-Type,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:40 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459901915803807')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b98e1-701e-005c-33b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'f0ab8bd6-a524-4eb2-aee2-6f0e94349e8e',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:40 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_upload_block_blob_return_versionid.js
+++ b/sdk/storage/storage-blob/recordings/node/blob_versioning/recording_upload_block_blob_return_versionid.js
@@ -1,0 +1,132 @@
+let nock = require('nock');
+
+module.exports.hash = "c3f7171fc37c565be96c4886a01aeb79";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158459901551208800","blob":"blob158459901575305766"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901551208800')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:35 GMT',
+  'ETag',
+  '"0x8D7CBCE0E16E264"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e53c7-b01e-0088-57b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '54572add-57d1-43f1-a53d-10285dab39a3',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:35 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901551208800/blob158459901575305766', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:35 GMT',
+  'ETag',
+  '"0x8D7CBCE0E3BA7BE"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8e08-701e-005c-2fb6-fd8f9a000000',
+  'x-ms-client-request-id',
+  'ef32afdb-4217-441f-b9a4-e3dc9e30c746',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:35.8706622Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:35 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901551208800/blob158459901575305766')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:36 GMT',
+  'ETag',
+  '"0x8D7CBCE0E6137ED"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5477-b01e-0088-73b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '94e6dc5e-a2af-4077-bc38-7267e1d077a3',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:36.1178365Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:35 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158459901551208800/blob158459901575305766', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Thu, 19 Mar 2020 06:23:36 GMT',
+  'ETag',
+  '"0x8D7CBCE0E86C816"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'b42b8f29-701e-005c-39b6-fd8f9a000000',
+  'x-ms-client-request-id',
+  '7bc516fc-9a82-49d9-a1fb-30af2a644ec9',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-19T06:23:36.3640102Z',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:35 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158459901551208800')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '775e5517-b01e-0088-07b6-fd3fcb000000',
+  'x-ms-client-request-id',
+  '56381488-cecc-4669-9ac6-fb8680910163',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Thu, 19 Mar 2020 06:23:36 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/blobclient/recording_undelete.js
+++ b/sdk/storage/storage-blob/recordings/node/blobclient/recording_undelete.js
@@ -1,60 +1,62 @@
 let nock = require('nock');
 
-module.exports.testInfo = {"uniqueName":{"container":"container158224819242602498","blob":"blob158224819384806465"},"newDate":{}}
+module.exports.hash = "4b2d62f655814eebf5c7065e3e0abe19";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158501877471701789","blob":"blob158501877599206974"},"newDate":{}}
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158224819242602498')
+  .put('/container158501877471701789')
   .query(true)
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Last-Modified',
-  'Fri, 21 Feb 2020 01:23:13 GMT',
+  'Tue, 24 Mar 2020 02:59:35 GMT',
   'ETag',
-  '"0x8D7B66C9F05446C"',
+  '"0x8D7CF9F62B3E84F"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '16a15905-f01e-0048-4755-e84232000000',
+  '700eb905-b01e-0020-0588-01a5c1000000',
   'x-ms-client-request-id',
-  '0701b4e0-e23c-4571-b062-a811c675cc23',
+  'b214e4df-c810-4499-9125-9747306b8258',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'Date',
-  'Fri, 21 Feb 2020 01:23:12 GMT'
+  'Tue, 24 Mar 2020 02:59:35 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158224819242602498/blob158224819384806465', "Hello World")
+  .put('/container158501877471701789/blob158501877599206974', "Hello World")
   .reply(201, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Content-MD5',
   'sQqNsWTgdUEFt6mb5y4/5Q==',
   'Last-Modified',
-  'Fri, 21 Feb 2020 01:23:14 GMT',
+  'Tue, 24 Mar 2020 02:59:36 GMT',
   'ETag',
-  '"0x8D7B66C9FB99A69"',
+  '"0x8D7CF9F62D9DF53"',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  'f1569be6-a01e-0008-2155-e8450a000000',
+  '700eb921-b01e-0020-1188-01a5c1000000',
   'x-ms-client-request-id',
-  '1d217bd0-430b-4927-92e8-c9e983188d6e',
+  '6bf10953-d471-4765-8698-2f8a72220d82',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'x-ms-content-crc64',
   'YeJLfssylmU=',
   'x-ms-request-server-encrypted',
   'true',
   'Date',
-  'Fri, 21 Feb 2020 01:23:14 GMT'
+  'Tue, 24 Mar 2020 02:59:36 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
   .get('/')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>true</Read><Write>true</Write><Delete>true</Delete><RetentionPolicy><Enabled>true</Enabled><Days>5</Days></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>3</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>4</Days></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>DELETE,GET,HEAD,MERGE,POST,OPTIONS,PUT,PATCH</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule><CorsRule><AllowedMethods>GET</AllowedMethods><AllowedOrigins>example.com</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>8888</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><StorageServiceProperties><Logging><Version>1.0</Version><Read>false</Read><Write>false</Write><Delete>false</Delete><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></Logging><HourMetrics><Version>1.0</Version><Enabled>true</Enabled><IncludeAPIs>true</IncludeAPIs><RetentionPolicy><Enabled>true</Enabled><Days>7</Days></RetentionPolicy></HourMetrics><MinuteMetrics><Version>1.0</Version><Enabled>false</Enabled><RetentionPolicy><Enabled>false</Enabled></RetentionPolicy></MinuteMetrics><Cors><CorsRule><AllowedMethods>PATCH,PUT,OPTIONS,POST,MERGE,HEAD,GET,DELETE</AllowedMethods><AllowedOrigins>*</AllowedOrigins><AllowedHeaders>*</AllowedHeaders><ExposedHeaders>*</ExposedHeaders><MaxAgeInSeconds>86400</MaxAgeInSeconds></CorsRule></Cors><DeleteRetentionPolicy><Enabled>true</Enabled><Days>7</Days></DeleteRetentionPolicy><AutomaticSnapshotPolicy><Enabled>false</Enabled></AutomaticSnapshotPolicy><StaticWebsite><Enabled>false</Enabled></StaticWebsite></StorageServiceProperties>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -62,42 +64,42 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '1206a6c6-601e-0017-1555-e8f60e000000',
+  '700eb92e-b01e-0020-1888-01a5c1000000',
   'x-ms-client-request-id',
-  'a54eeccd-225e-4712-8fc2-a0ecd57f1cca',
+  '5d24c616-5071-4003-917c-3077e1e7dbb5',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Fri, 21 Feb 2020 01:23:15 GMT'
+  'Tue, 24 Mar 2020 02:59:36 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158224819242602498/blob158224819384806465')
+  .delete('/container158501877471701789/blob158501877599206974')
   .reply(202, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '4317385a-801e-0052-2355-e823ed000000',
+  '700eb945-b01e-0020-2688-01a5c1000000',
   'x-ms-client-request-id',
-  '74edeedb-f29f-4143-bc94-24d1ce31e039',
+  '8cb27e45-844c-475b-b607-97d315268c50',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'x-ms-delete-type-permanent',
   'false',
   'Date',
-  'Fri, 21 Feb 2020 01:23:16 GMT'
+  'Tue, 24 Mar 2020 02:59:36 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158224819242602498')
+  .get('/container158501877471701789')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224819242602498\"><MaxResults>1</MaxResults><Blobs><Blob><Name>blob158224819384806465</Name><Deleted>true</Deleted><Properties><Creation-Time>Fri, 21 Feb 2020 01:23:14 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:23:14 GMT</Last-Modified><Etag>0x8D7B66C9FB99A69</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Fri, 21 Feb 2020 01:23:17 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158501877471701789\"><MaxResults>1</MaxResults><Blobs><Blob><Name>blob158501877599206974</Name><Deleted>true</Deleted><Properties><Creation-Time>Tue, 24 Mar 2020 02:59:36 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 02:59:36 GMT</Last-Modified><Etag>0x8D7CF9F62D9DF53</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus /><ServerEncrypted>true</ServerEncrypted><DeletedTime>Tue, 24 Mar 2020 02:59:36 GMT</DeletedTime><RemainingRetentionDays>6</RemainingRetentionDays></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -105,41 +107,41 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '16a15f77-f01e-0048-0455-e84232000000',
+  '700eb95e-b01e-0020-3288-01a5c1000000',
   'x-ms-client-request-id',
-  '9ee5fb28-702d-4320-9897-bb38ddd5bf82',
+  '30d3af48-4b56-47c8-9d5a-2c3229b30017',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Fri, 21 Feb 2020 01:23:16 GMT'
+  'Tue, 24 Mar 2020 02:59:36 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .put('/container158224819242602498/blob158224819384806465')
+  .put('/container158501877471701789/blob158501877599206974')
   .query(true)
   .reply(200, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '4317393f-801e-0052-7755-e823ed000000',
+  '700eb976-b01e-0020-3f88-01a5c1000000',
   'x-ms-client-request-id',
-  '9b5fb2c2-879c-4747-88cb-05d2adbde60e',
+  'bd930e1b-6345-4c14-adff-152086897948',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'Date',
-  'Fri, 21 Feb 2020 01:23:16 GMT'
+  'Tue, 24 Mar 2020 02:59:37 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .get('/container158224819242602498')
+  .get('/container158501877471701789')
   .query(true)
-  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158224819242602498\"><Blobs><Blob><Name>blob158224819384806465</Name><Properties><Creation-Time>Fri, 21 Feb 2020 01:23:14 GMT</Creation-Time><Last-Modified>Fri, 21 Feb 2020 01:23:14 GMT</Last-Modified><Etag>0x8D7B66C9FB99A69</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
+  .reply(200, "﻿<?xml version=\"1.0\" encoding=\"utf-8\"?><EnumerationResults ServiceEndpoint=\"https://fakestorageaccount.blob.core.windows.net/\" ContainerName=\"container158501877471701789\"><Blobs><Blob><Name>blob158501877599206974</Name><Properties><Creation-Time>Tue, 24 Mar 2020 02:59:36 GMT</Creation-Time><Last-Modified>Tue, 24 Mar 2020 02:59:36 GMT</Last-Modified><Etag>0x8D7CF9F62D9DF53</Etag><Content-Length>11</Content-Length><Content-Type>application/octet-stream</Content-Type><Content-Encoding /><Content-Language /><Content-CRC64 /><Content-MD5>sQqNsWTgdUEFt6mb5y4/5Q==</Content-MD5><Cache-Control /><Content-Disposition /><BlobType>BlockBlob</BlobType><AccessTier>Hot</AccessTier><AccessTierInferred>true</AccessTierInferred><LeaseStatus>unlocked</LeaseStatus><LeaseState>available</LeaseState><ServerEncrypted>true</ServerEncrypted></Properties></Blob></Blobs><NextMarker /></EnumerationResults>", [
   'Transfer-Encoding',
   'chunked',
   'Content-Type',
@@ -147,33 +149,33 @@ nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParam
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '16a16073-f01e-0048-6355-e84232000000',
+  '700eb98e-b01e-0020-4f88-01a5c1000000',
   'x-ms-client-request-id',
-  '7231eea9-7bf1-40a0-a359-811726cc6404',
+  '56a91a00-9001-4d3d-9b8a-b27d4b76899f',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'Access-Control-Expose-Headers',
   'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Length,Date,Transfer-Encoding',
   'Access-Control-Allow-Origin',
   '*',
   'Date',
-  'Fri, 21 Feb 2020 01:23:17 GMT'
+  'Tue, 24 Mar 2020 02:59:37 GMT'
 ]);
 
 nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
-  .delete('/container158224819242602498')
+  .delete('/container158501877471701789')
   .query(true)
   .reply(202, "", [
-  'Content-Length',
-  '0',
+  'Transfer-Encoding',
+  'chunked',
   'Server',
   'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
   'x-ms-request-id',
-  '16a16113-f01e-0048-7355-e84232000000',
+  '700eb99d-b01e-0020-5988-01a5c1000000',
   'x-ms-client-request-id',
-  '500e08dc-9fa1-487c-91d0-3ca0ac351314',
+  'b42f7831-4621-4161-aea7-63c7f45e0669',
   'x-ms-version',
-  '2019-02-02',
+  '2019-12-12',
   'Date',
-  'Fri, 21 Feb 2020 01:23:17 GMT'
+  'Tue, 24 Mar 2020 02:59:37 GMT'
 ]);

--- a/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_generateaccountsasqueryparameters_should_work_for_blob_version_delete.js
+++ b/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_generateaccountsasqueryparameters_should_work_for_blob_version_delete.js
@@ -1,0 +1,123 @@
+let nock = require('nock');
+
+module.exports.hash = "f704b5dcd1c546c6f4f50313162c61c3";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158471578931806353","blob":"blob158471579109309092"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158471578931806353')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Fri, 20 Mar 2020 14:49:50 GMT',
+  'ETag',
+  '"0x8D7CCDDF17A45A9"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f2d5-901e-0054-20c6-fe9595000000',
+  'x-ms-client-request-id',
+  '2f99cd47-c510-49f5-a983-1df5c8624b2d',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:50 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158471578931806353/blob158471579109309092', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Fri, 20 Mar 2020 14:49:51 GMT',
+  'ETag',
+  '"0x8D7CCDDF1D974B6"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f395-901e-0054-3cc6-fe9595000000',
+  'x-ms-client-request-id',
+  'f529905c-b10d-401f-9517-fba0b651d652',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-20T14:49:51.3613494Z',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:51 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158471578931806353/blob158471579109309092')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Fri, 20 Mar 2020 14:49:52 GMT',
+  'ETag',
+  '"0x8D7CCDDF2630918"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f4e8-901e-0054-6bc6-fe9595000000',
+  'x-ms-client-request-id',
+  'ee33a835-5520-4e67-ad27-d3db046a380e',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-20T14:49:52.2639912Z',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:52 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158471578931806353/blob158471579109309092')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f5f1-901e-0054-56c6-fe9595000000',
+  'x-ms-client-request-id',
+  '4330c16a-03e1-4fee-a6aa-e44f79d76e79',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:53 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158471578931806353')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f62f-901e-0054-08c6-fe9595000000',
+  'x-ms-client-request-id',
+  '07ff1691-d8fa-4c81-9196-9d15f0591b7b',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:53 GMT'
+]);

--- a/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_generateblobsasqueryparameters_should_work_for_blob_version_delete.js
+++ b/sdk/storage/storage-blob/recordings/node/shared_access_signature_sas_generation_nodejs_only/recording_generateblobsasqueryparameters_should_work_for_blob_version_delete.js
@@ -1,0 +1,147 @@
+let nock = require('nock');
+
+module.exports.hash = "92b0673837b9baab3cd04f2d9b8dc183";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158471579366104189","blob":"blob158471579420409236"},"newDate":{"now":"2020-03-20T14:49:55.260Z","tmr":"2020-03-20T14:49:55.260Z"}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158471579366104189')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Fri, 20 Mar 2020 14:49:53 GMT',
+  'ETag',
+  '"0x8D7CCDDF3609B95"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f6aa-901e-0054-70c6-fe9595000000',
+  'x-ms-client-request-id',
+  '02a94cdb-5c8c-42c4-af5f-b384d8777f6a',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:53 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158471579366104189/blob158471579420409236', "Hello World")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'sQqNsWTgdUEFt6mb5y4/5Q==',
+  'Last-Modified',
+  'Fri, 20 Mar 2020 14:49:54 GMT',
+  'ETag',
+  '"0x8D7CCDDF3AC3FE2"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f74e-901e-0054-80c6-fe9595000000',
+  'x-ms-client-request-id',
+  'e23b331a-0cb7-45b9-991a-e438b987ec95',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'YeJLfssylmU=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-20T14:49:54.4205282Z',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:54 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158471579366104189/blob158471579420409236')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  '1B2M2Y8AsgTpgAmY7PhCfg==',
+  'Last-Modified',
+  'Fri, 20 Mar 2020 14:49:54 GMT',
+  'ETag',
+  '"0x8D7CCDDF3F5D968"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f7d0-901e-0054-72c6-fe9595000000',
+  'x-ms-client-request-id',
+  '1d54c74e-db0e-4464-8684-bf3f4a6754d4',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-content-crc64',
+  'AAAAAAAAAAA=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'x-ms-version-id',
+  '2020-03-20T14:49:54.9038712Z',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:54 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158471579366104189/blob158471579420409236')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f86f-901e-0054-6bc6-fe9595000000',
+  'x-ms-client-request-id',
+  'e7540387-84f6-4f09-9ac6-8e4b4a96b44b',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-delete-type-permanent',
+  'false',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:55 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158471579366104189/blob158471579420409236')
+  .query(true)
+  .reply(404, "", [
+  'Transfer-Encoding',
+  'chunked',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f8fb-901e-0054-52c6-fe9595000000',
+  'x-ms-client-request-id',
+  '32396bd5-d460-4146-a80a-55f6a68ab779',
+  'x-ms-version',
+  '2019-12-12',
+  'x-ms-error-code',
+  'BlobNotFound',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,x-ms-error-code,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:55 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158471579366104189')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '91e6f9a1-901e-0054-48c6-fe9595000000',
+  'x-ms-client-request-id',
+  '2040ee62-ec75-47b5-b962-42287278bb1e',
+  'x-ms-version',
+  '2019-12-12',
+  'Date',
+  'Fri, 20 Mar 2020 14:49:56 GMT'
+]);

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -48,6 +48,7 @@ export class AccountSASPermissions {
     add: boolean;
     create: boolean;
     delete: boolean;
+    deleteVersion: boolean;
     list: boolean;
     static parse(permissions: string): AccountSASPermissions;
     process: boolean;
@@ -379,6 +380,7 @@ export class BlobClient extends StorageClient {
     syncCopyFromURL(copySource: string, options?: BlobSyncCopyFromURLOptions): Promise<BlobCopyFromURLResponse>;
     undelete(options?: BlobUndeleteOptions): Promise<BlobUndeleteResponse>;
     withSnapshot(snapshot: string): BlobClient;
+    withVersionId(versionId: string): BlobClient;
 }
 
 // @public
@@ -452,6 +454,8 @@ export interface BlobDeleteOptions extends CommonOptions {
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
     deleteSnapshots?: DeleteSnapshotsOptionType;
+    snapshot?: string;
+    versionId?: string;
 }
 
 // @public
@@ -535,6 +539,7 @@ export interface BlobDownloadOptions extends CommonOptions {
     rangeGetContentCrc64?: boolean;
     rangeGetContentMD5?: boolean;
     snapshot?: string;
+    versionId?: string;
 }
 
 // @public
@@ -552,14 +557,20 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
     blockSize?: number;
     concurrency?: number;
     conditions?: BlobRequestConditions;
+    customerProvidedKey?: CpkInfo;
     maxRetryRequestsPerBlock?: number;
     onProgress?: (progress: TransferProgressEvent) => void;
+    snapshot?: string;
+    versionId?: string;
 }
 
 // @public
 export interface BlobExistsOptions extends CommonOptions {
     abortSignal?: AbortSignalLike;
+    conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
+    snapshot?: string;
+    versionId?: string;
 }
 
 // @public
@@ -629,6 +640,8 @@ export interface BlobGetPropertiesOptions extends CommonOptions {
     abortSignal?: AbortSignalLike;
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
+    snapshot?: string;
+    versionId?: string;
 }
 
 // @public
@@ -826,6 +839,7 @@ export class BlobSASPermissions {
     add: boolean;
     create: boolean;
     delete: boolean;
+    deleteVersion: boolean;
     static parse(permissions: string): BlobSASPermissions;
     read: boolean;
     toString(): string;
@@ -844,11 +858,12 @@ export interface BlobSASSignatureValues {
     expiresOn?: Date;
     identifier?: string;
     ipRange?: SasIPRange;
-    permissions?: BlobSASPermissions;
+    permissions?: BlobSASPermissions | ContainerSASPermissions;
     protocol?: SASProtocol;
     snapshotTime?: string;
     startsOn?: Date;
     version?: string;
+    versionId?: string;
 }
 
 // @public
@@ -1546,6 +1561,7 @@ export interface ContainerListBlobsOptions extends CommonOptions {
     includeMetadata?: boolean;
     includeSnapshots?: boolean;
     includeUncommitedBlobs?: boolean;
+    includeVersions?: boolean;
     prefix?: string;
 }
 
@@ -1790,7 +1806,7 @@ export interface ListBlobsHierarchySegmentResponse {
     maxPageSize?: number;
     // (undocumented)
     prefix?: string;
-    // (undocumented)
+    // (undocumented)`
     segment: BlobHierarchyListSegment;
     // (undocumented)
     serviceEndpoint: string;

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -380,7 +380,7 @@ export class BlobClient extends StorageClient {
     syncCopyFromURL(copySource: string, options?: BlobSyncCopyFromURLOptions): Promise<BlobCopyFromURLResponse>;
     undelete(options?: BlobUndeleteOptions): Promise<BlobUndeleteResponse>;
     withSnapshot(snapshot: string): BlobClient;
-    withVersionId(versionId: string): BlobClient;
+    withVersion(versionId: string): BlobClient;
 }
 
 // @public
@@ -454,7 +454,6 @@ export interface BlobDeleteOptions extends CommonOptions {
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
     deleteSnapshots?: DeleteSnapshotsOptionType;
-    versionId?: string;
 }
 
 // @public
@@ -538,7 +537,6 @@ export interface BlobDownloadOptions extends CommonOptions {
     rangeGetContentCrc64?: boolean;
     rangeGetContentMD5?: boolean;
     snapshot?: string;
-    versionId?: string;
 }
 
 // @public
@@ -559,7 +557,6 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
     customerProvidedKey?: CpkInfo;
     maxRetryRequestsPerBlock?: number;
     onProgress?: (progress: TransferProgressEvent) => void;
-    versionId?: string;
 }
 
 // @public
@@ -567,7 +564,6 @@ export interface BlobExistsOptions extends CommonOptions {
     abortSignal?: AbortSignalLike;
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
-    versionId?: string;
 }
 
 // @public
@@ -637,7 +633,6 @@ export interface BlobGetPropertiesOptions extends CommonOptions {
     abortSignal?: AbortSignalLike;
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
-    versionId?: string;
 }
 
 // @public
@@ -1342,7 +1337,7 @@ export class ContainerClient extends StorageClient {
     get containerName(): string;
     create(options?: ContainerCreateOptions): Promise<ContainerCreateResponse>;
     delete(options?: ContainerDeleteMethodOptions): Promise<ContainerDeleteResponse>;
-    deleteBlob(blobName: string, options?: BlobDeleteOptions): Promise<BlobDeleteResponse>;
+    deleteBlob(blobName: string, options?: ContainerDeleteBlobOptions): Promise<BlobDeleteResponse>;
     exists(options?: ContainerExistsOptions): Promise<boolean>;
     getAccessPolicy(options?: ContainerGetAccessPolicyOptions): Promise<ContainerGetAccessPolicyResponse>;
     getAppendBlobClient(blobName: string): AppendBlobClient;
@@ -1391,6 +1386,11 @@ export type ContainerCreateResponse = ContainerCreateHeaders & {
         parsedHeaders: ContainerCreateHeaders;
     };
 };
+
+// @public
+export interface ContainerDeleteBlobOptions extends BlobDeleteOptions {
+    versionId?: string;
+}
 
 // @public
 export interface ContainerDeleteHeaders {

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -373,7 +373,6 @@ export class BlobClient extends StorageClient {
     getBlockBlobClient(): BlockBlobClient;
     getPageBlobClient(): PageBlobClient;
     getProperties(options?: BlobGetPropertiesOptions): Promise<BlobGetPropertiesResponse>;
-    getURLWithVersionId(versionId: string): string;
     get name(): string;
     setAccessTier(tier: BlockBlobTier | PremiumPageBlobTier | string, options?: BlobSetTierOptions): Promise<BlobSetTierResponse>;
     setHTTPHeaders(blobHTTPHeaders?: BlobHTTPHeaders, options?: BlobSetHTTPHeadersOptions): Promise<BlobSetHTTPHeadersResponse>;
@@ -381,6 +380,7 @@ export class BlobClient extends StorageClient {
     syncCopyFromURL(copySource: string, options?: BlobSyncCopyFromURLOptions): Promise<BlobCopyFromURLResponse>;
     undelete(options?: BlobUndeleteOptions): Promise<BlobUndeleteResponse>;
     withSnapshot(snapshot: string): BlobClient;
+    withVersionId(versionId: string): BlobClient;
 }
 
 // @public

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -454,7 +454,6 @@ export interface BlobDeleteOptions extends CommonOptions {
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
     deleteSnapshots?: DeleteSnapshotsOptionType;
-    snapshot?: string;
     versionId?: string;
 }
 
@@ -560,7 +559,6 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
     customerProvidedKey?: CpkInfo;
     maxRetryRequestsPerBlock?: number;
     onProgress?: (progress: TransferProgressEvent) => void;
-    snapshot?: string;
     versionId?: string;
 }
 
@@ -569,7 +567,6 @@ export interface BlobExistsOptions extends CommonOptions {
     abortSignal?: AbortSignalLike;
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
-    snapshot?: string;
     versionId?: string;
 }
 
@@ -640,7 +637,6 @@ export interface BlobGetPropertiesOptions extends CommonOptions {
     abortSignal?: AbortSignalLike;
     conditions?: BlobRequestConditions;
     customerProvidedKey?: CpkInfo;
-    snapshot?: string;
     versionId?: string;
 }
 

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -1478,7 +1478,6 @@ export interface ContainerGetPropertiesHeaders {
     };
     requestId?: string;
     version?: string;
-    versionId?: string;
 }
 
 // @public
@@ -1803,7 +1802,7 @@ export interface ListBlobsHierarchySegmentResponse {
     maxPageSize?: number;
     // (undocumented)
     prefix?: string;
-    // (undocumented)`
+    // (undocumented)
     segment: BlobHierarchyListSegment;
     // (undocumented)
     serviceEndpoint: string;

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -373,6 +373,7 @@ export class BlobClient extends StorageClient {
     getBlockBlobClient(): BlockBlobClient;
     getPageBlobClient(): PageBlobClient;
     getProperties(options?: BlobGetPropertiesOptions): Promise<BlobGetPropertiesResponse>;
+    getURLWithVersionId(versionId: string): string;
     get name(): string;
     setAccessTier(tier: BlockBlobTier | PremiumPageBlobTier | string, options?: BlobSetTierOptions): Promise<BlobSetTierResponse>;
     setHTTPHeaders(blobHTTPHeaders?: BlobHTTPHeaders, options?: BlobSetHTTPHeadersOptions): Promise<BlobSetHTTPHeadersResponse>;
@@ -380,7 +381,6 @@ export class BlobClient extends StorageClient {
     syncCopyFromURL(copySource: string, options?: BlobSyncCopyFromURLOptions): Promise<BlobCopyFromURLResponse>;
     undelete(options?: BlobUndeleteOptions): Promise<BlobUndeleteResponse>;
     withSnapshot(snapshot: string): BlobClient;
-    withVersionId(versionId: string): BlobClient;
 }
 
 // @public

--- a/sdk/storage/storage-blob/review/storage-blob.api.md
+++ b/sdk/storage/storage-blob/review/storage-blob.api.md
@@ -1482,6 +1482,7 @@ export interface ContainerGetPropertiesHeaders {
     };
     requestId?: string;
     version?: string;
+    versionId?: string;
 }
 
 // @public

--- a/sdk/storage/storage-blob/src/AccountSASPermissions.ts
+++ b/sdk/storage/storage-blob/src/AccountSASPermissions.ts
@@ -36,6 +36,9 @@ export class AccountSASPermissions {
         case "d":
           accountSASPermissions.delete = true;
           break;
+        case "x":
+          accountSASPermissions.deleteVersion = true;
+          break;
         case "l":
           accountSASPermissions.list = true;
           break;
@@ -82,6 +85,14 @@ export class AccountSASPermissions {
    * @memberof AccountSASPermissions
    */
   public delete: boolean = false;
+
+  /**
+   * Permission to delete versions granted.
+   *
+   * @type {boolean}
+   * @memberof AccountSASPermissions
+   */
+  public deleteVersion: boolean = false;
 
   /**
    * Permission to list blob containers, blobs, shares, directories, and files granted.
@@ -148,6 +159,9 @@ export class AccountSASPermissions {
     }
     if (this.delete) {
       permissions.push("d");
+    }
+    if (this.deleteVersion) {
+      permissions.push("x");
     }
     if (this.list) {
       permissions.push("l");

--- a/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
+++ b/sdk/storage/storage-blob/src/BlobDownloadResponse.ts
@@ -413,7 +413,7 @@ export class BlobDownloadResponse implements BlobDownloadResponseModel {
   }
 
   /**
-   * Indicates the version of the File service used
+   * Indicates the version of the Blob service used
    * to execute the request.
    *
    * @readonly
@@ -422,6 +422,17 @@ export class BlobDownloadResponse implements BlobDownloadResponseModel {
    */
   public get version(): string | undefined {
     return this.originalResponse.version;
+  }
+
+  /**
+   * Indicates the versionId of the downloaded blob version.
+   *
+   * @readonly
+   * @type {(string | undefined)}
+   * @memberof BlobDownloadResponse
+   */
+  public get versionId(): string | undefined {
+    return this.originalResponse.versionId;
   }
 
   /**

--- a/sdk/storage/storage-blob/src/BlobSASPermissions.ts
+++ b/sdk/storage/storage-blob/src/BlobSASPermissions.ts
@@ -43,6 +43,9 @@ export class BlobSASPermissions {
         case "d":
           blobSASPermissions.delete = true;
           break;
+        case "x":
+          blobSASPermissions.deleteVersion = true;
+          break;
         default:
           throw new RangeError(`Invalid permission: ${char}`);
       }
@@ -92,6 +95,14 @@ export class BlobSASPermissions {
   public delete: boolean = false;
 
   /**
+   * Specifies Delete version access granted.
+   *
+   * @type {boolean}
+   * @memberof BlobSASPermissions
+   */
+  public deleteVersion: boolean = false;
+
+  /**
    * Converts the given permissions to a string. Using this method will guarantee the permissions are in an
    * order accepted by the service.
    *
@@ -114,6 +125,9 @@ export class BlobSASPermissions {
     }
     if (this.delete) {
       permissions.push("d");
+    }
+    if (this.deleteVersion) {
+      permissions.push("x");
     }
     return permissions.join("");
   }

--- a/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
@@ -92,7 +92,7 @@ export interface BlobSASSignatureValues {
    * Optional. Snapshot timestamp string the SAS user may access. Only supported from API version 2018-11-09.
    *
    * @type {string}
-   * @memberof IBlobSASSignatureValues
+   * @memberof BlobSASSignatureValues
    */
   snapshotTime?: string;
 
@@ -100,7 +100,7 @@ export interface BlobSASSignatureValues {
    * Optional. VersionId of the blob version the SAS user may access. Only supported from API version 2019-10-10.
    *
    * @type {string}
-   * @memberof IBlobSASSignatureValues
+   * @memberof BlobSASSignatureValues
    */
   versionId?: string;
 

--- a/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
+++ b/sdk/storage/storage-blob/src/BlobSASSignatureValues.ts
@@ -59,10 +59,10 @@ export interface BlobSASSignatureValues {
    * Please refer to either {@link ContainerSASPermissions} or {@link BlobSASPermissions} depending on the resource
    * being accessed for help constructing the permissions string.
    *
-   * @type {BlobSASPermissions}
+   * @type {BlobSASPermissions | ContainerSASPermissions}
    * @memberof BlobSASSignatureValues
    */
-  permissions?: BlobSASPermissions;
+  permissions?: BlobSASPermissions | ContainerSASPermissions;
 
   /**
    * Optional. IP ranges allowed in this SAS.
@@ -81,7 +81,7 @@ export interface BlobSASSignatureValues {
   containerName: string;
 
   /**
-   * Optional. The blob name of the SAS user may access. Required if snapshotTime is provided.
+   * Optional. The blob name of the SAS user may access. Required if snapshotTime or versionId is provided.
    *
    * @type {string}
    * @memberof BlobSASSignatureValues
@@ -95,6 +95,14 @@ export interface BlobSASSignatureValues {
    * @memberof IBlobSASSignatureValues
    */
   snapshotTime?: string;
+
+  /**
+   * Optional. VersionId of the blob version the SAS user may access. Only supported from API version 2019-10-10.
+   *
+   * @type {string}
+   * @memberof IBlobSASSignatureValues
+   */
+  versionId?: string;
 
   /**
    * Optional. The name of the access policy on the container this SAS references if any.
@@ -362,6 +370,10 @@ function generateBlobSASQueryParameters20150405(
     throw RangeError("'version' must be >= '2018-11-09' when provided 'snapshotTime'.");
   }
 
+  if (blobSASSignatureValues.versionId) {
+    throw RangeError("'version' must be >= '2019-10-10' when provided 'versionId'.");
+  }
+
   if (blobSASSignatureValues.blobName) {
     resource = "b";
   }
@@ -464,10 +476,18 @@ function generateBlobSASQueryParameters20181109(
     throw RangeError("Must provide 'blobName' when provided 'snapshotTime'.");
   }
 
+  if (blobSASSignatureValues.blobName === undefined && blobSASSignatureValues.versionId) {
+    throw RangeError("Must provide 'blobName' when provided 'versionId'.");
+  }
+
+  let timestamp = blobSASSignatureValues.snapshotTime;
   if (blobSASSignatureValues.blobName) {
     resource = "b";
     if (blobSASSignatureValues.snapshotTime) {
       resource = "bs";
+    } else if (blobSASSignatureValues.versionId) {
+      resource = "bv";
+      timestamp = blobSASSignatureValues.versionId;
     }
   }
 
@@ -503,7 +523,7 @@ function generateBlobSASQueryParameters20181109(
     blobSASSignatureValues.protocol ? blobSASSignatureValues.protocol : "",
     version,
     resource,
-    blobSASSignatureValues.snapshotTime,
+    timestamp,
     blobSASSignatureValues.cacheControl ? blobSASSignatureValues.cacheControl : "",
     blobSASSignatureValues.contentDisposition ? blobSASSignatureValues.contentDisposition : "",
     blobSASSignatureValues.contentEncoding ? blobSASSignatureValues.contentEncoding : "",
@@ -566,10 +586,18 @@ function generateBlobSASQueryParametersUDK20181109(
     throw RangeError("Must provide 'blobName' when provided 'snapshotTime'.");
   }
 
+  if (blobSASSignatureValues.blobName === undefined && blobSASSignatureValues.versionId) {
+    throw RangeError("Must provide 'blobName' when provided 'versionId'.");
+  }
+
+  let timestamp = blobSASSignatureValues.snapshotTime;
   if (blobSASSignatureValues.blobName) {
     resource = "b";
     if (blobSASSignatureValues.snapshotTime) {
       resource = "bs";
+    } else if (blobSASSignatureValues.versionId) {
+      resource = "bv";
+      timestamp = blobSASSignatureValues.versionId;
     }
   }
 
@@ -614,7 +642,7 @@ function generateBlobSASQueryParametersUDK20181109(
     blobSASSignatureValues.protocol ? blobSASSignatureValues.protocol : "",
     version,
     resource,
-    blobSASSignatureValues.snapshotTime,
+    timestamp,
     blobSASSignatureValues.cacheControl,
     blobSASSignatureValues.contentDisposition,
     blobSASSignatureValues.contentEncoding,

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -301,14 +301,6 @@ export interface BlobExistsOptions extends CommonOptions {
    */
   conditions?: BlobRequestConditions;
   /**
-   * An opaque DateTime value that, when present, specifies the blob
-   * snapshot to retrieve.
-   * 
-   * @type {string}
-   * @memberof BlobExistsOptions
-   */
-  snapshot?: string;
-  /**
    * An opaque DateTime value that, when present, specifies the version
    * of the blob to retrieve. It's for service version 2019-10-10 and newer.
    * 
@@ -347,14 +339,6 @@ export interface BlobGetPropertiesOptions extends CommonOptions {
    * @memberof BlobGetPropertiesOptions
    */
   customerProvidedKey?: CpkInfo;
-  /**
-   * An opaque DateTime value that, when present, specifies the blob
-   * snapshot to retrieve.
-   * 
-   * @type {string}
-   * @memberof BlobGetPropertiesOptions
-   */
-  snapshot?: string;
   /**
    * An opaque DateTime value that, when present, specifies the version
    * of the blob to retrieve. It's for service version 2019-10-10 and newer.
@@ -403,13 +387,6 @@ export interface BlobDeleteOptions extends CommonOptions {
    * @memberof BlobDeleteOptions
    */
   customerProvidedKey?: CpkInfo;
-  /**
-   * An opaque DateTime value that, when present, specifies the blob snapshot to delete.
-   * 
-   * @type {string}
-   * @memberof BlobDeleteOptions
-   */
-  snapshot?: string;
   /**
    * An opaque DateTime value that, when present, specifies the version
    * of the blob to delete. It's for service version 2019-10-10 and newer.
@@ -916,13 +893,6 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
    */
   customerProvidedKey?: CpkInfo;
   /**
-   * An opaque DateTime string value that, when present, specifies the blob snapshot to retrieve.
-   *
-   * @type {string}
-   * @memberof BlobDownloadToBufferOptions
-   */
-  snapshot?: string;
-  /**
    * An opaque DateTime string value that, when present, specifies the version of the blob
    * to retrieve. It's for service version 2019-10-10 and newer.
    *
@@ -1363,7 +1333,6 @@ export class BlobClient extends StorageClient {
         abortSignal: options.abortSignal,
         customerProvidedKey: options.customerProvidedKey,
         versionId: options.versionId,
-        snapshot: options.snapshot,
         conditions: options.conditions,
         tracingOptions: {
           ...options.tracingOptions,
@@ -1415,7 +1384,6 @@ export class BlobClient extends StorageClient {
         leaseAccessConditions: options.conditions,
         modifiedAccessConditions: options.conditions,
         cpkInfo: options.customerProvidedKey,
-        snapshot: options.snapshot,
         versionId: options.versionId,
         spanOptions
       });
@@ -1450,7 +1418,6 @@ export class BlobClient extends StorageClient {
         deleteSnapshots: options.deleteSnapshots,
         leaseAccessConditions: options.conditions,
         modifiedAccessConditions: options.conditions,
-        snapshot: options.snapshot,
         versionId: options.versionId,
         spanOptions
       });
@@ -1972,7 +1939,6 @@ export class BlobClient extends StorageClient {
             conditions: options.conditions,
             maxRetryRequests: options.maxRetryRequestsPerBlock,
             customerProvidedKey: options.customerProvidedKey,
-            snapshot: options.snapshot,
             versionId: options.versionId,
             tracingOptions: {
               ...options.tracingOptions,

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1102,21 +1102,18 @@ export class BlobClient extends StorageClient {
   }
 
   /**
-   * Creates a new BlobClient object pointing to a version of this blob.
-   * Provide "" will remove the versionId and return a Client to the base blob.
+   * Get the URL pointing to a version of this blob.
+   * Provide "" will remove the versionId and return the URL to the base blob.
    *
    * @param {string} versionId The versionId.
-   * @returns {BlobClient} A new BlobClient object pointing to the version of this blob.
+   * @returns {string} A URL pointing to the version of this blob.
    * @memberof BlobClient
    */
-  public withVersionId(versionId: string): BlobClient {
-    return new BlobClient(
-      setURLParameter(
-        this.url,
-        URLConstants.Parameters.VERSIONID,
-        versionId.length === 0 ? undefined : versionId
-      ),
-      this.pipeline
+  public getURLWithVersionId(versionId: string): string {
+    return setURLParameter(
+      this.url,
+      URLConstants.Parameters.VERSIONID,
+      versionId.length === 0 ? undefined : versionId
     );
   }
 

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1102,18 +1102,21 @@ export class BlobClient extends StorageClient {
   }
 
   /**
-   * Get the URL pointing to a version of this blob.
-   * Provide "" will remove the versionId and return the URL to the base blob.
+   * Creates a new BlobClient object pointing to a version of this blob.
+   * Provide "" will remove the versionId and return a Client to the base blob.
    *
    * @param {string} versionId The versionId.
-   * @returns {string} A URL pointing to the version of this blob.
+   * @returns {BlobClient} A new BlobClient object pointing to the version of this blob.
    * @memberof BlobClient
    */
-  public getURLWithVersionId(versionId: string): string {
-    return setURLParameter(
-      this.url,
-      URLConstants.Parameters.VERSIONID,
-      versionId.length === 0 ? undefined : versionId
+  public withVersionId(versionId: string): BlobClient {
+    return new BlobClient(
+      setURLParameter(
+        this.url,
+        URLConstants.Parameters.VERSIONID,
+        versionId.length === 0 ? undefined : versionId
+      ),
+      this.pipeline
     );
   }
 

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -1132,6 +1132,25 @@ export class BlobClient extends StorageClient {
   }
 
   /**
+   * Creates a new BlobClient object pointing to a version of this blob.
+   * Provide "" will remove the versionId and return a Client to the base blob.
+   *
+   * @param {string} versionId The versionId.
+   * @returns {BlobClient} A new BlobClient object pointing to the version of this blob.
+   * @memberof BlobClient
+   */
+  public withVersionId(versionId: string): BlobClient {
+    return new BlobClient(
+      setURLParameter(
+        this.url,
+        URLConstants.Parameters.VERSIONID,
+        versionId.length === 0 ? undefined : versionId
+      ),
+      this.pipeline
+    );
+  }
+
+  /**
    * Creates a AppendBlobClient object.
    *
    * @returns {AppendBlobClient}

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -205,7 +205,7 @@ export interface BlobDownloadOptions extends CommonOptions {
   snapshot?: string;
   /**
    * An opaque DateTime string value that, when present, specifies the version of the blob
-   * to retrieve. It for service version 2019-10-10 and newer.
+   * to retrieve. It's for service version 2019-10-10 and newer.
    *
    * @type {string}
    * @memberof BlobDownloadOptions
@@ -310,7 +310,7 @@ export interface BlobExistsOptions extends CommonOptions {
   snapshot?: string;
   /**
    * An opaque DateTime value that, when present, specifies the version
-   * of the blob to retrieve. It for service version 2019-10-10 and newer.
+   * of the blob to retrieve. It's for service version 2019-10-10 and newer.
    * 
    * @type {string}
    * @memberof BlobExistsOptions
@@ -357,7 +357,7 @@ export interface BlobGetPropertiesOptions extends CommonOptions {
   snapshot?: string;
   /**
    * An opaque DateTime value that, when present, specifies the version
-   * of the blob to retrieve. It for service version 2019-10-10 and newer.
+   * of the blob to retrieve. It's for service version 2019-10-10 and newer.
    * 
    * @type {string}
    * @memberof BlobGetPropertiesOptions
@@ -412,7 +412,7 @@ export interface BlobDeleteOptions extends CommonOptions {
   snapshot?: string;
   /**
    * An opaque DateTime value that, when present, specifies the version
-   * of the blob to delete. It for service version 2019-10-10 and newer.
+   * of the blob to delete. It's for service version 2019-10-10 and newer.
    * 
    * @type {string}
    * @memberof BlobDeleteOptions
@@ -924,7 +924,7 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
   snapshot?: string;
   /**
    * An opaque DateTime string value that, when present, specifies the version of the blob
-   * to retrieve. It for service version 2019-10-10 and newer.
+   * to retrieve. It's for service version 2019-10-10 and newer.
    *
    * @type {string}
    * @memberof BlobDownloadToBufferOptions

--- a/sdk/storage/storage-blob/src/Clients.ts
+++ b/sdk/storage/storage-blob/src/Clients.ts
@@ -204,6 +204,14 @@ export interface BlobDownloadOptions extends CommonOptions {
    */
   snapshot?: string;
   /**
+   * An opaque DateTime string value that, when present, specifies the version of the blob
+   * to retrieve. It for service version 2019-10-10 and newer.
+   *
+   * @type {string}
+   * @memberof BlobDownloadOptions
+   */
+  versionId?: string;
+  /**
    * When this is set to true and download range of blob, the service returns the MD5 hash for the range,
    * as long as the range is less than or equal to 4 MB in size.
    *
@@ -285,6 +293,29 @@ export interface BlobExistsOptions extends CommonOptions {
    * @memberof BlobExistsOptions
    */
   customerProvidedKey?: CpkInfo;
+  /**
+   * Conditions to meet.
+   *
+   * @type {BlobRequestConditions}
+   * @memberof BlobExistsOptions
+   */
+  conditions?: BlobRequestConditions;
+  /**
+   * An opaque DateTime value that, when present, specifies the blob
+   * snapshot to retrieve.
+   * 
+   * @type {string}
+   * @memberof BlobExistsOptions
+   */
+  snapshot?: string;
+  /**
+   * An opaque DateTime value that, when present, specifies the version
+   * of the blob to retrieve. It for service version 2019-10-10 and newer.
+   * 
+   * @type {string}
+   * @memberof BlobExistsOptions
+   */
+  versionId?: string;
 }
 
 /**
@@ -316,6 +347,22 @@ export interface BlobGetPropertiesOptions extends CommonOptions {
    * @memberof BlobGetPropertiesOptions
    */
   customerProvidedKey?: CpkInfo;
+  /**
+   * An opaque DateTime value that, when present, specifies the blob
+   * snapshot to retrieve.
+   * 
+   * @type {string}
+   * @memberof BlobGetPropertiesOptions
+   */
+  snapshot?: string;
+  /**
+   * An opaque DateTime value that, when present, specifies the version
+   * of the blob to retrieve. It for service version 2019-10-10 and newer.
+   * 
+   * @type {string}
+   * @memberof BlobGetPropertiesOptions
+   */
+  versionId?: string;
 }
 
 /**
@@ -356,6 +403,21 @@ export interface BlobDeleteOptions extends CommonOptions {
    * @memberof BlobDeleteOptions
    */
   customerProvidedKey?: CpkInfo;
+  /**
+   * An opaque DateTime value that, when present, specifies the blob snapshot to delete.
+   * 
+   * @type {string}
+   * @memberof BlobDeleteOptions
+   */
+  snapshot?: string;
+  /**
+   * An opaque DateTime value that, when present, specifies the version
+   * of the blob to delete. It for service version 2019-10-10 and newer.
+   * 
+   * @type {string}
+   * @memberof BlobDeleteOptions
+   */
+  versionId?: string;
 }
 
 /**
@@ -846,6 +908,28 @@ export interface BlobDownloadToBufferOptions extends CommonOptions {
    * @memberof BlobDownloadToBufferOptions
    */
   concurrency?: number;
+  /**
+   * Customer Provided Key Info.
+   *
+   * @type {CpkInfo}
+   * @memberof BlobDownloadToBufferOptions
+   */
+  customerProvidedKey?: CpkInfo;
+  /**
+   * An opaque DateTime string value that, when present, specifies the blob snapshot to retrieve.
+   *
+   * @type {string}
+   * @memberof BlobDownloadToBufferOptions
+   */
+  snapshot?: string;
+  /**
+   * An opaque DateTime string value that, when present, specifies the version of the blob
+   * to retrieve. It for service version 2019-10-10 and newer.
+   *
+   * @type {string}
+   * @memberof BlobDownloadToBufferOptions
+   */
+  versionId?: string;
 }
 
 /**
@@ -1158,6 +1242,7 @@ export class BlobClient extends StorageClient {
         rangeGetContentMD5: options.rangeGetContentMD5,
         rangeGetContentCRC64: options.rangeGetContentCrc64,
         snapshot: options.snapshot,
+        versionId: options.versionId,
         cpkInfo: options.customerProvidedKey,
         spanOptions
       });
@@ -1203,6 +1288,7 @@ export class BlobClient extends StorageClient {
             rangeGetContentMD5: options.rangeGetContentMD5,
             rangeGetContentCRC64: options.rangeGetContentCrc64,
             snapshot: options.snapshot,
+            versionId: options.versionId,
             cpkInfo: options.customerProvidedKey
           };
 
@@ -1257,6 +1343,9 @@ export class BlobClient extends StorageClient {
       await this.getProperties({
         abortSignal: options.abortSignal,
         customerProvidedKey: options.customerProvidedKey,
+        versionId: options.versionId,
+        snapshot: options.snapshot,
+        conditions: options.conditions,
         tracingOptions: {
           ...options.tracingOptions,
           spanOptions
@@ -1307,6 +1396,8 @@ export class BlobClient extends StorageClient {
         leaseAccessConditions: options.conditions,
         modifiedAccessConditions: options.conditions,
         cpkInfo: options.customerProvidedKey,
+        snapshot: options.snapshot,
+        versionId: options.versionId,
         spanOptions
       });
     } catch (e) {
@@ -1340,6 +1431,8 @@ export class BlobClient extends StorageClient {
         deleteSnapshots: options.deleteSnapshots,
         leaseAccessConditions: options.conditions,
         modifiedAccessConditions: options.conditions,
+        snapshot: options.snapshot,
+        versionId: options.versionId,
         spanOptions
       });
     } catch (e) {
@@ -1859,6 +1952,9 @@ export class BlobClient extends StorageClient {
             abortSignal: options.abortSignal,
             conditions: options.conditions,
             maxRetryRequests: options.maxRetryRequestsPerBlock,
+            customerProvidedKey: options.customerProvidedKey,
+            snapshot: options.snapshot,
+            versionId: options.versionId,
             tracingOptions: {
               ...options.tracingOptions,
               spanOptions
@@ -5920,9 +6016,13 @@ export interface ContainerListBlobsOptions extends CommonOptions {
    */
   includeMetadata?: boolean;
   /**
-   * Specifies whether snapshots should be included in the enumeration. Snapshots are listed from oldest to newest in the response
+   * Specifies whether snapshots should be included in the enumeration. Snapshots are listed from oldest to newest in the response.
    */
   includeSnapshots?: boolean;
+  /**
+   * Specifies whether versions should be included in the enumeration. Versions are listed from oldest to newest in the response.
+   */
+  includeVersions?: boolean;
   /**
    * Specifies whether blobs for which blocks have been uploaded, but which have not been committed using Put Block List, be included in the response.
    */
@@ -6813,6 +6913,9 @@ export class ContainerClient extends StorageClient {
     if (options.includeSnapshots) {
       include.push("snapshots");
     }
+    if (options.includeVersions) {
+      include.push("versions");
+    }
     if (options.includeUncommitedBlobs) {
       include.push("uncommittedblobs");
     }
@@ -7017,6 +7120,9 @@ export class ContainerClient extends StorageClient {
     }
     if (options.includeSnapshots) {
       include.push("snapshots");
+    }
+    if (options.includeVersions) {
+      include.push("versions");
     }
     if (options.includeUncommitedBlobs) {
       include.push("uncommittedblobs");

--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -6689,6 +6689,12 @@ export interface BlobQueryHeaders {
    */
   version?: string;
   /**
+   * A DateTime value returned by the service that uniquely identifies the blob. The value of this
+   * header indicates the blob version, and may be used in subsequent requests to access this
+   * version of the blob.
+   */
+  versionId?: string;
+  /**
    * Indicates that the service supports requests for partial blob content.
    */
   acceptRanges?: string;

--- a/sdk/storage/storage-blob/src/generated/src/models/index.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/index.ts
@@ -6689,12 +6689,6 @@ export interface BlobQueryHeaders {
    */
   version?: string;
   /**
-   * A DateTime value returned by the service that uniquely identifies the blob. The value of this
-   * header indicates the blob version, and may be used in subsequent requests to access this
-   * version of the blob.
-   */
-  versionId?: string;
-  /**
    * Indicates that the service supports requests for partial blob content.
    */
   acceptRanges?: string;

--- a/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
@@ -3830,6 +3830,12 @@ export const BlobDownloadHeaders: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
+      versionId: {
+        serializedName: "x-ms-version-id",
+        type: {
+          name: "String"
+        }
+      },
       acceptRanges: {
         serializedName: "accept-ranges",
         type: {

--- a/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
@@ -4806,6 +4806,12 @@ export const BlobSetHTTPHeadersHeaders: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
+      versionId: {
+        serializedName: "x-ms-version-id",
+        type: {
+          name: "String"
+        }
+      },
       date: {
         serializedName: "date",
         type: {

--- a/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
+++ b/sdk/storage/storage-blob/src/generated/src/models/mappers.ts
@@ -3830,12 +3830,6 @@ export const BlobDownloadHeaders: coreHttp.CompositeMapper = {
           name: "String"
         }
       },
-      versionId: {
-        serializedName: "x-ms-version-id",
-        type: {
-          name: "String"
-        }
-      },
       acceptRanges: {
         serializedName: "accept-ranges",
         type: {
@@ -4808,12 +4802,6 @@ export const BlobSetHTTPHeadersHeaders: coreHttp.CompositeMapper = {
       },
       version: {
         serializedName: "x-ms-version",
-        type: {
-          name: "String"
-        }
-      },
-      versionId: {
-        serializedName: "x-ms-version-id",
         type: {
           name: "String"
         }

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "12.2.0-preview";
+const packageVersion = "12.2.0-preview.1";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "12.1.2";
+const packageVersion = "12.2.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "12.2.0";
+const packageVersion = "12.2.0-preview";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.1.2";
-export const SERVICE_VERSION: string = "2019-07-07";
+export const SDK_VERSION: string = "12.2.0";
+export const SERVICE_VERSION: string = "2019-12-12";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB
 export const BLOCK_BLOB_MAX_STAGE_BLOCK_BYTES: number = 100 * 1024 * 1024; // 100MB
@@ -20,6 +20,7 @@ export const URLConstants = {
     FORCE_BROWSER_NO_CACHE: "_",
     SIGNATURE: "sig",
     SNAPSHOT: "snapshot",
+    VERSIONID: "versionid",
     TIMEOUT: "timeout"
   }
 };

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.2.0";
+export const SDK_VERSION: string = "12.2.0-preview";
 export const SERVICE_VERSION: string = "2019-12-12";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -8,7 +8,8 @@ import {
   bodyToString,
   getBSU,
   getSASConnectionStringFromEnvironment,
-  recorderEnvSetup
+  recorderEnvSetup,
+  isBlobVersioningDisabled,
 } from "./utils";
 import { record, delay } from "@azure/test-utils-recorder";
 import {
@@ -252,7 +253,8 @@ describe("BlobClient", () => {
 
     const iter = containerClient
       .listBlobsFlat({
-        includeDeleted: true
+        includeDeleted: true,
+        includeVersions: true, // Need this when blob versioning is turned on.
       })
       .byPage({ maxPageSize: 1 });
 
@@ -276,7 +278,7 @@ describe("BlobClient", () => {
 
     assert.ok(
       result.segment.blobItems,
-      "Expect non empty result from list blobs({ includeDeleted: true }) with page size of 1."
+      "Expect non empty result from list blobs({ includeDeleted: true, includeVersions: true }) with page size of 1."
     );
 
     assert.equal(
@@ -290,13 +292,16 @@ describe("BlobClient", () => {
       "Expect a valid element in result array from list blobs({ includeDeleted: true }) with page size of 1."
     );
 
-    assert.ok(result.segment.blobItems![0].deleted, "Expect that the blob is marked for deletion");
+    if (isBlobVersioningDisabled()) {
+      assert.ok(result.segment.blobItems![0].deleted, "Expect that the blob is marked for deletion");
+    }
 
     await blobClient.undelete();
 
     const iter2 = containerClient
       .listBlobsFlat({
-        includeDeleted: true
+        includeDeleted: true,
+        includeVersions: true, // Need this when blob versioning is turned on.
       })
       .byPage();
 

--- a/sdk/storage/storage-blob/test/blobversioning.spec.ts
+++ b/sdk/storage/storage-blob/test/blobversioning.spec.ts
@@ -138,9 +138,8 @@ describe("Blob versioning", () => {
     const snapshotRes = await blobClient.createSnapshot();
     let exceptionCaught = false;
     try {
-      await blobClient.getProperties({
+      await blobClient.withSnapshot(snapshotRes.snapshot!).getProperties({
         versionId: uploadRes.versionId,
-        snapshot: snapshotRes.snapshot
       });
     } catch (err) {
       assert.equal(err.details.errorCode, "MutuallyExclusiveQueryParameters");
@@ -249,10 +248,9 @@ describe("Blob versioning", () => {
     assert.ok(result.snapshot);
     assert.ok(result.versionId);
 
-    await blobClient.delete({ snapshot: result.snapshot });
-    const snapshotExists = await blobClient.exists({
-      snapshot: result.snapshot,
-    });
+    const snapshotClient = blobClient.withSnapshot(result.snapshot!);
+    await snapshotClient.delete();
+    const snapshotExists = await snapshotClient.exists();
     assert.ok(!snapshotExists);
 
     const rootExists = await blobClient.exists();
@@ -273,9 +271,7 @@ describe("Blob versioning", () => {
     assert.ok(exceptionCaught);
 
     blobClient.delete({ deleteSnapshots: "include" });
-    const snapshotExists = await blobClient.exists({
-      snapshot: result.snapshot,
-    });
+    const snapshotExists = await blobClient.withSnapshot(result.snapshot!).exists();
     assert.ok(!snapshotExists);
     const rootExists = await blobClient.exists();
     assert.ok(!rootExists);

--- a/sdk/storage/storage-blob/test/blobversioning.spec.ts
+++ b/sdk/storage/storage-blob/test/blobversioning.spec.ts
@@ -21,6 +21,9 @@ import {
 import {
   setURLParameter,
 } from "../src/utils/utils.common";
+import {
+  URLConstants,
+} from "../src/utils/constants";
 dotenv.config({ path: "../.env" });
 
 describe("Blob versioning", () => {
@@ -290,10 +293,7 @@ describe("Blob versioning", () => {
   });
 
   it("promote a version: as the copy source", async () => {
-    const versionBlobClient = blobClient.withVersionId(uploadRes.versionId!);
-    await versionBlobClient.getProperties();
-
-    const versionURL = setURLParameter(blobClient.url, "versionid", uploadRes.versionId);
+    const versionURL = setURLParameter(blobClient.url, URLConstants.Parameters.VERSIONID, uploadRes.versionId);
     const copyRes = await (await blobClient.beginCopyFromURL(versionURL)).pollUntilDone();
     assert.ok(copyRes.copyId);
 

--- a/sdk/storage/storage-blob/test/blobversioning.spec.ts
+++ b/sdk/storage/storage-blob/test/blobversioning.spec.ts
@@ -92,11 +92,13 @@ describe("Blob versioning", () => {
       versionId: uploadRes.versionId
     });
     assert.deepStrictEqual(await bodyToString(downloadRes, content.length), content);
+    assert.deepStrictEqual(downloadRes.versionId, uploadRes.versionId);
 
     const downloadRes2 = await blobClient.download(undefined, undefined, {
       versionId: uploadRes2.versionId
     });
     assert.deepStrictEqual(await bodyToString(downloadRes2), "");
+    assert.deepStrictEqual(downloadRes2.versionId, uploadRes2.versionId);
 
     if (isNode) {
       const downloadToBufferRes = await blobClient.downloadToBuffer(undefined, undefined, {

--- a/sdk/storage/storage-blob/test/blobversioning.spec.ts
+++ b/sdk/storage/storage-blob/test/blobversioning.spec.ts
@@ -124,6 +124,27 @@ describe("Blob versioning", () => {
       versionId: uploadRes.versionId,
     })
     assert.equal(getRes.contentLength, content.length);
+    assert.equal(getRes.versionId, uploadRes.versionId);
+    assert.ok(!getRes.isCurrentVersion);
+
+    const getRes2 = await blobClient.getProperties();
+    assert.equal(getRes2.contentLength, 0);
+    assert.equal(getRes2.versionId, uploadRes2.versionId);
+    assert.ok(getRes2.isCurrentVersion);
+
+    // specify both snapshot and versionId
+    const snapshotRes = await blobClient.createSnapshot();
+    let exceptionCaught = false;
+    try {
+      await blobClient.getProperties({
+        versionId: uploadRes.versionId,
+        snapshot: snapshotRes.snapshot
+      });
+    } catch (err) {
+      assert.equal(err.details.errorCode, "MutuallyExclusiveQueryParameters");
+      exceptionCaught = true;
+    }
+    assert.ok(exceptionCaught);
 
     const existRes = await blobClient.exists({
       versionId: uploadRes.versionId,

--- a/sdk/storage/storage-blob/test/blobversioning.spec.ts
+++ b/sdk/storage/storage-blob/test/blobversioning.spec.ts
@@ -21,9 +21,6 @@ import {
 import {
   setURLParameter,
 } from "../src/utils/utils.common";
-import {
-  URLConstants,
-} from "../src/utils/constants";
 dotenv.config({ path: "../.env" });
 
 describe("Blob versioning", () => {
@@ -293,7 +290,10 @@ describe("Blob versioning", () => {
   });
 
   it("promote a version: as the copy source", async () => {
-    const versionURL = setURLParameter(blobClient.url, URLConstants.Parameters.VERSIONID, uploadRes.versionId);
+    const versionBlobClient = blobClient.withVersionId(uploadRes.versionId!);
+    await versionBlobClient.getProperties();
+
+    const versionURL = setURLParameter(blobClient.url, "versionid", uploadRes.versionId);
     const copyRes = await (await blobClient.beginCopyFromURL(versionURL)).pollUntilDone();
     assert.ok(copyRes.copyId);
 

--- a/sdk/storage/storage-blob/test/blobversioning.spec.ts
+++ b/sdk/storage/storage-blob/test/blobversioning.spec.ts
@@ -1,0 +1,345 @@
+import * as assert from "assert";
+import * as dotenv from "dotenv";
+import * as fs from "fs";
+import { isNode, delay } from "@azure/core-http";
+import {
+  getBSU,
+  recorderEnvSetup,
+  bodyToString,
+  getGenericCredential,
+} from "./utils";
+import { record, Recorder } from "@azure/test-utils-recorder";
+import {
+  ContainerClient,
+  BlobServiceClient,
+  BlobClient,
+  BlockBlobClient,
+  BlockBlobUploadResponse,
+  BlobBatch,
+} from "../src";
+import {
+  setURLParameter,
+} from "../src/utils/utils.common";
+dotenv.config({ path: "../.env" });
+
+describe("Blob versioning", () => {
+  let blobServiceClient: BlobServiceClient;
+  let containerName: string;
+  let containerClient: ContainerClient;
+  let blobName: string;
+  let blobClient: BlobClient;
+  let blockBlobClient: BlockBlobClient;
+  let uploadRes: BlockBlobUploadResponse;
+  let uploadRes2: BlockBlobUploadResponse;
+  const content = "Hello World";
+
+  let recorder: Recorder;
+
+  beforeEach(async function () {
+    recorder = record(this, recorderEnvSetup);
+    blobServiceClient = getBSU();
+    containerName = recorder.getUniqueName("container");
+    containerClient = blobServiceClient.getContainerClient(containerName);
+    await containerClient.create();
+    blobName = recorder.getUniqueName("blob");
+    blobClient = containerClient.getBlobClient(blobName);
+    blockBlobClient = blobClient.getBlockBlobClient();
+    uploadRes = await blockBlobClient.upload(content, content.length);
+    uploadRes2 = await blockBlobClient.upload("", 0);
+  });
+
+  afterEach(async function () {
+    await containerClient.delete();
+    recorder.stop();
+  });
+
+  it("List Blobs include versions", async () => {
+    const blobClients = [];
+    blobClients.push(blobClient);
+
+    const prefix = "blockblob";
+    for (let i = 0; i < 2; i++) {
+      const tmpBlobClient = containerClient.getBlobClient(recorder.getUniqueName(`${prefix}/${i}`));
+      const tmpBlockBlobClient = tmpBlobClient.getBlockBlobClient();
+      await tmpBlockBlobClient.upload("", 0);
+      blobClients.push(tmpBlobClient);
+    }
+
+    const result = (
+      await containerClient
+        .listBlobsFlat({
+          includeVersions: true,
+        })
+        .byPage()
+        .next()
+    ).value;
+
+    assert.equal(result.segment.blobItems!.length, 4);
+    assert.equal(result.segment.blobItems![0].versionId, uploadRes.versionId);
+    assert.equal(result.segment.blobItems![1].versionId, uploadRes2.versionId);
+    assert.ok(result.segment.blobItems![1].isCurrentVersion);
+  });
+
+  it("download a blob version", async () => {
+    const downloadRes = await blobClient.download(0, undefined, {
+      versionId: uploadRes.versionId
+    });
+    assert.deepStrictEqual(await bodyToString(downloadRes, content.length), content);
+
+    const downloadRes2 = await blobClient.download(undefined, undefined, {
+      versionId: uploadRes2.versionId
+    });
+    assert.deepStrictEqual(await bodyToString(downloadRes2), "");
+
+    if (isNode) {
+      const downloadToBufferRes = await blobClient.downloadToBuffer(undefined, undefined, {
+        versionId: uploadRes.versionId
+      });
+      assert.ok(downloadToBufferRes.equals(Buffer.from(content)));
+    }
+  });
+
+  it("download a version to file", async function () {
+    if (!isNode) { this.skip(); }
+
+    recorder.skip("node", "Temp file - recorder doesn't support saving the file");
+    const downloadedFilePath = recorder.getUniqueName("downloadedtofile");
+    await blobClient.downloadToFile(downloadedFilePath, undefined, undefined, {
+      versionId: uploadRes.versionId
+    });
+    const downloadedFileContent = fs.readFileSync(downloadedFilePath);
+    assert.ok(downloadedFileContent.equals(Buffer.from(downloadedFileContent)));
+    fs.unlinkSync(downloadedFilePath);
+  });
+
+  it("get properties of a blob version", async () => {
+    const getRes = await blobClient.getProperties({
+      versionId: uploadRes.versionId,
+    })
+    assert.equal(getRes.contentLength, content.length);
+
+    const existRes = await blobClient.exists({
+      versionId: uploadRes.versionId,
+    })
+    assert.ok(existRes);
+  });
+
+  it("delete a version", async () => {
+    await blobClient.delete({
+      versionId: uploadRes.versionId,
+    })
+
+    const versionExists = await blobClient.exists({
+      versionId: uploadRes.versionId,
+    });
+    assert.ok(!versionExists);
+
+    const rootExists = await blobClient.exists();
+    assert.ok(rootExists);
+  });
+
+  it("deleteBlobs should work for batch delete", async () => {
+    recorder.skip(
+      undefined,
+      "UUID is randomly generated within the SDK and used in the HTTP request and cannot be preserved."
+    );
+    const blockBlobCount = 3;
+    let blockBlobClients: BlockBlobClient[] = new Array(blockBlobCount);
+    let versions: string[] = new Array(blockBlobCount);
+    for (let i = 0; i < blockBlobCount; i++) {
+      let tmpBlobName = `blob${i}`;
+      let tmpBlockBlobClient = containerClient.getBlockBlobClient(tmpBlobName);
+      blockBlobClients[i] = tmpBlockBlobClient;
+    }
+    // Upload blobs.
+    for (let i = 0; i < blockBlobCount; i++) {
+      const tmpRes = await blockBlobClients[i].upload("", 0);
+      versions[i] = tmpRes.versionId!;
+      await blockBlobClients[i].upload(content, content.length);
+    }
+
+    // Assemble batch delete request.
+    const blobBatchClient = blobServiceClient.getBlobBatchClient();
+    const credential = getGenericCredential("");
+    let batchDeleteRequest = new BlobBatch();
+    for (let i = 0; i < blockBlobCount; i++) {
+      await batchDeleteRequest.deleteBlob(blockBlobClients[i].url, credential, { versionId: versions[i] });
+    }
+
+    // Submit batch request and verify response.
+    const resp = await blobBatchClient.submitBatch(batchDeleteRequest, {});
+
+    assert.equal(resp.subResponses.length, blockBlobCount);
+    assert.equal(resp.subResponsesSucceededCount, blockBlobCount);
+    assert.equal(resp.subResponsesFailedCount, 0);
+
+    for (let i = 0; i < blockBlobCount; i++) {
+      assert.equal(resp.subResponses[i].errorCode, undefined);
+      assert.equal(resp.subResponses[i].status, 202);
+      assert.ok(resp.subResponses[i].statusMessage != "");
+      assert.ok(resp.subResponses[i].headers.contains("x-ms-request-id"));
+      assert.equal(resp.subResponses[i]._request.url, blockBlobClients[i].url);
+    }
+
+    // Verify blob versions deleted.
+    const resp2 = (
+      await containerClient
+        .listBlobsFlat({
+          includeVersions: true,
+        })
+        .byPage()
+        .next()
+    ).value;
+    assert.equal(resp2.segment.blobItems.length, 2 + blockBlobCount);
+  });
+
+  it("deleting root blob with versionId should fail", async () => {
+    await containerClient.deleteBlob(blobName, {
+      versionId: uploadRes.versionId,
+    });
+    const versionExists = await blobClient.exists({
+      versionId: uploadRes.versionId,
+    });
+    assert.ok(!versionExists);
+
+    let exceptionCaught: boolean = false;
+    try {
+      await containerClient.deleteBlob(blobName, {
+        versionId: uploadRes2.versionId,
+      });
+    } catch (err) {
+      assert.equal(err.details.errorCode, "OperationNotAllowedOnRootBlob");
+      exceptionCaught = true;
+    }
+    assert.ok(exceptionCaught);
+  });
+
+  it("delete a snapshot", async () => {
+    const result = await blobClient.createSnapshot();
+    assert.ok(result.snapshot);
+    assert.ok(result.versionId);
+
+    await blobClient.delete({ snapshot: result.snapshot });
+    const snapshotExists = await blobClient.exists({
+      snapshot: result.snapshot,
+    });
+    assert.ok(!snapshotExists);
+
+    const rootExists = await blobClient.exists();
+    assert.ok(rootExists);
+  });
+
+  it("deleting a blob that has snapshots needs deleteSnapshots option", async () => {
+    const result = await blobClient.createSnapshot();
+    assert.ok(result.snapshot);
+
+    let exceptionCaught: boolean = false;
+    try {
+      await blobClient.delete();
+    } catch (err) {
+      assert.equal(err.details.errorCode, "SnapshotsPresent");
+      exceptionCaught = true;
+    }
+    assert.ok(exceptionCaught);
+
+    blobClient.delete({ deleteSnapshots: "include" });
+    const snapshotExists = await blobClient.exists({
+      snapshot: result.snapshot,
+    });
+    assert.ok(!snapshotExists);
+    const rootExists = await blobClient.exists();
+    assert.ok(!rootExists);
+  });
+
+  it("deleting a versioned blob without extra parameters should succeed", async () => {
+    await blobClient.delete();
+
+    const rootExists = await blobClient.exists();
+    assert.ok(!rootExists);
+
+    const versionExists = await blobClient.exists({
+      versionId: uploadRes.versionId,
+    });
+    assert.ok(versionExists);
+  });
+
+  it("promote a version: as the copy source", async () => {
+    const versionURL = setURLParameter(blobClient.url, "versionId", uploadRes.versionId);
+
+    const copyRes = await (await blobClient.beginCopyFromURL(versionURL)).pollUntilDone();
+    assert.ok(copyRes.copyId);
+
+    const listRes = (
+      await containerClient
+        .listBlobsFlat({
+          includeVersions: true,
+        })
+        .byPage()
+        .next()
+    ).value;
+    assert.equal(listRes.segment.blobItems!.length, 3);
+    assert.equal(listRes.segment.blobItems![2].versionId, copyRes.versionId);
+    assert.ok(listRes.segment.blobItems![2].isCurrentVersion);
+
+    const downloadRes = await blobClient.download();
+    assert.deepStrictEqual(await bodyToString(downloadRes, content.length), content);
+  });
+
+  it("blob create return versionId", async () => {
+    const appendBlobName = recorder.getUniqueName("appendblob");
+    const appendBlobClient = containerClient.getBlobClient(appendBlobName).getAppendBlobClient();
+    const appendCreateRes = await appendBlobClient.create();
+    assert.ok(appendCreateRes.versionId);
+
+    const pageBlobName = recorder.getUniqueName("pageblob");
+    const pageBlobClient = containerClient.getBlobClient(pageBlobName).getAppendBlobClient();
+    const pageCreateRes = await pageBlobClient.create();
+    assert.ok(pageCreateRes.versionId);
+  });
+
+  it("upload block blob return versionId", async () => {
+    const containerUploadRes = await containerClient.uploadBlockBlob(blobName, content, content.length);
+    assert.ok(containerUploadRes.response.versionId);
+
+    if (!isNode) {
+      const uploadBrowserDataRes = await blockBlobClient.uploadBrowserData(new Blob([content]));
+      assert.ok(uploadBrowserDataRes.versionId);
+    }
+  });
+
+  it("asynchorous copy return versionId", async () => {
+    const newBlobClient = containerClient.getBlobClient(recorder.getUniqueName("copiedblob"));
+    const result = await (await newBlobClient.beginCopyFromURL(blobClient.url)).pollUntilDone();
+    assert.ok(result.versionId);
+  });
+
+  it("setMetaData", async () => {
+    const metadata = {
+      keya: "a",
+      keyb: "c"
+    };
+    const setMetaRes = await blobClient.setMetadata(metadata);
+    assert.ok(setMetaRes.versionId);
+  });
+
+  it("undelete a soft-deleted version", async () => {
+    let properties = await blobServiceClient.getProperties();
+    if (!properties.deleteRetentionPolicy!.enabled) {
+      await blobServiceClient.setProperties({
+        deleteRetentionPolicy: {
+          days: 7,
+          enabled: true
+        }
+      });
+      await delay(30 * 1000);
+      properties = await blobServiceClient.getProperties();
+      assert.ok(properties.deleteRetentionPolicy!.enabled, "deleteRetentionPolicy should be enabled.");
+    }
+
+    await blobClient.delete({ versionId: uploadRes.versionId });
+    assert.ok(!(await blobClient.exists({ versionId: uploadRes.versionId })));
+
+    await blobClient.undelete();
+    assert.ok(await blobClient.exists({ versionId: uploadRes.versionId }));
+  });
+});

--- a/sdk/storage/storage-blob/test/encrytion.spec.ts
+++ b/sdk/storage/storage-blob/test/encrytion.spec.ts
@@ -31,11 +31,7 @@ describe("Encryption Scope", function() {
 
   let recorder: any;
 
-<<<<<<< HEAD
-  before(function() {
-=======
-  before(async function () {
->>>>>>> support 'bv' SAS
+  before(async function() {
     if (!encryptionScopeName1 || !encryptionScopeName2) {
       this.skip();
     }

--- a/sdk/storage/storage-blob/test/encrytion.spec.ts
+++ b/sdk/storage/storage-blob/test/encrytion.spec.ts
@@ -31,7 +31,11 @@ describe("Encryption Scope", function() {
 
   let recorder: any;
 
+<<<<<<< HEAD
   before(function() {
+=======
+  before(async function () {
+>>>>>>> support 'bv' SAS
     if (!encryptionScopeName1 || !encryptionScopeName2) {
       this.skip();
     }

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -22,7 +22,8 @@ import {
   createRandomLocalFile,
   getBSU,
   getConnectionStringFromEnvironment,
-  recorderEnvSetup
+  recorderEnvSetup,
+  isBlobVersioningDisabled,
 } from "../utils";
 import { assertClientUsesTokenCredential } from "../utils/assert";
 import { readStreamToLocalFileWithLogs } from "../utils/testutils.node";
@@ -216,7 +217,7 @@ describe("BlobClient Node.js only", () => {
 
     const copyURL = blobClient.url + "?" + sas;
     const result = await newBlobClient.syncCopyFromURL(copyURL);
-    assert.ok(result.versionId);
+    assert.ok(isBlobVersioningDisabled() || result.versionId);
 
     const properties1 = await blobClient.getProperties();
     const properties2 = await newBlobClient.getProperties();

--- a/sdk/storage/storage-blob/test/node/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blobclient.spec.ts
@@ -41,7 +41,7 @@ describe("BlobClient Node.js only", () => {
   let recorder: any;
 
   let blobServiceClient: BlobServiceClient;
-  beforeEach(async function() {
+  beforeEach(async function () {
     recorder = record(this, recorderEnvSetup);
     blobServiceClient = getBSU();
     containerName = recorder.getUniqueName("container");
@@ -53,7 +53,7 @@ describe("BlobClient Node.js only", () => {
     await blockBlobClient.upload(content, content.length);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     await containerClient.delete();
     recorder.stop();
   });
@@ -216,6 +216,7 @@ describe("BlobClient Node.js only", () => {
 
     const copyURL = blobClient.url + "?" + sas;
     const result = await newBlobClient.syncCopyFromURL(copyURL);
+    assert.ok(result.versionId);
 
     const properties1 = await blobClient.getProperties();
     const properties2 = await newBlobClient.getProperties();

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { PassThrough } from "stream";
 
 import { AbortController } from "@azure/abort-controller";
-import { createRandomLocalFile, getBSU, recorderEnvSetup } from "../utils";
+import { createRandomLocalFile, getBSU, recorderEnvSetup, isBlobVersioningDisabled } from "../utils";
 import { RetriableReadableStreamOptions } from "../../src/utils/RetriableReadableStream";
 import { record, Recorder } from "@azure/test-utils-recorder";
 import { ContainerClient, BlobClient, BlockBlobClient, BlobServiceClient } from "../../src";
@@ -217,7 +217,7 @@ describe("Highlevel", () => {
     bufferStream.end(buf);
 
     const uploadStreamRes = await blockBlobClient.uploadStream(bufferStream, 4 * 1024 * 1024, 20);
-    assert.ok(uploadStreamRes.versionId);
+    assert.ok(isBlobVersioningDisabled() || uploadStreamRes.versionId);
 
     const downloadResponse = await blockBlobClient.download(0);
 

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -27,7 +27,7 @@ describe("Highlevel", () => {
   let recorder: Recorder;
 
   let blobServiceClient: BlobServiceClient;
-  beforeEach(async function() {
+  beforeEach(async function () {
     recorder = record(this, recorderEnvSetup);
     blobServiceClient = getBSU();
     containerName = recorder.getUniqueName("container");
@@ -45,7 +45,7 @@ describe("Highlevel", () => {
     }
   });
 
-  before(async function() {
+  before(async function () {
     recorder = record(this, recorderEnvSetup);
     if (!fs.existsSync(tempFolderPath)) {
       fs.mkdirSync(tempFolderPath);
@@ -57,7 +57,7 @@ describe("Highlevel", () => {
     recorder.stop();
   });
 
-  after(async function() {
+  after(async function () {
     recorder = record(this, recorderEnvSetup);
     fs.unlinkSync(tempFileLarge);
     fs.unlinkSync(tempFileSmall);
@@ -166,7 +166,7 @@ describe("Highlevel", () => {
           aborter.abort();
         }
       });
-    } catch (err) {}
+    } catch (err) { }
     assert.ok(eventTriggered);
   });
 
@@ -189,7 +189,7 @@ describe("Highlevel", () => {
           aborter.abort();
         }
       });
-    } catch (err) {}
+    } catch (err) { }
     assert.ok(eventTriggered);
   });
 
@@ -216,7 +216,8 @@ describe("Highlevel", () => {
     const bufferStream = new PassThrough();
     bufferStream.end(buf);
 
-    await blockBlobClient.uploadStream(bufferStream, 4 * 1024 * 1024, 20);
+    const uploadStreamRes = await blockBlobClient.uploadStream(bufferStream, 4 * 1024 * 1024, 20);
+    assert.ok(uploadStreamRes.versionId);
 
     const downloadResponse = await blockBlobClient.download(0);
 
@@ -373,7 +374,7 @@ describe("Highlevel", () => {
           aborter.abort();
         }
       });
-    } catch (err) {}
+    } catch (err) { }
     assert.ok(eventTriggered);
   });
 

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -884,7 +884,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
       sharedKeyCredential as StorageSharedKeyCredential
     );
 
-    const sasURL = `${blobClient.getURLWithVersionId(uploadRes.versionId!)}&${blobSAS}`;
+    const sasURL = `${blobClient.withVersionId(uploadRes.versionId!).url}&${blobSAS}`;
     const blobClientWithSAS = new BlobClient(sasURL, newPipeline(new AnonymousCredential()));
     await blobClientWithSAS.delete({ versionId: uploadRes.versionId });
     assert.ok(!(await blobClientWithSAS.exists({ versionId: uploadRes.versionId })));
@@ -947,7 +947,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
       accountName
     );
 
-    const sasURL = `${blobClient.getURLWithVersionId(uploadRes.versionId!)}&${blobSAS}`;
+    const sasURL = `${blobClient.withVersionId(uploadRes.versionId!).url}&${blobSAS}`;
     const blobClientWithSAS = new BlobClient(sasURL, newPipeline(new AnonymousCredential()));
     await blobClientWithSAS.delete({ versionId: uploadRes.versionId });
     assert.ok(!(await blobClientWithSAS.exists({ versionId: uploadRes.versionId })));

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -884,10 +884,10 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
       sharedKeyCredential as StorageSharedKeyCredential
     );
 
-    const sasURL = `${blobClient.withVersionId(uploadRes.versionId!).url}&${blobSAS}`;
+    const sasURL = `${blobClient.withVersion(uploadRes.versionId!).url}&${blobSAS}`;
     const blobClientWithSAS = new BlobClient(sasURL, newPipeline(new AnonymousCredential()));
-    await blobClientWithSAS.delete({ versionId: uploadRes.versionId });
-    assert.ok(!(await blobClientWithSAS.exists({ versionId: uploadRes.versionId })));
+    await blobClientWithSAS.delete();
+    assert.ok(!(await blobClientWithSAS.exists()));
 
     await containerClient.delete();
   });
@@ -947,10 +947,10 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
       accountName
     );
 
-    const sasURL = `${blobClient.withVersionId(uploadRes.versionId!).url}&${blobSAS}`;
+    const sasURL = `${blobClient.withVersion(uploadRes.versionId!).url}&${blobSAS}`;
     const blobClientWithSAS = new BlobClient(sasURL, newPipeline(new AnonymousCredential()));
-    await blobClientWithSAS.delete({ versionId: uploadRes.versionId });
-    assert.ok(!(await blobClientWithSAS.exists({ versionId: uploadRes.versionId })));
+    await blobClientWithSAS.delete();
+    assert.ok(!(await blobClientWithSAS.exists()));
 
     await containerClient.delete();
   });

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -884,7 +884,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
       sharedKeyCredential as StorageSharedKeyCredential
     );
 
-    const sasURL = `${blobClient.withVersionId(uploadRes.versionId!).url}&${blobSAS}`;
+    const sasURL = `${blobClient.getURLWithVersionId(uploadRes.versionId!)}&${blobSAS}`;
     const blobClientWithSAS = new BlobClient(sasURL, newPipeline(new AnonymousCredential()));
     await blobClientWithSAS.delete({ versionId: uploadRes.versionId });
     assert.ok(!(await blobClientWithSAS.exists({ versionId: uploadRes.versionId })));
@@ -947,7 +947,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
       accountName
     );
 
-    const sasURL = `${blobClient.withVersionId(uploadRes.versionId!).url}&${blobSAS}`;
+    const sasURL = `${blobClient.getURLWithVersionId(uploadRes.versionId!)}&${blobSAS}`;
     const blobClientWithSAS = new BlobClient(sasURL, newPipeline(new AnonymousCredential()));
     await blobClientWithSAS.delete({ versionId: uploadRes.versionId });
     assert.ok(!(await blobClientWithSAS.exists({ versionId: uploadRes.versionId })));

--- a/sdk/storage/storage-blob/test/node/sas.spec.ts
+++ b/sdk/storage/storage-blob/test/node/sas.spec.ts
@@ -802,7 +802,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await containerClient.delete();
   });
 
-  it.only("generateAccountSASQueryParameters should work for blob version delete", async function () {
+  it("generateAccountSASQueryParameters should work for blob version delete", async function () {
     if (isBlobVersioningDisabled()) { this.skip(); }
 
     // create versions
@@ -846,7 +846,7 @@ describe("Shared Access Signature (SAS) generation Node.js only", () => {
     await containerClientwithSAS.delete();
   });
 
-  it.only("generateBlobSASQueryParameters should work for blob version delete", async function () {
+  it("generateBlobSASQueryParameters should work for blob version delete", async function () {
     if (isBlobVersioningDisabled()) { this.skip(); }
 
     // create versions

--- a/sdk/storage/storage-blob/test/utils/index.browser.ts
+++ b/sdk/storage/storage-blob/test/utils/index.browser.ts
@@ -174,3 +174,8 @@ export function getSASConnectionStringFromEnvironment(): string {
   const env = (window as any).__env__;
   return `BlobEndpoint=https://${env.ACCOUNT_NAME}.blob.core.windows.net/;QueueEndpoint=https://${env.ACCOUNT_NAME}.queue.core.windows.net/;FileEndpoint=https://${env.ACCOUNT_NAME}.file.core.windows.net/;TableEndpoint=https://${env.ACCOUNT_NAME}.table.core.windows.net/;SharedAccessSignature=${env.ACCOUNT_SAS}`;
 }
+
+export function isBlobVersioningDisabled(): boolean {
+  const env = (window as any).__env__;
+  return !env["BLOB_VERSIONING_ENABLED"];
+}

--- a/sdk/storage/storage-blob/test/utils/index.ts
+++ b/sdk/storage/storage-blob/test/utils/index.ts
@@ -232,3 +232,7 @@ export function getSASConnectionStringFromEnvironment(): string {
     ".file."
   )}/;TableEndpoint=${blobEndpoint.replace(".queue.", ".table.")}/;SharedAccessSignature=${sas}`;
 }
+
+export function isBlobVersioningDisabled(): boolean {
+  return !process.env.BLOB_VERSIONING_ENABLED;
+}


### PR DESCRIPTION
Reference: https://review.docs.microsoft.com/en-us/azure/storage/blobs/versioning-overview?branch=pr-en-us-104390&tabs=powershell

When blob versioning is turned on, each write operation creates a new version.
### The `versionId` will be returned to retrieve the version later.
- setMetadata
- PageBlobClient.create
- appendBlobClient.create
- Block blob upload
  - Blob and container
  - uploadResetableStream, uploadFile
  - uploadSeekableBlob, uploadBrowserData
  - uploadStream
- Copy blob
  - startCopyFromURL, beginCopyFromURL
  - syncCopyFromURL

### Read operations now has a `versionId` query param to read a version.
- Download: also added `versionId` to response headers
  - download
  - downloadToFile
  - downloadToBuffer
- Get properties
  - getProperties: also added `isCurrentVersion` and `versionId` to response headers
  - exists
- Get metadata
- createSnapshot

### List Blobs now supports includeVersions to list blob versions
- request: include={versions}
- response: `isCurrentVersion` and `versionId` added to BlobItem

### Added `versionId` query param to Delete Blob to support deleting a version.
- delete
  - ContainerClient.deleteBlob
  - BlobBatch.deleteBlob

## Added SAS support for deleting blob versions
- Blob level SAS:  use resource type **`bv`** , along with permission `x` ; put the timestamp of the version - `versionId` in the place of snapshot timestamp to sign.
- Account SAS: resource type use `o`, add permission `x`