### PR TITLE
[ai-text-analytics] Fix code sample in docs

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -133,11 +133,11 @@ export class TextAnalyticsClient {
    *
    * Example usage:
    * ```ts
-   * import { TextAnalyticsClient, KeyCredential } from "@azure/ai-text-analytics";
+   * import { TextAnalyticsClient, AzureKeyCredential } from "@azure/ai-text-analytics";
    *
    * const client = new TextAnalyticsClient(
    *    "<service endpoint>",
-   *    new KeyCredential("<api key>")
+   *    new AzureKeyCredential("<api key>")
    * );
    * ```
    * @param {string} endpointUrl The URL to the TextAnalytics endpoint


### PR DESCRIPTION
The implmentation of `KeyCredential` is now spelled
`AzureKeyCredential`. Update the doc comment on the constructor.