### PR TITLE
[recorder] afterEach is now always executed

### DIFF
--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2020-04-30
+
+- Since Mocha 7.0.0, Mocha behaves as follows: "When conditionally skipping in a it test, related afterEach hooks are now executed"
+  ([Source](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#700--2020-01-05)), now the `recorder.stop()` calls in the `afterEach()` will always be executed. Calling `recorder.skip` should not call `recorder.stop()` anymore.
+
 ## 2020-02-06
 
 - If any URLs are meant to be replaced in the recordings with `replaceableVariables`, hostname from the URLs will be independently matched and replaced. [#7204](https://github.com/Azure/azure-sdk-for-js/issues/7204)

--- a/sdk/test-utils/recorder/CHANGELOG.md
+++ b/sdk/test-utils/recorder/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2020-04-30
 
-- Since Mocha 7.0.0, Mocha behaves as follows: "When conditionally skipping in a it test, related afterEach hooks are now executed"
+- Since Mocha 7.0.0, Mocha behaves as follows: "When conditionally skipping in the `it` test, related afterEach hooks are now executed"
   ([Source](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#700--2020-01-05)), now the `recorder.stop()` calls in the `afterEach()` will always be executed. Calling `recorder.skip` should not call `recorder.stop()` anymore.
 
 ## 2020-02-06

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -182,12 +182,6 @@ export function record(
         (runtime === "browser" && isBrowser()) ||
         !runtime
       ) {
-        // Since Mocha 7.0.0, Mocha behaves as follows:
-        // "When conditionally skipping in a it test, related afterEach hooks are now executed"
-        // Source: https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#700--2020-01-05
-        // Therefore, now the recorder.stop() calls in the afterEach() will always be executed.
-        // if (isRecordMode()) recorder.stop();
-
         // record/playback modes
         // - test title is updated with the given reason
         // - test is skipped

--- a/sdk/test-utils/recorder/src/recorder.ts
+++ b/sdk/test-utils/recorder/src/recorder.ts
@@ -182,8 +182,11 @@ export function record(
         (runtime === "browser" && isBrowser()) ||
         !runtime
       ) {
-        // record mode - recorder is stopped
-        if (isRecordMode()) recorder.stop();
+        // Since Mocha 7.0.0, Mocha behaves as follows:
+        // "When conditionally skipping in a it test, related afterEach hooks are now executed"
+        // Source: https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#700--2020-01-05
+        // Therefore, now the recorder.stop() calls in the afterEach() will always be executed.
+        // if (isRecordMode()) recorder.stop();
 
         // record/playback modes
         // - test title is updated with the given reason


### PR DESCRIPTION
Since Mocha 7.0.0, Mocha behaves as follows:

> "When conditionally skipping in a it test, related afterEach hooks are now executed"
> [Source](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#700--2020-01-05)

Therefore, now the `recorder.stop()` calls in the `afterEach()` will always be executed. Calling `stop()` in `recorder.skip()` causes a double execution of `recorder.stop()`, which hangs the browser tests.