### PR TITLE
[service-bus] recreate Connection object on disconnect

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -35,7 +35,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-wP2Jw6uPp8DEDy0n4KNidvwzDjyVV2xnycEIq7nPzj1rHyb/r+t3OPeNT1INZePP2wy5ZqlwyuyOMTi0ePyY1A==
-  /@azure/amqp-common/1.0.0-preview.12:
+  /@azure/amqp-common/1.0.0-preview.13:
     dependencies:
       '@types/async-lock': 1.1.1
       '@types/is-buffer': 2.0.0
@@ -54,7 +54,7 @@ packages:
       util: 0.11.1
     dev: false
     resolution:
-      integrity: sha512-Oj/DzJAsJLpyztqpvxVcngQ1wbERVtd5Vb+tIO2+jHvuIF4zZQOLkwy+KsOdcVAM9PHd5TswpycQl6G26SW4hw==
+      integrity: sha512-v19NGXFm8Hzr2bj/DSWYc2anaDcoAeFQXJGuBT8QO7eS13vaELQNGaynOGipEcI313A1778R/FFCk4o+dylIiw==
   /@azure/amqp-common/1.0.0-preview.9:
     dependencies:
       '@azure/ms-rest-nodeauth': 0.9.3
@@ -9043,7 +9043,7 @@ packages:
     version: 0.0.0
   'file:projects/service-bus.tgz':
     dependencies:
-      '@azure/amqp-common': 1.0.0-preview.12
+      '@azure/amqp-common': 1.0.0-preview.13
       '@azure/eslint-plugin-azure-sdk': 2.0.1_303bc1d883bbfc108111733cb7ab69e3
       '@azure/ms-rest-nodeauth': 0.9.3
       '@microsoft/api-extractor': 7.7.8
@@ -9119,7 +9119,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-nWbN1RSxfbV1q8pCpCw+4ipfAJj6ADNl9rLhJ3+8O82+JOuLy5R7Lw9hFmhsPUlcJdEnHxamlYWXTXjp6YdsPQ==
+      integrity: sha512-llb8A1T3NjbTypZM83KL280Y7Gd/0UiefCEJ6Nygxfj++e4VvqxDc2Yfij4tUmX16/40mJd3TO+r8sPkG233pA==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -8,8 +8,10 @@
 - Fixes an issue where non-retryable errors caused by a connection disconnecting were not getting surfaced to the user's registered error handler
   when using the `registerMessageHandler` method on a receiver.
   [PR 8401](https://github.com/Azure/azure-sdk-for-js/pull/8401)
-- Updates the way connection disconnects are handled to create a new connection object rather than re-using the existing one.
-  This should reduce some issues caused when the existing connection gets into an unexpected state.
+- Fixes reconnection issues by creating a new connection object rather than re-using the existing one.
+  [PR 8447](https://github.com/Azure/azure-sdk-for-js/pull/8447)
+- Adds a new method `open()` on the sender to allow you to front load the work of setting up the underlying AMQP links. Use this if you want to avoid having your first `send()` operation pay the tax of link set up.
+  [PR 8329](https://github.com/Azure/azure-sdk-for-js/pull/8329). This PR also fixes a bug where a sender recovering from connection loss does not report the error back to the user from ongoing send operations.
 
 ## 1.1.5 (2020-03-24)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.1.6 (TBD)
+## 1.1.6 (2020-04-23)
 
 - Removes the `@azure/ms-rest-nodeauth` dependency.
   This allows users to use any version of `@azure/ms-rest-nodeauth` directly with `@azure/service-bus` without TypeScript compilation errors.
@@ -8,6 +8,8 @@
 - Fixes an issue where non-retryable errors caused by a connection disconnecting were not getting surfaced to the user's registered error handler
   when using the `registerMessageHandler` method on a receiver.
   [PR 8401](https://github.com/Azure/azure-sdk-for-js/pull/8401)
+- Updates the way connection disconnects are handled to create a new connection object rather than re-using the existing one.
+  This should reduce some issues caused when the existing connection gets into an unexpected state.
 
 ## 1.1.5 (2020-03-24)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Fixes reconnection issues by creating a new connection object rather than re-using the existing one.
   [PR 8447](https://github.com/Azure/azure-sdk-for-js/pull/8447)
 - Adds a new method `open()` on the sender to allow you to front load the work of setting up the underlying AMQP links. Use this if you want to avoid having your first `send()` operation pay the tax of link set up.
-  [PR 8329](https://github.com/Azure/azure-sdk-for-js/pull/8329). This PR also fixes a bug where a sender recovering from connection loss does not report the error back to the user from ongoing send operations.
+  [PR 8329](https://github.com/Azure/azure-sdk-for-js/pull/8329). This PR also fixes a bug where a sender recovering from connection loss does not report the error back to the user from ongoing send operations in expected time.
 
 ## 1.1.5 (2020-03-24)
 

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -78,7 +78,7 @@
     ]
   },
   "dependencies": {
-    "@azure/amqp-common": "1.0.0-preview.12",
+    "@azure/amqp-common": "1.0.0-preview.13",
     "@azure/core-http": "^1.0.0",
     "@opentelemetry/types": "^0.2.0",
     "@types/is-buffer": "^2.0.0",

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -201,63 +201,65 @@ export namespace ClientEntityContext {
 
     (entityContext as ClientEntityContext).onDetached = async (error?: AmqpError | Error) => {
       const connectionId = entityContext.namespace.connectionId;
-
+      const detachCalls: Promise<void>[] = [];
       // Call onDetached() on sender so that it can decide whether to reconnect or not
       const sender = entityContext.sender;
       if (sender && !sender.isConnecting) {
-        try {
-          log.error("[%s] calling detached on sender '%s'.", connectionId, sender.name);
-          await sender.onDetached();
-        } catch (err) {
-          log.error(
-            "[%s] An error occurred while calling onDetached() the sender '%s': %O.",
-            connectionId,
-            sender.name,
-            err
-          );
-        }
+        log.error("[%s] calling detached on sender '%s'.", connectionId, sender.name);
+        detachCalls.push(
+          sender.onDetached().catch((err) => {
+            log.error(
+              "[%s] An error occurred while calling onDetached() the sender '%s': %O.",
+              connectionId,
+              sender.name,
+              err
+            );
+          })
+        );
       }
 
       // Call onDetached() on batchingReceiver so that it can gracefully close any ongoing batch operation.
       const batchingReceiver = entityContext.batchingReceiver;
       if (batchingReceiver && !batchingReceiver.isConnecting) {
-        try {
-          log.error(
-            "[%s] calling detached on batching receiver '%s'.",
-            connectionId,
-            batchingReceiver.name
-          );
-          await batchingReceiver.onDetached(error);
-        } catch (err) {
-          log.error(
-            "[%s] An error occurred while calling onDetached() on the batching receiver '%s': %O.",
-            connectionId,
-            batchingReceiver.name,
-            err
-          );
-        }
+        log.error(
+          "[%s] calling detached on batching receiver '%s'.",
+          connectionId,
+          batchingReceiver.name
+        );
+        detachCalls.push(
+          batchingReceiver.onDetached(error).catch((err) => {
+            log.error(
+              "[%s] An error occurred while calling onDetached() on the batching receiver '%s': %O.",
+              connectionId,
+              batchingReceiver.name,
+              err
+            );
+          })
+        );
       }
 
       // Call onDetached() on streamingReceiver so that it can decide whether to reconnect or not
       const streamingReceiver = entityContext.streamingReceiver;
       if (streamingReceiver && !streamingReceiver.isConnecting) {
-        try {
-          log.error(
-            "[%s] calling detached on streaming receiver '%s'.",
-            connectionId,
-            streamingReceiver.name
-          );
-          const causedByDisconnect = true;
-          await streamingReceiver.onDetached(error, causedByDisconnect);
-        } catch (err) {
-          log.error(
-            "[%s] An error occurred while calling onDetached() on the streaming receiver '%s': %O.",
-            connectionId,
-            streamingReceiver.name,
-            err
-          );
-        }
+        log.error(
+          "[%s] calling detached on streaming receiver '%s'.",
+          connectionId,
+          streamingReceiver.name
+        );
+        const causedByDisconnect = true;
+        detachCalls.push(
+          streamingReceiver.onDetached(error, causedByDisconnect).catch((err) => {
+            log.error(
+              "[%s] An error occurred while calling onDetached() on the streaming receiver '%s': %O.",
+              connectionId,
+              streamingReceiver.name,
+              err
+            );
+          })
+        );
       }
+
+      await Promise.all(detachCalls);
     };
 
     const isManagementClientSharedWithOtherClients = (): boolean => {

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -185,9 +185,10 @@ export namespace ConnectionContext {
       const originalConnectionId = connectionContext.connectionId;
       try {
         await cleanConnectionContext(connectionContext);
-      } catch {
+      } catch (err) {
         log.error(
-          `[${connectionContext.connectionId}] There was an error closing the connection before reconnecting.`
+          `[${connectionContext.connectionId}] There was an error closing the connection before reconnecting: %O`,
+          err
         );
       }
       // Create a new connection, id, locks, and cbs client.

--- a/sdk/servicebus/service-bus/src/connectionContext.ts
+++ b/sdk/servicebus/service-bus/src/connectionContext.ts
@@ -216,8 +216,6 @@ export namespace ConnectionContext {
       connectionContext.connection.removeListener(ConnectionEvents.disconnected, disconnected);
       connectionContext.connection.removeListener(ConnectionEvents.protocolError, protocolError);
       connectionContext.connection.removeListener(ConnectionEvents.error, error);
-      // Close the cbs session.
-      await connectionContext.cbsSession.close();
       // Close the connection
       await connectionContext.connection.close();
     }

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -312,10 +312,12 @@ export class ManagementClient extends LinkEntity {
    */
   async close(): Promise<void> {
     try {
+      // Always clear the timeout, as the isOpen check may report
+      // false without ever having cleared the timeout otherwise.
+      clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
       if (this._isMgmtRequestResponseLinkOpen()) {
         const mgmtLink = this._mgmtReqResLink;
         this._mgmtReqResLink = undefined;
-        clearTimeout(this._tokenRenewalTimer as NodeJS.Timer);
         await mgmtLink!.close();
         log.mgmt("Successfully closed the management session.");
       }

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -1135,3 +1135,59 @@ describe("Batch Receiver - Others", function(): void {
     await testAskForMore(true);
   });
 });
+
+describe("Batching - disconnects", function(): void {
+  afterEach(async () => {
+    return afterEachTest();
+  });
+
+  it("can receive and settle messages after a disconnect", async function(): Promise<void> {
+    // Create the sender and receiver.
+    sbClient = getServiceBusClient();
+    const { receiverClient, senderClient } = await getSenderReceiverClients(
+      sbClient,
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue
+    );
+    const receiver = receiverClient.createReceiver(ReceiveMode.peekLock);
+    const sender = senderClient.createSender();
+    // Send a message so we can be sure when the receiver is open and active.
+    await sender.send(TestMessage.getSample());
+
+    let settledMessageCount = 0;
+
+    const messages1 = await receiver.receiveMessages(1, 5);
+    for (const message of messages1) {
+      await message.complete();
+      settledMessageCount++;
+    }
+
+    settledMessageCount.should.equal(1, "Unexpected number of settled messages.");
+
+    const connectionContext = receiver["_context"].namespace;
+    const refreshConnection = connectionContext.refreshConnection;
+    let refreshConnectionCalled = 0;
+    connectionContext.refreshConnection = function(...args) {
+      refreshConnectionCalled++;
+      refreshConnection.apply(this, args);
+    };
+
+    // Simulate a disconnect being called with a non-retryable error.
+    receiver["_context"].namespace.connection["_connection"].idle();
+
+    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
+    // Otherwise, it will get into a bad internal state with uncaught exceptions.
+    await delay(2000);
+    // send a second message to trigger the message handler again.
+    await sender.send(TestMessage.getSample());
+
+    // wait for the 2nd message to be received.
+    const messages2 = await receiver.receiveMessages(1, 5);
+    for (const message of messages2) {
+      await message.complete();
+      settledMessageCount++;
+    }
+    settledMessageCount.should.equal(2, "Unexpected number of settled messages.");
+    refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+  });
+});

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -1,0 +1,112 @@
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { delay, QueueClient, ServiceBusClient } from "../src";
+import {
+  TestClientType,
+  getSenderReceiverClients,
+  TestMessage,
+  getServiceBusClient
+} from "./utils/testUtils";
+chai.should();
+chai.use(chaiAsPromised);
+let sbClient: ServiceBusClient;
+
+async function afterEachTest(): Promise<void> {
+  await sbClient.close();
+}
+
+describe("ManagementClient - disconnects", function(): void {
+  afterEach(async () => {
+    return afterEachTest();
+  });
+
+  it("can receive and settle messages after a disconnect", async function(): Promise<void> {
+    // Create the sender and receiver.
+    sbClient = getServiceBusClient();
+    const { receiverClient, senderClient } = await getSenderReceiverClients(
+      sbClient,
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue
+    );
+    const sender = senderClient.createSender();
+    // Send a message so we have something to peek.
+
+    await sender.sendBatch([TestMessage.getSample(), TestMessage.getSample()]);
+
+    let peekedMessageCount = 0;
+    let messages = await receiverClient.peek(1);
+    peekedMessageCount += messages.length;
+
+    peekedMessageCount.should.equal(1, "Unexpected number of peeked messages.");
+
+    const connectionContext = (receiverClient as QueueClient)["_context"].namespace;
+    const refreshConnection = connectionContext.refreshConnection;
+    let refreshConnectionCalled = 0;
+    connectionContext.refreshConnection = function(...args) {
+      refreshConnectionCalled++;
+      refreshConnection.apply(this, args);
+    };
+
+    // Simulate a disconnect being called with a non-retryable error.
+    connectionContext.connection["_connection"].idle();
+
+    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
+    // Otherwise, it will get into a bad internal state with uncaught exceptions.
+    await delay(2000);
+
+    // peek additional messages
+    messages = await receiverClient.peek(1);
+    peekedMessageCount += messages.length;
+    peekedMessageCount.should.equal(2, "Unexpected number of peeked messages.");
+
+    refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+  });
+
+  it("schedule can receive and settle messages after a disconnect", async function(): Promise<
+    void
+  > {
+    // Create the sender and receiver.
+    sbClient = getServiceBusClient();
+    const { receiverClient, senderClient } = await getSenderReceiverClients(
+      sbClient,
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue
+    );
+    const sender = senderClient.createSender();
+    // Send a message so we have something to peek.
+
+    const deliveryIds = [];
+    let deliveryId = await sender.scheduleMessage(
+      new Date("2020-04-25T12:00:00Z"),
+      TestMessage.getSample()
+    );
+    deliveryIds.push(deliveryId);
+
+    deliveryIds.length.should.equal(1, "Unexpected number of scheduled messages.");
+
+    const connectionContext = (receiverClient as QueueClient)["_context"].namespace;
+    const refreshConnection = connectionContext.refreshConnection;
+    let refreshConnectionCalled = 0;
+    connectionContext.refreshConnection = function(...args) {
+      refreshConnectionCalled++;
+      refreshConnection.apply(this, args);
+    };
+
+    // Simulate a disconnect being called with a non-retryable error.
+    connectionContext.connection["_connection"].idle();
+
+    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
+    // Otherwise, it will get into a bad internal state with uncaught exceptions.
+    await delay(2000);
+
+    // peek additional messages
+    deliveryId = await sender.scheduleMessage(
+      new Date("2020-04-25T12:00:00Z"),
+      TestMessage.getSample()
+    );
+    deliveryIds.push(deliveryId);
+    deliveryIds.length.should.equal(2, "Unexpected number of scheduled messages.");
+
+    refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+  });
+});

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -603,6 +603,11 @@ describe("Peek session", function(): void {
   });
 });
 
+/**
+ * SessionReceiver intentionally does not recover after a disconnect:
+ * https://github.com/Azure/azure-sdk-for-js/pull/8447#issuecomment-618510245
+ * If support for this is added in the future, we can stop skipping this test.
+ */
 describe.skip("SessionReceiver - disconnects", function(): void {
   afterEach(async () => {
     return afterEachTest();

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -1306,3 +1306,92 @@ describe("Streaming - onDetached", function(): void {
     receivedErrors.length.should.equal(1, "Unexpected number of errors received.");
   });
 });
+
+describe("Streaming - disconnects", function(): void {
+  afterEach(async () => {
+    return afterEachTest();
+  });
+
+  it("can receive and settle messages after a disconnect", async function(): Promise<void> {
+    /**
+     * If onDetached is called with a non-retryable error, it is assumed that
+     * the onSessionError or onAmqpError has already called the user's
+     * error handler.
+     */
+    // Create the sender and receiver.
+    sbClient = getServiceBusClient();
+    const { receiverClient, senderClient } = await getSenderReceiverClients(
+      sbClient,
+      TestClientType.UnpartitionedQueue,
+      TestClientType.UnpartitionedQueue
+    );
+    const receiver = receiverClient.createReceiver(ReceiveMode.peekLock);
+    const sender = senderClient.createSender();
+    // Send a message so we can be sure when the receiver is open and active.
+    await sender.send(TestMessage.getSample());
+    const receivedErrors: any[] = [];
+    let settledMessageCount = 0;
+
+    let messageHandlerCount = 0;
+    let receiverIsActiveResolver: Function;
+    let receiverSecondMessageResolver: Function;
+    const receiverIsActive = new Promise((resolve) => {
+      receiverIsActiveResolver = resolve;
+    });
+    const receiverSecondMessage = new Promise((resolve) => {
+      receiverSecondMessageResolver = resolve;
+    });
+
+    // Start the receiver.
+    receiver.registerMessageHandler(
+      async (message) => {
+        messageHandlerCount++;
+        try {
+          await message.complete();
+          settledMessageCount++;
+        } catch (err) {
+          receivedErrors.push(err);
+        }
+        if (messageHandlerCount === 1) {
+          // Since we've received a message, mark the receiver as active.
+          receiverIsActiveResolver();
+        } else {
+          // Mark the second message resolver!
+          receiverSecondMessageResolver();
+        }
+      },
+      (err) => {
+        receivedErrors.push(err);
+      }
+    );
+
+    // Wait until we're sure the receiver is open and receiving messages.
+    await receiverIsActive;
+
+    settledMessageCount.should.equal(1, "Unexpected number of settled messages.");
+    receivedErrors.length.should.equal(0, "Encountered an unexpected number of errors.");
+
+    const connectionContext = receiver["_context"].namespace;
+    const refreshConnection = connectionContext.refreshConnection;
+    let refreshConnectionCalled = 0;
+    connectionContext.refreshConnection = function(...args) {
+      refreshConnectionCalled++;
+      refreshConnection.apply(this, args);
+    };
+
+    // Simulate a disconnect being called with a non-retryable error.
+    receiver["_context"].namespace.connection["_connection"].idle();
+
+    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
+    // Otherwise, it will get into a bad internal state with uncaught exceptions.
+    await delay(2000);
+    // send a second message to trigger the message handler again.
+    await sender.send(TestMessage.getSample());
+
+    // wait for the 2nd message to be received.
+    await receiverSecondMessage;
+    settledMessageCount.should.equal(2, "Unexpected number of settled messages.");
+    receivedErrors.length.should.equal(0, "Encountered an unexpected number of errors.");
+    refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+  });
+});


### PR DESCRIPTION
This change updates the `ConnectionContext` disconnect behavior.

Previous to this change, when a `disconnect` event was detect and the SDK attempted to recreate its links/sessions/connection, it would do some cleanup of the `rhea-promise` connection object and re-use it. Normally this works fine, but over time we've seen issues in logs that indicate that the connection object may be getting into an unexpected state in some cases.

This PR updates the `disconnect` behavior to create a new `rhea-promise` connection object when the SDK determines that the links/sessions/connection should be recreated.

This relies on #8444 to be merged first.

## Testing
To test this change, I create a streaming receiver and run inside a docker container. With logging enabled, I disable the network connection for the docker container until I see a `disconnect` event fire. Then I re-enable the connection and observe that the receiver begins reading messages again.

/cc @ramya-rao-a 