### PR TITLE
[service-bus] Minor fixes prior to preview.2 release

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -114,7 +114,7 @@ await sender.send([
     body: "my-message-body"
   },
   {
-    body: "another-message-body
+    body: "another-message-body"
   }
 ]);
 ```

--- a/sdk/servicebus/service-bus/samples/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/session.js
@@ -76,7 +76,7 @@ async function sendMessage(sbClient, scientist, sessionId) {
 
 async function receiveMessages(sbClient, sessionId) {
   // If receiving from a subscription you can use the createSessionReceiver(topic, subscription) overload
-  const receiver = sbClient.createSessionReceiver(queueName, "peekLock", {
+  const receiver = await sbClient.createSessionReceiver(queueName, "peekLock", {
     sessionId: sessionId
   });
 


### PR DESCRIPTION
- session sample for JS was missing the await keyword on createSessionReceiver()
- readme was missing a quote in one of the snippets, making it invalid