### PR TITLE
Fix cosmos public CI pipeline

### DIFF
--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -29,10 +29,10 @@ stages:
             NODE_TLS_REJECT_UNAUTHORIZED: 0
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ? ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}
-    : - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
-        parameters:
-          DependsOn: Build
-          ServiceDirectory: ${{parameters.ServiceDirectory}}
-          Artifacts: ${{parameters.Artifacts}}
-          ArtifactName: packages
+  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+    - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
+      parameters:
+        DependsOn: Build
+        ServiceDirectory: ${{parameters.ServiceDirectory}}
+        Artifacts: ${{parameters.Artifacts}}
+        ArtifactName: packages

--- a/eng/pipelines/templates/stages/cosmos-sdk-client.yml
+++ b/eng/pipelines/templates/stages/cosmos-sdk-client.yml
@@ -15,6 +15,8 @@ stages:
         parameters:
           PackagePath: "sdk/cosmosdb/cosmos/"
           PackageName: "@azure/cosmos"
+          TestBrowser: false
+          TestSamples: false
           Matrix:
             Windows_Node8:
               OSVmImage: "windows-2019"
@@ -27,10 +29,10 @@ stages:
             NODE_TLS_REJECT_UNAUTHORIZED: 0
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
-      parameters:
-        DependsOn: Build
-        ServiceDirectory: ${{parameters.ServiceDirectory}}
-        Artifacts: ${{parameters.Artifacts}}
-        ArtifactName: packages
+  - ? ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}
+    : - template: pipelines/stages/archetype-js-release.yml@azure-sdk-build-tools
+        parameters:
+          DependsOn: Build
+          ServiceDirectory: ${{parameters.ServiceDirectory}}
+          Artifacts: ${{parameters.Artifacts}}
+          ArtifactName: packages


### PR DESCRIPTION
Cosmos CI pipeline uses the emulator (and `archetype-sdk-integration.yml`) which automatically adds browser and samples testing to the test matrix. These tests are not required in this scenario and should be skipped. 