### PR TITLE
[core-http] revert back to use non-rollup type definition file

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -31,8 +31,8 @@
   "types": "./types/latest/src/coreHttp.d.ts",
   "typesVersions": {
     "<3.6": {
-      "types/latest/*": [
-        "types/3.1/*"
+      "types/latest/src/*": [
+        "types/3.1/src/*"
       ]
     }
   },
@@ -42,8 +42,8 @@
     "dom-shim.d.ts",
     "es/src/**/*.js",
     "es/src/**/*.js.map",
-    "types/latest/coreHttp.d.ts",
-    "types/3.1/coreHttp.d.ts",
+    "types/*/src/**/*.d.ts",
+    "types/*/src/**/*.d.ts.map",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Due to the following api-extractor issue, our tripple slash reference to
`../dom-shim.d.ts` is not kept in the rollup type definition file.

https://github.com/microsoft/rushstack/issues/1761

Until the issue is fixed, we will have to stay with the non-rollup type
definition files.