### PR TITLE
[KeyVault Certificates Hotfix 4.0.1] Commits to make sure the builds work

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -115,22 +115,9 @@ jobs:
           artifactName: packages
           path: $(Build.ArtifactStagingDirectory)
 
-      - script: |
-          npm i -g typedoc
-        displayName: "Install typedoc"
-
-      - script: |
-          npm install
-        workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/generate-doc
-        displayName: "Install tool dependencies"
-
-      - pwsh: |
-          node $(Build.SourcesDirectory)/eng/tools/generate-doc/index.js --dgOp "dg" -i "inc" --inc "${{parameters.ServiceDirectory}}"
-        displayName: "Run Typedoc Docs"
-
-      - pwsh: |
-          $(Build.SourcesDirectory)/eng/tools/compress-subfolders.ps1 "$(Build.SourcesDirectory)/docGen" "$(Build.ArtifactStagingDirectory)/Documentation"
-        displayName: "Generate Typedoc Docs"
+      - template: ../steps/generate-doc.yml
+        parameters:
+          ServiceDirectory: ${{parameters.ServiceDirectory}}
 
       - task: PublishPipelineArtifact@1
         condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -12,13 +12,13 @@ parameters:
       OSVmImage: "ubuntu-16.04"
       NodeVersion: "12.x"
     macOS_Node8:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       NodeVersion: "8.x"
     macOS_Node10:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       NodeVersion: "10.x"
     macOS_Node12:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       NodeVersion: "12.x"
     Windows_Node8:
       OSVmImage: "windows-2019"

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -13,7 +13,7 @@ parameters:
       OSVmImage: "windows-2019"
       TestType: "node"
     macOS_Node10:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       TestType: "node"
     Browser_Linux_Node10:
       OSVmImage: "ubuntu-16.04"
@@ -22,7 +22,7 @@ parameters:
       OSVmImage: "windows-2019"
       TestType: "browser"
     Browser_macOS_Node10:
-      OSVmImage: "macOS-10.13"
+      OSVmImage: "macOS-10.15"
       TestType: "browser"
 
 jobs:

--- a/eng/pipelines/templates/steps/generate-doc.yml
+++ b/eng/pipelines/templates/steps/generate-doc.yml
@@ -1,0 +1,20 @@
+parameters:
+  ServiceDirectory: not-specified
+
+steps:
+  - script: |
+      npm i -g typedoc@0.16.x
+    displayName: "Install typedoc"
+
+  - script: |
+      npm install
+    workingDirectory: $(System.DefaultWorkingDirectory)/eng/tools/generate-doc
+    displayName: "Install tool dependencies"
+
+  - pwsh: |
+      node $(Build.SourcesDirectory)/eng/tools/generate-doc/index.js --dgOp "dg" -i "inc" --inc "${{parameters.ServiceDirectory}}"
+    displayName: "Run Typedoc Docs"
+
+  - pwsh: |
+      $(Build.SourcesDirectory)/eng/tools/compress-subfolders.ps1 "$(Build.SourcesDirectory)/docGen" "$(Build.ArtifactStagingDirectory)/Documentation"
+    displayName: "Generate Typedoc Docs"

--- a/sdk/eventhub/event-processor-host/tests.yml
+++ b/sdk/eventhub/event-processor-host/tests.yml
@@ -22,7 +22,7 @@ jobs:
           OSVmImage: "windows-2019"
           TestType: "node"
         macOS_Node10:
-          OSVmImage: "macOS-10.13"
+          OSVmImage: "macOS-10.15"
           TestType: "node"
       EnvVars:
         EVENTHUB_NAME: $(EVENTHUB_NAME)

--- a/sdk/test-utils/recorder/src/utils.ts
+++ b/sdk/test-utils/recorder/src/utils.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+import fs from "fs-extra";
 export interface TestInfo {
   uniqueName: { [x: string]: string };
   newDate: { [x: string]: string };
@@ -106,13 +107,71 @@ export function delay(milliseconds: number): Promise<void> | null {
  */
 export function parseUrl(url: string): any {
   const [cleanUrl, ...queryParts] = url.split(/[?&]/);
-  const query = queryParts.reduce((query: { [key:string]: any }, part) => {	
+  const query = queryParts.reduce((query: { [key: string]: any }, part) => {
     const [name, value] = part.split(/=/);
-    query[name] = decodeURIComponent(value.replace(/\+/g, ' '));
+    query[name] = decodeURIComponent(value.replace(/\+/g, " "));
     return query;
   }, {});
   return {
     url: cleanUrl,
     query
+  };
+}
+
+/**
+ * ONLY WORKS IN THE NODE.JS ENVIRONMENT
+ *
+ * Meant to be called during the playback for the node tests.
+ * 1. Takes the test filePath as argument.
+ * 2. Looks for the `recordings` folder in its hierarchical path.
+ * 3. Returns the full path of the `recordings` folder
+ *
+ * While running the tests, `filePath` can vary depending on location of the test files, examples below
+ *
+ * 1. If roll-up generated bundle files are being leveraged to run the tests
+ *    filePath = `<base path>\azure-sdk-for-js\sdk\storage\storage-blob\dist-test\index.node.js`
+ * 2. If ts complied dist-esm files are being used to run the tests
+ *    filePath = `<base path>\azure-sdk-for-js\sdk\storage\storage-blob\dist-esm\test\utils.spec.js`
+ *    filePath = `<base path>\azure-sdk-for-js\sdk\storage\storage-blob\dist-esm\test\node\utils.spec.js`
+ * 3. If `.spec.ts` test files are being used directly
+ *    filePath = `<base path>\azure-sdk-for-js\sdk\storage\storage-blob\test\utils.spec.ts`
+ *    filePath = `<base path>\azure-sdk-for-js\sdk\storage\storage-blob\test\node\utils.spec.ts`
+ * In the above example, no matter where the test files are,
+ *    the recordings are located at `<base path>\azure-sdk-for-js\sdk\storage\storage-blob\recordings\`.
+ * In order to playback the tests, exact location of the recordings is to be found,
+ *    this is done by checking the parent(s) folders until the `recordings` folder is found.
+ *
+ * @export
+ * @param {string} filePath
+ * @returns {string} location of the `recordings` folder
+ */
+export function findRecordingsFolderPath(filePath: string): string {
+  let path = require("path");
+
+  // Stripping away the file name
+  let currentPath = path.resolve(filePath, "..");
+  // File/folder path of a closest child of `currentPath` in the folder hierarchy of `filePath`
+  let lastPath = filePath;
+  try {
+    // While loop to find the `recordings` folder
+    while (!fs.existsSync(path.resolve(currentPath, "recordings/"))) {
+      if (fs.existsSync(path.resolve(currentPath, "package.json"))) {
+        // package.json of the SDK is found but not the `recordings` folder
+        // which is supposed to be present at the same level as package.json
+        throw new Error(`'recordings' folder is not found at ${currentPath}`);
+      } else if (lastPath === currentPath) {
+        throw new Error(
+          `'recordings' folder is not found at ${currentPath} (reached the root directory)`
+        );
+      } else {
+        lastPath = currentPath;
+        currentPath = path.resolve(currentPath, "..");
+      }
+    }
+    return path.resolve(currentPath, "recordings/");
+  } catch (error) {
+    throw new Error(
+      `Unable to locate the 'recordings' folder anywhere in the hierarchy of the file path ${filePath}\n ${error}`
+    );
   }
 }


### PR DESCRIPTION
This PR has what is needed to make the base branch for the challenge based authentication hotfix stable.

The base branch, `hotfix/keyvault-challengeAuth-certificates-from-4.0.0`, comes from the commit `7c1b8d7f174f90456932acce99b9d0bf49dc197b`, which comes from the stable KeyVault release https://github.com/Azure/azure-sdk-for-js/releases/tag/%40azure%2Fkeyvault-certificates_4.0.0

I made a couple PRs before this one, but the git history and the builds got weird. This one should be fine.