### PR TITLE
[KeyVault] Forcing the purge tests to run only on record

### DIFF
--- a/sdk/keyvault/keyvault-certificates/test/list.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/list.test.ts
@@ -41,7 +41,7 @@ describe("Certificates client - list certificates in various ways", () => {
   // Use this while recording to make sure the target keyvault is clean.
   // The next tests will produce a more consistent output.
   // This test is only useful while developing locally.
-  it("can purge all certificates (only valuable before recording)", async function() {
+  it("can purge all certificates", async function() {
     // WARNING: When TEST_MODE equals "record", all of the certificates in the indicated KEYVAULT_NAME will be deleted as part of this test.
     if (!isRecordMode()) {
       return this.skip();

--- a/sdk/keyvault/keyvault-certificates/test/list.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/list.test.ts
@@ -44,7 +44,7 @@ describe("Certificates client - list certificates in various ways", () => {
   it("can purge all certificates (only valuable before recording)", async function() {
     // WARNING: When TEST_MODE equals "record", all of the certificates in the indicated KEYVAULT_NAME will be deleted as part of this test.
     if (!isRecordMode()) {
-      this.skip();
+      return this.skip();
     }
     for await (const certificate of client.listPropertiesOfCertificates({
       includePending: true

--- a/sdk/keyvault/keyvault-certificates/test/list.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/list.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import chai from "chai";
 import { CertificateClient } from "../src";
-import { env, isPlaybackMode, Recorder } from "@azure/test-utils-recorder";
+import { env, isPlaybackMode, Recorder, isRecordMode } from "@azure/test-utils-recorder";
 import { testPollerProperties } from "./utils/recorderUtils";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
@@ -38,10 +38,14 @@ describe("Certificates client - list certificates in various ways", () => {
 
   // The tests follow
 
-  // Use this while recording to make sure the target keyvault is clean. The next tests will produce a more consistent output.
-  it("can purge all certificates", async function() {
-    // WARNING: When running integration-tests, or having TEST_MODE="record", all of the certificates in the indicated KEYVAULT_NAME will be deleted as part of this test.
-    recorder.skip(undefined, "Skipping this test on playback.");
+  // Use this while recording to make sure the target keyvault is clean.
+  // The next tests will produce a more consistent output.
+  // This test is only useful while developing locally.
+  it("can purge all certificates (only valuable before recording)", async function() {
+    // WARNING: When TEST_MODE equals "record", all of the certificates in the indicated KEYVAULT_NAME will be deleted as part of this test.
+    if (!isRecordMode()) {
+      this.skip();
+    }
     for await (const certificate of client.listPropertiesOfCertificates({
       includePending: true
     })) {

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import { KeyClient } from "../src";
 import { testPollerProperties } from "./utils/recorderUtils";
-import { env, Recorder } from "@azure/test-utils-recorder";
+import { env, Recorder, isRecordMode } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
 import { assertThrowsAbortError } from "./utils/utils.common";
@@ -30,10 +30,14 @@ describe("Keys client - list keys in various ways", () => {
 
   // The tests follow
 
-  // This test is only useful while developing locally
+  // Use this while recording to make sure the target keyvault is clean.
+  // The next tests will produce a more consistent output.
+  // This test is only useful while developing locally.
   it("can purge all keys", async function() {
-    // WARNING: When running integration-tests, or having TEST_MODE="record", all of the keys in the indicated KEYVAULT_NAME will be deleted as part of this test.
-    recorder.skip(undefined, "Skipping this test on playback.");
+    // WARNING: When TEST_MODE equals "record", all of the keys in the indicated KEYVAULT_NAME will be deleted as part of this test.
+    if (!isRecordMode()) {
+      this.skip();
+    }
     for await (const properties of client.listPropertiesOfKeys()) {
       try {
         await testClient.flushKey(properties.name);

--- a/sdk/keyvault/keyvault-keys/test/list.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/list.test.ts
@@ -36,7 +36,7 @@ describe("Keys client - list keys in various ways", () => {
   it("can purge all keys", async function() {
     // WARNING: When TEST_MODE equals "record", all of the keys in the indicated KEYVAULT_NAME will be deleted as part of this test.
     if (!isRecordMode()) {
-      this.skip();
+      return this.skip();
     }
     for await (const properties of client.listPropertiesOfKeys()) {
       try {

--- a/sdk/keyvault/keyvault-secrets/test/list.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/list.test.ts
@@ -39,7 +39,7 @@ describe("Secret client - list secrets in various ways", () => {
   it("can purge all secrets", async function() {
     // WARNING: When TEST_MODE equals "record", all of the secrets in the indicated KEYVAULT_NAME will be deleted as part of this test.
     if (!isRecordMode()) {
-      this.skip();
+      return this.skip();
     }
     for await (const secretProperties of client.listPropertiesOfSecrets()) {
       try {

--- a/sdk/keyvault/keyvault-secrets/test/list.test.ts
+++ b/sdk/keyvault/keyvault-secrets/test/list.test.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import chai from "chai";
 import { SecretClient } from "../src";
 import { testPollerProperties } from "./utils/recorderUtils";
-import { env, Recorder } from "@azure/test-utils-recorder";
+import { env, Recorder, isRecordMode } from "@azure/test-utils-recorder";
 import { authenticate } from "./utils/testAuthentication";
 import TestClient from "./utils/testClient";
 import { assertThrowsAbortError } from "./utils/utils.common";
@@ -33,10 +33,14 @@ describe("Secret client - list secrets in various ways", () => {
 
   // The tests follow
 
-  // This test is only useful while developing locally
+  // Use this while recording to make sure the target keyvault is clean.
+  // The next tests will produce a more consistent output.
+  // This test is only useful while developing locally.
   it("can purge all secrets", async function() {
-    // WARNING: When running integration-tests, or having TEST_MODE="record", all of the secrets in the indicated KEYVAULT_NAME will be deleted as part of this test.
-    recorder.skip(undefined, "Skipping this test on playback.");
+    // WARNING: When TEST_MODE equals "record", all of the secrets in the indicated KEYVAULT_NAME will be deleted as part of this test.
+    if (!isRecordMode()) {
+      this.skip();
+    }
     for await (const secretProperties of client.listPropertiesOfSecrets()) {
       try {
         await testClient.flushSecret(secretProperties.name);


### PR DESCRIPTION
This PR is for my own sanity. This shouldn't affect the builds other than reducing build time, but these tests right now are not valuable on CI. I am planning to clean this up once we release the new test guidelines. For now, all I want is to not see them running on CI.