### PR TITLE
[core-http] Fix constant flattened property serialization

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -12,6 +12,7 @@
 ## 1.1.2 (2020-05-07)
 
 - Fix issue with null/undefined values in array and tabs/space delimiter arrays during sendOperationRequest. [PR #8604](https://github.com/Azure/azure-sdk-for-js/pull/8604)
+- Fix issue with flattened model serialization, where constant properties are being dropped [PR#8658](https://github.com/Azure/azure-sdk-for-js/pull/8658)
 
 ## 1.1.1 (2020-04-28)
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Release History
 
 ## 1.1.4 (Unreleased)
-
+- Fix issue with flattened model serialization, where constant properties are being dropped [PR#8658](https://github.com/Azure/azure-sdk-for-js/pull/8658)
 
 ## 1.1.3 (2020-06-03)
 
@@ -12,7 +12,6 @@
 ## 1.1.2 (2020-05-07)
 
 - Fix issue with null/undefined values in array and tabs/space delimiter arrays during sendOperationRequest. [PR #8604](https://github.com/Azure/azure-sdk-for-js/pull/8604)
-- Fix issue with flattened model serialization, where constant properties are being dropped [PR#8658](https://github.com/Azure/azure-sdk-for-js/pull/8658)
 
 ## 1.1.1 (2020-04-28)
 

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -573,7 +573,10 @@ function serializeCompositeType(
 
         for (const pathName of paths) {
           const childObject = parentObject[pathName];
-          if (childObject == undefined && object[key] != undefined) {
+          if (
+            childObject == undefined &&
+            (object[key] != undefined || propertyMapper.defaultValue !== undefined)
+          ) {
             parentObject[pathName] = {};
           }
           parentObject = parentObject[pathName];

--- a/sdk/core/core-http/test/data/TestClient/src/models/mappers.ts
+++ b/sdk/core/core-http/test/data/TestClient/src/models/mappers.ts
@@ -5,6 +5,82 @@
  */
 const internalMappers: any = {};
 
+internalMappers.SimpleProduct = {
+  type: {
+    name: "Composite",
+    className: "SimpleProduct",
+    modelProperties: {
+      id: {
+        serializedName: "id",
+        constraints: {},
+        required: true,
+        type: {
+          name: "Number"
+        }
+      },
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      maxProductDisplayName: {
+        serializedName: "details.max_product_display_name",
+        type: {
+          name: "String"
+        }
+      },
+      capacity: {
+        defaultValue: "Large",
+        isConstant: true,
+        serializedName: "details.max_product_capacity",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+internalMappers.SimpleProductConstFirst = {
+  type: {
+    name: "Composite",
+    className: "SimpleProduct",
+    modelProperties: {
+      id: {
+        serializedName: "id",
+        constraints: {},
+        required: true,
+        type: {
+          name: "Number"
+        }
+      },
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      capacity: {
+        defaultValue: "Large",
+        isConstant: true,
+        serializedName: "details.max_product_capacity",
+        type: {
+          name: "String"
+        }
+      },
+      maxProductDisplayName: {
+        serializedName: "details.max_product_display_name",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
 internalMappers.Cat = {
   required: false,
   serializedName: "cat",

--- a/sdk/core/core-http/test/serializationTests.ts
+++ b/sdk/core/core-http/test/serializationTests.ts
@@ -21,6 +21,54 @@ function stringToByteArray(str: string): Uint8Array {
 
 describe("msrest", function() {
   describe("serializeObject", function() {
+    it("should correctly serialize flattened properties", (done) => {
+      const expected = {
+        id: 1,
+        name: "testProduct",
+        details: {
+          max_product_capacity: "Large",
+          max_product_display_name: "MaxDisplayName"
+        }
+      };
+
+      const serialized = Serializer.serialize(
+        Mappers.SimpleProduct,
+        {
+          id: 1,
+          name: "testProduct",
+          maxProductDisplayName: "MaxDisplayName"
+        },
+        "SimpleProduct"
+      );
+
+      assert.deepEqual(serialized, expected);
+      done();
+    });
+
+    it("should correctly serialize flattened properties when flattened constant is defined first", (done) => {
+      const expected = {
+        id: 1,
+        name: "testProduct",
+        details: {
+          max_product_capacity: "Large",
+          max_product_display_name: "MaxDisplayName"
+        }
+      };
+
+      const serialized = Serializer.serialize(
+        Mappers.SimpleProductConstFirst,
+        {
+          id: 1,
+          name: "testProduct",
+          maxProductDisplayName: "MaxDisplayName"
+        },
+        "SimpleProduct"
+      );
+
+      assert.deepEqual(serialized, expected);
+      done();
+    });
+
     it("should correctly serialize a Date Object", function(done) {
       const dateObj = new Date("2015-01-01");
       const dateISO = "2015-01-01T00:00:00.000Z";


### PR DESCRIPTION
**Problem**
Given a mapper with flattened modelProperties, if the first defined parameter of a flattened property is a constant, we drop it in serialization.

For example, the mapper below would drop `details.capacity` when serializing since it is the first property of details defined and it is also a constant. However if `maxProductDisplayName` was defined before capacity, both properties would be serialized as expected.

```typescript
{
   type: {
    name: "Composite",
    className: "SimpleProduct",
    modelProperties: {
      id: {
        serializedName: "id",
        constraints: {},
        required: true,
        type: {
          name: "Number"
        }
      },
      name: {
        serializedName: "name",
        required: true,
        type: {
          name: "String"
        }
      },
      capacity: {
        defaultValue: "Large",
        isConstant: true,
        serializedName: "details.max_product_capacity",
        type: {
          name: "String"
        }
      },
      maxProductDisplayName: {
        serializedName: "details.max_product_display_name",
        type: {
          name: "String"
        }
      }
    }
  }
}
```

The reason it gets dropped is that before creating the "parent" object, we currently check the passed object for the property to have a value. ([link](https://github.com/Azure/azure-sdk-for-js/blob/26065ace6daf94cbeea598bac4819b88484093d7/sdk/core/core-http/src/serializer.ts#L576))

However this check will be false for constants since they are not passed explicitly, instead their defaultValue is used.

**Fix:**
To check for value or mapper.defaultValue
