### PR TITLE
[event-hubs] Updated @azure/eslint-plugin-azure-sdk

### DIFF
--- a/sdk/eventhub/event-hubs/.eslintrc.json
+++ b/sdk/eventhub/event-hubs/.eslintrc.json
@@ -1,7 +1,4 @@
 {
   "plugins": ["@azure/azure-sdk"],
-  "extends": ["../../.eslintrc.old.json", "plugin:@azure/azure-sdk/recommended"],
-  "parserOptions": {
-    "createDefaultProgram": true
-  }
+  "extends": ["plugin:@azure/azure-sdk/azure-sdk-base"]
 }

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -46,7 +46,7 @@
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/*.spec.js dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
-    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o search-lintReport.html || exit 0",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o event-hubs-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -8,14 +8,9 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/eventhub/event-hubs",
   "repository": "github:Azure/azure-sdk-for-js",
   "sideEffects": false,
-  "keywords": [
-    "azure",
-    "cloud",
-    "event hubs",
-    "events"
-  ],
+  "keywords": ["azure", "cloud", "event hubs", "events", "Azure"],
   "bugs": {
-    "url": "https://github.com/azure/azure-sdk-for-js/issues"
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
   },
   "main": "./dist/index.js",
   "module": "dist-esm/src/index.js",
@@ -50,8 +45,8 @@
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 1200000 --full-trace dist-esm/test/*.spec.js dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",
-    "lint:fix": "eslint package.json tsconfig.json src test samples --ext .ts --fix",
-    "lint": "eslint package.json tsconfig.json src test samples --ext .ts -f html -o event-hubs-lintReport.html || exit 0",
+    "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --fix --fix-type [problem,suggestion]",
+    "lint": "eslint package.json api-extractor.json src test --ext .ts -f html -o search-lintReport.html || exit 0",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean",
     "test:browser": "npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
@@ -87,7 +82,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@azure/eslint-plugin-azure-sdk": "^2.0.1",
+    "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "@azure/identity": "^1.1.0-preview",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "^11.0.1",

--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { logger } from "./log";
 import { getRuntimeInfo } from "./util/runtimeInfo";

--- a/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/instrumentEventData.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { getTraceParentHeader, extractSpanContextFromTraceParentHeader } from "@azure/core-tracing";
 import { Span, SpanContext } from "@opentelemetry/api";

--- a/sdk/eventhub/event-hubs/src/diagnostics/messageSpan.ts
+++ b/sdk/eventhub/event-hubs/src/diagnostics/messageSpan.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { getTracer } from "@azure/core-tracing";
 import { Span, SpanContext, SpanKind } from "@opentelemetry/api";

--- a/sdk/eventhub/event-hubs/src/eventData.ts
+++ b/sdk/eventhub/event-hubs/src/eventData.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { Message, MessageAnnotations, DeliveryAnnotations } from "rhea-promise";
 import { Constants } from "@azure/core-amqp";

--- a/sdk/eventhub/event-hubs/src/eventDataBatch.ts
+++ b/sdk/eventhub/event-hubs/src/eventDataBatch.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { EventData, toAmqpMessage } from "./eventData";
 import { ConnectionContext } from "./connectionContext";

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClient.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { EventHubClient } from "./impl/eventHubClient";
 import {

--- a/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubConsumerClientModels.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { CloseReason } from "./models/public";
 import { ReceivedEventData } from "./eventData";
 import { LastEnqueuedEventProperties } from "./eventHubReceiver";

--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { isTokenCredential, TokenCredential } from "@azure/core-amqp";
 import { EventDataBatch, isEventDataBatch } from "./eventDataBatch";

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import uuid from "uuid/v4";
 import { logger, logErrorStackTrace } from "./log";

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import uuid from "uuid/v4";
 import { logger, logErrorStackTrace } from "./log";

--- a/sdk/eventhub/event-hubs/src/eventPosition.ts
+++ b/sdk/eventhub/event-hubs/src/eventPosition.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { translate, Constants, ErrorNameConditionMapper } from "@azure/core-amqp";
 

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import uuid from "uuid/v4";
 import { EventHubClient } from "./impl/eventHubClient";

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { logger, logErrorStackTrace } from "../log";
 import {

--- a/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
+++ b/sdk/eventhub/event-hubs/src/impl/partitionGate.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 /**
  * Used by EventHubConsumerClient to prevent accidentally spinning up multiple

--- a/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
+++ b/sdk/eventhub/event-hubs/src/inMemoryCheckpointStore.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { PartitionOwnership, CheckpointStore } from "./eventProcessor";
 import { Checkpoint } from "./partitionProcessor";
@@ -62,7 +62,7 @@ export class InMemoryCheckpointStore implements CheckpointStore {
         !this._partitionOwnershipMap.has(ownership.partitionId) ||
         this._partitionOwnershipMap.get(ownership.partitionId)!.etag === ownership.etag
       ) {
-        var date = new Date();
+        const date = new Date();
 
         const newOwnership = {
           ...ownership,

--- a/sdk/eventhub/event-hubs/src/index.ts
+++ b/sdk/eventhub/event-hubs/src/index.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 /// <reference lib="esnext.asynciterable" />
 

--- a/sdk/eventhub/event-hubs/src/linkEntity.ts
+++ b/sdk/eventhub/event-hubs/src/linkEntity.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import uuid from "uuid/v4";
 import {

--- a/sdk/eventhub/event-hubs/src/log.ts
+++ b/sdk/eventhub/event-hubs/src/log.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { createClientLogger } from "@azure/logger";
 

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import uuid from "uuid/v4";
 import {

--- a/sdk/eventhub/event-hubs/src/models/private.ts
+++ b/sdk/eventhub/event-hubs/src/models/private.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { PartitionLoadBalancer } from "../partitionLoadBalancer";
 import { RetryOptions } from "@azure/core-amqp";

--- a/sdk/eventhub/event-hubs/src/models/public.ts
+++ b/sdk/eventhub/event-hubs/src/models/public.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { OperationOptions } from "../util/operationOptions";
 import { RetryOptions, WebSocketOptions } from "@azure/core-amqp";

--- a/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
+++ b/sdk/eventhub/event-hubs/src/partitionLoadBalancer.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { PartitionOwnership } from "./eventProcessor";
 import { logger } from "./log";
@@ -236,7 +236,7 @@ export class FairPartitionLoadBalancer implements PartitionLoadBalancer {
   ): Map<string, PartitionOwnership> {
     const activePartitionOwnershipMap: Map<string, PartitionOwnership> = new Map();
     partitionOwnershipMap.forEach((partitionOwnership: PartitionOwnership, partitionId: string) => {
-      var date = new Date();
+      const date = new Date();
       if (
         partitionOwnership.lastModifiedTimeInMs &&
         date.getTime() - partitionOwnership.lastModifiedTimeInMs < this._inactiveTimeLimitInMS &&

--- a/sdk/eventhub/event-hubs/src/partitionProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/partitionProcessor.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { CheckpointStore } from "./eventProcessor";
 import { CloseReason } from "./models/public";
 import { ReceivedEventData } from "./eventData";

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { logger, logErrorStackTrace } from "./log";
 import { CommonEventProcessorOptions } from "./models/private";

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { EventHubClient } from "./impl/eventHubClient";
 import { EventPosition } from "./eventPosition";

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { EventHubReceiver } from "./eventHubReceiver";
 import { logger, logErrorStackTrace } from "./log";

--- a/sdk/eventhub/event-hubs/src/receiver.ts
+++ b/sdk/eventhub/event-hubs/src/receiver.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { logger, logErrorStackTrace } from "./log";
 import { ConnectionContext } from "./connectionContext";

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { EventData } from "./eventData";
 import { EventHubSender } from "./eventHubSender";

--- a/sdk/eventhub/event-hubs/src/util/constants.ts
+++ b/sdk/eventhub/event-hubs/src/util/constants.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 /**
  * @ignore

--- a/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
+++ b/sdk/eventhub/event-hubs/src/util/delayWithoutThrow.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { delay } from "@azure/core-amqp";
 import { AbortSignalLike } from "@azure/abort-controller";

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { logger, logErrorStackTrace } from "../log";
 import { ConnectionContext } from "../connectionContext";

--- a/sdk/eventhub/event-hubs/src/util/operationOptions.ts
+++ b/sdk/eventhub/event-hubs/src/util/operationOptions.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { AbortSignalLike } from "@azure/abort-controller";
 import { Span, SpanContext } from "@opentelemetry/api";

--- a/sdk/eventhub/event-hubs/src/util/retries.ts
+++ b/sdk/eventhub/event-hubs/src/util/retries.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { Constants, RetryOptions } from "@azure/core-amqp";
 

--- a/sdk/eventhub/event-hubs/src/util/runtimeInfo.browser.ts
+++ b/sdk/eventhub/event-hubs/src/util/runtimeInfo.browser.ts
@@ -1,7 +1,8 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 interface Window {}
-declare var self: Window & typeof globalThis & { navigator: Navigator };
+declare let self: Window & typeof globalThis & { navigator: Navigator };
 
 interface Navigator {
   /**

--- a/sdk/eventhub/event-hubs/src/util/runtimeInfo.ts
+++ b/sdk/eventhub/event-hubs/src/util/runtimeInfo.ts
@@ -1,5 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import * as os from "os";
 
 /**

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 import * as os from "os";

--- a/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventHubConsumerClient.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import {
   EventHubProducerClient,
@@ -199,7 +199,7 @@ describe("EventHubConsumerClient", () => {
     let clients: EventHubConsumerClient[];
     let producerClient: EventHubProducerClient;
     let partitionIds: string[];
-    let subscriptions: Subscription[] = [];
+    const subscriptions: Subscription[] = [];
 
     beforeEach(async () => {
       producerClient = new EventHubProducerClient(service.connectionString!, service.path!, {});

--- a/sdk/eventhub/event-hubs/test/eventPosition.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventPosition.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 chai.should();

--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 const should = chai.should();
@@ -79,7 +79,7 @@ describe("Event Processor", function(): void {
       it("no checkpoint or user specified default", async () => {
         const processor = createEventProcessor(emptyCheckpointStore);
 
-        let eventPosition = await processor["_getStartingPosition"]("0");
+        const eventPosition = await processor["_getStartingPosition"]("0");
         isLatestPosition(eventPosition).should.be.ok;
       });
 
@@ -98,7 +98,7 @@ describe("Event Processor", function(): void {
           latestEventPosition
         );
 
-        let eventPosition = await processor["_getStartingPosition"]("0");
+        const eventPosition = await processor["_getStartingPosition"]("0");
         eventPosition!.offset!.should.equal(1009);
         should.not.exist(eventPosition!.sequenceNumber);
       });
@@ -117,7 +117,7 @@ describe("Event Processor", function(): void {
 
         const processor = createEventProcessor(checkpointStore);
 
-        let eventPosition = await processor["_getStartingPosition"]("0");
+        const eventPosition = await processor["_getStartingPosition"]("0");
         eventPosition!.offset!.should.equal(0);
         should.not.exist(eventPosition!.sequenceNumber);
       });
@@ -125,7 +125,7 @@ describe("Event Processor", function(): void {
       it("using a single default event position for any partition", async () => {
         const processor = createEventProcessor(emptyCheckpointStore, { offset: 1009 });
 
-        let eventPosition = await processor["_getStartingPosition"]("0");
+        const eventPosition = await processor["_getStartingPosition"]("0");
         eventPosition!.offset!.should.equal(1009);
         should.not.exist(eventPosition!.sequenceNumber);
       });
@@ -136,11 +136,11 @@ describe("Event Processor", function(): void {
 
         const processor = createEventProcessor(emptyCheckpointStore, fallbackPositions);
 
-        let eventPositionForPartitionZero = await processor["_getStartingPosition"]("0");
+        const eventPositionForPartitionZero = await processor["_getStartingPosition"]("0");
         eventPositionForPartitionZero!.offset!.should.equal(2001);
         should.not.exist(eventPositionForPartitionZero!.sequenceNumber);
 
-        let eventPositionForPartitionOne = await processor["_getStartingPosition"]("1");
+        const eventPositionForPartitionOne = await processor["_getStartingPosition"]("1");
         isLatestPosition(eventPositionForPartitionOne).should.be.ok;
       });
 
@@ -673,7 +673,7 @@ describe("Event Processor", function(): void {
     // ensure we have at least 2 partitions
     partitionIds.length.should.gte(2);
 
-    let {
+    const {
       subscriptionEventHandler,
       startPosition
     } = await SubscriptionHandlerForTests.startingFromHere(client);
@@ -826,7 +826,7 @@ describe("Event Processor", function(): void {
 
       let didError = false;
       let processedAtLeastOneEvent = new Set();
-      let checkpointSequenceNumbers: Map<string, number> = new Map();
+      const checkpointSequenceNumbers: Map<string, number> = new Map();
 
       let partionCount: { [x: string]: number } = {};
 
@@ -1264,7 +1264,7 @@ describe("Event Processor", function(): void {
         if (!partitionOwnershipMap.has(ownership.ownerId)) {
           partitionOwnershipMap.set(ownership.ownerId, [ownership.partitionId]);
         } else {
-          let arr = partitionOwnershipMap.get(ownership.ownerId);
+          const arr = partitionOwnershipMap.get(ownership.ownerId);
           arr!.push(ownership.partitionId);
           partitionOwnershipMap.set(ownership.ownerId, arr!);
         }
@@ -1451,7 +1451,7 @@ describe("Event Processor", function(): void {
         await producer.close();
       }
 
-      let partitionIdsSet = new Set();
+      const partitionIdsSet = new Set();
       const lastEnqueuedEventPropertiesMap: Map<string, LastEnqueuedEventProperties> = new Map();
       class SimpleEventProcessor implements SubscriptionEventHandlers {
         async processEvents(events: ReceivedEventData[], context: PartitionContext) {
@@ -1513,7 +1513,7 @@ function ownershipListToMap(partitionOwnership: PartitionOwnership[]): Map<strin
     if (!partitionOwnershipMap.has(ownership.ownerId)) {
       partitionOwnershipMap.set(ownership.ownerId, [ownership.partitionId]);
     } else {
-      let arr = partitionOwnershipMap.get(ownership.ownerId);
+      const arr = partitionOwnershipMap.get(ownership.ownerId);
       arr!.push(ownership.partitionId);
       partitionOwnershipMap.set(ownership.ownerId, arr!);
     }

--- a/sdk/eventhub/event-hubs/test/eventdata.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventdata.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 chai.should();

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 const should = chai.should();

--- a/sdk/eventhub/event-hubs/test/impl/partitionGate.spec.ts
+++ b/sdk/eventhub/event-hubs/test/impl/partitionGate.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { PartitionGate } from "../../src/impl/partitionGate";
 import chai from "chai";

--- a/sdk/eventhub/event-hubs/test/loadBalancer.spec.ts
+++ b/sdk/eventhub/event-hubs/test/loadBalancer.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import {
   GreedyPartitionLoadBalancer,

--- a/sdk/eventhub/event-hubs/test/misc.spec.ts
+++ b/sdk/eventhub/event-hubs/test/misc.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import uuid from "uuid/v4";
 import chai from "chai";

--- a/sdk/eventhub/event-hubs/test/node/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/node/client.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 const should = chai.should();

--- a/sdk/eventhub/event-hubs/test/node/packageInfo.spec.ts
+++ b/sdk/eventhub/event-hubs/test/node/packageInfo.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 const should = chai.should();

--- a/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
+++ b/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import { createProcessingSpan, trace } from "../src/partitionPump";
 import { TestTracer, setTracer, TestSpan, NoOpSpan } from "@azure/core-tracing";

--- a/sdk/eventhub/event-hubs/test/receiver.spec.ts
+++ b/sdk/eventhub/event-hubs/test/receiver.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 import uuid from "uuid/v4";
@@ -671,7 +671,7 @@ describe("EventHub Receiver", function(): void {
         }
       );
 
-      let data = await receiver.receiveBatch(1, 10);
+      const data = await receiver.receiveBatch(1, 10);
       debug("receiver.runtimeInfo ", receiver.lastEnqueuedEventProperties);
       data.length.should.equal(1);
       should.exist(receiver.lastEnqueuedEventProperties);

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import chai from "chai";
 const should = chai.should();
@@ -288,7 +288,7 @@ describe("EventHub Sender", function(): void {
       batch.maxSizeInBytes.should.be.gt(0);
 
       batch.tryAdd({ body: list[0] }).should.be.ok;
-      batch.tryAdd({ body: list[1] }).should.not.be.ok; //The Mike message will be rejected - it's over the limit.
+      batch.tryAdd({ body: list[1] }).should.not.be.ok; // The Mike message will be rejected - it's over the limit.
       batch.tryAdd({ body: list[2] }).should.be.ok; // Marie should get added";
 
       const {
@@ -500,7 +500,7 @@ describe("EventHub Sender", function(): void {
     it("should throw when maxMessageSize is greater than maximum message size on the AMQP sender link", async function(): Promise<
       void
     > {
-      let newClient: EventHubProducerClient = new EventHubProducerClient(
+      const newClient: EventHubProducerClient = new EventHubProducerClient(
         service.connectionString,
         service.path
       );

--- a/sdk/eventhub/event-hubs/test/utils/fakeSubscriptionEventHandlers.ts
+++ b/sdk/eventhub/event-hubs/test/utils/fakeSubscriptionEventHandlers.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { SubscriptionEventHandlers, ReceivedEventData, PartitionContext } from "../../src";
 
 export class FakeSubscriptionEventHandlers implements SubscriptionEventHandlers {

--- a/sdk/eventhub/event-hubs/test/utils/logHelpers.ts
+++ b/sdk/eventhub/event-hubs/test/utils/logHelpers.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import debugModule from "debug";
 

--- a/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
+++ b/sdk/eventhub/event-hubs/test/utils/receivedMessagesTester.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import { CloseReason, ReceivedEventData, EventHubProducerClient } from "../../src/";
 import {
   SubscriptionEventHandlers,
@@ -148,7 +151,7 @@ export class ReceivedMessagesTester implements Required<SubscriptionEventHandler
       });
     }
 
-    let lastExpectedMessageCount = this.expectedMessageBodies.size;
+    const lastExpectedMessageCount = this.expectedMessageBodies.size;
 
     for (const messageToSend of messagesToSend) {
       const batch = await client.createBatch({ partitionId: messageToSend.partitionId });

--- a/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
+++ b/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 import {
   SubscriptionEventHandlers,
   PartitionContext

--- a/sdk/eventhub/event-hubs/test/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/utils/testUtils.ts
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 import * as dotenv from "dotenv";
 import { loggerForTest } from "./logHelpers";


### PR DESCRIPTION
Fixes #8347 

ESLint keeps causing errors, since it's currently not required due to the `|| exit 0` at the end of the `lint` command.

The current list of errors and warnings can be seen here: https://gist.github.com/sadasant/d1c4818d8fd947723f70b7771bf2825c

So far, I have only fixed what could be automatically fixed with `lint:fix`. Going through all of the errors will take considerable more time. Depending on how much time I have left this week, I could add some other fixes in this PR.