### PR TITLE
[Cosmos] Add partitionKey back to FeedOptions

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,7 +1,25 @@
 # Release History
 
-## 3.6.3 (Unreleased)
+## 3.7.0 (2020-4-08)
 
+- FEATURE: Add `partitionKey` to `FeedOptions` for scoping a query to a single partition key value
+
+@azure/cosmos V2 has two different but equivalent ways to specify the partition key for a query:
+
+```js
+// V2 These are effectively the same
+container.items.query("SELECT * from c", { partitionKey: "foo" }).toArray();
+container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').toArray();
+```
+
+In an effort to simplify, the V3 SDK removed `partitionKey` from `FeedOptions` so there was only one way to specify the partition key:
+
+```js
+// V3
+container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').fetchAll();
+```
+
+Based on customer feedback, we identified scenarios where it still makes sense to support passing the partition key via `FeedOptions` and have decided to restore the behavior.
 
 ## 3.6.2 (2020-2-20)
 

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -84,7 +84,8 @@ export class Items {
         resourceId: id,
         resultFn: (result) => (result ? result.Documents : []),
         query,
-        options: innerOptions
+        options: innerOptions,
+        partitionKey: options.partitionKey
       });
     };
 

--- a/sdk/cosmosdb/cosmos/src/request/FeedOptions.ts
+++ b/sdk/cosmosdb/cosmos/src/request/FeedOptions.ts
@@ -85,4 +85,15 @@ export interface FeedOptions extends SharedOptions {
    * and ensure parallelism can happen. Useful for when you know you're doing cross-partition or aggregate queries.
    */
   forceQueryPlan?: boolean;
+  /** Limits the query to a specific partition key. Default: undefined
+   *
+   *  Scoping a query to a single partition can be accomplished two ways:
+   *
+   * container.items.query('SELECT * from c', { partitionKey: "foo" }).toArray()
+   * container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').toArray()
+   *
+   * The former is useful when the query body is out of your control
+   * but you still want to restrict it to a single partition. Example: an end user specified query.
+   */
+  partitionKey?: any;
 }

--- a/sdk/cosmosdb/cosmos/test/integration/query.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/integration/query.spec.ts
@@ -59,7 +59,7 @@ describe("Test Query Metrics", function() {
     );
     const createdContainer = database.container(createdCollectionDef.id);
 
-    await createdContainer.items.create(document);
+    await createdContainer.items.create(doc);
     const query = "SELECT * from " + collectionId;
     const queryOptions: FeedOptions = { populateQueryMetrics: true };
     const queryIterator = createdContainer.items.query(query, queryOptions);


### PR DESCRIPTION
@azure/cosmos V2 has two different but equivalent ways to specify the partition key for a query:

```js
// V2 These are effectively the same
container.items.query("SELECT * from c", { partitionKey: "foo" }).toArray();
container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').toArray();
```

In an effort to simplify, the V3 SDK removed `partitionKey` from `FeedOptions` so there was only one way to specify the partition key:

```js
// V3
container.items.query('SELECT * from c WHERE c.yourPartitionKey = "foo"').fetchAll();
```

Based on customer feedback, we identified scenarios where it still makes sense to support passing the partition key via `FeedOptions` and have decided to restore the behavior.