### PR TITLE
[Service Bus] Add downleveling for service-bus track 1

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.1.7 #Unreleased
+
+- Provided down-leveled type declaration files to support older TypeScript versions between 3.1 and 3.6.
+  [PR 8515](https://github.com/Azure/azure-sdk-for-js/pull/8515)
+
 ## 1.1.6 (2020-04-23)
 
 - Removes the `@azure/ms-rest-nodeauth` dependency.

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.7 #Unreleased
 
-- Provided down-leveled type declaration files to support older TypeScript versions between 3.1 and 3.6.
+- Provided down-leveled type declaration files to support older TypeScript versions 3.1 to 3.6.
   [PR 8515](https://github.com/Azure/azure-sdk-for-js/pull/8515)
 
 ## 1.1.6 (2020-04-23)

--- a/sdk/servicebus/service-bus/api-extractor.json
+++ b/sdk/servicebus/service-bus/api-extractor.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "mainEntryPointFilePath": "typings/src/index.d.ts",
+  "mainEntryPointFilePath": "types/src/index.d.ts",
   "docModel": {
     "enabled": false
   },
@@ -11,7 +11,7 @@
   "dtsRollup": {
     "enabled": true,
     "untrimmedFilePath": "",
-    "publicTrimmedFilePath": "./typings/service-bus.d.ts"
+    "publicTrimmedFilePath": "./types/latest/service-bus.d.ts"
   },
   "messages": {
     "tsdocMessageReporting": {

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/service-bus",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "license": "MIT",
   "description": "Azure Service Bus SDK for Node.js",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -26,7 +26,14 @@
     "buffer": "buffer",
     "stream": "stream-browserify"
   },
-  "types": "./typings/service-bus.d.ts",
+  "types": "./types/latest/service-bus.d.ts",
+  "typesVersions": {
+    "<3.6": {
+      "types/latest/*": [
+        "types/3.1/*"
+      ]
+    }
+  },
   "engine": {
     "node": ">=8.0.0"
   },
@@ -35,7 +42,8 @@
     "dist-esm/src/",
     "src/",
     "browser/",
-    "typings/service-bus.d.ts",
+    "types/latest/service-bus.d.ts",
+    "types/3.1",
     "tsconfig.json"
   ],
   "scripts": {
@@ -46,9 +54,10 @@
     "build:test:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c rollup.test.config.js 2>&1",
     "build:test:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c rollup.test.config.js 2>&1",
     "build:test": "npm run build:test:node && npm run build:test:browser",
-    "build": "tsc -p . && rollup -c 2>&1 && npm run extract-api",
+    "build:types": "downlevel-dts types/latest types/3.1",
+    "build": "tsc -p . && rollup -c 2>&1 && npm run extract-api && npm run build:types",
     "check-format": "prettier --list-different --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
-    "clean": "rimraf dist dist-esm test-dist typings *.tgz *.log coverage coverage-browser .nyc_output",
+    "clean": "rimraf dist dist-esm test-dist types *.tgz *.log coverage coverage-browser .nyc_output",
     "execute:js-samples": "node ../../../common/scripts/run-samples.js samples/javascript/",
     "execute:ts-samples": "node ../../../common/scripts/run-samples.js samples/typescript/dist/samples/typescript/src/",
     "execute:samples": "echo skipped",
@@ -119,6 +128,7 @@
     "cross-env": "^6.0.3",
     "delay": "^4.2.0",
     "dotenv": "^8.2.0",
+    "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",

--- a/sdk/servicebus/service-bus/samples/tsconfig.json
+++ b/sdk/servicebus/service-bus/samples/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "typescript/dist"
   },
   "include": ["typescript/src/**.ts"],
-  "exclude": ["typescript/*.json", "**/node_modules/", "../node_modules", "../typings"]
+  "exclude": ["typescript/*.json", "**/node_modules/", "../node_modules", "../types"]
 }

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -3,7 +3,7 @@
 
 export const packageJsonInfo = {
   name: "@azure/service-bus",
-  version: "1.1.6"
+  version: "1.1.7"
 };
 
 export const messageDispositionTimeout = 20000;

--- a/sdk/servicebus/service-bus/tsconfig.json
+++ b/sdk/servicebus/service-bus/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true /* Generates corresponding '.map' file. */,
     "outDir": "./dist-esm" /* Redirect output structure to the directory. */,
     "stripInternal": true /* Do not emit declarations for code with @internal annotation*/,
-    "declarationDir": "./typings" /* Output directory for generated declaration files.*/,
+    "declarationDir": "./types" /* Output directory for generated declaration files.*/,
     "importHelpers": true /* Import emit helpers from 'tslib'. */,
 
     /* Strict Type-Checking Options */
@@ -32,11 +32,6 @@
     "resolveJsonModule": true
   },
   "compileOnSave": true,
-  "exclude": [
-    "node_modules",
-    "typings/**",
-    "./samples/**/*.ts",
-    "./test/perf/azure-sb-package/*.ts"
-  ],
+  "exclude": ["node_modules", "types/**", "./samples/**/*.ts", "./test/perf/azure-sb-package/*.ts"],
   "include": ["./src/**/*.ts", "./test/**/*.ts"]
 }


### PR DESCRIPTION
Service Bus library would not work for the users relying on Typescript 3.1-3.5 since the types are incompatible.
This PR attempts to provide the types for the lower versions of typescript(3.1-3.5) along with the latest.

- [x] TO DO - Test with samples