### PR TITLE
[KeyVault Certificates Hotfix 4.0.1] Addressing the challenge authentication cache bug

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 4.0.1 (2020-05-11)
+
+- Fixed a bug on related to the challenge based authentication that caused consecutive new authentications on new requests.
+
 ## 4.0.0-preview.11 (2019-12-03)
 
 - To better align keyvault-certificate APIs across languages, we've made a number of improvements and updates. For the full list, please see https://github.com/Azure/azure-sdk-for-js/issues/6291

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/keyvault-certificates",
   "sdk-type": "client",
   "author": "Microsoft Corporation",
-  "version": "4.0.0-preview.11",
+  "version": "4.0.1",
   "license": "MIT",
   "description": "Isomorphic client library for Azure KeyVault's certificates.",
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",

--- a/sdk/keyvault/keyvault-certificates/src/core/challengeBasedAuthenticationPolicy.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/challengeBasedAuthenticationPolicy.ts
@@ -10,21 +10,49 @@ import { WebResource } from "@azure/core-http";
 import { AccessTokenCache, ExpiringAccessTokenCache } from "@azure/core-http";
 
 /**
+ * Representation of the Authentication Challenge
+ */
+export class AuthenticationChallenge {
+  constructor(public authorization: string, public scope: string) {
+  }
+
+  /**
+   * Checks that this AuthenticationChallenge is equal to another one given.
+   * @param other The other AuthenticationChallenge
+   */
+  public equalTo(other: AuthenticationChallenge | undefined) {
+    if (!other) {
+      return false;
+    }
+    return this.authorization === other.authorization && this.scope === other.scope;
+  }
+}
+
+/**
+ * Helps keep a copy of any previous authentication challenges,
+ * so that we can compare on any further request.
+ */
+export class AuthenticationChallengeCache {
+  public challenge?: AuthenticationChallenge;
+
+  public setCachedChallenge(challenge: AuthenticationChallenge) {
+    this.challenge = challenge;
+  }
+}
+
+/**
  * Creates a new ChallengeBasedAuthenticationPolicy factory.
  *
  * @param credential The TokenCredential implementation that can supply the challenge token.
  */
 export function challengeBasedAuthenticationPolicy(credential: TokenCredential): RequestPolicyFactory {
   const tokenCache: AccessTokenCache = new ExpiringAccessTokenCache();
+  const challengeCache = new AuthenticationChallengeCache();
   return {
     create: (nextPolicy: RequestPolicy, options: RequestPolicyOptions) => {
-      return new ChallengeBasedAuthenticationPolicy(nextPolicy, options, credential, tokenCache);
+      return new ChallengeBasedAuthenticationPolicy(nextPolicy, options, credential, tokenCache, challengeCache);
     }
   };
-}
-
-export class AuthenticationChallenge {
-  constructor(public scopes: string[] | string) { }
 }
 
 /**
@@ -35,7 +63,6 @@ export class AuthenticationChallenge {
  *
  */
 export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
-  private challenge: AuthenticationChallenge | undefined = undefined;
 
   /**
    * Creates a new ChallengeBasedAuthenticationPolicy object.
@@ -49,33 +76,42 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
     nextPolicy: RequestPolicy,
     options: RequestPolicyOptions,
     private credential: TokenCredential,
-    private tokenCache: AccessTokenCache
+    private tokenCache: AccessTokenCache,
+    private challengeCache: AuthenticationChallengeCache
   ) {
     super(nextPolicy, options);
   }
 
-  private parseWWWAuthenticate(www_authenticate: string): string {
+  private parseWWWAuthenticate(www_authenticate: string): {
+    authorization: string,
+    resource: string
+  } {
+    const returnValue = {
+      authorization: "",
+      resource: ""
+    };
     // Parses an authentication message like:
     // ```
     // Bearer authorization="some_authorization", resource="https://some.url"
     // ```
-    let authenticateArray = www_authenticate.split(" ");
-
-    // Remove the "Bearer" piece
-    delete authenticateArray[0];
+    let spaceSep = www_authenticate.split(" ");
 
     // Split the KV comma-separated list
-    let commaSep = authenticateArray.join().split(",");
-    for (let item of commaSep) {
-      // Split the key/value pairs
-      let kv = item.split("=");
-      if (kv[0].trim() == "resource") {
-        // Remove the quotations around the string
-        let resource = kv[1].trim().replace(/['"]+/g, '');
-        return resource;
+    for (const spaceItem of spaceSep) {
+      const commaSep = spaceItem.split(",");
+      for (const commaItem of commaSep) {
+        // Split the key/value pairs
+        const kv = commaItem.split("=");
+        const key = kv[0].trim();
+        const removeQuotes = (x: string): string => x.trim().replace(/['"]+/g, '');
+        if (key == "authorization" || key == "authorization_uri") {
+          returnValue.authorization = removeQuotes(kv[1]);
+        } else if (key == "resource" || key == "scope") {
+          returnValue.resource = removeQuotes(kv[1]);
+        }
       }
     }
-    return "";
+    return returnValue;
   }
 
   /**
@@ -87,9 +123,14 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
   ): Promise<HttpOperationResponse> {
     if (!webResource.headers) webResource.headers = new HttpHeaders();
 
-    let originalBody = webResource.body;
+    // Ensure that we're about to use a secure connection
+    if (!webResource.url.startsWith("https:")) {
+      throw new Error("The resource address for authorization must use the 'https' protocol.");
+    }
 
-    if (this.challenge == undefined) {
+    const originalBody = webResource.body;
+
+    if (this.challengeCache.challenge == undefined) {
       // Use a blank to start the challenge
       webResource.body = "";
     } else {
@@ -97,7 +138,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       await this.authenticateRequest(webResource);
     }
 
-    let response = await this._nextPolicy.sendRequest(webResource);
+    const response = await this._nextPolicy.sendRequest(webResource);
 
     if (response.status == 401) {
       webResource.body = originalBody;
@@ -105,17 +146,21 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
       let www_authenticate = response.headers.get("WWW-Authenticate");
 
       if (www_authenticate) {
-        let resource = this.parseWWWAuthenticate(www_authenticate);
-        let challenge = new AuthenticationChallenge(resource + "/.default")
+        // The challenge based authentication will contain both an authorization URI with a token,
+        // and the resource to which that token is valid against (also called the scope).
+        const { authorization, resource } = this.parseWWWAuthenticate(www_authenticate);
+        const challenge = new AuthenticationChallenge(authorization, resource + "/.default")
 
-        if (this.challenge != challenge) {
-          this.challenge = challenge;
+        if (!challenge.equalTo(this.challengeCache.challenge)) {
+          this.challengeCache.setCachedChallenge(challenge);
           this.tokenCache.setCachedToken(undefined);
 
           await this.authenticateRequest(webResource);
+          return this._nextPolicy.sendRequest(webResource);
         }
+        return response;
       }
-      return this._nextPolicy.sendRequest(webResource);
+      return response;
     } else {
       return response;
     }
@@ -124,7 +169,7 @@ export class ChallengeBasedAuthenticationPolicy extends BaseRequestPolicy {
   private async authenticateRequest(webResource: WebResource): Promise<void> {
     let accessToken = this.tokenCache.getCachedToken();
     if (accessToken === undefined) {
-      accessToken = (await this.credential.getToken(this.challenge!.scopes)) || undefined;
+      accessToken = (await this.credential.getToken(this.challengeCache.challenge!.scope)) || undefined;
       this.tokenCache.setCachedToken(accessToken);
     }
 

--- a/sdk/keyvault/keyvault-certificates/src/core/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/keyVaultClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "@azure/keyvault-certificates";
-const packageVersion = "4.0.0-preview.11";
+const packageVersion = "4.0.1";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: string;

--- a/sdk/keyvault/keyvault-certificates/src/core/utils/constants.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/utils/constants.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-export const SDK_VERSION: string = "4.0.0-preview.11";
+export const SDK_VERSION: string = "4.0.1";
 
 export const RetryConstants = {
   MIN_RETRY_INTERVAL_MS: 3000

--- a/sdk/keyvault/keyvault-certificates/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/CRUD.test.ts
@@ -220,11 +220,8 @@ describe("Certificates client - create, read, update and delete", () => {
     } catch (e) {
       error = e;
     }
-    assert.equal(
-      error.message,
-      `Certificate not found: ${certificateName}`,
-      "Unexpected error after trying to get a certificate"
-    );
+    assert.equal(error.code, "CertificateNotFound");
+    assert.equal(error.statusCode, 404);
   });
 
   it("can delete a certificate", async function() {
@@ -246,7 +243,7 @@ describe("Certificates client - create, read, update and delete", () => {
       throw Error("Expecting an error but not catching one.");
     } catch (e) {
       if (e.statusCode === 404) {
-        assert.equal(e.message, `Certificate not found: ${certificateName}`);
+        assert.equal(e.code, "CertificateNotFound");
       } else {
         throw e;
       }
@@ -283,11 +280,8 @@ describe("Certificates client - create, read, update and delete", () => {
     } catch (e) {
       error = e;
     }
-    assert.equal(
-      error.message,
-      `Certificate not found: ${certificateName}`,
-      "Unexpected error after trying to get a disabled certificate"
-    );
+    assert.equal(error.code, "CertificateNotFound");
+    assert.equal(error.statusCode, 404);
   });
 
   it("can get a deleted certificate", async function() {
@@ -316,11 +310,8 @@ describe("Certificates client - create, read, update and delete", () => {
     } catch (e) {
       error = e;
     }
-    assert.equal(
-      error.message,
-      `Certificate not found: ${certificateName}`,
-      "Unexpected certificate name in result from getKey()."
-    );
+    assert.equal(error.code, "CertificateNotFound");
+    assert.equal(error.statusCode, 404);
   });
 
   it("can create, read, and delete a certificate issuer", async function() {
@@ -448,7 +439,8 @@ describe("Certificates client - create, read, update and delete", () => {
     } catch (e) {
       error = e;
     }
-    assert.equal(error.message, `Pending certificate not found: ${certificateName}`);
+    assert.equal(error.code, "CertificateNotFound");
+    assert.equal(error.statusCode, 404);
 
     await testClient.flushCertificate(certificateName);
   });

--- a/sdk/keyvault/keyvault-certificates/test/challengeBasedAuthenticationPolicy.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/challengeBasedAuthenticationPolicy.test.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { CertificateClient } from "../src";
+import { env, Recorder } from "@azure/test-utils-recorder";
+import { authenticate } from "./utils/testAuthentication";
+import TestClient from "./utils/testClient";
+import {
+  AuthenticationChallengeCache,
+  AuthenticationChallenge
+} from "../src/core/challengeBasedAuthenticationPolicy";
+import { testPollerProperties } from "./utils/recorderUtils";
+
+describe("Challenge based authentication tests", () => {
+  const certificatePrefix = `challengeAuth${env.KEY_NAME || "CertificateName"}`;
+  let certificateSuffix: string;
+  let client: CertificateClient;
+  let testClient: TestClient;
+  let recorder: Recorder;
+  let originalSetCachedChallenge: any;
+
+  beforeEach(async function() {
+    const authentication = await authenticate(this);
+    certificateSuffix = authentication.certificateSuffix;
+    client = authentication.client;
+    testClient = authentication.testClient;
+    recorder = authentication.recorder;
+
+    // Since the Challenge based authentication is protected from writing normally,
+    // and is involved in considerable core-http machinery,
+    // the easiest way to test it is to hack into the `AuthenticationChallengeCache` class.
+    // We will restore it on the `afterEach`.
+    originalSetCachedChallenge = AuthenticationChallengeCache.prototype.setCachedChallenge;
+  });
+
+  afterEach(async function() {
+    recorder.stop();
+
+    // Restoring `AuthenticationChallengeCache` back to normal.
+    AuthenticationChallengeCache.prototype.setCachedChallenge = originalSetCachedChallenge;
+  });
+
+  // The tests follow
+
+  it("Once authenticated, new requests should not authenticate again", async function() {
+    // Our goal is to intercept how our pipelines are storing the challenge.
+    // The first network call should indeed set the challenge in memory.
+    // Subsequent network calls should not set new challenges.
+
+    const challenges: AuthenticationChallenge[] = [];
+
+    AuthenticationChallengeCache.prototype.setCachedChallenge = function(
+      challenge: AuthenticationChallenge
+    ): void {
+      challenges.push(challenge);
+      originalSetCachedChallenge.call(this, challenge);
+    };
+
+    // Now we run what would be a normal use of the client.
+    // Here we will create a certificates, then we flush it.
+    // testClient.flushCertificate deletes, then purges the certificates.
+    const certificateName = testClient.formatName(
+      `${certificatePrefix}-${this!.test!.title}-${certificateSuffix}`
+    );
+    await client.beginCreateCertificate(
+      certificateName,
+      {
+        issuerName: "Self",
+        subject: "cn=MyCert"
+      },
+      testPollerProperties
+    );
+    await testClient.flushCertificate(certificateName);
+
+    // We should have recorded a total of ONE challenge.
+    // Failing to authenticate will make network requests throw.
+    assert.equal(challenges.length, 1);
+  });
+});

--- a/sdk/keyvault/keyvault-certificates/test/recoverBackupRestore.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/recoverBackupRestore.test.ts
@@ -72,7 +72,8 @@ describe("Certificates client - restore certificates and recover backups", () =>
     } catch (e) {
       error = e;
     }
-    assert.equal(error.message, `Certificate not found: ${certificateName}`);
+    assert.equal(error.code, "CertificateNotFound");
+    assert.equal(error.statusCode, 404);
   });
 
   // This is taking forever


### PR DESCRIPTION
This PR highlights the changes needed to release the hotfix that resolves an issue reported by a customer: https://github.com/Azure/azure-sdk-for-js/issues/8378

The PR to master is: https://github.com/Azure/azure-sdk-for-js/pull/8558/

Related to:
- [KeyVault Certificates Hotfix 4.0.1] Bringing certificates 4.0.0 into the existing hotfix branch #8786
- [KeyVault Certificates Hotfix 4.0.1] Recordings #8787