### PR TITLE
[Service Bus] Fix test failures

### DIFF
--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -430,19 +430,6 @@ describe("invalid parameters", () => {
       );
     });
 
-    it("PeekBySequenceNumber: Missing sequenceNumber in SessionReceiver", async function(): Promise<
-      void
-    > {
-      let caughtError: Error | undefined;
-      try {
-        await receiver.browseMessages({ fromSequenceNumber: undefined as any });
-      } catch (error) {
-        caughtError = error;
-      }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "fromSequenceNumber"`);
-    });
-
     it("RegisterMessageHandler: Missing onMessage in SessionReceiver", async function(): Promise<
       void
     > {

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -103,19 +103,6 @@ describe("invalid parameters", () => {
         `The parameter "fromSequenceNumber" should be of type "Long"`
       );
     });
-
-    it("PeekBySequenceNumber: Missing fromSequenceNumber for Queue", async function(): Promise<
-      void
-    > {
-      let caughtError: Error | undefined;
-      try {
-        await receiver.browseMessages({ fromSequenceNumber: undefined as any });
-      } catch (error) {
-        caughtError = error;
-      }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "fromSequenceNumber"`);
-    });
   });
 
   describe("Invalid parameters in Sender/ReceiverClients for PartitionedSubscription #RunInBrowser", function(): void {

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -195,19 +195,6 @@ describe("invalid parameters", () => {
       );
     });
 
-    it("PeekBySequenceNumber: Missing fromSequenceNumber for Subscription", async function(): Promise<
-      void
-    > {
-      let caughtError: Error | undefined;
-      try {
-        await subscriptionReceiverClient.browseMessages({ fromSequenceNumber: undefined as any });
-      } catch (error) {
-        caughtError = error;
-      }
-      should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "fromSequenceNumber"`);
-    });
-
     it("AddRule: Missing ruleName", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {


### PR DESCRIPTION
browseMessages operation accepts "undefined" as fromSeqNum, so removing the tests.