### PR TITLE
fixing daily dev builds for storage

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -43,6 +43,7 @@
   "allowedAlternativeVersions": {
     "@azure/ms-rest-js": ["^2.0.0"],
     "@azure/core-http": ["^1.1.0"],
+    "@azure/storage-blob": ["^12.0.2"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -99,7 +99,7 @@
     "@azure/core-paging": "^1.1.0",
     "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
-    "@azure/storage-blob": "^12.0.0",
+    "@azure/storage-blob": "^12.0.2",
     "events": "^3.0.0",
     "tslib": "^1.10.0"
   },


### PR DESCRIPTION
- the daily dev builds for storage have been failing due to the npm dependency storage-blob and source code's storage-file-datalake depending on different versions of core-http. The incorrect thing here (that goes against our own guidelines) is that we have used concrete class references instead of interfaces inside of public signatures.