### PR TITLE
[identity] Fix browser bundle issue

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -13,6 +13,7 @@
     "./dist-esm/src/credentials/managedIdentityCredential.js": "./dist-esm/src/credentials/managedIdentityCredential.browser.js",
     "./dist-esm/src/credentials/clientCertificateCredential.js": "./dist-esm/src/credentials/clientCertificateCredential.browser.js",
     "./dist-esm/src/credentials/deviceCodeCredential.js": "./dist-esm/src/credentials/deviceCodeCredential.browser.js",
+    "./dist-esm/src/credentials/defaultAzureCredential.js": "./dist-esm/src/credentials/defaultAzureCredential.browser.js",
     "./dist-esm/src/credentials/authorizationCodeCredential.js": "./dist-esm/src/credentials/authorizationCodeCredential.browser.js",
     "./dist-esm/src/credentials/interactiveBrowserCredential.js": "./dist-esm/src/credentials/interactiveBrowserCredential.browser.js",
     "./dist-esm/src/credentials/vscodeCredential.js": "./dist-esm/src/credentials/vscodeCredential.browser.js"

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.browser.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.browser.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TokenCredentialOptions } from "../client/identityClient";
+import { ChainedTokenCredential } from "./chainedTokenCredential";
+import { EnvironmentCredential } from "./environmentCredential";
+import { ManagedIdentityCredential } from "./managedIdentityCredential";
+import { AzureCliCredential } from "./azureCliCredential";
+import { VSCodeCredential } from "./vscodeCredential";
+
+/**
+ * Provides a default {@link ChainedTokenCredential} configuration for
+ * applications that will be deployed to Azure.  The following credential
+ * types will be tried, in order:
+ *
+ * - {@link EnvironmentCredential}
+ * - {@link ManagedIdentityCredential}
+ *
+ * Consult the documentation of these credential types for more information
+ * on how they attempt authentication.
+ */
+export class DefaultAzureCredential extends ChainedTokenCredential {
+  /**
+   * Creates an instance of the DefaultAzureCredential class.
+   *
+   * @param options Options for configuring the client which makes the authentication request.
+   */
+  constructor(tokenCredentialOptions?: TokenCredentialOptions) {
+    let credentials = [];
+    credentials.push(new EnvironmentCredential(tokenCredentialOptions));
+    credentials.push(new ManagedIdentityCredential(tokenCredentialOptions));
+    credentials.push(new AzureCliCredential());
+    credentials.push(new VSCodeCredential(tokenCredentialOptions));
+
+    super(...credentials);
+  }
+}


### PR DESCRIPTION
PR #7994 introduced a build break to rollup by referencing `process` inside `DefaultAzureCredential`.

This fix adds a browser version of `DefaultAzureCredential` without the reference to `process`.