### PR TITLE
[Identity] Change expires_on precendence for IMDS

### DIFF
--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -245,6 +245,19 @@ export class ManagedIdentityCredential implements TokenCredential {
           authRequestOptions = this.createCloudShellMsiAuthRequest(resource, clientId);
         }
       } else {
+        expiresInParser = (requestBody: any) => {
+          if (requestBody.expires_on) {
+            // Use the expires_on timestamp if it's available
+            const expires = +requestBody.expires_on * 1000;
+            logger.info(`ManagedIdentityCredential: IMDS using expires_on: ${expires} (original value: ${requestBody.expires_on})`);
+            return expires;
+          } else {
+            // If these aren't possible, use expires_in and calculate a timestamp
+            const expires = Date.now() + requestBody.expires_in * 1000;
+            logger.info(`ManagedIdentityCredential: IMDS using expires_in: ${expires} (original value: ${requestBody.expires_in})`);
+            return expires;
+          }
+        };
         // Ping the IMDS endpoint to see if it's available
         if (
           !checkIfImdsEndpointAvailable ||


### PR DESCRIPTION
This adds the IMDS expires_on precedence fix that was rolled into 1.0.3 into the current preview as well.

This allows us to use expires_on, if available, if we're using IMDS. Previously, we would only use expires_in, which meant that under some conditions, we wouldn't have an updated expiration of the token.