### PR TITLE
[Service Bus] Update param names to match those in Event Hubs

### DIFF
--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -162,7 +162,7 @@ export interface Sender {
 // @public
 export class ServiceBusClient {
     constructor(connectionString: string, options?: ServiceBusClientOptions);
-    constructor(hostName: string, tokenCredential: TokenCredential, options?: ServiceBusClientOptions);
+    constructor(fullyQualifiedNamespace: string, credential: TokenCredential, options?: ServiceBusClientOptions);
     close(): Promise<void>;
     getDeadLetterReceiver(queueName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
     getDeadLetterReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -63,11 +63,11 @@ export class ServiceBusClient {
   ) {
     if (isTokenCredential(credentialOrOptions2)) {
       const fullyQualifiedNamespace: string = fullyQualifiedNamespaceOrConnectionString1;
-      const tokenCredential: TokenCredential = credentialOrOptions2;
+      const credential: TokenCredential = credentialOrOptions2;
       this._clientOptions = options3 || {};
 
       this._connectionContext = createConnectionContextForTokenCredential(
-        tokenCredential,
+        credential,
         fullyQualifiedNamespace,
         this._clientOptions
       );

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -62,13 +62,13 @@ export class ServiceBusClient {
     options3?: ServiceBusClientOptions
   ) {
     if (isTokenCredential(credentialOrOptions2)) {
-      const hostName: string = fullyQualifiedNamespaceOrConnectionString1;
+      const fullyQualifiedNamespace: string = fullyQualifiedNamespaceOrConnectionString1;
       const tokenCredential: TokenCredential = credentialOrOptions2;
       this._clientOptions = options3 || {};
 
       this._connectionContext = createConnectionContextForTokenCredential(
         tokenCredential,
-        hostName,
+        fullyQualifiedNamespace,
         this._clientOptions
       );
     } else {

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -42,24 +42,25 @@ export class ServiceBusClient {
   constructor(connectionString: string, options?: ServiceBusClientOptions);
   /**
    *
-   * @param host The hostname of your Azure Service Bus.
-   * @param tokenCredential A valid TokenCredential for Service Bus or a
-   * Service Bus entity.
+   * @param fullyQualifiedNamespace The full namespace of your Service Bus instance which is 
+   * likely to be similar to <yournamespace>.servicebus.windows.net.
+   * @param credential A credential object used by the client to get the token to authenticate the connection
+   * with the Azure Service Bus. See &commat;azure/identity for creating the credentials.
    * @param options Options for the service bus client.
    */
   constructor(
-    hostName: string,
-    tokenCredential: TokenCredential,
+    fullyQualifiedNamespace: string,
+    credential: TokenCredential,
     options?: ServiceBusClientOptions
   );
   constructor(
-    connectionStringOrHostName1: string,
-    tokenCredentialOrServiceBusOptions2?: TokenCredential | ServiceBusClientOptions,
+    fullyQualifiedNamespaceOrConnectionString1: string,
+    credentialOrOptions2?: TokenCredential | ServiceBusClientOptions,
     options3?: ServiceBusClientOptions
   ) {
-    if (isTokenCredential(tokenCredentialOrServiceBusOptions2)) {
-      const hostName: string = connectionStringOrHostName1;
-      const tokenCredential: TokenCredential = tokenCredentialOrServiceBusOptions2;
+    if (isTokenCredential(credentialOrOptions2)) {
+      const hostName: string = fullyQualifiedNamespaceOrConnectionString1;
+      const tokenCredential: TokenCredential = credentialOrOptions2;
       this._clientOptions = options3 || {};
 
       this._connectionContext = createConnectionContextForTokenCredential(
@@ -68,8 +69,8 @@ export class ServiceBusClient {
         this._clientOptions
       );
     } else {
-      const connectionString: string = connectionStringOrHostName1;
-      this._clientOptions = tokenCredentialOrServiceBusOptions2 || {};
+      const connectionString: string = fullyQualifiedNamespaceOrConnectionString1;
+      this._clientOptions = credentialOrOptions2 || {};
 
       this._connectionContext = createConnectionContextForConnectionString(
         connectionString,

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -46,7 +46,10 @@ export class ServiceBusClient {
    * likely to be similar to <yournamespace>.servicebus.windows.net.
    * @param credential A credential object used by the client to get the token to authenticate the connection
    * with the Azure Service Bus. See &commat;azure/identity for creating the credentials.
-   * @param options Options for the service bus client.
+   * @param options - A set of options to apply when configuring the client.
+   * - `retryOptions`   : Configures the retry policy for all the operations on the client.
+   * For example, `{ "maxRetries": 4 }` or `{ "maxRetries": 4, "retryDelayInMs": 30000 }`.
+   * - `webSocketOptions`: Configures the channelling of the AMQP connection over Web Sockets.
    */
   constructor(
     fullyQualifiedNamespace: string,


### PR DESCRIPTION
This PR updates the parameter names in the client constructor to match with those in Event Hubs after the internal API review 

Reference: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts#L84-L108