### PR TITLE
[service-bus] Allow users to call `open()` on a Sender and initialize the connection

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -88,6 +88,13 @@ You can also use the [sendBatch](https://docs.microsoft.com/en-us/javascript/api
 ```javascript
 const queueClient = serviceBusClient.createQueueClient("my-queue");
 const sender = queueClient.createSender();
+
+// Optionally, you can await on `sender.open()` if you want to front load the work of setting
+// up the AMQP link to the service. If not called, the `sender` will call `open()` on your behalf
+// on the first send operation.
+//
+// await sender.open()
+
 await sender.send({
   body: "my-message-body"
 });

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -143,6 +143,7 @@ export class Sender {
     cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void>;
     close(): Promise<void>;
     get isClosed(): boolean;
+    open(): Promise<void>;
     scheduleMessage(scheduledEnqueueTimeUtc: Date, message: SendableMessageInfo): Promise<Long>;
     scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: SendableMessageInfo[]): Promise<Long[]>;
     send(message: SendableMessageInfo): Promise<void>;

--- a/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
@@ -68,6 +68,12 @@ async function main() {
   const queueClient = sbClient.createQueueClient(queueName);
   const sender = queueClient.createSender();
 
+  // Optionally, you can await on `sender.open()` if you want to front load the work of setting
+  // up the AMQP link to the service. If not called, the `sender` will call `open()` on your behalf
+  // on the first send operation.
+  //
+  // await sender.open()
+
   try {
     for (let index = 0; index < listOfScientists.length; index++) {
       const scientist = listOfScientists[index];

--- a/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
@@ -39,6 +39,12 @@ export async function main() {
   const queueClient = sbClient.createQueueClient(queueName);
   const sender = queueClient.createSender();
 
+  // Optionally, you can await on `sender.open()` if you want to front load the work of setting
+  // up the AMQP link to the service. If not called, the `sender` will call `open()` on your behalf
+  // on the first send operation.
+  //
+  // await sender.open()
+
   try {
     for (let index = 0; index < listOfScientists.length; index++) {
       const scientist = listOfScientists[index];

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -421,7 +421,7 @@ export class MessageSender extends LinkEntity {
   }
 
   /**
-   * Initializes the sender session on the connection.
+   * Initializes the `ClientEntityContext.sender` associated with this `MessageSender`.
    */
   public async open(options?: SenderOptions): Promise<void> {
     return defaultLock.acquire(this.senderLock, async () => {

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -423,7 +423,7 @@ export class MessageSender extends LinkEntity {
   /**
    * Initializes the sender session on the connection.
    */
-  private async _init(options?: SenderOptions): Promise<void> {
+  public async open(options?: SenderOptions): Promise<void> {
     try {
       // isOpen isConnecting  Should establish
       // true     false          No
@@ -552,7 +552,7 @@ export class MessageSender extends LinkEntity {
           // shall retry forever at an interval of 15 seconds if the error is a retryable error
           // else bail out when the error is not retryable or the oepration succeeds.
           const config: RetryConfig<void> = {
-            operation: () => this._init(options),
+            operation: () => this.open(options),
             connectionId: this._context.namespace.connectionId!,
             operationType: RetryOperationType.senderLink,
             times: Constants.defaultConnectionRetryAttempts,
@@ -623,7 +623,7 @@ export class MessageSender extends LinkEntity {
           this.senderLock
         );
         await defaultLock.acquire(this.senderLock, () => {
-          return this._init();
+          return this.open();
         });
       }
       const amqpMessage = toAmqpMessage(data);
@@ -683,7 +683,7 @@ export class MessageSender extends LinkEntity {
           this.senderLock
         );
         await defaultLock.acquire(this.senderLock, () => {
-          return this._init();
+          return this.open();
         });
       }
       log.sender(

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -427,15 +427,20 @@ export class MessageSender extends LinkEntity {
   }
 
   /**
-   * Initializes the `ClientEntityContext.sender` associated with this
+   * Initializes the underlying AMQP sender link from rhea associated with this
    * `MessageSender`.
    *
-   * If the connection is already open this method resolves immediately.
+   * If the underlying AMQP sender link is already open this method resolves immediately.
    */
   public async open(options?: SenderOptions): Promise<void> {
     if (this.isOpen()) {
       return;
     }
+
+    log.sender(
+      "Acquiring lock %s for initializing the session, sender and possibly the connection.",
+      this.openLock
+    );
 
     return defaultLock.acquire(this.openLock, async () => {
       try {

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -625,7 +625,7 @@ export class MessageSender extends LinkEntity {
           this.senderLock
         );
 
-        return this.open();
+        await this.open();
       }
       const amqpMessage = toAmqpMessage(data);
       amqpMessage.body = this._context.namespace.dataTransformer.encode(data.body);
@@ -684,7 +684,7 @@ export class MessageSender extends LinkEntity {
           this.senderLock
         );
 
-        return this.open();
+        await this.open();
       }
       log.sender(
         "[%s] Sender '%s', trying to send Message[]: %O",

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -99,7 +99,7 @@ export class Sender {
    * and/or `partitionKey` properties respectively on the messages.
    * - When doing so, all
    * messages in the batch should have the same `sessionId` (if using sessions) and the same
-   * `parititionKey` (if using paritions).
+   * `partitionKey` (if using partitions).
    *
    * @param messages - An array of SendableMessageInfo objects to be sent in a Batch message.
    * @return Promise<void>

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -86,12 +86,11 @@ export class Sender {
    * This method will be called on-demand by the Sender. Only call this method if you need
    * to force the opening of the connection and link.
    */
-  async open() {
+  open() {
     // the underlying `MessageSender` initialization will both
     // cache the sender in the context for the next send and
     // ensure the link and connection are initialized.
-    const tempSender = MessageSender.create(this._context);
-    return tempSender.open();
+    return MessageSender.create(this._context).open();
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -91,7 +91,7 @@ export class Sender {
     // cache the sender in the context for the next send and
     // ensure the link and connection are initialized.
     const tempSender = MessageSender.create(this._context);
-    return tempSender["_init"]();
+    return tempSender.open();
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -81,10 +81,11 @@ export class Sender {
   }
 
   /**
-   * Ensures that the Service Bus connection and sender link is open.
+   * Opens the AMQP link to Azure Service Bus from the sender.
    *
-   * This method will be called on-demand by the Sender. Only call this method if you need
-   * to force the opening of the connection and link.
+   * It is not necessary to call this method in order to use the sender. It is
+   * recommended to call this before your first send() or sendBatch() call if you
+   * want to front load the work of setting up the AMQP link to the service.
    */
   open() {
     // the underlying `MessageSender` initialization will both

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -87,7 +87,7 @@ export class Sender {
    * recommended to call this before your first send() or sendBatch() call if you
    * want to front load the work of setting up the AMQP link to the service.
    */
-  open() {
+  async open(): Promise<void> {
     // the underlying `MessageSender` initialization will both
     // cache the sender in the context for the next send and
     // ensure the link and connection are initialized.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -81,6 +81,20 @@ export class Sender {
   }
 
   /**
+   * Ensures that the Service Bus connection and sender link is open.
+   *
+   * This method will be called on-demand by the Sender. Only call this method if you need
+   * to force the opening of the connection and link.
+   */
+  async open() {
+    // the underlying `MessageSender` initialization will both
+    // cache the sender in the context for the next send and
+    // ensure the link and connection are initialized.
+    const tempSender = MessageSender.create(this._context);
+    return tempSender["_init"]();
+  }
+
+  /**
    * Sends the given messages in a single batch i.e. in a single AMQP message after creating an AMQP
    * Sender link if it doesnt already exists.
    *

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -88,9 +88,6 @@ export class Sender {
    * want to front load the work of setting up the AMQP link to the service.
    */
   async open(): Promise<void> {
-    // the underlying `MessageSender` initialization will both
-    // cache the sender in the context for the next send and
-    // ensure the link and connection are initialized.
     return MessageSender.create(this._context).open();
   }
 

--- a/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
@@ -70,7 +70,7 @@ describe("controlled connection initialization", () => {
 
     // acquire the same lock that open() uses and then, while it's 100% locked,
     // attempt to call .open() and see that it just blocks...
-    defaultLock.acquire(sender["_context"]!.sender!.senderLock, async () => {
+    await defaultLock.acquire(sender["_context"]!.sender!.senderLock, async () => {
       const secondOpenCallPromise = sender.open();
       const ret = await Promise.race([delay(1000, 999), secondOpenCallPromise]);
       assert.equal(typeof ret, "number");

--- a/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import chai from "chai";
+const assert = chai.assert;
+import chaiAsPromised from "chai-as-promised";
+import {
+  QueueClient,
+  Sender,
+  Receiver,
+  SubscriptionClient,
+  TopicClient,
+  ReceiveMode
+} from "../src";
+import { getServiceBusClient, getSenderReceiverClients, TestClientType } from "./utils/testUtils";
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+
+describe("controlled connection initialization", () => {
+  let closeAll: () => Promise<void>;
+  let sender: Sender;
+  let receiver: Receiver;
+
+  beforeEach(async () => {
+    let serviceBusClient = getServiceBusClient();
+    let senderClient: QueueClient | TopicClient;
+    let receiverClient: QueueClient | SubscriptionClient;
+
+    ({ senderClient, receiverClient } = await getSenderReceiverClients(
+      serviceBusClient,
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue
+    ));
+
+    sender = senderClient.createSender();
+    receiver = receiverClient.createReceiver(ReceiveMode.receiveAndDelete);
+
+    closeAll = async () => {
+      await sender.close();
+      await senderClient.close();
+
+      await receiver.close();
+      await receiverClient.close();
+
+      await serviceBusClient?.close();
+    };
+  });
+
+  afterEach(async () => {
+    if (closeAll) {
+      await closeAll();
+    }
+  });
+
+  it("baseline - normal lazy init()", async () => {
+    // first, establish some baseline - the connection is not yet open, right?
+    should.not.exist(sender["_context"].sender);
+
+    await sender.send({
+      body: "message sent just to prove the sender() initialization flow"
+    });
+
+    await checkThatInitializationDoesntReoccur(sender);
+  });
+
+  it("non-lazy init", async () => {
+    // first, establish some baseline - the connection is not yet open, right?
+    should.not.exist(sender["_context"].sender);
+
+    await sender.open();
+
+    await checkThatInitializationDoesntReoccur(sender);
+  });
+
+  // connection should not get opened more than once (ie, underlying to _init(), nothing else should get called)
+  // ['negotiateClaim'] doesn't get called on the second time through.
+  // context.sender is initialized?
+});
+async function checkThatInitializationDoesntReoccur(sender: Sender) {
+  // validate that the internals haven't shifted out from underneath me...
+  should.exist(sender["_context"].sender);
+  should.exist(sender["_context"].sender!["_negotiateClaim"]);
+  assert.isTrue(sender["_context"].sender!["isOpen"](), "The connection is actually open()");
+
+  // stub out the `MessageSender` methods that handle initializing the
+  // connection - now that everything is up we should always see that it
+  // takes the "early exit" path when it sees that the connection is open
+  let negotiateClaimWasCalled = false;
+
+  // now we'll just fake the rest
+  let isOpenWasCalled = false;
+
+  sender["_context"].sender!["isOpen"] = () => {
+    isOpenWasCalled = true;
+    return true;
+  };
+
+  sender["_context"].sender!["_negotiateClaim"] = async () => {
+    negotiateClaimWasCalled = true;
+  };
+
+  await sender.send({
+    body: "sending another message just to prove the connection checks work"
+  });
+
+  assert.isTrue(isOpenWasCalled, "we should have checked that the connection was open");
+  assert.isFalse(
+    negotiateClaimWasCalled,
+    "we should NOT have tried to _negotiateClaim since the connection was open"
+  );
+}


### PR DESCRIPTION
Adding an .open() method on Sender to allow users to control when connection and link initialization occur.

Fixes #3212 