### PR TITLE
[Service Bus] Improve error when settling messages after Queue/Subscription client is closed

### DIFF
--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -275,6 +275,7 @@ export namespace ClientEntityContext {
     };
 
     (entityContext as ClientEntityContext).close = async () => {
+      entityContext.isClosed = true;
       if (!context.connection || !context.connection.isOpen()) {
         return;
       }
@@ -320,8 +321,6 @@ export namespace ClientEntityContext {
       if (entityContext.managementClient && !isManagementClientSharedWithOtherClients()) {
         await entityContext.managementClient.close();
       }
-
-      entityContext.isClosed = true;
 
       log.entityCtxt(
         "[%s] Closed client entity context for %s: %O",

--- a/sdk/servicebus/service-bus/src/clientEntityContext.ts
+++ b/sdk/servicebus/service-bus/src/clientEntityContext.ts
@@ -319,7 +319,6 @@ export namespace ClientEntityContext {
       // Close the managementClient unless it is shared with other clients
       if (entityContext.managementClient && !isManagementClientSharedWithOtherClients()) {
         await entityContext.managementClient.close();
-        entityContext.managementClient = undefined;
       }
 
       entityContext.isClosed = true;

--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -40,7 +40,8 @@ import {
   throwTypeErrorIfParameterMissing,
   throwTypeErrorIfParameterNotLong,
   throwTypeErrorIfParameterTypeMismatch,
-  throwTypeErrorIfParameterIsEmptyString
+  throwTypeErrorIfParameterIsEmptyString,
+  throwErrorIfClientOrConnectionClosed
 } from "../util/errors";
 import { Typed } from "rhea-promise";
 import { max32BitNumber } from "../util/constants";
@@ -343,7 +344,11 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<ReceivedSBMessage[]>
    */
   async peek(messageCount?: number): Promise<ReceivedMessageInfo[]> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     return this.peekBySequenceNumber(this._lastPeekedSequenceNumber.add(1), messageCount);
   }
 
@@ -363,7 +368,11 @@ export class ManagementClient extends LinkEntity {
     sessionId: string,
     messageCount?: number
   ): Promise<ReceivedMessageInfo[]> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     return this.peekBySequenceNumber(
       this._lastPeekedSequenceNumber.add(1),
       messageCount,
@@ -383,7 +392,11 @@ export class ManagementClient extends LinkEntity {
     maxMessageCount?: number,
     sessionId?: string
   ): Promise<ReceivedMessageInfo[]> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     const connId = this._context.namespace.connectionId;
 
     // Checks for fromSequenceNumber
@@ -477,7 +490,11 @@ export class ManagementClient extends LinkEntity {
    * @returns {Promise<Date>} Promise<Date> New lock token expiry date and time in UTC format.
    */
   async renewLock(lockToken: string, options?: SendRequestOptions): Promise<Date> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     if (!options) options = {};
     if (options.delayInSeconds == null) options.delayInSeconds = 1;
     if (options.timeoutInSeconds == null) options.timeoutInSeconds = 5;
@@ -539,7 +556,11 @@ export class ManagementClient extends LinkEntity {
     scheduledEnqueueTimeUtc: Date,
     messages: SendableMessageInfo[]
   ): Promise<Long[]> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     const messageBody: any[] = [];
     for (let i = 0; i < messages.length; i++) {
       const item = messages[i];
@@ -635,7 +656,11 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<void>
    */
   async cancelScheduledMessages(sequenceNumbers: Long[]): Promise<void> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     const messageBody: any = {};
     messageBody[Constants.sequenceNumbers] = [];
     for (let i = 0; i < sequenceNumbers.length; i++) {
@@ -711,7 +736,11 @@ export class ManagementClient extends LinkEntity {
     receiveMode: ReceiveMode,
     sessionId?: string
   ): Promise<ServiceBusMessage[]> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
 
     const messageList: ServiceBusMessage[] = [];
     const messageBody: any = {};
@@ -816,7 +845,11 @@ export class ManagementClient extends LinkEntity {
     dispositionStatus: DispositionStatus,
     options?: DispositionStatusOptions
   ): Promise<void> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
 
     if (!options) options = {};
     try {
@@ -881,7 +914,11 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<Date> New lock token expiry date and time in UTC format.
    */
   async renewSessionLock(sessionId: string, options?: SendRequestOptions): Promise<Date> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     if (!options) options = {};
     if (options.delayInSeconds == null) options.delayInSeconds = 1;
     if (options.timeoutInSeconds == null) options.timeoutInSeconds = 5;
@@ -939,8 +976,11 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<void>
    */
   async setSessionState(sessionId: string, state: any): Promise<void> {
-    throwErrorIfConnectionClosed(this._context.namespace);
-
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     try {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
@@ -986,7 +1026,11 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<any> The state of that session
    */
   async getSessionState(sessionId: string): Promise<any> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     try {
       const messageBody: any = {};
       messageBody[Constants.sessionIdMapKey] = sessionId;
@@ -1036,7 +1080,11 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<string[]> A list of session ids.
    */
   async listMessageSessions(skip: number, top: number, lastUpdatedTime?: Date): Promise<string[]> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     const defaultLastUpdatedTimeForListingSessions: number = 259200000; // 3 * 24 * 3600 * 1000
     if (typeof skip !== "number") {
       throw new Error("'skip' is a required parameter and must be of type 'number'.");
@@ -1093,7 +1141,11 @@ export class ManagementClient extends LinkEntity {
    * @returns Promise<RuleDescription[]> A list of rules.
    */
   async getRules(): Promise<RuleDescription[]> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     try {
       const request: AmqpMessage = {
         body: {
@@ -1209,7 +1261,11 @@ export class ManagementClient extends LinkEntity {
    * @param ruleName
    */
   async removeRule(ruleName: string): Promise<void> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
     throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "ruleName", ruleName);
     ruleName = String(ruleName);
     throwTypeErrorIfParameterIsEmptyString(
@@ -1265,7 +1321,11 @@ export class ManagementClient extends LinkEntity {
     filter: boolean | string | CorrelationFilter,
     sqlRuleActionExpression?: string
   ): Promise<void> {
-    throwErrorIfConnectionClosed(this._context.namespace);
+    throwErrorIfClientOrConnectionClosed(
+      this._context.namespace,
+      this._context.entityPath,
+      this._context.isClosed
+    );
 
     throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "ruleName", ruleName);
     ruleName = String(ruleName);

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -1,13 +1,23 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { delay, QueueClient, ServiceBusClient } from "../src";
+import Long from "long";
+import {
+  delay,
+  QueueClient,
+  ServiceBusClient,
+  TopicClient,
+  SubscriptionClient,
+  Receiver,
+  Sender,
+  ReceiveMode
+} from "../src";
 import {
   TestClientType,
   getSenderReceiverClients,
   TestMessage,
   getServiceBusClient
 } from "./utils/testUtils";
-chai.should();
+const should = chai.should();
 chai.use(chaiAsPromised);
 let sbClient: ServiceBusClient;
 
@@ -15,98 +25,179 @@ async function afterEachTest(): Promise<void> {
   await sbClient.close();
 }
 
-describe("ManagementClient - disconnects", function(): void {
-  afterEach(async () => {
-    return afterEachTest();
+describe("ManagementClient", function(): void {
+  describe("ManagementClient - disconnects", function(): void {
+    afterEach(async () => {
+      return afterEachTest();
+    });
+
+    it("can receive and settle messages after a disconnect", async function(): Promise<void> {
+      // Create the sender and receiver.
+      sbClient = getServiceBusClient();
+      const { receiverClient, senderClient } = await getSenderReceiverClients(
+        sbClient,
+        TestClientType.UnpartitionedQueue,
+        TestClientType.UnpartitionedQueue
+      );
+      const sender = senderClient.createSender();
+      // Send a message so we have something to peek.
+
+      await sender.sendBatch([TestMessage.getSample(), TestMessage.getSample()]);
+
+      let peekedMessageCount = 0;
+      let messages = await receiverClient.peek(1);
+      peekedMessageCount += messages.length;
+
+      peekedMessageCount.should.equal(1, "Unexpected number of peeked messages.");
+
+      const connectionContext = (receiverClient as QueueClient)["_context"].namespace;
+      const refreshConnection = connectionContext.refreshConnection;
+      let refreshConnectionCalled = 0;
+      connectionContext.refreshConnection = function(...args) {
+        refreshConnectionCalled++;
+        refreshConnection.apply(this, args);
+      };
+
+      // Simulate a disconnect being called with a non-retryable error.
+      connectionContext.connection["_connection"].idle();
+
+      // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
+      // Otherwise, it will get into a bad internal state with uncaught exceptions.
+      await delay(2000);
+
+      // peek additional messages
+      messages = await receiverClient.peek(1);
+      peekedMessageCount += messages.length;
+      peekedMessageCount.should.equal(2, "Unexpected number of peeked messages.");
+
+      refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+    });
+
+    it("schedule can receive and settle messages after a disconnect", async function(): Promise<
+      void
+    > {
+      // Create the sender and receiver.
+      sbClient = getServiceBusClient();
+      const { receiverClient, senderClient } = await getSenderReceiverClients(
+        sbClient,
+        TestClientType.UnpartitionedQueue,
+        TestClientType.UnpartitionedQueue
+      );
+      const sender = senderClient.createSender();
+      // Send a message so we have something to peek.
+
+      const deliveryIds = [];
+      let deliveryId = await sender.scheduleMessage(
+        new Date("2020-04-25T12:00:00Z"),
+        TestMessage.getSample()
+      );
+      deliveryIds.push(deliveryId);
+
+      deliveryIds.length.should.equal(1, "Unexpected number of scheduled messages.");
+
+      const connectionContext = (receiverClient as QueueClient)["_context"].namespace;
+      const refreshConnection = connectionContext.refreshConnection;
+      let refreshConnectionCalled = 0;
+      connectionContext.refreshConnection = function(...args) {
+        refreshConnectionCalled++;
+        refreshConnection.apply(this, args);
+      };
+
+      // Simulate a disconnect being called with a non-retryable error.
+      connectionContext.connection["_connection"].idle();
+
+      // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
+      // Otherwise, it will get into a bad internal state with uncaught exceptions.
+      await delay(2000);
+
+      // peek additional messages
+      deliveryId = await sender.scheduleMessage(
+        new Date("2020-04-25T12:00:00Z"),
+        TestMessage.getSample()
+      );
+      deliveryIds.push(deliveryId);
+      deliveryIds.length.should.equal(2, "Unexpected number of scheduled messages.");
+
+      refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+    });
   });
 
-  it("can receive and settle messages after a disconnect", async function(): Promise<void> {
-    // Create the sender and receiver.
-    sbClient = getServiceBusClient();
-    const { receiverClient, senderClient } = await getSenderReceiverClients(
-      sbClient,
-      TestClientType.UnpartitionedQueue,
-      TestClientType.UnpartitionedQueue
-    );
-    const sender = senderClient.createSender();
-    // Send a message so we have something to peek.
+  describe("Management operations should throw error if the Client is closed", function(): void {
+    afterEach(async () => {
+      return afterEachTest();
+    });
 
-    await sender.sendBatch([TestMessage.getSample(), TestMessage.getSample()]);
-
-    let peekedMessageCount = 0;
-    let messages = await receiverClient.peek(1);
-    peekedMessageCount += messages.length;
-
-    peekedMessageCount.should.equal(1, "Unexpected number of peeked messages.");
-
-    const connectionContext = (receiverClient as QueueClient)["_context"].namespace;
-    const refreshConnection = connectionContext.refreshConnection;
-    let refreshConnectionCalled = 0;
-    connectionContext.refreshConnection = function(...args) {
-      refreshConnectionCalled++;
-      refreshConnection.apply(this, args);
-    };
-
-    // Simulate a disconnect being called with a non-retryable error.
-    connectionContext.connection["_connection"].idle();
-
-    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
-    // Otherwise, it will get into a bad internal state with uncaught exceptions.
-    await delay(2000);
-
-    // peek additional messages
-    messages = await receiverClient.peek(1);
-    peekedMessageCount += messages.length;
-    peekedMessageCount.should.equal(2, "Unexpected number of peeked messages.");
-
-    refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
-  });
-
-  it("schedule can receive and settle messages after a disconnect", async function(): Promise<
-    void
-  > {
-    // Create the sender and receiver.
-    sbClient = getServiceBusClient();
-    const { receiverClient, senderClient } = await getSenderReceiverClients(
-      sbClient,
-      TestClientType.UnpartitionedQueue,
-      TestClientType.UnpartitionedQueue
-    );
-    const sender = senderClient.createSender();
-    // Send a message so we have something to peek.
-
-    const deliveryIds = [];
-    let deliveryId = await sender.scheduleMessage(
-      new Date("2020-04-25T12:00:00Z"),
-      TestMessage.getSample()
-    );
-    deliveryIds.push(deliveryId);
-
-    deliveryIds.length.should.equal(1, "Unexpected number of scheduled messages.");
-
-    const connectionContext = (receiverClient as QueueClient)["_context"].namespace;
-    const refreshConnection = connectionContext.refreshConnection;
-    let refreshConnectionCalled = 0;
-    connectionContext.refreshConnection = function(...args) {
-      refreshConnectionCalled++;
-      refreshConnection.apply(this, args);
-    };
-
-    // Simulate a disconnect being called with a non-retryable error.
-    connectionContext.connection["_connection"].idle();
-
-    // Allow rhea to clear internal setTimeouts (since we're triggering idle manually).
-    // Otherwise, it will get into a bad internal state with uncaught exceptions.
-    await delay(2000);
-
-    // peek additional messages
-    deliveryId = await sender.scheduleMessage(
-      new Date("2020-04-25T12:00:00Z"),
-      TestMessage.getSample()
-    );
-    deliveryIds.push(deliveryId);
-    deliveryIds.length.should.equal(2, "Unexpected number of scheduled messages.");
-
-    refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+    let senderClient: QueueClient | TopicClient;
+    let receiverClient: QueueClient | SubscriptionClient;
+    let sender: Sender;
+    let receiver: Receiver;
+    async function beforeEachTest(senderType: TestClientType, receiverType: TestClientType) {
+      // Create the sender and receiver.
+      sbClient = getServiceBusClient();
+      const clients = await getSenderReceiverClients(sbClient, senderType, receiverType);
+      senderClient = clients.senderClient;
+      receiverClient = clients.receiverClient;
+      sender = senderClient.createSender();
+      receiver = receiverClient.createReceiver(ReceiveMode.peekLock);
+      sender;
+      receiver;
+    }
+    async function verifyClientClosedError(func: Function, partialErrorMsg: string) {
+      let errorWasThrown = false;
+      try {
+        await func();
+      } catch (error) {
+        should.equal(
+          (error.message as string).includes(partialErrorMsg),
+          true,
+          `Unexpected Error Message - ${error.message}`
+        );
+        errorWasThrown = true;
+      }
+      should.equal(errorWasThrown, true, "Error wasn't thrown");
+    }
+    it.only("peek throws error after the client is closed", async function(): Promise<void> {
+      await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+      await verifyClientClosedError(async () => {
+        await receiverClient.close();
+        await receiverClient.peek();
+      }, "has been closed and can no longer be used. Please create a new client using an instance of ServiceBusClient.");
+    });
+    it.only("peekBySequenceNumber throws error after the client is closed", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+      await verifyClientClosedError(async () => {
+        await receiverClient.close();
+        await receiverClient.peekBySequenceNumber(new Long(0));
+      }, "has been closed and can no longer be used. Please create a new client using an instance of ServiceBusClient.");
+    });
+    it.only("receiveDeferredMessage throws error after the client is closed", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+      await verifyClientClosedError(async () => {
+        await receiverClient.close();
+        await receiver.receiveDeferredMessage(new Long(0));
+      }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
+    });
+    it.only("receiveDeferredMessages throws error after the client is closed", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+      await verifyClientClosedError(async () => {
+        await receiverClient.close();
+        await receiver.receiveDeferredMessages([new Long(0)]);
+      }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
+    });
+    it.only("renewMessageLock throws error after the client is closed", async function(): Promise<
+      void
+    > {
+      await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+      await verifyClientClosedError(async () => {
+        await receiverClient.close();
+        await receiver.renewMessageLock();
+      }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
+    });
   });
 });

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -194,5 +194,13 @@ describe("ManagementClient", function(): void {
         await receiver.receiveDeferredMessages([new Long(0)]);
       }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
     });
+
+    it("renewMessageLock throws error after the client is closed", async function(): Promise<void> {
+      await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
+      await verifyClientClosedError(async () => {
+        await receiverClient.close();
+        await receiver.renewMessageLock("");
+      }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
+    });
   });
 });

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -156,14 +156,16 @@ describe("ManagementClient", function(): void {
       }
       should.equal(errorWasThrown, true, "Error wasn't thrown");
     }
-    it.only("peek throws error after the client is closed", async function(): Promise<void> {
+
+    it("peek throws error after the client is closed", async function(): Promise<void> {
       await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
       await verifyClientClosedError(async () => {
         await receiverClient.close();
         await receiverClient.peek();
       }, "has been closed and can no longer be used. Please create a new client using an instance of ServiceBusClient.");
     });
-    it.only("peekBySequenceNumber throws error after the client is closed", async function(): Promise<
+
+    it("peekBySequenceNumber throws error after the client is closed", async function(): Promise<
       void
     > {
       await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
@@ -172,7 +174,8 @@ describe("ManagementClient", function(): void {
         await receiverClient.peekBySequenceNumber(new Long(0));
       }, "has been closed and can no longer be used. Please create a new client using an instance of ServiceBusClient.");
     });
-    it.only("receiveDeferredMessage throws error after the client is closed", async function(): Promise<
+
+    it("receiveDeferredMessage throws error after the client is closed", async function(): Promise<
       void
     > {
       await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
@@ -181,22 +184,14 @@ describe("ManagementClient", function(): void {
         await receiver.receiveDeferredMessage(new Long(0));
       }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
     });
-    it.only("receiveDeferredMessages throws error after the client is closed", async function(): Promise<
+
+    it("receiveDeferredMessages throws error after the client is closed", async function(): Promise<
       void
     > {
       await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
       await verifyClientClosedError(async () => {
         await receiverClient.close();
         await receiver.receiveDeferredMessages([new Long(0)]);
-      }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
-    });
-    it.only("renewMessageLock throws error after the client is closed", async function(): Promise<
-      void
-    > {
-      await beforeEachTest(TestClientType.UnpartitionedQueue, TestClientType.UnpartitionedQueue);
-      await verifyClientClosedError(async () => {
-        await receiverClient.close();
-        await receiver.renewMessageLock();
       }, "has been closed. The receiver created by it can no longer be used. Please create a new client using an instance of ServiceBusClient.");
     });
   });


### PR DESCRIPTION
Do not set managementClient to undefined to avoid TypeError and to allow using managementClient for settlement to surface better errors. 

#### Moving `isClosed=true` to the top
- isOpen() would return false in case the client is being closed was unused(meaning never sent/received any messages or any other operations)
   ![image](https://user-images.githubusercontent.com/10452642/80651503-e1d03680-8a2a-11ea-897e-3e3fdc096a55.png)
 - And the close() would return right away, we never set the `isClosed` flag to true. This would allow using the client even after it is closed. 
- To avoid the above, moved this `isClosed=true` to the top which would make the SDK throw an error when user tries to operate on a closed client.
