### PR TITLE
[FormRecognizer] Remove the need to shim FileReader for end users

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/dom-shims.d.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/dom-shims.d.ts
@@ -6,24 +6,4 @@
 // d.ts shims provide types for things we use internally but are not part
 // of this package's surface area.
 
-interface RequestInit {}
-
-interface RequestInfo {}
-
-interface Response {}
-
-interface Headers {}
-
-interface FileReader {
-  onloadend: ((this: FileReader, ev: any) => any) | null;
-  readonly result: string | ArrayBuffer | null;
-  readAsArrayBuffer(blob: Blob): void;
-}
-
-declare var FileReader: {
-  prototype: FileReader;
-  new (): FileReader;
-  readonly DONE: number;
-  readonly EMPTY: number;
-  readonly LOADING: number;
-};
+interface FileReader {}

--- a/sdk/formrecognizer/ai-form-recognizer/dom-shims.d.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/dom-shims.d.ts
@@ -3,6 +3,17 @@
 
 /* eslint  @typescript-eslint/no-empty-interface: 0 */
 
+// d.ts shims provide types for things we use internally but are not part
+// of this package's surface area.
+
+interface RequestInit {}
+
+interface RequestInfo {}
+
+interface Response {}
+
+interface Headers {}
+
 interface FileReader {
   onloadend: ((this: FileReader, ev: any) => any) | null;
   readonly result: string | ArrayBuffer | null;

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -27,6 +27,7 @@
   "files": [
     "dist/",
     "dist-esm/src/",
+    "dom-shims.d.ts",
     "types/ai-form-recognizer.d.ts",
     "README.md",
     "LICENSE"

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -588,7 +588,7 @@ export type ValueTypes = "string" | "date" | "time" | "phoneNumber" | "number" |
 
 // Warnings were encountered during analysis:
 //
-// src/formRecognizerClient.ts:69:3 - (ae-forgotten-export) The symbol "BeginRecognizePollState" needs to be exported by the entry point index.d.ts
+// src/formRecognizerClient.ts:70:3 - (ae-forgotten-export) The symbol "BeginRecognizePollState" needs to be exported by the entry point index.d.ts
 // src/formTrainingClient.ts:67:3 - (ae-forgotten-export) The symbol "BeginTrainingPollState" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/README.md
@@ -50,10 +50,16 @@ npm run build
 
 4. Add additional environment variables specified in the sample file you wish to run.
 
-5. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+5. Change directory to `dist`
 
 ```bash
-node dist/recognizeReceipt.js
+cd dist
+```
+
+6. Run whichever samples you like (note that some samples may require additional setup, see the table above):
+
+```bash
+node recognizeReceipt.js
 ```
 
 ## Next Steps

--- a/sdk/formrecognizer/ai-form-recognizer/src/common.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/common.ts
@@ -4,7 +4,7 @@
 import { PipelineOptions, OperationOptions } from "@azure/core-http";
 import { FormRecognizerRequestBody } from "./models";
 import { ContentType, SourcePath } from "./generated/models";
-import { streamToBuffer } from "./utils/utils.node";
+import { getFirstFourBytesFromBlob, streamToBuffer } from "./utils/utils.node";
 import { MAX_INPUT_DOCUMENT_SIZE } from "./constants";
 
 /**
@@ -86,22 +86,7 @@ export async function getContentType(
     bytes = new Uint8Array(data.buffer, 0, 4);
   } else if (isBlob(data)) {
     // Blob
-    const arrayPromise = new Promise<ArrayBuffer>(function(resolve) {
-      const reader = new FileReader();
-
-      reader.onloadend = function() {
-        resolve(reader.result as ArrayBuffer);
-      };
-
-      reader.readAsArrayBuffer(data);
-    });
-
-    const buffer = await arrayPromise;
-    if (buffer.byteLength < 4) {
-      throw new RangeError("Invalid input. Expect more than 4 bytes of data");
-    }
-
-    bytes = new Uint8Array(buffer, 0, 4);
+    bytes = await getFirstFourBytesFromBlob(data);
   } else {
     throw new Error("unsupported request body type");
   }

--- a/sdk/formrecognizer/ai-form-recognizer/src/common.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/common.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { PipelineOptions, OperationOptions, HttpRequestBody } from "@azure/core-http";
+import { PipelineOptions, OperationOptions } from "@azure/core-http";
 import { FormRecognizerRequestBody } from "./models";
 import { ContentType, SourcePath } from "./generated/models";
 import { streamToBuffer } from "./utils/utils.node";
@@ -34,7 +34,7 @@ export async function toRequestBody(
       return streamToBuffer(body, MAX_INPUT_DOCUMENT_SIZE);
     }
 
-    return body as HttpRequestBody;
+    return body;
   }
 }
 

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -25,7 +25,8 @@ import {
   FormRecognizerClientAnalyzeWithCustomModelResponse as AnalyzeWithCustomModelResponseModel,
   FormRecognizerClientAnalyzeLayoutAsyncResponse as AnalyzeLayoutAsyncResponseModel,
   FormRecognizerClientAnalyzeReceiptAsyncResponse as AnalyzeReceiptAsyncResponseModel,
-  ContentType
+  ContentType,
+  SourcePath
 } from "./generated/models";
 import { PollOperationState, PollerLike } from "@azure/core-lro";
 import {
@@ -428,7 +429,7 @@ ng", and "image/tiff";
     }
     const analyzePollerClient: RecognizePollerClient<RecognizeFormResultResponse> = {
       beginRecognize: (
-        body: FormRecognizerRequestBody,
+        body: FormRecognizerRequestBody | string,
         contentType?: ContentType,
         analyzeOptions: RecognizeOptions = {},
         modelId?: string
@@ -487,7 +488,7 @@ ng", and "image/tiff";
     }
     const analyzePollerClient: RecognizePollerClient<RecognizeFormResultResponse> = {
       beginRecognize: (
-        body: FormRecognizerRequestBody,
+        body: FormRecognizerRequestBody | string,
         contentType?: ContentType,
         analyzeOptions: RecognizeOptions = {},
         modelId?: string
@@ -700,13 +701,19 @@ async function recognizeLayoutInternal(
   const { span, updatedOptions: finalOptions } = createSpan("analyzeLayoutInternal", realOptions);
   const requestBody = await toRequestBody(body);
   const requestContentType =
-    contentType !== undefined ? contentType : await getContentType(requestBody);
+    contentType ? contentType : await getContentType(requestBody);
 
   try {
+    if (requestContentType) {
+      return await client.analyzeLayoutAsync({
+        ...operationOptionsToRequestOptionsBase(finalOptions),
+        contentType: requestContentType,
+        fileStream: requestBody as Blob | ArrayBuffer | ArrayBufferView
+      });
+    }
     return await client.analyzeLayoutAsync({
       ...operationOptionsToRequestOptionsBase(finalOptions),
-      contentType: requestContentType,
-      fileStream: requestBody
+      fileStream: requestBody as SourcePath
     });
   } catch (e) {
     span.setStatus({
@@ -724,7 +731,7 @@ async function recognizeLayoutInternal(
  */
 async function recognizeCustomFormInternal(
   client: GeneratedClient,
-  body: FormRecognizerRequestBody,
+  body: FormRecognizerRequestBody | string,
   contentType?: ContentType,
   options: RecognizeFormsOptions = {},
   modelId?: string
@@ -732,13 +739,19 @@ async function recognizeCustomFormInternal(
   const { span, updatedOptions: finalOptions } = createSpan("analyzeCustomFormInternal", options);
   const requestBody = await toRequestBody(body);
   const requestContentType =
-    contentType !== undefined ? contentType : await getContentType(requestBody);
+    contentType ? contentType : await getContentType(requestBody);
 
   try {
+    if (requestContentType) {
+      return await client.analyzeWithCustomModel(modelId!, {
+        ...operationOptionsToRequestOptionsBase(finalOptions),
+        contentType: requestContentType,
+        fileStream: requestBody as Blob | ArrayBuffer | ArrayBufferView
+      });
+    }
     return await client.analyzeWithCustomModel(modelId!, {
       ...operationOptionsToRequestOptionsBase(finalOptions),
-      contentType: requestContentType,
-      fileStream: requestBody
+      fileStream: requestBody as SourcePath
     });
   } catch (e) {
     span.setStatus({
@@ -756,7 +769,7 @@ async function recognizeCustomFormInternal(
  */
 async function recognizeReceiptInternal(
   client: GeneratedClient,
-  body: FormRecognizerRequestBody,
+  body: FormRecognizerRequestBody | string,
   contentType?: ContentType,
   options?: RecognizeReceiptsOptions,
   _modelId?: string
@@ -768,10 +781,16 @@ async function recognizeReceiptInternal(
     contentType !== undefined ? contentType : await getContentType(requestBody);
 
   try {
+    if (requestContentType) {
+      return await client.analyzeReceiptAsync({
+        ...operationOptionsToRequestOptionsBase(finalOptions),
+        contentType: requestContentType,
+        fileStream: requestBody as Blob | ArrayBuffer | ArrayBufferView
+      });
+    }
     return await client.analyzeReceiptAsync({
       ...operationOptionsToRequestOptionsBase(finalOptions),
-      contentType: requestContentType,
-      fileStream: requestBody
+      fileStream: requestBody as SourcePath
     });
   } catch (e) {
     span.setStatus({

--- a/sdk/formrecognizer/ai-form-recognizer/src/index.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/index.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+/// <reference path="../dom-shims.d.ts" />
+
 export { AzureKeyCredential } from "@azure/core-auth";
 
 export { FormRecognizerClientOptions, FormRecognizerOperationOptions } from "./common";

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/analyze/poller.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/analyze/poller.ts
@@ -40,7 +40,7 @@ export interface PollerOperationOptions<T> {
 export type RecognizePollerClient<T> = {
   // returns a result id to retrieve results
   beginRecognize: (
-    source: FormRecognizerRequestBody,
+    source: FormRecognizerRequestBody | string,
     contentType?: ContentType,
     analyzeOptions?: RecognizeOptions,
     modelId?: string
@@ -51,7 +51,7 @@ export type RecognizePollerClient<T> = {
 
 export interface BeginRecognizePollState<T> extends PollOperationState<T> {
   readonly client: RecognizePollerClient<T>;
-  source?: FormRecognizerRequestBody;
+  source?: FormRecognizerRequestBody | string;
   contentType?: ContentType;
   modelId?: string;
   resultId?: string;

--- a/sdk/formrecognizer/ai-form-recognizer/src/shims.d.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/shims.d.ts
@@ -1,29 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-/* eslint  @typescript-eslint/no-empty-interface: 0 */
-
-// d.ts shims provide types for things we use internally but are not part
-// of this package's surface area.
-
-interface RequestInit {}
-
-interface RequestInfo {}
-
-interface Response {}
-
-interface Headers {}
-
-interface FileReader {
-  onloadend: ((this: FileReader, ev: any) => any) | null;
-  readonly result: string | ArrayBuffer | null;
-  readAsArrayBuffer(blob: Blob): void;
-}
-
-declare var FileReader: {
-  prototype: FileReader;
-  new (): FileReader;
-  readonly DONE: number;
-  readonly EMPTY: number;
-  readonly LOADING: number;
-};
+/// <reference lib="dom" />

--- a/sdk/formrecognizer/ai-form-recognizer/src/utils/utils.browser.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/utils/utils.browser.ts
@@ -2,3 +2,22 @@
 // Licensed under the MIT license.
 
 export function streamToBuffer() {}
+
+export async function getFirstFourBytesFromBlob(data: Blob): Promise<Uint8Array> {
+  const arrayPromise = new Promise<ArrayBuffer>(function(resolve) {
+    const reader = new FileReader();
+
+    reader.onloadend = function() {
+      resolve(reader.result as ArrayBuffer);
+    };
+
+    reader.readAsArrayBuffer(data);
+  });
+
+  const buffer = await arrayPromise;
+  if (buffer.byteLength < 4) {
+    throw new RangeError("Invalid input. Expect more than 4 bytes of data");
+  }
+
+  return new Uint8Array(buffer, 0, 4);
+}

--- a/sdk/formrecognizer/ai-form-recognizer/src/utils/utils.node.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/utils/utils.node.ts
@@ -22,7 +22,7 @@ export async function streamToBuffer(
 
   return new Promise<Buffer>((resolve, reject) => {
     stream.on("readable", () => {
-      let chunk = stream.read();
+      const chunk = stream.read();
       if (!chunk) {
         return;
       }
@@ -57,4 +57,8 @@ export async function streamToBuffer(
 
     stream.on("error", reject);
   });
+}
+
+export function getFirstFourBytesFromBlob(_data: Blob): Promise<Uint8Array> {
+  throw new Error("Blob is not supported in NodeJS environment")
 }

--- a/sdk/formrecognizer/ai-form-recognizer/tsconfig.json
+++ b/sdk/formrecognizer/ai-form-recognizer/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "./dist-esm",
     "declarationDir": "./types"
   },
-  "exclude": ["node_modules", "types", "temp", "browser", "dist", "dist-esm", "./samples/**/*.ts"]
+  "exclude": ["node_modules", "types", "temp", "browser", "dist", "dist-esm", "./samples/**/*.ts", "./dom-shims.d.ts"]
 }


### PR DESCRIPTION
This change applies the same approach we used for `core-http`.  A `dom-shims.d.ts` is packed in the package to provide shims for DOM types this library uses internally.  In our code we actually compile another file `src/shims.d.ts` that references the the "dom" library.

Fixes #8420 