### PR TITLE
[Event Hubs] sendBatch(array) api proposal

### DIFF
--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -110,7 +110,8 @@ export class EventHubProducerClient {
     getEventHubProperties(options?: GetEventHubPropertiesOptions): Promise<EventHubProperties>;
     getPartitionIds(options?: GetPartitionIdsOptions): Promise<Array<string>>;
     getPartitionProperties(partitionId: string, options?: GetPartitionPropertiesOptions): Promise<PartitionProperties>;
-    sendBatch(batch: EventDataBatch, options?: SendBatchOptions): Promise<void>;
+    sendBatch(eventData: EventData[], options?: SendBatchOptions): Promise<void>;
+    sendBatch(batch: EventDataBatch, options?: OperationOptions): Promise<void>;
 }
 
 // @public
@@ -225,6 +226,8 @@ export { RetryOptions }
 
 // @public
 export interface SendBatchOptions extends OperationOptions {
+    partitionId?: string;
+    partitionKey?: string;
 }
 
 // @public

--- a/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
@@ -100,6 +100,14 @@ export async function main(): Promise<void> {
     if (numEventsSent !== eventsToSend.length) {
       throw new Error(`Not all messages were sent (${numEventsSent}/${eventsToSend.length})`);
     }
+
+    // Alternatively, if you know beforehand that the set of events you have will not exceed the 
+    // size limits, you can use the `send()` api directly
+    const eventDataToSend = eventsToSend.map(event => {
+      return { body: event}
+    });
+    await producer.send(eventDataToSend);
+
   } catch (err) {
     console.log("Error when creating & sending a batch of events: ", err);
   }

--- a/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
@@ -106,7 +106,7 @@ export async function main(): Promise<void> {
     const eventDataToSend = eventsToSend.map(event => {
       return { body: event}
     });
-    await producer.send(eventDataToSend);
+    await producer.sendBatch(eventDataToSend);
 
   } catch (err) {
     console.log("Error when creating & sending a batch of events: ", err);

--- a/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/sendEvents.ts
@@ -26,7 +26,18 @@ export async function main(): Promise<void> {
 
   console.log("Creating and sending a batch of events...");
 
-  const eventsToSend = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"];
+  const eventsToSend = [
+    { body: "1" },
+    { body: "2" },
+    { body: "3" },
+    { body: "4" },
+    { body: "5" },
+    { body: "6" },
+    { body: "7" },
+    { body: "8" },
+    { body: "9" },
+    { body: "10" }
+  ];
 
   try {
     // By not specifying a partition ID or a partition key we allow the server to choose
@@ -101,13 +112,9 @@ export async function main(): Promise<void> {
       throw new Error(`Not all messages were sent (${numEventsSent}/${eventsToSend.length})`);
     }
 
-    // Alternatively, if you know beforehand that the set of events you have will not exceed the 
-    // size limits, you can use the `send()` api directly
-    const eventDataToSend = eventsToSend.map(event => {
-      return { body: event}
-    });
-    await producer.sendBatch(eventDataToSend);
-
+    // Alternatively, if you know beforehand that the set of events you have will not exceed the
+    // size limits, you can use the `sendBatch()` api directly
+    await producer.sendBatch(eventsToSend);
   } catch (err) {
     console.log("Error when creating & sending a batch of events: ", err);
   }


### PR DESCRIPTION
This PR shows the proposal and sample code for the overload for sendBatch() api on the `EventProducerClient` to send an array of events

See https://github.com/Azure/azure-sdk/issues/1259 for details on the proposal

This will throw validation errors for the below cases:
- sendBatch(any-batch, {partitionKey})  // unless partitionKey is the same as that used in batch
- batch = await createBatch({partitionId});
   sendBatch(batch, {some-other-partitionId}) 
- batch = await createBatch({partitionKey});
   sendBatch(batch, {partitionId}) 
- sendBatch(anything, {partitionId, partitionKey})

cc @chradek, @richardpark-msft, @bterlson   