### PR TITLE
[Service Bus] Removing `dataTransformer` from the ClientOptions

### DIFF
--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -73,15 +73,14 @@ export enum CloseReason {
 
 /**
  * Describes the options that can be provided while creating the EventHubClient.
- * - `dataTransformer`: A set of `encode`/`decode` methods to be used to encode an event before sending to service
- * and to decode the event received from the service
- * - `userAgent`      : A string to append to the built in user agent string that is passed as a connection property
+ * - `userAgent`        : A string to append to the built in user agent string that is passed as a connection property
  * to the service.
- * - `websocket`      : The WebSocket constructor used to create an AMQP connection if you choose to make the connection
+ * - `webSocketOptions` : Options to configure the channelling of the AMQP connection over Web Sockets.
+ *    - `websocket`     : The WebSocket constructor used to create an AMQP connection if you choose to make the connection
  * over a WebSocket.
- * - `webSocketConstructorOptions` : Options to pass to the Websocket constructor when you choose to make the connection
+ *    - `webSocketConstructorOptions` : Options to pass to the Websocket constructor when you choose to make the connection
  * over a WebSocket.
- * - `retryOptions`   : The retry options for all the operations on the client/producer/consumer.
+ * - `retryOptions`     : The retry options for all the operations on the client/producer/consumer.
  * A simple usage can be `{ "maxRetries": 4 }`.
  *
  * Example usage:

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -7,7 +7,7 @@ Use the client library for Azure Service Bus in your Node.js application to
 - Send messages to a Queue or Topic
 - Receive messages from a Queue or Subscription
 
-[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus) | [Package (npm)](https://www.npmjs.com/package/@azure/service-bus) | [API Reference Documentation](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/index.html) | [Product documentation](https://azure.microsoft.com/en-us/services/service-bus/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples)
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus) | [Package (npm)](https://www.npmjs.com/package/@azure/service-bus) | [API Reference Documentation](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/index.html) | [Product documentation](https://azure.microsoft.com/en-us/services/service-bus/) | [Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples)
 
 **NOTE**: If you are using version 1.1.x or lower, then please use the below links instead
 
@@ -40,21 +40,21 @@ You also need to enable `compilerOptions.allowSyntheticDefaultImports` in your t
 
 ### Authenticate the client
 
-Interaction with Service Bus starts with an instance of the [ServiceBusClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html) class.
+Interaction with Service Bus starts with an instance of the [ServiceBusClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html) class.
 
 You can instantiate this class using its constructors:
 
-- [Create using a connection string](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html#constructor)
+- [Create using a connection string](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#constructor)
   - This method takes the connection string to your Service Bus instance. You can get the connection string
     from the Azure portal.
-- [Create using a TokenCredential](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html#constructor)
+- [Create using a TokenCredential](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#constructor)
   - This method takes the host name of your Service Bus instance and a credentials object that you need
     to generate using the [@azure/identity](https://www.npmjs.com/package/@azure/identity)
     library. The host name is of the format `name-of-service-bus-instance.servicebus.windows.net`.
 
 ### Key concepts
 
-Once you have initialized the [ServiceBusClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html)
+Once you have initialized the [ServiceBusClient](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html)
 class, create a sender or receiver based on whether you want to send or receive messages.
 to interact with existing Service Bus entities.
 
@@ -73,12 +73,12 @@ The following sections provide code snippets that cover some of the common tasks
 ### Send messages
 
 Once you have created an instance of a `ServiceBusClient` class, you can get a `Sender`
-using the [getSender](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html#getsender) method.
+using the [getSender](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#getsender) method.
 
-This gives you a sender which you can use to [send](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/interfaces/sender.html#send)
+This gives you a sender which you can use to [send](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html#send)
 messages.
 
-You can also use the [sendBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/interfaces/sender.html#sendbatch)
+You can also use the [sendBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html#sendbatch)
 method to efficiently send multiple messages in a single send.
 
 ```javascript
@@ -101,7 +101,7 @@ await sender.sendBatch(batch);
 ### Receive messages
 
 Once you have created an instance of a `ServiceBusClient` class, you can get a `Receiver`
-using the [getReceiver](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html#getreceiver) function.
+using the [getReceiver](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#getreceiver) function.
 
 ```javascript
 const receiver = serviceBusClient.getReceiver("my-queue", "peekLock");
@@ -111,7 +111,7 @@ You can use this receiver in one of 3 ways to receive messages:
 
 #### Get an array of messages
 
-Use the [receiveBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/interfaces/receiver.html#receivebatch) function which returns a promise that
+Use the [receiveBatch](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/receiver.html#receivebatch) function which returns a promise that
 resolves to an array of messages.
 
 ```javascript
@@ -120,7 +120,7 @@ const myMessages = await receiver.receiveBatch(10);
 
 #### Subscribe using a message handler
 
-Use the [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/interfaces/receiver.html#subscribe) method
+Use the [subscribe](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/receiver.html#subscribe) method
 to set up message handlers and have it running as long as you need.
 
 When you are done, call `receiver.close()` to stop receiving any more messages.
@@ -140,7 +140,7 @@ receiver.subscribe({
 
 #### Use async iterator
 
-Use the [getMessageIterator](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/interfaces/receiver.html#getmessageiterator) to get an async iterator over messages
+Use the [getMessageIterator](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/receiver.html#getmessageiterator) to get an async iterator over messages
 
 ```javascript
 for await (let message of receiver.getMessageIterator()) {
@@ -159,8 +159,8 @@ To learn more, please read [Settling Received Messages](https://docs.microsoft.c
 
 To send messages using sessions, you first need to create a session enabled Queue or Subscription. You can do this
 in the Azure portal. Then, use an instance of a `ServiceBusClient` to create a sender using the using
-the [getSender](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html#getsender)
-function. This gives you a sender which you can use to [send](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/interfaces/sender.html#send) messages.
+the [getSender](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#getsender)
+function. This gives you a sender which you can use to [send](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html#send) messages.
 
 When sending the message, set the `sessionId` property in the message body to ensure your message
 lands in the right session.
@@ -177,7 +177,7 @@ await sender.send({
 
 To receive messages from sessions, you first need to create a session enabled Queue and send messages
 to it. Then, use an instance of `ServiceBusClient` to create a receiver
-using the [getSessionReceiver](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/5.0.0-preview.1/classes/servicebusclient.html#getsessionreceiver) function.
+using the [getSessionReceiver](https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#getsessionreceiver) function.
 
 Note that you will need to specify the session from which you want to receive messages.
 

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "5.0.0-preview.1",
+  "version": "7.0.0-preview.1",
   "license": "MIT",
   "description": "Azure Service Bus SDK for Node.js",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus",

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -5,7 +5,6 @@
 ```ts
 
 import { AmqpMessage } from '@azure/core-amqp';
-import { DataTransformer } from '@azure/core-amqp';
 import { delay } from '@azure/core-amqp';
 import { Delivery } from 'rhea-promise';
 import Long from 'long';
@@ -35,8 +34,6 @@ export interface CreateBatchOptions extends OperationOptions {
     maxSizeInBytes?: number;
     retryOptions?: RetryOptions;
 }
-
-export { DataTransformer }
 
 // @public
 export interface DeadLetterOptions {

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -167,7 +167,6 @@ export class ServiceBusClient {
 
 // @public
 export interface ServiceBusClientOptions {
-    dataTransformer?: DataTransformer;
     webSocketOptions?: WebSocketOptions;
 }
 

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -53,7 +53,8 @@ export namespace ConnectionContext {
     const parameters: CreateConnectionContextBaseParameters = {
       config: config,
       tokenCredential: tokenCredential,
-      dataTransformer: options.dataTransformer,
+      // re-enabling this will be a post-GA discussion similar to event-hubs.
+      // dataTransformer: options.dataTransformer,
       isEntityPathRequired: false,
       connectionProperties: {
         product: "MSJSClient",

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -6,7 +6,6 @@ import {
   TokenCredential,
   ConnectionConfig,
   SharedKeyCredential,
-  DataTransformer,
   WebSocketOptions
 } from "@azure/core-amqp";
 import { ConnectionContext } from "./connectionContext";
@@ -16,13 +15,6 @@ import { ConnectionContext } from "./connectionContext";
  * @interface ServiceBusClientOptions
  */
 export interface ServiceBusClientOptions {
-  /**
-   * @property The data transformer that will be used to encode
-   * and decode the sent and received messages respectively. If not provided then we will use the
-   * DefaultDataTransformer. The default transformer should handle majority of the cases. This
-   * option needs to be used only for specialized scenarios.
-   */
-  dataTransformer?: DataTransformer;
   /**
    * @property
    * Options to configure the channelling of the AMQP connection over Web Sockets.

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -8,7 +8,6 @@ export { ServiceBusClientOptions } from "./constructorHelpers";
 export {
   TokenType,
   TokenCredential,
-  DataTransformer,
   delay,
   MessagingError,
   RetryOptions,

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -3,7 +3,7 @@
 
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "5.0.0-preview.1"
+  version: "7.0.0-preview.1"
 };
 
 export const messageDispositionTimeout = 20000;


### PR DESCRIPTION
- Disable dataTransformer by removing from the ClientOptions to be in sync with event-hubs
- Version 5.0.0 to 7.0.0
- Update API report