### PR TITLE
[service-bus] Adding in AbortSignal support for sending messages

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 7.0.0-preview.1 (2020-04-06)
+## 7.0.0-preview.1 (2020-04-07)
 
 - This release is a preview of our efforts to create a client library that is user friendly and
   idiomatic to the JavaScript ecosystem. The reasons for most of the changes in this update can be found in the

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,19 +1,25 @@
 # Release History
 
-## 2.0.0-preview.1 (Unreleased)
+## 7.0.0-preview.1 (2020-04-06)
+
+- This release is a preview of our efforts to create a client library that is user friendly and
+  idiomatic to the JavaScript ecosystem. The reasons for most of the changes in this update can be found in the
+  [Azure SDK Design Guidelines for TypeScript](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html).
+
+  We also provide a migration guide for users familiar with the stable package that would like to try the preview: [migration guide to move from Service Bus V1 to Service Bus V7 Preview](https://github.com/azure/azure-sdk-for-js/blob/%40azure/service-bus_7.0.0-preview.1/sdk/servicebus/service-bus/migrationguide.md).
 
 - Fixes [bug 7598][https://github.com/azure/azure-sdk-for-js/issues/7958] where the dead letter error and description could be populated incorrectly.
 
 ### Breaking Changes
 
 - Fixes [bug 6816](https://github.com/Azure/azure-sdk-for-js/issues/6816) affecting messages sent using the `scheduleMessage()` and `scheduleMessages()` methods. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
-  - Users on version-`1.x.x` of `@azure/service-bus` library had to rely on the [workaround of encoding the message body with `DefaultDataTransformer`](https://github.com/Azure/azure-sdk-for-js/pull/6983) before calling `scheduleMessage()`/`scheduleMessages()` methods. The workaround is no longer needed since the bug has been fixed here starting from version-`2.0.0-preview.1`. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
+  - Users on version-`1.x.x` of `@azure/service-bus` library had to rely on the [workaround of encoding the message body with `DefaultDataTransformer`](https://github.com/Azure/azure-sdk-for-js/pull/6983) before calling `scheduleMessage()`/`scheduleMessages()` methods. The workaround is no longer needed since the bug has been fixed here starting from version-`7.0.0-preview.1`. [PR 7372](https://github.com/Azure/azure-sdk-for-js/pull/7372).
 
 ## 1.1.5 (2020-03-24)
 
 - Removed interfaces related to unreleased management api features from the API surface that were accidentally exported in version 1.1.3
   [PR 7992](https://github.com/Azure/azure-sdk-for-js/issues/7992).
-  
+
 ## 1.1.4 (2020-03-17)
 
 - Updated to use the latest version of `@azure/amqp-common` where the timeout for authorization requests sent to the service is increased from 10s to 60s to reduce the frequency of timeout errors.

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -140,8 +140,8 @@ export interface Sender {
     isClosed: boolean;
     scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage, options?: OperationOptions): Promise<Long_2>;
     scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[], options?: OperationOptions): Promise<Long_2[]>;
-    send(message: ServiceBusMessage): Promise<void>;
-    sendBatch(messageBatch: ServiceBusMessageBatch): Promise<void>;
+    send(message: ServiceBusMessage, options?: OperationOptions): Promise<void>;
+    sendBatch(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -37,7 +37,7 @@ import { throwErrorIfConnectionClosed } from "../util/errors";
 import { ServiceBusMessageBatch, ServiceBusMessageBatchImpl } from "../serviceBusMessageBatch";
 import { CreateBatchOptions } from "../models";
 import { OperationOptions } from "../modelsToBeSharedWithEventHubs";
-import { AbortError } from "@azure/abort-controller";
+import { AbortError, AbortSignalLike } from "@azure/abort-controller";
 
 /**
  * @internal
@@ -254,67 +254,49 @@ export class MessageSender extends LinkEntity {
   private _trySend(
     encodedMessage: Buffer,
     sendBatch: boolean,
-    options: OperationOptions
+    options: OperationOptions | undefined
   ): Promise<void> {
     const abortSignal = options?.abortSignal;
 
     const sendEventPromise = () =>
       new Promise<void>(async (resolve, reject) => {
-        const rejectOnAbort = () => {
-          const desc: string =
-            `[${this._context.namespace.connectionId}] The send operation on the Sender "${this.name}" with ` +
-            `address "${this.address}" has been cancelled by the user.`;
-          // Cancellation is user-intended, so log to info instead of warning.
-          log.error(desc);
-          return reject(new AbortError("The send operation has been cancelled by the user."));
-        };
+        let initTimeoutTimer: any;
 
-        if (abortSignal && abortSignal.aborted) {
-          // operation has been cancelled, so exit quickly
-          return rejectOnAbort();
-        }
-
-        const removeListeners = (): void => {
-          clearTimeout(waitTimer);
-          if (abortSignal) {
-            abortSignal.removeEventListener("abort", onAborted);
-          }
-        };
-
-        const onAborted = () => {
-          removeListeners();
-          return rejectOnAbort();
-        };
-
-        if (abortSignal) {
-          abortSignal.addEventListener("abort", onAborted);
-        }
+        this._checkAndSetupAbortSignalCleanup(
+          abortSignal,
+          () => clearTimeout(initTimeoutTimer),
+          reject
+        );
 
         const initStartTime = Date.now();
         if (!this.isOpen()) {
-          const initTimeoutAction = () => {
-            const desc: string =
-              `[${this._context.namespace.connectionId}] Sender "${this.name}" ` +
-              `with address "${this.address}", was not able to send the message right now, due ` +
-              `to operation timeout.`;
-            log.error(desc);
-            const e: AmqpError = {
-              condition: ErrorNameConditionMapper.ServiceUnavailableError,
-              description: desc
-            };
-            return reject(translate(e));
-          };
+          const initTimeoutPromise = new Promise((res, rejectInitTimeoutPromise) => {
+            initTimeoutTimer = setTimeout(() => {
+              const desc: string =
+                `[${this._context.namespace.connectionId}] Sender "${this.name}" ` +
+                `with address "${this.address}", was not able to send the message right now, due ` +
+                `to operation timeout.`;
+              log.error(desc);
+              const e: AmqpError = {
+                condition: ErrorNameConditionMapper.ServiceUnavailableError,
+                description: desc
+              };
+              return rejectInitTimeoutPromise(translate(e));
+            }, this._retryOptions.timeoutInMs);
+          });
 
-          const initTimeoutTimer = setTimeout(initTimeoutAction, this._retryOptions.timeoutInMs);
-          log.sender(
-            "Acquiring lock %s for initializing the session, sender and " +
-              "possibly the connection.",
-            this.senderLock
-          );
           try {
-            await defaultLock.acquire(this.senderLock, () => {
+            log.sender(
+              "Acquiring lock %s for initializing the session, sender and " +
+                "possibly the connection.",
+              this.senderLock
+            );
+
+            const initPromise = defaultLock.acquire(this.senderLock, () => {
               return this._init();
             });
+
+            await Promise.race([initPromise, initTimeoutPromise]);
           } catch (err) {
             err = translate(err);
             log.warning(
@@ -329,6 +311,7 @@ export class MessageSender extends LinkEntity {
           }
         }
         const timeTakenByInit = Date.now() - initStartTime;
+
         log.sender(
           "[%s] Sender '%s', credit: %d available: %d",
           this._context.namespace.connectionId,
@@ -336,6 +319,7 @@ export class MessageSender extends LinkEntity {
           this._sender!.credit,
           this._sender!.session.outgoing.available()
         );
+
         if (!this._sender!.sendable()) {
           log.sender(
             "[%s] Sender '%s', waiting for 1 second for sender to become sendable",
@@ -356,7 +340,7 @@ export class MessageSender extends LinkEntity {
         if (this._sender!.sendable()) {
           try {
             this._sender!.sendTimeoutInSeconds =
-              (retryOptions.timeoutInMs! - timeTakenByInit) / 1000;
+              (this._retryOptions.timeoutInMs - timeTakenByInit) / 1000;
             const delivery = await this._sender!.send(
               encodedMessage,
               undefined,
@@ -396,7 +380,8 @@ export class MessageSender extends LinkEntity {
       operation: sendEventPromise,
       connectionId: this._context.namespace.connectionId!,
       operationType: RetryOperationType.sendMessage,
-      retryOptions: retryOptions
+      retryOptions: this._retryOptions,
+      abortSignal: abortSignal
     };
 
     return retry<void>(config);
@@ -595,12 +580,13 @@ export class MessageSender extends LinkEntity {
    * @param {ServiceBusMessage} data Message to send.  Will be sent as UTF8-encoded JSON string.
    * @returns {Promise<void>}
    */
-  async send(data: ServiceBusMessage): Promise<void> {
+  async send(data: ServiceBusMessage, options?: OperationOptions): Promise<void> {
     throwErrorIfConnectionClosed(this._context.namespace);
     try {
       const amqpMessage = toAmqpMessage(data);
       amqpMessage.body = this._context.namespace.dataTransformer.encode(data.body);
 
+      // TODO: this body of logic is really similar to what's in sendMessages. Unify what we can.
       let encodedMessage;
       try {
         encodedMessage = RheaMessageUtil.encode(amqpMessage);
@@ -620,7 +606,7 @@ export class MessageSender extends LinkEntity {
         this.name,
         data
       );
-      return await this._trySend(encodedMessage);
+      return await this._trySend(encodedMessage, false, options);
     } catch (err) {
       log.error(
         "[%s] Sender '%s': An error occurred while sending the message: %O\nError: %O",
@@ -642,7 +628,10 @@ export class MessageSender extends LinkEntity {
    * Batch message.
    * @return {Promise<void>}
    */
-  async sendMessages(inputMessages: ServiceBusMessage[]): Promise<void> {
+  async sendMessages(
+    inputMessages: ServiceBusMessage[],
+    options?: OperationOptions
+  ): Promise<void> {
     throwErrorIfConnectionClosed(this._context.namespace);
     try {
       if (!Array.isArray(inputMessages)) {
@@ -698,7 +687,7 @@ export class MessageSender extends LinkEntity {
         this.name,
         encodedBatchMessage
       );
-      return await this._trySend(encodedBatchMessage, true);
+      return await this._trySend(encodedBatchMessage, true, options);
     } catch (err) {
       log.error(
         "[%s] Sender '%s': An error occurred while sending the messages: %O\nError: %O",
@@ -771,7 +760,7 @@ export class MessageSender extends LinkEntity {
     return new ServiceBusMessageBatchImpl(this._context, maxMessageSize!);
   }
 
-  async sendBatch(batchMessage: ServiceBusMessageBatch): Promise<void> {
+  async sendBatch(batchMessage: ServiceBusMessageBatch, options?: OperationOptions): Promise<void> {
     throwErrorIfConnectionClosed(this._context.namespace);
     try {
       log.sender(
@@ -780,7 +769,7 @@ export class MessageSender extends LinkEntity {
         this.name,
         batchMessage
       );
-      return await this._trySend(batchMessage._message!, true);
+      return await this._trySend(batchMessage._message!, true, options);
     } catch (err) {
       log.error(
         "[%s] Sender '%s': An error occurred while sending the messages: %O\nError: %O",
@@ -791,6 +780,38 @@ export class MessageSender extends LinkEntity {
       );
       throw err;
     }
+  }
+
+  private _checkAndSetupAbortSignalCleanup(
+    abortSignal: AbortSignalLike | undefined,
+    clearStateFn: () => void,
+    reject: (err: Error) => void
+  ) {
+    if (abortSignal == null) {
+      return;
+    }
+
+    const rejectOnAbort = () => {
+      const desc: string =
+        `[${this._context.namespace.connectionId}] The send operation on the Sender "${this.name}" with ` +
+        `address "${this.address}" has been cancelled by the user.`;
+      // Cancellation is user-intended, so log to info instead of warning.
+      log.error(desc);
+      return reject(new AbortError("The send operation has been cancelled by the user."));
+    };
+
+    if (abortSignal.aborted) {
+      // operation has been cancelled, so exit quickly
+      return rejectOnAbort();
+    }
+
+    const onAborted = () => {
+      clearStateFn();
+      abortSignal.removeEventListener("abort", onAborted);
+      return rejectOnAbort();
+    };
+
+    abortSignal.addEventListener("abort", onAborted);
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -32,11 +32,12 @@ export interface Sender {
    * and/or `partitionKey` properties respectively on the message.
    *
    * @param message - Message to send.
+   * @param options - Options for aborting and tracing.
    * @returns Promise<void>
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws MessagingError if the service returns an error while sending messages to the service.
    */
-  send(message: ServiceBusMessage): Promise<void>;
+  send(message: ServiceBusMessage, options?: OperationOptions): Promise<void>;
 
   // sendBatch(<Array of messages>) - Commented
   // /**
@@ -74,12 +75,13 @@ export interface Sender {
    * Sends a batch of messages to the associated service-bus entity.
    *
    * @param {ServiceBusMessageBatch} messageBatch A batch of messages that you can create using the {@link createBatch} method.
+   * @param options - Options for aborting and tracing.
    * @returns {Promise<void>}
    * @throws MessagingError if an error is encountered while sending a message.
    * @throws Error if the underlying connection or sender has been closed.
    * @memberof Sender
    */
-  sendBatch(messageBatch: ServiceBusMessageBatch): Promise<void>;
+  sendBatch(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
 
   /**
    * @property Returns `true` if either the sender or the client that created it has been closed
@@ -193,35 +195,25 @@ export class SenderImpl implements Sender {
     return this._isClosed || this._context.isClosed;
   }
 
-  async send(message: ServiceBusMessage): Promise<void> {
+  async send(message: ServiceBusMessage, options?: OperationOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "message", message);
-    return this._sender.send(message);
+    return this._sender.send(message, options);
   }
-
-  // sendBatch(<Array of messages>) - Commented
-  // async sendBatch(messages: ServiceBusMessage[]): Promise<void> {
-  //   this._throwIfSenderOrConnectionClosed();
-  //   throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "messages", messages);
-  //   if (!Array.isArray(messages)) {
-  //     messages = [messages];
-  //   }
-  //   return this._sender.sendBatch(messages);
-  // }
 
   async createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch> {
     this._throwIfSenderOrConnectionClosed();
     return this._sender.createBatch(options);
   }
 
-  async sendBatch(messageBatch: ServiceBusMessageBatch): Promise<void> {
+  async sendBatch(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
     throwTypeErrorIfParameterMissing(
       this._context.namespace.connectionId,
       "messageBatch",
       messageBatch
     );
-    return this._sender.sendBatch(messageBatch);
+    return this._sender.sendBatch(messageBatch, options);
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -32,7 +32,7 @@ export interface Sender {
    * and/or `partitionKey` properties respectively on the message.
    *
    * @param message - Message to send.
-   * @param options - Options for aborting and tracing.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns Promise<void>
    * @throws Error if the underlying connection, client or sender is closed.
    * @throws MessagingError if the service returns an error while sending messages to the service.
@@ -75,7 +75,7 @@ export interface Sender {
    * Sends a batch of messages to the associated service-bus entity.
    *
    * @param {ServiceBusMessageBatch} messageBatch A batch of messages that you can create using the {@link createBatch} method.
-   * @param options - Options for aborting and tracing.
+   * @param options - Options bag to pass an abort signal or tracing options.
    * @returns {Promise<void>}
    * @throws MessagingError if an error is encountered while sending a message.
    * @throws Error if the underlying connection or sender has been closed.

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -37,16 +37,42 @@ export function getUniqueName(name: string): string {
 /**
  * @internal
  * @ignore
+ *
+ * TODO: I think this is duplicated from core-amqp and should be du-duped, but _before_
+ * that happens we should question whether it's even a legitimate way of setting the timeout
+ * because it just squashes all timeouts beneath 60 seconds to be 60 seconds instead.
  */
 export function getRetryAttemptTimeoutInMs(retryOptions: RetryOptions | undefined): number {
   const timeoutInMs =
     retryOptions == undefined ||
     typeof retryOptions.timeoutInMs !== "number" ||
     !isFinite(retryOptions.timeoutInMs) ||
+    // TODO: not sure what the justification is for always forcing at least 60 seconds.
     retryOptions.timeoutInMs < CoreAMQPConstants.defaultOperationTimeoutInMs
       ? CoreAMQPConstants.defaultOperationTimeoutInMs
       : retryOptions.timeoutInMs;
+
   return timeoutInMs;
+}
+
+/**
+ * @internal
+ * @ignore
+ */
+export type RetryOptionsInternal =
+  | NonNullable<Pick<RetryOptions, "timeoutInMs">>
+  | Exclude<RetryOptions, "timeoutInMs">;
+
+/**
+ * @internal
+ * @ignore
+ */
+export function normalizeRetryOptions(
+  retryOptions: RetryOptions | undefined
+): RetryOptionsInternal {
+  const actualRetryOptions: RetryOptions = { ...retryOptions };
+  actualRetryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(actualRetryOptions);
+  return actualRetryOptions;
 }
 
 /**

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -59,9 +59,8 @@ export function getRetryAttemptTimeoutInMs(retryOptions: RetryOptions | undefine
  * @internal
  * @ignore
  */
-export type RetryOptionsInternal =
-  | NonNullable<Pick<RetryOptions, "timeoutInMs">>
-  | Exclude<RetryOptions, "timeoutInMs">;
+export type RetryOptionsInternal = Required<Pick<RetryOptions, "timeoutInMs">> &
+  Exclude<RetryOptions, "timeoutInMs">;
 
 /**
  * @internal
@@ -70,9 +69,10 @@ export type RetryOptionsInternal =
 export function normalizeRetryOptions(
   retryOptions: RetryOptions | undefined
 ): RetryOptionsInternal {
-  const actualRetryOptions: RetryOptions = { ...retryOptions };
-  actualRetryOptions.timeoutInMs = getRetryAttemptTimeoutInMs(actualRetryOptions);
-  return actualRetryOptions;
+  return {
+    ...retryOptions,
+    timeoutInMs: getRetryAttemptTimeoutInMs(retryOptions)
+  };
 }
 
 /**

--- a/sdk/servicebus/service-bus/test/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/abortSignal.spec.ts
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+import { ClientEntityContext } from "../src/clientEntityContext";
+import { MessageSender } from "../src/core/messageSender";
+import { OperationOptions } from "../src/modelsToBeSharedWithEventHubs";
+import { DefaultDataTransformer } from "@azure/core-amqp";
+import { AbortSignalLike } from "@azure/abort-controller";
+import { ServiceBusMessageBatch } from "../src/serviceBusMessageBatch";
+import { delay, AwaitableSender } from "rhea-promise";
+
+describe("AbortSignal #RunInBrowser", () => {
+  const testMessageThatDoesntMatter = {
+    body: "doesn't matter"
+  };
+
+  describe("sender", () => {
+    let clientEntityContext: ReturnType<typeof createClientEntityContextForTests>;
+
+    beforeEach(() => {
+      clientEntityContext = createClientEntityContextForTests();
+    });
+
+    it("AbortSignal is plumbed through all send operations", async () => {
+      const sender = new MessageSender(clientEntityContext, {});
+
+      let passedInOptions: OperationOptions | undefined;
+
+      sender["_trySend"] = async (buffer, sendBatch, options) => {
+        passedInOptions = options;
+      };
+
+      await sender.send(testMessageThatDoesntMatter, {
+        abortSignal: createTaggedAbortSignal("passed with send", false)
+      });
+
+      assert.equal((passedInOptions?.abortSignal as any).tag, "passed with send");
+
+      await sender.sendBatch({} as ServiceBusMessageBatch, {
+        abortSignal: createTaggedAbortSignal("passed with sendBatch", false)
+      });
+
+      assert.equal((passedInOptions?.abortSignal as any).tag, "passed with sendBatch");
+
+      await sender.sendMessages([testMessageThatDoesntMatter], {
+        abortSignal: createTaggedAbortSignal("passed with sendMessages", false)
+      });
+
+      assert.equal((passedInOptions?.abortSignal as any).tag, "passed with sendMessages");
+    });
+
+    it("_trySend with an already aborted AbortSignal", async () => {
+      const sender = new MessageSender(clientEntityContext, { timeoutInMs: 1 });
+
+      sender["_init"] = async () => {
+        throw new Error("INIT SHOULD NEVER HAVE BEEN CALLED");
+      };
+
+      const abortSignal = createTaggedAbortSignal("_trySend test", true);
+
+      try {
+        await sender["_trySend"]({} as Buffer, true, {
+          abortSignal
+        });
+        assert.fail("AbortError should be thrown when the signal is already in an aborted state");
+      } catch (err) {
+        assert.equal(err.message, "The send operation has been cancelled by the user.");
+
+        // we aborted in the sync part of the abort check so these event listeners are never set up
+        assert.isFalse(abortSignal.addWasCalled);
+        assert.isFalse(abortSignal.removeWasCalled);
+
+        // init() doesn't get called - we abort early on this one.
+        assert.isFalse(clientEntityContext.initWasCalled);
+      }
+    });
+
+    it("_trySend with a signal aborted while init() is still running", async () => {
+      const sender = new MessageSender(clientEntityContext, {
+        timeoutInMs: 1
+      });
+      sender["_retryOptions"].timeoutInMs = 1;
+      sender["_retryOptions"].maxRetries = 1;
+      sender["_retryOptions"].retryDelayInMs = 1;
+
+      sender["_sender"] = {
+        credit: 999,
+        isOpen: () => false,
+        session: {
+          outgoing: {
+            available: () => true
+          }
+        }
+      } as AwaitableSender;
+
+      let initWasCalled = true;
+
+      sender["_init"] = async () => {
+        initWasCalled = true;
+        // long enough to let the init timeout expiration code to run.
+        await delay(1000);
+      };
+
+      try {
+        await sender["_trySend"]({} as Buffer, true, {
+          abortSignal: createTaggedAbortSignal("not used for this test", false)
+        });
+        assert.fail("Sender should have thrown in the async portion of the abort handling");
+      } catch (err) {
+        // in this case init() does get called - we abort through a timer.
+        assert.isTrue(initWasCalled);
+
+        assert.match(
+          err.message,
+          /.*was not able to send the message right now, due to operation timeout.*/
+        );
+      }
+    });
+  });
+});
+
+function createClientEntityContextForTests(): ClientEntityContext & { initWasCalled: boolean } {
+  let initWasCalled = false;
+
+  const fakeClientEntityContext = {
+    entityPath: "queue",
+    sender: {
+      credit: 999
+    },
+    namespace: {
+      config: { endpoint: "my.service.bus" },
+      connectionId: "connection-id",
+      dataTransformer: new DefaultDataTransformer(),
+      cbsSession: {
+        cbsLock: "cbs-lock",
+        async init() {
+          initWasCalled = true;
+        }
+      }
+    },
+    initWasCalled
+  };
+
+  return (fakeClientEntityContext as any) as ReturnType<typeof createClientEntityContextForTests>;
+}
+
+function createTaggedAbortSignal(
+  tag: string,
+  aborted: boolean
+): AbortSignalLike & { tag: string; removeWasCalled: boolean; addWasCalled: boolean } {
+  let removeWasCalled = false;
+  let addWasCalled = false;
+
+  const signal = {
+    aborted,
+    addEventListener(): void {
+      addWasCalled = true;
+    },
+    removeEventListener(): void {
+      this.removeWasCalled = true;
+    },
+    tag,
+    removeWasCalled,
+    addWasCalled
+  };
+
+  return signal;
+}


### PR DESCRIPTION
Support aborting (at least on init and retries) for when the user sends.

Future work: move this support deeper into the stack so we can start properly aborting, rather than setting up a timer around init().