### PR TITLE
[event-hubs] improve EventDataBatch.tryAdd performance

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.1.1 (Unreleased)
 
 - Updates the `EventHubProducerClient.sendBatch` API to accept an array of events.
+- Improves the performance of the `EventDataBatch.tryAdd` method.
 
 ## 5.1.0 (2020-04-07)
 

--- a/sdk/eventhub/event-hubs/review/event-hubs.api.md
+++ b/sdk/eventhub/event-hubs/review/event-hubs.api.md
@@ -59,9 +59,9 @@ export interface EventData {
 // @public
 export interface EventDataBatch {
     readonly count: number;
-    readonly maxSizeInBytes: number;
     // @internal
-    readonly _message: Buffer | undefined;
+    _generateMessage(): Buffer;
+    readonly maxSizeInBytes: number;
     // @internal
     readonly _messageSpanContexts: SpanContext[];
     // @internal

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -4,11 +4,24 @@
 import { EventData, toAmqpMessage } from "./eventData";
 import { ConnectionContext } from "./connectionContext";
 import { AmqpMessage } from "@azure/core-amqp";
-import { message } from "rhea-promise";
+import { message, MessageAnnotations } from "rhea-promise";
 import { throwTypeErrorIfParameterMissing } from "./util/error";
 import { Span, SpanContext } from "@opentelemetry/api";
 import { instrumentEventData, TRACEPARENT_PROPERTY } from "./diagnostics/instrumentEventData";
 import { createMessageSpan } from "./diagnostics/messageSpan";
+
+/**
+ * The amount of bytes to reserve as overhead for a small message.
+ */
+const smallMessageOverhead = 5;
+/**
+ * The amount of bytes to reserve as overhead for a large message.
+ */
+const largeMessageOverhead = 8;
+/**
+ * The maximum number of bytes that a message may be to be considered small.
+ */
+const smallMessageMaxBytes = 255;
 
 /**
  * Checks if the provided eventDataBatch is an instance of `EventDataBatch`.
@@ -149,13 +162,16 @@ export class EventDataBatchImpl implements EventDataBatch {
    */
   private _count: number;
   /**
-   * @property Encoded batch message.
-   */
-  private _batchMessage: Buffer | undefined;
-  /**
    * List of 'message' span contexts.
    */
   private _spanContexts: SpanContext[] = [];
+  /**
+   * The message annotations to apply on the batch envelope.
+   * This will reflect the message annotations on the first event
+   * that was added to the batch.
+   * A common annotation is the partition key.
+   */
+  private _batchAnnotations?: MessageAnnotations;
 
   /**
    * EventDataBatch should not be constructed using `new EventDataBatch()`
@@ -231,9 +247,8 @@ export class EventDataBatchImpl implements EventDataBatch {
    * @readonly
    */
   get _message(): Buffer | undefined {
-    return this._batchMessage;
+    return this._generateBatch(this._encodedMessages, this._batchAnnotations);
   }
-
   /**
    * Gets the "message" span contexts that were created when adding events to the batch.
    * @internal
@@ -241,6 +256,21 @@ export class EventDataBatchImpl implements EventDataBatch {
    */
   get _messageSpanContexts(): SpanContext[] {
     return this._spanContexts;
+  }
+
+  /**
+   * Generates an AMQP message that contains the provided encoded events and annotations.
+   * @param encodedEvents The already encoded events to include in the AMQP batch.
+   * @param annotations The message annotations to set on the batch.
+   */
+  private _generateBatch(encodedEvents: Buffer[], annotations?: MessageAnnotations): Buffer {
+    const batchEnvelope: AmqpMessage = {
+      body: message.data_sections(encodedEvents)
+    };
+    if (annotations) {
+      batchEnvelope.message_annotations = annotations;
+    }
+    return message.encode(batchEnvelope);
   }
 
   /**
@@ -258,42 +288,49 @@ export class EventDataBatchImpl implements EventDataBatch {
     const previouslyInstrumented = Boolean(
       eventData.properties && eventData.properties[TRACEPARENT_PROPERTY]
     );
+    let spanContext: SpanContext | undefined;
     if (!previouslyInstrumented) {
       const messageSpan = createMessageSpan(options.parentSpan);
       eventData = instrumentEventData(eventData, messageSpan);
-      this._spanContexts.push(messageSpan.context());
+      spanContext = messageSpan.context();
       messageSpan.end();
     }
+
     // Convert EventData to AmqpMessage.
     const amqpMessage = toAmqpMessage(eventData, this._partitionKey);
     amqpMessage.body = this._context.dataTransformer.encode(eventData.body);
+    const encodedMessage = message.encode(amqpMessage);
 
-    // Encode every amqp message and then convert every encoded message to amqp data section
-    this._encodedMessages.push(message.encode(amqpMessage));
+    // The first time an event is added, we need to calculate
+    // the overhead of creating an AMQP batch, including the
+    // message_annotations that are taken from the 1st message.
+    if (this.count === 0) {
+      if (amqpMessage.message_annotations) {
+        this._batchAnnotations = amqpMessage.message_annotations;
+      }
 
-    const batchMessage: AmqpMessage = {
-      body: message.data_sections(this._encodedMessages)
-    };
-
-    if (amqpMessage.message_annotations) {
-      batchMessage.message_annotations = amqpMessage.message_annotations;
+      // Figure out the overhead of creating a batch by generating an empty batch
+      // with the expected batch annotations.
+      this._sizeInBytes += this._generateBatch([], this._batchAnnotations).length;
     }
 
-    const encodedBatchMessage = message.encode(batchMessage);
-    const currentSize = encodedBatchMessage.length;
+    const messageSize = encodedMessage.length;
+    const messageOverhead =
+      messageSize <= smallMessageMaxBytes ? smallMessageOverhead : largeMessageOverhead;
+    const currentSize = this._sizeInBytes + messageSize + messageOverhead;
 
-    // this._batchMessage will be used for final send operation
+    // Check if the size of the batch exceeds the maximum allowed size
+    // once we add the new event to it.
     if (currentSize > this._maxSizeInBytes) {
-      this._encodedMessages.pop();
-      if (
-        !previouslyInstrumented &&
-        Boolean(eventData.properties && eventData.properties[TRACEPARENT_PROPERTY])
-      ) {
-        this._spanContexts.pop();
-      }
       return false;
     }
-    this._batchMessage = encodedBatchMessage;
+
+    // The event will fit in the batch, so it is now safe to store it.
+    this._encodedMessages.push(encodedMessage);
+    if (spanContext) {
+      this._spanContexts.push(spanContext);
+    }
+
     this._sizeInBytes = currentSize;
     this._count++;
     return true;

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -112,11 +112,10 @@ export interface EventDataBatch {
    * Used internally by the `sendBatch()` method on the `EventHubProducerClient`.
    * This is not meant for the user to use directly.
    *
-   * @readonly
    * @internal
    * @ignore
    */
-  readonly _message: Buffer | undefined;
+  _generateMessage(): Buffer;
 
   /**
    * Gets the "message" span contexts that were created when adding events to the batch.
@@ -237,19 +236,6 @@ export class EventDataBatchImpl implements EventDataBatch {
   }
 
   /**
-   * @property Represents the single AMQP message which is the result of encoding all the events
-   * added into the `EventDataBatch` instance.
-   *
-   * This is not meant for the user to use directly.
-   *
-   * When the `EventDataBatch` instance is passed to the `send()` method on the `EventHubProducer`,
-   * this single batched AMQP message is what gets sent over the wire to the service.
-   * @readonly
-   */
-  get _message(): Buffer | undefined {
-    return this._generateBatch(this._encodedMessages, this._batchAnnotations);
-  }
-  /**
    * Gets the "message" span contexts that were created when adding events to the batch.
    * @internal
    * @ignore
@@ -271,6 +257,20 @@ export class EventDataBatchImpl implements EventDataBatch {
       batchEnvelope.message_annotations = annotations;
     }
     return message.encode(batchEnvelope);
+  }
+
+  /**
+   * Generates the single AMQP message which is the result of encoding all the events
+   * added into the `EventDataBatch` instance.
+   *
+   * This is not meant for the user to use directly.
+   *
+   * When the `EventDataBatch` instance is passed to the `send()` method on the `EventHubProducer`,
+   * this single batched AMQP message is what gets sent over the wire to the service.
+   * @readonly
+   */
+  _generateMessage(): Buffer {
+    return this._generateBatch(this._encodedMessages, this._batchAnnotations);
   }
 
   /**

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -301,6 +301,7 @@ export class EventDataBatchImpl implements EventDataBatch {
     amqpMessage.body = this._context.dataTransformer.encode(eventData.body);
     const encodedMessage = message.encode(amqpMessage);
 
+    let currentSize = this._sizeInBytes;
     // The first time an event is added, we need to calculate
     // the overhead of creating an AMQP batch, including the
     // message_annotations that are taken from the 1st message.
@@ -311,13 +312,13 @@ export class EventDataBatchImpl implements EventDataBatch {
 
       // Figure out the overhead of creating a batch by generating an empty batch
       // with the expected batch annotations.
-      this._sizeInBytes += this._generateBatch([], this._batchAnnotations).length;
+      currentSize += this._generateBatch([], this._batchAnnotations).length;
     }
 
     const messageSize = encodedMessage.length;
     const messageOverhead =
       messageSize <= smallMessageMaxBytes ? smallMessageOverhead : largeMessageOverhead;
-    const currentSize = this._sizeInBytes + messageSize + messageOverhead;
+    currentSize += messageSize + messageOverhead;
 
     // Check if the size of the batch exceeds the maximum allowed size
     // once we add the new event to it.

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -330,7 +330,7 @@ export class EventHubSender extends LinkEntity {
 
       let encodedBatchMessage: Buffer | undefined;
       if (isEventDataBatch(events)) {
-        encodedBatchMessage = events._message!;
+        encodedBatchMessage = events._generateMessage();
       } else {
         const partitionKey = (options && options.partitionKey) || undefined;
         const messages: AmqpMessage[] = [];

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -276,6 +276,24 @@ describe("EventHub Sender", function(): void {
       consumerClient.close();
     });
 
+    describe("tryAdd", function() {
+      it("doesn't grow if invalid events are added", async () => {
+        const batch = await producerClient.createBatch({ maxSizeInBytes: 20 });
+        const event = { body: Buffer.alloc(30).toString() };
+
+        const numToAdd = 5;
+        let failures = 0;
+        for (let i = 0; i < numToAdd; i++) {
+          if (!batch.tryAdd(event)) {
+            failures++;
+          }
+        }
+
+        failures.should.equal(5);
+        batch.sizeInBytes.should.equal(0);
+      });
+    });
+
     it("should be sent successfully", async function(): Promise<void> {
       const list = ["Albert", `${Buffer.from("Mike".repeat(1300000))}`, "Marie"];
 


### PR DESCRIPTION
Fixes #8567 

Previously, the `tryAdd` method would encode an AMQP message that contained all the events added to the batch in order to calculate the size of the batch with the new event added. This ends up being very expensive as more events are added to the batch (Making adding an event an O(n^2) operation).

With this change, the individual events are still encoded and stored as before, but now we calculate what the new size will be based on the known overhead of creating a batch. I took the overhead values from what [.NET](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpEventBatch.cs#L23-L29) and python have (5 bytes for small messages, 8 bytes for large messages) and verified through testing that these are correct. We also create an empty batch (with message annotations if applicable) the 1st time a message is able to be added to the batch in order to calculate the overhead for the batch envelope.

I tested these changes against the current implementation a few different ways.
1. I created 2 batches (one using the old tryAdd, one using the new tryAdd), each with 10,000 identical events. I found that:
   - The `_sizeInBytes` and event counts matched exactly in both.
   - The total time to add events dropped drastically (from 30404 ms to 68 ms in this test).
2. I created 2 batches (one using the old tryAdd, one using the new tryAdd) each with 5000 random events that ranged in size of 1 byte to 512 bytes. Again the batch sizes matched.

Since this was a perf improvement with no API changes, I didn't add many additional tests. The existing tests continue to pass. I think this is a good operation to write performance tests around so we don't regress in future updates but that might be better in a separate PR.
