### PR TITLE
[Event Hubs] getParentSpan to take tracing options directly

### DIFF
--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -361,7 +361,7 @@ export class EventHubClient {
    */
   async getProperties(options: GetEventHubPropertiesOptions = {}): Promise<EventHubProperties> {
     throwErrorIfConnectionClosed(this._context);
-    const clientSpan = this._createClientSpan("getEventHubProperties", getParentSpan(options));
+    const clientSpan = this._createClientSpan("getEventHubProperties", getParentSpan(options.tracingOptions));
     try {
       const result = await this._context.managementSession!.getHubRuntimeInformation({
         retryOptions: this._clientOptions.retryOptions,
@@ -391,7 +391,7 @@ export class EventHubClient {
    */
   async getPartitionIds(options: GetPartitionIdsOptions): Promise<Array<string>> {
     throwErrorIfConnectionClosed(this._context);
-    const clientSpan = this._createClientSpan("getPartitionIds", getParentSpan(options), true);
+    const clientSpan = this._createClientSpan("getPartitionIds", getParentSpan(options.tracingOptions), true);
     try {
       const runtimeInfo = await this.getProperties({
         ...options,
@@ -436,7 +436,7 @@ export class EventHubClient {
       partitionId
     );
     partitionId = String(partitionId);
-    const clientSpan = this._createClientSpan("getPartitionProperties", getParentSpan(options));
+    const clientSpan = this._createClientSpan("getPartitionProperties", getParentSpan(options.tracingOptions));
     try {
       const result = await this._context.managementSession!.getPartitionProperties(partitionId, {
         retryOptions: this._clientOptions.retryOptions,

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -188,7 +188,7 @@ export function createProcessingSpan(
   const span = getTracer().startSpan("Azure.EventHubs.process", {
     kind: SpanKind.CONSUMER,
     links,
-    parent: getParentSpan({ tracingOptions: options?.tracingOptions })
+    parent: getParentSpan(options?.tracingOptions)
   });
 
   span.setAttributes({

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -185,7 +185,7 @@ export class EventHubProducer {
       for (let i = 0; i < eventData.length; i++) {
         const event = eventData[i];
         if (!event.properties || !event.properties[TRACEPARENT_PROPERTY]) {
-          const messageSpan = createMessageSpan(getParentSpan(options));
+          const messageSpan = createMessageSpan(getParentSpan(options.tracingOptions));
           // since these message spans are created from same context as the send span,
           // these message spans don't need to be linked.
           // replace the original event with the instrumented one
@@ -197,7 +197,7 @@ export class EventHubProducer {
       spanContextsToLink = eventData._messageSpanContexts;
     }
 
-    const sendSpan = this._createSendSpan(getParentSpan(options), spanContextsToLink);
+    const sendSpan = this._createSendSpan(getParentSpan(options.tracingOptions), spanContextsToLink);
 
     try {
       const result = await this._eventHubSender!.send(eventData, {

--- a/sdk/eventhub/event-hubs/src/util/operationOptions.ts
+++ b/sdk/eventhub/event-hubs/src/util/operationOptions.ts
@@ -26,7 +26,7 @@ export interface OperationOptions {
  * @ignore
  */
 export function getParentSpan(
-  options: Pick<OperationOptions, "tracingOptions">
+  options?: OperationTracingOptions
 ): Span | SpanContext | null | undefined {
-  return options.tracingOptions?.spanOptions?.parent;
+  return options?.spanOptions?.parent;
 }


### PR DESCRIPTION
This PR refactors the `getParentSpan()` function to take tracing options directly to simplify its signature. Fixes #8407