### PR TITLE
[Service Bus] Porting `unset mgmtClient to undefined from track 1 to avoid TypeError`

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -18,8 +18,7 @@ import {
   getReceiverClosedErrorMsg,
   throwTypeErrorIfParameterMissing,
   throwTypeErrorIfParameterNotLong,
-  throwTypeErrorIfParameterNotLongArray,
-  throwErrorIfClientOrConnectionClosed
+  throwTypeErrorIfParameterNotLongArray
 } from "../util/errors";
 import * as log from "../log";
 import { OnMessage, OnError, ReceiveOptions } from "../core/messageReceiver";
@@ -166,10 +165,7 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
   private _throwIfReceiverOrConnectionClosed(): void {
     throwErrorIfConnectionClosed(this._context.namespace);
     if (this.isClosed) {
-      const errorMessage = getReceiverClosedErrorMsg(
-        this._context.entityPath,
-        this._context.isClosed
-      );
+      const errorMessage = getReceiverClosedErrorMsg(this._context.entityPath);
       const error = new Error(errorMessage);
       log.error(`[${this._context.namespace.connectionId}] %O`, error);
       throw error;
@@ -409,15 +405,8 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
     return retry<ReceivedMessageT[]>(config);
   }
 
-  // ManagementClient methods # Begin
-
   async browseMessages(options: BrowseMessagesOptions = {}): Promise<ReceivedMessage[]> {
-    throwErrorIfClientOrConnectionClosed(
-      this._context.namespace,
-      this._context.entityPath,
-      this._context.isClosed
-    );
-
+    this._throwIfReceiverOrConnectionClosed();
     const managementRequestOptions = {
       ...options,
       requestName: "browseMessages",

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -169,11 +169,7 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
   private _throwIfReceiverOrConnectionClosed(): void {
     throwErrorIfConnectionClosed(this._context.namespace);
     if (this.isClosed) {
-      const errorMessage = getReceiverClosedErrorMsg(
-        this._context.entityPath,
-        this._context.isClosed,
-        this.sessionId!
-      );
+      const errorMessage = getReceiverClosedErrorMsg(this._context.entityPath, this.sessionId!);
       const error = new Error(errorMessage);
       log.error(`[${this._context.namespace.connectionId}] %O`, error);
       throw error;

--- a/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
+++ b/sdk/servicebus/service-bus/src/receivers/subscriptionRuleManager.ts
@@ -80,11 +80,7 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
 
   // #region topic-filters
   getRules(options: OperationOptions = {}): Promise<RuleDescription[]> {
-    throwErrorIfClientOrConnectionClosed(
-      this._context.namespace,
-      this._context.entityPath,
-      this._context.isClosed
-    );
+    throwErrorIfClientOrConnectionClosed(this._context, "ruleManager");
 
     const getRulesOperationPromise = async () => {
       return this._context.managementClient!.getRules({
@@ -104,11 +100,7 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
   }
 
   removeRule(ruleName: string, options: OperationOptions = {}): Promise<void> {
-    throwErrorIfClientOrConnectionClosed(
-      this._context.namespace,
-      this._context.entityPath,
-      this._context.isClosed
-    );
+    throwErrorIfClientOrConnectionClosed(this._context, "ruleManager");
 
     const removeRuleOperationPromise = () => {
       return this._context.managementClient!.removeRule(ruleName, {
@@ -133,11 +125,7 @@ export class SubscriptionRuleManagerImpl implements SubscriptionRuleManager {
     sqlRuleActionExpression?: string,
     options: OperationOptions = {}
   ): Promise<void> {
-    throwErrorIfClientOrConnectionClosed(
-      this._context.namespace,
-      this._context.entityPath,
-      this._context.isClosed
-    );
+    throwErrorIfClientOrConnectionClosed(this._context, "ruleManager");
 
     const addRuleOperationPromise = async () => {
       return this._context.managementClient!.addRule(ruleName, filter, sqlRuleActionExpression, {

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -199,10 +199,7 @@ export class SenderImpl implements Sender {
   private _throwIfSenderOrConnectionClosed(): void {
     throwErrorIfConnectionClosed(this._context.namespace);
     if (this.isClosed) {
-      const errorMessage = getSenderClosedErrorMsg(
-        this._context.entityPath,
-        this._context.isClosed
-      );
+      const errorMessage = getSenderClosedErrorMsg(this._context.entityPath);
       const error = new Error(errorMessage);
       log.error(`[${this._context.namespace.connectionId}] %O`, error);
       throw error;

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -1,22 +1,35 @@
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { delay, Sender, Receiver, ReceivedMessageWithLock } from "../src";
+import { delay, Sender, Receiver, ReceivedMessageWithLock, SessionReceiver } from "../src";
 import { TestClientType, TestMessage } from "./utils/testUtils";
-import { ServiceBusClientForTests, createServiceBusClientForTests } from "./utils/testutils2";
+import {
+  ServiceBusClientForTests,
+  createServiceBusClientForTests,
+  EntityName
+} from "./utils/testutils2";
 import { isNode } from "@azure/core-amqp";
-chai.should();
+import Long from "long";
+import { ReceiveMode, DispositionType } from "../src/serviceBusMessage";
+import { ReceiverImpl } from "../src/receivers/receiver";
+import {
+  getReceiverClosedErrorMsg,
+  getSubscriptionRuleManagerClosedErrorMsg,
+  getSenderClosedErrorMsg
+} from "../src/util/errors";
+import { SenderImpl } from "../src/sender";
+const should = chai.should();
 chai.use(chaiAsPromised);
 
 describe("ManagementClient - disconnects", function(): void {
   let serviceBusClient: ServiceBusClientForTests;
-  let senderClient: Sender;
-  let receiverClient: Receiver<ReceivedMessageWithLock>;
+  let sender: Sender;
+  let receiver: Receiver<ReceivedMessageWithLock>;
 
   async function beforeEachTest(entityType: TestClientType): Promise<void> {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
-    receiverClient = await serviceBusClient.test.getPeekLockReceiver(entityNames);
+    receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
-    senderClient = serviceBusClient.test.addToCleanup(
+    sender = serviceBusClient.test.addToCleanup(
       await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
@@ -48,16 +61,16 @@ describe("ManagementClient - disconnects", function(): void {
     await beforeEachTest(TestClientType.UnpartitionedQueue);
     // Send a message so we have something to peek.
 
-    await senderClient.send(TestMessage.getSample());
-    await senderClient.send(TestMessage.getSample());
+    await sender.send(TestMessage.getSample());
+    await sender.send(TestMessage.getSample());
 
     let peekedMessageCount = 0;
-    let messages = await receiverClient.browseMessages({ maxMessageCount: 1 });
+    let messages = await receiver.browseMessages({ maxMessageCount: 1 });
     peekedMessageCount += messages.length;
 
     peekedMessageCount.should.equal(1, "Unexpected number of peeked messages.");
 
-    const connectionContext = (receiverClient as any)["_context"].namespace;
+    const connectionContext = (receiver as any)["_context"].namespace;
     const refreshConnection = connectionContext.refreshConnection;
     let refreshConnectionCalled = 0;
     connectionContext.refreshConnection = function(...args: any) {
@@ -73,7 +86,7 @@ describe("ManagementClient - disconnects", function(): void {
     await delay(2000);
 
     // peek additional messages
-    messages = await receiverClient.browseMessages({ maxMessageCount: 1 });
+    messages = await receiver.browseMessages({ maxMessageCount: 1 });
     peekedMessageCount += messages.length;
     peekedMessageCount.should.equal(2, "Unexpected number of peeked messages.");
 
@@ -88,7 +101,7 @@ describe("ManagementClient - disconnects", function(): void {
     // Send a message so we have something to peek.
 
     const deliveryIds = [];
-    let deliveryId = await senderClient.scheduleMessage(
+    let deliveryId = await sender.scheduleMessage(
       new Date("2020-04-25T12:00:00Z"),
       TestMessage.getSample()
     );
@@ -96,7 +109,7 @@ describe("ManagementClient - disconnects", function(): void {
 
     deliveryIds.length.should.equal(1, "Unexpected number of scheduled messages.");
 
-    const connectionContext = (receiverClient as any)["_context"].namespace;
+    const connectionContext = (receiver as any)["_context"].namespace;
     const refreshConnection = connectionContext.refreshConnection;
     let refreshConnectionCalled = 0;
     connectionContext.refreshConnection = function(...args: any) {
@@ -112,7 +125,7 @@ describe("ManagementClient - disconnects", function(): void {
     await delay(2000);
 
     // peek additional messages
-    deliveryId = await senderClient.scheduleMessage(
+    deliveryId = await sender.scheduleMessage(
       new Date("2020-04-25T12:00:00Z"),
       TestMessage.getSample()
     );
@@ -120,5 +133,203 @@ describe("ManagementClient - disconnects", function(): void {
     deliveryIds.length.should.equal(2, "Unexpected number of scheduled messages.");
 
     refreshConnectionCalled.should.be.greaterThan(0, "refreshConnection was not called.");
+  });
+});
+
+describe("Management operations should throw error if the ClientEntityContext is closed", function(): void {
+  afterEach(async () => {
+    await sbClient.test.after();
+  });
+  let sbClient: ServiceBusClientForTests;
+  let sender: Sender;
+  let receiver: Receiver<ReceivedMessageWithLock> | SessionReceiver<ReceivedMessageWithLock>;
+  let entityNames: EntityName;
+  async function beforeEachTest(entityType: TestClientType) {
+    // Create the sender and receiver.
+    sbClient = createServiceBusClientForTests();
+    entityNames = await sbClient.test.createTestEntities(entityType);
+    receiver = await sbClient.test.getPeekLockReceiver(entityNames);
+
+    sender = sbClient.test.addToCleanup(
+      await sbClient.createSender(entityNames.queue ?? entityNames.topic!)
+    );
+  }
+  async function verifyClientClosedError(func: Function, partialErrorMsg: string) {
+    let errorWasThrown = false;
+    try {
+      await func();
+    } catch (error) {
+      should.equal(
+        (error.message as string).includes(partialErrorMsg),
+        true,
+        `Unexpected Error Message - ${error.message}`
+      );
+      errorWasThrown = true;
+    }
+    should.equal(errorWasThrown, true, "Error wasn't thrown");
+  }
+
+  it("peek throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedQueue);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.peek();
+    }, getReceiverClosedErrorMsg(entityNames.queue!));
+
+    // Just to make sure that the new managementClient is usable
+    receiver = sbClient.test.addToCleanup(sbClient.createReceiver(entityNames.queue!, "peekLock"));
+    sender = sbClient.test.addToCleanup(await sbClient.createSender(entityNames.queue!));
+    await sender.send({ body: "random-message" });
+    (await receiver.browseMessages()).length.should.equal(
+      1,
+      "BrowseMessages gave unexpected number of messages"
+    );
+    await (await receiver.receiveBatch(1))[0].complete();
+  });
+
+  it("peekBySequenceNumber throws error after the client is closed", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(TestClientType.UnpartitionedQueue);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.peekBySequenceNumber(new Long(0));
+    }, getReceiverClosedErrorMsg(entityNames.queue!));
+  });
+
+  it("receiveDeferredMessages throws error after the client is closed", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(TestClientType.UnpartitionedQueue);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.receiveDeferredMessages([new Long(0)], ReceiveMode.peekLock);
+    }, getReceiverClosedErrorMsg(entityNames.queue!));
+  });
+
+  it("renewSessionLock throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.renewSessionLock(TestMessage.sessionId);
+    }, getReceiverClosedErrorMsg(entityNames.queue!, TestMessage.sessionId));
+  });
+
+  it("getState throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.getSessionState(TestMessage.sessionId);
+    }, getReceiverClosedErrorMsg(entityNames.queue!, TestMessage.sessionId));
+  });
+
+  it("setState throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.setSessionState(TestMessage.sessionId, "random");
+    }, getReceiverClosedErrorMsg(entityNames.queue!, TestMessage.sessionId));
+  });
+
+  it("addRule throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedSubscription);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.addRule("random", "1=1");
+    }, getSubscriptionRuleManagerClosedErrorMsg(`${entityNames.topic!}/Subscriptions/${entityNames.subscription!}`));
+  });
+
+  it("removeRule throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedSubscription);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.removeRule("random");
+    }, getSubscriptionRuleManagerClosedErrorMsg(`${entityNames.topic!}/Subscriptions/${entityNames.subscription!}`));
+  });
+
+  it("getRule throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedSubscription);
+    await verifyClientClosedError(async () => {
+      const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+      const preservedMgmtClient = receiverContext.managementClient;
+      const clientId = receiverContext.clientId;
+      await receiverContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.getRules();
+    }, getSubscriptionRuleManagerClosedErrorMsg(`${entityNames.topic!}/Subscriptions/${entityNames.subscription!}`));
+  });
+
+  it("renewMessageLock should not throw error after the client is closed", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(TestClientType.UnpartitionedSubscription);
+    await sender.send({ body: "random message" });
+    const msg = (await receiver.receiveBatch(1))[0];
+    const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+    const preservedMgmtClient = receiverContext.managementClient;
+    const clientId = receiverContext.clientId;
+    await receiverContext.namespace.clientContexts[clientId].close();
+    await preservedMgmtClient!.renewLock(msg.lockToken!);
+  });
+
+  it("updateDispositionStatus should not throw error after the client is closed", async function(): Promise<
+    void
+  > {
+    await beforeEachTest(TestClientType.UnpartitionedSubscription);
+    await sender.send({ body: "random message" });
+    const msg = (await receiver.receiveBatch(1))[0];
+    const receiverContext = (receiver as ReceiverImpl<ReceivedMessageWithLock>)["_context"];
+    const preservedMgmtClient = receiverContext.managementClient;
+    const clientId = receiverContext.clientId;
+    await receiverContext.namespace.clientContexts[clientId].close();
+    await preservedMgmtClient!.updateDispositionStatus(msg.lockToken!, DispositionType.complete);
+  });
+
+  // TODO: Fix this test, not sure why the error isn't thrown
+  it("schedule throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedQueue);
+    await verifyClientClosedError(async () => {
+      const senderContext = (sender as SenderImpl)["_context"];
+      const preservedMgmtClient = senderContext.managementClient;
+      const clientId = senderContext.clientId;
+      await senderContext.namespace.clientContexts[clientId].close();
+      console.log(sender.isClosed);
+      await preservedMgmtClient!.scheduleMessages(new Date(), [{ body: "random message" }]);
+    }, getSenderClosedErrorMsg(entityNames.queue!));
+  });
+
+  // TODO: Fix this test, not sure why the error isn't thrown
+  it("cancel-scheduled throws error after the client is closed", async function(): Promise<void> {
+    await beforeEachTest(TestClientType.UnpartitionedQueue);
+    await verifyClientClosedError(async () => {
+      const senderContext = (sender as SenderImpl)["_context"];
+      const preservedMgmtClient = senderContext.managementClient;
+      const clientId = senderContext.clientId;
+      await senderContext.namespace.clientContexts[clientId].close();
+      await preservedMgmtClient!.cancelScheduledMessages([new Long(0)]);
+    }, getSenderClosedErrorMsg(entityNames.queue!));
   });
 });

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -829,7 +829,7 @@ describe("Errors after close()", function(): void {
     it("Unpartitioned Queue: errors after close() on receiver", async function(): Promise<void> {
       await beforeEachTest(TestClientType.UnpartitionedQueue, entityToClose);
 
-      await testReceiver(getReceiverClosedErrorMsg(receiver.entityPath, false));
+      await testReceiver(getReceiverClosedErrorMsg(receiver.entityPath));
     });
 
     it("Unpartitioned Queue with sessions: errors after close() on receiver", async function(): Promise<
@@ -837,9 +837,7 @@ describe("Errors after close()", function(): void {
     > {
       await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions, entityToClose);
 
-      await testReceiver(
-        getReceiverClosedErrorMsg(receiver.entityPath, false, TestMessage.sessionId)
-      );
+      await testReceiver(getReceiverClosedErrorMsg(receiver.entityPath, TestMessage.sessionId));
     });
 
     it("Unpartitioned Topic/Subscription: errors after close() on receiver", async function(): Promise<
@@ -847,7 +845,7 @@ describe("Errors after close()", function(): void {
     > {
       await beforeEachTest(TestClientType.UnpartitionedSubscription, entityToClose);
 
-      await testReceiver(getReceiverClosedErrorMsg(receiver.entityPath, false));
+      await testReceiver(getReceiverClosedErrorMsg(receiver.entityPath));
       // TODO - rules are independent of receiver
       // await testRules(getClientClosedErrorMsg(receiver.entityPath));
     });
@@ -858,7 +856,7 @@ describe("Errors after close()", function(): void {
       await beforeEachTest(TestClientType.UnpartitionedSubscriptionWithSessions, entityToClose);
 
       await testSessionReceiver(
-        getReceiverClosedErrorMsg(receiver.entityPath, false, TestMessage.sessionId)
+        getReceiverClosedErrorMsg(receiver.entityPath, TestMessage.sessionId)
       );
       // TODO - rules are independent of receiver
       // await testRules(getClientClosedErrorMsg(receiver.entityPath));
@@ -889,7 +887,7 @@ describe("Errors after close()", function(): void {
       await beforeEachTest(TestClientType.UnpartitionedQueueWithSessions, entityToClose);
 
       await testSessionReceiver(
-        getReceiverClosedErrorMsg(receiver.entityPath, false, TestMessage.sessionId)
+        getReceiverClosedErrorMsg(receiver.entityPath, TestMessage.sessionId)
       );
       await testAllDispositions();
     });


### PR DESCRIPTION
**Postponing this in favor of more investigations and probably the removal of clientEntityContext from #8143** 

Porting #8537 
- Do not set managementClient to undefined to avoid TypeError
- Error message refactorings
- Allow renewlock and settlement even if the ClientEntityContext is closed
- And other minor changes
- [ ] TODO: yet to figure out and fix the two sender test failures from the new tests