### PR TITLE
[service-bus] track2 - make ClientType match the customer facing names for logging

### DIFF
--- a/sdk/servicebus/service-bus/src/client.ts
+++ b/sdk/servicebus/service-bus/src/client.ts
@@ -25,9 +25,6 @@ export interface Client {
  * @internal
  */
 export enum ClientType {
-  ServiceBusSenderClient = "ServiceBusSenderClient",
-  ServiceBusReceiverClient = "ServiceBusReceiverClient",
-  QueueClient = "QueueClient",
-  SubscriptionClient = "SubscriptionClient",
-  TopicClient = "TopicClient"
+  ServiceBusSender = "Sender",
+  ServiceBusReceiver = "Receiver"
 }

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -132,7 +132,7 @@ export class ServiceBusClient {
 
     const clientEntityContext = ClientEntityContext.create(
       entityPath,
-      ClientType.ServiceBusReceiverClient,
+      ClientType.ServiceBusReceiver,
       this._connectionContext,
       `${entityPath}/${generate_uuid()}`
     );
@@ -212,7 +212,7 @@ export class ServiceBusClient {
 
     const clientEntityContext = ClientEntityContext.create(
       entityPath,
-      ClientType.ServiceBusReceiverClient,
+      ClientType.ServiceBusReceiver,
       this._connectionContext,
       `${entityPath}/${generate_uuid()}`
     );
@@ -233,7 +233,7 @@ export class ServiceBusClient {
 
     const clientEntityContext = ClientEntityContext.create(
       queueOrTopicName,
-      ClientType.ServiceBusReceiverClient,
+      ClientType.ServiceBusReceiver,
       this._connectionContext,
       `${queueOrTopicName}/${generate_uuid()}`
     );
@@ -251,7 +251,7 @@ export class ServiceBusClient {
     const entityPath = `${topic}/Subscriptions/${subscription}`;
     const clientEntityContext = ClientEntityContext.create(
       entityPath,
-      ClientType.ServiceBusReceiverClient, // TODO:what are these names for? We can make one for management client...
+      ClientType.ServiceBusReceiver, // TODO:what are these names for? We can make one for management client...
       this._connectionContext,
       `${entityPath}/${generate_uuid()}`
     );


### PR DESCRIPTION
ClientType is used when we log - changing this over to match the names we've now arrived on for track2 (Receiver and Sender).

This is basically a cosmetic change, useful for diagnostics.

Fixes #7936 