### PR TITLE
[Service Bus] Pass abortsignal to retry()

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -323,7 +323,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       connectionId: this._context.namespace.connectionId,
       operation: receiveMessages,
       operationType: RetryOperationType.receiveMessage,
-      abortSignal: undefined,
+      abortSignal: options?.abortSignal,
       retryOptions: this._receiverOptions.retryOptions
     };
     return retry<ReceivedMessageT[]>(config);
@@ -389,7 +389,8 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       operation: receiveDeferredMessageOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._receiverOptions.retryOptions
+      retryOptions: this._receiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessageT | undefined>(config);
   }
@@ -440,7 +441,8 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       operation: receiveDeferredMessagesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._receiverOptions.retryOptions
+      retryOptions: this._receiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessageT[]>(config);
   }
@@ -469,7 +471,8 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       operation: peekOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._receiverOptions.retryOptions
+      retryOptions: this._receiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessage[]>(config);
   }
@@ -502,7 +505,8 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
       operation: peekBySequenceNumberOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._receiverOptions.retryOptions
+      retryOptions: this._receiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessage[]>(config);
   }

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -285,7 +285,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: renewSessionLockOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<Date>(config);
   }
@@ -314,7 +315,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: setSessionStateOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<void>(config);
   }
@@ -342,7 +344,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: getSessionStateOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<any>(config);
   }
@@ -385,7 +388,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: peekOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessage[]>(config);
   }
@@ -431,7 +435,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: peekBySequenceNumberOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessage[]>(config);
   }
@@ -480,7 +485,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: receiveDeferredMessageOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessageT | undefined>(config);
   }
@@ -532,7 +538,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: receiveDeferredMessagesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessageT[]>(config);
   }
@@ -573,7 +580,8 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       operation: receiveBatchOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.receiveMessage,
-      retryOptions: this._sessionReceiverOptions.retryOptions
+      retryOptions: this._sessionReceiverOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<ReceivedMessageT[]>(config);
   }

--- a/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
@@ -102,7 +102,8 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
       operation: getRulesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._ruleManagerOptions.retryOptions
+      retryOptions: this._ruleManagerOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<RuleDescription[]>(config);
   }
@@ -125,7 +126,8 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
       operation: removeRuleOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._ruleManagerOptions.retryOptions
+      retryOptions: this._ruleManagerOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<void>(config);
   }
@@ -153,7 +155,8 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
       operation: addRuleOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._ruleManagerOptions.retryOptions
+      retryOptions: this._ruleManagerOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<void>(config);
   }

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -273,7 +273,8 @@ export class SenderImpl implements Sender {
       operation: scheduleMessageOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._senderOptions.retryOptions
+      retryOptions: this._senderOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<Long.Long>(config);
   }
@@ -305,7 +306,8 @@ export class SenderImpl implements Sender {
       operation: scheduleMessageOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._senderOptions.retryOptions
+      retryOptions: this._senderOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<Long.Long[]>(config);
   }
@@ -337,7 +339,8 @@ export class SenderImpl implements Sender {
       operation: cancelSchedulesMessagesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._senderOptions.retryOptions
+      retryOptions: this._senderOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<void>(config);
   }
@@ -372,7 +375,8 @@ export class SenderImpl implements Sender {
       operation: cancelSchedulesMessagesOperationPromise,
       connectionId: this._context.namespace.connectionId,
       operationType: RetryOperationType.management,
-      retryOptions: this._senderOptions.retryOptions
+      retryOptions: this._senderOptions.retryOptions,
+      abortSignal: options?.abortSignal
     };
     return retry<void>(config);
   }


### PR DESCRIPTION
The retry() method takes an abort signal and uses it abort the waiting done in between retries.
This PR ensures that the abortSignal gets passed in to this method.

