### PR TITLE
[Service Bus] Use create instead of get when creating senders and receivers

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -68,9 +68,9 @@ You can instantiate this class using its constructors:
 
 Once you have initialized the [ServiceBusClient][sbclient] class you will be able to:
 
-- Send messages, to a queue or topic, using a [`Sender`][sender] created using [`ServiceBusClient.getSender()`][sbclient_getsender].
-- Receive messages, from either a queue or a subscription, using a [`Receiver`][receiver] created using [`ServiceBusClient.getReceiver()`][sbclient_getreceiver].
-- Receive messages, from session enabled queues or subscriptions, using a [`SessionReceiver`][sessionreceiver] created using [`ServiceBusClient.getSessionReceiver()`][sbclient_getsessionreceiver].
+- Send messages, to a queue or topic, using a [`Sender`][sender] created using [`ServiceBusClient.createSender()`][sbclient_createSender].
+- Receive messages, from either a queue or a subscription, using a [`Receiver`][receiver] created using [`ServiceBusClient.createReceiver()`][sbclient_createReceiver].
+- Receive messages, from session enabled queues or subscriptions, using a [`SessionReceiver`][sessionreceiver] created using [`ServiceBusClient.createSessionReceiver()`][sbclient_createSessionReceiver].
 
 Please note that the Queues, Topics and Subscriptions should be created prior to using this library.
 
@@ -87,7 +87,7 @@ The following sections provide code snippets that cover some of the common tasks
 ### Send messages
 
 Once you have created an instance of a `ServiceBusClient` class, you can get a `Sender`
-using the [getSender][sbclient_getsender] method.
+using the [createSender][sbclient_createSender] method.
 
 This gives you a sender which you can use to [send][sender_send] messages.
 
@@ -95,7 +95,7 @@ You can also use the [sendBatch][sender_sendbatch]
 method to efficiently send multiple messages in a single send.
 
 ```javascript
-const sender = serviceBusClient.getSender("my-queue");
+const sender = serviceBusClient.createSender("my-queue");
 await sender.send({
   body: "my-message-body"
 });
@@ -114,10 +114,10 @@ await sender.sendBatch(batch);
 ### Receive messages
 
 Once you have created an instance of a `ServiceBusClient` class, you can get a `Receiver`
-using the [getReceiver][sbclient_getreceiver] function.
+using the [createReceiver][sbclient_createReceiver] function.
 
 ```javascript
-const receiver = serviceBusClient.getReceiver("my-queue", "peekLock");
+const receiver = serviceBusClient.createReceiver("my-queue", "peekLock");
 ```
 
 You can use this receiver in one of 3 ways to receive messages:
@@ -172,14 +172,14 @@ To learn more, please read [Settling Received Messages](https://docs.microsoft.c
 
 To send messages using sessions, you first need to create a session enabled Queue or Subscription. You can do this
 in the Azure portal. Then, use an instance of a `ServiceBusClient` to create a sender using the using
-the [getSender][sbclient_getsender]
+the [createSender][sbclient_createSender]
 function. This gives you a sender which you can use to [send][sender_send] messages.
 
 When sending the message, set the `sessionId` property in the message body to ensure your message
 lands in the right session.
 
 ```javascript
-const sender = serviceBusClient.getSender("my-session-queue");
+const sender = serviceBusClient.createSender("my-session-queue");
 await sender.send({
   body: "my-message-body",
   sessionId: "my-session"
@@ -190,12 +190,12 @@ await sender.send({
 
 To receive messages from sessions, you first need to create a session enabled Queue and send messages
 to it. Then, use an instance of `ServiceBusClient` to create a receiver
-using the [getSessionReceiver][sbclient_getsessionreceiver] function.
+using the [createSessionReceiver][sbclient_createSessionReceiver] function.
 
 Note that you will need to specify the session from which you want to receive messages.
 
 ```javascript
-const receiver = serviceBusClient.getSessionReceiver("my-session-queue", "peekLock", {
+const receiver = serviceBusClient.createSessionReceiver("my-session-queue", "peekLock", {
   sessionId: "my-session"
 });
 ```
@@ -273,9 +273,9 @@ If you'd like to contribute to this library, please read the [contributing guide
 [apiref]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/index.html
 [sbclient]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html
 [sbclient_constructor]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#constructor
-[sbclient_getsender]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#getsender
-[sbclient_getreceiver]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#getreceiver
-[sbclient_getsessionreceiver]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#getsessionreceiver
+[sbclient_createSender]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#createSender
+[sbclient_createReceiver]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#createReceiver
+[sbclient_createSessionReceiver]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#createSessionReceiver
 [sender]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html
 [sender_send]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html#send
 [sender_sendbatch]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html#sendbatch

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -57,14 +57,14 @@ brings this package in line with the [Azure SDK Design Guidelines for Typescript
   const serviceBusClient = new ServiceBusClient("connection string");
 
   // for queues
-  const queueSender = serviceBusClient.getSender("queue");
-  const queueReceiver = serviceBusClient.getReceiver("queue", "peekLock");
+  const queueSender = serviceBusClient.createSender("queue");
+  const queueReceiver = serviceBusClient.createReceiver("queue", "peekLock");
 
   // for topics
-  const topicSender = serviceBusClient.getSender("topic");
+  const topicSender = serviceBusClient.createSender("topic");
 
   // for subscriptions
-  const subscriptionReceiver = serviceBusClient.getReceiver("topic", "subscription", "peekLock");
+  const subscriptionReceiver = serviceBusClient.createReceiver("topic", "subscription", "peekLock");
   ```
 
 * `registerMessageHandler` on `Receiver` has been renamed to `subscribe` and takes different arguments.

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -164,19 +164,19 @@ export class ServiceBusClient {
     constructor(connectionString: string, options?: ServiceBusClientOptions);
     constructor(fullyQualifiedNamespace: string, credential: TokenCredential, options?: ServiceBusClientOptions);
     close(): Promise<void>;
-    getDeadLetterReceiver(queueName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
-    getDeadLetterReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
-    getDeadLetterReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
-    getDeadLetterReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
-    getReceiver(queueName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
-    getReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
-    getReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
-    getReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
-    getSender(queueOrTopicName: string, options?: GetSenderOptions): Sender;
-    getSessionReceiver(queueName: string, receiveMode: "peekLock", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessageWithLock>;
-    getSessionReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessage>;
-    getSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessageWithLock>;
-    getSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessage>;
+    createDeadLetterReceiver(queueName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
+    createDeadLetterReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
+    createDeadLetterReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
+    createDeadLetterReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
+    createReceiver(queueName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
+    createReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
+    createReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetReceiverOptions): Receiver<ReceivedMessageWithLock>;
+    createReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetReceiverOptions): Receiver<ReceivedMessage>;
+    createSender(queueOrTopicName: string, options?: GetSenderOptions): Sender;
+    createSessionReceiver(queueName: string, receiveMode: "peekLock", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessageWithLock>;
+    createSessionReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessage>;
+    createSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessageWithLock>;
+    createSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete", options?: GetSessionReceiverOptions): SessionReceiver<ReceivedMessage>;
     getSubscriptionRuleManager(topic: string, subscription: string, options?: GetSubscriptionRuleManagerOptions): SubscriptionRuleManager;
 }
 

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
@@ -32,8 +32,8 @@ async function main() {
 // Shuffle and send messages
 async function sendMessages() {
   const sbClient = new ServiceBusClient(connectionString);
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   const data = [
     { step: 1, title: "Shop" },
@@ -70,8 +70,8 @@ async function sendMessages() {
 async function receiveMessage() {
   const sbClient = new ServiceBusClient(connectionString);
 
-  // If receiving from a subscription you can use the getReceiver(topicName, subscriptionName) overload
-  let receiver = sbClient.getReceiver(queueName, "peekLock");
+  // If receiving from a subscription you can use the createReceiver(topicName, subscriptionName) overload
+  let receiver = sbClient.createReceiver(queueName, "peekLock");
 
   const deferredSteps = new Map();
   let lastProcessedRecipeStep = 0;
@@ -117,7 +117,7 @@ async function receiveMessage() {
     await receiver.close();
     console.log("Total number of deferred messages:", deferredSteps.size);
 
-    receiver = sbClient.getReceiver(queueName, "peekLock");
+    receiver = sbClient.createReceiver(queueName, "peekLock");
     // Now we process the deferred messages
     while (deferredSteps.size > 0) {
       const step = lastProcessedRecipeStep + 1;

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
@@ -34,8 +34,8 @@ async function main() {
 }
 
 async function sendMessage() {
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: {
@@ -50,8 +50,8 @@ async function sendMessage() {
 }
 
 async function receiveMessage() {
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
-  const receiver = sbClient.getReceiver(queueName, "peekLock");
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
+  const receiver = sbClient.createReceiver(queueName, "peekLock");
 
   const messages = await receiver.receiveBatch(1);
 

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
@@ -33,8 +33,8 @@ async function main() {
 }
 
 async function processDeadletterMessageQueue() {
-  // If connecting to a subscription's dead letter queue you can use the getDeadLetterReceiver(topic, subscription) overload
-  const receiver = sbClient.getDeadLetterReceiver(queueName, "peekLock");
+  // If connecting to a subscription's dead letter queue you can use the createDeadLetterReceiver(topic, subscription) overload
+  const receiver = sbClient.createDeadLetterReceiver(queueName, "peekLock");
 
   const messages = await receiver.receiveBatch(1);
 
@@ -55,8 +55,8 @@ async function processDeadletterMessageQueue() {
 
 // Send repaired message back to the current queue / topic
 async function fixAndResendMessage(oldMessage) {
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   // Inspect given message and make any changes if necessary
   const repairedMessage = { ...oldMessage };

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
@@ -73,8 +73,8 @@ async function runScenario() {
   await getSessionState("bob");
 }
 async function getSessionState(sessionId) {
-  // If receiving from a subscription you can use the getSessionReceiver(topic, subscription) overload
-  const sessionReceiver = sbClient.getSessionReceiver(
+  // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
+  const sessionReceiver = sbClient.createSessionReceiver(
     userEventsQueueName,
     "peekLock",
     {
@@ -91,8 +91,8 @@ async function getSessionState(sessionId) {
   await sessionReceiver.close();
 }
 async function sendMessagesForSession(shoppingEvents, sessionId) {
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(userEventsQueueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(userEventsQueueName);
   for (let index = 0; index < shoppingEvents.length; index++) {
     const message = {
       sessionId: sessionId,
@@ -104,8 +104,8 @@ async function sendMessagesForSession(shoppingEvents, sessionId) {
   await sender.close();
 }
 async function processMessageFromSession(sessionId) {
-  // If receiving from a subscription you can use the getSessionReceiver(topic, subscription) overload
-  const sessionReceiver = sbClient.getSessionReceiver(
+  // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
+  const sessionReceiver = sbClient.createSessionReceiver(
     userEventsQueueName,
     "peekLock",
     {

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/topicFilters.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/topicFilters.js
@@ -69,7 +69,7 @@ async function addRules(sbClient) {
 
 // Sends 100 messages with a user property called "priority" whose value is between 1 and 4
 async function sendMessages(sbClient) {
-  const sender = sbClient.getSender(topicName);
+  const sender = sbClient.createSender(topicName);
   for (let index = 0; index < 10; index++) {
     const priority = Math.ceil(Math.random() * 4);
     const message = {
@@ -82,17 +82,17 @@ async function sendMessages(sbClient) {
 }
 // Prints messages from the 3 subscriptions
 async function receiveMessages(sbClient) {
-  const subscription1 = sbClient.getReceiver(
+  const subscription1 = sbClient.createReceiver(
     topicName,
     subscriptionName1,
     "peekLock"
   );
-  const subscription2 = sbClient.getReceiver(
+  const subscription2 = sbClient.createReceiver(
     topicName,
     subscriptionName2,
     "peekLock"
   );
-  const subscription3 = sbClient.getReceiver(
+  const subscription3 = sbClient.createReceiver(
     topicName,
     subscriptionName3,
     "peekLock"

--- a/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
@@ -25,10 +25,10 @@ const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {
   const sbClient = new ServiceBusClient(connectionString);
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // In this case since we're using `diagnostics.peek()` that any lock mode will work.
   // `diagnostics.peek()` does not lock messages in either lock mode.
-  const queueReceiver = sbClient.getReceiver(queueName, "receiveAndDelete");
+  const queueReceiver = sbClient.createReceiver(queueName, "receiveAndDelete");
   try {
     for (let i = 0; i < 20; i++) {
       const messages = await queueReceiver.diagnostics.peek();

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
@@ -19,9 +19,9 @@ const connectionString =
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 async function main() {
   const sbClient = new ServiceBusClient(connectionString);
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // instead.
-  const queueReceiver = sbClient.getReceiver(queueName, "peekLock");
+  const queueReceiver = sbClient.createReceiver(queueName, "peekLock");
 
   // To receive messages from sessions, use getSessionReceiver instead of getReceiver or look at
   // the sample in sessions.ts file

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -21,10 +21,10 @@ const connectionString =
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 async function main() {
   const sbClient = new ServiceBusClient(connectionString);
-  // - If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // - If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // instead.
   // - See session.ts for how to receive using sessions.
-  const receiver = sbClient.getReceiver(queueName, "peekLock");
+  const receiver = sbClient.createReceiver(queueName, "peekLock");
 
   const processMessage = async brokeredMessage => {
     console.log(`Received message: ${brokeredMessage.body}`);

--- a/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
@@ -47,8 +47,8 @@ async function main() {
 
 // Scheduling messages to be sent after 10 seconds from now
 async function sendScheduledMessages(sbClient) {
-  // getSender() handles sending to a queue or a topic
-  const sender = sbClient.getSender(queueName);
+  // createSender() handles sending to a queue or a topic
+  const sender = sbClient.createSender(queueName);
 
   const messages = listOfScientists.map(scientist => ({
     body: `${scientist.firstName} ${scientist.lastName}`,
@@ -66,9 +66,9 @@ async function sendScheduledMessages(sbClient) {
 }
 
 async function receiveMessages(sbClient) {
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // instead.
-  let queueReceiver = sbClient.getReceiver(queueName, "peekLock");
+  let queueReceiver = sbClient.createReceiver(queueName, "peekLock");
 
   let numOfMessagesReceived = 0;
   const processMessage = async brokeredMessage => {
@@ -94,7 +94,7 @@ async function receiveMessages(sbClient) {
   await delay(5000);
 
   console.log(`\nStarting receiver at ${new Date(Date.now())}`);
-  queueReceiver = sbClient.getReceiver(queueName, "peekLock");
+  queueReceiver = sbClient.createReceiver(queueName, "peekLock");
   queueReceiver.subscribe({
     processMessage,
     processError

--- a/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
@@ -37,8 +37,8 @@ const listOfScientists = [
 async function main() {
   const sbClient = new ServiceBusClient(connectionString);
 
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   try {
     for (let index = 0; index < listOfScientists.length; index++) {

--- a/sdk/servicebus/service-bus/samples/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/session.js
@@ -60,8 +60,8 @@ async function main() {
 }
 
 async function sendMessage(sbClient, scientist, sessionId) {
-  // getSender() also works with topics
-  const sender = sbClient.getSender(queueName);
+  // createSender() also works with topics
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: `${scientist.firstName} ${scientist.lastName}`,
@@ -76,8 +76,8 @@ async function sendMessage(sbClient, scientist, sessionId) {
 }
 
 async function receiveMessages(sbClient, sessionId) {
-  // If receiving from a subscription you can use the getSessionReceiver(topic, subscription) overload
-  const receiver = sbClient.getSessionReceiver(queueName, "peekLock", {
+  // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
+  const receiver = sbClient.createSessionReceiver(queueName, "peekLock", {
     sessionId: sessionId
   });
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
@@ -34,8 +34,8 @@ export async function main() {
 // Shuffle and send messages
 async function sendMessages() {
   const sbClient = new ServiceBusClient(connectionString);
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   const data = [
     { step: 1, title: "Shop" },
@@ -72,8 +72,8 @@ async function sendMessages() {
 async function receiveMessage() {
   const sbClient = new ServiceBusClient(connectionString);
 
-  // If receiving from a subscription, you can use the getReceiver(topic, subscription) overload
-  let receiver = sbClient.getReceiver(queueName, "peekLock");
+  // If receiving from a subscription, you can use the createReceiver(topic, subscription) overload
+  let receiver = sbClient.createReceiver(queueName, "peekLock");
 
   const deferredSteps = new Map();
   let lastProcessedRecipeStep = 0;
@@ -120,7 +120,7 @@ async function receiveMessage() {
     await receiver.close();
     console.log("Total number of deferred messages:", deferredSteps.size);
 
-    receiver = sbClient.getReceiver(queueName, "peekLock");
+    receiver = sbClient.createReceiver(queueName, "peekLock");
     // Now we process the deferred messages
     while (deferredSteps.size > 0) {
       const step = lastProcessedRecipeStep + 1;

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -37,8 +37,8 @@ export async function main() {
 }
 
 async function sendMessage() {
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: {
@@ -53,8 +53,8 @@ async function sendMessage() {
 }
 
 async function receiveMessage() {
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
-  const receiver = sbClient.getReceiver(queueName, "peekLock");
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
+  const receiver = sbClient.createReceiver(queueName, "peekLock");
 
   const messages = await receiver.receiveBatch(1);
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
@@ -35,8 +35,8 @@ export async function main() {
 }
 
 async function processDeadletterMessageQueue() {
-  // If connecting to a subscription's dead letter queue you can use the getDeadLetterReceiver(topic, subscription) overload
-  const receiver = sbClient.getDeadLetterReceiver(queueName, "peekLock");
+  // If connecting to a subscription's dead letter queue you can use the createDeadLetterReceiver(topic, subscription) overload
+  const receiver = sbClient.createDeadLetterReceiver(queueName, "peekLock");
 
   const messages = await receiver.receiveBatch(1);
 
@@ -57,8 +57,8 @@ async function processDeadletterMessageQueue() {
 
 // Send repaired message back to the current queue / topic
 async function fixAndResendMessage(oldMessage: ServiceBusMessage) {
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   // Inspect given message and make any changes if necessary
   const repairedMessage = { ...oldMessage };

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
@@ -85,8 +85,8 @@ async function runScenario() {
 }
 
 async function getSessionState(sessionId: string) {
-  // If receiving from a subscription you can use the getSessionReceiver(topic, subscription) overload
-  const sessionReceiver = sbClient.getSessionReceiver(
+  // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
+  const sessionReceiver = sbClient.createSessionReceiver(
     userEventsQueueName,
     "peekLock",
     {
@@ -109,8 +109,8 @@ async function sendMessagesForSession(
   shoppingEvents: any[],
   sessionId: string
 ) {
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(userEventsQueueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(userEventsQueueName);
 
   for (let index = 0; index < shoppingEvents.length; index++) {
     const message = {
@@ -124,8 +124,8 @@ async function sendMessagesForSession(
 }
 
 async function processMessageFromSession(sessionId: string) {
-  // If receiving from a subscription you can use the getSessionReceiver(topic, subscription) overload
-  const sessionReceiver = sbClient.getSessionReceiver(
+  // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
+  const sessionReceiver = sbClient.createSessionReceiver(
     userEventsQueueName,
     "peekLock",
     {

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/topicFilters.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/topicFilters.ts
@@ -80,7 +80,7 @@ async function addRules(sbClient: ServiceBusClient) {
 
 // Sends 100 messages with a user property called "priority" whose value is between 1 and 4
 async function sendMessages(sbClient: ServiceBusClient) {
-  const sender = sbClient.getSender(topicName);
+  const sender = sbClient.createSender(topicName);
   for (let index = 0; index < 10; index++) {
     const priority = Math.ceil(Math.random() * 4);
     const message: ServiceBusMessage = {
@@ -95,17 +95,17 @@ async function sendMessages(sbClient: ServiceBusClient) {
 
 // Prints messages from the 3 subscriptions
 async function receiveMessages(sbClient: ServiceBusClient) {
-  const subscription1 = sbClient.getReceiver(
+  const subscription1 = sbClient.createReceiver(
     topicName,
     subscriptionName1,
     "peekLock"
   );
-  const subscription2 = sbClient.getReceiver(
+  const subscription2 = sbClient.createReceiver(
     topicName,
     subscriptionName2,
     "peekLock"
   );
-  const subscription3 = sbClient.getReceiver(
+  const subscription3 = sbClient.createReceiver(
     topicName,
     subscriptionName3,
     "peekLock"

--- a/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
@@ -28,10 +28,10 @@ const queueName = process.env.QUEUE_NAME || "<queue name>";
 export async function main() {
   const sbClient = new ServiceBusClient(connectionString);
 
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // In this case since we're using `diagnostics.peek()` that any lock mode will work.
   // `diagnostics.peek()` does not lock messages in either lock mode.
-  const queueReceiver = sbClient.getReceiver(queueName, "receiveAndDelete");
+  const queueReceiver = sbClient.createReceiver(queueName, "receiveAndDelete");
 
   try {
     for (let i = 0; i < 20; i++) {

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
@@ -26,9 +26,9 @@ const queueName = process.env.QUEUE_NAME || "<queue name>";
 export async function main() {
   const sbClient = new ServiceBusClient(connectionString);
 
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // instead.
-  const queueReceiver = sbClient.getReceiver(queueName, "peekLock");
+  const queueReceiver = sbClient.createReceiver(queueName, "peekLock");
 
   // To receive messages from sessions, use getSessionReceiver instead of getReceiver or look at
   // the sample in sessions.ts file

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -26,10 +26,10 @@ const queueName = process.env.QUEUE_NAME || "<queue name>";
 export async function main() {
   const sbClient = new ServiceBusClient(connectionString);
 
-  // - If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // - If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // instead.
   // - See session.ts for how to receive using sessions.
-  const receiver = sbClient.getReceiver(queueName, "peekLock");
+  const receiver = sbClient.createReceiver(queueName, "peekLock");
 
   const processMessage = async brokeredMessage => {
     console.log(`Received message: ${brokeredMessage.body}`);

--- a/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
@@ -50,8 +50,8 @@ export async function main() {
 
 // Scheduling messages to be sent after 10 seconds from now
 async function sendScheduledMessages(sbClient: ServiceBusClient) {
-  // getSender() handles sending to a queue or a topic
-  const sender = sbClient.getSender(queueName);
+  // createSender() handles sending to a queue or a topic
+  const sender = sbClient.createSender(queueName);
 
   const messages: ServiceBusMessage[] = listOfScientists.map(scientist => ({
     body: `${scientist.firstName} ${scientist.lastName}`,
@@ -69,9 +69,9 @@ async function sendScheduledMessages(sbClient: ServiceBusClient) {
 }
 
 async function receiveMessages(sbClient: ServiceBusClient) {
-  // If receiving from a subscription you can use the getReceiver(topic, subscription) overload
+  // If receiving from a subscription you can use the createReceiver(topic, subscription) overload
   // instead.
-  let queueReceiver = sbClient.getReceiver(queueName, "peekLock");
+  let queueReceiver = sbClient.createReceiver(queueName, "peekLock");
 
   let numOfMessagesReceived = 0;
   const processMessage = async brokeredMessage => {
@@ -98,7 +98,7 @@ async function receiveMessages(sbClient: ServiceBusClient) {
   await delay(5000);
   console.log(`\nStarting receiver at ${new Date(Date.now())}`);
 
-  queueReceiver = sbClient.getReceiver(queueName, "peekLock");
+  queueReceiver = sbClient.createReceiver(queueName, "peekLock");
 
   queueReceiver.subscribe({
     processMessage,

--- a/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
@@ -40,8 +40,8 @@ const listOfScientists = [
 export async function main() {
   const sbClient = new ServiceBusClient(connectionString);
 
-  // getSender() can also be used to create a sender for a topic.
-  const sender = sbClient.getSender(queueName);
+  // createSender() can also be used to create a sender for a topic.
+  const sender = sbClient.createSender(queueName);
 
   try {
     for (let index = 0; index < listOfScientists.length; index++) {

--- a/sdk/servicebus/service-bus/samples/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/session.ts
@@ -68,8 +68,8 @@ async function sendMessage(
   scientist: any,
   sessionId: string
 ) {
-  // getSender() also works with topics
-  const sender = sbClient.getSender(queueName);
+  // createSender() also works with topics
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: `${scientist.firstName} ${scientist.lastName}`,
@@ -84,8 +84,8 @@ async function sendMessage(
 }
 
 async function receiveMessages(sbClient: ServiceBusClient, sessionId: string) {
-  // If receiving from a subscription you can use the getSessionReceiver(topic, subscription) overload
-  const receiver = sbClient.getSessionReceiver(queueName, "peekLock", {
+  // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
+  const receiver = sbClient.createSessionReceiver(queueName, "peekLock", {
     sessionId: sessionId
   });
 

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -42,7 +42,7 @@ export class ServiceBusClient {
   constructor(connectionString: string, options?: ServiceBusClientOptions);
   /**
    *
-   * @param fullyQualifiedNamespace The full namespace of your Service Bus instance which is 
+   * @param fullyQualifiedNamespace The full namespace of your Service Bus instance which is
    * likely to be similar to <yournamespace>.servicebus.windows.net.
    * @param credential A credential object used by the client to get the token to authenticate the connection
    * with the Azure Service Bus. See &commat;azure/identity for creating the credentials.
@@ -89,7 +89,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getReceiver(
+  createReceiver(
     queueName: string,
     receiveMode: "peekLock",
     options?: GetReceiverOptions
@@ -101,7 +101,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getReceiver(
+  createReceiver(
     queueName: string,
     receiveMode: "receiveAndDelete",
     options?: GetReceiverOptions
@@ -114,7 +114,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getReceiver(
+  createReceiver(
     topicName: string,
     subscriptionName: string,
     receiveMode: "peekLock",
@@ -128,13 +128,13 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getReceiver(
+  createReceiver(
     topicName: string,
     subscriptionName: string,
     receiveMode: "receiveAndDelete",
     options?: GetReceiverOptions
   ): Receiver<ReceivedMessage>;
-  getReceiver(
+  createReceiver(
     queueOrTopicName1: string,
     receiveModeOrSubscriptionName2: "peekLock" | "receiveAndDelete" | string,
     receiveModeOrOptions3?: "peekLock" | "receiveAndDelete" | GetReceiverOptions,
@@ -176,7 +176,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getSessionReceiver(
+  createSessionReceiver(
     queueName: string,
     receiveMode: "peekLock",
     options?: GetSessionReceiverOptions
@@ -188,7 +188,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getSessionReceiver(
+  createSessionReceiver(
     queueName: string,
     receiveMode: "receiveAndDelete",
     options?: GetSessionReceiverOptions
@@ -201,7 +201,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getSessionReceiver(
+  createSessionReceiver(
     topicName: string,
     subscriptionName: string,
     receiveMode: "peekLock",
@@ -215,13 +215,13 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getSessionReceiver(
+  createSessionReceiver(
     topicName: string,
     subscriptionName: string,
     receiveMode: "receiveAndDelete",
     options?: GetSessionReceiverOptions
   ): SessionReceiver<ReceivedMessage>;
-  getSessionReceiver(
+  createSessionReceiver(
     queueOrTopicName1: string,
     receiveModeOrSubscriptionName2: "peekLock" | "receiveAndDelete" | string,
     receiveModeOrOptions3?: "peekLock" | "receiveAndDelete" | GetSessionReceiverOptions,
@@ -253,7 +253,7 @@ export class ServiceBusClient {
    * Creates a Sender which can be used to send messages, schedule messages to be sent at a later time
    * and cancel such scheduled messages.
    */
-  getSender(queueOrTopicName: string, options?: GetSenderOptions): Sender {
+  createSender(queueOrTopicName: string, options?: GetSenderOptions): Sender {
     validateEntityNamesMatch(this._connectionContext.config.entityPath, queueOrTopicName, "sender");
 
     const clientEntityContext = ClientEntityContext.create(
@@ -298,7 +298,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getDeadLetterReceiver(
+  createDeadLetterReceiver(
     queueName: string,
     receiveMode: "peekLock",
     options?: GetReceiverOptions
@@ -310,7 +310,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getDeadLetterReceiver(
+  createDeadLetterReceiver(
     queueName: string,
     receiveMode: "receiveAndDelete",
     options?: GetReceiverOptions
@@ -323,7 +323,7 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getDeadLetterReceiver(
+  createDeadLetterReceiver(
     topicName: string,
     subscriptionName: string,
     receiveMode: "peekLock",
@@ -337,13 +337,13 @@ export class ServiceBusClient {
    * @param receiveMode The receive mode to use (defaults to PeekLock)
    * @param options Options for the receiver itself.
    */
-  getDeadLetterReceiver(
+  createDeadLetterReceiver(
     topicName: string,
     subscriptionName: string,
     receiveMode: "receiveAndDelete",
     options?: GetReceiverOptions
   ): Receiver<ReceivedMessage>;
-  getDeadLetterReceiver(
+  createDeadLetterReceiver(
     queueOrTopicName1: string,
     receiveModeOrSubscriptionName2: "peekLock" | "receiveAndDelete" | string,
     receiveModeOrOptions3?: "peekLock" | "receiveAndDelete" | GetReceiverOptions,
@@ -362,9 +362,9 @@ export class ServiceBusClient {
     const deadLetterEntityPath = `${entityPath}/$DeadLetterQueue`;
 
     if (receiveMode === "peekLock") {
-      return this.getReceiver(deadLetterEntityPath, receiveMode, options);
+      return this.createReceiver(deadLetterEntityPath, receiveMode, options);
     } else {
-      return this.getReceiver(deadLetterEntityPath, receiveMode, options);
+      return this.createReceiver(deadLetterEntityPath, receiveMode, options);
     }
   }
 

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -42,10 +42,10 @@ describe("batchReceiver", () => {
     receiverClient = serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
+    deadLetterClient = serviceBusClient.test.createDeadLetterReceiver(entityNames);
   }
 
   function afterEachTest(): Promise<void> {

--- a/sdk/servicebus/service-bus/test/deadLetter.spec.ts
+++ b/sdk/servicebus/service-bus/test/deadLetter.spec.ts
@@ -33,7 +33,7 @@ describe("dead lettering", () => {
 
     // send a test message with the body being the title of the test (for something unique)
     const sender = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue)
+      serviceBusClient.createSender(entityNames.queue)
     );
 
     await sender.send({
@@ -42,7 +42,7 @@ describe("dead lettering", () => {
 
     deadLetterReceiver = serviceBusClient.test.addToCleanup(
       // receiveAndDelete since I don't care about further settlement after it's been dead lettered!
-      serviceBusClient.getDeadLetterReceiver(entityNames.queue, "receiveAndDelete")
+      serviceBusClient.createDeadLetterReceiver(entityNames.queue, "receiveAndDelete")
     );
 
     receiver = serviceBusClient.test.getPeekLockReceiver(entityNames);

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -32,10 +32,10 @@ describe("deferred messages", () => {
     receiverClient = serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
+    deadLetterClient = serviceBusClient.test.createDeadLetterReceiver(entityNames);
   }
 
   async function afterEachTest(): Promise<void> {

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -135,7 +135,7 @@ describe("serviceBusClient unit tests", () => {
   });
 
   describe("validateEntityNamesMatch", () => {
-    // the receiver cases are all covered above in `extractReceiverArguments`. So this is just covering the way the getSender() call uses it.
+    // the receiver cases are all covered above in `extractReceiverArguments`. So this is just covering the way the createSender() call uses it.
     it("failures", () => {
       assert.throws(
         () => validateEntityNamesMatch("the queue", "but I specified a different thing", "sender"),

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -325,7 +325,9 @@ describe("invalid parameters", () => {
         TestClientType.PartitionedQueueWithSessions
       );
 
-      sender = serviceBusClient.test.addToCleanup(serviceBusClient.getSender(entityNames.queue!));
+      sender = serviceBusClient.test.addToCleanup(
+        serviceBusClient.createSender(entityNames.queue!)
+      );
 
       receiver = serviceBusClient.test.getSessionPeekLockReceiver(entityNames, {
         sessionId: TestMessage.sessionId
@@ -387,7 +389,7 @@ describe("invalid parameters", () => {
           TestClientType.PartitionedQueueWithSessions
         );
 
-        await serviceBusClient.getSessionReceiver(queue!, 123 as any, {
+        await serviceBusClient.createSessionReceiver(queue!, 123 as any, {
           sessionId: TestMessage.sessionId
         });
       } catch (error) {
@@ -803,7 +805,7 @@ describe("invalid parameters", () => {
       );
 
       //const clients = await getSenderReceiverClients(TestClientType.PartitionedQueue, "peekLock");
-      sender = serviceBusClient.test.addToCleanup(serviceBusClient.getSender(queue!));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(queue!));
     });
 
     after(() => {

--- a/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
@@ -38,7 +38,7 @@ describe("receive and delete", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
     receiverClient = serviceBusClient.test.getReceiveAndDeleteReceiver(entityNames);
 

--- a/sdk/servicebus/service-bus/test/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLock.spec.ts
@@ -30,7 +30,7 @@ describe("renew lock", () => {
     receiverClient = serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
@@ -35,7 +35,7 @@ describe("renew lock sessions", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     sender = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     sessionId = Date.now().toString();

--- a/sdk/servicebus/service-bus/test/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/retries.spec.ts
@@ -47,7 +47,7 @@ describe("Retries - ManagementClient", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
     receiverClient = serviceBusClient.test.getPeekLockReceiver(entityNames);
     subscriptionRuleManager = serviceBusClient.test.addToCleanup(
@@ -259,7 +259,7 @@ describe("Retries - MessageSender", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!, {
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!, {
         retryOptions: retryOptions || {
           timeoutInMs: 10000,
           maxRetries: defaultMaxRetries,
@@ -464,7 +464,7 @@ describe("Retries - onDetached", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
     receiverClient = serviceBusClient.test.getPeekLockReceiver(entityNames);
   }

--- a/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
@@ -36,7 +36,7 @@ describe("send scheduled messages", () => {
     receiverClient = serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -32,7 +32,7 @@ describe("Send Batch", () => {
     entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
@@ -36,7 +36,7 @@ describe("sessions tests -  requires completely clean entity for each test", () 
     });
 
     sender = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     // Observation -

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -49,7 +49,7 @@ describe("session tests", () => {
     });
 
     sender = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     // Observation -

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -56,10 +56,10 @@ describe("Streaming", () => {
     receiverClient = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
+    deadLetterClient = serviceBusClient.test.createDeadLetterReceiver(entityNames);
 
     errorWasThrown = false;
     unexpectedError = undefined;

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -48,10 +48,10 @@ describe("Streaming with sessions", () => {
     const entityNames = await createReceiverForTests(testClientType);
 
     senderClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
-    deadLetterClient = serviceBusClient.test.getDeadLetterReceiver(entityNames);
+    deadLetterClient = serviceBusClient.test.createDeadLetterReceiver(entityNames);
 
     errorWasThrown = false;
     unexpectedError = undefined;
@@ -61,10 +61,10 @@ describe("Streaming with sessions", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(testClientType);
     receiverClient = serviceBusClient.test.addToCleanup(
       entityNames.queue
-        ? serviceBusClient.getSessionReceiver(entityNames.queue, "peekLock", {
+        ? serviceBusClient.createSessionReceiver(entityNames.queue, "peekLock", {
             sessionId: TestMessage.sessionId
           })
-        : serviceBusClient.getSessionReceiver(
+        : serviceBusClient.createSessionReceiver(
             entityNames.topic!,
             entityNames.subscription!,
             "peekLock",

--- a/sdk/servicebus/service-bus/test/topicFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/topicFilters.spec.ts
@@ -47,7 +47,7 @@ describe("topic filters", () => {
 
     subscriptionClient = await serviceBusClient.test.getPeekLockReceiver(entityNames);
     topicClient = serviceBusClient.test.addToCleanup(
-      serviceBusClient.getSender(entityNames.topic!)
+      serviceBusClient.createSender(entityNames.topic!)
     );
 
     subscriptionRuleManager = subscriptionRuleManager = serviceBusClient.test.addToCleanup(

--- a/sdk/servicebus/service-bus/test/track2.samples.spec.ts
+++ b/sdk/servicebus/service-bus/test/track2.samples.spec.ts
@@ -35,7 +35,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
     });
 
     beforeEach(() => {
-      sender = serviceBusClient.test.addToCleanup(serviceBusClient.getSender(queueName));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(queueName));
     });
 
     afterEach(async () => {
@@ -44,7 +44,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Queue, peek/lock", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(queueName, "peekLock")
+        serviceBusClient.createReceiver(queueName, "peekLock")
       );
 
       await sendSampleMessage(sender, "Queue, peek/lock");
@@ -67,7 +67,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Queue, peek/lock, receiveBatch", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(queueName, "receiveAndDelete")
+        serviceBusClient.createReceiver(queueName, "receiveAndDelete")
       );
 
       await sendSampleMessage(sender, "Queue, peek/lock, receiveBatch");
@@ -84,7 +84,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Queue, peek/lock, iterate messages", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(queueName, "peekLock")
+        serviceBusClient.createReceiver(queueName, "peekLock")
       );
 
       await sendSampleMessage(sender, "Queue, peek/lock, iterate messages");
@@ -117,7 +117,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Queue, receive and delete", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(queueName, "receiveAndDelete")
+        serviceBusClient.createReceiver(queueName, "receiveAndDelete")
       );
 
       await sendSampleMessage(sender, "Queue, receiveAndDelete");
@@ -139,7 +139,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Queue, receive and delete, iterate messages", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(queueName, "receiveAndDelete")
+        serviceBusClient.createReceiver(queueName, "receiveAndDelete")
       );
 
       await sendSampleMessage(sender, "Queue, receive and delete, iterate messages");
@@ -192,7 +192,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
     });
 
     beforeEach(() => {
-      sender = serviceBusClient.test.addToCleanup(serviceBusClient.getSender(topic));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(topic));
     });
 
     afterEach(async () => {
@@ -201,7 +201,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Subscription, peek/lock", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(topic, subscription, "peekLock")
+        serviceBusClient.createReceiver(topic, subscription, "peekLock")
       );
 
       await sendSampleMessage(sender, "Subscription, peek/lock");
@@ -226,7 +226,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Subscription, receive and delete", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(topic, subscription, "receiveAndDelete")
+        serviceBusClient.createReceiver(topic, subscription, "receiveAndDelete")
       );
 
       await sendSampleMessage(sender, "Subscription, receive and delete");
@@ -250,7 +250,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Subscription, peek/lock, iterate messages", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(topic, subscription, "peekLock")
+        serviceBusClient.createReceiver(topic, subscription, "peekLock")
       );
 
       await sendSampleMessage(sender, "Subscription, peek/lock, iterate messages");
@@ -288,7 +288,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
 
     it("Subscription, receive and delete, iterate messages", async () => {
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getReceiver(topic, subscription, "receiveAndDelete")
+        serviceBusClient.createReceiver(topic, subscription, "receiveAndDelete")
       );
 
       await sendSampleMessage(sender, "Subscription, receive and delete, iterate messages");
@@ -332,13 +332,13 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
         TestClientType.UnpartitionedQueueWithSessions
       );
       queue = entities.queue!;
-      sender = serviceBusClient.test.addToCleanup(serviceBusClient.getSender(queue));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(queue));
     });
 
     it("Queue, receive and delete, sessions", async () => {
       const sessionId = Date.now().toString();
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getSessionReceiver(queue, "receiveAndDelete", { sessionId })
+        serviceBusClient.createSessionReceiver(queue, "receiveAndDelete", { sessionId })
       );
 
       sendSampleMessage(sender, "Queue, receive and delete, sessions", sessionId);
@@ -371,7 +371,7 @@ describe("Sample scenarios for track 2 #RunInBrowser", () => {
       const sessionId = Date.now().toString();
 
       const receiver = serviceBusClient.test.addToCleanup(
-        serviceBusClient.getSessionReceiver(queue, "peekLock", { sessionId })
+        serviceBusClient.createSessionReceiver(queue, "peekLock", { sessionId })
       );
 
       sendSampleMessage(sender, "Queue, peek/lock, sessions", sessionId);

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -272,8 +272,8 @@ export class ServiceBusTestHelpers {
 
     return this.addToCleanup(
       entityNames.queue
-        ? this._serviceBusClient.getReceiver(entityNames.queue, "peekLock")
-        : this._serviceBusClient.getReceiver(
+        ? this._serviceBusClient.createReceiver(entityNames.queue, "peekLock")
+        : this._serviceBusClient.createReceiver(
             entityNames.topic!,
             entityNames.subscription!,
             "peekLock"
@@ -293,12 +293,12 @@ export class ServiceBusTestHelpers {
 
     return this.addToCleanup(
       entityNames.queue
-        ? this._serviceBusClient.getSessionReceiver(
+        ? this._serviceBusClient.createSessionReceiver(
             entityNames.queue,
             "peekLock",
             getSessionReceiverOptions
           )
-        : this._serviceBusClient.getSessionReceiver(
+        : this._serviceBusClient.createSessionReceiver(
             entityNames.topic!,
             entityNames.subscription!,
             "peekLock",
@@ -326,10 +326,10 @@ export class ServiceBusTestHelpers {
     if (entityNames.usesSessions) {
       return this.addToCleanup(
         entityNames.queue
-          ? this._serviceBusClient.getSessionReceiver(entityNames.queue, "receiveAndDelete", {
+          ? this._serviceBusClient.createSessionReceiver(entityNames.queue, "receiveAndDelete", {
               sessionId
             })
-          : this._serviceBusClient.getSessionReceiver(
+          : this._serviceBusClient.createSessionReceiver(
               entityNames.topic!,
               entityNames.subscription!,
               "receiveAndDelete",
@@ -341,8 +341,8 @@ export class ServiceBusTestHelpers {
     } else {
       return this.addToCleanup(
         entityNames.queue
-          ? this._serviceBusClient.getReceiver(entityNames.queue, "receiveAndDelete")
-          : this._serviceBusClient.getReceiver(
+          ? this._serviceBusClient.createReceiver(entityNames.queue, "receiveAndDelete")
+          : this._serviceBusClient.createReceiver(
               entityNames.topic!,
               entityNames.subscription!,
               "receiveAndDelete"
@@ -351,13 +351,13 @@ export class ServiceBusTestHelpers {
     }
   }
 
-  getDeadLetterReceiver(
+  createDeadLetterReceiver(
     entityNames: ReturnType<typeof getEntityNames>
   ): Receiver<ReceivedMessageWithLock> {
     return this.addToCleanup(
       entityNames.queue
-        ? this._serviceBusClient.getDeadLetterReceiver(entityNames.queue, "peekLock")
-        : this._serviceBusClient.getDeadLetterReceiver(
+        ? this._serviceBusClient.createDeadLetterReceiver(entityNames.queue, "peekLock")
+        : this._serviceBusClient.createDeadLetterReceiver(
             entityNames.topic!,
             entityNames.subscription!,
             "peekLock"
@@ -378,18 +378,18 @@ async function purgeForTestClientType(
   let deadLetterReceiver: Receiver<ReceivedMessage>;
 
   if (entityPaths.queue) {
-    receiver = serviceBusClient.getReceiver(entityPaths.queue, "receiveAndDelete");
-    deadLetterReceiver = serviceBusClient.getDeadLetterReceiver(
+    receiver = serviceBusClient.createReceiver(entityPaths.queue, "receiveAndDelete");
+    deadLetterReceiver = serviceBusClient.createDeadLetterReceiver(
       entityPaths.queue,
       "receiveAndDelete"
     );
   } else if (entityPaths.topic && entityPaths.subscription) {
-    receiver = serviceBusClient.getReceiver(
+    receiver = serviceBusClient.createReceiver(
       entityPaths.topic,
       entityPaths.subscription,
       "receiveAndDelete"
     );
-    deadLetterReceiver = serviceBusClient.getDeadLetterReceiver(
+    deadLetterReceiver = serviceBusClient.createDeadLetterReceiver(
       entityPaths.topic,
       entityPaths.subscription,
       "receiveAndDelete"


### PR DESCRIPTION
This PR resolves #8180 by using the `create` verb instead of `get` when creating senders and receivers.

This PR doesnt change the name of the below options as @HarshaNalluru is working on removing these options altogether:
- GetReceiverOptions
- GetSenderOptions