### PR TITLE
[Storage] Change StorageSharedKeyCredential browser stub to class

### DIFF
--- a/sdk/storage/storage-blob/src/credentials/StorageSharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-blob/src/credentials/StorageSharedKeyCredential.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const StorageSharedKeyCredential = undefined;
+export class StorageSharedKeyCredential {}

--- a/sdk/storage/storage-file-datalake/src/credentials/StorageSharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-file-datalake/src/credentials/StorageSharedKeyCredential.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const StorageSharedKeyCredential = undefined;
+export class StorageSharedKeyCredential {}

--- a/sdk/storage/storage-file-share/src/credentials/StorageSharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-file-share/src/credentials/StorageSharedKeyCredential.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const StorageSharedKeyCredential = undefined;
+export class StorageSharedKeyCredential {}

--- a/sdk/storage/storage-queue/src/credentials/StorageSharedKeyCredential.browser.ts
+++ b/sdk/storage/storage-queue/src/credentials/StorageSharedKeyCredential.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const StorageSharedKeyCredential = undefined;
+export class StorageSharedKeyCredential {}


### PR DESCRIPTION
This fixes #8499.

The issue was that in `StorageClient.ts` we have the following check
and assume that in browser scenario `isNode` would be `false` which
would short-circuit the evaluation of `factory instanceof
StorageSharedKeyCredential`. So we added an `undefined` const for
browser stub of `StorageSharedKeyCredential`.

```typescript
      if (
        (isNode && factory instanceof StorageSharedKeyCredential) ||
        factory instanceof AnonymousCredential ||
        isTokenCredential(factory)
      ) {
        this.credential = factory;
      }
```

However, in an Electron + Angular application, `isNode` is `true` but
browser files are used. So the condition after `&&` is evaluated and
caused an error:

```
TypeError: Right-hand side of 'instanceof' is not an object
at DataLakeServiceClient.StorageClient (StorageClient.js:35)
at new DataLakeServiceClient (DataLakeServiceClient.js:39)
```

This fix changes the stub of `StorageSharedKeyCredential` to an empty
class instead so the condition will not throw but be evaluated to
`false` because this credential type is not supported in browser.