### PR TITLE
[identity] Fix build:test break

### DIFF
--- a/sdk/eventhub/eventhubs-checkpointstore-blob/rollup.base.config.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/rollup.base.config.js
@@ -20,9 +20,10 @@ const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
   const externalNodeBuiltins = ["events", "util", "os"];
+  const additionalExternals = ["keytar"];
   const baseConfig = {
     input: input,
-    external: depNames.concat(externalNodeBuiltins),
+    external: depNames.concat(externalNodeBuiltins, additionalExternals),
     output: { file: "dist/index.js", format: "cjs", sourcemap: true },
     preserveSymlinks: false,
     plugins: [

--- a/sdk/keyvault/keyvault-certificates/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-certificates/rollup.base.config.js
@@ -31,9 +31,10 @@ const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
   const externalNodeBuiltins = ["crypto", "fs", "os", "url", "assert"];
+  const additionalExternals = ["keytar"];
   const baseConfig = {
     input: "dist-esm/src/index.js",
-    external: depNames.concat(externalNodeBuiltins),
+    external: depNames.concat(externalNodeBuiltins, additionalExternals),
     output: {
       file: "dist/index.js",
       format: "cjs",

--- a/sdk/keyvault/keyvault-keys/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-keys/rollup.base.config.js
@@ -31,9 +31,10 @@ const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
   const externalNodeBuiltins = ["crypto", "fs", "os", "url", "assert"];
+  const additionalExternals = ["keytar"];
   const baseConfig = {
     input: "dist-esm/src/index.js",
-    external: depNames.concat(externalNodeBuiltins),
+    external: depNames.concat(externalNodeBuiltins, additionalExternals),
     output: {
       file: "dist/index.js",
       format: "cjs",

--- a/sdk/keyvault/keyvault-secrets/rollup.base.config.js
+++ b/sdk/keyvault/keyvault-secrets/rollup.base.config.js
@@ -31,9 +31,10 @@ const production = process.env.NODE_ENV === "production";
 
 export function nodeConfig(test = false) {
   const externalNodeBuiltins = ["crypto", "fs", "os", "url", "assert"];
+  const additionalExternals = ["keytar"];
   const baseConfig = {
     input: "dist-esm/src/index.js",
-    external: depNames.concat(externalNodeBuiltins),
+    external: depNames.concat(externalNodeBuiltins, additionalExternals),
     output: {
       file: "dist/index.js",
       format: "cjs",


### PR DESCRIPTION
PR #7994 also introduced a problem where a new dependency `keytar` is not bundle safe and needed to be excluded in test bundles that referenced it indirectly via @azure/identity.