### PR TITLE
[Identity] Fix the auth host function if the environment variable isn't available

### DIFF
--- a/sdk/identity/identity/src/util/authHostEnv.ts
+++ b/sdk/identity/identity/src/util/authHostEnv.ts
@@ -1,5 +1,9 @@
-export function getAuthorityHostEnvironment() { 
-  return {
-    authorityHost: process.env.AZURE_AUTHORITY_HOST
-  };
+export function getAuthorityHostEnvironment() {
+  if (process.env.AZURE_AUTHORITY_HOST) {
+    return {
+      authorityHost: process.env.AZURE_AUTHORITY_HOST
+    };
+  } else {
+    return undefined;
+  }
 }


### PR DESCRIPTION
The auth host function will now return undefined if the environment variable isn't available.  This should allow the defaults to work.