### PR TITLE
[Service Bus] Set lockedUntilUtc property on the message after renewLock

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusMessage.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessage.ts
@@ -1056,7 +1056,8 @@ export class ServiceBusMessageImpl implements ReceivedMessageWithLock {
    */
   async renewLock(): Promise<Date> {
     this.throwIfMessageCannotBeSettled(this.getReceiverFromContext(), "renew the lock on");
-    return await this._context.managementClient!.renewLock(this.lockToken!);
+    this.lockedUntilUtc = await this._context.managementClient!.renewLock(this.lockToken!);
+    return this.lockedUntilUtc;
   }
 
   /**

--- a/sdk/servicebus/service-bus/test/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLock.spec.ts
@@ -498,7 +498,7 @@ describe("renew lock", () => {
   ): void {
     if (actualTimeInUTC) {
       should.equal(
-        Math.pow((actualTimeInUTC.valueOf() - expectedTimeInUTC.valueOf()) / 1000, 2) < 100, // Within +/- 10 seconds
+        Math.pow((actualTimeInUTC.valueOf() - expectedTimeInUTC.valueOf()) / 1000, 2) < 9, // Within +/- 3 seconds
         true,
         `${label}: Actual time ${actualTimeInUTC} must be approximately equal to ${expectedTimeInUTC}`
       );


### PR DESCRIPTION
### Changes in the PR
- Updating lockedUntilUTC property on the message once the renewLock operation completes.
- Fixed an assertion that would properly verify the above.
  - Previously, if the diff between the expected and actual is less than 10s, the assertion succeeded. Due to this, the test succeeded though the lockedUntilUTC property didn't change.