### PR TITLE
[WIP] [KeyVault Certificates Hotfix 4.0.1] Commits to make sure the builds work

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -115,22 +115,9 @@ jobs:
           artifactName: packages
           path: $(Build.ArtifactStagingDirectory)
 
-      - script: |
-          npm i -g typedoc
-        displayName: "Install typedoc"
-
-      - script: |
-          npm install
-        workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/generate-doc
-        displayName: "Install tool dependencies"
-
-      - pwsh: |
-          node $(Build.SourcesDirectory)/eng/tools/generate-doc/index.js --dgOp "dg" -i "inc" --inc "${{parameters.ServiceDirectory}}"
-        displayName: "Run Typedoc Docs"
-
-      - pwsh: |
-          $(Build.SourcesDirectory)/eng/tools/compress-subfolders.ps1 "$(Build.SourcesDirectory)/docGen" "$(Build.ArtifactStagingDirectory)/Documentation"
-        displayName: "Generate Typedoc Docs"
+      - template: ../steps/generate-doc.yml
+        parameters:
+          ServiceDirectory: ${{parameters.ServiceDirectory}}
 
       - task: PublishPipelineArtifact@1
         condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -12,13 +12,13 @@ parameters:
       OSVmImage: "ubuntu-16.04"
       NodeVersion: "12.x"
     macOS_Node8:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       NodeVersion: "8.x"
     macOS_Node10:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       NodeVersion: "10.x"
     macOS_Node12:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       NodeVersion: "12.x"
     Windows_Node8:
       OSVmImage: "windows-2019"

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -13,7 +13,7 @@ parameters:
       OSVmImage: "windows-2019"
       TestType: "node"
     macOS_Node10:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       TestType: "node"
     Browser_Linux_Node10:
       OSVmImage: "ubuntu-16.04"
@@ -22,7 +22,7 @@ parameters:
       OSVmImage: "windows-2019"
       TestType: "browser"
     Browser_macOS_Node10:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       TestType: "browser"
 
 jobs:

--- a/eng/pipelines/templates/steps/generate-doc.yml
+++ b/eng/pipelines/templates/steps/generate-doc.yml
@@ -1,0 +1,20 @@
+parameters:
+  ServiceDirectory: not-specified
+
+steps:
+  - script: |
+      npm i -g typedoc@0.16.x
+    displayName: "Install typedoc"
+
+  - script: |
+      npm install
+    workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/generate-doc
+    displayName: "Install tool dependencies"
+
+  - pwsh: |
+      node $(Build.SourcesDirectory)/eng/tools/generate-doc/index.js --dgOp "dg" -i "inc" --inc "${{parameters.ServiceDirectory}}"
+    displayName: "Run Typedoc Docs"
+
+  - pwsh: |
+      $(Build.SourcesDirectory)/eng/tools/compress-subfolders.ps1 "$(Build.SourcesDirectory)/docGen" "$(Build.ArtifactStagingDirectory)/Documentation"
+    displayName: "Generate Typedoc Docs"

--- a/sdk/eventhub/event-processor-host/tests.yml
+++ b/sdk/eventhub/event-processor-host/tests.yml
@@ -22,7 +22,7 @@ jobs:
           OSVmImage: "windows-2019"
           TestType: "node"
         macOS_Node10:
-          OSVmImage: "macOS-10.13"
+          OSVmImage: "macOS-10.15"
           TestType: "node"
       EnvVars:
         EVENTHUB_NAME: $(EVENTHUB_NAME)


### PR DESCRIPTION
This PR has what is needed to make the base branch for the challenge based authentication hotfix stable.

The base branch, `hotfix/keyvault-challengeAuth-certificates-from-4.0.0`, comes from the commit `7c1b8d7f174f90456932acce99b9d0bf49dc197b`, which comes from the stable KeyVault release https://github.com/Azure/azure-sdk-for-js/releases/tag/%40azure%2Fkeyvault-certificates_4.0.0