### PR TITLE
[amqp-common] OperationTimeoutError should also be considered a retryable error

### DIFF
--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,3 +1,8 @@
+### 2020-05-13 1.0.0-preview.15
+
+- Fixes [bug 8835](https://github.com/Azure/azure-sdk-for-js/issues/8835) where OperationTimeoutError was not
+  considered retryable.
+
 ### 2020-05-05 1.0.0-preview.14
 
 - Relaxes the scheme check for the endpoint while parsing the connection string.

--- a/sdk/core/amqp-common/changelog.md
+++ b/sdk/core/amqp-common/changelog.md
@@ -1,4 +1,4 @@
-### 2020-05-13 1.0.0-preview.15
+### 2020-05-12 1.0.0-preview.15
 
 - Fixes [bug 8835](https://github.com/Azure/azure-sdk-for-js/issues/8835) where OperationTimeoutError was not
   considered retryable.

--- a/sdk/core/amqp-common/package.json
+++ b/sdk/core/amqp-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azure/amqp-common",
   "sdk-type": "client",
-  "version": "1.0.0-preview.14",
+  "version": "1.0.0-preview.15",
   "description": "Common library for amqp based azure sdks like @azure/event-hubs.",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/sdk/core/amqp-common/src/errors.ts
+++ b/sdk/core/amqp-common/src/errors.ts
@@ -128,7 +128,7 @@ export enum ConditionErrorNameMapper {
   /**
    * Error is thrown when timeout happens for the said operation.
    */
-  "amqp:operation-timeout" = "OperationTimeoutError",
+  "amqp:operation-timeout" = "OperationTimeoutError", // Retryable
   /**
    * Error is thrown when an argument has a value that is out of the admissible range.
    */
@@ -334,7 +334,7 @@ export enum ErrorNameConditionMapper {
   /**
    * Error is thrown when timeout happens for the said operation.
    */
-  OperationTimeoutError = "amqp:operation-timeout",
+  OperationTimeoutError = "amqp:operation-timeout", // Retryable
   /**
    * Error is thrown when an argument has a value that is out of the admissible range.
    */
@@ -493,7 +493,8 @@ export const retryableErrors: string[] = [
   "MessagingError",
   "DetachForcedError",
   "ConnectionForcedError",
-  "TransferLimitExceededError"
+  "TransferLimitExceededError",
+  "OperationTimeoutError"
 ];
 
 /**

--- a/sdk/core/amqp-common/src/errors.ts
+++ b/sdk/core/amqp-common/src/errors.ts
@@ -482,7 +482,7 @@ export class MessagingError extends Error {
  * Provides a list of retryable AMQP errors.
  * "InternalServerError", "ServerBusyError", "ServiceUnavailableError", "OperationCancelledError",
  * "SenderBusyError", "MessagingError", "DetachForcedError", "ConnectionForcedError",
- * "TransferLimitExceededError"
+ * "TransferLimitExceededError", "OperationTimeoutError"
  */
 export const retryableErrors: string[] = [
   "InternalServerError",


### PR DESCRIPTION
OperationTimeoutError should be retryable. We've already made this change in track 2.

Fixes #8835