### PR TITLE
converting storage-blob exported references to src references

### DIFF
--- a/sdk/storage/storage-blob/test/blobbatch.spec.ts
+++ b/sdk/storage/storage-blob/test/blobbatch.spec.ts
@@ -8,7 +8,7 @@ import {
   recorderEnvSetup
 } from "./utils";
 import { record, Recorder } from "@azure/test-utils-recorder";
-import { BlobBatch } from "../src/BlobBatch";
+import { BlobBatch } from "../src";
 import {
   ContainerClient,
   BlockBlobClient,

--- a/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobserviceclient.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 
 import * as dotenv from "dotenv";
-import { BlobServiceClient } from "../src/BlobServiceClient";
+import { BlobServiceClient } from "../src";
 import {
   getAlternateBSU,
   getBSU,

--- a/sdk/storage/storage-blob/test/node/containerclient.spec.ts
+++ b/sdk/storage/storage-blob/test/node/containerclient.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 
 import { getBSU, getConnectionStringFromEnvironment, recorderEnvSetup } from "../utils";
-import { PublicAccessType } from "../../src/generated/src/models/index";
+import { PublicAccessType } from "../../src";
 import {
   ContainerClient,
   newPipeline,

--- a/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
+++ b/sdk/storage/storage-blob/test/node/highlevel.node.spec.ts
@@ -8,7 +8,7 @@ import { createRandomLocalFile, getBSU, recorderEnvSetup } from "../utils";
 import { RetriableReadableStreamOptions } from "../../src/utils/RetriableReadableStream";
 import { record, Recorder } from "@azure/test-utils-recorder";
 import { ContainerClient, BlobClient, BlockBlobClient, BlobServiceClient } from "../../src";
-import { readStreamToLocalFileWithLogs } from "../../test/utils/testutils.node";
+import { readStreamToLocalFileWithLogs } from "../utils/testutils.node";
 
 // tslint:disable:no-empty
 describe("Highlevel", () => {

--- a/sdk/storage/storage-blob/test/node/utils.spec.ts
+++ b/sdk/storage/storage-blob/test/node/utils.spec.ts
@@ -43,7 +43,7 @@ describe("Utility Helpers Node.js only", () => {
     } catch (error) {
       assert.ok(
         error.message ===
-          "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'"
+        "Invalid DefaultEndpointsProtocol in the provided Connection String. Expecting 'https' or 'http'"
       );
     }
   });
@@ -341,7 +341,7 @@ describe("Utility Helpers Node.js only", () => {
       }
     ];
 
-    tests.forEach(function(test) {
+    tests.forEach(function (test) {
       it(test.title, async () => {
         const inputBuffer = randomBytes(test.streamLength);
 

--- a/sdk/storage/storage-blob/test/retrypolicy.spec.ts
+++ b/sdk/storage/storage-blob/test/retrypolicy.spec.ts
@@ -4,7 +4,7 @@ import * as dotenv from "dotenv";
 
 import { AbortController } from "@azure/abort-controller";
 import { ContainerClient, RestError, BlobServiceClient } from "../src";
-import { newPipeline, Pipeline } from "../src/Pipeline";
+import { newPipeline, Pipeline } from "../src";
 import { getBSU, recorderEnvSetup } from "./utils";
 import { InjectorPolicyFactory } from "./utils/InjectorPolicyFactory";
 import { record, Recorder } from "@azure/test-utils-recorder";

--- a/sdk/storage/storage-blob/test/utils/constants.ts
+++ b/sdk/storage/storage-blob/test/utils/constants.ts
@@ -1,4 +1,4 @@
-import { CpkInfo } from "../../src/generated/src/models";
+import { CpkInfo } from "../../src";
 
 export const Test_CPK_INFO: CpkInfo = {
   encryptionKey: "MDEyMzQ1NjcwMTIzNDU2NzAxMjM0NTY3MDEyMzQ1Njc=",

--- a/sdk/storage/storage-blob/test/utils/index.browser.ts
+++ b/sdk/storage/storage-blob/test/utils/index.browser.ts
@@ -1,6 +1,6 @@
-import { AnonymousCredential } from "../../src/credentials/AnonymousCredential";
-import { BlobServiceClient } from "../../src/BlobServiceClient";
-import { newPipeline } from "../../src/Pipeline";
+import { AnonymousCredential } from "../../src";
+import { BlobServiceClient } from "../../src";
+import { newPipeline } from "../../src";
 import { SimpleTokenCredential } from "./testutils.common";
 import { TokenCredential } from "@azure/core-http";
 

--- a/sdk/storage/storage-blob/test/utils/index.ts
+++ b/sdk/storage/storage-blob/test/utils/index.ts
@@ -4,10 +4,10 @@ import * as fs from "fs";
 import * as path from "path";
 
 import { SimpleTokenCredential } from "./testutils.common";
-import { StorageSharedKeyCredential } from "../../src/credentials/StorageSharedKeyCredential";
-import { BlobServiceClient } from "../../src/BlobServiceClient";
+import { StorageSharedKeyCredential } from "../../src";
+import { BlobServiceClient } from "../../src";
 import { getUniqueName } from "./testutils.common";
-import { newPipeline } from "../../src/Pipeline";
+import { newPipeline } from "../../src";
 import {
   generateAccountSASQueryParameters,
   AccountSASPermissions,
@@ -163,7 +163,7 @@ export async function createRandomLocalFile(
 
     ws.on("open", () => {
       // tslint:disable-next-line:no-empty
-      while (offsetInMB++ < blockNumber && ws.write(randomValueHex())) {}
+      while (offsetInMB++ < blockNumber && ws.write(randomValueHex())) { }
       if (offsetInMB >= blockNumber) {
         ws.end();
       }
@@ -171,7 +171,7 @@ export async function createRandomLocalFile(
 
     ws.on("drain", () => {
       // tslint:disable-next-line:no-empty
-      while (offsetInMB++ < blockNumber && ws.write(randomValueHex())) {}
+      while (offsetInMB++ < blockNumber && ws.write(randomValueHex())) { }
       if (offsetInMB >= blockNumber) {
         ws.end();
       }


### PR DESCRIPTION
This is preferable for all packages to identify the tests that are using exported public members v/s internal references
Eg of min-max testing issues we run into - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=386486&view=logs&j=1c9290f0-7664-5780-0e82-5fab6e3e2db5&t=b211ce22-692d-5fec-1417-52e3b1830f7c