### PR TITLE
[service-bus] track1 - porting sessionRoundRobin sample

### DIFF
--- a/sdk/servicebus/service-bus/samples/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples/javascript/README.md
@@ -12,22 +12,23 @@ urlFragment: service-bus-javascript
 
 These sample programs show how to use the JavaScript client libraries for Azure Service Bus in some common scenarios.
 
-| **File Name**                                                       | **Description**                                                                                                         |
-| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| [sendMessages.js][sendmessages]                                     | uses the send() function to send messages to Service Bus Queue/Topic                                                    |
-| [receiveMessagesStreaming.js][receivemessagesstreaming]             | uses the receive() function to receive Service Bus messages in a stream                                                 |
-| [receiveMessagesLoop.js][receivemessagesloop]                       | uses the receiveMessages() function to receive Service Bus messages in a loop                                           |
-| [scheduledMessages.js][scheduledmessages]                           | uses the scheduleMessage() function to schedule messages to appear on a Service Bus Queue/Subscription at a later time  |
-| [session.js][session]                                               | sends/receives messages to/from session enabled queues/subscriptions in Service Bus                                     |
-| [browseMessages.js][browsemessages]                                 | uses the peek() function to browse a Service Bus                                                                        |
-| [serviceprincipallogin.js][serviceprincipallogin]                   | creates a namespace using aad token credentials obtained from using service principal secrets                           |
-| [interactivelogin.js][interactivelogin]                             | creates a namespace using aad token credentials obtained from interactive login                                         |
-| [useProxy.js][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                           |
-| [advanced/movingMessagesToDLQ.js][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                     |
-| [advanced/deferral.js][advanced-deferral]                           | uses the defer() function to defer a message for later processing                                                       |
-| [advanced/processMessageFromDLQ.js][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue                             |
-| [advanced/sessionState.js][advanced-sessionstate]                   | uses a "shopping cart" example to demonstrate how SessionState information can be read and maintained in an application |
-| [advanced/topicFilters.js][advanced-topicfilters]                   | use topic subscriptions and filters for splitting up a message stream into multiple streams based on message properties |
+| **File Name**                                                       | **Description**                                                                                                                |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [sendMessages.js][sendmessages]                                     | uses the send() function to send messages to Service Bus Queue/Topic                                                           |
+| [receiveMessagesStreaming.js][receivemessagesstreaming]             | uses the receive() function to receive Service Bus messages in a stream                                                        |
+| [receiveMessagesLoop.js][receivemessagesloop]                       | uses the receiveMessages() function to receive Service Bus messages in a loop                                                  |
+| [scheduledMessages.js][scheduledmessages]                           | uses the scheduleMessage() function to schedule messages to appear on a Service Bus Queue/Subscription at a later time         |
+| [session.js][session]                                               | sends/receives messages to/from session enabled queues/subscriptions in Service Bus                                            |
+| [browseMessages.js][browsemessages]                                 | uses the peek() function to browse a Service Bus                                                                               |
+| [serviceprincipallogin.js][serviceprincipallogin]                   | creates a namespace using aad token credentials obtained from using service principal secrets                                  |
+| [interactivelogin.js][interactivelogin]                             | creates a namespace using aad token credentials obtained from interactive login                                                |
+| [useProxy.js][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                                  |
+| [advanced/movingMessagesToDLQ.js][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                            |
+| [advanced/deferral.js][advanced-deferral]                           | uses the defer() function to defer a message for later processing                                                              |
+| [advanced/processMessageFromDLQ.js][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue                                    |
+| [advanced/sessionRoundRobin.js][advanced-session-round-robin]       | uses `SessionReceiver`'s ability to get the next available session to round-robin through all sessions in a Queue/Subscription |
+| [advanced/sessionState.js][advanced-sessionstate]                   | uses a "shopping cart" example to demonstrate how SessionState information can be read and maintained in an application        |
+| [advanced/topicFilters.js][advanced-topicfilters]                   | use topic subscriptions and filters for splitting up a message stream into multiple streams based on message properties        |
 
 ## Prerequisites
 
@@ -83,4 +84,3 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [azsvcbus]: https://docs.microsoft.com/azure/service-bus-messaging/service-bus-create-namespace-portal
 [freesub]: https://azure.microsoft.com/free/
 [package]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/README.md
-

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -1,0 +1,169 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how you can continually read through all the available
+  sessions in a Service Bus queue or subscription.
+
+  Run the sendMessages sample with different session ids before running this sample.
+*/
+
+const {
+  ServiceBusClient,
+  delay,
+  ReceiveMode,
+} = require("@azure/service-bus");
+const dotenv = require("dotenv");
+const { env } = require("process");
+const { AbortController } = require("@azure/abort-controller");
+
+dotenv.config();
+
+const serviceBusConnectionString =
+  env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+
+// NOTE: this sample uses a queue but would also work a session enabled subscription.
+const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+
+const maxSessionsToProcessSimultaneously = 8;
+const sessionIdleTimeoutSeconds = 3;
+const delayOnErrorMs = 5 * 1000;
+
+// This can be used control when the round-robin processing will terminate
+// by calling abortController.abort().
+const abortController = new AbortController();
+
+// Called just before we start processing the first message of a session.
+// NOTE: This function is used only in the sample and is not part of the Service Bus library.
+async function sessionAccepted(sessionId) {
+  console.log(`[${sessionId}] will start processing...`);
+}
+
+// Called by the SessionReceiver when a message is received.
+// This is passed as part of the handlers when calling `SessionReceiver.subscribe()`.
+async function processMessage(msg) {
+  console.log(`[${msg.sessionId}] received message with body ${msg.body}`);
+}
+
+// Called by the SessionReceiver when an error occurs.
+// This will be called in the handlers we pass in `SessionReceiver.subscribe()`
+// and by the sample when we encounter an error opening a session.
+function processError(err, sessionId) {
+  if (sessionId) {
+    console.log(`Error when receiving messages from the session ${sessionId}: `, err);
+  } else {
+    console.log(`Error when creating the receiver for next available session`, err);
+  }
+}
+
+// Called if we are closing a session.
+// `reason` will be:
+// * 'error' if we are closing because of an error(the error will be delivered
+//   to `processError` above)
+// * 'idle_timeout' if `sessionIdleTimeoutMs` milliseconds pass without
+//   any messages being received (ie, session can be considered empty).
+// NOTE: This function is used only in the sample and is not part of the Service Bus library.
+async function sessionClosed(reason, sessionId) {
+  console.log(`[${sessionId}] was closed because of ${reason}`);
+}
+
+// utility function to create a timer that can be refreshed
+function createRefreshableTimer(timeoutMs, resolve) {
+  let timer;
+
+  return () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => resolve(), timeoutMs);
+  };
+}
+
+// Queries Service Bus for the next available session and processes it.
+async function receiveFromNextSession(queueClient) {
+  let sessionReceiver = queueClient.createReceiver(ReceiveMode.peekLock, {
+    sessionId: undefined
+  });
+
+  try {
+    await sessionReceiver.getState();
+  } catch (err) {
+    if (
+      err.name === "SessionCannotBeLockedError" ||
+      err.name === "OperationTimeoutError"
+    ) {
+      console.log(`INFO: no available sessions, sleeping for ${delayOnErrorMs}`);
+    } else {
+      processError(err, undefined);
+    }
+
+    await delay(delayOnErrorMs);
+    return;
+  }
+
+  await sessionAccepted(sessionReceiver.sessionId);
+
+  let onAbort;
+
+  const sessionFullyRead = new Promise((resolveSessionAsFullyRead, rejectSessionWithError) => {
+    onAbort = () => {
+      abortController.signal.removeEventListener("abort", onAbort);
+      rejectSessionWithError(new Error("Process terminated by user."));
+    };
+
+    const refreshTimer = createRefreshableTimer(
+      sessionIdleTimeoutSeconds * 1000,
+      resolveSessionAsFullyRead
+    );
+
+    refreshTimer();
+
+    abortController.signal.addEventListener("abort", onAbort);
+
+    sessionReceiver.registerMessageHandler(
+      async (msg) => {
+        refreshTimer();
+        await processMessage(msg);
+      },
+      (err) => {
+        rejectSessionWithError(err);
+      }
+    );
+  });
+
+  try {
+    await sessionFullyRead;
+    await sessionClosed("idle_timeout", sessionReceiver.sessionId);
+  } catch (err) {
+    processError(err, sessionReceiver.sessionId);
+    await sessionClosed("error", sessionReceiver.sessionId);
+  } finally {
+    abortController.signal.removeEventListener("abort", onAbort);
+    await sessionReceiver.close();
+  }
+}
+
+async function roundRobinThroughAvailableSessions() {
+  const serviceBusClient = ServiceBusClient.createFromConnectionString(serviceBusConnectionString);
+  const queueClient = serviceBusClient.createQueueClient(queueName);
+
+  const receiverPromises = [];
+
+  for (let i = 0; i < maxSessionsToProcessSimultaneously; ++i) {
+    receiverPromises.push(
+      (async () => {
+        while (!abortController.signal.aborted) {
+          await receiveFromNextSession(queueClient);
+        }
+      })()
+    );
+  }
+
+  console.log(`Listening for available sessions...`);
+  await Promise.all(receiverPromises);
+
+  await queueClient.close();
+  await serviceBusClient.close();
+  console.log(`Exiting...`);
+}
+
+// To stop the round-robin processing you can just call abortController.abort()
+roundRobinThroughAvailableSessions().catch((err) => console.log(`Fatal error: ${err}`));

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -84,6 +84,7 @@ async function receiveFromNextSession(queueClient) {
   });
 
   try {
+   // Use `getState()`, but ignore its result to force open the underlying receiver link
     await sessionReceiver.getState();
   } catch (err) {
     if (

--- a/sdk/servicebus/service-bus/samples/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/javascript/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "azure-storage-blob-samples-js",
+  "name": "azure-service-bus-samples-js",
   "private": true,
   "version": "0.1.0",
-  "description": "Azure Storage Blob client library samples for TypeScript",
+  "description": "Azure Service Bus client library samples for JavaScript",
   "engine": {
     "node": ">=8.0.0"
   },
@@ -12,8 +12,7 @@
   },
   "keywords": [
     "Azure",
-    "Storage",
-    "Blob",
+    "Service Bus",
     "Node.js",
     "JavaScript"
   ],
@@ -26,9 +25,11 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "latest",
-    "@azure/identity": "latest",
-    "@azure/storage-blob": "latest",
-    "dotenv": "^8.2.0"
+    "@azure/ms-rest-nodeauth": "^0.9.2",
+    "@azure/service-bus": "latest",
+    "dotenv": "^8.2.0",
+    "https-proxy-agent": "^4.0.0",
+    "ws": "^7.0.0"
   },
   "devDependencies": {
     "rimraf": "^3.0.0"

--- a/sdk/servicebus/service-bus/samples/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples/javascript/package.json
@@ -25,7 +25,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "latest",
-    "@azure/ms-rest-nodeauth": "^0.9.2",
+    "@azure/ms-rest-nodeauth": "^3.0.0",
     "@azure/service-bus": "latest",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^4.0.0",

--- a/sdk/servicebus/service-bus/samples/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples/typescript/README.md
@@ -12,22 +12,23 @@ urlFragment: service-bus-typescript
 
 These sample programs show how to use the TypeScript client libraries for Azure Service Bus in some common scenarios.
 
-| **File Name**                                                       | **Description**                                                                                                         |
-| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| [sendMessages.ts][sendmessages]                                     | uses the send() function to send messages to Service Bus Queue/Topic                                                    |
-| [receiveMessagesStreaming.ts][receivemessagesstreaming]             | uses the receive() function to receive Service Bus messages in a stream                                                 |
-| [receiveMessagesLoop.ts][receivemessagesloop]                       | uses the receiveMessages() function to receive Service Bus messages in a loop                                           |
-| [scheduledMessages.ts][scheduledmessages]                           | uses the scheduleMessage() function to schedule messages to appear on a Service Bus Queue/Subscription at a later time  |
-| [session.ts][session]                                               | sends/receives messages to/from session enabled queues/subscriptions in Service Bus                                     |
-| [browseMessages.ts][browsemessages]                                 | uses the peek() function to browse a Service Bus                                                                        |
-| [serviceprincipallogin.ts][serviceprincipallogin]                   | creates a namespace using aad token credentials obtained from using service principal secrets                           |
-| [interactivelogin.ts][interactivelogin]                             | creates a namespace using aad token credentials obtained from interactive login                                         |
-| [useProxy.ts][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                           |
-| [advanced/movingMessagesToDLQ.ts][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                     |
-| [advanced/deferral.ts][advanced-deferral]                           | uses the defer() function to defer a message for later processing                                                       |
-| [advanced/processMessageFromDLQ.ts][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue                             |
-| [advanced/sessionState.ts][advanced-sessionstate]                   | uses a "shopping cart" example to demonstrate how SessionState information can be read and maintained in an application |
-| [advanced/topicFilters.ts][advanced-topicfilters]                   | use topic subscriptions and filters for splitting up a message stream into multiple streams based on message properties |
+| **File Name**                                                       | **Description**                                                                                                                |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| [sendMessages.ts][sendmessages]                                     | uses the send() function to send messages to Service Bus Queue/Topic                                                           |
+| [receiveMessagesStreaming.ts][receivemessagesstreaming]             | uses the receive() function to receive Service Bus messages in a stream                                                        |
+| [receiveMessagesLoop.ts][receivemessagesloop]                       | uses the receiveMessages() function to receive Service Bus messages in a loop                                                  |
+| [scheduledMessages.ts][scheduledmessages]                           | uses the scheduleMessage() function to schedule messages to appear on a Service Bus Queue/Subscription at a later time         |
+| [session.ts][session]                                               | sends/receives messages to/from session enabled queues/subscriptions in Service Bus                                            |
+| [browseMessages.ts][browsemessages]                                 | uses the peek() function to browse a Service Bus                                                                               |
+| [serviceprincipallogin.ts][serviceprincipallogin]                   | creates a namespace using aad token credentials obtained from using service principal secrets                                  |
+| [interactivelogin.ts][interactivelogin]                             | creates a namespace using aad token credentials obtained from interactive login                                                |
+| [useProxy.ts][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                                  |
+| [advanced/movingMessagesToDLQ.ts][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                            |
+| [advanced/deferral.ts][advanced-deferral]                           | uses the defer() function to defer a message for later processing                                                              |
+| [advanced/processMessageFromDLQ.ts][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue                                    |
+| [advanced/sessionRoundRobin.ts][advanced-session-round-robin]       | uses `SessionReceiver`'s ability to get the next available session to round-robin through all sessions in a Queue/Subscription |
+| [advanced/sessionState.ts][advanced-sessionstate]                   | uses a "shopping cart" example to demonstrate how SessionState information can be read and maintained in an application        |
+| [advanced/topicFilters.ts][advanced-topicfilters]                   | use topic subscriptions and filters for splitting up a message stream into multiple streams based on message properties        |
 
 ## Prerequisites
 

--- a/sdk/servicebus/service-bus/samples/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/typescript/package.json
@@ -29,7 +29,7 @@
   "sideEffects": false,
   "dependencies": {
     "@azure/abort-controller": "latest",
-    "@azure/ms-rest-nodeauth": "^0.9.2",
+    "@azure/ms-rest-nodeauth": "^3.0.0",
     "@azure/service-bus": "latest",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^4.0.0",

--- a/sdk/servicebus/service-bus/samples/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples/typescript/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
+    "@azure/abort-controller": "latest",
     "@azure/ms-rest-nodeauth": "^0.9.2",
     "@azure/service-bus": "latest",
     "dotenv": "^8.2.0",

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -87,6 +87,7 @@ async function receiveFromNextSession(queueClient: QueueClient): Promise<void> {
   });
 
   try {
+    // Use `getState()`, but ignore its result to force open the underlying receiver link
     await sessionReceiver.getState();
   } catch (err) {
     if (

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -1,0 +1,152 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how you can continually read through all the available
+  sessions in a Service Bus queue or subscription.
+
+  Run the sendMessages sample with different session ids before running this sample.
+*/
+
+import {
+  ServiceBusClient,
+  delay,
+  ReceivedMessageWithLock,
+  SessionReceiver,
+  MessagingError
+} from "@azure/service-bus";
+import * as dotenv from "dotenv";
+import { env } from "process";
+import { AbortController } from "@azure/abort-controller";
+
+dotenv.config();
+
+const serviceBusConnectionString =
+  env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+
+// NOTE: this sample uses a queue but would also work a session enabled subscription.
+const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+
+const maxSessionsToProcessSimultaneously = 8;
+const sessionIdleTimeoutMs = 3 * 1000;
+const delayOnErrorMs = 5 * 1000;
+
+// This can be used control when the round-robin processing will terminate
+// by calling abortController.abort().
+const abortController = new AbortController();
+
+// Called just before we start processing the first message of a session.
+// NOTE: This function is used only in the sample and is not part of the Service Bus library.
+async function sessionAccepted(sessionId: string) {
+  console.log(`[${sessionId}] will start processing...`);
+}
+
+// Called by the SessionReceiver when a message is received.
+// This is passed as part of the handlers when calling `SessionReceiver.subscribe()`.
+async function processMessage(msg: ReceivedMessageWithLock) {
+  console.log(`[${msg.sessionId}] received message with body ${msg.body}`);
+}
+
+// Called by the SessionReceiver when an error occurs.
+// This will be called in the handlers we pass in `SessionReceiver.subscribe()`
+// and by the sample when we encounter an error opening a session.
+async function processError(err: Error, sessionId?: string) {
+  if (sessionId) {
+    console.log(`Error when receiving messages from the session ${sessionId}: `, err);
+  } else {
+    console.log(`Error when creating the receiver for next available session`, err);
+  }
+}
+
+// Called if we are closing a session.
+// `reason` will be:
+// * 'error' if we are closing because of an error(the error will be delivered
+//   to `processError` above)
+// * 'idle_timeout' if `sessionIdleTimeoutMs` milliseconds pass without
+//   any messages being received (ie, session can be considered empty).
+// NOTE: This function is used only in the sample and is not part of the Service Bus library.
+async function sessionClosed(reason: "error" | "idle_timeout", sessionId: string) {
+  console.log(`[${sessionId}] was closed because of ${reason}`);
+}
+
+// utility function to create a timer that can be refreshed
+function createRefreshableTimer(timeoutMs: number, resolve: Function): () => void {
+  let timer: any;
+
+  return () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => resolve(), timeoutMs);
+  };
+}
+
+// Queries Service Bus for the next available session and processes it.
+async function receiveFromNextSession(serviceBusClient: ServiceBusClient): Promise<void> {
+  let sessionReceiver: SessionReceiver<ReceivedMessageWithLock>;
+
+  try {
+    sessionReceiver = await serviceBusClient.createSessionReceiver(queueName, "peekLock", {
+      autoRenewLockDurationInMs: sessionIdleTimeoutMs
+    });
+  } catch (err) {
+    if (
+      (err as MessagingError).code === "SessionCannotBeLockedError" ||
+      (err as MessagingError).code === "OperationTimeoutError"
+    ) {
+      console.log(`INFO: no available sessions, sleeping for ${delayOnErrorMs}`);
+    } else {
+      await processError(err, undefined);
+    }
+
+    await delay(delayOnErrorMs);
+    return;
+  }
+
+  await sessionAccepted(sessionReceiver.sessionId);
+
+  const sessionFullyRead = new Promise((resolveSessionAsFullyRead, rejectSessionWithError) => {
+    const refreshTimer = createRefreshableTimer(sessionIdleTimeoutMs, resolveSessionAsFullyRead);
+    refreshTimer();
+
+    sessionReceiver.subscribe(
+      {
+        async processMessage(msg) {
+          refreshTimer();
+          await processMessage(msg);
+        },
+        async processError(err) {
+          rejectSessionWithError(err);
+        }
+      },
+      {
+        abortSignal: abortController.signal
+      }
+    );
+  });
+
+  try {
+    await sessionFullyRead;
+    await sessionClosed("idle_timeout", sessionReceiver.sessionId);
+  } catch (err) {
+    await processError(err, sessionReceiver.sessionId);
+    await sessionClosed("error", sessionReceiver.sessionId);
+  } finally {
+    await sessionReceiver.close();
+  }
+}
+
+async function roundRobinThroughAvailableSessions(): Promise<void> {
+  const serviceBusClient = new ServiceBusClient(serviceBusConnectionString);
+
+  for (let i = 0; i < maxSessionsToProcessSimultaneously; ++i) {
+    (async () => {
+      while (!abortController.signal.aborted) {
+        await receiveFromNextSession(serviceBusClient);
+      }
+    })();
+  }
+
+  console.log(`Listening for available sessions...`);
+}
+
+// To stop the round-robin processing you can just call abortController.abort()
+roundRobinThroughAvailableSessions().catch((err) => console.log(`Fatal error: ${err}`));


### PR DESCRIPTION
Porting over the sessionRoundRobin sample we wrote for Track 2 to Track 1. 

Some changes apart from the obvious ones:
- The track 1 API doesn't work with abortSignals so I needed to hook up the handler explicitly.
- Use `sessionReceiver.getSessionState` as a proxy call for explicitly opening a session. In Track 2 we open the session receiver explicitly when we create it.

For reviewer convenience I checked in the track 2 sample first and then modified it so you can see the changes more easily.

Addresses #8691 