### PR TITLE
[service-bus] sender.open() should clear the internal _isClosed flag #8466 

### DIFF
--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -88,6 +88,7 @@ export class Sender {
    * want to front load the work of setting up the AMQP link to the service.
    */
   async open(): Promise<void> {
+    this._throwIfSenderOrConnectionClosed();
     return MessageSender.create(this._context).open();
   }
 


### PR DESCRIPTION
As part of the fixing #8329 we allowed the user to call open() on a sender to preemptively initialize it.  However, it didn't work if you had closed the sender.

This commit goes all the way and allows you to reopen a sender after it has been closed. 