### PR TITLE
[Service Bus] maxWaitTimeInSeconds -> maxWaitTimeInMs

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -253,7 +253,7 @@ export { TokenType }
 
 // @public
 export interface WaitTimeOptions {
-    maxWaitTimeSeconds: number;
+    maxWaitTimeInMs: number;
 }
 
 export { WebSocketImpl }

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
@@ -134,7 +134,7 @@ async function processMessageFromSession(sessionId: string) {
   );
 
   const messages = await sessionReceiver.receiveBatch(1, {
-    maxWaitTimeSeconds: 10
+    maxWaitTimeInMs: 10000
   });
 
   // Custom logic for processing the messages

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/topicFilters.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/topicFilters.ts
@@ -112,7 +112,7 @@ async function receiveMessages(sbClient: ServiceBusClient) {
   );
 
   const messagesFromSubscription1 = await subscription1.receiveBatch(10, {
-    maxWaitTimeSeconds: 5
+    maxWaitTimeInMs: 5000
   });
   console.log(">>>>> Messages from the first subscription:");
   for (let i = 0; i < messagesFromSubscription1.length; i++) {
@@ -122,7 +122,7 @@ async function receiveMessages(sbClient: ServiceBusClient) {
   await subscription1.close();
 
   const messagesFromSubscription2 = await subscription2.receiveBatch(10, {
-    maxWaitTimeSeconds: 5
+    maxWaitTimeInMs: 5000
   });
   console.log(">>>>> Messages from the second subscription:");
   for (let i = 0; i < messagesFromSubscription2.length; i++) {
@@ -132,7 +132,7 @@ async function receiveMessages(sbClient: ServiceBusClient) {
   await subscription2.close();
 
   const messagesFromSubscription3 = await subscription3.receiveBatch(10, {
-    maxWaitTimeSeconds: 5
+    maxWaitTimeInMs: 5000
   });
   console.log(">>>>> Messages from the third subscription:");
   for (let i = 0; i < messagesFromSubscription3.length; i++) {

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
@@ -35,7 +35,7 @@ export async function main() {
   try {
     for (let i = 0; i < 10; i++) {
       const messages = await queueReceiver.receiveBatch(1, {
-        maxWaitTimeSeconds: 5
+        maxWaitTimeInMs: 5000
       });
 
       if (!messages.length) {

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -319,10 +319,10 @@ export class BatchingReceiver extends MessageReceiver {
       // Action to be performed after the max wait time is over.
       const actionAfterWaitTimeout = (): void => {
         log.batching(
-          "[%s] Batching Receiver '%s'  max wait time in seconds %d over.",
+          "[%s] Batching Receiver '%s'  max wait time in milliseconds %d over.",
           this._context.namespace.connectionId,
           this.name,
-          maxWaitTimeInMs / 1000
+          maxWaitTimeInMs
         );
         return finalAction();
       };
@@ -379,9 +379,9 @@ export class BatchingReceiver extends MessageReceiver {
         // be of size upto maxMessageCount. Then the user needs to accordingly dispose
         // (complete/abandon/defer/deadletter) the messages from the array.
         this._receiver!.addCredit(maxMessageCount);
-        let msg: string = "[%s] Setting the wait timer for %d seconds for receiver '%s'.";
+        let msg: string = "[%s] Setting the wait timer for %d milliseconds for receiver '%s'.";
         if (reuse) msg += " Receiver link already present, hence reusing it.";
-        log.batching(msg, this._context.namespace.connectionId, maxWaitTimeInMs / 1000, this.name);
+        log.batching(msg, this._context.namespace.connectionId, maxWaitTimeInMs, this.name);
         totalWaitTimer = setTimeout(actionAfterWaitTimeout, maxWaitTimeInMs);
         // TODO: Disabling this for now. We would want to give the user a decent chance to receive
         // the first message and only timeout faster if successive messages from there onwards are

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -29,9 +29,9 @@ export interface MessageHandlers<ReceivedMessageT> {
 export interface WaitTimeOptions {
   /**
    * The maximum amount of time to wait for messages to arrive.
-   *  **Default**: `60` seconds.
+   *  **Default**: `60000` milliseconds.
    */
-  maxWaitTimeSeconds: number;
+  maxWaitTimeInMs: number;
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -29,7 +29,7 @@ import { assertValidMessageHandlers, getMessageIterator } from "./shared";
 import { convertToInternalReceiveMode } from "../constructorHelpers";
 import Long from "long";
 import { ServiceBusMessageImpl, ReceivedMessageWithLock } from "../serviceBusMessage";
-import { RetryConfig, RetryOperationType, retry } from "@azure/core-amqp";
+import { RetryConfig, RetryOperationType, retry, Constants } from "@azure/core-amqp";
 import { getRetryAttemptTimeoutInMs } from "../util/utils";
 
 /**
@@ -307,7 +307,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       }
       const receivedMessages = await this._context.batchingReceiver.receive(
         maxMessageCount,
-        options?.maxWaitTimeSeconds
+        options?.maxWaitTimeInMs || Constants.defaultOperationTimeoutInMs
       );
       return (receivedMessages as unknown) as ReceivedMessageT[];
     };

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -279,7 +279,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
    * Returns a promise that resolves to an array of messages based on given count and timeout over
    * an AMQP receiver link from a Queue/Subscription.
    *
-   * The `maxWaitTimeSeconds` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
+   * The `maxWaitTimeInMs` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
    * Throws an error if there is another receive operation in progress on the same receiver. If you
    * are not sure whether there is another receive operation running, check the `isReceivingMessages`
    * property on the receiver.
@@ -325,7 +325,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
   /**
    * Gets an async iterator over messages from the receiver.
    *
-   * The `maxWaitTimeSeconds` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
+   * The `maxWaitTimeInMs` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
    * Throws an error if there is another receive operation in progress on the same receiver. If you
    * are not sure whether there is another receive operation running, check the `isReceivingMessages`
    * property on the receiver.

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -307,7 +307,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       }
       const receivedMessages = await this._context.batchingReceiver.receive(
         maxMessageCount,
-        options?.maxWaitTimeInMs || Constants.defaultOperationTimeoutInMs
+        options?.maxWaitTimeInMs ?? Constants.defaultOperationTimeoutInMs
       );
       return (receivedMessages as unknown) as ReceivedMessageT[];
     };

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -28,7 +28,7 @@ import { convertToInternalReceiveMode } from "../constructorHelpers";
 import { Receiver } from "./receiver";
 import Long from "long";
 import { ServiceBusMessageImpl, ReceivedMessageWithLock } from "../serviceBusMessage";
-import { RetryConfig, RetryOperationType, retry } from "@azure/core-amqp";
+import { RetryConfig, RetryOperationType, retry, Constants } from "@azure/core-amqp";
 import { getRetryAttemptTimeoutInMs } from "../util/utils";
 
 /**
@@ -535,7 +535,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
 
       const receivedMessages = await this._messageSession!.receiveMessages(
         maxMessageCount,
-        options?.maxWaitTimeSeconds
+        options?.maxWaitTimeInMs || Constants.defaultOperationTimeoutInMs
       );
 
       return (receivedMessages as any) as ReceivedMessageT[];

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -512,7 +512,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
    * Returns a promise that resolves to an array of messages based on given count and timeout over
    * an AMQP receiver link from a Queue/Subscription.
    *
-   * The `maxWaitTimeSeconds` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
+   * The `maxWaitTimeInMs` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
    * Throws an error if there is another receive operation in progress on the same receiver. If you
    * are not sure whether there is another receive operation running, check the `isReceivingMessages`
    * property on the receiver.
@@ -624,7 +624,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
   /**
    * Gets an async iterator over messages from the receiver.
    *
-   * The `maxWaitTimeSeconds` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
+   * The `maxWaitTimeInMs` provided via the options overrides the `timeoutInMs` provided in the `retryOptions`.
    * Throws an error if there is another receive operation in progress on the same receiver. If you
    * are not sure whether there is another receive operation running, check the `isReceivingMessages`
    * property on the receiver.

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -535,7 +535,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
 
       const receivedMessages = await this._messageSession!.receiveMessages(
         maxMessageCount,
-        options?.maxWaitTimeInMs || Constants.defaultOperationTimeoutInMs
+        options?.maxWaitTimeInMs ?? Constants.defaultOperationTimeoutInMs
       );
 
       return (receivedMessages as any) as ReceivedMessageT[];

--- a/sdk/servicebus/service-bus/src/session/messageSession.ts
+++ b/sdk/servicebus/service-bus/src/session/messageSession.ts
@@ -964,10 +964,10 @@ export class MessageSession extends LinkEntity {
       // Action to be performed after the max wait time is over.
       const actionAfterWaitTimeout: Func<void, void> = (): void => {
         log.batching(
-          "[%s] Batching Receiver '%s'  max wait time in seconds %d over.",
+          "[%s] Batching Receiver '%s'  max wait time in milliseconds %d over.",
           this._context.namespace.connectionId,
           this.name,
-          maxWaitTimeInMs / 1000
+          maxWaitTimeInMs
         );
         return finalAction();
       };
@@ -1103,9 +1103,9 @@ export class MessageSession extends LinkEntity {
         // be of size upto maxMessageCount. Then the user needs to accordingly dispose
         // (complete,/abandon/defer/deadletter) the messages from the array.
         this._receiver!.addCredit(maxMessageCount);
-        let msg: string = "[%s] Setting the wait timer for %d seconds for receiver '%s'.";
+        let msg: string = "[%s] Setting the wait timer for %d milliseconds for receiver '%s'.";
         if (reuse) msg += " Receiver link already present, hence reusing it.";
-        log.batching(msg, this._context.namespace.connectionId, maxWaitTimeInMs / 1000, this.name);
+        log.batching(msg, this._context.namespace.connectionId, maxWaitTimeInMs, this.name);
         totalWaitTimer = setTimeout(actionAfterWaitTimeout, maxWaitTimeInMs);
       };
 

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -703,7 +703,7 @@ describe("batchReceiver", () => {
 
     // We use an empty queue/topic here so that the first receiveMessages call takes time to return
     async function testParallelReceiveCalls(useSessions?: boolean): Promise<void> {
-      const firstBatchPromise = receiverClient.receiveBatch(1, { maxWaitTimeSeconds: 10 });
+      const firstBatchPromise = receiverClient.receiveBatch(1, { maxWaitTimeInMs: 10000 });
       await delay(5000);
 
       let errorMessage;

--- a/sdk/servicebus/service-bus/test/deadLetter.spec.ts
+++ b/sdk/servicebus/service-bus/test/deadLetter.spec.ts
@@ -48,7 +48,7 @@ describe("dead lettering", () => {
     receiver = serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     const receivedMessages = await receiver.receiveBatch(1, {
-      maxWaitTimeSeconds: 1
+      maxWaitTimeInMs: 1000
     });
 
     if (receivedMessages.length == 0) {

--- a/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
@@ -685,7 +685,7 @@ describe("send scheduled messages", () => {
     expectedReceivedMsgsLength: number
   ): Promise<void> {
     const receivedMsgs = await receiverClient.receiveBatch(expectedReceivedMsgsLength + 1, {
-      maxWaitTimeSeconds: 5
+      maxWaitTimeInMs: 5000
     });
 
     should.equal(

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -85,7 +85,7 @@ describe("session tests", () => {
       const testMessage = TestMessage.getSessionSample();
       await sender.send(testMessage);
 
-      let msgs = await receiver.receiveBatch(1, { maxWaitTimeSeconds: 10 });
+      let msgs = await receiver.receiveBatch(1, { maxWaitTimeInMs: 10000 });
       should.equal(msgs.length, 0, "Unexpected number of messages received");
 
       await receiver.close();

--- a/sdk/servicebus/service-bus/test/track2.samples.spec.ts
+++ b/sdk/servicebus/service-bus/test/track2.samples.spec.ts
@@ -74,7 +74,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
       const receivedBodies: string[] = [];
 
-      for (const message of await receiver.receiveBatch(1, { maxWaitTimeSeconds: 5 })) {
+      for (const message of await receiver.receiveBatch(1, { maxWaitTimeInMs: 5000 })) {
         receivedBodies.push(message.body);
       }
 

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -112,7 +112,7 @@ async function createTestEntities(
 
 export async function drainAllMessages(receiver: Receiver<{}>): Promise<void> {
   while (true) {
-    const messages = await receiver.receiveBatch(10, { maxWaitTimeSeconds: 1 });
+    const messages = await receiver.receiveBatch(10, { maxWaitTimeInMs: 1000 });
 
     if (messages.length === 0) {
       break;
@@ -159,7 +159,7 @@ export class ServiceBusTestHelpers {
       receivedMsgs = await receiverClient.receiveBatch(sentMessages.length, {
         // To Do - Maybe change the maxWaitTime
         // Currently set same as numberOfMessages being received
-        maxWaitTimeSeconds: sentMessages.length
+        maxWaitTimeInMs: sentMessages.length
       });
       await receiverClient.close();
     } else {
@@ -185,7 +185,7 @@ export class ServiceBusTestHelpers {
         const msgs = await receiverClient.receiveBatch(numOfMsgsWithSessionId[id], {
           // Since we know the exact number of messages to be received per session-id,
           //   a higher `maxWaitTimeSeconds` is not a problem
-          maxWaitTimeSeconds: 5 * numOfMsgsWithSessionId[id]
+          maxWaitTimeInMs: 5 * numOfMsgsWithSessionId[id]
         });
         should.equal(
           msgs.length,
@@ -419,7 +419,7 @@ export function createServiceBusClientForTests(
 export async function drainReceiveAndDeleteReceiver(receiver: Receiver<{}>): Promise<void> {
   try {
     while (true) {
-      const messages = await receiver.receiveBatch(10, { maxWaitTimeSeconds: 1000 });
+      const messages = await receiver.receiveBatch(10, { maxWaitTimeInMs: 1000 });
 
       if (messages.length === 0) {
         break;

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -159,7 +159,7 @@ export class ServiceBusTestHelpers {
       receivedMsgs = await receiverClient.receiveBatch(sentMessages.length, {
         // To Do - Maybe change the maxWaitTime
         // Currently set same as numberOfMessages being received
-        maxWaitTimeInMs: sentMessages.length
+        maxWaitTimeInMs: sentMessages.length * 1000
       });
       await receiverClient.close();
     } else {
@@ -184,8 +184,8 @@ export class ServiceBusTestHelpers {
         });
         const msgs = await receiverClient.receiveBatch(numOfMsgsWithSessionId[id], {
           // Since we know the exact number of messages to be received per session-id,
-          //   a higher `maxWaitTimeSeconds` is not a problem
-          maxWaitTimeInMs: 5 * numOfMsgsWithSessionId[id]
+          //   a higher `maxWaitTimeInMs` is not a problem
+          maxWaitTimeInMs: 5000 * numOfMsgsWithSessionId[id]
         });
         should.equal(
           msgs.length,


### PR DESCRIPTION
Fixes #8165 by renaming the `maxWaitTimeInSeconds` parameter to `maxWaitTimeInMs`