### PR TITLE
[core-http] Support text/plain request endpoints

### DIFF
--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -506,6 +506,7 @@ export function serializeRequestBody(
     const bodyMapper = operationSpec.requestBody.mapper;
     const { required, xmlName, xmlElementName, serializedName } = bodyMapper;
     const typeName = bodyMapper.type.name;
+
     try {
       if (httpRequest.body != undefined || required) {
         const requestBodyParameterPathString: string = getPathStringFromParameter(
@@ -516,7 +517,9 @@ export function serializeRequestBody(
           httpRequest.body,
           requestBodyParameterPathString
         );
+
         const isStream = typeName === MapperType.Stream;
+
         if (operationSpec.isXML) {
           if (typeName === MapperType.Sequence) {
             httpRequest.body = stringifyXML(
@@ -531,6 +534,10 @@ export function serializeRequestBody(
               rootName: xmlName || serializedName
             });
           }
+        } else if (typeName === "String" && operationSpec.contentType?.match("text/plain")) {
+          // the String serializer has validated that request body is a string
+          // so just send the string.
+          return;
         } else if (!isStream) {
           httpRequest.body = JSON.stringify(httpRequest.body);
         }

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -534,7 +534,7 @@ export function serializeRequestBody(
               rootName: xmlName || serializedName
             });
           }
-        } else if (typeName === "String" && operationSpec.contentType?.match("text/plain")) {
+        } else if (typeName === MapperType.String && operationSpec.contentType?.match("text/plain")) {
           // the String serializer has validated that request body is a string
           // so just send the string.
           return;

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -575,6 +575,34 @@ describe("ServiceClient", function() {
       );
       assert.strictEqual(httpRequest.body, "body value");
     });
+
+    it("should serialize a string send to a text/plain endpoint as just a string", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          contentType: "text/plain; charset=UTF-8",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperType.String
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer()
+        }
+      );
+      assert.strictEqual(httpRequest.body, "body value");
+    });
   });
 
   describe("getOperationArgumentValueFromParameterPath()", () => {


### PR DESCRIPTION
This small change avoids JSON.stringifying strings when sending them to text/plain endpoints.

This will work assuming it is expected that an operation spec for a text/plain endpoint should have a contentType including `text/plain`, which is presently not the case in the latest autorest.