### PR TITLE
[KeyVault] Restore backup tests cannot be trusted to run live

### DIFF
--- a/sdk/keyvault/keyvault-certificates/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/recoverBackupRestore.test.ts
@@ -3,7 +3,7 @@
 
 import * as assert from "assert";
 import { CertificateClient } from "../src";
-import { env, isPlaybackMode, Recorder, delay } from "@azure/test-utils-recorder";
+import { env, isPlaybackMode, Recorder, delay, isRecordMode } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
 import { testPollerProperties } from "./utils/recorderUtils";
@@ -75,34 +75,37 @@ describe("Certificates client - restore certificates and recover backups", () =>
     assert.equal(error.message, `Certificate not found: ${certificateName}`);
   });
 
-  // This is taking forever
-  it("can restore a certificate", async function() {
-    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
-    await client.beginCreateCertificate(
-      certificateName,
-      basicCertificatePolicy,
-      testPollerProperties
-    );
-    const backup = await client.backupCertificate(certificateName);
-    await testClient.flushCertificate(certificateName);
-    while (true) {
-      try {
-        await client.restoreCertificateBackup(backup as Uint8Array);
-        break;
-      } catch (e) {
-        console.log("Can't restore the certificate since it's not fully deleted:", e.message);
-        console.log("Retrying in one second...");
-        await delay(1000);
+  if (isRecordMode() || isPlaybackMode()) {
+    // This test can't run live,
+    // since the purge operation currently can't be expected to finish anytime soon.
+    it("can restore a certificate", async function() {
+      const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+      await client.beginCreateCertificate(
+        certificateName,
+        basicCertificatePolicy,
+        testPollerProperties
+      );
+      const backup = await client.backupCertificate(certificateName);
+      await testClient.flushCertificate(certificateName);
+      while (true) {
+        try {
+          await client.restoreCertificateBackup(backup as Uint8Array);
+          break;
+        } catch (e) {
+          console.log("Can't restore the certificate since it's not fully deleted:", e.message);
+          console.log("Retrying in one second...");
+          await delay(1000);
+        }
       }
-    }
-    const getResult = await client.getCertificate(certificateName);
-    assert.equal(
-      getResult.properties.name,
-      certificateName,
-      "Unexpected certificate name in result from getCertificate()."
-    );
-    await testClient.flushCertificate(certificateName);
-  });
+      const getResult = await client.getCertificate(certificateName);
+      assert.equal(
+        getResult.properties.name,
+        certificateName,
+        "Unexpected certificate name in result from getCertificate()."
+      );
+      await testClient.flushCertificate(certificateName);
+    });
+  }
 
   if (isNode && !isPlaybackMode()) {
     // On playback mode, the tests happen too fast for the timeout to work

--- a/sdk/keyvault/keyvault-secrets/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/recoverBackupRestore.test.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import { SecretClient } from "../src";
 import { isNode } from "@azure/core-http";
 import { testPollerProperties } from "./utils/recorderUtils";
-import { env, isPlaybackMode, Recorder, delay } from "@azure/test-utils-recorder";
+import { env, isPlaybackMode, Recorder, delay, isRecordMode } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
 import { assertThrowsAbortError } from "./utils/utils.common";
@@ -131,27 +131,35 @@ describe("Secret client - restore secrets and recover backups", () => {
     assert.equal(error.message, `Secret not found: ${secretName}`);
   });
 
-  it("can restore a secret", async function() {
-    const secretName = testClient.formatName(
-      `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
-    );
-    await client.setSecret(secretName, "RSA");
-    const backup = await client.backupSecret(secretName);
-    await testClient.flushSecret(secretName);
-    while (true) {
-      try {
-        await client.restoreSecretBackup(backup as Uint8Array);
-        break;
-      } catch (e) {
-        console.log("Can't restore the secret since it's not fully deleted:", e.message);
-        console.log("Retrying in one second...");
-        await delay(1000);
+  if (isRecordMode() || isPlaybackMode()) {
+    // This test can't run live,
+    // since the purge operation currently can't be expected to finish anytime soon.
+    it("can restore a secret", async function() {
+      const secretName = testClient.formatName(
+        `${secretPrefix}-${this!.test!.title}-${secretSuffix}`
+      );
+      await client.setSecret(secretName, "RSA");
+      const backup = await client.backupSecret(secretName);
+      await testClient.flushSecret(secretName);
+      while (true) {
+        try {
+          await client.restoreSecretBackup(backup as Uint8Array);
+          break;
+        } catch (e) {
+          console.log("Can't restore the secret since it's not fully deleted:", e.message);
+          console.log("Retrying in one second...");
+          await delay(1000);
+        }
       }
-    }
-    const getResult = await client.getSecret(secretName);
-    assert.equal(getResult.name, secretName, "Unexpected secret name in result from getSecret().");
-    await testClient.flushSecret(secretName);
-  });
+      const getResult = await client.getSecret(secretName);
+      assert.equal(
+        getResult.name,
+        secretName,
+        "Unexpected secret name in result from getSecret()."
+      );
+      await testClient.flushSecret(secretName);
+    });
+  }
 
   it("can restore a secret (Malformed Backup Bytes)", async function() {
     const backup = new Uint8Array(4728);


### PR DESCRIPTION
The testClient's "flush" methods wait until the resource is deleted, then purge the resource, but they can't wait for the resource to finish being purged, therefore we can't trust that we can recover the backup at any reasonable time. We've already contacted the KeyVault service team to see if they can make the purge methods LRO-friendly. If they do that, we will be able to clean this up and simply use LROs.

With this PR, these tests will only run in `record` and `playback` mode. We have unlimited time to wait for recordings to happen, and playback tests don't experience any timeout. Live tests won't encounter this problem after this PR.