### PR TITLE
[core-http] Add shouldDeserialize to WebResource in SendOperationRequest

### DIFF
--- a/sdk/core/core-http/src/operationOptions.ts
+++ b/sdk/core/core-http/src/operationOptions.ts
@@ -1,6 +1,7 @@
 import { AbortSignalLike } from "@azure/abort-controller";
 import { SpanOptions } from "@opentelemetry/types";
 import { TransferProgressEvent, RequestOptionsBase } from "./webResource";
+import { HttpOperationResponse } from "./httpOperationResponse";
 
 /**
  * The base options type for all operations.
@@ -48,6 +49,11 @@ export interface OperationRequestOptions {
    * Callback which fires upon download progress.
    */
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
+  /**
+   * Whether or not the HttpOperationResponse should be deserialized. If this is undefined, then the
+   * HttpOperationResponse should be deserialized.
+   */
+  shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
 }
 
 /**

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -58,7 +58,7 @@ import { logger } from "./log";
 import { InternalPipelineOptions } from "./pipelineOptions";
 import { DefaultKeepAliveOptions, keepAlivePolicy } from "./policies/keepAlivePolicy";
 import { tracingPolicy } from "./policies/tracingPolicy";
-import { disableResponseDecompressionPolicy } from './policies/disableResponseDecompressionPolicy';
+import { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
 
 /**
  * Options to configure a proxy for outgoing requests (Node.js only).
@@ -448,6 +448,10 @@ export class ServiceClient {
 
         if (options.spanOptions) {
           httpRequest.spanOptions = options.spanOptions;
+        }
+
+        if (options.shouldDeserialize !== undefined) {
+          httpRequest.shouldDeserialize = options.shouldDeserialize;
         }
       }
 

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -648,6 +648,12 @@ export interface RequestOptionsBase {
   onDownloadProgress?: (progress: TransferProgressEvent) => void;
 
   /**
+   * Whether or not the HttpOperationResponse should be deserialized. If this is undefined, then the
+   * HttpOperationResponse should be deserialized.
+   */
+  shouldDeserialize?: boolean | ((response: HttpOperationResponse) => boolean);
+
+  /**
    * Options used to create a span when tracing is enabled.
    */
   spanOptions?: SpanOptions;


### PR DESCRIPTION
**Problem**
Currently serviceClient.sendOperation request is not adding shouldDeserialize to the WebResource

**Fix**
When shouldDeserialized is passed in the request options, add it to the httpRequest WebResource