### PR TITLE
Change build and test condition to succeeded()

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -47,12 +47,12 @@ jobs:
           npm install ./eng/tools/versioning
           node eng/tools/versioning/set-dev.js --build-id "$(Build.BuildNumber)" --repo-root "$(Build.SourcesDirectory)" --service "$(folder)"
           node common/scripts/install-run-rush.js update
-        condition: and(succeededOrFailed(),eq(variables['SetDevVersion'],'true'))
+        condition: and(succeeded(),eq(variables['SetDevVersion'],'true'))
         displayName: "Update package versions for dev build"
 
       - script: |
           node common/scripts/install-run-rush.js install
-        condition: and(succeededOrFailed(),ne(variables['SetDevVersion'],'true'))
+        condition: and(succeeded(),ne(variables['SetDevVersion'],'true'))
         displayName: "Install dependencies"
 
       - template: eng/pipelines/templates/scripts/replace-relative-links.yml@azure-sdk-tools
@@ -226,14 +226,14 @@ jobs:
         - script: |
             node eng/tools/rush-runner.js unit-test:node "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"
-          condition: and(succeededOrFailed(),eq(variables['TestType'], 'node'))
+          condition: and(succeeded(),eq(variables['TestType'], 'node'))
         
         # Option "-p max" ensures parallelism is set to the number of cores on all platforms, which improves build times.
         # The default on Windows is "cores - 1" (microsoft/rushstack#436).
         - script: |
             node eng/tools/rush-runner.js unit-test:browser "${{parameters.ServiceDirectory}}" --verbose -p max
           displayName: "Test libraries"
-          condition: and(succeededOrFailed(),eq(variables['TestType'], 'browser'))
+          condition: and(succeeded(),eq(variables['TestType'], 'browser'))
 
         # Unlink node_modules folders to significantly improve performance of subsequent tasks
         # which need to walk the directory tree (and are hardcoded to follow symlinks).

--- a/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-integration.yml
@@ -111,7 +111,7 @@ jobs:
         env:
           TEST_MODE: "live"
           ${{ insert }}: ${{ parameters.EnvVars }}
-        condition: and(succeededOrFailed(),ne(variables['TestType'],'sample'))
+        condition: and(succeeded(),ne(variables['TestType'],'sample'))
 
       - ${{if ne(parameters.PostIntegrationSteps, '')}}:
           - template: ../steps/${{parameters.PostIntegrationSteps}}.yml
@@ -122,7 +122,7 @@ jobs:
         env:
           TEST_MODE: "live"
           ${{ insert }}: ${{ parameters.EnvVars }}
-        condition: and(succeededOrFailed(),eq(variables['TestType'],'sample'))
+        condition: and(succeeded(),eq(variables['TestType'],'sample'))
 
       - ${{ if ne(parameters.ResourceServiceDirectory, '') }}:
         - template: /eng/common/TestResources/remove-test-resources.yml


### PR DESCRIPTION
- Build and test steps should only run if previous steps succeeded
- Introduced in #8518 (succeededOrFailed() was used incorrectly)