### PR TITLE
Correctly select version if on the "latest" page

### DIFF
--- a/eng/tools/generate-doc/theme/default/assets/js/get_options.js
+++ b/eng/tools/generate-doc/theme/default/assets/js/get_options.js
@@ -66,15 +66,22 @@ function populateOptions(optionSelector, otherSelectors) {
   }
 }
 
-function populateVersionDropDown(selector, values) {
-  var select = $(selector);
+function populateVersionDropDown(selector, values){
+    var select = $(selector)
+    
+    $('option', select).remove()
 
-  $("option", select).remove();
+    $.each(values, function(index, text) {
+      $('<option/>', { 'value' : text, 'text': text }).appendTo(select)
+    });
 
-  $.each(values, function(index, text) {
-    $("<option/>", { value: text, text: text }).appendTo(select);
-  });
-  select.val(currentVersion());
+    var version = currentVersion()
+    if(version==='latest'){
+      select.selectedIndex = 0
+    }
+    else {
+      select.val(version)  
+    }
 }
 
 function getPackageUrl(language, package, version) {


### PR DESCRIPTION
When you visit a page like [this one](https://azuresdkdocsdev.blob.core.windows.net/$web/python/azure-core/latest/index.html) (notice the `latest` instead of a valid version) we want the drop down to properly default to the actual latest released version. 