### PR TITLE
[service-bus] deadletter() changes for API compliance and bugs

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ## 2.0.0-preview.1 (Unreleased)
 
-- Fixes [bug 7598][https://github.com/azure/azure-sdk-for-js/issues/7958] where the dead letter error and description could be populated
-  incorrectly.
+- Fixes [bug 7598][https://github.com/azure/azure-sdk-for-js/issues/7958] where the dead letter error and description could be populated incorrectly.
 
 ### Breaking Changes
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.0.0-preview.1 (Unreleased)
 
+- Fixes [bug 7598][https://github.com/azure/azure-sdk-for-js/issues/7958] where the dead letter error and description could be populated
+  incorrectly.
+
 ### Breaking Changes
 
 - Fixes [bug 6816](https://github.com/Azure/azure-sdk-for-js/issues/6816) affecting messages sent using the `scheduleMessage()` and `scheduleMessages()` methods. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
@@ -11,7 +14,7 @@
 
 - Updated to use the latest version of `@azure/amqp-common` where the timeout for authorization requests sent to the service is increased from 10s to 60s to reduce the frequency of timeout errors.
   [PR 7823](https://github.com/Azure/azure-sdk-for-js/issues/7823).
-  
+
 ## 1.1.3 (2020-02-11)
 
 - Fixes issue where the promise returned by `receiveMessages` would sometimes fail to settle when the underlying connection

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -41,7 +41,7 @@ export { DataTransformer }
 // @public
 export interface DeadLetterOptions {
     deadLetterErrorDescription: string;
-    deadletterReason: string;
+    deadLetterReason: string;
 }
 
 export { delay }
@@ -96,7 +96,9 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
         [key: string]: any;
     }): Promise<void>;
     complete(): Promise<void>;
-    deadLetter(options?: DeadLetterOptions): Promise<void>;
+    deadLetter(options?: DeadLetterOptions & {
+        [key: string]: any;
+    }): Promise<void>;
     defer(propertiesToModify?: {
         [key: string]: any;
     }): Promise<void>;

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -124,7 +124,7 @@ export interface DeadLetterOptions {
   /**
    * @property The reason for deadlettering the message.
    */
-  deadletterReason: string;
+  deadLetterReason: string;
   /**
    * @property The error description for deadlettering the message.
    */
@@ -558,7 +558,7 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
    *
    * @returns Promise<void>
    */
-  deadLetter(options?: DeadLetterOptions): Promise<void>;
+  deadLetter(options?: DeadLetterOptions & { [key: string]: any }): Promise<void>;
 
   /**
    * Renews the lock on the message for the duration as specified during the Queue/Subscription
@@ -983,14 +983,19 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   /**
    * See ReceivedMessageWithLock.deadLetter().
    */
-  async deadLetter(options?: DeadLetterOptions): Promise<void> {
+  async deadLetter(propertiesToModify?: DeadLetterOptions & { [key: string]: any }): Promise<void> {
     const error: AmqpError = {
       condition: Constants.deadLetterName
     };
-    if (options) {
+
+    if (
+      propertiesToModify &&
+      (propertiesToModify.deadLetterReason != null ||
+        propertiesToModify.deadLetterErrorDescription != null)
+    ) {
       error.info = {
-        DeadLetterReason: options.deadletterReason,
-        DeadLetterErrorDescription: options.deadLetterErrorDescription
+        DeadLetterReason: propertiesToModify.deadLetterReason,
+        DeadLetterErrorDescription: propertiesToModify.deadLetterErrorDescription
       };
     }
     log.message(
@@ -998,13 +1003,25 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
       this._context.namespace.connectionId,
       this.messageId
     );
+
+    const actualPropertiesToModify: Partial<DeadLetterOptions> = {
+      ...propertiesToModify
+    };
+
+    // these two fields are handled specially and don't need to be in here.
+    delete actualPropertiesToModify.deadLetterErrorDescription;
+    delete actualPropertiesToModify.deadLetterReason;
+
+    // this handles deferred messages that have been received via the management link
+    // and thus need to be settled there.
     if (this._context.requestResponseLockedMessages.has(this.lockToken!)) {
       await this._context.managementClient!.updateDispositionStatus(
         this.lockToken!,
         DispositionStatus.suspended,
         {
-          deadLetterReason: error.condition,
-          deadLetterDescription: error.description,
+          propertiesToModify: actualPropertiesToModify,
+          deadLetterReason: propertiesToModify?.deadLetterReason,
+          deadLetterDescription: propertiesToModify?.deadLetterErrorDescription,
           sessionId: this.sessionId
         }
       );
@@ -1017,6 +1034,7 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
     this.throwIfMessageCannotBeSettled(receiver, DispositionType.deadletter);
 
     return receiver!.settleMessage(this, DispositionType.deadletter, {
+      propertiesToModify: actualPropertiesToModify,
       error: error
     });
   }

--- a/sdk/servicebus/service-bus/test/deadLetter.spec.ts
+++ b/sdk/servicebus/service-bus/test/deadLetter.spec.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import chai from "chai";
+const should = chai.should();
+
+import { createServiceBusClientForTests } from "./utils/testutils2";
+import { TestClientType } from "./utils/testUtils";
+import { Receiver, ReceivedMessage, ReceivedMessageWithLock } from "../src";
+
+describe("dead lettering", () => {
+  let serviceBusClient: ReturnType<typeof createServiceBusClientForTests>;
+  let deadLetterReceiver: Receiver<ReceivedMessage>;
+  let receiver: Receiver<ReceivedMessageWithLock>;
+  let receivedMessage: ReceivedMessageWithLock;
+
+  before(() => {
+    serviceBusClient = createServiceBusClientForTests();
+  });
+
+  after(async () => {
+    await serviceBusClient.test.after();
+  });
+
+  beforeEach(async function() {
+    const entityNames = await serviceBusClient.test.createTestEntities(
+      TestClientType.UnpartitionedQueue
+    );
+
+    if (entityNames.queue == null) {
+      throw new Error("Specifically asked for a queue");
+    }
+
+    // send a test message with the body being the title of the test (for something unique)
+    const sender = serviceBusClient.test.addToCleanup(
+      serviceBusClient.getSender(entityNames.queue)
+    );
+
+    await sender.send({
+      body: this.currentTest?.title
+    });
+
+    deadLetterReceiver = serviceBusClient.test.addToCleanup(
+      // receiveAndDelete since I don't care about further settlement after it's been dead lettered!
+      serviceBusClient.getDeadLetterReceiver(entityNames.queue, "receiveAndDelete")
+    );
+
+    receiver = serviceBusClient.test.getPeekLockReceiver(entityNames);
+
+    const receivedMessages = await receiver.receiveBatch(1, {
+      maxWaitTimeSeconds: 1
+    });
+
+    if (receivedMessages.length == 0) {
+      throw new Error("No messages were received");
+    }
+
+    receivedMessage = receivedMessages[0];
+  });
+
+  afterEach(async () => {
+    await serviceBusClient.test.afterEach();
+  });
+
+  // dead lettering a deferred message actually goes down a different code path
+  // than dead lettering a message received any other way since it uses the
+  // management link.
+  it("dead lettering a deferred message", async () => {
+    // defer this message so we can pick it up via the management API
+    await receivedMessage.defer();
+
+    const deferredMessage = await receiver.receiveDeferredMessage(receivedMessage.sequenceNumber!);
+
+    await deferredMessage!.deadLetter({
+      deadLetterErrorDescription: "this is the dead letter error description (was deferred)",
+      deadLetterReason: "this is the dead letter reason (was deferred)",
+      customProperty: "hello, setting this custom property"
+    });
+
+    // now from the dead letter queue....
+    await checkDeadLetteredMessage({
+      reason: "this is the dead letter reason (was deferred)",
+      description: "this is the dead letter error description (was deferred)",
+      customProperty: "hello, setting this custom property"
+    });
+  });
+
+  it("dead lettering a typical received message", async () => {
+    // defer this message so we can pick it up via the management API (which
+    // is what handles receiving deferred messages)
+    await receivedMessage.deadLetter({
+      deadLetterErrorDescription: "this is the dead letter error description",
+      deadLetterReason: "this is the dead letter reason",
+      customProperty: "hello, setting this custom property"
+    });
+
+    // now from the dead letter queue....
+    await checkDeadLetteredMessage({
+      reason: "this is the dead letter reason",
+      description: "this is the dead letter error description",
+      // TODO: https://github.com/Azure/azure-sdk-for-js/issues/7959
+      customProperty: undefined
+    });
+  });
+
+  async function checkDeadLetteredMessage(expected: {
+    reason: string;
+    description: string;
+    customProperty?: string;
+  }) {
+    const deadLetterMessages = await deadLetterReceiver.receiveBatch(1);
+    should.exist(deadLetterMessages[0]);
+
+    const reason = deadLetterMessages[0]!.userProperties!["DeadLetterReason"];
+    const description = deadLetterMessages[0]!.userProperties!["DeadLetterErrorDescription"];
+    const customProperty = deadLetterMessages[0]!.userProperties!["customProperty"];
+
+    should.equal(reason, expected.reason);
+    should.equal(description, expected.description);
+    should.equal(customProperty, expected.customProperty);
+  }
+});


### PR DESCRIPTION
deadLetter() changes and fixes!

- Function arguments have now been made consistent with the other settlement methods - it takes a propertiesToModify with two extra named fields called out (deadLetterReason, deadLetterErrorDescription) but is otherwise just an object.
- Fixed bug where it wasn't actually setting the error description and reason when the message being settled was a deferred message.
- Fixed a similar bug where it wasn't properly setting custom properties either. There's more to do here, filed as issue 7959.

Sundry:
- There was a slight (but annoying) mis-casing in the DeadLetterOptions for deadLetterReason

Fixes #7958