### PR TITLE
[search] Create continuation token.

### DIFF
--- a/sdk/search/search/CHANGELOG.md
+++ b/sdk/search/search/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Breaking] In `SearchIndexClient`, removed options `mergeIfExists` and `uploadIfNotExists` on `uploadDocuments` and `mergeDocuments` and replaced them with new helper `mergeOrUploadDocuments`.
 - The type `IndexAction` was renamed to `IndexDocumentsAction`.
 - [Breaking] Removed `SearchApiKeyCredential` and replaced with `AzureKeyCredential`.
+- [Breaking] Search results accessed `byPage` now have an opaque `continuationToken` in place of `nextLink` and `nextPageParameters`.
 
 ## 11.0.0-preview.1 (2020-03-09)
 

--- a/sdk/search/search/package.json
+++ b/sdk/search/search/package.json
@@ -41,6 +41,9 @@
     "README.md",
     "LICENSE"
   ],
+  "browser": {
+    "./dist-esm/src/base64.js": "./dist-esm/src/base64.browser.js"
+  },
   "//metadata": {
     "constantPaths": [
       {

--- a/sdk/search/search/review/search.api.md
+++ b/sdk/search/search/review/search.api.md
@@ -541,8 +541,7 @@ export interface ListIndexesOptions extends OperationOptions {
 
 // @public
 export interface ListSearchResultsPageSettings {
-    nextLink?: string;
-    nextPageParameters?: RawSearchRequest;
+    continuationToken?: string;
 }
 
 // @public
@@ -737,8 +736,7 @@ export interface ScoringProfile {
 
 // @public (undocumented)
 export interface SearchDocumentsPageResult<T> extends SearchDocumentsResultBase {
-    readonly nextLink?: string;
-    readonly nextPageParameters?: RawSearchRequest;
+    continuationToken?: string;
     readonly results: SearchResult<T>[];
 }
 

--- a/sdk/search/search/src/base64.browser.ts
+++ b/sdk/search/search/src/base64.browser.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Encodes a string in base64 format.
+ * @param value the string to encode
+ */
+export function encode(value: string): string {
+  return btoa(value);
+}
+
+/**
+ * Decodes a base64 string into a byte array.
+ * @param value the base64 string to decode
+ */
+export function decode(value: string): string {
+  return atob(value);
+}

--- a/sdk/search/search/src/base64.browser.ts
+++ b/sdk/search/search/src/base64.browser.ts
@@ -3,15 +3,15 @@
 
 /**
  * Encodes a string in base64 format.
- * @param value the string to encode
+ * @param value The string to encode.
  */
 export function encode(value: string): string {
   return btoa(value);
 }
 
 /**
- * Decodes a base64 string into a byte array.
- * @param value the base64 string to decode
+ * Decodes a base64 string into a regular string.
+ * @param value The base64 string to decode.
  */
 export function decode(value: string): string {
   return atob(value);

--- a/sdk/search/search/src/base64.ts
+++ b/sdk/search/search/src/base64.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+/**
+ * Encodes a string in base64 format.
+ * @param value the string to encode
+ */
+export function encode(value: string): string {
+  return Buffer.from(value).toString("base64");
+}
+
+/**
+ * Decodes a base64 string into a regular string
+ * @param value the base64 string to decode
+ */
+export function decode(value: string): string {
+  return Buffer.from(value, "base64").toString();
+}

--- a/sdk/search/search/src/base64.ts
+++ b/sdk/search/search/src/base64.ts
@@ -3,15 +3,15 @@
 
 /**
  * Encodes a string in base64 format.
- * @param value the string to encode
+ * @param value The string to encode.
  */
 export function encode(value: string): string {
   return Buffer.from(value).toString("base64");
 }
 
 /**
- * Decodes a base64 string into a regular string
- * @param value the base64 string to decode
+ * Decodes a base64 string into a regular string.
+ * @param value The base64 string to decode.
  */
 export function decode(value: string): string {
   return Buffer.from(value, "base64").toString();

--- a/sdk/search/search/src/indexModels.ts
+++ b/sdk/search/search/src/indexModels.ts
@@ -8,7 +8,7 @@ import {
   FacetResult,
   AutocompleteMode,
   IndexActionType,
-  SearchRequest as RawSearchRequest
+  SearchDocumentsResult as GeneratedSearchResult
 } from "./generated/data/models";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
@@ -76,13 +76,10 @@ export type DeleteDocumentsOptions = IndexDocuments;
  */
 export interface ListSearchResultsPageSettings {
   /**
-   * When server pagination occurs, this is the URL to the next result page.
+   * A token used for retrieving the next page of results when the server
+   * enforces pagination.
    */
-  nextLink?: string;
-  /**
-   * When server pagination occurs, this is the set of parameters to include in the POST body.
-   */
-  nextPageParameters?: RawSearchRequest;
+  continuationToken?: string;
 }
 
 /**
@@ -95,6 +92,20 @@ export type SearchIterator<Fields> = PagedAsyncIterableIterator<
   SearchDocumentsPageResult<Fields>,
   ListSearchResultsPageSettings
 >;
+
+/**
+ * An intermediate type for encoding the continuation token.
+ */
+export type ContinuableSearchResult = Omit<
+  GeneratedSearchResult,
+  "nextPageParameters" | "nextLink"
+> & {
+  /**
+   * A token used for retrieving the next page of results when the server
+   * enforces pagination.
+   */
+  continuationToken?: string;
+};
 
 // BEGIN manually modified generated interfaces
 //
@@ -261,20 +272,10 @@ export interface SearchDocumentsPageResult<T> extends SearchDocumentsResultBase 
    */
   readonly results: SearchResult<T>[];
   /**
-   * Continuation JSON payload returned when Azure Cognitive Search can't return all the requested
-   * results in a single Search response. You can use this JSON along with @odata.nextLink to
-   * formulate another POST Search request to get the next part of the search response.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   * A token used for retrieving the next page of results when the server
+   * enforces pagination.
    */
-  readonly nextPageParameters?: RawSearchRequest;
-  /**
-   * Continuation URL returned when Azure Cognitive Search can't return all the requested results
-   * in a single Search response. You can use this URL to formulate another GET or POST Search
-   * request to get the next part of the search response. Make sure to use the same verb (GET or
-   * POST) as the request that produced this response.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly nextLink?: string;
+  continuationToken?: string;
 }
 
 /**

--- a/sdk/search/search/src/searchIndexClient.ts
+++ b/sdk/search/search/src/searchIndexClient.ts
@@ -60,6 +60,9 @@ export type SearchIndexClientOptions = PipelineOptions;
  * adding, updating, and removing them.
  */
 export class SearchIndexClient<T> {
+  /// Maintenance note: when updating supported API versions,
+  /// the ContinuationToken logic will need to be updated below.
+
   /**
    * The API version to use when communicating with the service.
    */

--- a/sdk/search/search/src/searchIndexClient.ts
+++ b/sdk/search/search/src/searchIndexClient.ts
@@ -42,10 +42,12 @@ import {
   MergeDocumentsOptions,
   DeleteDocumentsOptions,
   SearchDocumentsPageResult,
-  MergeOrUploadDocumentsOptions
+  MergeOrUploadDocumentsOptions,
+  ContinuableSearchResult
 } from "./indexModels";
 import { odataMetadataPolicy } from "./odataMetadataPolicy";
 import { IndexDocumentsBatch } from "./indexDocumentsBatch";
+import { encode, decode } from "./base64";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -250,7 +252,17 @@ export class SearchIndexClient<T> {
         fullOptions,
         operationOptionsToRequestOptionsBase(updatedOptions)
       );
-      return deserialize<SearchDocumentsPageResult<Pick<T, Fields>>>(result);
+
+      const { results, count, coverage, facets, nextLink, nextPageParameters } = result;
+      const converted: ContinuableSearchResult = {
+        results,
+        count,
+        coverage,
+        facets,
+        continuationToken: this.encodeContinuationToken(nextLink, nextPageParameters)
+      };
+
+      return deserialize<SearchDocumentsPageResult<Pick<T, Fields>>>(converted);
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -266,14 +278,19 @@ export class SearchIndexClient<T> {
     options: SearchOptions<Fields> = {},
     settings: ListSearchResultsPageSettings = {}
   ): AsyncIterableIterator<SearchDocumentsPageResult<Pick<T, Fields>>> {
-    let result = await this.searchDocuments<Fields>(options, settings.nextPageParameters);
+    const decodedContinuation = this.decodeContinuationToken(settings.continuationToken);
+    let result = await this.searchDocuments<Fields>(
+      options,
+      decodedContinuation?.nextPageParameters
+    );
 
     yield result;
 
     // Technically, we should also leverage nextLink, but the generated code
     // doesn't support this yet.
-    while (result.nextPageParameters) {
-      result = await this.searchDocuments(options, result.nextPageParameters);
+    while (result.continuationToken) {
+      const decodedContinuation = this.decodeContinuationToken(settings.continuationToken);
+      result = await this.searchDocuments(options, decodedContinuation?.nextPageParameters);
       yield result;
     }
   }
@@ -283,10 +300,9 @@ export class SearchIndexClient<T> {
     options: SearchOptions<Fields> = {}
   ): AsyncIterableIterator<SearchResult<Pick<T, Fields>>> {
     yield* firstPage.results;
-    if (firstPage.nextPageParameters) {
+    if (firstPage.continuationToken) {
       for await (const page of this.listSearchResultsPage(options, {
-        nextLink: firstPage.nextLink,
-        nextPageParameters: firstPage.nextPageParameters
+        continuationToken: firstPage.continuationToken
       })) {
         yield* page.results;
       }
@@ -559,6 +575,50 @@ export class SearchIndexClient<T> {
       throw e;
     } finally {
       span.end();
+    }
+  }
+
+  private encodeContinuationToken(
+    nextLink: string | undefined,
+    nextPageParameters: SearchRequest | undefined
+  ): string | undefined {
+    if (!nextLink || !nextPageParameters) {
+      return undefined;
+    }
+    const payload = JSON.stringify({
+      apiVersion: this.apiVersion,
+      nextLink,
+      nextPageParameters
+    });
+    return encode(payload);
+  }
+
+  private decodeContinuationToken(
+    token?: string
+  ): { nextPageParameters: SearchRequest; nextLink: string } | undefined {
+    if (!token) {
+      return undefined;
+    }
+
+    const decodedToken = decode(token);
+
+    try {
+      const result: {
+        apiVersion: string;
+        nextLink: string;
+        nextPageParameters: SearchRequest;
+      } = JSON.parse(decodedToken);
+
+      if (result.apiVersion !== this.apiVersion) {
+        throw new RangeError(`Continuation token uses unsupported apiVersion "${this.apiVersion}"`);
+      }
+
+      return {
+        nextLink: result.nextLink,
+        nextPageParameters: result.nextPageParameters
+      };
+    } catch (e) {
+      throw new Error(`Corrupted or invalid continuation token: ${decodedToken}`);
     }
   }
 

--- a/sdk/search/search/src/shims.d.ts
+++ b/sdk/search/search/src/shims.d.ts
@@ -11,3 +11,6 @@ interface RequestInfo {}
 interface Response {}
 
 interface Headers {}
+
+declare function atob(data: string): string;
+declare function btoa(data: string): string;

--- a/sdk/search/search/test/base64.spec.ts
+++ b/sdk/search/search/test/base64.spec.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { assert } from "chai";
+import { encode, decode } from "../src/base64";
+
+describe("base64", () => {
+  it("strings can roundtrip", () => {
+    const message = "Only *you* can prevent null dereferences!";
+    const encoded = encode(message);
+    const decoded = decode(encoded);
+    assert.strictEqual(decoded, message);
+  });
+});


### PR DESCRIPTION
Give users an opaque string for continuation instead of exposing service internals.

Fixes #7843

Related to Azure/azure-sdk-for-net#10590