### PR TITLE
[service-bus] add timeout around receiver drain

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Removes the `@azure/ms-rest-nodeauth` dependency.
   This allows users to use any version of `@azure/ms-rest-nodeauth` directly with `@azure/service-bus` without TypeScript compilation errors.
   Fixes [bug 8041](https://github.com/Azure/azure-sdk-for-js/issues/8041).
+- Fixes issue where `receiveMessages` would wait indefinitely to return if the
+  receiver's `receiver_drained` event was never fired.
 
 ## 1.1.5 (2020-03-24)
 

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -175,7 +175,7 @@ export class BatchingReceiver extends MessageReceiver {
             await Promise.race([drainPromise, drainTimeout]);
           } catch {
             // Close the receiver link since we have not received the receiver drain event.
-            await this.onDetached();
+            await this.close();
           }
 
           // Turn off draining.

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -8,6 +8,13 @@ export const packageJsonInfo = {
 
 export const messageDispositionTimeout = 20000;
 
+/**
+ * The amount of time in milliseconds that a receiver
+ * will wait while draining credits before returning
+ * the received messages.
+ */
+export const receiveDrainTimeoutInMs = 200;
+
 export const max32BitNumber = Math.pow(2, 31) - 1;
 
 /**

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -1181,7 +1181,7 @@ describe("Batch Receiver - drain", function(): void {
       );
     }, 0);
 
-    const results = await receiver.receiveMessages(1, 1);
+    const results = await receiver.receiveMessages(5, 1);
 
     Array.isArray(results).should.be.true;
     results.length.should.equal(1, "Received an unexpected number of messages.");
@@ -1221,14 +1221,14 @@ describe("Batch Receiver - drain", function(): void {
       );
     }, 0);
 
-    (receiver as any)._context.batchingReceiver._drainTimeoutInMs = 10;
-    const results1 = await receiver.receiveMessages(1, 1);
+    (receiver as any)._context.batchingReceiver._drainTimeoutInMs = 0;
+    const results1 = await receiver.receiveMessages(5, 1);
     Array.isArray(results1).should.be.true;
-    results1.length.should.equal(1, "Received an unexpected number of messages.");
+    results1.length.should.equal(2, "Received an unexpected number of messages.");
 
-    (receiver as any)._context.batchingReceiver._drainTimeoutInMs = 200;
-    const results2 = await receiver.receiveMessages(1, 1);
+    await sender.sendBatch(testMessages);
+    const results2 = await receiver.receiveMessages(5, 1);
     Array.isArray(results2).should.be.true;
-    results2.length.should.equal(1, "Received an unexpected number of messages.");
+    results2.length.should.equal(3, "Received an unexpected number of messages.");
   });
 });


### PR DESCRIPTION
This change attempts to remove an edge case where `receiveMessages` may hang indefinitely.

Currently, once the `BatchingReceiver` (`receiveMessages`) reaches either the `maxMessageCount` or `maxWaitTime`, it will drain any remaining credits on the receiver link and then return the messages.

However if for some reason the service was unable to report back that credits were drained, the messages would never be returned and the operation would appear to hang indefinitely.

Now the receiver will wait a maximum of 200 ms for the service to indicate that credits are drained. If this timeout is reached, then the received messages are returned from `receiveMessages`.

I chose 200 ms because in my local testing, it typically took ~80 ms between when the receiver triggered a drain and when the `receiver_drained` event was fired. This gives an additional 150% buffer. I had considered using `newMessageWaitTimeoutInSeconds` instead, which currently is set to 1 second, but was trying to minimize how long we'd wait so that message locks wouldn't need to be renewed.

Currently in draft until I can verify the full live test suite passes.