### PR TITLE
[Service Bus] Port round robin sample to v1 folder

### DIFF
--- a/sdk/servicebus/service-bus/samples-v1/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/README.md
@@ -26,6 +26,7 @@ These sample programs show how to use the JavaScript client libraries for Azure 
 | [advanced/movingMessagesToDLQ.js][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                     |
 | [advanced/deferral.js][advanced-deferral]                           | uses the defer() function to defer a message for later processing                                                       |
 | [advanced/processMessageFromDLQ.js][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue                             |
+| [advanced/sessionRoundRobin.js][advanced-sessionroundrobin]       | uses `SessionReceiver`'s ability to get the next available session to round-robin through all sessions in a Queue/Subscription |
 | [advanced/sessionState.js][advanced-sessionstate]                   | uses a "shopping cart" example to demonstrate how SessionState information can be read and maintained in an application |
 | [advanced/topicFilters.js][advanced-topicfilters]                   | use topic subscriptions and filters for splitting up a message stream into multiple streams based on message properties |
 
@@ -75,6 +76,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [advanced-movingmessagestodlq]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/javascript/advanced/movingMessagesToDLQ.js
 [advanced-deferral]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/javascript/advanced/deferral.js
 [advanced-processmessagefromdlq]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/javascript/advanced/processMessageFromDLQ.js
+[advanced-sessionroundrobin]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionRoundRobin.js
 [advanced-sessionstate]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionState.js
 [advanced-topicfilters]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/javascript/advanced/topicFilters.js
 [sendmessages]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/javascript/sendMessages.js

--- a/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionRoundRobin.js
@@ -14,16 +14,15 @@ const {
     ReceiveMode,
   } = require("@azure/service-bus");
   const dotenv = require("dotenv");
-  const { env } = require("process");
   const { AbortController } = require("@azure/abort-controller");
   
   dotenv.config();
   
   const serviceBusConnectionString =
-    env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
   
   // NOTE: this sample uses a queue but would also work a session enabled subscription.
-  const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+  const queueName = process.env.QUEUE_NAME || "<queue name>";
   
   const maxSessionsToProcessSimultaneously = 8;
   const sessionIdleTimeoutSeconds = 3;

--- a/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/advanced/sessionRoundRobin.js
@@ -1,0 +1,170 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how you can continually read through all the available
+  sessions in a Service Bus queue or subscription.
+
+  Run the sendMessages sample with different session ids before running this sample.
+*/
+
+const {
+    ServiceBusClient,
+    delay,
+    ReceiveMode,
+  } = require("@azure/service-bus");
+  const dotenv = require("dotenv");
+  const { env } = require("process");
+  const { AbortController } = require("@azure/abort-controller");
+  
+  dotenv.config();
+  
+  const serviceBusConnectionString =
+    env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+  
+  // NOTE: this sample uses a queue but would also work a session enabled subscription.
+  const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+  
+  const maxSessionsToProcessSimultaneously = 8;
+  const sessionIdleTimeoutSeconds = 3;
+  const delayOnErrorMs = 5 * 1000;
+  
+  // This can be used control when the round-robin processing will terminate
+  // by calling abortController.abort().
+  const abortController = new AbortController();
+  
+  // Called just before we start processing the first message of a session.
+  // NOTE: This function is used only in the sample and is not part of the Service Bus library.
+  async function sessionAccepted(sessionId) {
+    console.log(`[${sessionId}] will start processing...`);
+  }
+  
+  // Called by the SessionReceiver when a message is received.
+  // This is passed as part of the handlers when calling `SessionReceiver.subscribe()`.
+  async function processMessage(msg) {
+    console.log(`[${msg.sessionId}] received message with body ${msg.body}`);
+  }
+  
+  // Called by the SessionReceiver when an error occurs.
+  // This will be called in the handlers we pass in `SessionReceiver.subscribe()`
+  // and by the sample when we encounter an error opening a session.
+  function processError(err, sessionId) {
+    if (sessionId) {
+      console.log(`Error when receiving messages from the session ${sessionId}: `, err);
+    } else {
+      console.log(`Error when creating the receiver for next available session`, err);
+    }
+  }
+  
+  // Called if we are closing a session.
+  // `reason` will be:
+  // * 'error' if we are closing because of an error(the error will be delivered
+  //   to `processError` above)
+  // * 'idle_timeout' if `sessionIdleTimeoutMs` milliseconds pass without
+  //   any messages being received (ie, session can be considered empty).
+  // NOTE: This function is used only in the sample and is not part of the Service Bus library.
+  async function sessionClosed(reason, sessionId) {
+    console.log(`[${sessionId}] was closed because of ${reason}`);
+  }
+  
+  // utility function to create a timer that can be refreshed
+  function createRefreshableTimer(timeoutMs, resolve) {
+    let timer;
+  
+    return () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => resolve(), timeoutMs);
+    };
+  }
+  
+  // Queries Service Bus for the next available session and processes it.
+  async function receiveFromNextSession(queueClient) {
+    let sessionReceiver = queueClient.createReceiver(ReceiveMode.peekLock, {
+      sessionId: undefined
+    });
+  
+    try {
+     // Use `getState()`, but ignore its result to force open the underlying receiver link
+      await sessionReceiver.getState();
+    } catch (err) {
+      if (
+        err.name === "SessionCannotBeLockedError" ||
+        err.name === "OperationTimeoutError"
+      ) {
+        console.log(`INFO: no available sessions, sleeping for ${delayOnErrorMs}`);
+      } else {
+        processError(err, undefined);
+      }
+  
+      await delay(delayOnErrorMs);
+      return;
+    }
+  
+    await sessionAccepted(sessionReceiver.sessionId);
+  
+    let onAbort;
+  
+    const sessionFullyRead = new Promise((resolveSessionAsFullyRead, rejectSessionWithError) => {
+      onAbort = () => {
+        abortController.signal.removeEventListener("abort", onAbort);
+        rejectSessionWithError(new Error("Process terminated by user."));
+      };
+  
+      const refreshTimer = createRefreshableTimer(
+        sessionIdleTimeoutSeconds * 1000,
+        resolveSessionAsFullyRead
+      );
+  
+      refreshTimer();
+  
+      abortController.signal.addEventListener("abort", onAbort);
+  
+      sessionReceiver.registerMessageHandler(
+        async (msg) => {
+          refreshTimer();
+          await processMessage(msg);
+        },
+        (err) => {
+          rejectSessionWithError(err);
+        }
+      );
+    });
+  
+    try {
+      await sessionFullyRead;
+      await sessionClosed("idle_timeout", sessionReceiver.sessionId);
+    } catch (err) {
+      processError(err, sessionReceiver.sessionId);
+      await sessionClosed("error", sessionReceiver.sessionId);
+    } finally {
+      abortController.signal.removeEventListener("abort", onAbort);
+      await sessionReceiver.close();
+    }
+  }
+  
+  async function roundRobinThroughAvailableSessions() {
+    const serviceBusClient = ServiceBusClient.createFromConnectionString(serviceBusConnectionString);
+    const queueClient = serviceBusClient.createQueueClient(queueName);
+  
+    const receiverPromises = [];
+  
+    for (let i = 0; i < maxSessionsToProcessSimultaneously; ++i) {
+      receiverPromises.push(
+        (async () => {
+          while (!abortController.signal.aborted) {
+            await receiveFromNextSession(queueClient);
+          }
+        })()
+      );
+    }
+  
+    console.log(`Listening for available sessions...`);
+    await Promise.all(receiverPromises);
+  
+    await queueClient.close();
+    await serviceBusClient.close();
+    console.log(`Exiting...`);
+  }
+  
+  // To stop the round-robin processing you can just call abortController.abort()
+  roundRobinThroughAvailableSessions().catch((err) => console.log(`Fatal error: ${err}`));

--- a/sdk/servicebus/service-bus/samples-v1/javascript/package.json
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "azure-service-bus-samples-ts",
+  "name": "azure-service-bus-samples-js",
   "private": true,
   "version": "0.1.0",
-  "description": "Azure Service Bus client library samples for TypeScript",
+  "description": "Azure Service Bus client library samples for JavaScript",
   "engine": {
     "node": ">=8.0.0"
   },
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/identity": "^1.0.2",
+    "@azure/abort-controller": "latest",
+    "@azure/ms-rest-nodeauth": "^3.0.0",
     "@azure/service-bus": "^1.1.6",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^4.0.0",

--- a/sdk/servicebus/service-bus/samples-v1/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/README.md
@@ -25,7 +25,7 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 | [useProxy.ts][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                           |
 | [advanced/movingMessagesToDLQ.ts][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                     |
 | [advanced/deferral.ts][advanced-deferral]                           | uses the defer() function to defer a message for later processing                                                       |
-| [advanced/processMessageFromDLQ.ts][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue     
+| [advanced/processMessageFromDLQ.ts][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue                                  |
 | [advanced/sessionRoundRobin.ts][advanced-sessionroundrobin]       | uses `SessionReceiver`'s ability to get the next available session to round-robin through all sessions in a Queue/Subscription |
 | [advanced/sessionState.ts][advanced-sessionstate]                   | uses a "shopping cart" example to demonstrate how SessionState information can be read and maintained in an application |
 | [advanced/topicFilters.ts][advanced-topicfilters]                   | use topic subscriptions and filters for splitting up a message stream into multiple streams based on message properties |

--- a/sdk/servicebus/service-bus/samples-v1/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/README.md
@@ -25,7 +25,8 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 | [useProxy.ts][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                           |
 | [advanced/movingMessagesToDLQ.ts][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                     |
 | [advanced/deferral.ts][advanced-deferral]                           | uses the defer() function to defer a message for later processing                                                       |
-| [advanced/processMessageFromDLQ.ts][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue                             |
+| [advanced/processMessageFromDLQ.ts][advanced-processmessagefromdlq] | retrieves a message from a dead-letter queue, edits it, and sends it back to the main queue     
+| [advanced/sessionRoundRobin.ts][advanced-sessionroundrobin]       | uses `SessionReceiver`'s ability to get the next available session to round-robin through all sessions in a Queue/Subscription |
 | [advanced/sessionState.ts][advanced-sessionstate]                   | uses a "shopping cart" example to demonstrate how SessionState information can be read and maintained in an application |
 | [advanced/topicFilters.ts][advanced-topicfilters]                   | use topic subscriptions and filters for splitting up a message stream into multiple streams based on message properties |
 
@@ -87,6 +88,7 @@ Take a look at our [API Documentation][apiref] for more information about the AP
 [advanced-movingmessagestodlq]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/movingMessagesToDLQ.ts
 [advanced-deferral]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/deferral.ts
 [advanced-processmessagefromdlq]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/processMessageFromDLQ.ts
+[advanced-sessionroundrobin]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionRoundRobin.ts
 [advanced-sessionstate]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionState.ts
 [advanced-topicfilters]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/topicFilters.ts
 [sendmessages]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples-v1/typescript/src/sendMessages.ts

--- a/sdk/servicebus/service-bus/samples-v1/typescript/package.json
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/package.json
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/identity": "^1.0.2",
+    "@azure/abort-controller": "latest",
+    "@azure/ms-rest-nodeauth": "^3.0.0",
     "@azure/service-bus": "^1.1.6",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^4.0.0",

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionRoundRobin.ts
@@ -1,0 +1,173 @@
+/*
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  Licensed under the MIT Licence.
+
+  This sample demonstrates how you can continually read through all the available
+  sessions in a Service Bus queue or subscription.
+
+  Run the sendMessages sample with different session ids before running this sample.
+*/
+
+import {
+    ServiceBusClient,
+    delay,
+    QueueClient,
+    ReceiveMode,
+    ReceivedMessageInfo,
+    MessagingError
+  } from "@azure/service-bus";
+  import * as dotenv from "dotenv";
+  import { env } from "process";
+  import { AbortController } from "@azure/abort-controller";
+  
+  dotenv.config();
+  
+  const serviceBusConnectionString =
+    env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+  
+  // NOTE: this sample uses a queue but would also work a session enabled subscription.
+  const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+  
+  const maxSessionsToProcessSimultaneously = 8;
+  const sessionIdleTimeoutSeconds = 3;
+  const delayOnErrorMs = 5 * 1000;
+  
+  // This can be used control when the round-robin processing will terminate
+  // by calling abortController.abort().
+  const abortController = new AbortController();
+  
+  // Called just before we start processing the first message of a session.
+  // NOTE: This function is used only in the sample and is not part of the Service Bus library.
+  async function sessionAccepted(sessionId: string) {
+    console.log(`[${sessionId}] will start processing...`);
+  }
+  
+  // Called by the SessionReceiver when a message is received.
+  // This is passed as part of the handlers when calling `SessionReceiver.subscribe()`.
+  async function processMessage(msg: ReceivedMessageInfo) {
+    console.log(`[${msg.sessionId}] received message with body ${msg.body}`);
+  }
+  
+  // Called by the SessionReceiver when an error occurs.
+  // This will be called in the handlers we pass in `SessionReceiver.subscribe()`
+  // and by the sample when we encounter an error opening a session.
+  function processError(err: Error, sessionId?: string) {
+    if (sessionId) {
+      console.log(`Error when receiving messages from the session ${sessionId}: `, err);
+    } else {
+      console.log(`Error when creating the receiver for next available session`, err);
+    }
+  }
+  
+  // Called if we are closing a session.
+  // `reason` will be:
+  // * 'error' if we are closing because of an error(the error will be delivered
+  //   to `processError` above)
+  // * 'idle_timeout' if `sessionIdleTimeoutMs` milliseconds pass without
+  //   any messages being received (ie, session can be considered empty).
+  // NOTE: This function is used only in the sample and is not part of the Service Bus library.
+  async function sessionClosed(reason: "error" | "idle_timeout", sessionId: string) {
+    console.log(`[${sessionId}] was closed because of ${reason}`);
+  }
+  
+  // utility function to create a timer that can be refreshed
+  function createRefreshableTimer(timeoutMs: number, resolve: Function): () => void {
+    let timer: any;
+  
+    return () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => resolve(), timeoutMs);
+    };
+  }
+  
+  // Queries Service Bus for the next available session and processes it.
+  async function receiveFromNextSession(queueClient: QueueClient): Promise<void> {
+    let sessionReceiver = queueClient.createReceiver(ReceiveMode.peekLock, {
+      sessionId: undefined
+    });
+  
+    try {
+      // Use `getState()`, but ignore its result to force open the underlying receiver link
+      await sessionReceiver.getState();
+    } catch (err) {
+      if (
+        (err as MessagingError).name === "SessionCannotBeLockedError" ||
+        (err as MessagingError).name === "OperationTimeoutError"
+      ) {
+        console.log(`INFO: no available sessions, sleeping for ${delayOnErrorMs}`);
+      } else {
+        processError(err, undefined);
+      }
+  
+      await delay(delayOnErrorMs);
+      return;
+    }
+  
+    await sessionAccepted(sessionReceiver.sessionId);
+  
+    let onAbort: () => void;
+  
+    const sessionFullyRead = new Promise((resolveSessionAsFullyRead, rejectSessionWithError) => {
+      onAbort = () => {
+        abortController.signal.removeEventListener("abort", onAbort);
+        rejectSessionWithError(new Error("Process terminated by user."));
+      };
+  
+      const refreshTimer = createRefreshableTimer(
+        sessionIdleTimeoutSeconds * 1000,
+        resolveSessionAsFullyRead
+      );
+  
+      refreshTimer();
+  
+      abortController.signal.addEventListener("abort", onAbort);
+  
+      sessionReceiver.registerMessageHandler(
+        async (msg) => {
+          refreshTimer();
+          await processMessage(msg);
+        },
+        (err) => {
+          rejectSessionWithError(err);
+        }
+      );
+    });
+  
+    try {
+      await sessionFullyRead;
+      await sessionClosed("idle_timeout", sessionReceiver.sessionId);
+    } catch (err) {
+      processError(err, sessionReceiver.sessionId);
+      await sessionClosed("error", sessionReceiver.sessionId);
+    } finally {
+      abortController.signal.removeEventListener("abort", onAbort);
+      await sessionReceiver.close();
+    }
+  }
+  
+  async function roundRobinThroughAvailableSessions(): Promise<void> {
+    const serviceBusClient = ServiceBusClient.createFromConnectionString(serviceBusConnectionString);
+    const queueClient = serviceBusClient.createQueueClient(queueName);
+  
+    const receiverPromises = [];
+  
+    for (let i = 0; i < maxSessionsToProcessSimultaneously; ++i) {
+      receiverPromises.push(
+        (async () => {
+          while (!abortController.signal.aborted) {
+            await receiveFromNextSession(queueClient);
+          }
+        })()
+      );
+    }
+  
+    console.log(`Listening for available sessions...`);
+    await Promise.all(receiverPromises);
+  
+    await queueClient.close();
+    await serviceBusClient.close();
+    console.log(`Exiting...`);
+  }
+  
+  // To stop the round-robin processing you can just call abortController.abort()
+  roundRobinThroughAvailableSessions().catch((err) => console.log(`Fatal error: ${err}`));

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/advanced/sessionRoundRobin.ts
@@ -17,16 +17,15 @@ import {
     MessagingError
   } from "@azure/service-bus";
   import * as dotenv from "dotenv";
-  import { env } from "process";
   import { AbortController } from "@azure/abort-controller";
   
   dotenv.config();
   
   const serviceBusConnectionString =
-    env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
   
   // NOTE: this sample uses a queue but would also work a session enabled subscription.
-  const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+  const queueName = process.env.QUEUE_NAME || "<queue name>";
   
   const maxSessionsToProcessSimultaneously = 8;
   const sessionIdleTimeoutSeconds = 3;

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -10,16 +10,15 @@
 
 const { ServiceBusClient, delay } = require("@azure/service-bus");
 const dotenv = require("dotenv");
-const { env } = require("process");
 const { AbortController } = require("@azure/abort-controller");
 
 dotenv.config();
 
 const serviceBusConnectionString =
-  env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
 // NOTE: this sample uses a queue but would also work a session enabled subscription.
-const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const maxSessionsToProcessSimultaneously = 8;
 const sessionIdleTimeoutMs = 3 * 1000;

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -16,16 +16,15 @@ import {
   MessagingError
 } from "@azure/service-bus";
 import * as dotenv from "dotenv";
-import { env } from "process";
 import { AbortController } from "@azure/abort-controller";
 
 dotenv.config();
 
 const serviceBusConnectionString =
-  env["SERVICEBUS_CONNECTION_STRING"] || "<service bus connection string not in environment>";
+process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
 // NOTE: this sample uses a queue but would also work a session enabled subscription.
-const queueName = env["QUEUE_NAME_WITH_SESSIONS"] || "<queue name not in environment>";
+const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 const maxSessionsToProcessSimultaneously = 8;
 const sessionIdleTimeoutMs = 3 * 1000;


### PR DESCRIPTION
Recently, we moved the Track 1 samples to the master branch in https://github.com/Azure/azure-sdk-for-js/pull/8607 to fix https://github.com/Azure/azure-sdk-for-js/issues/7317

This PR makes the below changes on top of that move
- Copy the new sample for round robin sessions that was added to 1.1.7 hot fix branch
- Fix wrong dependencies in package.json