### PR TITLE
Include sourcemap file in karma files section

### DIFF
--- a/sdk/core/abort-controller/karma.conf.js
+++ b/sdk/core/abort-controller/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "test-browser/index.js",
-      "test-browser/index.js.map"
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/core/abort-controller/karma.conf.js
+++ b/sdk/core/abort-controller/karma.conf.js
@@ -25,7 +25,10 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: ["test-browser/index.js"],
+    files: [
+      "test-browser/index.js",
+      "test-browser/index.js.map"
+    ],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/core/core-amqp/karma.conf.js
+++ b/sdk/core/core-amqp/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "test-browser/index.js",
-      "test-browser/index.js.map"
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/core/core-amqp/karma.conf.js
+++ b/sdk/core/core-amqp/karma.conf.js
@@ -16,7 +16,10 @@ module.exports = function(config) {
     plugins: ["karma-mocha", require("karma-chrome-launcher")],
 
     // list of files / patterns to load in the browser
-    files: ["test-browser/index.js"],
+    files: [
+      "test-browser/index.js",
+      "test-browser/index.js.map"
+    ],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/core/core-https/karma.conf.js
+++ b/sdk/core/core-https/karma.conf.js
@@ -28,7 +28,8 @@ module.exports = function(config) {
       // Uncomment the cdn link below for the polyfill service to support IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ],
 
     // list of files / patterns to exclude
@@ -40,7 +41,7 @@ module.exports = function(config) {
       "**/*.js": ["env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "dist-test/index.js": ["coverage"]
     },
 
     // inject following environment values into browser testing with window.__env__

--- a/sdk/core/core-https/karma.conf.js
+++ b/sdk/core/core-https/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/core/core-lro/karma.conf.js
+++ b/sdk/core/core-lro/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ],
 
     exclude: [],

--- a/sdk/core/core-lro/karma.conf.js
+++ b/sdk/core/core-lro/karma.conf.js
@@ -24,7 +24,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ],
 
     exclude: [],

--- a/sdk/core/logger/karma.conf.js
+++ b/sdk/core/logger/karma.conf.js
@@ -28,7 +28,10 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: ["test-browser/index.js"],
+    files: [
+      "test-browser/index.js",
+      "test-browser/index.js.map"
+    ],
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/core/logger/karma.conf.js
+++ b/sdk/core/logger/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "test-browser/index.js",
-      "test-browser/index.js.map"
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/eventhub/event-hubs/karma.conf.js
+++ b/sdk/eventhub/event-hubs/karma.conf.js
@@ -29,7 +29,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "test-browser/index.js"
+      "test-browser/index.js",
+      "test-browser/index.js.map"
     ],
 
     // list of files / patterns to exclude

--- a/sdk/eventhub/event-hubs/karma.conf.js
+++ b/sdk/eventhub/event-hubs/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "test-browser/index.js",
-      "test-browser/index.js.map"
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
@@ -28,7 +28,8 @@ module.exports = function(config) {
       // Uncomment the cdn link below for the polyfill service to support IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ],
 
     // list of files / patterns to exclude
@@ -40,7 +41,7 @@ module.exports = function(config) {
       "**/*.js": ["env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "dist-test/index.browser.js": ["coverage"]
     },
 
     // inject following environment values into browser testing with window.__env__

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/formrecognizer/ai-form-recognizer/karma.conf.js
+++ b/sdk/formrecognizer/ai-form-recognizer/karma.conf.js
@@ -37,7 +37,10 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: ["test-browser/index.browser.js"].concat(
+    files: [
+      "test-browser/index.browser.js",
+      "test-browser/index.browser.js.map"
+    ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),
 
@@ -51,7 +54,7 @@ module.exports = function(config) {
       "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "dist-test/index.browser.js": ["coverage"]
+      "test-browser/index.browser.js": ["coverage"]
     },
 
     envPreprocessor: [

--- a/sdk/formrecognizer/ai-form-recognizer/karma.conf.js
+++ b/sdk/formrecognizer/ai-form-recognizer/karma.conf.js
@@ -30,7 +30,6 @@ module.exports = function(config) {
       "karma-env-preprocessor",
       "karma-coverage",
       "karma-remap-istanbul",
-      "karma-sourcemap-loader",
       "karma-junit-reporter",
       "karma-json-to-file-reporter",
       "karma-json-preprocessor"
@@ -38,8 +37,8 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      "test-browser/index.browser.js",
-      "test-browser/index.browser.js.map"
+      "test-browser/index.js",
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),
@@ -50,11 +49,11 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "**/*.js": ["env", "sourcemap"],
+      "**/*.js": ["env"],
       "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.browser.js": ["coverage"]
+      "test-browser/index.js": ["coverage"]
     },
 
     envPreprocessor: [

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -124,7 +124,6 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.5",
     "karma-remap-istanbul": "^0.6.0",
-    "karma-sourcemap-loader": "^0.3.7",
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",

--- a/sdk/formrecognizer/ai-form-recognizer/rollup.base.config.js
+++ b/sdk/formrecognizer/ai-form-recognizer/rollup.base.config.js
@@ -112,7 +112,7 @@ export function browserConfig(test = false) {
     // Entry points - test files under the `test` folder(common for both browser and node), browser specific test files
     baseConfig.input = ["dist-esm/test/*.spec.js", "dist-esm/test/browser/*.spec.js"];
     baseConfig.plugins.unshift(multiEntry({ exports: false }));
-    baseConfig.output.file = "test-browser/index.browser.js";
+    baseConfig.output.file = "test-browser/index.js";
 
     baseConfig.onwarn = (warning) => {
       if (

--- a/sdk/identity/identity/karma.conf.js
+++ b/sdk/identity/identity/karma.conf.js
@@ -31,8 +31,10 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "test-browser/index.js",
-      "recordings/browsers/**/*.json"
-    ],
+      "test-browser/index.js.map"
+    ].concat(
+      isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
+    ),
 
     // list of files / patterns to exclude
     exclude: [],

--- a/sdk/identity/identity/karma.conf.js
+++ b/sdk/identity/identity/karma.conf.js
@@ -1,6 +1,10 @@
 // https://github.com/karma-runner/karma-chrome-launcher
 process.env.CHROME_BIN = require("puppeteer").executablePath();
 require("dotenv").config({ path: "../.env" });
+const {
+  isPlaybackMode,
+  isSoftRecordMode
+} = require("@azure/test-utils-recorder");
 
 module.exports = function(config) {
   config.set({

--- a/sdk/identity/identity/karma.conf.js
+++ b/sdk/identity/identity/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "test-browser/index.js",
-      "test-browser/index.js.map"
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -90,6 +90,7 @@
   },
   "devDependencies": {
     "@azure/abort-controller": "^1.0.0",
+    "@azure/test-utils-recorder": "^1.0.0",
     "@microsoft/api-extractor": "7.7.11",
     "@rollup/plugin-commonjs": "^11.0.1",
     "@rollup/plugin-json": "^4.0.0",

--- a/sdk/keyvault/keyvault-certificates/karma.conf.js
+++ b/sdk/keyvault/keyvault-certificates/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/keyvault/keyvault-certificates/karma.conf.js
+++ b/sdk/keyvault/keyvault-certificates/karma.conf.js
@@ -32,7 +32,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/keyvault/keyvault-keys/karma.conf.js
+++ b/sdk/keyvault/keyvault-keys/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/keyvault/keyvault-keys/karma.conf.js
+++ b/sdk/keyvault/keyvault-keys/karma.conf.js
@@ -32,7 +32,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/keyvault/keyvault-secrets/karma.conf.js
+++ b/sdk/keyvault/keyvault-secrets/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/keyvault/keyvault-secrets/karma.conf.js
+++ b/sdk/keyvault/keyvault-secrets/karma.conf.js
@@ -32,7 +32,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/search/search-documents/karma.conf.js
+++ b/sdk/search/search-documents/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),

--- a/sdk/search/search-documents/karma.conf.js
+++ b/sdk/search/search-documents/karma.conf.js
@@ -32,7 +32,10 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: ["dist-test/index.browser.js"].concat(
+    files: [
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
+    ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),
 
@@ -46,7 +49,7 @@ module.exports = function(config) {
       "recordings/browsers/**/*.json": ["json"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "dist-test/index.js": ["coverage"]
     },
 
     // inject following environment values into browser testing with window.__env__

--- a/sdk/servicebus/service-bus/karma.conf.js
+++ b/sdk/servicebus/service-bus/karma.conf.js
@@ -29,7 +29,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "test-browser/index.js"
+      "test-browser/index.js",
+      "test-browser/index.js.map"
     ],
 
     // list of files / patterns to exclude

--- a/sdk/servicebus/service-bus/karma.conf.js
+++ b/sdk/servicebus/service-bus/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "test-browser/index.js",
-      "test-browser/index.js.map"
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -37,7 +37,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map",
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map",
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-file-datalake/karma.conf.js
+++ b/sdk/storage/storage-file-datalake/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-file-datalake/karma.conf.js
+++ b/sdk/storage/storage-file-datalake/karma.conf.js
@@ -37,7 +37,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-file-share/karma.conf.js
+++ b/sdk/storage/storage-file-share/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-file-share/karma.conf.js
+++ b/sdk/storage/storage-file-share/karma.conf.js
@@ -37,7 +37,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-queue/karma.conf.js
+++ b/sdk/storage/storage-queue/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-queue/karma.conf.js
+++ b/sdk/storage/storage-queue/karma.conf.js
@@ -37,7 +37,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/template/template/karma.conf.js
+++ b/sdk/template/template/karma.conf.js
@@ -28,7 +28,8 @@ module.exports = function(config) {
       // Uncomment the cdn link below for the polyfill service to support IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ],
 
     // list of files / patterns to exclude
@@ -40,7 +41,7 @@ module.exports = function(config) {
       "**/*.js": ["env"],
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      "test-browser/index.js": ["coverage"]
+      "dist-test/index.js": ["coverage"]
     },
 
     // inject following environment values into browser testing with window.__env__

--- a/sdk/template/template/karma.conf.js
+++ b/sdk/template/template/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/test-utils/perfstress/karma.conf.js
+++ b/sdk/test-utils/perfstress/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/test-utils/perfstress/karma.conf.js
+++ b/sdk/test-utils/perfstress/karma.conf.js
@@ -18,7 +18,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ],
 
     // list of files / patterns to exclude

--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -30,7 +30,8 @@ module.exports = function(config) {
       // polyfill service supporting IE11 missing features
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
-      "dist-test/index.browser.js"
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
     ],
 
     // list of files / patterns to exclude

--- a/sdk/textanalytics/ai-text-analytics/karma.conf.js
+++ b/sdk/textanalytics/ai-text-analytics/karma.conf.js
@@ -36,7 +36,10 @@ module.exports = function(config) {
     ],
 
     // list of files / patterns to load in the browser
-    files: ["dist-test/index.browser.js"].concat(
+    files: [
+      "dist-test/index.browser.js",
+      "dist-test/index.browser.js.map"
+    ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),
 
@@ -50,7 +53,7 @@ module.exports = function(config) {
       "recordings/browsers/**/*.json": ["json"]
       // IMPORTANT: COMMENT following line if you want to debug in your browsers!!
       // Preprocess source file to calculate code coverage, however this will make source file unreadable
-      // "test-browser/index.js": ["coverage"]
+      // "dist-test/index.js": ["coverage"]
     },
 
     envPreprocessor: [

--- a/sdk/textanalytics/ai-text-analytics/karma.conf.js
+++ b/sdk/textanalytics/ai-text-analytics/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      "dist-test/index.browser.js.map"
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),


### PR DESCRIPTION
so we can debug TypeScript source code for browser tests. One still
needs to disable code coverage first though to have the source mapping
working.