### PR TITLE
[core-auth] hotfix to provide downleveled types

### DIFF
--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.1 (2020-03-31)
+## 1.1.1 (2020-04-01)
 
 - Provided down-leveled type declaration files for users of older TypeScript versions between 3.1 and 3.6.
 

--- a/sdk/core/core-auth/CHANGELOG.md
+++ b/sdk/core/core-auth/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 1.1.1 (2020-03-31)
+
+- Provided down-leveled type declaration files for users of older TypeScript versions between 3.1 and 3.6.
+
 ## 1.1.0 (2020-03-31)
 
 - Added an `AzureKeyCredential` class that supports credential rotation and a corresponding `KeyCredential` interface to support the use of static string-based keys in Azure clients.

--- a/sdk/core/core-auth/api-extractor.json
+++ b/sdk/core/core-auth/api-extractor.json
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./types/core-auth.d.ts"
+    "publicTrimmedFilePath": "./types/latest/core-auth.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -1,18 +1,26 @@
 {
   "name": "@azure/core-auth",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Provides low-level interfaces and helper methods for authentication in Azure SDK",
   "sdk-type": "client",
   "main": "dist/index.js",
   "module": "dist-esm/src/index.js",
-  "types": "types/core-auth.d.ts",
+  "types": "./types/latest/core-auth.d.ts",
+  "typesVersions": {
+    "<3.6": {
+      "types/latest/*": [
+        "types/3.1/*"
+      ]
+    }
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "cd samples && tsc -p .",
     "build:test": "tsc -p . && rollup -c rollup.test.config.js 2>&1",
-    "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local",
+    "build:types": "downlevel-dts types/latest types/3.1",
+    "build": "tsc -p . && rollup -c 2>&1 && api-extractor run --local && npm run build:types",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "clean": "rimraf dist dist-esm test-dist types *.tgz *.log",
     "execute:samples": "echo skipped",
@@ -35,7 +43,8 @@
   "files": [
     "dist/",
     "dist-esm/src/",
-    "types/core-auth.d.ts",
+    "types/latest/core-auth.d.ts",
+    "types/3.1",
     "README.md",
     "LICENSE"
   ],
@@ -74,6 +83,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "cross-env": "^6.0.3",
+    "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",

--- a/sdk/textanalytics/ai-text-analytics/test/tracing.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/tracing.spec.ts
@@ -6,7 +6,7 @@ import * as sinon from "sinon";
 import { createSpan } from "../src/tracing";
 import { setTracer, TestTracer, TestSpan } from "@azure/core-tracing";
 import { SpanKind } from "@opentelemetry/types";
-import { OperationOptions } from "../../../core/core-auth/types/core-auth";
+import { OperationOptions } from "@azure/core-auth";
 
 describe("tracing.createSpan", () => {
   it("returns a created span with the right metadata", () => {


### PR DESCRIPTION
When we released core-auth 1.1.0 today, I didn't catch an issue with the types file being incompatible with older versions of TypeScript. This is a 1.1.1 patch version that adds the downleveled types to the package.

I've tested this with the Text Analytics samples by packing core-auth and installing/building using TS 3.1.

@bterlson and @xirzec I think this is everything I need to do to make the downleveling work, but I'm not 100% sure so I'd appreciate your checking this.