### PR TITLE
[service-bus] Improve doc strings for create() methods on ServiceBusClient

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -84,8 +84,9 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    *
-   * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue, after which they get sent to a separate dead letter queue.
+   * Messages that are not settled within the lock duration will be redelivered as many times as
+   * the max delivery count set on the queue, after which they get sent to a separate dead letter
+   * queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -109,8 +110,9 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * subscription.
    *
-   * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the subscription, after which they get sent to a separate dead letter queue.
+   * Messages that are not settled within the lock duration will be redelivered as many times as
+   * the max delivery count set on the subscription, after which they get sent to a separate dead letter
+   * queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -176,11 +178,12 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in peekLock mode.
    *
-   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * In peekLock mode, the receiver has a lock on the session for the duration specified on the
    * queue.
    *
-   * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue, after which they get sent to a separate dead letter queue.
+   * Messages that are not settled within the lock duration will be redelivered as many times as
+   * the max delivery count set on the queue, after which they get sent to a separate dead letter
+   * queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -211,11 +214,12 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
    *
-   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * In peekLock mode, the receiver has a lock on the session for the duration specified on the
    * subscription.
    *
-   * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the subscription, after which they get sent to a separate dead letter queue.
+   * Messages that are not settled within the lock duration will be redelivered as many times as
+   * the max delivery count set on the subscription, after which they get sent to a separate dead letter
+   * queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -320,10 +324,10 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue.
    *
-   * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue, after which they get sent to a separate dead letter queue.
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue. Messages that are not settled within the lock duration will be redelivered.
    *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * You can settle a message by calling complete(), abandon() or defer() methods on
    * the message.
    *
    * @param queueName The name of the queue to receive from.
@@ -349,12 +353,9 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus subscription's dead letter queue in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * subscription.
+   * subscription. Messages that are not settled within the lock duration will be redelivered.
    *
-   * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the subscription, after which they get sent to a separate dead letter queue.
-   *
-   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * You can settle a message by calling complete(), abandon() or defer() methods on
    * the message.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -79,25 +79,25 @@ export class ServiceBusClient {
   }
 
   /**
-   * Creates a receiver for an Azure Service Bus queue.
+   * Creates a receiver for an Azure Service Bus queue in peekLock mode.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to peekLock.
    */
   createReceiver(queueName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;
   /**
-   * Creates a receiver for an Azure Service Bus queue.
+   * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    */
   createReceiver(queueName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription.
+   * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to peekLock.
    */
   createReceiver(
     topicName: string,
@@ -105,11 +105,11 @@ export class ServiceBusClient {
     receiveMode: "peekLock"
   ): Receiver<ReceivedMessageWithLock>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription.
+   * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    */
   createReceiver(
     topicName: string,
@@ -152,10 +152,10 @@ export class ServiceBusClient {
   }
 
   /**
-   * Creates a receiver for an Azure Service Bus queue.
+   * Creates a receiver for an Azure Service Bus queue in peekLock mode.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to peekLock.
    * @param options Options for the receiver itself.
    */
   createSessionReceiver(
@@ -164,10 +164,10 @@ export class ServiceBusClient {
     options?: CreateSessionReceiverOptions
   ): Promise<SessionReceiver<ReceivedMessageWithLock>>;
   /**
-   * Creates a receiver for an Azure Service Bus queue.
+   * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    * @param options Options for the receiver itself.
    */
   createSessionReceiver(
@@ -176,11 +176,11 @@ export class ServiceBusClient {
     options?: CreateSessionReceiverOptions
   ): Promise<SessionReceiver<ReceivedMessage>>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription.
+   * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to peekLock.
    * @param options Options for the receiver itself.
    */
   createSessionReceiver(
@@ -190,11 +190,11 @@ export class ServiceBusClient {
     options?: CreateSessionReceiverOptions
   ): Promise<SessionReceiver<ReceivedMessageWithLock>>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription.
+   * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    * @param options Options for the receiver itself.
    */
   createSessionReceiver(
@@ -271,31 +271,31 @@ export class ServiceBusClient {
   // }
 
   /**
-   * Creates a receiver for an Azure Service Bus queue's dead letter queue.
+   * Creates a receiver for an Azure Service Bus queue's dead letter queue in peekLock mode.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode.
    */
   createDeadLetterReceiver(
     queueName: string,
     receiveMode: "peekLock"
   ): Receiver<ReceivedMessageWithLock>;
   /**
-   * Creates a receiver for an Azure Service Bus queue's dead letter queue.
+   * Creates a receiver for an Azure Service Bus queue's dead letter queue in receiveAndDelete mode.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode.
    */
   createDeadLetterReceiver(
     queueName: string,
     receiveMode: "receiveAndDelete"
   ): Receiver<ReceivedMessage>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription's dead letter queue.
+   * Creates a receiver for an Azure Service Bus subscription's dead letter queue in peekLock mode.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode.
    */
   createDeadLetterReceiver(
     topicName: string,
@@ -303,11 +303,11 @@ export class ServiceBusClient {
     receiveMode: "peekLock"
   ): Receiver<ReceivedMessageWithLock>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription's dead letter queue.
+   * Creates a receiver for an Azure Service Bus subscription's dead letter queue in receiveAndDelete mode.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode to use (defaults to PeekLock)
+   * @param receiveMode The receive mode.
    */
   createDeadLetterReceiver(
     topicName: string,

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -81,6 +81,11 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in peekLock mode.
    *
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue or subscription.
+   *
+   * If the message is not settled during this time it becomes available to other receivers.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
    */
@@ -88,12 +93,20 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode.
    *
+   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
+   * received.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    */
   createReceiver(queueName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
   /**
    * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
+   *
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue or subscription.
+   *
+   * If the message is not settled during this time it becomes available to other receivers.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -106,6 +119,9 @@ export class ServiceBusClient {
   ): Receiver<ReceivedMessageWithLock>;
   /**
    * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode.
+   *
+   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
+   * received.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -154,6 +170,11 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in peekLock mode.
    *
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue or subscription.
+   *
+   * If the message is not settled during this time it becomes available to other receivers.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
    * @param options Options for the receiver itself.
@@ -166,6 +187,9 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode.
    *
+   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
+   * received.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    * @param options Options for the receiver itself.
@@ -177,6 +201,11 @@ export class ServiceBusClient {
   ): Promise<SessionReceiver<ReceivedMessage>>;
   /**
    * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
+   *
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue or subscription.
+   *
+   * If the message is not settled during this time it becomes available to other receivers.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -191,6 +220,9 @@ export class ServiceBusClient {
   ): Promise<SessionReceiver<ReceivedMessageWithLock>>;
   /**
    * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode.
+   *
+   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
+   * received.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -273,6 +305,11 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue's dead letter queue in peekLock mode.
    *
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue or subscription.
+   *
+   * If the message is not settled during this time it becomes available to other receivers.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode.
    */
@@ -283,6 +320,9 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue's dead letter queue in receiveAndDelete mode.
    *
+   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
+   * received.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode.
    */
@@ -292,6 +332,11 @@ export class ServiceBusClient {
   ): Receiver<ReceivedMessage>;
   /**
    * Creates a receiver for an Azure Service Bus subscription's dead letter queue in peekLock mode.
+   *
+   * In peekLock mode, the receiver has a lock on the message for the duration specified on the
+   * queue or subscription.
+   *
+   * If the message is not settled during this time it becomes available to other receivers.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -304,6 +349,9 @@ export class ServiceBusClient {
   ): Receiver<ReceivedMessageWithLock>;
   /**
    * Creates a receiver for an Azure Service Bus subscription's dead letter queue in receiveAndDelete mode.
+   *
+   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
+   * received.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -85,7 +85,7 @@ export class ServiceBusClient {
    * queue.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue.
+   * set on the queue, after which they get sent to a separate dead letter queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -110,7 +110,7 @@ export class ServiceBusClient {
    * subscription.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the subscription.
+   * set on the subscription, after which they get sent to a separate dead letter queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -180,7 +180,7 @@ export class ServiceBusClient {
    * queue.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue.
+   * set on the queue, after which they get sent to a separate dead letter queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -215,7 +215,7 @@ export class ServiceBusClient {
    * subscription.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the subscription.
+   * set on the subscription, after which they get sent to a separate dead letter queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -321,7 +321,7 @@ export class ServiceBusClient {
    * queue.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue.
+   * set on the queue, after which they get sent to a separate dead letter queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -352,7 +352,7 @@ export class ServiceBusClient {
    * subscription.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the subscription.
+   * set on the subscription, after which they get sent to a separate dead letter queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -90,6 +90,9 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
+   * 
+   * More information about how peekLock and message settlement works here:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
@@ -116,6 +119,9 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
+   * 
+   * More information about how peekLock and message settlement works here:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -187,6 +193,9 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
+   * 
+   * More information about how peekLock and message settlement works here:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
@@ -223,6 +232,9 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
+   * 
+   * More information about how peekLock and message settlement works here:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -332,6 +344,9 @@ export class ServiceBusClient {
    *
    * See here for more information about dead letter queues:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   * 
+   * More information about how peekLock and message settlement works here:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
@@ -366,6 +381,9 @@ export class ServiceBusClient {
    *
    * See here for more information about dead letter queues:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   * 
+   * More information about how peekLock and message settlement works here:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -330,6 +330,9 @@ export class ServiceBusClient {
    * You can settle a message by calling complete(), abandon() or defer() methods on
    * the message.
    *
+   * See here for more information about dead letter queues:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
    */
@@ -341,6 +344,9 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus queue's dead letter queue in receiveAndDelete mode.
    *
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
+   *
+   * See here for more information about dead letter queues:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to receiveAndDelete.
@@ -358,6 +364,9 @@ export class ServiceBusClient {
    * You can settle a message by calling complete(), abandon() or defer() methods on
    * the message.
    *
+   * See here for more information about dead letter queues:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
+   *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
@@ -371,6 +380,9 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus subscription's dead letter queue in receiveAndDelete mode.
    *
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
+   *
+   * See here for more information about dead letter queues:
+   * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -311,7 +311,7 @@ export class ServiceBusClient {
    * If the message is not settled during this time it becomes available to other receivers.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode.
+   * @param receiveMode The receive mode, defaulted to peekLock.
    */
   createDeadLetterReceiver(
     queueName: string,
@@ -324,7 +324,7 @@ export class ServiceBusClient {
    * received.
    *
    * @param queueName The name of the queue to receive from.
-   * @param receiveMode The receive mode.
+   * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    */
   createDeadLetterReceiver(
     queueName: string,
@@ -340,7 +340,7 @@ export class ServiceBusClient {
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode.
+   * @param receiveMode The receive mode, defaulted to peekLock.
    */
   createDeadLetterReceiver(
     topicName: string,
@@ -355,7 +355,7 @@ export class ServiceBusClient {
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
-   * @param receiveMode The receive mode.
+   * @param receiveMode The receive mode, defaulted to receiveAndDelete.
    */
   createDeadLetterReceiver(
     topicName: string,

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -86,6 +86,9 @@ export class ServiceBusClient {
    *
    * If the message is not settled during this time it becomes available to other receivers.
    *
+   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * the message.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
    */
@@ -107,6 +110,9 @@ export class ServiceBusClient {
    * queue or subscription.
    *
    * If the message is not settled during this time it becomes available to other receivers.
+   *
+   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * the message.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -175,6 +181,9 @@ export class ServiceBusClient {
    *
    * If the message is not settled during this time it becomes available to other receivers.
    *
+   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * the message.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
    * @param options Options for the receiver itself.
@@ -206,6 +215,9 @@ export class ServiceBusClient {
    * queue or subscription.
    *
    * If the message is not settled during this time it becomes available to other receivers.
+   *
+   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * the message.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -310,6 +322,9 @@ export class ServiceBusClient {
    *
    * If the message is not settled during this time it becomes available to other receivers.
    *
+   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * the message.
+   *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to peekLock.
    */
@@ -337,6 +352,9 @@ export class ServiceBusClient {
    * queue or subscription.
    *
    * If the message is not settled during this time it becomes available to other receivers.
+   *
+   * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
+   * the message.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -84,7 +84,8 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue or subscription.
    *
-   * If the message is not settled during this time it becomes available to other receivers.
+   * Messages that are not settled will be redelivered as many times as the max delivery count
+   * set on the queue or subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -96,8 +97,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode.
    *
-   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
-   * received.
+   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to receiveAndDelete.
@@ -109,7 +109,8 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue or subscription.
    *
-   * If the message is not settled during this time it becomes available to other receivers.
+   * Messages that are not settled will be redelivered as many times as the max delivery count
+   * set on the queue or subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -126,8 +127,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode.
    *
-   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
-   * received.
+   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -179,7 +179,8 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue or subscription.
    *
-   * If the message is not settled during this time it becomes available to other receivers.
+   * Messages that are not settled will be redelivered as many times as the max delivery count
+   * set on the queue or subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -196,8 +197,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode.
    *
-   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
-   * received.
+   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to receiveAndDelete.
@@ -214,7 +214,8 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue or subscription.
    *
-   * If the message is not settled during this time it becomes available to other receivers.
+   * Messages that are not settled will be redelivered as many times as the max delivery count
+   * set on the queue or subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -233,8 +234,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode.
    *
-   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
-   * received.
+   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.
@@ -320,7 +320,8 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue or subscription.
    *
-   * If the message is not settled during this time it becomes available to other receivers.
+   * Messages that are not settled will be redelivered as many times as the max delivery count
+   * set on the queue or subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -335,8 +336,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus queue's dead letter queue in receiveAndDelete mode.
    *
-   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
-   * received.
+   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param queueName The name of the queue to receive from.
    * @param receiveMode The receive mode, defaulted to receiveAndDelete.
@@ -351,7 +351,8 @@ export class ServiceBusClient {
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
    * queue or subscription.
    *
-   * If the message is not settled during this time it becomes available to other receivers.
+   * Messages that are not settled will be redelivered as many times as the max delivery count
+   * set on the queue or subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -368,8 +369,7 @@ export class ServiceBusClient {
   /**
    * Creates a receiver for an Azure Service Bus subscription's dead letter queue in receiveAndDelete mode.
    *
-   * In receiveAndDelete mode, messages are automatically removed from Service Bus as they are
-   * received.
+   * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
    * @param topicName Name of the topic for the subscription we want to receive from.
    * @param subscriptionName Name of the subscription (under the `topic`) that we want to receive from.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -82,10 +82,10 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus queue in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue or subscription.
+   * queue.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue or subscription.
+   * set on the queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -107,10 +107,10 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue or subscription.
+   * subscription.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue or subscription.
+   * set on the subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -177,10 +177,10 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus queue in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue or subscription.
+   * queue.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue or subscription.
+   * set on the queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -212,10 +212,10 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue or subscription.
+   * subscription.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue or subscription.
+   * set on the subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -318,10 +318,10 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus queue's dead letter queue in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue or subscription.
+   * queue.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue or subscription.
+   * set on the queue.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
@@ -349,10 +349,10 @@ export class ServiceBusClient {
    * Creates a receiver for an Azure Service Bus subscription's dead letter queue in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the message for the duration specified on the
-   * queue or subscription.
+   * subscription.
    *
    * Messages that are not settled will be redelivered as many times as the max delivery count
-   * set on the queue or subscription.
+   * set on the subscription.
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -176,7 +176,7 @@ export class ServiceBusClient {
   }
 
   /**
-   * Creates a receiver for an Azure Service Bus queue in peekLock mode.
+   * Creates a receiver for a session enabled Azure Service Bus queue in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the session for the duration specified on the
    * queue.
@@ -198,7 +198,7 @@ export class ServiceBusClient {
     options?: CreateSessionReceiverOptions
   ): Promise<SessionReceiver<ReceivedMessageWithLock>>;
   /**
-   * Creates a receiver for an Azure Service Bus queue in receiveAndDelete mode.
+   * Creates a receiver for a session enabled Azure Service Bus queue in receiveAndDelete mode.
    *
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *
@@ -212,7 +212,7 @@ export class ServiceBusClient {
     options?: CreateSessionReceiverOptions
   ): Promise<SessionReceiver<ReceivedMessage>>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription in peekLock mode.
+   * Creates a receiver for a session enabled Azure Service Bus subscription in peekLock mode.
    *
    * In peekLock mode, the receiver has a lock on the session for the duration specified on the
    * subscription.
@@ -236,7 +236,7 @@ export class ServiceBusClient {
     options?: CreateSessionReceiverOptions
   ): Promise<SessionReceiver<ReceivedMessageWithLock>>;
   /**
-   * Creates a receiver for an Azure Service Bus subscription in receiveAndDelete mode.
+   * Creates a receiver for a session enabled Azure Service Bus subscription in receiveAndDelete mode.
    *
    * In receiveAndDelete mode, messages are deleted from Service Bus as they are received.
    *


### PR DESCRIPTION
Simple improvements for the doc strings when describing the receiveMode for create*() methods in ServiceBusClient