### PR TITLE
Remove jstags that are redundant in a TS world in SB, EH & core-amqp

### DIFF
--- a/sdk/core/core-amqp/src/ConnectionContextBase.ts
+++ b/sdk/core/core-amqp/src/ConnectionContextBase.ts
@@ -13,7 +13,6 @@ import { getPlatformInfo, getFrameworkInfo } from "./util/runtimeInfo";
 import { isNode } from "./util/utils";
 
 /**
- * @interface ConnectionContextBase
  * Provides contextual information like the underlying amqp connection, cbs session, tokenProvider,
  * Connection config, data transformer, etc.
  */
@@ -67,7 +66,6 @@ export interface ConnectionContextBase {
 
 /**
  * Defines the properties that need to be set while establishing the AMQP connection.
- * @interface ConnectionProperties
  */
 export interface ConnectionProperties {
   /**
@@ -88,7 +86,6 @@ export interface ConnectionProperties {
 
 /**
  * Describes the parameters that can be provided to create the base connection context.
- * @interface CreateConnectionContextBaseParameters
  */
 export interface CreateConnectionContextBaseParameters {
   /**

--- a/sdk/core/core-amqp/src/auth/sas.ts
+++ b/sdk/core/core-amqp/src/auth/sas.ts
@@ -42,7 +42,6 @@ export class SharedKeyCredential {
   }
 
   /**
-   * @protected
    * Creates the sas token based on the provided information
    * @param {string | number} expiry - The time period in unix time after which the token will expire.
    * @param {string} [audience] - The audience for which the token is desired.

--- a/sdk/core/core-amqp/src/cbs.ts
+++ b/sdk/core/core-amqp/src/cbs.ts
@@ -21,7 +21,6 @@ import { RequestResponseLink } from "./requestResponseLink";
 
 /**
  * Describes the CBS Response.
- * @interface CbsResponse
  */
 export interface CbsResponse {
   correlationId: string;
@@ -59,7 +58,6 @@ export class CbsClient {
 
   /**
    * CBS sender, receiver on the same session.
-   * @private
    */
   private _cbsSenderReceiverLink?: RequestResponseLink;
 
@@ -261,7 +259,6 @@ export class CbsClient {
 
   /**
    * Indicates whether the cbs sender receiver link is open or closed.
-   * @private
    * @return {boolean} `true` open, `false` closed.
    */
   private _isCbsSenderReceiverLinkOpen(): boolean {

--- a/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/connectionConfig.ts
@@ -6,7 +6,6 @@ import { WebSocketImpl } from "rhea-promise";
 
 /**
  * Describes the options that can be provided while creating a connection config.
- * @interface ConnectionConfigOptions
  */
 export interface ConnectionConfigOptions {
   /**
@@ -19,7 +18,6 @@ export interface ConnectionConfigOptions {
 /**
  * Describes the connection config object that is created after parsing an EventHub or ServiceBus
  * connection string.
- * @interface ConnectionConfig
  */
 export interface ConnectionConfig {
   /**

--- a/sdk/core/core-amqp/src/connectionConfig/eventhubConnectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/eventhubConnectionConfig.ts
@@ -7,7 +7,6 @@ import { ConnectionConfig } from "./connectionConfig";
  * Describes the connection config object that is created after parsing an EventHub connection
  * string. It also provides some convenience methods for getting the address and audience for
  * different entities.
- * @interface EventHubConnectionConfig
  */
 export interface EventHubConnectionConfig extends ConnectionConfig {
   /**

--- a/sdk/core/core-amqp/src/connectionConfig/iothubConnectionConfig.ts
+++ b/sdk/core/core-amqp/src/connectionConfig/iothubConnectionConfig.ts
@@ -6,7 +6,6 @@ import { EventHubConnectionConfig } from "./eventhubConnectionConfig";
 import { parseConnectionString, IotHubConnectionStringModel } from "../util/utils";
 
 /**
- * @interface IotHubConnectionConfig
  * @ignore
  */
 export interface IotHubConnectionConfig {

--- a/sdk/core/core-amqp/src/dataTransformer.ts
+++ b/sdk/core/core-amqp/src/dataTransformer.ts
@@ -9,7 +9,6 @@ import { Buffer } from "buffer";
 /**
  * Describes the transformations that can be performed to encode/decode the data before sending it
  * on (or receiving it from) the wire.
- * @interface DataTransformer
  */
 export interface DataTransformer {
   /**

--- a/sdk/core/core-amqp/src/messageHeader.ts
+++ b/sdk/core/core-amqp/src/messageHeader.ts
@@ -6,7 +6,6 @@ import { logger } from "./log";
 
 /**
  * Describes the defined set of standard header properties of the message.
- * @interface MessageHeader
  */
 export interface MessageHeader {
   /**

--- a/sdk/core/core-amqp/src/messageProperties.ts
+++ b/sdk/core/core-amqp/src/messageProperties.ts
@@ -6,7 +6,6 @@ import { logger } from "./log";
 
 /**
  * Describes the defined set of standard properties of the message.
- * @interface MessageProperties
  */
 export interface MessageProperties {
   /**

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -21,7 +21,6 @@ import { logger, logErrorStackTrace } from "./log";
 
 /**
  * Describes the options that can be specified while sending a request.
- * @interface SendRequestOptions
  */
 export interface SendRequestOptions {
   /**

--- a/sdk/core/core-amqp/src/retry.ts
+++ b/sdk/core/core-amqp/src/retry.ts
@@ -88,7 +88,6 @@ export interface RetryOptions {
 
 /**
  * Describes the parameters that need to be configured for the retry operation.
- * @interface RetryConfig
  */
 export interface RetryConfig<T> {
   /**

--- a/sdk/core/core-amqp/src/util/utils.ts
+++ b/sdk/core/core-amqp/src/util/utils.ts
@@ -8,7 +8,6 @@ import { WebSocketImpl } from "rhea-promise";
 export { AsyncLock };
 /**
  * Describes the options that can be provided to create an async lock.
- * @interface AsyncLockOptions
  */
 export interface AsyncLockOptions {
   /**
@@ -60,7 +59,6 @@ export const isNode =
 
 /**
  * Describes the servicebus connection string model.
- * @interface ServiceBusConnectionStringModel
  */
 export interface ServiceBusConnectionStringModel {
   Endpoint: string;
@@ -72,7 +70,6 @@ export interface ServiceBusConnectionStringModel {
 
 /**
  * Describes the eventhub connection string model.
- * @interface EventHubConnectionStringModel
  */
 export interface EventHubConnectionStringModel {
   Endpoint: string;
@@ -84,7 +81,6 @@ export interface EventHubConnectionStringModel {
 
 /**
  * Describes the stroage connection string model.
- * @interface StorageConnectionStringModel
  */
 export interface StorageConnectionStringModel {
   DefaultEndpointsProtocol: string;
@@ -96,7 +92,6 @@ export interface StorageConnectionStringModel {
 
 /**
  * Describes the iothub connection string model.
- * @interface IotHubConnectionStringModel
  */
 export interface IotHubConnectionStringModel {
   HostName: string;

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -19,7 +19,6 @@ import { EventHubClientOptions } from "./models/public";
 import { Dictionary, OnAmqpEvent, EventContext, ConnectionEvents } from "rhea-promise";
 
 /**
- * @interface ConnectionContext
  * @internal
  * @ignore
  * Provides contextual information like the underlying amqp connection, cbs session, management session,

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -6,7 +6,6 @@ import { Constants } from "@azure/core-amqp";
 
 /**
  * Describes the delivery annotations.
- * @interface EventHubDeliveryAnnotations
  * @ignore
  */
 export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
@@ -34,7 +33,6 @@ export interface EventHubDeliveryAnnotations extends DeliveryAnnotations {
 
 /**
  * Map containing message attributes that will be held in the message header.
- * @interface EventHubMessageAnnotations
  * @ignore
  */
 export interface EventHubMessageAnnotations extends MessageAnnotations {
@@ -62,7 +60,6 @@ export interface EventHubMessageAnnotations extends MessageAnnotations {
 
 /**
  * Describes the structure of an event to be sent or received from the EventHub.
- * @interface
  * @ignore
  */
 export interface EventDataInternal {

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -34,7 +34,6 @@ interface CreateReceiverOptions {
 /**
  * A set of information about the last enqueued event of a partition, as observed by the consumer as
  * events are received from the Event Hubs service
- * @interface LastEnqueuedEventProperties
  */
 export interface LastEnqueuedEventProperties {
   /**
@@ -110,52 +109,42 @@ export class EventHubReceiver extends LinkEntity {
   options: EventHubConsumerOptions;
   /**
    * @property [_receiver] The RHEA AMQP-based receiver link.
-   * @private
    */
   private _receiver?: Receiver;
   /**
    * @property _onMessage The message handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
-   * @private
    */
   private _onMessage?: OnMessage;
   /**
    * @property _OnError The error handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
-   * @private
    */
   private _onError?: OnError;
   /**
    * @property _onAbort The abort handler provided by the batching or streaming flavors of receive operations on the `EventHubConsumer`
-   * @private
    */
   private _onAbort?: OnAbort;
   /**
    * @property _abortSignal An implementation of the `AbortSignalLike` interface to signal cancelling a receiver operation.
-   * @private
    */
   private _abortSignal?: AbortSignalLike;
   /**
    * @property _checkpoint The sequence number of the most recently received AMQP message.
-   * @private
    */
   private _checkpoint: number = -1;
   /**
    * @property _internalQueue A queue of events that were received from the AMQP link but not consumed externally by `EventHubConsumer`
-   * @private
    */
   private _internalQueue: ReceivedEventData[] = [];
   /**
    * @property _usingInternalQueue Indicates that events in the internal queue are being processed to be consumed by `EventHubConsumer`
-   * @private
    */
   private _usingInternalQueue: boolean = false;
   /**
    * @property _isReceivingMessages Indicates if messages are being received from this receiver.
-   * @private
    */
   private _isReceivingMessages: boolean = false;
   /**
    * @property _isStreaming Indicated if messages are being received in streaming mode.
-   * @private
    */
   private _isStreaming: boolean = false;
 

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -60,18 +60,15 @@ export class EventHubSender extends LinkEntity {
   /**
    * @property _onSessionError The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_error" event.
-   * @private
    */
   private _onSessionError: OnAmqpEvent;
   /**
    * @property _onSessionClose The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_close" event.
-   * @private
    */
   private _onSessionClose: OnAmqpEvent;
   /**
    * @property [_sender] The AMQP sender link.
-   * @private
    */
   private _sender?: AwaitableSender;
 

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -87,18 +87,15 @@ export class LinkEntity {
   /**
    * @property _context Provides relevant information about the amqp connection,
    * cbs and $management sessions, token provider, sender and receivers.
-   * @protected
    */
   protected _context: ConnectionContext;
   /**
    * @property _tokenRenewalTimer The token renewal timer that keeps track of when
    * the Link Entity is due for token renewal.
-   * @protected
    */
   protected _tokenRenewalTimer?: NodeJS.Timer;
   /**
    * @property _tokenTimeout Indicates token timeout in milliseconds
-   * @protected
    */
   protected _tokenTimeoutInMs?: number;
   /**
@@ -120,7 +117,6 @@ export class LinkEntity {
   /**
    * Negotiates cbs claim for the LinkEntity.
    * @ignore
-   * @protected
    * @param [setTokenRenewal] Set the token renewal timer. Default false.
    * @returns Promise<void>
    */
@@ -191,7 +187,6 @@ export class LinkEntity {
   /**
    * Ensures that the token is renewed within the predefined renewal margin.
    * @ignore
-   * @protected
    * @returns
    */
   protected async _ensureTokenRenewal(): Promise<void> {

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -30,7 +30,6 @@ import { getRetryAttemptTimeoutInMs } from "./util/retries";
 import { AbortSignalLike, AbortError } from "@azure/abort-controller";
 /**
  * Describes the runtime information of an Event Hub.
- * @interface HubRuntimeInformation
  */
 export interface EventHubProperties {
   /**
@@ -49,7 +48,6 @@ export interface EventHubProperties {
 
 /**
  * Describes the runtime information of an EventHub Partition.
- * @interface PartitionProperties
  */
 export interface PartitionProperties {
   /**
@@ -111,7 +109,6 @@ export class ManagementClient extends LinkEntity {
   replyTo: string = uuid();
   /**
    * $management sender, receiver on the same session.
-   * @private
    */
   private _mgmtReqResLink?: RequestResponseLink;
 
@@ -340,7 +337,6 @@ export class ManagementClient extends LinkEntity {
   }
 
   /**
-   * @private
    * Helper method to make the management request
    * @param request The AMQP message to send
    * @param options The options to use when sending a request over a $management link

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -91,7 +91,6 @@ export enum CloseReason {
  *     }
  * }
  * ```
- * @interface ClientOptions
  */
 export interface EventHubClientOptions {
   /**

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -14,7 +14,6 @@ import { logger, logErrorStackTrace } from "./log";
 export class ReceiveHandler {
   /**
    * @property _receiver  The underlying EventHubReceiver.
-   * @private
    */
   private _receiver: EventHubReceiver;
 

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -139,7 +139,6 @@ export class EventHubConsumer {
   /**
    * EventHubConsumer should not be constructed using `new EventHubConsumer()`
    * Use the `createConsumer()` method on your `EventHubClient` instead.
-   * @private
    * @constructor
    * @internal
    * @ignore

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -63,7 +63,6 @@ export class EventHubProducer {
   /**
    * EventHubProducer should not be constructed using `new EventHubProduer()`
    * Use the `createProducer()` method on your `EventHubClient` instead.
-   * @private
    * @constructor
    * @internal
    * @ignore

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -15,7 +15,6 @@ import { SessionManager } from "./session/sessionManager";
 import { MessagingError } from "@azure/core-amqp";
 
 /**
- * @interface ClientEntityContext
  * Provides contextual information like the underlying amqp connection, cbs session,
  * management session, tokenCredential, senders, receivers, etc. about the ServiceBus client.
  * @internal

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -20,7 +20,6 @@ import { OnAmqpEvent, EventContext, ConnectionEvents } from "rhea-promise";
 
 /**
  * @internal
- * @interface ConnectionContext
  * Provides contextual information like the underlying amqp connection, cbs session, management session,
  * tokenCredential, senders, receivers, etc. about the ServiceBus client.
  */

--- a/sdk/servicebus/service-bus/src/constructorHelpers.ts
+++ b/sdk/servicebus/service-bus/src/constructorHelpers.ts
@@ -13,13 +13,10 @@ import { ConnectionContext } from "./connectionContext";
 
 /**
  * Describes the options that can be provided while creating the ServiceBusClient.
- * @interface ServiceBusClientOptions
  */
 export interface ServiceBusClientOptions {
   /**
    * Retry policy options that determine the mode, number of retries, retry interval etc.
-   *
-   * @type {RetryOptions}
    */
   retryOptions?: RetryOptions;
   /**

--- a/sdk/servicebus/service-bus/src/core/linkEntity.ts
+++ b/sdk/servicebus/service-bus/src/core/linkEntity.ts
@@ -78,18 +78,15 @@ export class LinkEntity {
   /**
    * @property {ClientEntityContext} _context Provides relevant information about the amqp connection,
    * cbs and $management sessions, token provider, sender and receivers.
-   * @protected
    */
   protected _context: ClientEntityContext;
   /**
    * @property {NodeJS.Timer} _tokenRenewalTimer The token renewal timer that keeps track of when
    * the Client Entity is due for token renewal.
-   * @protected
    */
   protected _tokenRenewalTimer?: NodeJS.Timer;
   /**
    * @property _tokenTimeout Indicates token timeout
-   * @protected
    */
   protected _tokenTimeout?: number;
   /**
@@ -108,7 +105,6 @@ export class LinkEntity {
 
   /**
    * Negotiates the cbs claim for the ClientEntity.
-   * @protected
    * @param {boolean} [setTokenRenewal] Set the token renewal timer. Default false.
    * @return {Promise<void>} Promise<void>
    */
@@ -186,7 +182,6 @@ export class LinkEntity {
 
   /**
    * Ensures that the token is renewed within the predefined renewal margin.
-   * @protected
    * @returns {void}
    */
   protected async _ensureTokenRenewal(): Promise<void> {

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -186,12 +186,10 @@ export class ManagementClient extends LinkEntity {
   replyTo: string = generate_uuid();
   /**
    * @property $management sender, receiver on the same session.
-   * @private
    */
   private _mgmtReqResLink?: RequestResponseLink;
   /**
    * @property _lastPeekedSequenceNumber Provides the sequence number of the last peeked message.
-   * @private
    */
   private _lastPeekedSequenceNumber: Long = Long.ZERO;
 

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -82,8 +82,6 @@ export interface ReceiveOptions extends MessageHandlerOptions {
   receiveMode?: ReceiveMode;
   /**
    * Retry policy options that determine the mode, number of retries, retry interval etc.
-   *
-   * @type {RetryOptions}
    */
   retryOptions?: RetryOptions;
 }
@@ -92,7 +90,6 @@ export interface ReceiveOptions extends MessageHandlerOptions {
  * Describes the signature of the message handler passed to `registerMessageHandler` method.
  * @internal
  * @ignore
- * @interface OnMessage
  */
 export interface OnMessage {
   /**
@@ -106,7 +103,6 @@ export interface OnMessage {
  *
  * @internal
  * @ignore
- * @interface OnError
  */
 export interface OnError {
   /**
@@ -163,15 +159,10 @@ export class MessageReceiver extends LinkEntity {
   autoRenewLock: boolean;
   /**
    * @property {Receiver} [_receiver] The AMQP receiver link.
-   * @protected
    */
   protected _receiver?: Receiver;
   /**
    *Retry policy options that determine the mode, number of retries, retry interval etc.
-   *
-   * @private
-   * @type {RetryOptions}
-   * @memberof MessageReceiver
    */
   private _retryOptions: RetryOptions;
   /**
@@ -183,60 +174,50 @@ export class MessageReceiver extends LinkEntity {
   /**
    * @property {OnMessage} _onMessage The message handler provided by the user that will be wrapped
    * inside _onAmqpMessage.
-   * @protected
    */
   protected _onMessage!: OnMessage;
   /**
    * @property {OnMessage} _onError The error handler provided by the user that will be wrapped
    * inside _onAmqpError.
-   * @protected
    */
   protected _onError?: OnError;
   /**
    * @property {OnAmqpEventAsPromise} _onAmqpMessage The message handler that will be set as the handler on the
    * underlying rhea receiver for the "message" event.
-   * @protected
    */
   protected _onAmqpMessage: OnAmqpEventAsPromise;
   /**
    * @property {OnAmqpEventAsPromise} _onAmqpClose The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_close" event.
-   * @protected
    */
   protected _onAmqpClose: OnAmqpEventAsPromise;
   /**
    * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_error" event.
-   * @protected
    */
   protected _onSessionError: OnAmqpEvent;
   /**
    * @property {OnAmqpEventAsPromise} _onSessionClose The message handler that will be set as the handler on
    * the underlying rhea receiver's session for the "session_close" event.
-   * @protected
    */
   protected _onSessionClose: OnAmqpEventAsPromise;
   /**
    * @property {OnAmqpEvent} _onAmqpError The message handler that will be set as the handler on the
    * underlying rhea receiver for the "receiver_error" event.
-   * @protected
    */
   protected _onAmqpError: OnAmqpEvent;
   /**
    * @property {OnAmqpEvent} _onSettled The message handler that will be set as the handler on the
    * underlying rhea receiver for the "settled" event.
-   * @protected
    */
   protected _onSettled: OnAmqpEvent;
   /**
    * @property {boolean} wasCloseInitiated Denotes if receiver was explicitly closed by user.
-   * @protected
    */
   protected wasCloseInitiated?: boolean;
   /**
    * @property {Map<string, Function>} _messageRenewLockTimers Maintains a map of messages for which
    * the lock is automatically renewed.
-   * @protected
    */
   protected _messageRenewLockTimers: Map<string, NodeJS.Timer | undefined> = new Map<
     string,
@@ -254,13 +235,11 @@ export class MessageReceiver extends LinkEntity {
   /**
    * @property {Function} _clearMessageLockRenewTimer Clears the message lock renew timer for a
    * specific messageId.
-   * @protected
    */
   protected _clearMessageLockRenewTimer: (messageId: string) => void;
   /**
    * @property {Function} _clearMessageLockRenewTimer Clears the message lock renew timer for all
    * the active messages.
-   * @protected
    */
   protected _clearAllMessageLockRenewTimers: () => void;
   constructor(context: ClientEntityContext, receiverType: ReceiverType, options?: ReceiveOptions) {
@@ -773,7 +752,6 @@ export class MessageReceiver extends LinkEntity {
 
   /**
    * Creates a new AMQP receiver under a new AMQP session.
-   * @protected
    *
    * @returns {Promise<void>} Promise<void>.
    */

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -66,18 +66,15 @@ export class MessageSender extends LinkEntity {
   /**
    * @property {OnAmqpEvent} _onSessionError The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_error" event.
-   * @private
    */
   private _onSessionError: OnAmqpEvent;
   /**
    * @property {OnAmqpEvent} _onSessionClose The message handler that will be set as the handler on
    * the underlying rhea sender's session for the "session_close" event.
-   * @private
    */
   private _onSessionClose: OnAmqpEvent;
   /**
    * @property {Sender} [_sender] The AMQP sender link.
-   * @private
    */
   private _sender?: AwaitableSender;
   private _retryOptions: RetryOptionsInternal;
@@ -714,7 +711,6 @@ export class MessageSender extends LinkEntity {
    * ```
    * @param {{retryOptions?: RetryOptions}} [options={}]
    * @returns {Promise<number>}
-   * @memberof MessageSender
    */
   async getMaxMessageSize(
     options: {

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -80,7 +80,6 @@ export interface Receiver<ReceivedMessageT> {
    * - Returns an empty list if no messages are found.
    * @throws Error if the underlying connection or receiver is closed.
    * @throws MessagingError if the service returns an error while receiving deferred messages.
-   * @memberof SessionReceiver
    */
   receiveDeferredMessages(
     sequenceNumbers: Long[],
@@ -90,7 +89,6 @@ export interface Receiver<ReceivedMessageT> {
    * Indicates whether the receiver is currently receiving messages or not.
    * When this returns true, new `registerMessageHandler()` or `receiveMessages()` calls cannot be made.
    * @returns {boolean}
-   * @memberof SessionReceiver
    */
   isReceivingMessages(): boolean;
 
@@ -105,21 +103,12 @@ export interface Receiver<ReceivedMessageT> {
    * the sequenceNumber to start browsing from or an abortSignal to abort the operation.
    */
   browseMessages(options?: BrowseMessagesOptions): Promise<ReceivedMessage[]>;
-
-  // TODO: not sure these need to be on the interface
-
   /**
    * Path for the client entity.
-   *
-   * @type {string}
-   * @memberof SessionReceiver
    */
   entityPath: string;
   /**
    * ReceiveMode provided to the client.
-   *
-   * @type {("peekLock" | "receiveAndDelete")}
-   * @memberof SessionReceiver
    */
   receiveMode: "peekLock" | "receiveAndDelete";
 

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -55,7 +55,6 @@ export interface SessionReceiver<
    * Will return undefined until a AMQP receiver link has been successfully set up for the session.
    *
    * @readonly
-   * @memberof SessionReceiver
    */
   sessionLockedUntilUtc: Date | undefined;
 

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -67,7 +67,6 @@ export interface Sender {
    * @returns {Promise<ServiceBusMessageBatch>}
    * @throws MessagingError if an error is encountered while sending a message.
    * @throws Error if the underlying connection or sender has been closed.
-   * @memberof Sender
    */
   createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch>;
 
@@ -79,7 +78,6 @@ export interface Sender {
    * @returns {Promise<void>}
    * @throws MessagingError if an error is encountered while sending a message.
    * @throws Error if the underlying connection or sender has been closed.
-   * @memberof Sender
    */
   sendBatch(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
 

--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -30,13 +30,11 @@ export enum ReceiveMode {
    * Once a message is received in this mode, the receiver has a lock on the message for a
    * particular duration. If the message is not settled by this time, it lands back on Service Bus
    * to be fetched by the next receive operation.
-   * @type {Number}
    */
   peekLock = 1,
 
   /**
    * Messages received in this mode get automatically removed from Service Bus.
-   * @type {Number}
    */
   receiveAndDelete = 2
 }
@@ -65,7 +63,6 @@ export enum DispositionStatus {
 /**
  * @internal
  * Describes the delivery annotations for Service Bus.
- * @interface
  */
 export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
   /**
@@ -93,7 +90,6 @@ export interface ServiceBusDeliveryAnnotations extends DeliveryAnnotations {
 /**
  * @internal
  * Describes the message annotations for Service Bus.
- * @interface ServiceBusMessageAnnotations
  */
 export interface ServiceBusMessageAnnotations extends MessageAnnotations {
   /**
@@ -121,7 +117,6 @@ export interface ServiceBusMessageAnnotations extends MessageAnnotations {
 /**
  * Describes the reason and error description for dead lettering a message using the `deadLetter()`
  * method on the message received from Service Bus.
- * @interface DeadLetterOptions
  */
 export interface DeadLetterOptions {
   /**
@@ -1091,7 +1086,6 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
   }
 
   /**
-   * @private
    * Logs and Throws an error if the given message cannot be settled.
    * @param receiver Receiver to be used to settle this message
    * @param operation Settle operation: complete, abandon, defer or deadLetter

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -8,7 +8,6 @@ import { AmqpMessage } from "@azure/core-amqp";
  * A batch of messages that you can create using the {@link createBatch} method.
  *
  * @export
- * @interface ServiceBusMessageBatch
  */
 export interface ServiceBusMessageBatch {
   /**

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -327,8 +327,6 @@ export const CURRENT_API_VERSION = "2017-04";
 /**
  * Constant representing the Odata Error 'message' property
  *
- * @const
- * @type {string}
  * @internal
  * @ignore
  */
@@ -336,8 +334,6 @@ export const ODATA_ERROR_MESSAGE = "message";
 /**
  * Constant representing the 'value' property of Odata Error 'message' property
  *
- * @const
- * @type {string}
  * @internal
  * @ignore
  */
@@ -346,8 +342,6 @@ export const ODATA_ERROR_MESSAGE_VALUE = "value";
 /**
  * Marker for atom metadata.
  *
- * @const
- * @type {string}
  * @internal
  * @ignore
  */
@@ -356,8 +350,6 @@ export const XML_METADATA_MARKER = "$";
 /**
  * Marker for atom value.
  *
- * @const
- * @type {string}
  * @internal
  * @ignore
  */
@@ -366,8 +358,6 @@ export const XML_VALUE_MARKER = "_";
 /**
  * Constant representing the property where the atom default elements are stored.
  *
- * @const
- * @type {string}
  * @internal
  * @ignore
  */

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -14,7 +14,6 @@ import { Constants as CoreAMQPConstants, RetryOptions } from "@azure/core-amqp";
 /**
  * @ignore
  * @internal
- * @interface Navigator
  */
 interface Navigator {
   hardwareConcurrency: number;


### PR DESCRIPTION
The below tags are relevant in JS code, but not TS
- `@member`
- `@memberof`
- `@interface`
- `@private`
- `@protected`
- `@type`
- `@const`

There might be more, but these are the ones that annoy me the most :)

Also removed the `TODO: not sure these need to be on the interface` on the properties in `Sender`, `Receiver` and `SessionReceiver` interfaces. These are indeed needed if they are to be exposed to the end user.