### PR TITLE
[core-http/arm] remove deprecated configuration via mocha.opts

### DIFF
--- a/sdk/core/core-arm/package.json
+++ b/sdk/core/core-arm/package.json
@@ -85,7 +85,7 @@
     "test": "npm run build && npm run unit-test && npm run integration-test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "echo skipped",
-    "unit-test:node": "nyc mocha",
+    "unit-test:node": "nyc mocha --require ts-node/register --timeout 50000 --reporter ../../../common/tools/mocha-multi-reporter.js --colors \"test/**/*.ts\"",
     "pack": "npm pack 2>&1",
     "prebuild": "npm run clean"
   },

--- a/sdk/core/core-arm/test/mocha.opts
+++ b/sdk/core/core-arm/test/mocha.opts
@@ -1,5 +1,0 @@
---require ts-node/register
---timeout 50000
---reporter ../../../common/tools/mocha-multi-reporter.js
---colors
-test/**/*.ts

--- a/sdk/core/core-http/.vscode/launch.json
+++ b/sdk/core/core-http/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Unit Tests (Node)",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "cwd": "${workspaceFolder}",
+      "env": { "TS_NODE_FILES": "true" },
+      "args": [
+        "--require",
+        "ts-node/register",
+        "--timeout",
+        "50000",
+        "--colors",
+        "--exclude",
+        "test/**/*.browser.ts",
+        "test/**/*.ts"
+      ],
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": ["<node_internals>/**/async_hooks.js", "<node_internals>/**/*.js"]
+    }
+  ]
+}

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -92,7 +92,7 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "node ./node_modules/karma/bin/karma start karma.conf.ts --browsers ChromeNoSecurity --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true nyc mocha",
+    "unit-test:node": "cross-env TS_NODE_FILES=true mocha --require ts-node/register --timeout 50000 --reporter ../../../common/tools/mocha-multi-reporter.js --colors --exclude test/**/*.browser.ts test/**/*.ts",
     "check:packagejsonversion": "ts-node ./.scripts/checkPackageJsonVersion.ts",
     "check:foronlycalls": "ts-node ./.scripts/checkForOnlyCalls.ts",
     "check:everything": "ts-node ./.scripts/checkEverything.ts",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -92,7 +92,7 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "node ./node_modules/karma/bin/karma start karma.conf.ts --browsers ChromeNoSecurity --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true mocha --require ts-node/register --timeout 50000 --reporter ../../../common/tools/mocha-multi-reporter.js --colors --exclude \"test/**/*.browser.ts\" \"test/**/*.ts\"",
+    "unit-test:node": "cross-env TS_NODE_FILES=true nyc mocha --require ts-node/register --timeout 50000 --reporter ../../../common/tools/mocha-multi-reporter.js --colors --exclude \"test/**/*.browser.ts\" \"test/**/*.ts\"",
     "check:packagejsonversion": "ts-node ./.scripts/checkPackageJsonVersion.ts",
     "check:foronlycalls": "ts-node ./.scripts/checkForOnlyCalls.ts",
     "check:everything": "ts-node ./.scripts/checkEverything.ts",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -92,7 +92,7 @@
     "test": "npm run build:test && npm run unit-test && npm run integration-test",
     "unit-test": "npm run unit-test:node && npm run unit-test:browser",
     "unit-test:browser": "node ./node_modules/karma/bin/karma start karma.conf.ts --browsers ChromeNoSecurity --single-run",
-    "unit-test:node": "cross-env TS_NODE_FILES=true mocha --require ts-node/register --timeout 50000 --reporter ../../../common/tools/mocha-multi-reporter.js --colors --exclude test/**/*.browser.ts test/**/*.ts",
+    "unit-test:node": "cross-env TS_NODE_FILES=true mocha --require ts-node/register --timeout 50000 --reporter ../../../common/tools/mocha-multi-reporter.js --colors --exclude \"test/**/*.browser.ts\" \"test/**/*.ts\"",
     "check:packagejsonversion": "ts-node ./.scripts/checkPackageJsonVersion.ts",
     "check:foronlycalls": "ts-node ./.scripts/checkForOnlyCalls.ts",
     "check:everything": "ts-node ./.scripts/checkEverything.ts",

--- a/sdk/core/core-http/test/mocha.opts
+++ b/sdk/core/core-http/test/mocha.opts
@@ -1,6 +1,0 @@
---require ts-node/register
---timeout 50000
---reporter ../../../common/tools/mocha-multi-reporter.js
---colors
---exclude test/**/*.browser.ts
-test/**/*.ts


### PR DESCRIPTION
passing options via command line instead.

Also added a VS Code launch configuration for debugging Node tests.