### PR TITLE
[Service Bus] Custom props on deadLetter() for non-deferred messages

### DIFF
--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -1084,7 +1084,12 @@ export class MessageReceiver extends LinkEntity {
         if (options.propertiesToModify) params.message_annotations = options.propertiesToModify;
         delivery.modified(params);
       } else if (operation === DispositionType.deadletter) {
-        delivery.reject(options.error || {});
+        options.error = options.error || {};
+        options.error.info = {
+          ...options.error.info,
+          ...options.propertiesToModify
+        };
+        delivery.reject(options.error);
       }
     });
   }

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -1084,12 +1084,12 @@ export class MessageReceiver extends LinkEntity {
         if (options.propertiesToModify) params.message_annotations = options.propertiesToModify;
         delivery.modified(params);
       } else if (operation === DispositionType.deadletter) {
-        options.error = options.error || {};
-        options.error.info = {
-          ...options.error.info,
+        const error = options.error || {};
+        error.info = {
+          ...error.info,
           ...options.propertiesToModify
         };
-        delivery.reject(options.error);
+        delivery.reject(error);
       }
     });
   }

--- a/sdk/servicebus/service-bus/test/deadLetter.spec.ts
+++ b/sdk/servicebus/service-bus/test/deadLetter.spec.ts
@@ -96,8 +96,7 @@ describe("dead lettering", () => {
     await checkDeadLetteredMessage({
       reason: "this is the dead letter reason",
       description: "this is the dead letter error description",
-      // TODO: https://github.com/Azure/azure-sdk-for-js/issues/7959
-      customProperty: undefined
+      customProperty: "hello, setting this custom property"
     });
   });
 

--- a/sdk/servicebus/service-bus/test/deadLetter.spec.ts
+++ b/sdk/servicebus/service-bus/test/deadLetter.spec.ts
@@ -86,8 +86,6 @@ describe("dead lettering", () => {
   });
 
   it("dead lettering a typical received message", async () => {
-    // defer this message so we can pick it up via the management API (which
-    // is what handles receiving deferred messages)
     await receivedMessage.deadLetter({
       deadLetterErrorDescription: "this is the dead letter error description",
       deadLetterReason: "this is the dead letter reason",


### PR DESCRIPTION
### Issue 
The underlying rhea library for JS doesn’t allow us to pass the propertiesToModify when we deadletter the received message using the delivery object (the same is allowed for abandon/defer). 
As per the [AMQP spec](http://www.amqp.org/sites/amqp.org/files/amqp.pdf), we cannot provide the properties-to-modify(through message-annotations) when the delivery is being “rejected”(deadletter)

### Taking cues from the .NET SDK
[deadletter-ing in .NET SDK](https://github.com/Azure/azure-sdk-for-net/blob/81d6ed42d456bbb3b02eeec8253f93fc1c519a3f/sdk/servicebus/Azure.Messaging.ServiceBus/src/Amqp/AmqpReceiver.cs#L584-L619) – Key takeaway here is that the `props-to-modify` are loaded into the “error.info” field along with the deadletter-reason and deadletter-description.

### Fix in this PR
We do use the `info` field to populate the reason and description.. [Related Code](https://github.com/richardpark-msft/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/src/serviceBusMessage.ts#L996-L998)
Loading the props-to-modify too into the `error.info` fixed the issue.


More interesting info here - https://github.com/Azure/azure-sdk-for-js/issues/7959#issuecomment-612300562