### PR TITLE
[service-bus] Update track 2 readme to fix samples

### DIFF
--- a/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
@@ -62,7 +62,7 @@ async function receiveMessage() {
     );
     // Deadletter the message received
     await messages[0].deadLetter({
-      deadletterReason: "Incorrect Recipe type",
+      deadLetterReason: "Incorrect Recipe type",
       deadLetterErrorDescription: "Recipe type does not  match preferences."
     });
   } else {

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
@@ -63,7 +63,7 @@ async function receiveMessage() {
     // Deadletter the message received
     await messages[0].deadLetter({
       deadLetterReason: "Incorrect Recipe type",
-      deadLetterErrorDescription: "Recipe type does not  match preferences."
+      deadLetterErrorDescription: "Recipe type does not match preferences."
     });
   } else {
     console.log(">>>> Error: No messages were received from the main queue.");

--- a/sdk/servicebus/service-bus/samples/tsconfig.json
+++ b/sdk/servicebus/service-bus/samples/tsconfig.json
@@ -4,6 +4,6 @@
     "module": "commonjs",
     "outDir": "typescript/dist"
   },
-  "include": ["typescript/src/**.ts"],
+  "include": ["typescript/src/**/*.ts"],
   "exclude": ["typescript/*.json", "**/node_modules/", "../node_modules", "../typings"]
 }

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -20,8 +20,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 const sbClient: ServiceBusClient = new ServiceBusClient(connectionString);
 
@@ -65,7 +64,7 @@ async function receiveMessage() {
     );
     // Deadletter the message received
     await messages[0].deadLetter({
-      deadletterReason: "Incorrect Recipe type",
+      deadLetterReason: "Incorrect Recipe type",
       deadLetterErrorDescription: "Recipe type does not  match preferences."
     });
   } else {
@@ -75,6 +74,6 @@ async function receiveMessage() {
   await receiver.close();
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -65,7 +65,7 @@ async function receiveMessage() {
     // Deadletter the message received
     await messages[0].deadLetter({
       deadLetterReason: "Incorrect Recipe type",
-      deadLetterErrorDescription: "Recipe type does not  match preferences."
+      deadLetterErrorDescription: "Recipe type does not match preferences."
     });
   } else {
     console.log(">>>> Error: No messages were received from the main queue.");


### PR DESCRIPTION
Dead letter samples weren't compiling with the `build:samples` (they were in a subdirectory).

Altered wildcard to pick them up and also fixed some casing issues with the parameter.

Fixes #8417 