### PR TITLE
[Service Bus] Fix sendBatch test's cleanup failure for sessions

### DIFF
--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -181,7 +181,7 @@ describe("Send Batch", () => {
       await testSendBatch(true);
     });
     */
-    for (let iter = 0; iter < 1000; iter++) {
+    for (let iter = 0; iter < 100; iter++) {
       it(`Iteration #${iter} - Unpartitioned Queue with Sessions: SendBatch`, async function(): Promise<
         void
       > {
@@ -190,7 +190,7 @@ describe("Send Batch", () => {
       });
     }
 
-    for (let iter = 0; iter < 1000; iter++) {
+    for (let iter = 0; iter < 100; iter++) {
       it(`Iteration #${iter} - Unpartitioned Topic with Sessions: SendBatch`, async function(): Promise<
         void
       > {

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -181,6 +181,7 @@ describe("Send Batch", () => {
       await testSendBatch(true);
     });
     */
+
     it("Unpartitioned Queue with Sessions: SendBatch", async function(): Promise<void> {
       await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
       await testSendBatch(true);

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -125,7 +125,7 @@ describe("Send Batch", () => {
     });
   });
 
-  describe("Send multiple homogeneous messages - Multiple Sessions - size > max_batch_size_allowed", function(): void {
+  describe.only("Send multiple homogeneous messages - Multiple Sessions - size > max_batch_size_allowed", function(): void {
     afterEach(async () => {
       await afterEachTest();
     });
@@ -181,16 +181,23 @@ describe("Send Batch", () => {
       await testSendBatch(true);
     });
     */
+    for (let iter = 0; iter < 1000; iter++) {
+      it(`Iteration #${iter} - Unpartitioned Queue with Sessions: SendBatch`, async function(): Promise<
+        void
+      > {
+        await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
+        await testSendBatch(true);
+      });
+    }
 
-    it("Unpartitioned Queue with Sessions: SendBatch", async function(): Promise<void> {
-      await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
-      await testSendBatch(true);
-    });
-
-    it("Unpartitioned Topic with Sessions: SendBatch", async function(): Promise<void> {
-      await beforeEachTest(TestClientType.UnpartitionedSubscriptionWithSessions);
-      await testSendBatch(true);
-    });
+    for (let iter = 0; iter < 1000; iter++) {
+      it(`Iteration #${iter} - Unpartitioned Topic with Sessions: SendBatch`, async function(): Promise<
+        void
+      > {
+        await beforeEachTest(TestClientType.UnpartitionedSubscriptionWithSessions);
+        await testSendBatch(true);
+      });
+    }
   });
 
   describe("Send multiple homogeneous messages - size < max_batch_size_allowed", function(): void {

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -125,7 +125,7 @@ describe("Send Batch", () => {
     });
   });
 
-  describe.only("Send multiple homogeneous messages - Multiple Sessions - size > max_batch_size_allowed", function(): void {
+  describe("Send multiple homogeneous messages - Multiple Sessions - size > max_batch_size_allowed", function(): void {
     afterEach(async () => {
       await afterEachTest();
     });
@@ -181,23 +181,15 @@ describe("Send Batch", () => {
       await testSendBatch(true);
     });
     */
-    for (let iter = 0; iter < 100; iter++) {
-      it(`Iteration #${iter} - Unpartitioned Queue with Sessions: SendBatch`, async function(): Promise<
-        void
-      > {
-        await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
-        await testSendBatch(true);
-      });
-    }
+    it("Unpartitioned Queue with Sessions: SendBatch", async function(): Promise<void> {
+      await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
+      await testSendBatch(true);
+    });
 
-    for (let iter = 0; iter < 100; iter++) {
-      it(`Iteration #${iter} - Unpartitioned Topic with Sessions: SendBatch`, async function(): Promise<
-        void
-      > {
-        await beforeEachTest(TestClientType.UnpartitionedSubscriptionWithSessions);
-        await testSendBatch(true);
-      });
-    }
+    it("Unpartitioned Topic with Sessions: SendBatch", async function(): Promise<void> {
+      await beforeEachTest(TestClientType.UnpartitionedSubscriptionWithSessions);
+      await testSendBatch(true);
+    });
   });
 
   describe("Send multiple homogeneous messages - size < max_batch_size_allowed", function(): void {

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -184,7 +184,7 @@ export class ServiceBusTestHelpers {
         });
         const msgs = await receiverClient.receiveBatch(numOfMsgsWithSessionId[id], {
           // Since we know the exact number of messages to be received per session-id,
-          //   `maxWaitTimeSeconds` being a higher number is not a problem
+          //   a higher `maxWaitTimeSeconds` is not a problem
           maxWaitTimeSeconds: 5 * numOfMsgsWithSessionId[id]
         });
         should.equal(

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -183,10 +183,15 @@ export class ServiceBusTestHelpers {
           sessionId: id
         });
         const msgs = await receiverClient.receiveBatch(numOfMsgsWithSessionId[id], {
-          // To Do - Maybe change the maxWaitTime
-          // Currently set same as numberOfMessages being received
-          maxWaitTimeSeconds: numOfMsgsWithSessionId[id]
+          // Since we know the exact number of messages to be received per session-id,
+          //   `maxWaitTimeSeconds` being a higher number is not a problem
+          maxWaitTimeSeconds: 5 * numOfMsgsWithSessionId[id]
         });
+        should.equal(
+          msgs.length,
+          numOfMsgsWithSessionId[id],
+          `Unexpected number of messages received with session-id - "${id}".`
+        );
         receivedMsgs = !receivedMsgs! ? msgs : receivedMsgs!.concat(msgs);
         await receiverClient.close();
       }


### PR DESCRIPTION
Issue - #8019 
Fixing the flakey `receiveBatch` for sessions with a higher `maxWaitTime`.