### PR TITLE
[core-http] Support dashes in parameter names

### DIFF
--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -318,7 +318,7 @@ export class WebResource implements WebResourceLike {
         baseUrl +
         (baseUrl.endsWith("/") ? "" : "/") +
         (pathTemplate.startsWith("/") ? pathTemplate.slice(1) : pathTemplate);
-      const segments = url.match(/({\w*\s*\w*})/gi);
+      const segments = url.match(/({[\w\-]*\s*[\w\-]*})/gi);
       if (segments && segments.length) {
         if (!pathParameters) {
           throw new Error(

--- a/sdk/core/core-http/test/webResourceTests.ts
+++ b/sdk/core/core-http/test/webResourceTests.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { assert } from "chai";
+import { WebResource, RequestPrepareOptions } from "../src/webResource";
+
+describe("WebResource", function() {
+  it("supports dash in parameter name", function(done) {
+    const options: RequestPrepareOptions = {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      method: "GET",
+      url: "",
+      pathTemplate: "/pet/{pet-name}/{one-friend-name}",
+      pathParameters: {
+        "pet-name": "tom",
+        "one-friend-name": "jerry"
+      }
+    };
+    var request = new WebResource();
+    request = request.prepare(options);
+    assert.equal(request.url, "https://management.azure.com/pet/tom/jerry");
+    done();
+  });
+});

--- a/sdk/core/core-http/test/webResourceTests.ts
+++ b/sdk/core/core-http/test/webResourceTests.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 import { WebResource, RequestPrepareOptions } from "../src/webResource";
 
 describe("WebResource", function() {
-  it("supports dash in parameter name", function(done) {
+  it("supports dash in parameter name", function() {
     const options: RequestPrepareOptions = {
       headers: {
         "Content-Type": "application/x-www-form-urlencoded"
@@ -18,9 +18,8 @@ describe("WebResource", function() {
         "one-friend-name": "jerry"
       }
     };
-    var request = new WebResource();
+    let request = new WebResource();
     request = request.prepare(options);
     assert.equal(request.url, "https://management.azure.com/pet/tom/jerry");
-    done();
   });
 });


### PR DESCRIPTION
Porting fix from Azure/azure-sdk-for-node#5143