### PR TITLE
[amqp-common] Add ability to create a new Connection on existing  ConnectionContextBase

### DIFF
--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,3 +1,7 @@
+### 2020-04-01 1.0.0-preview.13
+
+- Adds capability for a `ConnectionContextBase` object to create a new rhea-promise `Connection` object.
+
 ### 2020-04-01 1.0.0-preview.12
 
 - Removes the `@azure/ms-rest-nodeauth` dependency.

--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,6 +1,6 @@
-### 2020-04-01 1.0.0-preview.13
+### 2020-04-21 1.0.0-preview.13
 
-- Adds capability for a `ConnectionContextBase` object to create a new rhea-promise `Connection` object.
+- Add a new method `refreshConnection()` on the `ConnectionContextBase` to replace the `connection` property on it with a new rhea-promise `Connection` object.
 
 ### 2020-04-01 1.0.0-preview.12
 

--- a/sdk/core/amqp-common/package.json
+++ b/sdk/core/amqp-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/amqp-common",
   "sdk-type": "client",
-  "version": "1.0.0-preview.12",
+  "version": "1.0.0-preview.13",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/amqp-common/src/ConnectionContextBase.ts
+++ b/sdk/core/amqp-common/src/ConnectionContextBase.ts
@@ -64,9 +64,7 @@ export interface ConnectionContextBase {
    */
   cbsSession: CbsClient;
   /**
-   * Updates the context to use a new underlying AMQP connection,
-   * a new cbs session, and new locks used when establishing an AMQP
-   * connection and negotiating cbs claims.
+   * Updates the context to use a new underlying AMQP connection and new cbs session.
    */
   refreshConnection: () => void;
 }

--- a/sdk/core/amqp-common/src/ConnectionContextBase.ts
+++ b/sdk/core/amqp-common/src/ConnectionContextBase.ts
@@ -63,7 +63,11 @@ export interface ConnectionContextBase {
    * underlying AMQP connection for the EventHub Client.
    */
   cbsSession: CbsClient;
-
+  /**
+   * Updates the context to use a new underlying AMQP connection,
+   * a new cbs session, and new locks used when establishing an AMQP
+   * connection and negotiating cbs claims.
+   */
   refreshConnection: () => void;
 }
 

--- a/sdk/core/amqp-common/test/context.spec.ts
+++ b/sdk/core/amqp-common/test/context.spec.ts
@@ -38,9 +38,7 @@ describe("ConnectionContextBase", function() {
     context.tokenProvider.should.instanceOf(SasTokenProvider);
     context.connection.should.instanceOf(Connection);
     context.connection.options.properties!.product.should.equal("MSJSClient");
-    context.connection.options.properties!["user-agent"].should.equal(
-      "/js-amqp-client"
-    );
+    context.connection.options.properties!["user-agent"].should.equal("/js-amqp-client");
     context.connection.options.properties!.version.should.equal("1.0.0");
     context.cbsSession.should.instanceOf(CbsClient);
     context.dataTransformer.should.instanceOf(DefaultDataTransformer);
@@ -111,5 +109,52 @@ describe("ConnectionContextBase", function() {
     }, /user-agent string cannot be more than 512 characters/);
 
     done();
+  });
+
+  describe("#refreshConnection", function() {
+    it("should update fields on the context", function() {
+      const connectionString =
+        "Endpoint=sb://hostname.servicebus.windows.net/;SharedAccessKeyName=sakName;SharedAccessKey=sak;EntityPath=ep";
+      const path = "mypath";
+      const config = ConnectionConfig.create(connectionString, path);
+      const context = ConnectionContextBase.create({
+        config: config,
+        connectionProperties: {
+          product: "MSJSClient",
+          userAgent: "/js-amqp-client",
+          version: "1.0.0"
+        }
+      });
+      // hold onto the refreshable values of the context
+      // so we can be sure they change after the refresh call.
+      const refreshableFields = {
+        cbsSession: context.cbsSession,
+        connection: context.connection,
+        connectionId: context.connectionId,
+        connectionLock: context.connectionLock,
+        negotiateClaimLock: context.negotiateClaimLock,
+        // change the value so refresh changes it back
+        wasConnectionCloseCalled: !context.wasConnectionCloseCalled
+      };
+      should.exist(context.config);
+      should.exist(context.connection);
+      should.exist(context.connectionId);
+      should.exist(context.connectionLock);
+      should.exist(context.negotiateClaimLock);
+      should.exist(context.tokenProvider);
+      should.exist(context.dataTransformer);
+      context.wasConnectionCloseCalled.should.equal(false);
+      context.cbsSession.should.instanceOf(CbsClient);
+
+      // update wasConnectionCloseCalled so we can make sure it refreshes
+      context.wasConnectionCloseCalled = true;
+
+      context.refreshConnection();
+
+      // ensure the refreshable fields have all been updated
+      for (const field of Object.keys(refreshableFields) as (keyof typeof refreshableFields)[]) {
+        context[field].should.not.equal(refreshableFields[field]);
+      }
+    });
   });
 });


### PR DESCRIPTION
This change adds a `refreshConnection` method to `ConectionContextBase`. `refreshConnection` creates a new connection object, locks, and CbsClient.

The idea is that when a connection `disconnect` event is handled by service-bus or event-hubs, they can call `connectionContext.refreshConnection()` so that a rhea Connection is used.