### PR TITLE
[ai-text-analytics] Throw an Error when documents is empty

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
+++ b/sdk/textanalytics/ai-text-analytics/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release History
 
-## 1.0.0-preview.4 (Unreleased)
+## 1.0.0-preview.4 (2020-04-07)
 - Renamed the first parameter of all operation methods from `inputs` to `documents`
 - [Breaking] Removed PII entity detection methods from `TextAnalyticsClient` as well as all associated samples and documentation
 - [Breaking] Replaced `TextAnalyticsApiKeyCredential` with `AzureKeyCredential` (re-exported through this package from `@azure/core-auth`).
+- `TextAnalyticsClient` methods now throw an error when the `documents` parameter is not an array or empty before sending a request to the Text Analytics service.
 
 ## 1.0.0-preview.3 (2020-03-10)
 - [Breaking] Renamed `id` to `dataSourceEntityId` in the `LinkedEntity` type.

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -236,6 +236,10 @@ export class TextAnalyticsClient {
     let realOptions: DetectLanguageOptions;
     let realInputs: DetectLanguageInput[];
 
+    if (!Array.isArray(documents) || documents.length == 0) {
+      throw new Error("'documents' must be a non-empty array");
+    }
+
     if (isStringArray(documents)) {
       const countryHint = (countryHintOrOptions as string) || this.defaultCountryHint;
       realInputs = convertToDetectLanguageInput(documents, countryHint);
@@ -324,6 +328,10 @@ export class TextAnalyticsClient {
     let realOptions: RecognizeCategorizedEntitiesOptions;
     let realInputs: TextDocumentInput[];
 
+    if (!Array.isArray(documents) || documents.length == 0) {
+      throw new Error("'documents' must be a non-empty array");
+    }
+
     if (isStringArray(documents)) {
       const language = (languageOrOptions as string) || this.defaultLanguage;
       realInputs = convertToTextDocumentInput(documents, language);
@@ -404,6 +412,10 @@ export class TextAnalyticsClient {
     let realOptions: AnalyzeSentimentOptions;
     let realInputs: TextDocumentInput[];
 
+    if (!Array.isArray(documents) || documents.length == 0) {
+      throw new Error("'documents' must be a non-empty array");
+    }
+
     if (isStringArray(documents)) {
       const language = (languageOrOptions as string) || this.defaultLanguage;
       realInputs = convertToTextDocumentInput(documents, language);
@@ -481,6 +493,10 @@ export class TextAnalyticsClient {
   ): Promise<ExtractKeyPhrasesResultCollection> {
     let realOptions: ExtractKeyPhrasesOptions;
     let realInputs: TextDocumentInput[];
+
+    if (!Array.isArray(documents) || documents.length == 0) {
+      throw new Error("'documents' must be a non-empty array");
+    }
 
     if (isStringArray(documents)) {
       const language = (languageOrOptions as string) || this.defaultLanguage;
@@ -561,6 +577,10 @@ export class TextAnalyticsClient {
   ): Promise<RecognizeLinkedEntitiesResultCollection> {
     let realOptions: RecognizeLinkedEntitiesOptions;
     let realInputs: TextDocumentInput[];
+
+    if (!Array.isArray(documents) || documents.length == 0) {
+      throw new Error("'documents' must be a non-empty array");
+    }
 
     if (isStringArray(documents)) {
       const language = (languageOrOptions as string) || this.defaultLanguage;

--- a/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
+++ b/sdk/textanalytics/ai-text-analytics/test/textAnalyticsClient.spec.ts
@@ -49,7 +49,7 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   describe("#analyzeSentiment", () => {
     it("client throws on empty list", async () => {
-      return assert.isRejected(client.analyzeSentiment([]));
+      return assert.isRejected(client.analyzeSentiment([]), /non-empty array/);
     });
 
     it("client accepts string[] and language", async () => {
@@ -114,7 +114,7 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   describe("#detectLanguage", () => {
     it("client throws on empty list", async () => {
-      return assert.isRejected(client.detectLanguage([]));
+      return assert.isRejected(client.detectLanguage([]), /non-empty array/);
     });
 
     it("client accepts no countryHint", async () => {
@@ -187,7 +187,7 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   describe("#recognizeEntities", () => {
     it("client throws on empty list", async () => {
-      return assert.isRejected(client.recognizeEntities([]));
+      return assert.isRejected(client.recognizeEntities([]), /non-empty array/);
     });
 
     it("client accepts string[] with no language", async () => {
@@ -241,7 +241,7 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   describe("#extractKeyPhrases", () => {
     it("client throws on empty list", async () => {
-      return assert.isRejected(client.extractKeyPhrases([]));
+      return assert.isRejected(client.extractKeyPhrases([]), /non-empty array/);
     });
 
     it("client accepts string[] with no language", async () => {
@@ -295,7 +295,7 @@ describe("[AAD] TextAnalyticsClient", function() {
 
   describe("#recognizeLinkedEntities", () => {
     it("client throws on empty list", async () => {
-      return assert.isRejected(client.recognizeLinkedEntities([]));
+      return assert.isRejected(client.recognizeLinkedEntities([]), /non-empty array/);
     });
 
     it("client accepts string[] with no language", async () => {


### PR DESCRIPTION
This PR guards all of our methods on TextAnalyticsClient with `Array.isArray` and checks to make sure the length is not zero.

This is to avoid sending requests to the Text Analytics service that are guaranteed to return an HTTP error so that we can provide a more instructive message.

We already tested the empty input case and asserted that it would throw, so all I've done on the tests is add a regexp to validate the Error message.

This is the last change to be included in preview 4, so I've also updated the CHANGELOG to include the release date.