### PR TITLE
[core-http] Fix default deserialization policy

### DIFF
--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -58,7 +58,7 @@ export function deserializationPolicy(
   };
 }
 
-export const defaultJsonContentTypes = ["application/json", "text/json", "text/plain"];
+export const defaultJsonContentTypes = ["application/json", "text/json"];
 export const defaultXmlContentTypes = ["application/xml", "application/atom+xml"];
 
 export const DefaultDeserializationOptions: DeserializationOptions = {

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -39,7 +39,17 @@ export class IdentityClient extends ServiceClient {
 
   constructor(options?: TokenCredentialOptions) {
     options = options || IdentityClient.getDefaultOptions();
-    super(undefined, createPipelineFromOptions(options));
+    super(
+      undefined,
+      createPipelineFromOptions({
+        ...options,
+        deserializationOptions: {
+          expectedContentTypes: {
+            json: ["application/json", "text/json", "text/plain"]
+          }
+        }
+      })
+    );
 
     this.baseUri = this.authorityHost = options.authorityHost || DefaultAuthorityHost;
 

--- a/sdk/search/search/src/searchIndexClient.ts
+++ b/sdk/search/search/src/searchIndexClient.ts
@@ -129,11 +129,6 @@ export class SearchIndexClient<T> {
             "Prefer",
             "throttle-reason"
           ]
-        },
-        deserializationOptions: {
-          expectedContentTypes: {
-            json: ["application/json", "text/json"]
-          }
         }
       }
     };

--- a/sdk/search/search/src/searchServiceClient.ts
+++ b/sdk/search/search/src/searchServiceClient.ts
@@ -114,11 +114,6 @@ export class SearchServiceClient {
             "Prefer",
             "throttle-reason"
           ]
-        },
-        deserializationOptions: {
-          expectedContentTypes: {
-            json: ["application/json", "text/json"]
-          }
         }
       }
     };


### PR DESCRIPTION
Replaces the fix done by #4975 to only apply to the identity package.

This prevents clients that have text/plain endpoints from getting serialization errors with the defaults.