### PR TITLE
[search] Fix odata metadata policy

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -109,9 +109,7 @@ export type CognitiveServicesAccount = DefaultCognitiveServicesAccount | Cogniti
 
 // @public
 export interface CognitiveServicesAccountKey {
-    // (undocumented)
     description?: string;
-    // (undocumented)
     key: string;
     odatatype: "#Microsoft.Azure.Search.CognitiveServicesByKey";
 }
@@ -229,7 +227,6 @@ export type DataSourceType = 'azuresql' | 'cosmosdb' | 'azureblob' | 'azuretable
 
 // @public
 export interface DefaultCognitiveServicesAccount {
-    // (undocumented)
     description?: string;
     odatatype: "#Microsoft.Azure.Search.DefaultCognitiveServices";
 }
@@ -1326,7 +1323,7 @@ export interface SplitSkill {
     defaultLanguageCode?: SplitSkillLanguage;
     description?: string;
     inputs: InputFieldMappingEntry[];
-    maximumPageLength?: number;
+    maxPageLength?: number;
     name?: string;
     odatatype: "#Microsoft.Skills.Text.SplitSkill";
     outputs: OutputFieldMappingEntry[];

--- a/sdk/search/search-documents/src/base64.browser.ts
+++ b/sdk/search/search-documents/src/base64.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * Encodes a string in base64 format.

--- a/sdk/search/search-documents/src/base64.ts
+++ b/sdk/search/search-documents/src/base64.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * Encodes a string in base64 format.

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -144,7 +144,7 @@ export class SearchIndexClient<T> {
       createSearchApiKeyCredentialPolicy(credential)
     );
     if (Array.isArray(pipeline.requestPolicyFactories)) {
-      pipeline.requestPolicyFactories.unshift(odataMetadataPolicy());
+      pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("none"));
     }
 
     // The contract with the generated client requires a credential, even though it is never used

--- a/sdk/search/search-documents/src/searchServiceClient.ts
+++ b/sdk/search/search-documents/src/searchServiceClient.ts
@@ -60,6 +60,7 @@ import {
 } from "./serviceModels";
 import * as utils from "./serviceUtils";
 import { createSpan } from "./tracing";
+import { odataMetadataPolicy } from "./odataMetadataPolicy";
 
 /**
  * Client options used to configure Cognitive Search API requests.
@@ -154,6 +155,11 @@ export class SearchServiceClient {
       internalPipelineOptions,
       createSearchApiKeyCredentialPolicy(credential)
     );
+
+    if (Array.isArray(pipeline.requestPolicyFactories)) {
+      pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
+    }
+
     this.client = new GeneratedClient(dummyCredential, this.apiVersion, this.endpoint, pipeline);
   }
 

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -275,7 +275,7 @@ export function publicSkillsetToGeneratedSkillset(skillset: Skillset): Generated
 }
 
 export function generatedSynonymMapToPublicSynonymMap(synonymMap: GeneratedSynonymMap): SynonymMap {
-  let result: SynonymMap = {
+  const result: SynonymMap = {
     name: synonymMap.name,
     encryptionKey: synonymMap.encryptionKey,
     etag: synonymMap.etag,


### PR DESCRIPTION
We are not explicitly setting an odata metadata policy for the service client.

This change extends the policy that the index client was using so that it can support either scenario and uses it for sending `minimal` in the service client case.