### PR TITLE
[Service Bus] Support cancellation on $management operations

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -4,13 +4,14 @@
 
 ```ts
 
+import { AbortSignalLike } from '@azure/abort-controller';
 import { AmqpMessage } from '@azure/core-amqp';
 import { delay } from '@azure/core-amqp';
 import { Delivery } from 'rhea-promise';
 import Long from 'long';
 import { MessagingError } from '@azure/core-amqp';
-import { OperationOptions } from '@azure/core-auth';
 import { RetryOptions } from '@azure/core-amqp';
+import { SpanOptions } from '@opentelemetry/types';
 import { TokenCredential } from '@azure/core-amqp';
 import { TokenType } from '@azure/core-amqp';
 import { WebSocketImpl } from 'rhea-promise';
@@ -83,6 +84,11 @@ export interface MessageHandlers<ReceivedMessageT> {
 export { MessagingError }
 
 // @public
+export interface OperationOptions extends TracingOptions {
+    abortSignal?: AbortSignalLike;
+}
+
+// @public
 export interface ReceiveBatchOptions extends OperationOptions, WaitTimeOptions {
 }
 
@@ -142,13 +148,13 @@ export interface RuleDescription {
 
 // @public
 export interface Sender {
-    cancelScheduledMessage(sequenceNumber: Long): Promise<void>;
-    cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void>;
+    cancelScheduledMessage(sequenceNumber: Long, options?: OperationOptions): Promise<void>;
+    cancelScheduledMessages(sequenceNumbers: Long[], options?: OperationOptions): Promise<void>;
     close(): Promise<void>;
     createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch>;
     isClosed: boolean;
-    scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage): Promise<Long>;
-    scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[]): Promise<Long[]>;
+    scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage, options?: OperationOptions): Promise<Long>;
+    scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[], options?: OperationOptions): Promise<Long[]>;
     send(message: ServiceBusMessage): Promise<void>;
     sendBatch(messageBatch: ServiceBusMessageBatch): Promise<void>;
 }
@@ -220,11 +226,11 @@ export interface SessionReceiver<ReceivedMessageT extends ReceivedMessage | Rece
         peek(maxMessageCount?: number): Promise<ReceivedMessage[]>;
         peekBySequenceNumber(fromSequenceNumber: Long, maxMessageCount?: number): Promise<ReceivedMessage[]>;
     };
-    getState(): Promise<any>;
-    renewSessionLock(): Promise<Date>;
+    getState(options?: OperationOptions): Promise<any>;
+    renewSessionLock(options?: OperationOptions): Promise<Date>;
     sessionId: string | undefined;
     sessionLockedUntilUtc: Date | undefined;
-    setState(state: any): Promise<void>;
+    setState(state: any, options?: OperationOptions): Promise<void>;
 }
 
 // @public
@@ -250,6 +256,13 @@ export interface SubscriptionRuleManager {
 export { TokenCredential }
 
 export { TokenType }
+
+// @public
+export interface TracingOptions {
+    tracingOptions?: {
+        spanOptions?: SpanOptions;
+    };
+}
 
 // @public
 export interface WaitTimeOptions {

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -41,6 +41,7 @@ export {
   GetSenderOptions,
   GetSubscriptionRuleManagerOptions
 } from "./models";
+export { OperationOptions, TracingOptions } from "./modelsToBeSharedWithEventHubs";
 
 export { Receiver } from "./receivers/receiver";
 export { SubscriptionRuleManager } from "./receivers/subscriptionRuleManager";

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { OperationOptions } from "@azure/core-auth";
+import { OperationOptions } from "./modelsToBeSharedWithEventHubs";
 import { RetryOptions } from "@azure/core-amqp";
 import { SessionReceiverOptions } from "./session/messageSession";
 

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -9,7 +9,7 @@ import {
   MessageHandlerOptions,
   GetReceiverOptions
 } from "../models";
-import { OperationOptions } from "@azure/core-auth";
+import { OperationOptions } from "../modelsToBeSharedWithEventHubs";
 import { ReceivedMessage } from "..";
 import { ClientEntityContext } from "../clientEntityContext";
 import {
@@ -59,6 +59,7 @@ export interface Receiver<ReceivedMessageT> {
   /**
    * Returns a promise that resolves to a deferred message identified by the given `sequenceNumber`.
    * @param {Long} sequenceNumber The sequence number of the message that needs to be received.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns {(Promise<ServiceBusMessage | undefined>)}
    * - Returns `Message` identified by sequence number.
    * - Returns `undefined` if no such message is found.
@@ -73,6 +74,7 @@ export interface Receiver<ReceivedMessageT> {
   /**
    * Returns a promise that resolves to an array of deferred messages identified by given `sequenceNumbers`.
    * @param {Long[]} sequenceNumbers An array of sequence numbers for the messages that need to be received.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns {Promise<ServiceBusMessage[]>}
    * - Returns a list of messages identified by the given sequenceNumbers.
    * - Returns an empty list if no messages are found.
@@ -183,6 +185,11 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
         this._peekBySequenceNumber(fromSequenceNumber, maxMessageCount)
     };
     this._receiverOptions = options;
+    if (this._receiverOptions.retryOptions) {
+      this._receiverOptions.retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(
+        this._receiverOptions.retryOptions
+      );
+    }
   }
 
   private _throwIfAlreadyReceiving(): void {
@@ -336,13 +343,17 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
   /**
    * Returns a promise that resolves to a deferred message identified by the given `sequenceNumber`.
    * @param sequenceNumber The sequence number of the message that needs to be received.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<ServiceBusMessage | undefined>
    * - Returns `Message` identified by sequence number.
    * - Returns `undefined` if no such message is found.
    * @throws Error if the underlying connection, client or receiver is closed.
    * @throws MessagingError if the service returns an error while receiving deferred message.
    */
-  async receiveDeferredMessage(sequenceNumber: Long): Promise<ReceivedMessageT | undefined> {
+  async receiveDeferredMessage(
+    sequenceNumber: Long,
+    options: OperationOptions = {}
+  ): Promise<ReceivedMessageT | undefined> {
     this._throwIfReceiverOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
       this._context.namespace.connectionId,
@@ -355,15 +366,16 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       sequenceNumber
     );
 
-    const retryOptions = this._receiverOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
     const receiveDeferredMessageOperationPromise = async () => {
       const messages = await this._context.managementClient!.receiveDeferredMessages(
         [sequenceNumber],
         convertToInternalReceiveMode(this.receiveMode),
         undefined,
-        retryOptions.timeoutInMs
+        {
+          ...options,
+          requestName: "receiveDeferredMessage",
+          timeoutInMs: this._receiverOptions.retryOptions?.timeoutInMs
+        }
       );
       return (messages[0] as unknown) as ReceivedMessageT;
     };
@@ -371,7 +383,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       operation: receiveDeferredMessageOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._receiverOptions.retryOptions
     };
     return retry<ReceivedMessageT | undefined>(config);
   }
@@ -379,13 +391,17 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
   /**
    * Returns a promise that resolves to an array of deferred messages identified by given `sequenceNumbers`.
    * @param sequenceNumbers An array of sequence numbers for the messages that need to be received.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<ServiceBusMessage[]>
    * - Returns a list of messages identified by the given sequenceNumbers.
    * - Returns an empty list if no messages are found.
    * @throws Error if the underlying connection, client or receiver is closed.
    * @throws MessagingError if the service returns an error while receiving deferred messages.
    */
-  async receiveDeferredMessages(sequenceNumbers: Long[]): Promise<ReceivedMessageT[]> {
+  async receiveDeferredMessages(
+    sequenceNumbers: Long[],
+    options: OperationOptions = {}
+  ): Promise<ReceivedMessageT[]> {
     this._throwIfReceiverOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
       this._context.namespace.connectionId,
@@ -401,15 +417,16 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       sequenceNumbers
     );
 
-    const retryOptions = this._receiverOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
     const receiveDeferredMessagesOperationPromise = async () => {
       const deferredMessages = await this._context.managementClient!.receiveDeferredMessages(
         sequenceNumbers,
         convertToInternalReceiveMode(this.receiveMode),
         undefined,
-        retryOptions.timeoutInMs
+        {
+          ...options,
+          requestName: "receiveDeferredMessage",
+          timeoutInMs: this._receiverOptions.retryOptions?.timeoutInMs
+        }
       );
       return (deferredMessages as any) as ReceivedMessageT[];
     };
@@ -417,56 +434,61 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       operation: receiveDeferredMessagesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._receiverOptions.retryOptions
     };
     return retry<ReceivedMessageT[]>(config);
   }
 
   // ManagementClient methods # Begin
 
-  private async _peek(maxMessageCount?: number): Promise<ReceivedMessage[]> {
-    throwErrorIfClientOrConnectionClosed(
-      this._context.namespace,
-      this._context.entityPath,
-      this._context.isClosed
-    );
-    const retryOptions = this._receiverOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
-    const peekOperationPromise = async () => {
-      const internalMessages = await this._context.managementClient!.peek(
-        maxMessageCount,
-        retryOptions.timeoutInMs
-      );
-      return internalMessages.map((m) => m as ReceivedMessage);
-    };
-    const config: RetryConfig<ReceivedMessage[]> = {
-      operation: peekOperationPromise,
-      connectionId: this._context.namespace.connectionId,
-      operationType: RetryOperationType.management,
-      retryOptions: retryOptions
-    };
-    return retry<ReceivedMessage[]>(config);
-  }
-
-  private async _peekBySequenceNumber(
-    fromSequenceNumber: Long,
-    maxMessageCount?: number
+  private async _peek(
+    maxMessageCount?: number,
+    options: OperationOptions = {}
   ): Promise<ReceivedMessage[]> {
     throwErrorIfClientOrConnectionClosed(
       this._context.namespace,
       this._context.entityPath,
       this._context.isClosed
     );
-    const retryOptions = this._receiverOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
+
+    const peekOperationPromise = async () => {
+      const internalMessages = await this._context.managementClient!.peek(maxMessageCount, {
+        ...options,
+        requestName: "peek",
+        timeoutInMs: this._receiverOptions.retryOptions?.timeoutInMs
+      });
+      return internalMessages.map((m) => m as ReceivedMessage);
+    };
+    const config: RetryConfig<ReceivedMessage[]> = {
+      operation: peekOperationPromise,
+      connectionId: this._context.namespace.connectionId,
+      operationType: RetryOperationType.management,
+      retryOptions: this._receiverOptions.retryOptions
+    };
+    return retry<ReceivedMessage[]>(config);
+  }
+
+  private async _peekBySequenceNumber(
+    fromSequenceNumber: Long,
+    maxMessageCount?: number,
+    options: OperationOptions = {}
+  ): Promise<ReceivedMessage[]> {
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
 
     const peekBySequenceNumberOperationPromise = async () => {
       const internalMessages = await this._context.managementClient!.peekBySequenceNumber(
         fromSequenceNumber,
         maxMessageCount,
         undefined,
-        retryOptions.timeoutInMs
+        {
+          ...options,
+          requestName: "peekBySequenceNumber",
+          timeoutInMs: this._receiverOptions.retryOptions?.timeoutInMs
+        }
       );
       return internalMessages.map((m) => m as ReceivedMessage);
     };
@@ -474,7 +496,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       operation: peekBySequenceNumberOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._receiverOptions.retryOptions
     };
     return retry<ReceivedMessage[]>(config);
   }

--- a/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
@@ -6,6 +6,7 @@ import { throwErrorIfClientOrConnectionClosed } from "../util/errors";
 import { ClientEntityContext } from "../clientEntityContext";
 import { GetSubscriptionRuleManagerOptions } from "../models";
 import { retry, RetryOperationType, RetryConfig } from "@azure/core-amqp";
+import { OperationOptions } from "../modelsToBeSharedWithEventHubs";
 import { getRetryAttemptTimeoutInMs } from "../util/utils";
 
 /**
@@ -15,6 +16,7 @@ import { getRetryAttemptTimeoutInMs } from "../util/utils";
 export interface SubscriptionRuleManager {
   /**
    * Gets all rules associated with the subscription
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the SubscriptionClient or the underlying connection is closed.
    * @throws MessagingError if the service returns an error while retrieving rules.
    */
@@ -26,6 +28,7 @@ export interface SubscriptionRuleManager {
    * **Caution**: If all rules on a subscription are removed, then the subscription will not receive
    * any more messages.
    * @param ruleName
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the SubscriptionClient or the underlying connection is closed.
    * @throws MessagingError if the service returns an error while removing rules.
    */
@@ -42,6 +45,7 @@ export interface SubscriptionRuleManager {
    * {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-filter SQLFilter syntax}.
    * @param sqlRuleActionExpression Action to perform if the message satisfies the filtering expression. For SQL Rule Action syntax,
    * see {@link https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-sql-rule-action SQLRuleAction syntax}.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @throws Error if the SubscriptionClient or the underlying connection is closed.
    * @throws MessagingError if the service returns an error while adding rules.
    */
@@ -71,49 +75,56 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
   private _ruleManagerOptions: GetSubscriptionRuleManagerOptions;
   constructor(private _context: ClientEntityContext, options: GetSubscriptionRuleManagerOptions) {
     this._ruleManagerOptions = options;
+    if (this._ruleManagerOptions.retryOptions) {
+      this._ruleManagerOptions.retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(
+        this._ruleManagerOptions.retryOptions
+      );
+    }
   }
 
   // #region topic-filters
-  getRules(): Promise<RuleDescription[]> {
+  getRules(options: OperationOptions = {}): Promise<RuleDescription[]> {
     throwErrorIfClientOrConnectionClosed(
       this._context.namespace,
       this._context.entityPath,
       this._context.isClosed
     );
 
-    const retryOptions = this._ruleManagerOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
     const getRulesOperationPromise = async () => {
-      return this._context.managementClient!.getRules(retryOptions.timeoutInMs!);
+      return this._context.managementClient!.getRules({
+        ...options,
+        requestName: "getRules",
+        timeoutInMs: this._ruleManagerOptions.retryOptions?.timeoutInMs
+      });
     };
     const config: RetryConfig<RuleDescription[]> = {
       operation: getRulesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._ruleManagerOptions.retryOptions
     };
     return retry<RuleDescription[]>(config);
   }
 
-  removeRule(ruleName: string): Promise<void> {
+  removeRule(ruleName: string, options: OperationOptions = {}): Promise<void> {
     throwErrorIfClientOrConnectionClosed(
       this._context.namespace,
       this._context.entityPath,
       this._context.isClosed
     );
 
-    const retryOptions = this._ruleManagerOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
     const removeRuleOperationPromise = () => {
-      return this._context.managementClient!.removeRule(ruleName, retryOptions.timeoutInMs!);
+      return this._context.managementClient!.removeRule(ruleName, {
+        ...options,
+        requestName: "removeRule",
+        timeoutInMs: this._ruleManagerOptions.retryOptions?.timeoutInMs
+      });
     };
     const config: RetryConfig<void> = {
       operation: removeRuleOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._ruleManagerOptions.retryOptions
     };
     return retry<void>(config);
   }
@@ -121,24 +132,27 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
   addRule(
     ruleName: string,
     filter: boolean | string | CorrelationFilter,
-    sqlRuleActionExpression?: string
+    sqlRuleActionExpression?: string,
+    options: OperationOptions = {}
   ): Promise<void> {
     throwErrorIfClientOrConnectionClosed(
       this._context.namespace,
       this._context.entityPath,
       this._context.isClosed
     );
-    const retryOptions = this._ruleManagerOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
 
     const addRuleOperationPromise = async () => {
-      return this._context.managementClient!.addRule(ruleName, filter, sqlRuleActionExpression);
+      return this._context.managementClient!.addRule(ruleName, filter, sqlRuleActionExpression, {
+        ...options,
+        requestName: "addRule",
+        timeoutInMs: this._ruleManagerOptions.retryOptions?.timeoutInMs
+      });
     };
     const config: RetryConfig<void> = {
       operation: addRuleOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._ruleManagerOptions.retryOptions
     };
     return retry<void>(config);
   }

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -16,6 +16,7 @@ import {
 import { ServiceBusMessageBatch } from "./serviceBusMessageBatch";
 import { CreateBatchOptions, GetSenderOptions } from "./models";
 import { retry, RetryOperationType, RetryConfig } from "@azure/core-amqp";
+import { OperationOptions } from "./modelsToBeSharedWithEventHubs";
 import { getRetryAttemptTimeoutInMs } from "./util/utils";
 
 /**
@@ -91,6 +92,7 @@ export interface Sender {
    *
    * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
    * @param message - The message that needs to be scheduled.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<Long> - The sequence number of the message that was scheduled.
    * You will need the sequence number if you intend to cancel the scheduling of the message.
    * Save the `Long` type as-is in your application without converting to number. Since JavaScript
@@ -98,13 +100,18 @@ export interface Sender {
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws MessagingError if the service returns an error while scheduling a message.
    */
-  scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage): Promise<Long>;
+  scheduleMessage(
+    scheduledEnqueueTimeUtc: Date,
+    message: ServiceBusMessage,
+    options?: OperationOptions
+  ): Promise<Long>;
 
   /**
    * Schedules given messages to appear on Service Bus Queue/Subscription at a later time.
    *
    * @param scheduledEnqueueTimeUtc - The UTC time at which the messages should be enqueued.
    * @param messages - Array of Messages that need to be scheduled.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<Long[]> - The sequence numbers of messages that were scheduled.
    * You will need the sequence number if you intend to cancel the scheduling of the messages.
    * Save the `Long` type as-is in your application without converting to number. Since JavaScript
@@ -112,24 +119,30 @@ export interface Sender {
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws MessagingError if the service returns an error while scheduling messages.
    */
-  scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[]): Promise<Long[]>;
+  scheduleMessages(
+    scheduledEnqueueTimeUtc: Date,
+    messages: ServiceBusMessage[],
+    options?: OperationOptions
+  ): Promise<Long[]>;
 
   /**
    * Cancels a message that was scheduled to appear on a ServiceBus Queue/Subscription.
    * @param sequenceNumber - The sequence number of the message to be cancelled.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<void>
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws MessagingError if the service returns an error while canceling a scheduled message.
    */
-  cancelScheduledMessage(sequenceNumber: Long): Promise<void>;
+  cancelScheduledMessage(sequenceNumber: Long, options?: OperationOptions): Promise<void>;
   /**
    * Cancels multiple messages that were scheduled to appear on a ServiceBus Queue/Subscription.
    * @param sequenceNumbers - An Array of sequence numbers of the messages to be cancelled.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<void>
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws MessagingError if the service returns an error while canceling scheduled messages.
    */
-  cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void>;
+  cancelScheduledMessages(sequenceNumbers: Long[], options?: OperationOptions): Promise<void>;
 
   /**
    * Closes the underlying AMQP sender link.
@@ -162,6 +175,11 @@ export class SenderImpl implements Sender {
     this._context = context;
     this._sender = MessageSender.create(this._context, options);
     this._senderOptions = options;
+    if (this._senderOptions.retryOptions) {
+      this._senderOptions.retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(
+        this._senderOptions.retryOptions
+      );
+    }
   }
 
   private _throwIfSenderOrConnectionClosed(): void {
@@ -218,6 +236,7 @@ export class SenderImpl implements Sender {
    *
    * @param scheduledEnqueueTimeUtc - The UTC time at which the message should be enqueued.
    * @param message - The message that needs to be scheduled.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<Long> - The sequence number of the message that was scheduled.
    * You will need the sequence number if you intend to cancel the scheduling of the message.
    * Save the `Long` type as-is in your application without converting to number. Since JavaScript
@@ -225,7 +244,11 @@ export class SenderImpl implements Sender {
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws MessagingError if the service returns an error while scheduling a message.
    */
-  async scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage): Promise<Long> {
+  async scheduleMessage(
+    scheduledEnqueueTimeUtc: Date,
+    message: ServiceBusMessage,
+    options: OperationOptions = {}
+  ): Promise<Long> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
       this._context.namespace.connectionId,
@@ -234,16 +257,15 @@ export class SenderImpl implements Sender {
     );
     throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "message", message);
 
-    const retryOptions = this._senderOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
-    const messages = [message];
-
     const scheduleMessageOperationPromise = async () => {
       const result = await this._context.managementClient!.scheduleMessages(
         scheduledEnqueueTimeUtc,
-        messages,
-        retryOptions.timeoutInMs!
+        [message],
+        {
+          ...options,
+          requestName: "scheduleMessage",
+          timeoutInMs: this._senderOptions.retryOptions?.timeoutInMs
+        }
       );
       return result[0];
     };
@@ -252,14 +274,15 @@ export class SenderImpl implements Sender {
       operation: scheduleMessageOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._senderOptions.retryOptions
     };
     return retry<Long.Long>(config);
   }
 
   async scheduleMessages(
     scheduledEnqueueTimeUtc: Date,
-    messages: ServiceBusMessage[]
+    messages: ServiceBusMessage[],
+    options: OperationOptions = {}
   ): Promise<Long[]> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
@@ -272,26 +295,26 @@ export class SenderImpl implements Sender {
       messages = [messages];
     }
 
-    const retryOptions = this._senderOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
     const scheduleMessageOperationPromise = async () => {
-      return this._context.managementClient!.scheduleMessages(
-        scheduledEnqueueTimeUtc,
-        messages,
-        retryOptions.timeoutInMs!
-      );
+      return this._context.managementClient!.scheduleMessages(scheduledEnqueueTimeUtc, messages, {
+        ...options,
+        requestName: "scheduleMessages",
+        timeoutInMs: this._senderOptions.retryOptions?.timeoutInMs
+      });
     };
     const config: RetryConfig<Long.Long[]> = {
       operation: scheduleMessageOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._senderOptions.retryOptions
     };
     return retry<Long.Long[]>(config);
   }
 
-  async cancelScheduledMessage(sequenceNumber: Long): Promise<void> {
+  async cancelScheduledMessage(
+    sequenceNumber: Long,
+    options: OperationOptions = {}
+  ): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
       this._context.namespace.connectionId,
@@ -304,25 +327,26 @@ export class SenderImpl implements Sender {
       sequenceNumber
     );
 
-    const retryOptions = this._senderOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
     const cancelSchedulesMessagesOperationPromise = async () => {
-      return this._context.managementClient!.cancelScheduledMessages(
-        [sequenceNumber],
-        retryOptions.timeoutInMs!
-      );
+      return this._context.managementClient!.cancelScheduledMessages([sequenceNumber], {
+        ...options,
+        requestName: "cancelScheduleMessage",
+        timeoutInMs: this._senderOptions.retryOptions?.timeoutInMs
+      });
     };
     const config: RetryConfig<void> = {
       operation: cancelSchedulesMessagesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._senderOptions.retryOptions
     };
     return retry<void>(config);
   }
 
-  async cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void> {
+  async cancelScheduledMessages(
+    sequenceNumbers: Long[],
+    options: OperationOptions = {}
+  ): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
       this._context.namespace.connectionId,
@@ -338,20 +362,18 @@ export class SenderImpl implements Sender {
       sequenceNumbers
     );
 
-    const retryOptions = this._senderOptions.retryOptions || {};
-    retryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(retryOptions);
-
     const cancelSchedulesMessagesOperationPromise = async () => {
-      return this._context.managementClient!.cancelScheduledMessages(
-        sequenceNumbers,
-        retryOptions.timeoutInMs!
-      );
+      return this._context.managementClient!.cancelScheduledMessages(sequenceNumbers, {
+        ...options,
+        requestName: "cancelScheduleMessages",
+        timeoutInMs: this._senderOptions.retryOptions?.timeoutInMs
+      });
     };
     const config: RetryConfig<void> = {
       operation: cancelSchedulesMessagesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: retryOptions
+      retryOptions: this._senderOptions.retryOptions
     };
     return retry<void>(config);
   }


### PR DESCRIPTION
This PR updates all the $management operations on the sender, receiver, session receiver and the  rule manager to respect the abort signal