### PR TITLE
[Service Bus] Remove entityPath validation

### DIFF
--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -98,7 +98,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -127,7 +127,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -162,7 +162,6 @@ export class ServiceBusClient {
     // NOTE: we don't currently have any options for this kind of receiver but
     // when we do make sure you pass them in and extract them.
     const { entityPath, receiveMode } = extractReceiverArguments(
-      this._connectionContext.config.entityPath,
       queueOrTopicName1,
       receiveModeOrSubscriptionName2,
       receiveMode3
@@ -201,7 +200,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -240,7 +239,7 @@ export class ServiceBusClient {
    *
    * You can settle a message by calling complete(), abandon(), defer() or deadletter() methods on
    * the message.
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -278,7 +277,6 @@ export class ServiceBusClient {
     options4?: CreateSessionReceiverOptions
   ): Promise<SessionReceiver<ReceivedMessage> | SessionReceiver<ReceivedMessageWithLock>> {
     const { entityPath, receiveMode, options } = extractReceiverArguments(
-      this._connectionContext.config.entityPath,
       queueOrTopicName1,
       receiveModeOrSubscriptionName2,
       receiveModeOrOptions3,
@@ -309,8 +307,6 @@ export class ServiceBusClient {
    * @param options Options for creating a sender.
    */
   async createSender(queueOrTopicName: string, options?: CreateSenderOptions): Promise<Sender> {
-    validateEntityNamesMatch(this._connectionContext.config.entityPath, queueOrTopicName, "sender");
-
     const clientEntityContext = ClientEntityContext.create(
       queueOrTopicName,
       this._connectionContext,
@@ -352,7 +348,7 @@ export class ServiceBusClient {
    *
    * See here for more information about dead letter queues:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -389,7 +385,7 @@ export class ServiceBusClient {
    *
    * See here for more information about dead letter queues:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues
-   * 
+   *
    * More information about how peekLock and message settlement works here:
    * https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-transfers-locks-settlement#peeklock
    *
@@ -427,7 +423,6 @@ export class ServiceBusClient {
     // NOTE: we don't currently have any options for this kind of receiver but
     // when we do make sure you pass them in and extract them.
     const { entityPath, receiveMode } = extractReceiverArguments(
-      this._connectionContext.config.entityPath,
       queueOrTopicName1,
       receiveModeOrSubscriptionName2,
       receiveMode3
@@ -463,7 +458,7 @@ function isReceiveMode(mode: any): mode is "peekLock" | "receiveAndDelete" {
 }
 
 /**
- * Helper to validate and extract the common arguments from both the get*Receiver() overloads that
+ * Helper to validate and extract the common arguments from both the create*Receiver() overloads that
  * have this pattern:
  *
  * queue, lockmode, options
@@ -473,7 +468,6 @@ function isReceiveMode(mode: any): mode is "peekLock" | "receiveAndDelete" {
  * @ignore
  */
 export function extractReceiverArguments<OptionsT>(
-  connectionStringEntityName: string | undefined,
   queueOrTopicName1: string,
   receiveModeOrSubscriptionName2: "peekLock" | "receiveAndDelete" | string,
   receiveModeOrOptions3: "peekLock" | "receiveAndDelete" | OptionsT,
@@ -487,16 +481,12 @@ export function extractReceiverArguments<OptionsT>(
     const topic = queueOrTopicName1;
     const subscription = receiveModeOrSubscriptionName2;
 
-    validateEntityNamesMatch(connectionStringEntityName, topic, "receiver-topic");
-
     return {
       entityPath: `${topic}/Subscriptions/${subscription}`,
       receiveMode: receiveModeOrOptions3,
       options: definitelyOptions4
     };
   } else if (isReceiveMode(receiveModeOrSubscriptionName2)) {
-    validateEntityNamesMatch(connectionStringEntityName, queueOrTopicName1, "receiver-queue");
-
     return {
       entityPath: queueOrTopicName1,
       receiveMode: receiveModeOrSubscriptionName2,
@@ -504,43 +494,5 @@ export function extractReceiverArguments<OptionsT>(
     };
   } else {
     throw new TypeError("Invalid receiveMode provided");
-  }
-}
-
-/**
- * @internal
- * @ignore
- */
-export function validateEntityNamesMatch(
-  connectionStringEntityName: string | undefined,
-  queueOrTopicName: string,
-  senderOrReceiverType: "receiver-topic" | "receiver-queue" | "sender"
-) {
-  if (!connectionStringEntityName) {
-    return;
-  }
-
-  if (queueOrTopicName !== connectionStringEntityName) {
-    let entityType;
-    let senderOrReceiver;
-
-    switch (senderOrReceiverType) {
-      case "receiver-queue":
-        entityType = "queue";
-        senderOrReceiver = "Receiver";
-        break;
-      case "receiver-topic":
-        entityType = "topic";
-        senderOrReceiver = "Receiver";
-        break;
-      case "sender":
-        entityType = "queue/topic";
-        senderOrReceiver = "Sender";
-        break;
-    }
-
-    throw new Error(
-      `The connection string for this ServiceBusClient had an EntityPath of '${connectionStringEntityName}' which doesn't match the name of the ${entityType} for this ${senderOrReceiver} ('${queueOrTopicName}')`
-    );
   }
 }

--- a/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/serviceBusClient.spec.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { extractReceiverArguments, validateEntityNamesMatch } from "../../src/serviceBusClient";
+import { extractReceiverArguments } from "../../src/serviceBusClient";
 import chai from "chai";
 import { CreateSessionReceiverOptions } from "../../src/models";
 const assert = chai.assert;
@@ -23,13 +23,7 @@ describe("serviceBusClient unit tests", () => {
     // any options
     allLockModes.forEach((lockMode) => {
       it(`queue, no options, ${lockMode}`, () => {
-        const result = extractReceiverArguments(
-          "", // simulate a connection string without an EntityPath in it
-          "queue",
-          lockMode,
-          undefined,
-          undefined
-        );
+        const result = extractReceiverArguments("queue", lockMode, undefined, undefined);
         assert.deepEqual(result, {
           entityPath: "queue",
           receiveMode: lockMode,
@@ -43,7 +37,6 @@ describe("serviceBusClient unit tests", () => {
     allLockModes.forEach((lockMode) => {
       it(`queue, with options, ${lockMode}`, () => {
         const result = extractReceiverArguments(
-          "queue", // simulate a connection string with an EntityPath in it
           "queue",
           lockMode,
           sessionReceiverOptions,
@@ -60,13 +53,7 @@ describe("serviceBusClient unit tests", () => {
     // basically, simulating getSessionReceiver which does take options (although this method just returns them verbatim with no interpretation)
     allLockModes.forEach((lockMode) => {
       it(`topic and subscription, no options, ${lockMode}`, () => {
-        const result = extractReceiverArguments(
-          undefined, // simulate a connection string without an EntityPath in it
-          "topic",
-          "subscription",
-          lockMode,
-          undefined
-        );
+        const result = extractReceiverArguments("topic", "subscription", lockMode, undefined);
 
         assert.deepEqual(result, {
           entityPath: "topic/Subscriptions/subscription",
@@ -80,7 +67,6 @@ describe("serviceBusClient unit tests", () => {
     allLockModes.forEach((lockMode) => {
       it(`topic and subscription, with options, ${lockMode}`, () => {
         const result = extractReceiverArguments(
-          "topic", // simulate a connection string with an EntityPath in it
           "topic",
           "subscription",
           lockMode,
@@ -99,47 +85,12 @@ describe("serviceBusClient unit tests", () => {
       assert.throws(
         () =>
           extractReceiverArguments(
-            "totally non-matching topic",
-            "topic",
-            "subscription",
-            "receiveAndDelete",
-            sessionReceiverOptions
-          ),
-        /The connection string for this ServiceBusClient had an EntityPath of 'totally non-matching topic' which doesn't match the name of the topic for this Receiver \('topic'\)/
-      );
-
-      assert.throws(
-        () =>
-          extractReceiverArguments(
-            "totally non-matching queue",
-            "queue",
-            "peekLock",
-            sessionReceiverOptions,
-            undefined
-          ),
-        /The connection string for this ServiceBusClient had an EntityPath of 'totally non-matching queue' which doesn't match the name of the queue for this Receiver \('queue'\)/
-      );
-
-      assert.throws(
-        () =>
-          extractReceiverArguments(
-            undefined,
             "topic",
             "subscription",
             "WOW THIS ISN'T A RECEIVE MODE" as "peekLock",
             sessionReceiverOptions
           ),
         /Invalid receiveMode provided/
-      );
-    });
-  });
-
-  describe("validateEntityNamesMatch", () => {
-    // the receiver cases are all covered above in `extractReceiverArguments`. So this is just covering the way the createSender() call uses it.
-    it("failures", () => {
-      assert.throws(
-        () => validateEntityNamesMatch("the queue", "but I specified a different thing", "sender"),
-        /The connection string for this ServiceBusClient had an EntityPath of 'the queue' which doesn't match the name of the queue\/topic for this Sender/
       );
     });
   });


### PR DESCRIPTION
1. `validateEntityNamesMatch` would throw an error saying the entity path provided in the connection string is undefined and hence mismatch if the user relies on the token credential way instead of a connection string. 
This would mean that the user can never be able to create a sender or a receiver if started from the tokencredential way.
2. We should not do the validation and let the service throw an error in case of inconsistencies.

Due to these reasons, I'm removing the `validateEntityNamesMatch` method and updated the relevant code that touches this.

Issue - Part 4 of #8192 