### PR TITLE
Run formatter on Service Bus

### DIFF
--- a/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
+++ b/sdk/servicebus/service-bus/src/modelsToBeSharedWithEventHubs.ts
@@ -33,7 +33,6 @@ export interface OperationOptions extends TracingOptions {
   abortSignal?: AbortSignalLike;
 }
 
-
 /**
  * @internal
  * @ignore

--- a/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
@@ -17,7 +17,7 @@ import {
   createServiceBusClientForTests,
   testPeekMsgsLength
 } from "./utils/testutils2";
-import { DispositionType, ReceivedMessageWithLock  } from "../src/serviceBusMessage";
+import { DispositionType, ReceivedMessageWithLock } from "../src/serviceBusMessage";
 
 let errorWasThrown: boolean;
 
@@ -343,7 +343,7 @@ describe("receive and delete", () => {
       const testMessages = useSessions ? TestMessage.getSessionSample() : TestMessage.getSample();
       // we have to force this cast - the type system doesn't allow this if you've chosen receiveAndDelete
       // as your lock mode.
-      const msg = (await sendReceiveMsg(testMessages)) as ReceivedMessageWithLock ;
+      const msg = (await sendReceiveMsg(testMessages)) as ReceivedMessageWithLock;
 
       try {
         if (operation === DispositionType.complete) {
@@ -682,7 +682,7 @@ describe("receive and delete", () => {
       const msg = await sendReceiveMsg(TestMessage.getSample());
 
       // have to cast it - the type system doesn't allow us to call into this method otherwise.
-      await (msg as ReceivedMessageWithLock ).renewLock().catch((err) => {
+      await (msg as ReceivedMessageWithLock).renewLock().catch((err) => {
         should.equal(
           err.message,
           getErrorMessageNotSupportedInReceiveAndDeleteMode("renew the lock on the message"),

--- a/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsMultipleQueues.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsMultipleQueues.ts
@@ -66,7 +66,10 @@ async function sendReceiveMessages(): Promise<void> {
   }
 }
 
-async function sendReceiveMessagesPerClient(sender: Sender, receiver: InternalReceiver): Promise<void> {
+async function sendReceiveMessagesPerClient(
+  sender: Sender,
+  receiver: InternalReceiver
+): Promise<void> {
   while (!isJobDone) {
     const message: SendableMessageInfo = {
       messageId: msgId,

--- a/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsSingleQueue.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_fixedNumberOfClientsSingleQueue.ts
@@ -68,7 +68,10 @@ async function sendReceiveMessages(): Promise<void> {
   }
 }
 
-async function sendReceiveMessagesPerClient(sender: Sender, receiver: InternalReceiver): Promise<void> {
+async function sendReceiveMessagesPerClient(
+  sender: Sender,
+  receiver: InternalReceiver
+): Promise<void> {
   while (!isJobDone) {
     const message: SendableMessageInfo = {
       messageId: msgId,

--- a/sdk/servicebus/service-bus/test/stress/stress_messageRandomDisposition.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_messageRandomDisposition.ts
@@ -11,13 +11,7 @@ For running this test, connection string of the Service Bus namespace and queue 
 must be supplied.
 */
 
-import {
-  SendableMessageInfo,
-  OnMessage,
-  OnError,
-  delay,
-  ReceiveMode
-} from "../../src";
+import { SendableMessageInfo, OnMessage, OnError, delay, ReceiveMode } from "../../src";
 import { ServiceBusClient } from "../../src/old/serviceBusClient";
 
 const connectionString = "";

--- a/sdk/servicebus/service-bus/test/stress/stress_sessionManualLockRenewal.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_sessionManualLockRenewal.ts
@@ -17,7 +17,7 @@ import {
   OnError,
   delay,
   ReceiveMode,
-  ServiceBusMessage,
+  ServiceBusMessage
 } from "../../src";
 import { InternalSessionReceiver } from "../../src/internalReceivers";
 import { ServiceBusClient } from "../../src/old/serviceBusClient";

--- a/sdk/servicebus/service-bus/test/stress/stress_singleMessageComplete.ts
+++ b/sdk/servicebus/service-bus/test/stress/stress_singleMessageComplete.ts
@@ -11,13 +11,7 @@ For running this test, connection string of the Service Bus namespace and queue 
 must be supplied.
 */
 
-import {
-  SendableMessageInfo,
-  OnMessage,
-  OnError,
-  delay,
-  ReceiveMode
-} from "../../src";
+import { SendableMessageInfo, OnMessage, OnError, delay, ReceiveMode } from "../../src";
 import { ServiceBusClient } from "../../src/old/serviceBusClient";
 
 const connectionString = "";

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -191,7 +191,7 @@ export class ServiceBusTestHelpers {
         await receiverClient.close();
       }
     }
-    should.equal(         
+    should.equal(
       receivedMsgs!.length,
       sentMessages.length,
       "Unexpected number of messages received."


### PR DESCRIPTION
Running the formatter to avoid noise in PRs that contain non-formatting changes