### PR TITLE
[service-bus] Track2 - adding in a send(messages[]) overload

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -91,24 +91,23 @@ using the [createSender][sbclient_createsender] method.
 
 This gives you a sender which you can use to [send][sender_send] messages.
 
-You can also use the [sendBatch][sender_sendbatch]
-method to efficiently send multiple messages in a single send.
-
 ```javascript
 const sender = serviceBusClient.createSender("my-queue");
+
+// sending a single message
 await sender.send({
-  body: "my-message-body",
+  body: "my-message-body"
 });
 
-const batch = await sender.createBatch();
-
-// NOTE: tryAdd() returns false if the message could not
-// be added because the batch is at capacity.
-batch.tryAdd({ body: "my-message-body-1" });
-batch.tryAdd({ body: "my-message-body-2" });
-batch.tryAdd({ body: "my-message-body-3" });
-
-await sender.sendBatch(batch);
+// sending multiple messages
+await sender.send([
+  {
+    body: "my-message-body"
+  },
+  {
+    body: "another-message-body
+  }
+]);
 ```
 
 ### Receive messages
@@ -147,7 +146,7 @@ const myErrorHandler = async (error) => {
 };
 receiver.subscribe({
   processMessage: myMessageHandler,
-  processError: myErrorHandler,
+  processError: myErrorHandler
 });
 ```
 
@@ -183,7 +182,7 @@ your message lands in the right session.
 const sender = serviceBusClient.createSender("my-session-queue");
 await sender.send({
   body: "my-message-body",
-  sessionId: "my-session",
+  sessionId: "my-session"
 });
 ```
 
@@ -208,7 +207,7 @@ There are two ways of choosing which session to open:
 
    ```javascript
    const receiver = serviceBusClient.createSessionReceiver("my-session-queue", "peekLock", {
-     sessionId: "my-session",
+     sessionId: "my-session"
    });
    ```
 
@@ -301,7 +300,6 @@ If you'd like to contribute to this library, please read the [contributing guide
 [sbclient_createsessionreceiver]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/classes/servicebusclient.html#createsessionreceiver
 [sender]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html
 [sender_send]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html#send
-[sender_sendbatch]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/sender.html#sendbatch
 [receiver]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/receiver.html
 [receiverreceivebatch]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/receiver.html#receivebatch
 [receiver_subscribe]: https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-service-bus/7.0.0-preview.1/interfaces/receiver.html#subscribe

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -146,7 +146,7 @@ export interface Sender {
     scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[], options?: OperationOptions): Promise<Long[]>;
     send(message: ServiceBusMessage, options?: OperationOptions): Promise<void>;
     send(messages: ServiceBusMessage[], options?: OperationOptions): Promise<void>;
-    sendBatch(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
+    send(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -145,6 +145,7 @@ export interface Sender {
     scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage, options?: OperationOptions): Promise<Long>;
     scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[], options?: OperationOptions): Promise<Long[]>;
     send(message: ServiceBusMessage, options?: OperationOptions): Promise<void>;
+    send(messages: ServiceBusMessage[], options?: OperationOptions): Promise<void>;
     sendBatch(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
 }
 

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -231,7 +231,7 @@ export class SenderImpl implements Sender {
         }
       }
 
-      return this.send(batch, options);
+      return this._sender.sendBatch(batch, options);
     } else if (isServiceBusMessageBatch(messageOrMessagesOrBatch)) {
       return this._sender.sendBatch(messageOrMessagesOrBatch, options);
     } else {

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -46,7 +46,7 @@ export interface Sender {
   send(message: ServiceBusMessage, options?: OperationOptions): Promise<void>;
   /**
    * Sends the given messages in a single batch i.e. in a single AMQP message after creating an AMQP
-   * Sender link if it doesnt already exists.
+   * Sender link if it doesn't already exist.
    *
    * - To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
    * and/or `partitionKey` properties respectively on the messages.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -229,7 +229,7 @@ export class SenderImpl implements Sender {
       for (const message of messageOrMessages) {
         if (!batch.tryAdd(message)) {
           throw new Error(
-            "Messages were too big to fit in a single batch. Remove some messages and try again or use createBatch() and sendBatch(), which give more fine-grained control."
+            "Messages were too big to fit in a single batch. Remove some messages and try again or use createBatch() and sendBatch(), which gives more fine-grained control."
           );
         }
       }

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -51,7 +51,7 @@ export interface Sender {
    * - To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
    * and/or `partitionKey` properties respectively on the messages.
    * - When doing so, all messages in the batch should have the same `sessionId` (if using
-   *  sessions) and the same `parititionKey` (if using paritions).
+   *  sessions) and the same `partitionKey` (if using partitions).
    *
    * @param messages - An array of ServiceBusMessage objects to be sent in a Batch message.
    * @param options - Options bag to pass an abort signal or tracing options.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -237,7 +237,7 @@ export class SenderImpl implements Sender {
     } else {
       throwTypeErrorIfParameterMissing(
         this._context.namespace.connectionId,
-        "message",
+        "message, messages or messageBatch",
         messageOrMessagesOrBatch
       );
       return this._sender.send(messageOrMessagesOrBatch, options);

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -422,9 +422,17 @@ export class SenderImpl implements Sender {
   }
 }
 
-function isServiceBusMessageBatch(
+/**
+ * @internal
+ * @ignore
+ */
+export function isServiceBusMessageBatch(
   messageBatchOrAnything: any
 ): messageBatchOrAnything is ServiceBusMessageBatch {
+  if (messageBatchOrAnything == null) {
+    return false;
+  }
+
   const possibleBatch = messageBatchOrAnything as ServiceBusMessageBatch;
 
   return (

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -227,11 +227,9 @@ export class SenderImpl implements Sender {
       const batch = await this.createBatch(options);
 
       for (const message of messageOrMessages) {
-        if (!batch.tryAdd(message)) {
-          throw new Error(
-            "Messages were too big to fit in a single batch. Remove some messages and try again or use createBatch() and sendBatch(), which gives more fine-grained control."
-          );
-        }
+        // we'll let the service throw it's normal error rather than
+        // attempt to do that here.
+        batch.tryAdd(message);
       }
 
       return this.sendBatch(batch, options);

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -233,12 +233,6 @@ export class SenderImpl implements Sender {
 
       return this.send(batch, options);
     } else if (isServiceBusMessageBatch(messageOrMessagesOrBatch)) {
-      this._throwIfSenderOrConnectionClosed();
-      throwTypeErrorIfParameterMissing(
-        this._context.namespace.connectionId,
-        "messageBatch",
-        messageOrMessagesOrBatch
-      );
       return this._sender.sendBatch(messageOrMessagesOrBatch, options);
     } else {
       throwTypeErrorIfParameterMissing(

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -61,7 +61,13 @@ export interface Sender {
    */
   send(messages: ServiceBusMessage[], options?: OperationOptions): Promise<void>;
   /**
-   * Sends a batch of messages to the associated service-bus entity.
+   * Sends a batch of messages to the associated service-bus entity after creating an AMQP
+   * Sender link if it doesn't already exist.
+   *
+   * - To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
+   * and/or `partitionKey` properties respectively on the messages.
+   * - When doing so, all messages in the batch should have the same `sessionId` (if using
+   *  sessions) and the same `partitionKey` (if using partitions).
    *
    * @param {ServiceBusMessageBatch} messageBatch A batch of messages that you can create using the {@link createBatch} method.
    * @param options - Options bag to pass an abort signal or tracing options.

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -65,24 +65,6 @@ export interface Sender {
    */
   send(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
 
-  // sendBatch(<Array of messages>) - Commented
-  // /**
-  //  * Sends the given messages in a single batch i.e. in a single AMQP message after creating an AMQP
-  //  * Sender link if it doesnt already exists.
-  //  *
-  //  * - To send messages to a `session` and/or `partition` enabled Queue/Topic, set the `sessionId`
-  //  * and/or `partitionKey` properties respectively on the messages.
-  //  * - When doing so, all
-  //  * messages in the batch should have the same `sessionId` (if using sessions) and the same
-  //  * `parititionKey` (if using paritions).
-  //  *
-  //  * @param messages - An array of ServiceBusMessage objects to be sent in a Batch message.
-  //  * @return Promise<void>
-  //  * @throws Error if the underlying connection, client or sender is closed.
-  //  * @throws MessagingError if the service returns an error while sending messages to the service.
-  //  */
-  // sendBatch(messages: ServiceBusMessage[]): Promise<void>;
-
   /**
    * Creates an instance of `ServiceBusMessageBatch` to which one can add messages until the maximum supported size is reached.
    * The batch can be passed to the {@link send} method to send the messages to Azure Service Bus.

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -797,7 +797,7 @@ describe("batchReceiver", () => {
       for (const message of testMessages) {
         batchMessageToSend.tryAdd(message);
       }
-      await senderClient.sendBatch(batchMessageToSend);
+      await senderClient.send(batchMessageToSend);
       const msgs1 = await receiverClient.receiveBatch(1);
       const msgs2 = await receiverClient.receiveBatch(1);
 

--- a/sdk/servicebus/service-bus/test/internal/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/sender.spec.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import chai from "chai";
+import { ServiceBusMessageBatchImpl } from "../../src/serviceBusMessageBatch";
+import { ClientEntityContext } from "../../src/clientEntityContext";
+import { ServiceBusMessage } from "../../src";
+import { isServiceBusMessageBatch } from "../../src/sender";
+const assert = chai.assert;
+
+describe("sender unit tests", () => {
+  it("isServiceBusMessageBatch", () => {
+    assert.isTrue(
+      isServiceBusMessageBatch(new ServiceBusMessageBatchImpl({} as ClientEntityContext, 100))
+    );
+
+    assert.isFalse(isServiceBusMessageBatch(undefined));
+    assert.isFalse(isServiceBusMessageBatch((4 as any) as ServiceBusMessage));
+    assert.isFalse(isServiceBusMessageBatch(({} as any) as ServiceBusMessage));
+  });
+});

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -684,7 +684,10 @@ describe("invalid parameters", () => {
         caughtError = error;
       }
       should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "message"`);
+      should.equal(
+        caughtError && caughtError.message,
+        `Missing parameter "message, messages or messageBatch"`
+      );
     });
 
     it("Sendbatch: Missing messageBatch in Sender", async function(): Promise<void> {
@@ -695,7 +698,10 @@ describe("invalid parameters", () => {
         caughtError = error;
       }
       should.equal(caughtError && caughtError.name, "TypeError");
-      should.equal(caughtError && caughtError.message, `Missing parameter "messageBatch"`);
+      should.equal(
+        caughtError && caughtError.message,
+        `Missing parameter "message, messages or messageBatch"`
+      );
     });
 
     it("ScheduledMessage: Missing date in Sender", async function(): Promise<void> {

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -690,7 +690,7 @@ describe("invalid parameters", () => {
     it("Sendbatch: Missing messageBatch in Sender", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await sender.sendBatch(undefined as any);
+        await sender.send(undefined as any);
       } catch (error) {
         caughtError = error;
       }

--- a/sdk/servicebus/service-bus/test/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLock.spec.ts
@@ -108,7 +108,7 @@ describe("renew lock", () => {
         },
         TestClientType.UnpartitionedQueue
       );
-    }).timeout(95000);
+    }).timeout(95000 + 30000);
 
     it("Streaming Receiver: No lock renewal when config value is less than lock duration", async function(): Promise<
       void

--- a/sdk/servicebus/service-bus/test/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/retries.spec.ts
@@ -311,7 +311,7 @@ describe("Retries - MessageSender", () => {
   it("Unpartitioned Queue: sendBatch", async function(): Promise<void> {
     await beforeEachTest(TestClientType.UnpartitionedQueue);
     await mockInitAndVerifyRetries(async () => {
-      await senderClient.sendBatch(1 as any);
+      await senderClient.send(1 as any);
     });
   });
 
@@ -332,7 +332,7 @@ describe("Retries - MessageSender", () => {
   it("Unpartitioned Queue with Sessions: sendBatch", async function(): Promise<void> {
     await beforeEachTest(TestClientType.UnpartitionedQueue);
     await mockInitAndVerifyRetries(async () => {
-      await senderClient.sendBatch(1 as any);
+      await senderClient.send(1 as any);
     });
   });
 });

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -57,15 +57,11 @@ describe("Send Batch", () => {
       return messagesToSend;
     }
 
-    async function testSendBatch(
-      useSessions: boolean,
-      // Max batch size
-      maxSizeInBytes?: number
-    ): Promise<void> {
+    async function testSendBatch(useSessions: boolean): Promise<void> {
       // Prepare messages to send
       const messagesToSend = prepareMessages(useSessions);
       const sentMessages: ServiceBusMessage[] = [];
-      const batchMessage = await senderClient.createBatch({ maxSizeInBytes });
+      const batchMessage = await senderClient.createBatch();
 
       for (const messageToSend of messagesToSend) {
         const batchHasCapacity = batchMessage.tryAdd(messageToSend);
@@ -218,30 +214,16 @@ describe("Send Batch", () => {
       return messagesToSend;
     }
 
-    async function testSendBatch(
-      useSessions: boolean,
-      // Max batch size
-      maxSizeInBytes?: number
-    ): Promise<void> {
+    async function testSendBatch(useSessions: boolean): Promise<void> {
       // Prepare messages to send
       const messagesToSend = prepareMessages(useSessions);
-      const sentMessages: ServiceBusMessage[] = [];
-      const batchMessage = await senderClient.createBatch({ maxSizeInBytes });
+      await senderClient.send(messagesToSend);
 
-      for (const messageToSend of messagesToSend) {
-        const batchHasCapacity = batchMessage.tryAdd(messageToSend);
-        if (!batchHasCapacity) {
-          break;
-        } else {
-          sentMessages.push(messageToSend);
-        }
-      }
-      await senderClient.sendBatch(batchMessage);
       // receive all the messages in receive and delete mode
       await serviceBusClient.test.verifyAndDeleteAllSentMessages(
         entityNames,
         useSessions,
-        sentMessages
+        messagesToSend
       );
     }
 
@@ -304,23 +286,14 @@ describe("Send Batch", () => {
     async function testSendBatch(useSessions: boolean): Promise<void> {
       // Prepare messages to send
       const messagesToSend = prepareMessages(useSessions);
-      const sentMessages: ServiceBusMessage[] = [];
-      const batchMessage = await senderClient.createBatch();
 
-      for (const messageToSend of messagesToSend) {
-        const batchHasCapacity = batchMessage.tryAdd(messageToSend);
-        if (!batchHasCapacity) {
-          break;
-        } else {
-          sentMessages.push(messageToSend);
-        }
-      }
-      await senderClient.sendBatch(batchMessage);
+      await senderClient.send(messagesToSend);
+
       // receive all the messages in receive and delete mode
       await serviceBusClient.test.verifyAndDeleteAllSentMessages(
         entityNames,
         useSessions,
-        sentMessages
+        messagesToSend
       );
     }
 
@@ -395,15 +368,11 @@ describe("Send Batch", () => {
       return messagesToSend;
     }
 
-    async function testSendBatch(
-      useSessions: boolean,
-      // Max batch size
-      maxSizeInBytes?: number
-    ): Promise<void> {
+    async function testSendBatch(useSessions: boolean): Promise<void> {
       // Prepare messages to send
       const messagesToSend = prepareMessages(useSessions);
       const sentMessages: ServiceBusMessage[] = [];
-      const batchMessage = await senderClient.createBatch({ maxSizeInBytes });
+      const batchMessage = await senderClient.createBatch();
 
       for (const messageToSend of messagesToSend) {
         const batchHasCapacity = batchMessage.tryAdd(messageToSend);

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -5,7 +5,7 @@ import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { ServiceBusMessage } from "../src";
+import { ServiceBusMessage, OperationOptions } from "../src";
 import { TestClientType } from "./utils/testUtils";
 import {
   ServiceBusClientForTests,
@@ -13,6 +13,7 @@ import {
   EntityName
 } from "./utils/testutils2";
 import { Sender } from "../src/sender";
+import { ConditionErrorNameMapper } from "@azure/core-amqp";
 
 describe("Send Batch", () => {
   let senderClient: Sender;
@@ -603,5 +604,28 @@ describe("Send Batch", () => {
       await beforeEachTest(TestClientType.UnpartitionedSubscriptionWithSessions);
       await testSendBatch(maxSizeInBytes);
     });
+  });
+
+  it("send(messages[]) overload throws an error if the size exceeds a single batch", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(TestClientType.PartitionedQueue);
+    try {
+      await senderClient.send(
+        [{ body: "ignored since anything will be bigger than the batch size I passed" }],
+        {
+          // this isn't a documented option for send(batch) but we do pass it through to the underlying
+          // createBatch call.
+          maxSizeInBytes: 1
+        } as OperationOptions
+      );
+      should.fail("Should have thrown - the batch is too big");
+    } catch (err) {
+      should.equal(
+        "Messages were too big to fit in a single batch. Remove some messages and try again or create your own batch using createBatch(), which gives more fine-grained control.",
+        err.message
+      );
+      should.equal(ConditionErrorNameMapper["amqp:link:message-size-exceeded"], err.code);
+    }
   });
 });

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -301,15 +301,11 @@ describe("Send Batch", () => {
       return messagesToSend;
     }
 
-    async function testSendBatch(
-      useSessions: boolean,
-      // Max batch size
-      maxSizeInBytes?: number
-    ): Promise<void> {
+    async function testSendBatch(useSessions: boolean): Promise<void> {
       // Prepare messages to send
       const messagesToSend = prepareMessages(useSessions);
       const sentMessages: ServiceBusMessage[] = [];
-      const batchMessage = await senderClient.createBatch({ maxSizeInBytes });
+      const batchMessage = await senderClient.createBatch();
 
       for (const messageToSend of messagesToSend) {
         const batchHasCapacity = batchMessage.tryAdd(messageToSend);

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -71,7 +71,7 @@ describe("Send Batch", () => {
           sentMessages.push(messageToSend);
         }
       }
-      await senderClient.sendBatch(batchMessage);
+      await senderClient.send(batchMessage);
       // receive all the messages in receive and delete mode
       await serviceBusClient.test.verifyAndDeleteAllSentMessages(
         entityNames,
@@ -156,7 +156,7 @@ describe("Send Batch", () => {
           sentMessages.push(messageToSend);
         }
       }
-      await senderClient.sendBatch(batchMessage);
+      await senderClient.send(batchMessage);
       // receive all the messages in receive and delete mode
       await serviceBusClient.test.verifyAndDeleteAllSentMessages(
         entityNames,
@@ -382,7 +382,7 @@ describe("Send Batch", () => {
           sentMessages.push(messageToSend);
         }
       }
-      await senderClient.sendBatch(batchMessage);
+      await senderClient.send(batchMessage);
       // receive all the messages in receive and delete mode
       await serviceBusClient.test.verifyAndDeleteAllSentMessages(
         entityNames,
@@ -491,7 +491,7 @@ describe("Send Batch", () => {
         false,
         "tryAdd should have failed for the fourth message"
       );
-      await senderClient.sendBatch(batchMessage);
+      await senderClient.send(batchMessage);
       // receive all the messages in receive and delete mode
       await serviceBusClient.test.verifyAndDeleteAllSentMessages(entityNames, useSessions, [
         messagesToSend[0]

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -5,7 +5,7 @@ import chai from "chai";
 const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
-import { ServiceBusMessage, OperationOptions } from "../src";
+import { ServiceBusMessage } from "../src";
 import { TestClientType } from "./utils/testUtils";
 import {
   ServiceBusClientForTests,
@@ -603,28 +603,5 @@ describe("Send Batch", () => {
       await beforeEachTest(TestClientType.UnpartitionedSubscriptionWithSessions);
       await testSendBatch(maxSizeInBytes);
     });
-  });
-
-  it("send(messages[]) overload throws an error if the size exceeds a single batch", async function(): Promise<
-    void
-  > {
-    await beforeEachTest(TestClientType.PartitionedQueue);
-
-    try {
-      await senderClient.send(
-        [{ body: "ignored since anything will be bigger than the batch size I passed" }],
-        {
-          // this isn't a documented option for send(batch) but we do pass it through to the underlying
-          // createBatch call.
-          maxSizeInBytes: 1
-        } as OperationOptions
-      );
-      should.fail("Should have thrown - the batch is too big");
-    } catch (err) {
-      should.equal(
-        "Messages were too big to fit in a single batch. Remove some messages and try again or use createBatch() and sendBatch(), which gives more fine-grained control.",
-        err.message
-      );
-    }
   });
 });

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -605,7 +605,7 @@ describe("Send Batch", () => {
     });
   });
 
-  it("send(batch) overload throws an error if the size exceeds a single batch", async function(): Promise<
+  it("send(messages[]) overload throws an error if the size exceeds a single batch", async function(): Promise<
     void
   > {
     await beforeEachTest(TestClientType.PartitionedQueue);

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -76,11 +76,23 @@ describe("Errors with non existing Namespace", function(): void {
   });
 
   const testError = (err: Error | MessagingError): void => {
-    const expectedErrCode = isNode ? "ENOTFOUND" : "ServiceCommunicationError";
     if (!isMessagingError(err)) {
       should.equal(true, false, "Error expected to be instance of MessagingError");
     } else {
-      should.equal(err.code, expectedErrCode, "Error code is different than expected");
+      if (isNode) {
+        should.equal(
+          err.code === "ENOTFOUND" || err.code === "EAI_AGAIN",
+          true,
+          `Error code ${err.code} is different than expected`
+        );
+      } else {
+        should.equal(
+          err.code,
+          "ServiceCommunicationError",
+          "Error code is different than expected"
+        );
+      }
+
       errorWasThrown = true;
     }
   };

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -106,7 +106,7 @@ describe("Errors with non existing Namespace", function(): void {
     void
   > {
     const sender = sbClient.createSender("some-queue");
-    await sender.sendBatch(1 as any).catch(testError);
+    await sender.send(1 as any).catch(testError);
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
   });
 
@@ -192,7 +192,7 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
     void
   > {
     const sender = sbClient.createSender("some-queue");
-    await sender.sendBatch(1 as any).catch((err) => testError(err, "some-queue"));
+    await sender.send(1 as any).catch((err) => testError(err, "some-queue"));
     should.equal(errorWasThrown, true, "Error thrown flag must be true");
   });
 
@@ -475,7 +475,7 @@ describe("Errors after close()", function(): void {
     should.equal(errorCreateBatch, expectedErrorMsg, "Expected error not thrown for createBatch()");
 
     let errorSendBatch: string = "";
-    await sender.sendBatch(1 as any).catch((err) => {
+    await sender.send(1 as any).catch((err) => {
       errorSendBatch = err.message;
     });
     should.equal(errorSendBatch, expectedErrorMsg, "Expected error not thrown for sendBatch()");

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -949,7 +949,7 @@ describe("Streaming", () => {
       testMessages.forEach((message) => {
         batchMessageToSend.tryAdd(message);
       });
-      await senderClient.sendBatch(batchMessageToSend);
+      await senderClient.send(batchMessageToSend);
 
       const settledMsgs: ReceivedMessage[] = [];
       const receivedMsgs: ReceivedMessage[] = [];
@@ -1068,7 +1068,7 @@ describe("Streaming", () => {
         messages.push(message);
         batch.tryAdd(message);
       }
-      await senderClient.sendBatch(batch);
+      await senderClient.send(batch);
 
       const receivedMsgs: ReceivedMessageWithLock[] = [];
 

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -866,7 +866,7 @@ describe("Streaming with sessions", () => {
       for (const message of testMessages) {
         batchMessageToSend.tryAdd(message);
       }
-      await senderClient.sendBatch(batchMessageToSend);
+      await senderClient.send(batchMessageToSend);
 
       const settledMsgs: ReceivedMessageWithLock[] = [];
       const receivedMsgs: ReceivedMessageWithLock[] = [];
@@ -1016,7 +1016,7 @@ describe("Streaming with sessions", () => {
         messages.push(message);
         batch.tryAdd(message);
       }
-      await senderClient.sendBatch(batch);
+      await senderClient.send(batch);
 
       const receivedMsgs: ReceivedMessageWithLock[] = [];
 


### PR DESCRIPTION
Created a send(messages[]) overload that transparently creates and sends a batch internally.