### PR TITLE
[Storage][Test] Omit the sig part when verifying copySource

### DIFF
--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -21,7 +21,7 @@ import {
 import { Test_CPK_INFO } from "./utils/constants";
 dotenv.config();
 
-describe.only("BlobClient", () => {
+describe("BlobClient", () => {
   let blobServiceClient: BlobServiceClient;
   let containerName: string;
   let containerClient: ContainerClient;

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -503,16 +503,20 @@ describe("BlobClient", () => {
     assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
 
     const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);
-    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!);
     sanitizedQuery.set("sig", undefined);
     sanitizedActualUrl.setQuery(sanitizedQuery.toString());
 
     const sanitizedExpectedUrl = URLBuilder.parse(blobClient.url);
-    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!);
     sanitizedQuery2.set("sig", undefined);
     sanitizedExpectedUrl.setQuery(sanitizedQuery.toString());
 
-    assert.strictEqual(sanitizedActualUrl, sanitizedExpectedUrl);
+    assert.strictEqual(
+      sanitizedActualUrl.toString(),
+      sanitizedExpectedUrl.toString(),
+      "copySource does not match original source"
+    );
 
     await newBlobURL.setAccessTier(BlockBlobTier.Hot);
     const properties3 = await newBlobURL.getProperties();

--- a/sdk/storage/storage-blob/test/blobclient.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclient.spec.ts
@@ -499,7 +499,8 @@ describe("BlobClient", () => {
     assert.deepStrictEqual(properties2.copyId, result.copyId);
     assert.equal(properties2.accessTier, initialTier);
 
-    // Some data center will sanitize the sig field
+    // A service feature is being rolling out which will sanitize the sig field
+    // so we remove it before comparing urls.
     assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
 
     const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);

--- a/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
@@ -15,7 +15,7 @@ import {
   PollerLike,
   PollOperationState
 } from "../src";
-import { URLBuilder, URLQuery } from '@azure/core-http';
+import { URLBuilder, URLQuery } from "@azure/core-http";
 dotenv.config();
 
 describe("BlobClient beginCopyFromURL Poller", () => {
@@ -77,16 +77,20 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
 
     const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);
-    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!);
     sanitizedQuery.set("sig", undefined);
     sanitizedActualUrl.setQuery(sanitizedQuery.toString());
 
     const sanitizedExpectedUrl = URLBuilder.parse(blobClient.url);
-    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!);
     sanitizedQuery2.set("sig", undefined);
     sanitizedExpectedUrl.setQuery(sanitizedQuery.toString());
 
-    assert.strictEqual(sanitizedActualUrl, sanitizedExpectedUrl);
+    assert.strictEqual(
+      sanitizedActualUrl.toString(),
+      sanitizedExpectedUrl.toString(),
+      "copySource does not match original source"
+    );
   });
 
   it("supports manual polling via poll", async () => {
@@ -110,7 +114,25 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     const properties2 = await newBlobClient.getProperties();
     assert.deepStrictEqual(properties1.contentMD5, properties2.contentMD5);
     assert.deepStrictEqual(properties2.copyId, result!.copyId);
-    assert.deepStrictEqual(properties2.copySource, blobClient.url);
+
+    // Some data center will sanitize the sig field
+    assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
+
+    const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);
+    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!);
+    sanitizedQuery.set("sig", undefined);
+    sanitizedActualUrl.setQuery(sanitizedQuery.toString());
+
+    const sanitizedExpectedUrl = URLBuilder.parse(blobClient.url);
+    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!);
+    sanitizedQuery2.set("sig", undefined);
+    sanitizedExpectedUrl.setQuery(sanitizedQuery.toString());
+
+    assert.strictEqual(
+      sanitizedActualUrl.toString(),
+      sanitizedExpectedUrl.toString(),
+      "copySource does not match original source"
+    );
   });
 
   it("supports cancellation of the copy", async function() {

--- a/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
@@ -15,9 +15,10 @@ import {
   PollerLike,
   PollOperationState
 } from "../src";
+import { URLBuilder, URLQuery } from '@azure/core-http';
 dotenv.config();
 
-describe("BlobClient beginCopyFromURL Poller", () => {
+describe.only("BlobClient beginCopyFromURL Poller", () => {
   let containerName: string;
   let containerClient: ContainerClient;
   let blobName: string;
@@ -71,7 +72,21 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     const properties2 = await newBlobClient.getProperties();
     assert.deepStrictEqual(properties1.contentMD5, properties2.contentMD5);
     assert.deepStrictEqual(properties2.copyId, result.copyId);
-    assert.deepStrictEqual(properties2.copySource, blobClient.url);
+
+    // Some data center will sanitize the sig field
+    assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
+
+    const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);
+    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    sanitizedQuery.set("sig", undefined);
+    sanitizedActualUrl.setQuery(sanitizedQuery.toString());
+
+    const sanitizedExpectedUrl = URLBuilder.parse(blobClient.url);
+    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    sanitizedQuery2.set("sig", undefined);
+    sanitizedExpectedUrl.setQuery(sanitizedQuery.toString());
+
+    assert.strictEqual(sanitizedActualUrl, sanitizedExpectedUrl);
   });
 
   it("supports manual polling via poll", async () => {

--- a/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
@@ -73,7 +73,8 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     assert.deepStrictEqual(properties1.contentMD5, properties2.contentMD5);
     assert.deepStrictEqual(properties2.copyId, result.copyId);
 
-    // Some data center will sanitize the sig field
+    // A service feature is being rolling out which will sanitize the sig field
+    // so we remove it before comparing urls.
     assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
 
     const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);
@@ -115,7 +116,8 @@ describe("BlobClient beginCopyFromURL Poller", () => {
     assert.deepStrictEqual(properties1.contentMD5, properties2.contentMD5);
     assert.deepStrictEqual(properties2.copyId, result!.copyId);
 
-    // Some data center will sanitize the sig field
+    // A service feature is being rolling out which will sanitize the sig field
+    // so we remove it before comparing urls.
     assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
 
     const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);

--- a/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
+++ b/sdk/storage/storage-blob/test/blobclientpollers.spec.ts
@@ -18,7 +18,7 @@ import {
 import { URLBuilder, URLQuery } from '@azure/core-http';
 dotenv.config();
 
-describe.only("BlobClient beginCopyFromURL Poller", () => {
+describe("BlobClient beginCopyFromURL Poller", () => {
   let containerName: string;
   let containerClient: ContainerClient;
   let blobName: string;

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -304,16 +304,20 @@ describe("FileClient", () => {
     assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
 
     const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);
-    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    const sanitizedQuery = URLQuery.parse(sanitizedActualUrl.getQuery()!);
     sanitizedQuery.set("sig", undefined);
     sanitizedActualUrl.setQuery(sanitizedQuery.toString());
 
     const sanitizedExpectedUrl = URLBuilder.parse(fileClient.url);
-    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!)!;
+    const sanitizedQuery2 = URLQuery.parse(sanitizedActualUrl.getQuery()!);
     sanitizedQuery2.set("sig", undefined);
     sanitizedExpectedUrl.setQuery(sanitizedQuery.toString());
 
-    assert.strictEqual(sanitizedActualUrl, sanitizedExpectedUrl);
+    assert.strictEqual(
+      sanitizedActualUrl.toString(),
+      sanitizedExpectedUrl.toString(),
+      "copySource does not match original source"
+    );
   });
 
   it("startCopyFromURL with smb options", async () => {

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -16,7 +16,7 @@ import { MockPolicyFactory } from "./utils/MockPolicyFactory";
 
 dotenv.config();
 
-describe.only("FileClient", () => {
+describe("FileClient", () => {
   let shareName: string;
   let shareClient: ShareClient;
   let dirName: string;

--- a/sdk/storage/storage-file-share/test/fileclient.spec.ts
+++ b/sdk/storage/storage-file-share/test/fileclient.spec.ts
@@ -300,7 +300,8 @@ describe("FileClient", () => {
     assert.deepStrictEqual(properties1.contentMD5, properties2.contentMD5);
     assert.deepStrictEqual(properties2.copyId, result.copyId);
 
-    // Some data center will sanitize the sig field
+    // A service feature is being rolling out which will sanitize the sig field
+    // so we remove it before comparing urls.
     assert.ok(properties2.copySource, "Expecting valid 'properties2.copySource");
 
     const sanitizedActualUrl = URLBuilder.parse(properties2.copySource!);


### PR DESCRIPTION
Storage Blob service in some data center/region may have a feature
enabled to sanitize the header to remove the `sig` part in the SAS
token. This change removes the `sig` part when verifying
`properties.copySource` against the original source url.