### PR TITLE
[app-configuration] Fixing some test suite timeouts from too many parallel requests

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/index.spec.ts
+++ b/sdk/appconfiguration/app-configuration/test/index.spec.ts
@@ -23,15 +23,9 @@ describe("AppConfigurationClient", () => {
   });
 
   after("cleanup", async () => {
-    const deletePromises = [];
-
     for (const setting of settings) {
-      deletePromises.push(
-        client.deleteConfigurationSetting({ key: setting.key, label: setting.label })
-      );
+      await client.deleteConfigurationSetting({ key: setting.key, label: setting.label });
     }
-
-    await Promise.all(deletePromises);
   });
 
   describe("simple usages", () => {


### PR DESCRIPTION
During test cleanup we do all the deletes for all the settings we've created in parallel. 

It appears we're getting throttled so, to fix that, I've changed it to do them serially instead.