### PR TITLE
[FormRecognizer] downgrade core-auth dependency version to v1.1.0

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -43,6 +43,7 @@
   "allowedAlternativeVersions": {
     "@azure/ms-rest-js": ["^2.0.0"],
     "@azure/core-http": ["^1.1.0"],
+    "@azure/core-auth": ["^1.1.0"],
     "@azure/core-tracing": ["1.0.0-preview.7"],
     /**
      * For example, allow some projects to use an older TypeScript compiler

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -77,7 +77,7 @@
   "autoPublish": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-auth": "^1.1.2",
+    "@azure/core-auth": "^1.1.0",
     "@azure/core-lro": "^1.0.0",
     "@azure/core-paging": "^1.1.0",
     "@azure/core-http": "^1.0.0",


### PR DESCRIPTION
for preview.1 release as core-auth v1.1.2 hasn't been released yet.