### PR TITLE
[Service Bus] Merge DispositionStatus and DispositionType

### DIFF
--- a/sdk/servicebus/service-bus/src/core/managementClient.ts
+++ b/sdk/servicebus/service-bus/src/core/managementClient.ts
@@ -897,7 +897,7 @@ export class ManagementClient extends LinkEntity {
       else if (dispositionType === DispositionType.complete) dispositionStatus = "completed";
       else if (dispositionType === DispositionType.defer) dispositionStatus = "defered";
       else if (dispositionType === DispositionType.deadletter) dispositionStatus = "suspended";
-      else throw new Error("Invalid `dispositionType` provided");
+      else throw new Error(`Provided "dispositionType" - ${dispositionType} is invalid`);
 
       const messageBody: any = {};
       const lockTokenBuffer: Buffer[] = [];

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -8,7 +8,6 @@ import isBuffer from "is-buffer";
 import { Buffer } from "buffer";
 import * as Constants from "../util/constants";
 import { Constants as CoreAMQPConstants, RetryOptions } from "@azure/core-amqp";
-import { DispositionStatus, DispositionType } from "../serviceBusMessage";
 
 // This is the only dependency we have on DOM types, so rather than require
 // the DOM lib we can just shim this in.
@@ -511,24 +510,6 @@ function buildRawAuthorizationRule(authorizationRule: AuthorizationRule): any {
 export function isAbsoluteUrl(url: string) {
   const _url = url.toLowerCase();
   return _url.startsWith("sb://") || _url.startsWith("http://") || _url.startsWith("https://");
-}
-
-/**
- * Helper method to map `DispositionStatus` to `DispositionType`
- *
- * @internal
- * @ignore
- * @param {DispositionStatus} dispositionStatus
- * @returns {(DispositionType | undefined)}
- */
-export function getDispositionType(
-  dispositionStatus: DispositionStatus
-): DispositionType | undefined {
-  if (dispositionStatus === DispositionStatus.abandoned) return DispositionType.abandon;
-  else if (dispositionStatus === DispositionStatus.completed) return DispositionType.complete;
-  else if (dispositionStatus === DispositionStatus.defered) return DispositionType.defer;
-  else if (dispositionStatus === DispositionStatus.suspended) return DispositionType.deadletter;
-  return undefined;
 }
 
 /**


### PR DESCRIPTION
Issue #8430 

### Changes
- Removing DispositionStatus enum and keeping DispositionType since the names are more clear w.r.t to the settlement methods.
- Updated managementClient's updateDispositionStatus method to take DispositionType as a parameter and internally mapping it as DispositionStatus.