### PR TITLE
Update CODEOWNERS with smoke test owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,9 @@
 
 /sdk/search/ @xirzec
 
+# Smoke Tests
+/common/smoke-test/ @ramya-rao-a @chradek @daviwil @sadasant @HarshaNalluru @southpolesteve
+
 # API review files
 /sdk/**/review/*api.md @bterlson
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 /sdk/search/ @xirzec
 
 # Smoke Tests
-/common/smoke-test/ @ramya-rao-a @chradek @daviwil @sadasant @HarshaNalluru @southpolesteve
+/common/smoke-test/ @ramya-rao-a @chradek @daviwil @sadasant @jeremymeng @southpolesteve
 
 # API review files
 /sdk/**/review/*api.md @bterlson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,7 @@
 /sdk/search/ @xirzec
 
 # Smoke Tests
-/common/smoke-test/ @ramya-rao-a @chradek @daviwil @sadasant @jeremymeng @southpolesteve
+/common/smoke-test/ @ramya-rao-a @chradek @jonathandturner @sadasant @jeremymeng @southpolesteve
 
 # API review files
 /sdk/**/review/*api.md @bterlson


### PR DESCRIPTION
This change (arbitrarily) selects code owners for the Smoke Tests pipelines. You will receive email notifications from Azure DevOps when the smoke tests fail. If someone else should be in your place please comment here. 

What are smoke tests? 
https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/198/Smoke-Testing

Who is being subscribed? 
@ramya-rao-a @chradek @daviwil @sadasant @HarshaNalluru @southpolesteve