### PR TITLE
[FormRecognizer] downgrade core-tracing to 1.0.0-preview.7

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -43,6 +43,7 @@
   "allowedAlternativeVersions": {
     "@azure/ms-rest-js": ["^2.0.0"],
     "@azure/core-http": ["^1.1.0"],
+    "@azure/core-tracing": ["1.0.0-preview.7"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -80,7 +80,7 @@
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.1.0",
     "@azure/core-http": "^1.0.0",
-    "@azure/core-tracing": "1.0.0-preview.8",
+    "@azure/core-tracing": "1.0.0-preview.7",
     "@azure/logger": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "tslib": "^1.10.0"


### PR DESCRIPTION
as FormRecognizer might be released before core-tracing preview.8.