### PR TITLE
[Storage] disable decompression of response when downloading

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -42,7 +42,7 @@
    */
   "allowedAlternativeVersions": {
     "@azure/ms-rest-js": ["^2.0.0"],
-    "@azure/core-http": ["^1.0.3"],
+    "@azure/core-http": ["^1.1.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/sdk/storage/storage-blob/README.md
+++ b/sdk/storage/storage-blob/README.md
@@ -67,6 +67,8 @@ This library depends on following ES features which need external polyfills load
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.
 
+- If a blob holds compressed data in `gzip` or `deflate` format and its content encoding is set accordingly, downloading behavior is different between Node.js and browsers. In Node.js storage clients will download the blob in its compressed format, while in browsers the data will be downloaded in de-compressed format.
+
 ##### Features, interfaces, classes or functions only available in Node.js
 
 - Shared Key Authorization based on account name and account key

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-blob",
   "sdk-type": "client",
-  "version": "12.1.2",
+  "version": "12.2.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Blob",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.1.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json && npm run build:types",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.3",
+    "@azure/core-http": "^1.1.0",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.7",

--- a/sdk/storage/storage-blob/recordings/node/blockblobclient_nodejs_only/recording_should_not_decompress_during_downloading.js
+++ b/sdk/storage/storage-blob/recordings/node/blockblobclient_nodejs_only/recording_should_not_decompress_during_downloading.js
@@ -1,0 +1,164 @@
+let nock = require('nock');
+
+module.exports.hash = "7340ea41fe9f44e79cf3b53f20578eab";
+
+module.exports.testInfo = {"uniqueName":{"container":"container158508695592200020","blob":"blob158508695710201278"},"newDate":{}}
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158508695592200020')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:55:56 GMT',
+  'ETag',
+  '"0x8D7D03E21B6DEB7"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'a39b5f39-d01e-0042-5026-02588f000000',
+  'x-ms-client-request-id',
+  '057f1ef1-50bb-437c-87dc-5bf496cbb96b',
+  'x-ms-version',
+  '2019-07-07',
+  'Date',
+  'Tue, 24 Mar 2020 21:55:56 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/container158508695592200020/blob158508695710201278', "789ccb48cdc9c95728cf2fca495148ca4fa954282e29cacc4b57040072de0903")
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'BYN1kjvCGsjiR9sU4v87xg==',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:55:56 GMT',
+  'ETag',
+  '"0x8D7D03E21C8F09C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'a39b5f7d-d01e-0042-0e26-02588f000000',
+  'x-ms-client-request-id',
+  '13e53506-6afd-4098-a3e9-c3db6882cdd0',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-content-crc64',
+  'KLRKd44qFFQ=',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Tue, 24 Mar 2020 21:55:56 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/container158508695592200020/blob158508695710201278')
+  .reply(200, [], [
+  'Content-Length',
+  '32',
+  'Content-Type',
+  'text/plain',
+  'Content-Encoding',
+  'deflate',
+  'Content-MD5',
+  'BYN1kjvCGsjiR9sU4v87xg==',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:55:56 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7D03E21C8F09C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'a39b60b5-d01e-0042-1f26-02588f000000',
+  'x-ms-client-request-id',
+  'f76e6006-e87a-4c36-8bc6-a5f357b06e06',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-creation-time',
+  'Tue, 24 Mar 2020 21:55:56 GMT',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-access-tier',
+  'Cool',
+  'x-ms-access-tier-inferred',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Encoding,Last-Modified,ETag,x-ms-creation-time,Content-MD5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,x-ms-access-tier,x-ms-access-tier-inferred,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 24 Mar 2020 21:55:57 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/container158508695592200020/blob158508695710201278')
+  .reply(206, ["789ccb48cdc9c95728cf2fca495148ca4fa954282e29cacc4b57040072de0903"], [
+  'Content-Length',
+  '32',
+  'Content-Type',
+  'text/plain',
+  'Content-Encoding',
+  'deflate',
+  'Content-Range',
+  'bytes 0-31/32',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:55:56 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7D03E21C8F09C"',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'a39b6179-d01e-0042-5226-02588f000000',
+  'x-ms-client-request-id',
+  '765ac405-9ded-4a15-b2f6-c0588b1ddbf2',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-creation-time',
+  'Tue, 24 Mar 2020 21:55:56 GMT',
+  'x-ms-blob-content-md5',
+  'BYN1kjvCGsjiR9sU4v87xg==',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-blob-type',
+  'BlockBlob',
+  'x-ms-server-encrypted',
+  'true',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Encoding,Last-Modified,ETag,x-ms-creation-time,x-ms-blob-content-md5,x-ms-lease-status,x-ms-lease-state,x-ms-blob-type,x-ms-server-encrypted,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 24 Mar 2020 21:55:57 GMT'
+]);
+
+nock('https://fakestorageaccount.blob.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/container158508695592200020')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  'a39b61b3-d01e-0042-0526-02588f000000',
+  'x-ms-client-request-id',
+  'ded5ad3c-34e1-4bfb-8b5f-d4b119677a61',
+  'x-ms-version',
+  '2019-07-07',
+  'Date',
+  'Tue, 24 Mar 2020 21:55:57 GMT'
+]);

--- a/sdk/storage/storage-blob/rollup.base.config.js
+++ b/sdk/storage/storage-blob/rollup.base.config.js
@@ -71,7 +71,7 @@ export function nodeConfig(test = false) {
     baseConfig.output.file = "dist-test/index.node.js";
 
     // mark assert as external
-    baseConfig.external.push("assert", "fs", "path");
+    baseConfig.external.push("assert", "fs", "path", "buffer", "zlib");
 
     baseConfig.context = "null";
 

--- a/sdk/storage/storage-blob/src/Pipeline.ts
+++ b/sdk/storage/storage-blob/src/Pipeline.ts
@@ -4,6 +4,7 @@
 import {
   BaseRequestPolicy,
   deserializationPolicy,
+  disableResponseDecompressionPolicy,
   HttpClient as IHttpClient,
   HttpHeaders,
   HttpOperationResponse,
@@ -206,8 +207,9 @@ export function newPipeline(
   ];
 
   if (isNode) {
-    // ProxyPolicy is only avaiable in Node.js runtime, not in browsers
+    // policies only avaiable in Node.js runtime, not in browsers
     factories.push(proxyPolicy(pipelineOptions.proxyOptions));
+    factories.push(disableResponseDecompressionPolicy());
   }
   factories.push(
     isTokenCredential(credential)

--- a/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-blob/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-blob";
-const packageVersion = "12.1.1";
+const packageVersion = "12.2.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;

--- a/sdk/storage/storage-blob/src/utils/constants.ts
+++ b/sdk/storage/storage-blob/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.1.2";
+export const SDK_VERSION: string = "12.2.0";
 export const SERVICE_VERSION: string = "2019-07-07";
 
 export const BLOCK_BLOB_MAX_UPLOAD_BLOB_BYTES: number = 256 * 1024 * 1024; // 256MB

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -153,7 +153,7 @@ describe("BlockBlobClient Node.js only", () => {
     assert.deepStrictEqual(await bodyToString(result, body.length), body);
   });
 
-  it.only("should not decompress during downloading", async () => {
+  it("should not decompress during downloading", async () => {
     const body: string = "hello world body string!";
     const deflated = zlib.deflateSync(body);
 

--- a/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/blockblobclient.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as zlib from "zlib";
 
 import {
   bodyToString,
@@ -150,5 +151,20 @@ describe("BlockBlobClient Node.js only", () => {
     await newClient.upload(body, body.length);
     const result = await newClient.download(0);
     assert.deepStrictEqual(await bodyToString(result, body.length), body);
+  });
+
+  it.only("should not decompress during downloading", async () => {
+    const body: string = "hello world body string!";
+    const deflated = zlib.deflateSync(body);
+
+    await blockBlobClient.upload(deflated, deflated.byteLength, {
+      blobHTTPHeaders: {
+        blobContentEncoding: "deflate",
+        blobContentType: "text/plain",
+      },
+    });
+
+    const downloaded = await blockBlobClient.downloadToBuffer();
+    assert.deepStrictEqual(downloaded, deflated);
   });
 });

--- a/sdk/storage/storage-file-datalake/README.md
+++ b/sdk/storage/storage-file-datalake/README.md
@@ -65,6 +65,8 @@ This library depends on following ES features which need external polyfills load
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.
 
+- If a file holds compressed data in `gzip` or `deflate` format and its content encoding is set accordingly, downloading behavior is different between Node.js and browsers. In Node.js storage clients will download the file in its compressed format, while in browsers the data will be downloaded in de-compressed format.
+
 ##### Features, interfaces, classes or functions only available in Node.js
 
 - Shared Key Authorization based on account name and account key

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/storage-file-datalake",
-  "version": "12.0.1",
+  "version": "12.1.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - DataLake",
   "sdk-type": "client",
   "main": "./dist/index.js",
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.3",
+    "@azure/core-http": "^1.1.0",
     "@azure/core-paging": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-datalake/src/Pipeline.ts
+++ b/sdk/storage/storage-file-datalake/src/Pipeline.ts
@@ -2,6 +2,7 @@ import {
   BaseRequestPolicy,
   bearerTokenAuthenticationPolicy,
   deserializationPolicy,
+  disableResponseDecompressionPolicy,
   generateClientRequestIdPolicy,
   HttpClient as IHttpClient,
   HttpHeaders,
@@ -208,8 +209,9 @@ export function newPipeline(
   ];
 
   if (isNode) {
-    // ProxyPolicy is only avaiable in Node.js runtime, not in browsers
+    // policies only avaiable in Node.js runtime, not in browsers
     factories.push(proxyPolicy(pipelineOptions.proxyOptions));
+    factories.push(disableResponseDecompressionPolicy());
   }
   factories.push(
     isTokenCredential(credential)

--- a/sdk/storage/storage-file-datalake/src/utils/constants.ts
+++ b/sdk/storage/storage-file-datalake/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.0.1";
+export const SDK_VERSION: string = "12.1.0";
 export const SERVICE_VERSION: string = "2019-07-07";
 
 export const KB: number = 1024;

--- a/sdk/storage/storage-file-share/README.md
+++ b/sdk/storage/storage-file-share/README.md
@@ -67,6 +67,8 @@ This library depends on following ES features which need external polyfills load
 
 There are differences between Node.js and browsers runtime. When getting started with this library, pay attention to APIs or classes marked with _"ONLY AVAILABLE IN NODE.JS RUNTIME"_ or _"ONLY AVAILABLE IN BROWSERS"_.
 
+- If a file holds compressed data in `gzip` or `deflate` format and its content encoding is set accordingly, downloading behavior is different between Node.js and browsers. In Node.js storage clients will download the file in its compressed format, while in browsers the data will be downloaded in de-compressed format.
+
 ##### Following features, interfaces, classes or functions are only available in Node.js
 
 - Shared Key Authorization based on account name and account key

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-file-share",
   "sdk-type": "client",
-  "version": "12.1.2",
+  "version": "12.2.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - File",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.1.1 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.2.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json && npm run build:types",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.3",
+    "@azure/core-http": "^1.1.0",
     "@azure/core-paging": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-share/recordings/node/fileclient_nodejs_only/recording_should_not_decompress_during_downloading.js
+++ b/sdk/storage/storage-file-share/recordings/node/fileclient_nodejs_only/recording_should_not_decompress_during_downloading.js
@@ -1,0 +1,252 @@
+let nock = require('nock');
+
+module.exports.hash = "17fd3fa89da89d22bb8d9173f969e0f3";
+
+module.exports.testInfo = {"uniqueName":{"share":"share158508697009707283","dir":"dir158508697135305464","file":"file158508697164002099"},"newDate":{}}
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share158508697009707283')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:56:10 GMT',
+  'ETag',
+  '"0x8D7D03E2A1423DE"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '442d17e9-a01a-00ec-0427-027be2000000',
+  'x-ms-client-request-id',
+  '26271d04-c903-4e4f-8cab-98c7e9451714',
+  'x-ms-version',
+  '2019-07-07',
+  'Date',
+  'Tue, 24 Mar 2020 21:56:10 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share158508697009707283/dir158508697135305464')
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:56:11 GMT',
+  'ETag',
+  '"0x8D7D03E2A4604FC"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '442d17ec-a01a-00ec-0527-027be2000000',
+  'x-ms-client-request-id',
+  'c8913f14-ed47-4f5c-b0b8-621bec41b01c',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-file-change-time',
+  '2020-03-24T21:56:11.1996156Z',
+  'x-ms-file-last-write-time',
+  '2020-03-24T21:56:11.1996156Z',
+  'x-ms-file-creation-time',
+  '2020-03-24T21:56:11.1996156Z',
+  'x-ms-file-permission-key',
+  '4124527601788187190*5901512198059681215',
+  'x-ms-file-attributes',
+  'Directory',
+  'x-ms-file-id',
+  '13835128424026341376',
+  'x-ms-file-parent-id',
+  '0',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Tue, 24 Mar 2020 21:56:10 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share158508697009707283/dir158508697135305464/file158508697164002099')
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:56:11 GMT',
+  'ETag',
+  '"0x8D7D03E2A718C62"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '442d17ee-a01a-00ec-0627-027be2000000',
+  'x-ms-client-request-id',
+  'a24960a0-3b2d-4770-b533-14a9db5d4ed3',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-file-change-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-last-write-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-creation-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-permission-key',
+  '17962196248988912945*5901512198059681215',
+  'x-ms-file-attributes',
+  'Archive',
+  'x-ms-file-id',
+  '11529285414812647424',
+  'x-ms-file-parent-id',
+  '13835128424026341376',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Tue, 24 Mar 2020 21:56:11 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .put('/share158508697009707283/dir158508697135305464/file158508697164002099', "789ccb48cdc9c95728cf2fca495148ca4fa954282e29cacc4b57040072de0903")
+  .query(true)
+  .reply(201, "", [
+  'Content-Length',
+  '0',
+  'Content-MD5',
+  'BYN1kjvCGsjiR9sU4v87xg==',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:56:11 GMT',
+  'ETag',
+  '"0x8D7D03E2A81479F"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '442d17ef-a01a-00ec-0727-027be2000000',
+  'x-ms-client-request-id',
+  '182a2888-fea1-4eb2-9fa7-e8102c893c0b',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-request-server-encrypted',
+  'true',
+  'Date',
+  'Tue, 24 Mar 2020 21:56:11 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .head('/share158508697009707283/dir158508697135305464/file158508697164002099')
+  .reply(200, [], [
+  'Content-Length',
+  '32',
+  'Content-Type',
+  'text/plain',
+  'Content-Encoding',
+  'deflate',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:56:11 GMT',
+  'ETag',
+  '"0x8D7D03E2A81479F"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '442d17f1-a01a-00ec-0827-027be2000000',
+  'x-ms-client-request-id',
+  '91ea62b7-7664-436d-a948-163088afb94b',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-type',
+  'File',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-file-change-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-last-write-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-creation-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-permission-key',
+  '17962196248988912945*5901512198059681215',
+  'x-ms-file-attributes',
+  'Archive',
+  'x-ms-file-id',
+  '11529285414812647424',
+  'x-ms-file-parent-id',
+  '13835128424026341376',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Encoding,Last-Modified,ETag,x-ms-type,x-ms-server-encrypted,x-ms-lease-status,x-ms-lease-state,x-ms-file-change-time,x-ms-file-last-write-time,x-ms-file-creation-time,x-ms-file-permission-key,x-ms-file-attributes,x-ms-file-id,x-ms-file-parent-id,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 24 Mar 2020 21:56:11 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .get('/share158508697009707283/dir158508697135305464/file158508697164002099')
+  .reply(206, ["789ccb48cdc9c95728cf2fca495148ca4fa954282e29cacc4b57040072de0903"], [
+  'Content-Length',
+  '32',
+  'Content-Type',
+  'text/plain',
+  'Content-Encoding',
+  'deflate',
+  'Content-Range',
+  'bytes 0-31/32',
+  'Last-Modified',
+  'Tue, 24 Mar 2020 21:56:11 GMT',
+  'Accept-Ranges',
+  'bytes',
+  'ETag',
+  '"0x8D7D03E2A81479F"',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '442d17f2-a01a-00ec-0927-027be2000000',
+  'x-ms-client-request-id',
+  '053d0cdf-41cd-4745-94b9-a4e3c7ec0780',
+  'x-ms-version',
+  '2019-07-07',
+  'x-ms-type',
+  'File',
+  'x-ms-server-encrypted',
+  'true',
+  'x-ms-lease-status',
+  'unlocked',
+  'x-ms-lease-state',
+  'available',
+  'x-ms-file-change-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-last-write-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-creation-time',
+  '2020-03-24T21:56:11.4848866Z',
+  'x-ms-file-permission-key',
+  '17962196248988912945*5901512198059681215',
+  'x-ms-file-attributes',
+  'Archive',
+  'x-ms-file-id',
+  '11529285414812647424',
+  'x-ms-file-parent-id',
+  '13835128424026341376',
+  'Access-Control-Expose-Headers',
+  'x-ms-request-id,x-ms-client-request-id,Server,x-ms-version,Content-Type,Content-Encoding,Last-Modified,ETag,x-ms-type,x-ms-server-encrypted,x-ms-lease-status,x-ms-lease-state,x-ms-file-change-time,x-ms-file-last-write-time,x-ms-file-creation-time,x-ms-file-permission-key,x-ms-file-attributes,x-ms-file-id,x-ms-file-parent-id,Content-Range,Accept-Ranges,Content-Length,Date,Transfer-Encoding',
+  'Access-Control-Allow-Origin',
+  '*',
+  'Date',
+  'Tue, 24 Mar 2020 21:56:11 GMT'
+]);
+
+nock('https://fakestorageaccount.file.core.windows.net:443', {"encodedQueryParams":true})
+  .delete('/share158508697009707283')
+  .query(true)
+  .reply(202, "", [
+  'Content-Length',
+  '0',
+  'Server',
+  'Windows-Azure-File/1.0 Microsoft-HTTPAPI/2.0',
+  'x-ms-request-id',
+  '442d17f4-a01a-00ec-0a27-027be2000000',
+  'x-ms-client-request-id',
+  'a9da0038-322a-4e36-b86b-fda639141548',
+  'x-ms-version',
+  '2019-07-07',
+  'Date',
+  'Tue, 24 Mar 2020 21:56:12 GMT'
+]);

--- a/sdk/storage/storage-file-share/rollup.base.config.js
+++ b/sdk/storage/storage-file-share/rollup.base.config.js
@@ -71,7 +71,7 @@ export function nodeConfig(test = false) {
     baseConfig.output.file = "dist-test/index.node.js";
 
     // mark assert as external
-    baseConfig.external.push("assert", "fs", "path");
+    baseConfig.external.push("assert", "fs", "path", "buffer", "zlib");
 
     baseConfig.context = "null";
 

--- a/sdk/storage/storage-file-share/src/Pipeline.ts
+++ b/sdk/storage/storage-file-share/src/Pipeline.ts
@@ -4,6 +4,7 @@
 import {
   BaseRequestPolicy,
   deserializationPolicy,
+  disableResponseDecompressionPolicy,
   HttpClient as IHttpClient,
   HttpHeaders,
   HttpOperationResponse,
@@ -199,8 +200,9 @@ export function newPipeline(
   ];
 
   if (isNode) {
-    // ProxyPolicy is only avaiable in Node.js runtime, not in browsers
+    // policies only avaiable in Node.js runtime, not in browsers
     factories.push(proxyPolicy(pipelineOptions.proxyOptions));
+    factories.push(disableResponseDecompressionPolicy());
   }
   factories.push(credential);
 

--- a/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-file-share/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-file-share";
-const packageVersion = "12.1.2";
+const packageVersion = "12.2.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   version: string;

--- a/sdk/storage/storage-file-share/src/utils/constants.ts
+++ b/sdk/storage/storage-file-share/src/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const SDK_VERSION: string = "12.1.2";
+export const SDK_VERSION: string = "12.2.0";
 export const SERVICE_VERSION: string = "2019-07-07";
 
 export const FILE_MAX_SIZE_BYTES: number = 1024 * 1024 * 1024 * 1024; // 1TB

--- a/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import { Buffer } from "buffer";
 import * as fs from "fs";
 import * as path from "path";
+import * as zlib from "zlib";
 import { Duplex } from "stream";
 
 import { record, Recorder } from "@azure/test-utils-recorder";
@@ -218,4 +219,20 @@ describe("FileClient Node.js only", () => {
     assert.equal(await bodyToString(range1, 512), "a".repeat(512));
     assert.equal(await bodyToString(range2, 512), "b".repeat(512));
   });
+
+  it.only("should not decompress during downloading", async () => {
+    const body: string = "hello world body string!";
+    const deflated = zlib.deflateSync(body);
+
+    await fileClient.uploadData(deflated, {
+      fileHttpHeaders: {
+        fileContentEncoding: "deflate",
+        fileContentType: "text/plain",
+      },
+    });
+
+    const downloaded = await fileClient.downloadToBuffer();
+    assert.deepStrictEqual(downloaded, deflated);
+  });
+
 });

--- a/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/node/fileclient.spec.ts
@@ -220,7 +220,7 @@ describe("FileClient Node.js only", () => {
     assert.equal(await bodyToString(range2, 512), "b".repeat(512));
   });
 
-  it.only("should not decompress during downloading", async () => {
+  it("should not decompress during downloading", async () => {
     const body: string = "hello world body string!";
     const deflated = zlib.deflateSync(body);
 

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/storage-queue",
   "sdk-type": "client",
-  "version": "12.0.5",
+  "version": "12.1.0",
   "description": "Microsoft Azure Storage SDK for JavaScript - Queue",
   "main": "./dist/index.js",
   "module": "./dist-esm/src/index.js",
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.0.4 --use=@microsoft.azure/autorest.typescript@5.0.1",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=12.1.0 --use=@microsoft.azure/autorest.typescript@5.0.1",
     "build:es6": "tsc -p tsconfig.json && npm run build:types",
     "build:nodebrowser": "rollup -c 2>&1",
     "build:samples": "npm run clean && npm run build:es6 && cross-env ONLY_NODE=true rollup -c 2>&1 && npm run build:prep-samples",
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.0.3",
+    "@azure/core-http": "^1.1.0",
     "@azure/core-paging": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
+++ b/sdk/storage/storage-queue/src/generated/src/storageClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "azure-storage-queue";
-const packageVersion = "12.0.5";
+const packageVersion = "12.1.0";
 
 export class StorageClientContext extends coreHttp.ServiceClient {
   url: string;


### PR DESCRIPTION
The default behavior of node-fetch client is to decompress according
to `Accept-Encoding` when retrieving data. In blob storage it is
supported to set the content encoding of blobs so that browsers and
other clients can decompress accordingly. However we don't want this
behavior in our SDK libraries, because

- there's inconsistency between incoming data and outgoing data. Most
customers would not expect `client.download()` would give them
different data than what they upload in compressed format.

- Retry for partial response would not work on the decompressed response.

This change disables the decompression behavior for storage clients in
NodeJS.

Note that for browsers we don't have control and browser will always
honor the `Accept-Encoding` header and decompress accordingly.

Related to #6411.