### PR TITLE
[core-http] Update sample

### DIFF
--- a/sdk/core/core-http/README.md
+++ b/sdk/core/core-http/README.md
@@ -15,7 +15,7 @@ npm install -g typescript
 
 ### Installation
 
-This package is not meant to be consumed directly by end users.
+This package is primarily used in generated code and not meant to be consumed directly by end users.
 
 ## Key concepts
 
@@ -27,7 +27,9 @@ Examples can be found in the `samples` folder.
 
 ## Next steps
 
-First obtain an access token to the management service used in the sample code
+- Build this library (`core-http`). For more information on how to build project in this repo, please refer to the [Contributing Guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md).
+
+- The code in `samples\node-sample.ts` shows how to create a `ServiceClient` instance with a test `TokenCredential` implementation and use the client instance to perform a `GET` operation from the Azure management service endpoint for subscriptions. To run the code, first obtain an access token to the Azure management service.
 
 One easy way to get an access token is using [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 
@@ -44,21 +46,9 @@ az account set -s <subscription id>
 az account get-access-token --resource=https://management.azure.com
 ```
 
-### Node.js
+### NodeJS
 
-- Set environment variables used in the sample code
-
-on \*Nix/MacOS
-```shell
-export AZURE_SUBSCRIPTION_ID=<subscription id>
-export ACCESS_TOKEN=<access token>
-```
-or on Windows,
-
-```shell
-set AZURE_SUBSCRIPTION_ID=<subscription id>
-set ACCESS_TOKEN=<access token>
-```
+- Set values of `subscriptionId` and `token` variable in `samples/node-sample.ts`
 
 - Change directory to samples folder, compile the TypeScript code, then run the sample
 

--- a/sdk/core/core-http/README.md
+++ b/sdk/core/core-http/README.md
@@ -7,7 +7,11 @@ This is the core HTTP pipeline for Azure SDK JavaScript libraries which work in 
 ### Requirements
 
 - [Node.js](https://nodejs.org) version > 8.x
-- npm install -g typescript
+- Typescript compiler
+
+```shell
+npm install -g typescript
+```
 
 ### Installation
 
@@ -25,25 +29,49 @@ Examples can be found in the `samples` folder.
 
 First obtain an access token to the management service used in the sample code
 
-One easy way to get the token using Azure CLI (https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+One easy way to get an access token is using [Azure CLI](https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
 
-1. `az login` using the above subscription
-2. `az account set -s <subscription id>`
-3. `az account get-access-token --resource=https://management.azure.com`
+1. Sign in
+```shell
+az login
+```
+2. Select the subscription to use
+```shell
+az account set -s <subscription id>
+```
+3. Obtain an access token
+```shell
+az account get-access-token --resource=https://management.azure.com
+```
 
 ### Node.js
 
-- Set the subscriptionId and token environment variables
-- Change directory to samples folder `cd samples`
-- Compile the TypeScript code `tsc node-sample.ts`
-- Run `node node-sample.js`
+- Set environment variables used in the sample code
 
-### In the browser
+on \*Nix/MacOS
+```shell
+export AZURE_SUBSCRIPTION_ID=<subscription id>
+export ACCESS_TOKEN=<access token>
+```
+or on Windows,
 
-- Change directory to samples folder `cd samples`
-- Set the subscriptionId and token in `index.js`
-- Follow the guide at https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md#using-parcel
-- Open index.html file in the browser. It should show the response from GET request on the storage account. From Chrome type Ctrl + Shift + I and you can see the logs in console.
+```shell
+set AZURE_SUBSCRIPTION_ID=<subscription id>
+set ACCESS_TOKEN=<access token>
+```
+
+- Change directory to samples folder, compile the TypeScript code, then run the sample
+
+```
+cd samples
+tsc node-sample.ts
+node node-sample.js
+```
+
+### Browser
+
+- Set values of `subscriptionId` and `token` variable in `samples/index.js`
+- Follow the instructions of [JavaScript Bundling Guide using Parcel](https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md#using-parcel) to build and run the code in the browser.
 
 ## Troubleshooting
 

--- a/sdk/core/core-http/README.md
+++ b/sdk/core/core-http/README.md
@@ -6,12 +6,12 @@ This is the core HTTP pipeline for Azure SDK JavaScript libraries which work in 
 
 ### Requirements
 
-- Node.js version > 6.x
+- [Node.js](https://nodejs.org) version > 8.x
 - npm install -g typescript
 
 ### Installation
 
-- After cloning the repo, execute `npm install`
+This package is not meant to be consumed directly by end users.
 
 ## Key concepts
 
@@ -23,14 +23,26 @@ Examples can be found in the `samples` folder.
 
 ## Next steps
 
+First obtain an access token to the management service used in the sample code
+
+One easy way to get the token using Azure CLI (https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+
+1. `az login` using the above subscription
+2. `az account set -s <subscription id>`
+3. `az account get-access-token --resource=https://management.azure.com`
+
 ### Node.js
 
-- Set the subscriptionId and token
-- Run `node samples/node-sample.js`
+- Set the subscriptionId and token environment variables
+- Change directory to samples folder `cd samples`
+- Compile the TypeScript code `tsc node-sample.ts`
+- Run `node node-sample.js`
 
 ### In the browser
 
-- Set the subscriptionId and token and then run
+- Change directory to samples folder `cd samples`
+- Set the subscriptionId and token in `index.js`
+- Follow the guide at https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md#using-parcel
 - Open index.html file in the browser. It should show the response from GET request on the storage account. From Chrome type Ctrl + Shift + I and you can see the logs in console.
 
 ## Troubleshooting

--- a/sdk/core/core-http/samples/index.html
+++ b/sdk/core/core-http/samples/index.html
@@ -2,23 +2,12 @@
 <html lang="en">
 
 <head>
-  <title>My Todos</title>
-  <script type="text/javascript" src="../dist/coreHttp.browser.js"></script>
-  <script type="text/javascript">
-    document.write('hello world');
-    const subscriptionId = "00977cdb-163f-435f-9c32-39ec8ae61f4d";
-    const token = "token";
-    const creds = new Azure.Core.HTTP.RawTokenCredential(token);
-    const client = new Azure.Core.HTTP.ServiceClient(creds);
-    const req = {
-      url: `https://management.azure.com/subscriptions/${subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2015-06-15`,
-      method: "GET"
-    };
-    client.sendRequest(req).then((res) => { document.write(res.bodyAsText); }).catch((err) => { console.log(err); });
-  </script>
+  <title>My Test</title>
 </head>
 
 <body>
+  <!-- This browser example uses the Parcel bundler as described in https://github.com/Azure/azure-sdk-for-js/blob/master/documentation/Bundling.md#using-parcel -->
+  <script type="text/javascript" src="./index.js"></script>
 </body>
 
 </html>

--- a/sdk/core/core-http/samples/index.js
+++ b/sdk/core/core-http/samples/index.js
@@ -1,0 +1,26 @@
+const { ServiceClient } = require("@azure/core-http");
+
+const subscriptionId = "<subscription id>";
+const token = "<access token>";
+
+class TestTokenCredential {
+  constructor(token, expiresOn) {
+    this.token = token;
+    this.expiresOn = expiresOn ? expiresOn.getTime() : Date.now() + 60*60*1000;
+  }
+  async getToken(_scopes,_options) {
+    return {
+      token : this.token,
+      expiresOnTimestamp : this.expiresOn
+    }
+  }
+}
+
+document.write('hello world');
+const creds = new TestTokenCredential(token);
+const client = new ServiceClient(creds);
+const req = {
+  url: `https://management.azure.com/subscriptions/${subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2015-06-15`,
+  method: "GET"
+};
+client.sendRequest(req).then((res) => { document.write(res.bodyAsText.substr(0, 1000)); }).catch((err) => { console.log(err); });

--- a/sdk/core/core-http/samples/index.js
+++ b/sdk/core/core-http/samples/index.js
@@ -16,11 +16,10 @@ class TestTokenCredential {
   }
 }
 
-document.write('hello world');
 const creds = new TestTokenCredential(token);
 const client = new ServiceClient(creds);
 const req = {
   url: `https://management.azure.com/subscriptions/${subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2015-06-15`,
   method: "GET"
 };
-client.sendRequest(req).then((res) => { document.write(res.bodyAsText.substr(0, 1000)); }).catch((err) => { console.log(err); });
+client.sendRequest(req).then((res) => { console.log(res.bodyAsText.substr(0, 1000)); }).catch((err) => { console.log(err); });

--- a/sdk/core/core-http/samples/node-sample.ts
+++ b/sdk/core/core-http/samples/node-sample.ts
@@ -3,52 +3,58 @@
 
 "use strict";
 
-import * as coreHttp from "../src/coreHttp";
-const clientOptions: coreHttp.ServiceClientOptions = {
-  requestPolicyFactories: [coreHttp.logPolicy()]
-};
+import * as coreHttp from "@azure/core-http";
 
 /* This is an example token credential that uses a token value directly. Ordinarily, clients should use a
  * TokenCredential provided by the user when the client is created. Users should use DefaultAzureCredential
  * from @azure/identity unless they have specific authentication needs.
  */
 class TestTokenCredential implements coreHttp.TokenCredential {
-  public token : string;
-  public expiresOn : number;
+  public token: string;
+  public expiresOn: number;
 
   constructor(token: string, expiresOn?: Date) {
     this.token = token;
-    this.expiresOn = expiresOn ? expiresOn.getTime() : Date.now() + 60*60*1000;
+    this.expiresOn = expiresOn
+      ? expiresOn.getTime()
+      : Date.now() + 60 * 60 * 1000;
   }
 
   async getToken(
     _scopes: string | string[],
-    _options? : coreHttp.GetTokenOptions
-  ) : Promise<coreHttp.AccessToken | null> { 
+    _options?: coreHttp.GetTokenOptions
+  ): Promise<coreHttp.AccessToken | null> {
     return {
-      token : this.token,
-      expiresOnTimestamp : this.expiresOn
-    }
+      token: this.token,
+      expiresOnTimestamp: this.expiresOn
+    };
   }
 }
 
 const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"] || "subscriptionId";
-// An easy way to get the token
-// 1. Go to this test drive link https://azure.github.io/projects/apis and authenticate by clicking on Authorize. Check the user impersoantion checkbox in the popup.
-// 1.1 select a subscription of your choice
-// 1.2 select the storage-2015-06-15 option from the first drop down list
-// 1.3 expand the url to list storage accounts in a subscription
-// 1.4 click on try it out button.
-// 1.5 in the curl tab you will see the actual curl request that has the bearer token in it
-// 1.6 copy paste that token here. That token is valid for 1 hour
+// An easy way to get the token using Azure CLI (https://docs.microsoft.com/cli/azure/?view=azure-cli-latest)
+// 1. `az login` using the above subscription
+// 2. `az account set -s <subscription id>`
+// 3. `az account get-access-token --resource=https://management.azure.com`
+// 4. copy paste that token here. That token is valid for 1 hour
 const token = process.env["ACCESS_TOKEN"] || "token";
 const creds = new TestTokenCredential(token);
+const clientOptions: coreHttp.ServiceClientOptions = {
+  requestPolicyFactories: [
+    coreHttp.logPolicy(),
+    coreHttp.bearerTokenAuthenticationPolicy(
+      creds,
+      "https://management.azure.com"
+    )
+  ]
+};
+
 const client = new coreHttp.ServiceClient(creds, clientOptions);
 const req: coreHttp.RequestPrepareOptions = {
   url: `https://management.azure.com/subscriptions/${subscriptionId}/providers/Microsoft.Storage/storageAccounts?api-version=2015-06-15`,
   method: "GET"
 };
 
-client.sendRequest(req).then(function (res: coreHttp.HttpOperationResponse) {
-  console.log(res.bodyAsText);
+client.sendRequest(req).then(function(res: coreHttp.HttpOperationResponse) {
+  console.log(res.bodyAsText!.substr(0, 1000));
 });

--- a/sdk/core/core-http/samples/node-sample.ts
+++ b/sdk/core/core-http/samples/node-sample.ts
@@ -3,7 +3,7 @@
 
 "use strict";
 
-import * as coreHttp from "@azure/core-http";
+import * as coreHttp from "../src/coreHttp";
 
 /* This is an example token credential that uses a token value directly. Ordinarily, clients should use a
  * TokenCredential provided by the user when the client is created. Users should use DefaultAzureCredential


### PR DESCRIPTION
- update instructions to obtain an access token
- fix request policy factories. When factories are passed in, the
  credential passed to constructor is not used.
- revamp browser sample to use the Parcel bundler as we no longer
  ship the browser distribution.

Fixes #7589