### PR TITLE
Workaround @types/qs breakage

### DIFF
--- a/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
@@ -64,7 +64,7 @@ describe("ClientCertificateCredential", function() {
         "Request URL doesn't contain expected clientId"
       );
 
-      const queryParams = qs.parse(authRequest.body);
+      const queryParams: any = qs.parse(authRequest.body);
       const jwtToken = jws.decode(queryParams.client_assertion);
 
       assert.strictEqual(jwtToken.header.x5t, (credential as any).certificateX5t);

--- a/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
+++ b/sdk/identity/identity/test/node/clientCertificateCredential.spec.ts
@@ -64,8 +64,8 @@ describe("ClientCertificateCredential", function() {
         "Request URL doesn't contain expected clientId"
       );
 
-      const queryParams: any = qs.parse(authRequest.body);
-      const jwtToken = jws.decode(queryParams.client_assertion);
+      const queryParams = qs.parse(authRequest.body);
+      const jwtToken = jws.decode(queryParams.client_assertion as string);
 
       assert.strictEqual(jwtToken.header.x5t, (credential as any).certificateX5t);
       assert.strictEqual(jwtToken.payload.iss, clientId);

--- a/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
@@ -163,10 +163,10 @@ describe("ManagedIdentityCredential", function() {
 
     assert.ok(authRequest.body !== undefined, "No body on request");
     if (authRequest.body) {
-      const bodyParams: any = qs.parse(authRequest.body);
+      const bodyParams = qs.parse(authRequest.body);
       assert.equal(authRequest.method, "POST");
       assert.equal(bodyParams.client_id, "client");
-      assert.equal(decodeURIComponent(bodyParams.resource), "https://service");
+      assert.equal(decodeURIComponent(bodyParams.resource as string), "https://service");
       assert.ok(
         authRequest.url.startsWith(process.env.MSI_ENDPOINT),
         "URL does not start with expected host and path"

--- a/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
+++ b/sdk/identity/identity/test/node/managedIdentityCredential.spec.ts
@@ -163,7 +163,7 @@ describe("ManagedIdentityCredential", function() {
 
     assert.ok(authRequest.body !== undefined, "No body on request");
     if (authRequest.body) {
-      const bodyParams = qs.parse(authRequest.body);
+      const bodyParams: any = qs.parse(authRequest.body);
       assert.equal(authRequest.method, "POST");
       assert.equal(bodyParams.client_id, "client");
       assert.equal(decodeURIComponent(bodyParams.resource), "https://service");


### PR DESCRIPTION
This fixes the @types/qs breakage, where return types were recently made more specific. This caused issues where we assume it's returning 'any'.

With this, it's possible to do a `rush update --full`

cc @KarishmaGhiya 