### PR TITLE
[event-hubs] Fixing flaky tests.

### DIFF
--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -7,12 +7,12 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import debugModule from "debug";
 const debug = debugModule("azure:event-hubs:hubruntime-spec");
-import { EnvVarKeys, getEnvVars } from "./utils/testUtils";
+import { EnvVarKeys, getEnvVars, setTracerForTest } from "./utils/testUtils";
 const env = getEnvVars();
 
 import { EventHubClient } from "../src/impl/eventHubClient";
 import { AbortController } from "@azure/abort-controller";
-import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
+import { SpanGraph } from "@azure/core-tracing";
 describe("RuntimeInformation", function(): void {
   let client: EventHubClient;
   const service = {
@@ -76,8 +76,7 @@ describe("RuntimeInformation", function(): void {
   });
 
   it("can be manually traced", async function(): Promise<void> {
-    const tracer = new TestTracer();
-    setTracer(tracer);
+    const { tracer, resetTracer } = setTracerForTest();
 
     const rootSpan = tracer.startSpan("root");
     client = new EventHubClient(service.connectionString, service.path);
@@ -116,6 +115,7 @@ describe("RuntimeInformation", function(): void {
 
     tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
     tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+    resetTracer();
   });
 
   describe("hub runtime information", function(): void {
@@ -150,8 +150,7 @@ describe("RuntimeInformation", function(): void {
     });
 
     it("can be manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
       client = new EventHubClient(service.connectionString, service.path);
@@ -187,6 +186,7 @@ describe("RuntimeInformation", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+      resetTracer();
     });
   });
 
@@ -262,8 +262,7 @@ describe("RuntimeInformation", function(): void {
     });
 
     it("can be manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
       client = new EventHubClient(service.connectionString, service.path);
@@ -301,6 +300,7 @@ describe("RuntimeInformation", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+      resetTracer();
     });
   });
 }).timeout(60000);

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -392,7 +392,7 @@ describe("EventHub Sender", function(): void {
         receivedEvents.map((event) => {
           return {
             body: event.body,
-            properties: { test: event.properties!["test"] }
+            properties: event.properties
           };
         }),
         "Received messages should be equal to our sent messages"

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -18,7 +18,7 @@ import { EventHubClient } from "../src/impl/eventHubClient";
 import { SendOptions, SendBatchOptions } from "../src/models/public";
 import { EnvVarKeys, getEnvVars, getStartingPositionsForTests } from "./utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
-import { TestTracer, setTracer, SpanGraph } from "@azure/core-tracing";
+import { TestTracer, setTracer, SpanGraph, getTracer } from "@azure/core-tracing";
 import { TRACEPARENT_PROPERTY } from "../src/diagnostics/instrumentEventData";
 import { EventHubProducer } from "../src/sender";
 import { SubscriptionHandlerForTests } from "./utils/subscriptionHandlerForTests";
@@ -120,6 +120,7 @@ describe("EventHub Sender", function(): void {
 
     it("can be manually traced", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("root");
@@ -165,6 +166,7 @@ describe("EventHub Sender", function(): void {
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
 
       await producer.close();
+      setTracer(existingTracer);
     });
   });
 
@@ -401,6 +403,7 @@ describe("EventHub Sender", function(): void {
 
     it("can be manually traced", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("root");
@@ -441,10 +444,12 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+      setTracer(existingTracer);
     });
 
     it("will not instrument already instrumented events", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("test");
@@ -492,10 +497,12 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+      setTracer(existingTracer);
     });
 
     it("will support tracing batch and send", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("root");
@@ -545,6 +552,7 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+      setTracer(existingTracer);
     });
 
     it("with partition key should be sent successfully.", async function(): Promise<void> {
@@ -786,6 +794,7 @@ describe("EventHub Sender", function(): void {
 
     it("can be manually traced", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("root");
@@ -847,10 +856,12 @@ describe("EventHub Sender", function(): void {
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
 
       await producer.close();
+      setTracer(existingTracer);
     });
 
     it("skips already instrumented events when manually traced", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("root");
@@ -909,6 +920,7 @@ describe("EventHub Sender", function(): void {
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
 
       await producer.close();
+      setTracer(existingTracer);
     });
   });
 

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -16,9 +16,14 @@ import {
 } from "../src";
 import { EventHubClient } from "../src/impl/eventHubClient";
 import { SendOptions, SendBatchOptions } from "../src/models/public";
-import { EnvVarKeys, getEnvVars, getStartingPositionsForTests } from "./utils/testUtils";
+import {
+  EnvVarKeys,
+  getEnvVars,
+  getStartingPositionsForTests,
+  setTracerForTest
+} from "./utils/testUtils";
 import { AbortController } from "@azure/abort-controller";
-import { TestTracer, setTracer, SpanGraph, getTracer } from "@azure/core-tracing";
+import { SpanGraph } from "@azure/core-tracing";
 import { TRACEPARENT_PROPERTY } from "../src/diagnostics/instrumentEventData";
 import { EventHubProducer } from "../src/sender";
 import { SubscriptionHandlerForTests } from "./utils/subscriptionHandlerForTests";
@@ -119,9 +124,7 @@ describe("EventHub Sender", function(): void {
     });
 
     it("can be manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
 
@@ -166,7 +169,7 @@ describe("EventHub Sender", function(): void {
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
 
       await producer.close();
-      setTracer(existingTracer);
+      resetTracer();
     });
   });
 
@@ -402,9 +405,7 @@ describe("EventHub Sender", function(): void {
     });
 
     it("can be manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
 
@@ -444,13 +445,11 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
-      setTracer(existingTracer);
+      resetTracer();
     });
 
     it("will not instrument already instrumented events", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("test");
 
@@ -497,13 +496,11 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
-      setTracer(existingTracer);
+      resetTracer();
     });
 
     it("will support tracing batch and send", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
 
@@ -552,7 +549,7 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
-      setTracer(existingTracer);
+      resetTracer();
     });
 
     it("with partition key should be sent successfully.", async function(): Promise<void> {
@@ -793,9 +790,7 @@ describe("EventHub Sender", function(): void {
     });
 
     it("can be manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
 
@@ -856,13 +851,11 @@ describe("EventHub Sender", function(): void {
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
 
       await producer.close();
-      setTracer(existingTracer);
+      resetTracer();
     });
 
     it("skips already instrumented events when manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
 
@@ -920,7 +913,7 @@ describe("EventHub Sender", function(): void {
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
 
       await producer.close();
-      setTracer(existingTracer);
+      resetTracer();
     });
   });
 
@@ -1036,9 +1029,7 @@ describe("EventHub Sender", function(): void {
     });
 
     it("can be manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
 
@@ -1095,13 +1086,11 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
-      setTracer(existingTracer);
+      resetTracer();
     });
 
     it("skips already instrumented events when manually traced", async function(): Promise<void> {
-      const tracer = new TestTracer();
-      const existingTracer = getTracer();
-      setTracer(tracer);
+      const { tracer, resetTracer } = setTracerForTest();
 
       const rootSpan = tracer.startSpan("root");
 
@@ -1155,7 +1144,7 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
-      setTracer(existingTracer);
+      resetTracer();
     });
   });
 

--- a/sdk/eventhub/event-hubs/test/sender.spec.ts
+++ b/sdk/eventhub/event-hubs/test/sender.spec.ts
@@ -1037,6 +1037,7 @@ describe("EventHub Sender", function(): void {
 
     it("can be manually traced", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("root");
@@ -1094,10 +1095,12 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+      setTracer(existingTracer);
     });
 
     it("skips already instrumented events when manually traced", async function(): Promise<void> {
       const tracer = new TestTracer();
+      const existingTracer = getTracer();
       setTracer(tracer);
 
       const rootSpan = tracer.startSpan("root");
@@ -1152,6 +1155,7 @@ describe("EventHub Sender", function(): void {
 
       tracer.getSpanGraph(rootSpan.context().traceId).should.eql(expectedGraph);
       tracer.getActiveSpans().length.should.equal(0, "All spans should have had end called.");
+      setTracer(existingTracer);
     });
   });
 

--- a/sdk/eventhub/event-hubs/test/utils/testUtils.ts
+++ b/sdk/eventhub/event-hubs/test/utils/testUtils.ts
@@ -7,6 +7,7 @@ import { delay } from "@azure/core-amqp";
 import { EventHubConsumerClient } from "../../src/eventHubConsumerClient";
 import { EventHubProducerClient } from "../../src/eventHubProducerClient";
 import { EventPosition } from "../../src/eventPosition";
+import { setTracer, TestTracer, NoOpTracer } from "@azure/core-tracing";
 
 dotenv.config();
 
@@ -80,4 +81,16 @@ export async function getStartingPositionsForTests(
   }
 
   return startingPositions;
+}
+
+export function setTracerForTest<T extends TestTracer>(
+  tracer?: T
+): { tracer: T; resetTracer: () => void } {
+  tracer = tracer ?? (new TestTracer() as T);
+  setTracer(tracer);
+
+  return {
+    tracer,
+    resetTracer: () => setTracer(new NoOpTracer())
+  };
 }


### PR DESCRIPTION
There were two sets of tests that were failing:
- A createBatch() test suddenly had diagnostic IDs populated. Looks like we were replacing the global tracer in tests that had activated tracing and that state was propagating to other tests. Most tests don't bother checking the event properties so it's gone unnoticed.
- A set of random tests for array sending that were using date that were _probably_ failing because of clock skew. To fix those I just swapped them over to our typical pattern of using sequence number.