### PR TITLE
Serve the source map files during karma test run

### DIFF
--- a/sdk/core/abort-controller/karma.conf.js
+++ b/sdk/core/abort-controller/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "test-browser/index.js",
-      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/core/core-amqp/karma.conf.js
+++ b/sdk/core/core-amqp/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "test-browser/index.js",
-      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/core/core-https/karma.conf.js
+++ b/sdk/core/core-https/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/core/core-lro/karma.conf.js
+++ b/sdk/core/core-lro/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],
 
     exclude: [],

--- a/sdk/core/logger/karma.conf.js
+++ b/sdk/core/logger/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "test-browser/index.js",
-      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/eventhub/event-hubs/karma.conf.js
+++ b/sdk/eventhub/event-hubs/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "test-browser/index.js",
-      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/formrecognizer/ai-form-recognizer/karma.conf.js
+++ b/sdk/formrecognizer/ai-form-recognizer/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "test-browser/index.js",
-      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: true }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),

--- a/sdk/identity/identity/karma.conf.js
+++ b/sdk/identity/identity/karma.conf.js
@@ -35,7 +35,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "test-browser/index.js",
-      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: true }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),

--- a/sdk/keyvault/keyvault-certificates/karma.conf.js
+++ b/sdk/keyvault/keyvault-certificates/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/keyvault/keyvault-keys/karma.conf.js
+++ b/sdk/keyvault/keyvault-keys/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/keyvault/keyvault-secrets/karma.conf.js
+++ b/sdk/keyvault/keyvault-secrets/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     exclude: [],

--- a/sdk/search/search-documents/karma.conf.js
+++ b/sdk/search/search-documents/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),

--- a/sdk/servicebus/service-bus/karma.conf.js
+++ b/sdk/servicebus/service-bus/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "test-browser/index.js",
-      { pattern: "test-browser/index.js.map", type: "html", included: false, served: false }
+      { pattern: "test-browser/index.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-blob/karma.conf.js
+++ b/sdk/storage/storage-blob/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false },
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true },
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-file-datalake/karma.conf.js
+++ b/sdk/storage/storage-file-datalake/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-file-share/karma.conf.js
+++ b/sdk/storage/storage-file-share/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/storage/storage-queue/karma.conf.js
+++ b/sdk/storage/storage-queue/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys,Symbol.iterator
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always,Symbol.iterator",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []),
 
     // list of files / patterns to exclude

--- a/sdk/template/template/karma.conf.js
+++ b/sdk/template/template/karma.conf.js
@@ -29,7 +29,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys
       // "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/test-utils/perfstress/karma.conf.js
+++ b/sdk/test-utils/perfstress/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/test-utils/recorder/karma.conf.js
+++ b/sdk/test-utils/recorder/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
       // Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys
       "https://cdn.polyfill.io/v2/polyfill.js?features=Symbol,Promise,String.prototype.startsWith,String.prototype.endsWith,String.prototype.repeat,String.prototype.includes,Array.prototype.includes,Object.assign,Object.keys|always",
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ],
 
     // list of files / patterns to exclude

--- a/sdk/textanalytics/ai-text-analytics/karma.conf.js
+++ b/sdk/textanalytics/ai-text-analytics/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
       "dist-test/index.browser.js",
-      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: false }
+      { pattern: "dist-test/index.browser.js.map", type: "html", included: false, served: true }
     ].concat(
       isPlaybackMode() || isSoftRecordMode() ? ["recordings/browsers/**/*.json"] : []
     ),


### PR DESCRIPTION
This is a follow up of #8839. Files do need to be served so browser
debugging tools can load them along side the tests. See
http://karma-runner.github.io/5.0/config/files.html for docs on files
options.