### PR TITLE
Add ServiceDirectory parameter to usages of remove-tests-resources.yml

### DIFF
--- a/common/smoke-test/smoke-tests.yml
+++ b/common/smoke-test/smoke-tests.yml
@@ -86,3 +86,5 @@ jobs:
         displayName: Run Smoke Test
 
       - template: ../../eng/common/TestResources/remove-test-resources.yml
+        parameters:
+          ServiceDirectory: "$(Build.SourcesDirectory)/common/smoke-test/"

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -102,8 +102,6 @@ remove-test-resources.yml like in the following examples:
 # Run tests
 
 - template: /eng/common/TestResources/remove-test-resources.yml
-  parameters:
-    ServiceDirectory: "${{ parameters.ServiceDirectory }}"
 ```
 
 Be sure to link the **Secrets for Resource Provisioner** variable group

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -102,6 +102,8 @@ remove-test-resources.yml like in the following examples:
 # Run tests
 
 - template: /eng/common/TestResources/remove-test-resources.yml
+  parameters:
+    ServiceDirectory: "${{ parameters.ServiceDirectory }}"
 ```
 
 Be sure to link the **Secrets for Resource Provisioner** variable group

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -114,6 +114,8 @@ jobs:
 
       - ${{ if ne(parameters.ResourceServiceDirectory, '') }}:
         - template: /eng/common/TestResources/remove-test-resources.yml
+          parameters:
+            ServiceDirectory: "${{ parameters.ResourceServiceDirectory }}"
 
       - task: PublishCodeCoverageResults@1
         displayName: "Publish NodeJs Code Coverage to DevOps"


### PR DESCRIPTION
The change that this is merging ahead of is: https://github.com/Azure/azure-sdk-tools/pull/549 

If we don't add the `ServiceDirectory` we'll see failures during the de-provisioning step.