### PR TITLE
[service-bus] Preview.1 - create separate rule manager and dead letter receiver methods.

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -118,7 +118,6 @@ export interface Receiver<ReceivedMessageT> {
     };
     entityPath: string;
     entityType: "queue" | "subscription";
-    getDeadLetterPath(): string;
     getMessageIterator(options?: GetMessageIteratorOptions): AsyncIterableIterator<ReceivedMessageT>;
     isReceivingMessages(): boolean;
     receiveBatch(maxMessages: number, options?: ReceiveBatchOptions): Promise<ReceivedMessageT[]>;
@@ -157,13 +156,14 @@ export class ServiceBusClient {
     close(): Promise<void>;
     getReceiver(queueName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;
     getReceiver(queueName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
-    getReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock> & SubscriptionRuleManagement;
-    getReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage> & SubscriptionRuleManagement;
+    getReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;
+    getReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
     getSender(queueOrTopicName: string): Sender;
     getSessionReceiver(queueName: string, receiveMode: "peekLock", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessageWithLock>;
     getSessionReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessage>;
-    getSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessageWithLock> & SubscriptionRuleManagement;
-    getSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessage> & SubscriptionRuleManagement;
+    getSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessageWithLock>;
+    getSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessage>;
+    getSubscriptionRuleManager(topic: string, subscription: string): SubscriptionRuleManager;
 }
 
 // @public
@@ -230,8 +230,9 @@ export interface SubscribeOptions extends OperationOptions, MessageHandlerOption
 }
 
 // @public
-export interface SubscriptionRuleManagement {
+export interface SubscriptionRuleManager {
     addRule(ruleName: string, filter: boolean | string | CorrelationFilter, sqlRuleActionExpression?: string): Promise<void>;
+    close(): Promise<void>;
     readonly defaultRuleName: string;
     getRules(): Promise<RuleDescription[]>;
     removeRule(ruleName: string): Promise<void>;

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -154,6 +154,10 @@ export class ServiceBusClient {
     constructor(connectionString: string, options?: ServiceBusClientOptions);
     constructor(hostName: string, tokenCredential: TokenCredential, options?: ServiceBusClientOptions);
     close(): Promise<void>;
+    getDeadLetterReceiver(queueName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;
+    getDeadLetterReceiver(queueName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
+    getDeadLetterReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;
+    getDeadLetterReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
     getReceiver(queueName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;
     getReceiver(queueName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
     getReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -41,7 +41,8 @@ export {
   CreateBatchOptions
 } from "./models";
 
-export { Receiver, SubscriptionRuleManagement } from "./receivers/receiver";
+export { Receiver } from "./receivers/receiver";
+export { SubscriptionRuleManager } from "./receivers/subscriptionRuleManager";
 export { SessionReceiver } from "./receivers/sessionReceiver";
 export { Sender } from "./sender";
 export { ServiceBusClient } from "./serviceBusClient";

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -9,7 +9,7 @@ import {
   MessageHandlerOptions
 } from "../models";
 import { OperationOptions } from "@azure/core-auth";
-import { RuleDescription, CorrelationFilter, ReceivedMessage } from "..";
+import { ReceivedMessage } from "..";
 import { ClientEntityContext } from "../clientEntityContext";
 import {
   throwErrorIfConnectionClosed,
@@ -24,13 +24,7 @@ import * as log from "../log";
 import { OnMessage, OnError, ReceiveOptions } from "../core/messageReceiver";
 import { StreamingReceiver } from "../core/streamingReceiver";
 import { BatchingReceiver } from "../core/batchingReceiver";
-import {
-  getSubscriptionRules,
-  removeSubscriptionRule,
-  addSubscriptionRule,
-  assertValidMessageHandlers,
-  getMessageIterator
-} from "./shared";
+import { assertValidMessageHandlers, getMessageIterator } from "./shared";
 import { convertToInternalReceiveMode } from "../constructorHelpers";
 import Long from "long";
 import { ServiceBusMessageImpl, ReceivedMessageWithLock } from "../serviceBusMessage";
@@ -94,12 +88,6 @@ export interface Receiver<ReceivedMessageT> {
    * @memberof SessionReceiver
    */
   isReceivingMessages(): boolean;
-  /**
-   * Returns the corresponding dead letter queue path for the client entity - meant for both queue and subscription.
-   * @returns {string}
-   * @memberof SessionReceiver
-   */
-  getDeadLetterPath(): string;
 
   // TODO: not sure these need to be on the interface
 
@@ -157,61 +145,11 @@ export interface Receiver<ReceivedMessageT> {
 }
 
 /**
- * Methods to manage rules for subscriptions. More information about subscription rules
- * can be found here: https://docs.microsoft.com/en-us/azure/service-bus-messaging/topic-filters
- */
-export interface SubscriptionRuleManagement {
-  /**
-   * Gets all rules associated with the subscription
-   * @throws Error if the SubscriptionClient or the underlying connection is closed.
-   * @throws MessagingError if the service returns an error while retrieving rules.
-   */
-  getRules(): Promise<RuleDescription[]>;
-
-  /**
-   * Removes the rule on the subscription identified by the given rule name.
-   *
-   * **Caution**: If all rules on a subscription are removed, then the subscription will not receive
-   * any more messages.
-   * @param ruleName
-   * @throws Error if the SubscriptionClient or the underlying connection is closed.
-   * @throws MessagingError if the service returns an error while removing rules.
-   */
-
-  removeRule(ruleName: string): Promise<void>;
-  /**
-   * Adds a rule on the subscription as defined by the given rule name, filter and action.
-   *
-   * **Note**: Remove the default true filter on the subscription before adding a rule.
-   * Otherwise, the added rule will have no affect as the true filter will always result in
-   * the subscription receiving all messages.
-   * @param ruleName Name of the rule
-   * @param filter A Boolean, SQL expression or a Correlation filter. For SQL Filter syntax, see
-   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-filter SQLFilter syntax}.
-   * @param sqlRuleActionExpression Action to perform if the message satisfies the filtering expression. For SQL Rule Action syntax,
-   * see {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-rule-action SQLRuleAction syntax}.
-   * @throws Error if the SubscriptionClient or the underlying connection is closed.
-   * @throws MessagingError if the service returns an error while adding rules.
-   */
-  addRule(
-    ruleName: string,
-    filter: boolean | string | CorrelationFilter,
-    sqlRuleActionExpression?: string
-  ): Promise<void>;
-
-  /**
-   * @readonly
-   * @property The name of the default rule on the subscription.
-   */
-  readonly defaultRuleName: string;
-}
-
-/**
  * @internal
  * @ignore
  */
 export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMessageWithLock>
-  implements Receiver<ReceivedMessageT>, SubscriptionRuleManagement {
+  implements Receiver<ReceivedMessageT> {
   /**
    * @property Describes the amqp connection context for the QueueClient.
    */
@@ -270,10 +208,6 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       log.error(`[${this._context.namespace.connectionId}] %O`, error);
       throw error;
     }
-  }
-
-  getDeadLetterPath(): string {
-    return `${this.entityPath}/$DeadLetterQueue`;
   }
 
   /**
@@ -502,32 +436,6 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       options
     );
   }
-
-  // #region topic-filters
-
-  getRules(): Promise<RuleDescription[]> {
-    return getSubscriptionRules(this._context);
-  }
-
-  removeRule(ruleName: string): Promise<void> {
-    return removeSubscriptionRule(this._context, ruleName);
-  }
-
-  addRule(
-    ruleName: string,
-    filter: boolean | string | CorrelationFilter,
-    sqlRuleActionExpression?: string
-  ): Promise<void> {
-    return addSubscriptionRule(this._context, ruleName, filter, sqlRuleActionExpression);
-  }
-
-  /**
-   * @readonly
-   * @property The name of the default rule on the subscription.
-   */
-  readonly defaultRuleName: string = "$Default";
-
-  // #endregion
 
   /**
    * Closes the underlying AMQP receiver link.

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -5,8 +5,6 @@ import { ClientEntityContext } from "../clientEntityContext";
 import {
   SessionReceiverOptions,
   SessionMessageHandlerOptions,
-  RuleDescription,
-  CorrelationFilter,
   MessageHandlers,
   SubscribeOptions,
   ReceiveBatchOptions,
@@ -26,13 +24,7 @@ import {
 } from "../util/errors";
 import * as log from "../log";
 import { OnMessage, OnError } from "../core/messageReceiver";
-import {
-  getSubscriptionRules,
-  removeSubscriptionRule,
-  addSubscriptionRule,
-  assertValidMessageHandlers,
-  getMessageIterator
-} from "./shared";
+import { assertValidMessageHandlers, getMessageIterator } from "./shared";
 import { convertToInternalReceiveMode } from "../constructorHelpers";
 import { Receiver } from "./receiver";
 import Long from "long";
@@ -224,10 +216,6 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       log.error(`[${this._context.namespace.connectionId}] %O`, error);
       throw error;
     }
-  }
-
-  getDeadLetterPath(): string {
-    return `${this.entityPath}/$DeadLetterQueue`;
   }
 
   /**
@@ -536,32 +524,6 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
   getMessageIterator(options?: GetMessageIteratorOptions): AsyncIterableIterator<ReceivedMessageT> {
     return getMessageIterator(this, options);
   }
-
-  // #region topic-filters
-
-  getRules(): Promise<RuleDescription[]> {
-    return getSubscriptionRules(this._context);
-  }
-
-  removeRule(ruleName: string): Promise<void> {
-    return removeSubscriptionRule(this._context, ruleName);
-  }
-
-  addRule(
-    ruleName: string,
-    filter: boolean | string | CorrelationFilter,
-    sqlRuleActionExpression?: string
-  ): Promise<void> {
-    return addSubscriptionRule(this._context, ruleName, filter, sqlRuleActionExpression);
-  }
-
-  /**
-   * @readonly
-   * @property The name of the default rule on the subscription.
-   */
-  readonly defaultRuleName: string = "$Default";
-
-  // #endregion
 
   /**
    * Closes the underlying AMQP receiver link.

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -1,60 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { throwErrorIfClientOrConnectionClosed } from "../util/errors";
-import { ClientEntityContext } from "../clientEntityContext";
-import { RuleDescription, CorrelationFilter } from "../core/managementClient";
 import { GetMessageIteratorOptions } from "../models";
 import { Receiver } from "./receiver";
-
-/**
- * @internal
- * @ignore
- */
-export function getSubscriptionRules(context: ClientEntityContext): Promise<RuleDescription[]> {
-  if (context.entityPath.includes("/Subscriptions/")) {
-    throwErrorIfClientOrConnectionClosed(context.namespace, context.entityPath, context.isClosed);
-    return context.managementClient!.getRules();
-  } else {
-    throw new Error("Only for a subscription");
-  }
-}
-
-/**
- * @internal
- * @ignore
- */
-export function removeSubscriptionRule(
-  context: ClientEntityContext,
-  ruleName: string
-): Promise<void> {
-  if (context.entityPath.includes("/Subscriptions/")) {
-    throwErrorIfClientOrConnectionClosed(context.namespace, context.entityPath, context.isClosed);
-    return context.managementClient!.removeRule(ruleName);
-  } else {
-    throw new Error("Only for a subscription");
-  }
-}
-
-/**
- * @internal
- * @ignore
- */
-export function addSubscriptionRule(
-  context: ClientEntityContext,
-  ruleName: string,
-  filter: boolean | string | CorrelationFilter,
-  sqlRuleActionExpression?: string
-): Promise<void> {
-  if (context.entityPath.includes("/Subscriptions/")) {
-    throwErrorIfClientOrConnectionClosed(context.namespace, context.entityPath, context.isClosed);
-    return context.managementClient!.addRule(ruleName, filter, sqlRuleActionExpression);
-  } else {
-    throw new Error("Only for a subscription");
-  }
-}
-
-// #endregion
 
 /**
  * @internal

--- a/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { RuleDescription, CorrelationFilter } from "../core/managementClient";
+import { throwErrorIfClientOrConnectionClosed } from "../util/errors";
+import { ClientEntityContext } from "../clientEntityContext";
+
+/**
+ * Manages rules for subscriptions.
+ * More information about subscription rules can be found here: https://docs.microsoft.com/en-us/azure/service-bus-messaging/topic-filters
+ */
+export interface SubscriptionRuleManager {
+  /**
+   * Gets all rules associated with the subscription
+   * @throws Error if the SubscriptionClient or the underlying connection is closed.
+   * @throws MessagingError if the service returns an error while retrieving rules.
+   */
+  getRules(): Promise<RuleDescription[]>;
+
+  /**
+   * Removes the rule on the subscription identified by the given rule name.
+   *
+   * **Caution**: If all rules on a subscription are removed, then the subscription will not receive
+   * any more messages.
+   * @param ruleName
+   * @throws Error if the SubscriptionClient or the underlying connection is closed.
+   * @throws MessagingError if the service returns an error while removing rules.
+   */
+
+  removeRule(ruleName: string): Promise<void>;
+  /**
+   * Adds a rule on the subscription as defined by the given rule name, filter and action.
+   *
+   * **Note**: Remove the default true filter on the subscription before adding a rule.
+   * Otherwise, the added rule will have no affect as the true filter will always result in
+   * the subscription receiving all messages.
+   * @param ruleName Name of the rule
+   * @param filter A Boolean, SQL expression or a Correlation filter. For SQL Filter syntax, see
+   * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-filter SQLFilter syntax}.
+   * @param sqlRuleActionExpression Action to perform if the message satisfies the filtering expression. For SQL Rule Action syntax,
+   * see {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-rule-action SQLRuleAction syntax}.
+   * @throws Error if the SubscriptionClient or the underlying connection is closed.
+   * @throws MessagingError if the service returns an error while adding rules.
+   */
+  addRule(
+    ruleName: string,
+    filter: boolean | string | CorrelationFilter,
+    sqlRuleActionExpression?: string
+  ): Promise<void>;
+
+  /**
+   * Closes any resources created for the rule manager.
+   */
+  close(): Promise<void>;
+
+  /**
+   * @readonly
+   * @property The name of the default rule on the subscription.
+   */
+  readonly defaultRuleName: string;
+}
+
+/**
+ * @internal
+ * @ignore
+ */
+export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
+  constructor(private _context: ClientEntityContext) {}
+
+  // #region topic-filters
+  getRules(): Promise<RuleDescription[]> {
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
+    return this._context.managementClient!.getRules();
+  }
+
+  removeRule(ruleName: string): Promise<void> {
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
+    return this._context.managementClient!.removeRule(ruleName);
+  }
+
+  addRule(
+    ruleName: string,
+    filter: boolean | string | CorrelationFilter,
+    sqlRuleActionExpression?: string
+  ): Promise<void> {
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
+    return this._context.managementClient!.addRule(ruleName, filter, sqlRuleActionExpression);
+  }
+
+  close(): Promise<void> {
+    return this._context.close();
+  }
+
+  /**
+   * @readonly
+   * @property The name of the default rule on the subscription.
+   */
+  readonly defaultRuleName: string = "$Default";
+
+  // #endregion
+}

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -287,6 +287,83 @@ export class ServiceBusClient {
   }
 
   /**
+   * Creates a receiver for an Azure Service Bus queue's dead letter queue.
+   *
+   * @param queueName The name of the queue to receive from.
+   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param options Options for the receiver itself.
+   */
+  getDeadLetterReceiver(
+    queueName: string,
+    receiveMode: "peekLock"
+  ): Receiver<ReceivedMessageWithLock>;
+  /**
+   * Creates a receiver for an Azure Service Bus queue's dead letter queue.
+   *
+   * @param queueName The name of the queue to receive from.
+   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param options Options for the receiver itself.
+   */
+  getDeadLetterReceiver(
+    queueName: string,
+    receiveMode: "receiveAndDelete"
+  ): Receiver<ReceivedMessage>;
+  /**
+   * Creates a receiver for an Azure Service Bus subscription's dead letter queue.
+   *
+   * @param topicName Name of the topic for the subscription we want to receive from.
+   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
+   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param options Options for the receiver itself.
+   */
+  getDeadLetterReceiver(
+    topicName: string,
+    subscriptionName: string,
+    receiveMode: "peekLock"
+  ): Receiver<ReceivedMessageWithLock>;
+  /**
+   * Creates a receiver for an Azure Service Bus subscription's dead letter queue.
+   *
+   * @param topicName Name of the topic for the subscription we want to receive from.
+   * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
+   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param options Options for the receiver itself.
+   */
+  getDeadLetterReceiver(
+    topicName: string,
+    subscriptionName: string,
+    receiveMode: "receiveAndDelete"
+  ): Receiver<ReceivedMessage>;
+  getDeadLetterReceiver(
+    queueOrTopicName1: string,
+    receiveModeOrSubscriptionName2: "peekLock" | "receiveAndDelete" | string,
+    receiveMode3?: "peekLock" | "receiveAndDelete"
+  ): Receiver<ReceivedMessageWithLock> | Receiver<ReceivedMessage> {
+    let entityPath;
+    let receiveMode: "peekLock" | "receiveAndDelete";
+
+    if (isReceiveMode(receiveMode3)) {
+      const topic = queueOrTopicName1;
+      const subscription = receiveModeOrSubscriptionName2;
+      receiveMode = receiveMode3;
+      entityPath = `${topic}/Subscriptions/${subscription}`;
+    } else if (isReceiveMode(receiveModeOrSubscriptionName2)) {
+      entityPath = queueOrTopicName1;
+      receiveMode = receiveModeOrSubscriptionName2;
+    } else {
+      throw new TypeError("Invalid receiveMode provided");
+    }
+
+    const deadLetterEntityPath = `${entityPath}/$DeadLetterQueue`;
+
+    if (receiveMode === "peekLock") {
+      return this.getReceiver(deadLetterEntityPath, receiveMode);
+    } else {
+      return this.getReceiver(deadLetterEntityPath, receiveMode);
+    }
+  }
+
+  /**
    * Closes the underlying AMQP connection.
    * NOTE: this will also disconnect any Receiver or Sender instances created from this
    * instance.

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -14,6 +14,7 @@ import {
   testPeekMsgsLength
 } from "./utils/testutils2";
 import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { getDeadLetterPath } from "./utils/transitional";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -44,7 +45,7 @@ describe("batchReceiver", () => {
     );
 
     deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(receiverClient.getDeadLetterPath(), "peekLock")
+      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
     );
   }
 

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -14,7 +14,6 @@ import {
   testPeekMsgsLength
 } from "./utils/testutils2";
 import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
-import { getDeadLetterPath } from "./utils/transitional";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -44,9 +43,7 @@ describe("batchReceiver", () => {
       serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
-    );
+    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
   }
 
   function afterEachTest(): Promise<void> {

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -11,6 +11,7 @@ import { testPeekMsgsLength, createServiceBusClientForTests } from "./utils/test
 import { Receiver } from "../src/receivers/receiver";
 import { Sender } from "../src/sender";
 import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { getDeadLetterPath } from "./utils/transitional";
 
 describe("deferred messages", () => {
   let serviceBusClient: ReturnType<typeof createServiceBusClientForTests>;
@@ -36,7 +37,7 @@ describe("deferred messages", () => {
     );
 
     deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(receiverClient.getDeadLetterPath(), "peekLock")
+      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
     );
   }
 

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -11,7 +11,6 @@ import { testPeekMsgsLength, createServiceBusClientForTests } from "./utils/test
 import { Receiver } from "../src/receivers/receiver";
 import { Sender } from "../src/sender";
 import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
-import { getDeadLetterPath } from "./utils/transitional";
 
 describe("deferred messages", () => {
   let serviceBusClient: ReturnType<typeof createServiceBusClientForTests>;
@@ -36,9 +35,7 @@ describe("deferred messages", () => {
       serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
-    );
+    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
   }
 
   async function afterEachTest(): Promise<void> {

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -123,9 +123,7 @@ describe("invalid parameters", () => {
         TestClientType.PartitionedSubscription
       );
 
-      subscriptionReceiverClient = serviceBusClient.test.getSubscriptionPeekLockReceiver(
-        entityNames
-      );
+      subscriptionReceiverClient = serviceBusClient.test.getPeekLockReceiver(entityNames);
 
       subscriptionRuleManager = serviceBusClient.test.addToCleanup(
         serviceBusClient.getSubscriptionRuleManager(entityNames.topic!, entityNames.subscription!)

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -8,10 +8,11 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import { TestMessage, TestClientType } from "./utils/testUtils";
 import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
-import { SubscriptionRuleManagement, Receiver } from "../src/receivers/receiver";
+import { Receiver } from "../src/receivers/receiver";
 import { Sender } from "../src/sender";
 import { SessionReceiver } from "../src/receivers/sessionReceiver";
 import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { SubscriptionRuleManager } from "../src/receivers/subscriptionRuleManager";
 
 describe("invalid parameters", () => {
   let serviceBusClient: ServiceBusClientForTests;
@@ -112,7 +113,8 @@ describe("invalid parameters", () => {
   });
 
   describe("Invalid parameters in Sender/ReceiverClients for PartitionedSubscription #RunInBrowser", function(): void {
-    let subscriptionReceiverClient: Receiver<ReceivedMessageWithLock> & SubscriptionRuleManagement;
+    let subscriptionReceiverClient: Receiver<ReceivedMessageWithLock>;
+    let subscriptionRuleManager: SubscriptionRuleManager;
 
     // Since, the below tests never actually make use of any AMQP links, there is no need to create
     // new sender/receiver clients before each test. Doing it once for each describe block.
@@ -123,6 +125,10 @@ describe("invalid parameters", () => {
 
       subscriptionReceiverClient = serviceBusClient.test.getSubscriptionPeekLockReceiver(
         entityNames
+      );
+
+      subscriptionRuleManager = serviceBusClient.test.addToCleanup(
+        serviceBusClient.getSubscriptionRuleManager(entityNames.topic!, entityNames.subscription!)
       );
     });
 
@@ -210,7 +216,7 @@ describe("invalid parameters", () => {
     it("AddRule: Missing ruleName", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.addRule(undefined as any, undefined as any);
+        await subscriptionRuleManager.addRule(undefined as any, undefined as any);
       } catch (error) {
         caughtError = error;
       }
@@ -221,7 +227,7 @@ describe("invalid parameters", () => {
     it("AddRule: Empty string as ruleName", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.addRule("", false);
+        await subscriptionRuleManager.addRule("", false);
       } catch (error) {
         caughtError = error;
       }
@@ -235,7 +241,7 @@ describe("invalid parameters", () => {
     it("AddRule: Missing filter", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.addRule("myrule", undefined as any);
+        await subscriptionRuleManager.addRule("myrule", undefined as any);
       } catch (error) {
         caughtError = error;
       }
@@ -246,7 +252,7 @@ describe("invalid parameters", () => {
     it("AddRule: Invalid filter", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.addRule("myrule", { random: "value" } as any);
+        await subscriptionRuleManager.addRule("myrule", { random: "value" } as any);
       } catch (error) {
         caughtError = error;
       }
@@ -260,7 +266,7 @@ describe("invalid parameters", () => {
     it("RemoveRule: Missing ruleName", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.removeRule(undefined as any);
+        await subscriptionRuleManager.removeRule(undefined as any);
       } catch (error) {
         caughtError = error;
       }
@@ -271,7 +277,7 @@ describe("invalid parameters", () => {
     it("RemoveRule: Empty string as ruleName", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.removeRule("");
+        await subscriptionRuleManager.removeRule("");
       } catch (error) {
         caughtError = error;
       }
@@ -284,12 +290,12 @@ describe("invalid parameters", () => {
 
     it("Add and Remove Rule: Coerce RuleName into string", async function(): Promise<void> {
       // Clean up existing rules
-      let rules = await subscriptionReceiverClient.getRules();
-      await Promise.all(rules.map((rule) => subscriptionReceiverClient.removeRule(rule.name)));
+      let rules = await subscriptionRuleManager.getRules();
+      await Promise.all(rules.map((rule) => subscriptionRuleManager.removeRule(rule.name)));
 
       // Add rule with number as name
-      await subscriptionReceiverClient.addRule(123 as any, true);
-      rules = await subscriptionReceiverClient.getRules();
+      await subscriptionRuleManager.addRule(123 as any, true);
+      rules = await subscriptionRuleManager.getRules();
       should.equal(
         rules.some((rule) => rule.name === "123"),
         true,
@@ -297,8 +303,8 @@ describe("invalid parameters", () => {
       );
 
       // Remove rule with number as name
-      await subscriptionReceiverClient.removeRule(123 as any);
-      rules = await subscriptionReceiverClient.getRules();
+      await subscriptionRuleManager.removeRule(123 as any);
+      rules = await subscriptionRuleManager.getRules();
       should.equal(
         rules.some((rule) => rule.name === "123"),
         false,
@@ -306,7 +312,7 @@ describe("invalid parameters", () => {
       );
 
       // Add default rule so that other tests are not affected
-      await subscriptionReceiverClient.addRule(subscriptionReceiverClient.defaultRuleName, true);
+      await subscriptionRuleManager.addRule(subscriptionRuleManager.defaultRuleName, true);
     });
   });
 

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -21,7 +21,6 @@ import {
   testPeekMsgsLength
 } from "./utils/testutils2";
 import { getDeliveryProperty } from "./utils/misc";
-import { getDeadLetterPath } from "./utils/transitional";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -59,9 +58,7 @@ describe("Streaming", () => {
       serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
-    );
+    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
 
     errorWasThrown = false;
     unexpectedError = undefined;

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -21,6 +21,7 @@ import {
   testPeekMsgsLength
 } from "./utils/testutils2";
 import { getDeliveryProperty } from "./utils/misc";
+import { getDeadLetterPath } from "./utils/transitional";
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -59,7 +60,7 @@ describe("Streaming", () => {
     );
 
     deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(receiverClient.getDeadLetterPath(), "peekLock")
+      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
     );
 
     errorWasThrown = false;

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -16,6 +16,7 @@ import {
   testPeekMsgsLength
 } from "./utils/testutils2";
 import { getDeliveryProperty } from "./utils/misc";
+import { getDeadLetterPath } from "./utils/transitional";
 const should = chai.should();
 chai.use(chaiAsPromised);
 
@@ -52,7 +53,7 @@ describe("Streaming with sessions", () => {
     );
 
     deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(receiverClient.getDeadLetterPath(), "peekLock")
+      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
     );
 
     errorWasThrown = false;

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -16,7 +16,6 @@ import {
   testPeekMsgsLength
 } from "./utils/testutils2";
 import { getDeliveryProperty } from "./utils/misc";
-import { getDeadLetterPath } from "./utils/transitional";
 const should = chai.should();
 chai.use(chaiAsPromised);
 
@@ -52,9 +51,7 @@ describe("Streaming with sessions", () => {
       serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getReceiver(getDeadLetterPath(receiverClient), "peekLock")
-    );
+    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
 
     errorWasThrown = false;
     unexpectedError = undefined;

--- a/sdk/servicebus/service-bus/test/topicFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/topicFilters.spec.ts
@@ -8,7 +8,7 @@ chai.use(chaiAsPromised);
 import { ServiceBusMessage, CorrelationFilter } from "../src";
 
 import { TestClientType, checkWithTimeout } from "./utils/testUtils";
-import { Receiver, SubscriptionRuleManagement } from "../src/receivers/receiver";
+import { Receiver } from "../src/receivers/receiver";
 import { Sender } from "../src/sender";
 import {
   ServiceBusClientForTests,
@@ -16,9 +16,11 @@ import {
   testPeekMsgsLength
 } from "./utils/testutils2";
 import { ReceivedMessageWithLock } from "../src/serviceBusMessage";
+import { SubscriptionRuleManager } from "../src/receivers/subscriptionRuleManager";
 
 describe("topic filters", () => {
-  let subscriptionClient: Receiver<ReceivedMessageWithLock> & SubscriptionRuleManagement;
+  let subscriptionClient: Receiver<ReceivedMessageWithLock>;
+  let subscriptionRuleManager: SubscriptionRuleManager;
   let topicClient: Sender;
   let serviceBusClient: ServiceBusClientForTests;
 
@@ -47,17 +49,21 @@ describe("topic filters", () => {
       serviceBusClient.getSender(entityNames.topic!)
     );
 
+    subscriptionRuleManager = subscriptionRuleManager = serviceBusClient.test.addToCleanup(
+      serviceBusClient.getSubscriptionRuleManager(entityNames.topic!, entityNames.subscription!)
+    );
+
     if (receiverType === TestClientType.TopicFilterTestSubscription) {
-      await removeAllRules(subscriptionClient);
+      await removeAllRules(subscriptionRuleManager);
     }
   }
 
   async function afterEachTest(clearRules: boolean = true): Promise<void> {
     if (clearRules) {
-      await removeAllRules(subscriptionClient);
-      await subscriptionClient.addRule("DefaultFilter", true);
+      await removeAllRules(subscriptionRuleManager);
+      await subscriptionRuleManager.addRule("DefaultFilter", true);
 
-      const rules = await subscriptionClient.getRules();
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "DefaultFilter", "RuleName is different than expected");
     }
@@ -67,11 +73,11 @@ describe("topic filters", () => {
   }
 
   // We need to remove rules before adding one because otherwise the existing default rule will let in all messages.
-  async function removeAllRules(client: SubscriptionRuleManagement): Promise<void> {
-    const rules = await client.getRules();
+  async function removeAllRules(client: SubscriptionRuleManager): Promise<void> {
+    const rules = await subscriptionRuleManager.getRules();
     for (let i = 0; i < rules.length; i++) {
       const rule = rules[i];
-      await client.removeRule(rule.name);
+      await subscriptionRuleManager.removeRule(rule.name);
     }
   }
 
@@ -110,7 +116,7 @@ describe("topic filters", () => {
   }
 
   async function receiveOrders(
-    client: Receiver<ReceivedMessageWithLock> & SubscriptionRuleManagement,
+    client: Receiver<ReceivedMessageWithLock>,
     expectedMessageCount: number
   ): Promise<ReceivedMessageWithLock[]> {
     let errorFromErrorHandler: Error | undefined;
@@ -149,9 +155,9 @@ describe("topic filters", () => {
     filter: boolean | string | CorrelationFilter,
     sqlRuleActionExpression?: string
   ): Promise<void> {
-    await subscriptionClient.addRule(ruleName, filter, sqlRuleActionExpression);
+    await subscriptionRuleManager.addRule(ruleName, filter, sqlRuleActionExpression);
 
-    const rules = await subscriptionClient.getRules();
+    const rules = await subscriptionRuleManager.getRules();
     should.equal(rules.length, 1, "Unexpected number of rules");
     should.equal(rules[0].name, ruleName, "Expected Rule not found");
 
@@ -170,8 +176,8 @@ describe("topic filters", () => {
     });
 
     async function BooleanFilter(bool: boolean): Promise<void> {
-      await subscriptionClient.addRule("BooleanFilter", bool);
-      const rules = await subscriptionClient.getRules();
+      await subscriptionRuleManager.addRule("BooleanFilter", bool);
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "BooleanFilter", "RuleName is different than expected");
     }
@@ -185,41 +191,41 @@ describe("topic filters", () => {
     });
 
     it("Add SQL filter", async function(): Promise<void> {
-      await subscriptionClient.addRule(
+      await subscriptionRuleManager.addRule(
         "Priority_1",
         "(priority = 1 OR priority = 2) AND (sys.label LIKE '%String2')"
       );
-      const rules = await subscriptionClient.getRules();
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "Priority_1", "RuleName is different than expected");
     });
 
     it("Add SQL filter and action", async function(): Promise<void> {
-      await subscriptionClient.addRule(
+      await subscriptionRuleManager.addRule(
         "Priority_1",
         "(priority = 1 OR priority = 3) AND (sys.label LIKE '%String1')",
         "SET sys.label = 'MessageX'"
       );
-      const rules = await subscriptionClient.getRules();
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "Priority_1", "RuleName is different than expected");
     });
 
     it("Add Correlation filter", async function(): Promise<void> {
-      await subscriptionClient.addRule("Correlationfilter", {
+      await subscriptionRuleManager.addRule("Correlationfilter", {
         label: "red",
         correlationId: "high"
       });
-      const rules = await subscriptionClient.getRules();
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "Correlationfilter", "RuleName is different than expected");
     });
 
     it("Add rule with a name which matches with existing rule", async function(): Promise<void> {
-      await subscriptionClient.addRule("Priority_1", "priority = 1");
+      await subscriptionRuleManager.addRule("Priority_1", "priority = 1");
       let errorWasThrown = false;
       try {
-        await subscriptionClient.addRule("Priority_1", "priority = 2");
+        await subscriptionRuleManager.addRule("Priority_1", "priority = 2");
       } catch (error) {
         errorWasThrown = true;
         should.equal(
@@ -251,7 +257,7 @@ describe("topic filters", () => {
     > {
       let errorWasThrown = false;
       try {
-        await subscriptionClient.removeRule("Priority_5");
+        await subscriptionRuleManager.removeRule("Priority_5");
       } catch (error) {
         should.equal(
           !error.message.search("Priority_5' could not be found"),
@@ -273,8 +279,8 @@ describe("topic filters", () => {
     > {
       let errorWasThrown = false;
       try {
-        await subscriptionClient.addRule("Priority_1", "priority = 1");
-        await subscriptionClient.removeRule("Priority_5");
+        await subscriptionRuleManager.addRule("Priority_1", "priority = 1");
+        await subscriptionRuleManager.removeRule("Priority_5");
       } catch (error) {
         errorWasThrown = true;
       }
@@ -294,19 +300,19 @@ describe("topic filters", () => {
     it("Subscription with 0/1/multiple rules returns rules as expected", async function(): Promise<
       void
     > {
-      let rules = await subscriptionClient.getRules();
+      let rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 0, "Unexpected number of rules");
 
       const expr1 = "(priority = 1)";
-      await subscriptionClient.addRule("Priority_1", expr1);
-      rules = await subscriptionClient.getRules();
+      await subscriptionRuleManager.addRule("Priority_1", expr1);
+      rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "Priority_1", "RuleName is different than expected");
       should.equal(rules[0].filter, expr1, "Filter-expression is different than expected");
 
       const expr2 = "(priority = 1 OR priority = 3) AND (sys.label LIKE '%String1')";
-      await subscriptionClient.addRule("Priority_2", expr2);
-      rules = await subscriptionClient.getRules();
+      await subscriptionRuleManager.addRule("Priority_2", expr2);
+      rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 2, "Unexpected number of rules");
       should.equal(rules[0].name, "Priority_1", "RuleName is different than expected");
       should.equal(rules[0].filter, expr1, "Filter-expression is different than expected");
@@ -317,21 +323,21 @@ describe("topic filters", () => {
     it("Rule with SQL filter and action returns expected filter and action expression", async function(): Promise<
       void
     > {
-      await subscriptionClient.addRule(
+      await subscriptionRuleManager.addRule(
         "Priority_1",
         "(priority = 1 OR priority = 3) AND (sys.label LIKE '%String1')",
         "SET sys.label = 'MessageX'"
       );
-      const rules = await subscriptionClient.getRules();
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules[0].name, "Priority_1", "RuleName is different than expected");
     });
 
     it("Rule with Correlation filter returns expected filter", async function(): Promise<void> {
-      await subscriptionClient.addRule("Correlationfilter", {
+      await subscriptionRuleManager.addRule("Correlationfilter", {
         label: "red",
         correlationId: "high"
       });
-      const rules = await subscriptionClient.getRules();
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules[0].name, "Correlationfilter", "RuleName is different than expected");
       const expectedFilter = {
         correlationId: "high",
@@ -369,7 +375,7 @@ describe("topic filters", () => {
     it("Default rule is returned for the subscription for which no rules were added", async function(): Promise<
       void
     > {
-      const rules = await subscriptionClient.getRules();
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "$Default", "RuleName is different than expected");
     });
@@ -393,11 +399,11 @@ describe("topic filters", () => {
 
     async function addFilterAndReceiveOrders(
       bool: boolean,
-      client: Receiver<ReceivedMessageWithLock> & SubscriptionRuleManagement,
+      client: Receiver<ReceivedMessageWithLock>,
       expectedMessageCount: number
     ): Promise<void> {
-      await subscriptionClient.addRule("BooleanFilter", bool);
-      const rules = await subscriptionClient.getRules();
+      await subscriptionRuleManager.addRule("BooleanFilter", bool);
+      const rules = await subscriptionRuleManager.getRules();
       should.equal(rules.length, 1, "Unexpected number of rules");
       should.equal(rules[0].name, "BooleanFilter", "RuleName is different than expected");
 

--- a/sdk/servicebus/service-bus/test/topicFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/topicFilters.spec.ts
@@ -44,7 +44,7 @@ describe("topic filters", () => {
 
     const entityNames = await serviceBusClient.test.createTestEntities(receiverType);
 
-    subscriptionClient = await serviceBusClient.test.getSubscriptionPeekLockReceiver(entityNames);
+    subscriptionClient = await serviceBusClient.test.getPeekLockReceiver(entityNames);
     topicClient = serviceBusClient.test.addToCleanup(
       serviceBusClient.getSender(entityNames.topic!)
     );

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -3,13 +3,7 @@
 
 // Anything we expect to be available to users should come from this import
 // as a simple sanity check that we've exported things properly.
-import {
-  ServiceBusClient,
-  SessionReceiver,
-  Receiver,
-  SubscriptionRuleManagement,
-  GetSessionReceiverOptions
-} from "../../src";
+import { ServiceBusClient, SessionReceiver, Receiver, GetSessionReceiverOptions } from "../../src";
 
 import { TestClientType, TestMessage } from "./testUtils";
 import { getEnvVars, EnvVarNames } from "./envVarUtils";
@@ -22,6 +16,7 @@ import {
   ReceivedMessage,
   ServiceBusMessage
 } from "../../src/serviceBusMessage";
+import { getDeadLetterPath } from "./transitional";
 
 dotenv.config();
 const env = getEnvVars();
@@ -286,7 +281,7 @@ export class ServiceBusTestHelpers {
 
   getSubscriptionPeekLockReceiver(
     entityNames: ReturnType<typeof getEntityNames>
-  ): Receiver<ReceivedMessageWithLock> & SubscriptionRuleManagement {
+  ): Receiver<ReceivedMessageWithLock> {
     if (entityNames.topic == null || entityNames.subscription == null) {
       throw new TypeError("Not subscription entity - can't create a subscription receiver for it");
     }
@@ -394,7 +389,7 @@ async function purgeForTestClientType(
   await Promise.all([
     drainReceiveAndDeleteReceiver(receiver),
     drainReceiveAndDeleteReceiver(
-      serviceBusClient.getReceiver(receiver.getDeadLetterPath(), "receiveAndDelete")
+      serviceBusClient.getReceiver(getDeadLetterPath(receiver), "receiveAndDelete")
     )
   ]);
 }

--- a/sdk/servicebus/service-bus/test/utils/transitional.ts
+++ b/sdk/servicebus/service-bus/test/utils/transitional.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Receiver } from "../../src/receivers/receiver";
+
+export function getDeadLetterPath(receiver: Receiver<{}>) {
+  return `${receiver.entityPath}/$DeadLetterQueue`;
+}

--- a/sdk/servicebus/service-bus/test/utils/transitional.ts
+++ b/sdk/servicebus/service-bus/test/utils/transitional.ts
@@ -1,8 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-import { Receiver } from "../../src/receivers/receiver";
-
-export function getDeadLetterPath(receiver: Receiver<{}>) {
-  return `${receiver.entityPath}/$DeadLetterQueue`;
-}


### PR DESCRIPTION
This PR makes it so you can now create dead letter receivers and subscription rule management from the client, removing some clutter that was appearing on the Receiver interface.

Fixes #7815 
Fixes #1424 