### PR TITLE
[Identity] Add the ability to read AZURE_AUTHORITY_HOST from environment

### DIFF
--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -16,7 +16,8 @@
     "./dist-esm/src/credentials/defaultAzureCredential.js": "./dist-esm/src/credentials/defaultAzureCredential.browser.js",
     "./dist-esm/src/credentials/authorizationCodeCredential.js": "./dist-esm/src/credentials/authorizationCodeCredential.browser.js",
     "./dist-esm/src/credentials/interactiveBrowserCredential.js": "./dist-esm/src/credentials/interactiveBrowserCredential.browser.js",
-    "./dist-esm/src/credentials/vscodeCredential.js": "./dist-esm/src/credentials/vscodeCredential.browser.js"
+    "./dist-esm/src/credentials/vscodeCredential.js": "./dist-esm/src/credentials/vscodeCredential.browser.js",
+    "./dist-esm/src/util/authHostEnv.js": "./dist-esm/src/util/authHostEnv.browser.js"
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -9,7 +9,8 @@ import {
   WebResource,
   RequestPrepareOptions,
   GetTokenOptions,
-  createPipelineFromOptions
+  createPipelineFromOptions,
+  isNode
 } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/types";
 import { AuthenticationError, AuthenticationErrorName } from "./errors";
@@ -38,6 +39,9 @@ export class IdentityClient extends ServiceClient {
   public authorityHost: string;
 
   constructor(options?: TokenCredentialOptions) {
+    if (isNode) {
+      options = options || IdentityClient.getEnvironmentOptions();
+    }
     options = options || IdentityClient.getDefaultOptions();
     super(
       undefined,
@@ -179,6 +183,12 @@ export class IdentityClient extends ServiceClient {
     }
   }
 
+  static getEnvironmentOptions(): TokenCredentialOptions {
+    return {
+      authorityHost: process.env.AZURE_AUTHORITY_HOST
+    };
+  }
+  
   static getDefaultOptions(): TokenCredentialOptions {
     return {
       authorityHost: DefaultAuthorityHost

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -40,7 +40,9 @@ export class IdentityClient extends ServiceClient {
 
   constructor(options?: TokenCredentialOptions) {
     if (isNode) {
-      options = options || IdentityClient.getEnvironmentOptions();
+      options = options || {
+        authorityHost: process.env.AZURE_AUTHORITY_HOST
+      };
     }
     options = options || IdentityClient.getDefaultOptions();
     super(
@@ -183,12 +185,6 @@ export class IdentityClient extends ServiceClient {
     }
   }
 
-  static getEnvironmentOptions(): TokenCredentialOptions {
-    return {
-      authorityHost: process.env.AZURE_AUTHORITY_HOST
-    };
-  }
-  
   static getDefaultOptions(): TokenCredentialOptions {
     return {
       authorityHost: DefaultAuthorityHost

--- a/sdk/identity/identity/src/client/identityClient.ts
+++ b/sdk/identity/identity/src/client/identityClient.ts
@@ -16,6 +16,7 @@ import { CanonicalCode } from "@opentelemetry/types";
 import { AuthenticationError, AuthenticationErrorName } from "./errors";
 import { createSpan } from "../util/tracing";
 import { logger } from "../util/logging";
+import { getAuthorityHostEnvironment } from "../util/authHostEnv"
 
 const DefaultAuthorityHost = "https://login.microsoftonline.com";
 
@@ -40,9 +41,7 @@ export class IdentityClient extends ServiceClient {
 
   constructor(options?: TokenCredentialOptions) {
     if (isNode) {
-      options = options || {
-        authorityHost: process.env.AZURE_AUTHORITY_HOST
-      };
+      options = options || getAuthorityHostEnvironment();
     }
     options = options || IdentityClient.getDefaultOptions();
     super(

--- a/sdk/identity/identity/src/util/authHostEnv.browser.ts
+++ b/sdk/identity/identity/src/util/authHostEnv.browser.ts
@@ -1,0 +1,7 @@
+const BrowserNotSupportedError = new Error(
+  "getAuthorityHostEnvironment is not supported in the browser."
+);
+
+export function getAuthorityHostEnvironment() {
+  throw BrowserNotSupportedError;
+}

--- a/sdk/identity/identity/src/util/authHostEnv.ts
+++ b/sdk/identity/identity/src/util/authHostEnv.ts
@@ -1,0 +1,5 @@
+export function getAuthorityHostEnvironment() { 
+  return {
+    authorityHost: process.env.AZURE_AUTHORITY_HOST
+  };
+}

--- a/sdk/identity/identity/test/identityClient.spec.ts
+++ b/sdk/identity/identity/test/identityClient.spec.ts
@@ -8,6 +8,7 @@ import { AuthenticationError } from "../src/";
 import { IdentityClient } from "../src/client/identityClient";
 import { ClientSecretCredential } from "../src";
 import { setLogLevel, AzureLogger, getLogLevel, AzureLogLevel } from "@azure/logger";
+import { isNode } from "@azure/core-http";
 
 function isExpectedError(expectedErrorName: string): (error: any) => boolean {
   return (error: any) => {
@@ -76,6 +77,28 @@ describe("IdentityClient", function() {
       Error,
       "The authorityHost address must use the 'https' protocol."
     );
+  });
+
+  it("throws an exception when an Env AZURE_AUTHORITY_HOST using 'http' is provided", async () => {
+    if (isNode) {
+      process.env.AZURE_AUTHORITY_HOST ="http://totallyinsecure.lol";
+      assert.throws(
+        () => {
+          new IdentityClient();
+        },
+        Error,
+        "The authorityHost address must use the 'https' protocol."
+      );
+      process.env.AZURE_AUTHORITY_HOST ="httpsomg.com";
+      assert.throws(
+        () => {
+          new IdentityClient();
+        },
+        Error,
+        "The authorityHost address must use the 'https' protocol."
+      );
+      delete process.env.AZURE_AUTHORITY_HOST;
+    }
   });
 
   it("returns a usable error when the authentication response doesn't contain a body", async () => {

--- a/sdk/identity/identity/test/identityClient.spec.ts
+++ b/sdk/identity/identity/test/identityClient.spec.ts
@@ -79,26 +79,27 @@ describe("IdentityClient", function() {
     );
   });
 
-  it("throws an exception when an Env AZURE_AUTHORITY_HOST using 'http' is provided", async () => {
-    if (isNode) {
-      process.env.AZURE_AUTHORITY_HOST ="http://totallyinsecure.lol";
-      assert.throws(
-        () => {
-          new IdentityClient();
-        },
-        Error,
-        "The authorityHost address must use the 'https' protocol."
-      );
-      process.env.AZURE_AUTHORITY_HOST ="httpsomg.com";
-      assert.throws(
-        () => {
-          new IdentityClient();
-        },
-        Error,
-        "The authorityHost address must use the 'https' protocol."
-      );
-      delete process.env.AZURE_AUTHORITY_HOST;
+  it("throws an exception when an Env AZURE_AUTHORITY_HOST using 'http' is provided", async function() {
+    if (!isNode) {
+      return this.skip();
     }
+    process.env.AZURE_AUTHORITY_HOST ="http://totallyinsecure.lol";
+    assert.throws(
+      () => {
+        new IdentityClient();
+      },
+      Error,
+      "The authorityHost address must use the 'https' protocol."
+    );
+    process.env.AZURE_AUTHORITY_HOST ="httpsomg.com";
+    assert.throws(
+      () => {
+        new IdentityClient();
+      },
+      Error,
+      "The authorityHost address must use the 'https' protocol."
+    );
+    delete process.env.AZURE_AUTHORITY_HOST;    
   });
 
   it("returns a usable error when the authentication response doesn't contain a body", async () => {


### PR DESCRIPTION
Built from https://github.com/Azure/azure-sdk-for-js/pull/8001, this allows you to use the AZURE_AUTHORITY_HOST from your environment, if available.