### PR TITLE
[service-bus] Track1 receiver recovery sample

### DIFF
--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
@@ -47,7 +47,7 @@ export async function main() {
       };
 
       const onErrorHandler: OnError = (err) => {
-        if (!(err as MessagingError).retryable) {
+        if ((err as MessagingError).retryable === false) {
           console.log("Receiver will be recreated. A fatal error occurred:", err);
           resolve();
         } else {

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
@@ -8,7 +8,13 @@
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic
 */
 
-import { OnMessage, OnError, ServiceBusClient, ReceiveMode, MessagingError } from "@azure/service-bus";
+import {
+  OnMessage,
+  OnError,
+  ServiceBusClient,
+  ReceiveMode,
+  MessagingError
+} from "@azure/service-bus";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -35,6 +41,7 @@ export async function main() {
 
     const receiverPromise = new Promise((resolve, _reject) => {
       const onMessageHandler: OnMessage = async (brokeredMessage) => {
+       
         console.log(`Received message: ${brokeredMessage.body}`);
         await brokeredMessage.complete();
       };
@@ -46,18 +53,19 @@ export async function main() {
         } else {
           console.log("Non-fatal error occurred: ", err);
         }
-      };      
-      
+      };
+
       receiver.registerMessageHandler(onMessageHandler, onErrorHandler, { autoComplete: false });
     });
-    
+
     // This will only resolve if our receiver has failed in a way that is not recoverable.
-    await receiverPromise; 
+    await receiverPromise;
 
     // the Service Bus package is intended to be resilient in the face of transitive issues, like network
     // interruptions. If there are continual restarts this might indicate a more serious issue, like a network
     // outage.
-        
+    console.log(`Closing previous receiver and recreating - a fatal error has occurred.`);
+
     // we can close the old receiver and just let the loop start again.
     await receiver.close();
   } while (enableReceiverRecovery);

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
@@ -30,7 +30,7 @@ export async function main() {
   // If receiving from a Subscription, use `createSubscriptionClient` instead of `createQueueClient`
   const queueClient = sbClient.createQueueClient(queueName);
 
-  // To receive messages from sessions, use getSessionReceiver instead of getReceiver or look at
+  // To receive messages from sessions, use createSessionReceiver instead of createReceiver or look at
   // the sample in sessions.ts file
 
   // controls whether we continue to recover from fatal Receiver failures.

--- a/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples-v1/typescript/src/receiveMessagesStreaming.ts
@@ -8,7 +8,7 @@
   Setup: Please run "sendMessages.ts" sample before running this to populate the queue/topic
 */
 
-import { OnMessage, OnError, delay, ServiceBusClient, ReceiveMode } from "@azure/service-bus";
+import { OnMessage, OnError, ServiceBusClient, ReceiveMode, MessagingError } from "@azure/service-bus";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -26,27 +26,44 @@ export async function main() {
 
   // To receive messages from sessions, use getSessionReceiver instead of getReceiver or look at
   // the sample in sessions.ts file
-  const receiver = queueClient.createReceiver(ReceiveMode.peekLock);
 
-  const onMessageHandler: OnMessage = async (brokeredMessage) => {
-    console.log(`Received message: ${brokeredMessage.body}`);
-    await brokeredMessage.complete();
-  };
-  const onErrorHandler: OnError = (err) => {
-    console.log("Error occurred: ", err);
-  };
+  // controls whether we continue to recover from fatal Receiver failures.
+  let enableReceiverRecovery = true;
 
-  try {
-    receiver.registerMessageHandler(onMessageHandler, onErrorHandler, { autoComplete: false });
+  do {
+    const receiver = queueClient.createReceiver(ReceiveMode.peekLock);
 
-    // Waiting long enough before closing the receiver to receive messages
-    await delay(5000);
+    const receiverPromise = new Promise((resolve, _reject) => {
+      const onMessageHandler: OnMessage = async (brokeredMessage) => {
+        console.log(`Received message: ${brokeredMessage.body}`);
+        await brokeredMessage.complete();
+      };
 
+      const onErrorHandler: OnError = (err) => {
+        if (!(err as MessagingError).retryable) {
+          console.log("Receiver will be recreated. A fatal error occurred:", err);
+          resolve();
+        } else {
+          console.log("Non-fatal error occurred: ", err);
+        }
+      };      
+      
+      receiver.registerMessageHandler(onMessageHandler, onErrorHandler, { autoComplete: false });
+    });
+    
+    // This will only resolve if our receiver has failed in a way that is not recoverable.
+    await receiverPromise; 
+
+    // the Service Bus package is intended to be resilient in the face of transitive issues, like network
+    // interruptions. If there are continual restarts this might indicate a more serious issue, like a network
+    // outage.
+        
+    // we can close the old receiver and just let the loop start again.
     await receiver.close();
-    await queueClient.close();
-  } finally {
-    await sbClient.close();
-  }
+  } while (enableReceiverRecovery);
+
+  await queueClient.close();
+  await sbClient.close();
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Sample for track 1 to show users how to recover from fatal errors in their Receiver when using something like registerMessageHandler.

Note to reviewers - I'll generate the JS sample after we get through the review cycle for the typescript version. I'll also create a corresponding version track 2. :)

Fixes #6616