### PR TITLE
[event-hubs] set known amqp props on systemProperties

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.0.3 (Unreleased)
 
 - Fixes an issue where known properties were not being set on a received event's `systemProperties`.
+  ([PR #7973](https://github.com/Azure/azure-sdk-for-js/pull/7973))
 
 ## 5.0.2 (2020-03-09)
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 5.0.3 (Unreleased)
 
+- Fixes an issue where known properties were not being set on a received event's `systemProperties`.
 
 ## 5.0.2 (2020-03-09)
 

--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Release History
 
-## 5.0.3 (Unreleased)
+## 5.1.0 (Unreleased)
 
-- Fixes an issue where known properties were not being set on a received event's `systemProperties`.
+- Addresses [issue #7801](https://github.com/Azure/azure-sdk-for-js/pull/7973) by moving known AMQP message properties to received events' `systemProperties`.
   ([PR #7973](https://github.com/Azure/azure-sdk-for-js/pull/7973))
 
 ## 5.0.2 (2020-03-09)

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/event-hubs",
   "sdk-type": "client",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "description": "Azure Event Hubs SDK for JS.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -110,7 +110,7 @@ export interface EventDataInternal {
   /**
    * @property [systemProperties] The properties set by the service.
    */
-  systemProperties: { [property: string]: any };
+  systemProperties?: { [property: string]: any };
 }
 
 const messagePropertiesMap = {
@@ -136,8 +136,7 @@ const messagePropertiesMap = {
  */
 export function fromAmqpMessage(msg: Message): EventDataInternal {
   const data: EventDataInternal = {
-    body: msg.body,
-    systemProperties: {}
+    body: msg.body
   };
 
   if (msg.message_annotations) {
@@ -156,6 +155,9 @@ export function fromAmqpMessage(msg: Message): EventDataInternal {
           data.offset = msg.message_annotations[annotationKey];
           break;
         default:
+          if (!data.systemProperties) {
+            data.systemProperties = {};
+          }
           data.systemProperties[annotationKey] = msg.message_annotations[annotationKey];
           break;
       }
@@ -177,6 +179,9 @@ export function fromAmqpMessage(msg: Message): EventDataInternal {
     keyof typeof messagePropertiesMap
   >;
   for (const messageProperty of messageProperties) {
+    if (!data.systemProperties) {
+      data.systemProperties = {};
+    }
     if (msg[messageProperty] != null) {
       data.systemProperties[messagePropertiesMap[messageProperty]] = msg[messageProperty];
     }

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -6,5 +6,5 @@
  */
 export const packageJsonInfo = {
   name: "@azure/event-hubs",
-  version: "5.0.3"
+  version: "5.1.0"
 };

--- a/sdk/eventhub/event-hubs/test/eventdata.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventdata.spec.ts
@@ -89,6 +89,47 @@ describe("EventData #RunnableInBrowser", function(): void {
         testEventData.systemProperties!["x-iot-foo-prop"] = extraAnnotations["x-iot-foo-prop"];
         testEventData.systemProperties!["x-iot-bar-prop"] = extraAnnotations["x-iot-bar-prop"];
       });
+
+      it("returns systemProperties for special known properties", function(): void {
+        const testEventData = fromAmqpMessage({
+          body: testBody,
+          application_properties: applicationProperties,
+          message_annotations: testAnnotations,
+          message_id: "messageId",
+          user_id: "userId",
+          to: "to",
+          subject: "subject",
+          reply_to: "replyTo",
+          reply_to_group_id: "replyToGroupId",
+          content_encoding: "utf-8",
+          content_type: "application/json",
+          correlation_id: "id2",
+          absolute_expiry_time: 0,
+          creation_time: 0,
+          group_id: "groupId",
+          group_sequence: 1
+        });
+
+        testEventData
+          .enqueuedTimeUtc!.getTime()
+          .should.equal(testAnnotations["x-opt-enqueued-time"]);
+        testEventData.offset!.should.equal(testAnnotations["x-opt-offset"]);
+        testEventData.sequenceNumber!.should.equal(testAnnotations["x-opt-sequence-number"]);
+        testEventData.partitionKey!.should.equal(testAnnotations["x-opt-partition-key"]);
+        testEventData.systemProperties!["messageId"].should.equal("messageId");
+        testEventData.systemProperties!["userId"].should.equal("userId");
+        testEventData.systemProperties!["to"].should.equal("to");
+        testEventData.systemProperties!["subject"].should.equal("subject");
+        testEventData.systemProperties!["replyTo"].should.equal("replyTo");
+        testEventData.systemProperties!["replyToGroupId"].should.equal("replyToGroupId");
+        testEventData.systemProperties!["contentEncoding"].should.equal("utf-8");
+        testEventData.systemProperties!["contentType"].should.equal("application/json");
+        testEventData.systemProperties!["correlationId"].should.equal("id2");
+        testEventData.systemProperties!["absoluteExpiryTime"].should.equal(0);
+        testEventData.systemProperties!["creationTime"].should.equal(0);
+        testEventData.systemProperties!["groupId"].should.equal("groupId");
+        testEventData.systemProperties!["groupSequence"].should.equal(1);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #7801 

Since `systemProperties` was already an object with an index signature of string to any, no API changes were needed to support this.

It also turned out every one of the properties added is a typed field on the amqp message.