### PR TITLE
Use Linux for samples instead of Windows

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -59,7 +59,7 @@ jobs:
         # Add matrix entry for sample testing
         ${{ if eq(parameters.TestSamples, 'true') }}:
           Samples Linux Node 10:
-            OSVmImage: "windows-2019"
+            OSVmImage: "ubuntu-18.04"
             TestType: "sample"
             NodeVersion: "10.x"
             CloudType: "AzureCloud"


### PR DESCRIPTION
A more thorough audit of the integration test yml revealed that we're using Windows for samples testing when we agreed upon Linux. This corrects that. 