### PR TITLE
Add succeededOrFailed() to all custom conditions

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -31,7 +31,7 @@ jobs:
       - script: |
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"
-        condition: and(succeededOrFailed(),and(eq(variables['Build.SourceBranchName'],'master'),eq(variables['Build.Reason'],'Schedule')))
+        condition: and(always(),and(eq(variables['Build.SourceBranchName'],'master'),eq(variables['Build.Reason'],'Schedule')))
 
       - template: ../steps/common.yml
 

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -31,7 +31,7 @@ jobs:
       - script: |
           echo "##vso[build.addbuildtag]Scheduled"
         displayName: "Tag scheduled builds"
-        condition: and(eq(variables['Build.SourceBranchName'],'master'),eq(variables['Build.Reason'],'Schedule'))
+        condition: and(succeededOrFailed(),and(eq(variables['Build.SourceBranchName'],'master'),eq(variables['Build.Reason'],'Schedule')))
 
       - template: ../steps/common.yml
 
@@ -47,12 +47,12 @@ jobs:
           npm install ./eng/tools/versioning
           node eng/tools/versioning/set-dev.js --build-id "$(Build.BuildNumber)" --repo-root "$(Build.SourcesDirectory)" --service "$(folder)"
           node common/scripts/install-run-rush.js update
-        condition: eq(variables['SetDevVersion'],'true')
+        condition: and(succeededOrFailed(),eq(variables['SetDevVersion'],'true'))
         displayName: "Update package versions for dev build"
 
       - script: |
           node common/scripts/install-run-rush.js install
-        condition: ne(variables['SetDevVersion'],'true')
+        condition: and(succeededOrFailed(),ne(variables['SetDevVersion'],'true'))
         displayName: "Install dependencies"
 
       - template: eng/pipelines/templates/scripts/replace-relative-links.yml@azure-sdk-tools
@@ -225,14 +225,14 @@ jobs:
         - script: |
             node eng/tools/rush-runner.js unit-test:node "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"
-          condition: eq(variables['TestType'], 'node')
+          condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'))
         
         # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
         # The default on Windows is "cores - 1" (microsoft/rushstack#436).
         - script: |
             node eng/tools/rush-runner.js unit-test:browser "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"
-          condition: eq(variables['TestType'], 'browser')
+          condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'))
 
         # Unlink node_modules folders to significantly improve performance of subsequent tasks
         # which need to walk the directory tree (and are hardcoded to follow symlinks).

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           TEST_MODE: "live"
           ${{ insert }}: ${{ parameters.EnvVars }}
-        condition: ne(variables['TestType'],'sample')
+        condition: and(succeededOrFailed(),ne(variables['TestType'],'sample'))
 
       - ${{if ne(parameters.PostIntegrationSteps, '')}}:
           - template: ../steps/${{parameters.PostIntegrationSteps}}.yml
@@ -110,7 +110,7 @@ jobs:
         env:
           TEST_MODE: "live"
           ${{ insert }}: ${{ parameters.EnvVars }}
-        condition: eq(variables['TestType'],'sample')
+        condition: and(succeededOrFailed(),eq(variables['TestType'],'sample'))
 
       - ${{ if ne(parameters.ResourceServiceDirectory, '') }}:
         - template: /eng/common/TestResources/remove-test-resources.yml


### PR DESCRIPTION
- Ensures steps are killed when run is cancelled
- Exception is "Tag scheduled builds" which should always run
