### PR TITLE
[Service Bus] Port "scope" comments and websocket comments for useProxy sample from track 1

### DIFF
--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -62,6 +62,7 @@ You can instantiate this class using its constructors:
   - This method takes the host name of your Service Bus instance and a credentials object that you need
     to generate using the [@azure/identity](https://www.npmjs.com/package/@azure/identity)
     library. The host name is of the format `name-of-service-bus-instance.servicebus.windows.net`.
+    If you're using an own token provider against AAD, then set the "scopes" for service-bus to be `["https://servicebus.azure.net//user_impersonation"]` to get the appropriate token.
 
 ### Key concepts
 

--- a/sdk/servicebus/service-bus/samples-v1/javascript/useProxy.js
+++ b/sdk/servicebus/service-bus/samples-v1/javascript/useProxy.js
@@ -29,6 +29,8 @@ async function main() {
   const proxyAgent = new HttpsProxyAgent(proxyInfo);
 
   const sbClient = ServiceBusClient.createFromConnectionString(connectionString, {
+    // No need to pass the `WebSocket` from "ws" package if you're in the browser
+    // in which case the `window.WebSocket` is used by the library.
     webSocket: WebSocket,
     webSocketConstructorOptions: {
       agent: proxyAgent

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/useProxy.ts
@@ -30,6 +30,8 @@ export async function main() {
   const proxyAgent = new HttpsProxyAgent(proxyInfo);
 
   const sbClient = ServiceBusClient.createFromConnectionString(connectionString, {
+    // No need to pass the `WebSocket` from "ws" package if you're in the browser
+    // in which case the `window.WebSocket` is used by the library.
     webSocket: WebSocket,
     webSocketConstructorOptions: { agent: proxyAgent }
   });

--- a/sdk/servicebus/service-bus/samples/javascript/useProxy.js
+++ b/sdk/servicebus/service-bus/samples/javascript/useProxy.js
@@ -17,8 +17,7 @@ const HttpsProxyAgent = require("https-proxy-agent");
 require("dotenv").config();
 
 // Define connection string for your Service Bus instance here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
 async function main() {
   const proxyInfo = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
@@ -34,6 +33,8 @@ async function main() {
 
   const sbClient = new ServiceBusClient(connectionString, {
     webSocketOptions: {
+      // No need to pass the `WebSocket` from "ws" package if you're in the browser
+      // in which case the `window.WebSocket` is used by the library.
       webSocket: WebSocket,
       webSocketConstructorOptions: { agent: proxyAgent }
     }
@@ -46,6 +47,6 @@ async function main() {
   await sbClient.close();
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
@@ -19,8 +19,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string for your Service Bus instance here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
 export async function main() {
   const proxyInfo = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
@@ -36,6 +35,8 @@ export async function main() {
 
   const sbClient = new ServiceBusClient(connectionString, {
     webSocketOptions: {
+      // No need to pass the `WebSocket` from "ws" package if you're in the browser
+      // in which case the `window.WebSocket` is used by the library.
       webSocket: WebSocket,
       webSocketConstructorOptions: { agent: proxyAgent }
     }
@@ -48,6 +49,6 @@ export async function main() {
   await sbClient.close();
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -45,6 +45,8 @@ export class ServiceBusClient {
    * likely to be similar to <yournamespace>.servicebus.windows.net.
    * @param credential A credential object used by the client to get the token to authenticate the connection
    * with the Azure Service Bus. See &commat;azure/identity for creating the credentials.
+   * If you're using an own token provider against AAD, then set the "scopes" for service-bus
+   * to be `["https://servicebus.azure.net//user_impersonation"]` to get the appropriate token.
    * @param options - A set of options to apply when configuring the client.
    * - `retryOptions`   : Configures the retry policy for all the operations on the client.
    * For example, `{ "maxRetries": 4 }` or `{ "maxRetries": 4, "retryDelayInMs": 30000 }`.
@@ -98,7 +100,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -127,7 +129,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -201,7 +203,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -240,7 +242,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -352,7 +354,7 @@ export class ServiceBusClient {
    *
    * See here for more information about dead letter queues:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -389,7 +391,7 @@ export class ServiceBusClient {
    *
    * See here for more information about dead letter queues:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *


### PR DESCRIPTION
Porting #8889 
~~(Not porting the comments for "scope" since we rely on the AAD and `@azure/identity` for TokenCredentials which doesn't require scope to be passed.)~~