### PR TITLE
[service-bus] surface disconnect errors to streaming receiver error handler

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Removes the `@azure/ms-rest-nodeauth` dependency.
   This allows users to use any version of `@azure/ms-rest-nodeauth` directly with `@azure/service-bus` without TypeScript compilation errors.
   Fixes [bug 8041](https://github.com/Azure/azure-sdk-for-js/issues/8041).
+- Fixes an issue where errors caused by a connection disconnecting were not getting surfaced to the user's registered error handler
+  when using the `registerMessageHandler` method on a receiver.
 
 ## 1.1.5 (2020-03-24)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -5,8 +5,9 @@
 - Removes the `@azure/ms-rest-nodeauth` dependency.
   This allows users to use any version of `@azure/ms-rest-nodeauth` directly with `@azure/service-bus` without TypeScript compilation errors.
   Fixes [bug 8041](https://github.com/Azure/azure-sdk-for-js/issues/8041).
-- Fixes an issue where errors caused by a connection disconnecting were not getting surfaced to the user's registered error handler
+- Fixes an issue where non-retryable errors caused by a connection disconnecting were not getting surfaced to the user's registered error handler
   when using the `registerMessageHandler` method on a receiver.
+  [PR 8401](https://github.com/Azure/azure-sdk-for-js/pull/8401)
 
 ## 1.1.5 (2020-03-24)
 

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -95,7 +95,7 @@ export interface ClientEntityContextBase {
  * @internal
  */
 export interface ClientEntityContext extends ClientEntityContextBase {
-  onDetached(error?: AmqpError | Error): Promise<void>;
+  onDetached(error?: AmqpError | Error, connectionDidDisconnect?: boolean): Promise<void>;
   getReceiver(name: string, sessionId?: string): MessageReceiver | MessageSession | undefined;
   close(): Promise<void>;
 }
@@ -199,7 +199,10 @@ export namespace ClientEntityContext {
       return;
     };
 
-    (entityContext as ClientEntityContext).onDetached = async (error?: AmqpError | Error) => {
+    (entityContext as ClientEntityContext).onDetached = async (
+      error?: AmqpError | Error,
+      connectionDidDisconnect?: boolean
+    ) => {
       const connectionId = entityContext.namespace.connectionId;
 
       // Call onDetached() on sender so that it can decide whether to reconnect or not
@@ -247,7 +250,7 @@ export namespace ClientEntityContext {
             connectionId,
             streamingReceiver.name
           );
-          await streamingReceiver.onDetached(error);
+          await streamingReceiver.onDetached(error, connectionDidDisconnect);
         } catch (err) {
           log.error(
             "[%s] An error occurred while calling onDetached() on the streaming receiver '%s': %O.",

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -247,7 +247,8 @@ export namespace ClientEntityContext {
             connectionId,
             streamingReceiver.name
           );
-          await streamingReceiver.onDetached(error, true);
+          const causedByDisconnect = true;
+          await streamingReceiver.onDetached(error, causedByDisconnect);
         } catch (err) {
           log.error(
             "[%s] An error occurred while calling onDetached() on the streaming receiver '%s': %O.",

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -95,7 +95,7 @@ export interface ClientEntityContextBase {
  * @internal
  */
 export interface ClientEntityContext extends ClientEntityContextBase {
-  onDetached(error?: AmqpError | Error, connectionDidDisconnect?: boolean): Promise<void>;
+  onDetached(error?: AmqpError | Error): Promise<void>;
   getReceiver(name: string, sessionId?: string): MessageReceiver | MessageSession | undefined;
   close(): Promise<void>;
 }
@@ -199,10 +199,7 @@ export namespace ClientEntityContext {
       return;
     };
 
-    (entityContext as ClientEntityContext).onDetached = async (
-      error?: AmqpError | Error,
-      connectionDidDisconnect?: boolean
-    ) => {
+    (entityContext as ClientEntityContext).onDetached = async (error?: AmqpError | Error) => {
       const connectionId = entityContext.namespace.connectionId;
 
       // Call onDetached() on sender so that it can decide whether to reconnect or not
@@ -250,7 +247,7 @@ export namespace ClientEntityContext {
             connectionId,
             streamingReceiver.name
           );
-          await streamingReceiver.onDetached(error, connectionDidDisconnect);
+          await streamingReceiver.onDetached(error, true);
         } catch (err) {
           log.error(
             "[%s] An error occurred while calling onDetached() on the streaming receiver '%s': %O.",

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -134,7 +134,7 @@ export namespace ConnectionContext {
             connectionContext.connection.id,
             clientContext.clientId
           );
-          clientContext.onDetached(connectionError || contextError).catch((err) => {
+          clientContext.onDetached(connectionError || contextError, true).catch((err) => {
             log.error(
               "[%s] An error occurred while reconnecting the sender '%s': %O.",
               connectionContext.connection.id,

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -134,7 +134,7 @@ export namespace ConnectionContext {
             connectionContext.connection.id,
             clientContext.clientId
           );
-          clientContext.onDetached(connectionError || contextError, true).catch((err) => {
+          clientContext.onDetached(connectionError || contextError).catch((err) => {
             log.error(
               "[%s] An error occurred while reconnecting the sender '%s': %O.",
               connectionContext.connection.id,

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -944,32 +944,22 @@ export class MessageReceiver extends LinkEntity {
         };
         await retry<void>(config);
       } else if (causedByDisconnect) {
-        const state: any = {
-          wasCloseInitiated: this.wasCloseInitiated,
-          receiverError: translatedError,
-          _receiver: this._receiver
-        };
         log.error(
-          "[%s] Something went wrong and the connection disconnected. State of Receiver '%s' with address '%s' is: %O",
+          "[%s] Something went wrong and the connection disconnected. Receiver '%s' with address '%s' encountered error: %O",
           connectionId,
           this.name,
           this.address,
-          state
+          translatedError
         );
         // Not retrying, throw the error so it gets logged and forwarded to user's error handler.
         throw translatedError;
       } else {
-        const state: any = {
-          wasCloseInitiated: this.wasCloseInitiated,
-          receiverError: translatedError,
-          _receiver: this._receiver
-        };
         log.error(
-          "[%s] Something went wrong. State of Receiver '%s' with address '%s' is: %O",
+          "[%s] Something went wrong. Receiver '%s' with address '%s' encountered error: %O",
           connectionId,
           this.name,
           this.address,
-          state
+          translatedError
         );
       }
     } catch (err) {

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -882,7 +882,7 @@ export class MessageReceiver extends LinkEntity {
       // These should be ignored until the already running `onDetached` completes
       // its retry attempts or errors.
       log.error(
-        `[${connectionId}] Receiver '${this.name}' with address '${this.address}' has had onDetached called while already detaching.`
+        `[${connectionId}] Call to detached on streaming receiver '${this.name}' is already in progress.`
       );
       return;
     }

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -942,7 +942,7 @@ export class MessageReceiver extends LinkEntity {
         await retry<void>(config);
       } else if (causedByDisconnect) {
         log.error(
-          "[%s] Something went wrong and the connection disconnected. Receiver '%s' with address '%s' encountered error: %O",
+          "[%s] Encountered a non retryable error on the connection. Cannot recover receiver '%s' with address '%s': %O",
           connectionId,
           this.name,
           this.address,
@@ -952,7 +952,7 @@ export class MessageReceiver extends LinkEntity {
         throw translatedError;
       } else {
         log.error(
-          "[%s] Something went wrong. Receiver '%s' with address '%s' encountered error: %O",
+          "[%s] Encountered a non retryable error on the receiver. Cannot recover receiver '%s' with address '%s' encountered error: %O",
           connectionId,
           this.name,
           this.address,

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -866,9 +866,6 @@ export class MessageReceiver extends LinkEntity {
     // User explicitly called `close` on the receiver, so link is already closed
     // and we can exit early.
     if (this.wasCloseInitiated) {
-      log.error(
-        `[${connectionId}] Receiver '${this.name}' with address '${this.address}' has had onDetached called after being explictly closed.`
-      );
       return;
     }
 

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -955,6 +955,9 @@ export class MessageReceiver extends LinkEntity {
         if (!this.wasCloseInitiated) {
           await retry<void>(config);
         }
+      } else {
+        // If not retrying, throw the error so it gets logged and forwarded to user's error handler.
+        throw receiverError || new Error(`Unexpected error occurred.`);
       }
     } catch (err) {
       log.error(

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -1135,8 +1135,8 @@ describe("Streaming - Not receive messages after receiver is closed", function()
 });
 
 describe("Streaming - onDetached", function(): void {
-  this.afterEach(async () => {
-    await afterEachTest();
+  afterEach(() => {
+    return afterEachTest();
   });
 
   it("doesn't call user's error handler on non-retryable errors", async function(): Promise<void> {
@@ -1176,7 +1176,7 @@ describe("Streaming - onDetached", function(): void {
     // Simulate onDetached being called with a non-retryable error.
     const nonRetryableError = translate(new Error(`I break systems.`));
     nonRetryableError.retryable = false;
-    await (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError);
+    await receiver["_context"].streamingReceiver!.onDetached(nonRetryableError);
 
     receivedErrors.length.should.equal(0, "Unexpected number of errors received.");
   });
@@ -1215,7 +1215,7 @@ describe("Streaming - onDetached", function(): void {
     // Simulate onDetached being called with a non-retryable error.
     const nonRetryableError = translate(new Error(`I break systems.`));
     nonRetryableError.retryable = false;
-    await (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true);
+    await receiver["_context"].streamingReceiver!.onDetached(nonRetryableError, true);
 
     receivedErrors.length.should.equal(1, "Unexpected number of errors received.");
   });
@@ -1255,8 +1255,8 @@ describe("Streaming - onDetached", function(): void {
     const nonRetryableError = translate(new Error(`I break systems.`));
     nonRetryableError.retryable = false;
     await Promise.all([
-      (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true),
-      (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true)
+      receiver["_context"].streamingReceiver!.onDetached(nonRetryableError, true),
+      receiver["_context"].streamingReceiver!.onDetached(nonRetryableError, true)
     ]);
 
     receivedErrors.length.should.equal(1, "Unexpected number of errors received.");
@@ -1299,8 +1299,8 @@ describe("Streaming - onDetached", function(): void {
     const retryableError = new Error("I temporarily break systems.");
     (retryableError as any).retryable = true;
     await Promise.all([
-      (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true),
-      (receiver as any)._context.streamingReceiver.onDetached(retryableError)
+      receiver["_context"].streamingReceiver!.onDetached(nonRetryableError, true),
+      receiver["_context"].streamingReceiver!.onDetached(retryableError)
     ]);
 
     receivedErrors.length.should.equal(1, "Unexpected number of errors received.");

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -25,7 +25,7 @@ import {
   TestMessage,
   getServiceBusClient
 } from "./utils/testUtils";
-import { SasTokenProvider, TokenInfo, parseConnectionString } from "@azure/amqp-common";
+import { SasTokenProvider, TokenInfo, parseConnectionString, translate } from "@azure/amqp-common";
 import { getEnvVars, EnvVarNames } from "./utils/envVarUtils";
 import { StreamingReceiver } from "../src/core/streamingReceiver";
 
@@ -1131,5 +1131,178 @@ describe("Streaming - Not receive messages after receiver is closed", function()
       ReceiveMode.receiveAndDelete
     );
     await testReceiveMessages();
+  });
+});
+
+describe("Streaming - onDetached", function(): void {
+  this.afterEach(async () => {
+    await afterEachTest();
+  });
+
+  it("doesn't call user's error handler on non-retryable errors", async function(): Promise<void> {
+    /**
+     * If onDetached is called with a non-retryable error, it is assumed that
+     * the onSessionError or onAmqpError has already called the user's
+     * error handler.
+     */
+    // Create the sender and receiver.
+    await beforeEachTest(
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue,
+      ReceiveMode.receiveAndDelete
+    );
+    // Send a message so we can be sure when the receiver is open and active.
+    await sender.send(TestMessage.getSample());
+    const receivedErrors: any[] = [];
+
+    let receiverIsActiveResolver: Function;
+    const receiverIsActive = new Promise((resolve) => {
+      receiverIsActiveResolver = resolve;
+    });
+    // Start the receiver.
+    receiver.registerMessageHandler(
+      async () => {
+        // Since we've received a message, mark the receiver as active.
+        receiverIsActiveResolver();
+      },
+      (err) => {
+        receivedErrors.push(err);
+      }
+    );
+
+    // Wait until we're sure the receiver is open and receiving messages.
+    await receiverIsActive;
+
+    // Simulate onDetached being called with a non-retryable error.
+    const nonRetryableError = translate(new Error(`I break systems.`));
+    nonRetryableError.retryable = false;
+    await (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError);
+
+    receivedErrors.length.should.equal(0, "Unexpected number of errors received.");
+  });
+
+  it("does call user's error handler on non-retryable errors due to disconnect", async function(): Promise<
+    void
+  > {
+    // Create the sender and receiver.
+    await beforeEachTest(
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue,
+      ReceiveMode.receiveAndDelete
+    );
+    // Send a message so we can be sure when the receiver is open and active.
+    await sender.send(TestMessage.getSample());
+    const receivedErrors: any[] = [];
+
+    let receiverIsActiveResolver: Function;
+    const receiverIsActive = new Promise((resolve) => {
+      receiverIsActiveResolver = resolve;
+    });
+    // Start the receiver.
+    receiver.registerMessageHandler(
+      async () => {
+        // Since we've received a message, mark the receiver as active.
+        receiverIsActiveResolver();
+      },
+      (err) => {
+        receivedErrors.push(err);
+      }
+    );
+
+    // Wait until we're sure the receiver is open and receiving messages.
+    await receiverIsActive;
+
+    // Simulate onDetached being called with a non-retryable error.
+    const nonRetryableError = translate(new Error(`I break systems.`));
+    nonRetryableError.retryable = false;
+    await (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true);
+
+    receivedErrors.length.should.equal(1, "Unexpected number of errors received.");
+  });
+
+  it("doesn't call user's error handler multiple times (disconnect)", async function(): Promise<
+    void
+  > {
+    // Create the sender and receiver.
+    await beforeEachTest(
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue,
+      ReceiveMode.receiveAndDelete
+    );
+    // Send a message so we can be sure when the receiver is open and active.
+    await sender.send(TestMessage.getSample());
+    const receivedErrors: any[] = [];
+
+    let receiverIsActiveResolver: Function;
+    const receiverIsActive = new Promise((resolve) => {
+      receiverIsActiveResolver = resolve;
+    });
+    // Start the receiver.
+    receiver.registerMessageHandler(
+      async () => {
+        // Since we've received a message, mark the receiver as active.
+        receiverIsActiveResolver();
+      },
+      (err) => {
+        receivedErrors.push(err);
+      }
+    );
+
+    // Wait until we're sure the receiver is open and receiving messages.
+    await receiverIsActive;
+
+    // Simulate onDetached being called multiple times with non-retryable errors.
+    const nonRetryableError = translate(new Error(`I break systems.`));
+    nonRetryableError.retryable = false;
+    await Promise.all([
+      (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true),
+      (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true)
+    ]);
+
+    receivedErrors.length.should.equal(1, "Unexpected number of errors received.");
+  });
+
+  it("doesn't call user's error handler multiple times (retryable)", async function(): Promise<
+    void
+  > {
+    // Create the sender and receiver.
+    await beforeEachTest(
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue,
+      ReceiveMode.receiveAndDelete
+    );
+    // Send a message so we can be sure when the receiver is open and active.
+    await sender.send(TestMessage.getSample());
+    const receivedErrors: any[] = [];
+
+    let receiverIsActiveResolver: Function;
+    const receiverIsActive = new Promise((resolve) => {
+      receiverIsActiveResolver = resolve;
+    });
+    // Start the receiver.
+    receiver.registerMessageHandler(
+      async () => {
+        // Since we've received a message, mark the receiver as active.
+        receiverIsActiveResolver();
+      },
+      (err) => {
+        receivedErrors.push(err);
+      }
+    );
+
+    // Wait until we're sure the receiver is open and receiving messages.
+    await receiverIsActive;
+
+    // Simulate onDetached being called multiple times with non-retryable and then retryable errors.
+    const nonRetryableError = translate(new Error(`I break systems.`));
+    nonRetryableError.retryable = false;
+    const retryableError = new Error("I temporarily break systems.");
+    (retryableError as any).retryable = true;
+    await Promise.all([
+      (receiver as any)._context.streamingReceiver.onDetached(nonRetryableError, true),
+      (receiver as any)._context.streamingReceiver.onDetached(retryableError)
+    ]);
+
+    receivedErrors.length.should.equal(1, "Unexpected number of errors received.");
   });
 });


### PR DESCRIPTION
This change updates the `MessageReceiver.onDetached` method to surface more errors to the user's error handler when using the streaming receiver.

## Background
Currently `onDetached` is called in 3 places for the streaming receiver:
- onAmqpClose (our callback for the `close` event fired on the AMQP link object in rhea)
- onSessionClose (our callback for the `close` event fired on the AMQP session object in rhea)
- connection disconnect (our callback for the `disconnect` event fired on the AMQP connection object in rhea)

Previously, we had logic in place where if the `onAmqpError` or `onSessionError` handlers (our callbacks for the `error` events fired on either the AMQP link or session object in rhea) were called with a non-retryable error, we would invoke the user's error handler. We skip calling user's error handler for retryable errors as we are expected to retry and recover the broken link/session.

Retryable errors from a connection disconnect would cause the receiver to attempt to reconnect, and any errors from that reconnect would eventually surface to the user.

## Problem
_However_, we did not have any logic in place to forward non-retryable errors from a connection disconnect event to the user's error handler. This meant that if a connection disconnect occurred that was not retryable, the receiver would appear to hang indefinitely.

## Follow-up questions
I did notice that message settlement failures also cause the error handler on the streaming receiver to be invoked (due to lock auto-renewal failing). I wasn't sure if we wanted to disable these messages from being surfaced if the user's error handler was already invoked, so for now I left that logic as is.
