### PR TITLE
[KeyVault] Idea for testing tracing functionalities

### DIFF
--- a/sdk/keyvault/keyvault-keys/test/tracing.test.ts
+++ b/sdk/keyvault/keyvault-keys/test/tracing.test.ts
@@ -1,0 +1,245 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { KeyClient, JsonWebKey } from "../src";
+import * as assert from "assert";
+import { TestTracer, setTracer, OperationTracingOptions } from "@azure/core-tracing";
+import { Context as MochaTestContext, Test } from "mocha";
+import { env, Recorder, isRecordMode, isPlaybackMode, delay } from "@azure/test-utils-recorder";
+import { authenticate } from "./utils/testAuthentication";
+import TestClient from "./utils/testClient";
+import { testPollerProperties } from "./utils/recorderUtils";
+import { isNode } from "@azure/core-http";
+
+// This test file confirms that all of our methods that create tracing spans
+// are effectively doing so.
+
+/**
+ * A catch-all type for the SpanGraph root and its nodes.
+ */
+interface TestRecursiveGraph {
+  name?: string;
+  roots?: TestRecursiveGraph[];
+  children?: TestRecursiveGraph[];
+}
+
+/**
+ * Gets the names of all of the nodes of a SpanGraph from @azure/core-tracing
+ */
+function getNames(graph: TestRecursiveGraph): string[] {
+  const { name, roots, children = roots } = graph;
+  if (!children || !children!.length) {
+    return [];
+  }
+  const childrenNames = children.map(getNames).flat();
+  return [name!, ...childrenNames].filter((x) => x);
+}
+
+export type TracingTestFunc = (
+  this: MochaTestContext,
+  tracingOptions: OperationTracingOptions
+) => Promise<void>;
+
+interface TestTracingNodeNames {
+  (nodeNames: string[], test: TracingTestFunc): Test;
+  skip: (nodeNames: string[], test: TracingTestFunc) => Test;
+  only: (nodeNames: string[], test: TracingTestFunc) => Test;
+}
+
+function generateTracingTest(nodeNames: string[], test: TracingTestFunc): Mocha.Func {
+  return async function() {
+    const tracer = new TestTracer();
+    setTracer(tracer);
+    const rootSpan = tracer.startSpan("root");
+
+    await test.call(this, {
+      spanOptions: { parent: rootSpan.context() }
+    });
+
+    const graph = tracer.getSpanGraph(rootSpan.context().traceId);
+    const names = getNames(graph);
+    const uniqueNames = names.reduce(
+      (unique, next) => (unique.includes(next) ? unique : [...unique, next]),
+      ["root"]
+    );
+    assert.deepEqual(["root", ...nodeNames], uniqueNames);
+
+    rootSpan.end();
+    const activeSpans = tracer.getActiveSpans();
+    activeSpans.map((span) => console.log(`OPEN SPAN: ${span.name}`));
+    assert.equal(activeSpans.length, 0);
+  };
+}
+
+export const testTracingNodeNames: TestTracingNodeNames = function(
+  nodeNames: string[],
+  test: TracingTestFunc
+): Test {
+  return it(`traces the methods ${nodeNames.join(", ")}`, generateTracingTest(nodeNames, test));
+};
+
+testTracingNodeNames.skip = function(nodeNames: string[]): Test {
+  return it.skip(`Skipping tracing tests for the methods ${nodeNames.join(", ")}`);
+};
+
+testTracingNodeNames.only = function(nodeNames: string[], test: TracingTestFunc): Test {
+  return it.only(`traces the methods ${nodeNames.join(", ")}`, generateTracingTest(nodeNames, test));
+};
+
+describe("Keys client - tracing spans", () => {
+  const keyPrefix = `tracing${env.KEY_NAME || "KeyName"}`;
+  let keySuffix: string;
+  let client: KeyClient;
+  let testClient: TestClient;
+  let recorder: Recorder;
+
+  function getKeyName(context: MochaTestContext): string {
+    return testClient.formatName(`${keyPrefix}-${context!.test!.title}-${keySuffix}`);
+  }
+
+  beforeEach(async function() {
+    const authentication = await authenticate(this);
+    keySuffix = authentication.keySuffix;
+    client = authentication.client;
+    testClient = authentication.testClient;
+    recorder = authentication.recorder;
+  });
+
+  afterEach(async function() {
+    recorder.stop();
+  });
+
+  // The tests follow
+
+  testTracingNodeNames(
+    ["createKey", "deleteKey", "getDeletedKey", "getKey", "recoverDeletedKey", "purgeDeletedKey"],
+    async function(tracingOptions: OperationTracingOptions) {
+      const keyName = getKeyName(this);
+      await client.createKey(keyName, "RSA", { tracingOptions });
+      const pollerProperties = {
+        ...testPollerProperties,
+        tracingOptions
+      };
+
+      let deletePoller = await client.beginDeleteKey(keyName, pollerProperties);
+      await deletePoller.pollUntilDone();
+
+      const recoverPoller = await client.beginRecoverDeletedKey(keyName, pollerProperties);
+      await recoverPoller.pollUntilDone();
+
+      deletePoller = await client.beginDeleteKey(keyName, pollerProperties);
+      await deletePoller.pollUntilDone();
+
+      await client.purgeDeletedKey(keyName, { tracingOptions });
+    }
+  );
+
+  testTracingNodeNames(["importKey"], async function(tracingOptions: OperationTracingOptions) {
+    const keyName = getKeyName(this);
+    function toBytes(hex: string): Uint8Array {
+      if (hex.length % 2) {
+        hex = `0${hex}`;
+      }
+      if (isNode) {
+        return Buffer.from(hex, "hex");
+      } else {
+        return new Uint8Array(hex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)));
+      }
+    }
+    const jsonWebKey: JsonWebKey = {
+      kty: "RSA",
+      keyOps: ["encrypt", "decrypt", "sign", "verify", "wrapKey", "unwrapKey"],
+      n: toBytes(
+        "00a0914d00234ac683b21b4c15d5bed887bdc959c2e57af54ae734e8f00720d775d275e455207e3784ceeb60a50a4655dd72a7a94d271e8ee8f7959a669ca6e775bf0e23badae991b4529d978528b4bd90521d32dd2656796ba82b6bbfc7668c8f5eeb5053747fd199319d29a8440d08f4412d527ff9311eda71825920b47b1c46b11ab3e91d7316407e89c7f340f7b85a34042ce51743b27d4718403d34c7b438af6181be05e4d11eb985d38253d7fe9bf53fc2f1b002d22d2d793fa79a504b6ab42d0492804d7071d727a06cf3a8893aa542b1503f832b296371b6707d4dc6e372f8fe67d8ded1c908fde45ce03bc086a71487fa75e43aa0e0679aa0d20efe35"
+      ),
+      e: toBytes("10001"),
+      d: toBytes(
+        "627c7d24668148fe2252c7fa649ea8a5a9ed44d75c766cda42b29b660e99404f0e862d4561a6c95af6a83d213e0a2244b03cd28576473215073785fb067f015da19084ade9f475e08b040a9a2c7ba00253bb8125508c9df140b75161d266be347a5e0f6900fe1d8bbf78ccc25eeb37e0c9d188d6e1fc15169ba4fe12276193d77790d2326928bd60d0d01d6ead8d6ac4861abadceec95358fd6689c50a1671a4a936d2376440a41445501da4e74bfb98f823bd19c45b94eb01d98fc0d2f284507f018ebd929b8180dbe6381fdd434bffb7800aaabdd973d55f9eaf9bb88a6ea7b28c2a80231e72de1ad244826d665582c2362761019de2e9f10cb8bcc2625649"
+      ),
+      p: toBytes(
+        "00d1deac8d68ddd2c1fd52d5999655b2cf1565260de5269e43fd2a85f39280e1708ffff0682166cb6106ee5ea5e9ffd9f98d0becc9ff2cda2febc97259215ad84b9051e563e14a051dce438bc6541a24ac4f014cf9732d36ebfc1e61a00d82cbe412090f7793cfbd4b7605be133dfc3991f7e1bed5786f337de5036fc1e2df4cf3"
+      ),
+      q: toBytes(
+        "00c3dc66b641a9b73cd833bc439cd34fc6574465ab5b7e8a92d32595a224d56d911e74624225b48c15a670282a51c40d1dad4bc2e9a3c8dab0c76f10052dfb053bc6ed42c65288a8e8bace7a8881184323f94d7db17ea6dfba651218f931a93b8f738f3d8fd3f6ba218d35b96861a0f584b0ab88ddcf446b9815f4d287d83a3237"
+      ),
+      dp: toBytes(
+        "00c9a159be7265cbbabc9afcc4967eb74fe58a4c4945431902d1142da599b760e03838f8cbd26b64324fea6bdc9338503f459793636e59b5361d1e6951e08ddb089e1b507be952a81fbeaf7e76890ea4f536e25505c3f648b1e88377dfc19b4c304e738dfca07211b792286a392a704d0f444c0a802539110b7f1f121c00cff0a9"
+      ),
+      dq: toBytes(
+        "00a0bd4c0a3d9f64436a082374b5caf2488bac1568696153a6a5e4cd85d186db31e2f58f024c617d29f37b4e6b54c97a1e25efec59c4d1fd3061ac33509ce8cae5c11f4cd2e83f41a8264f785e78dc0996076ee23dfdfc43d67c463afaa0180c4a718357f9a6f270d542479a0f213870e661fb950abca4a14ca290570ba7983347"
+      ),
+      qi: toBytes(
+        "009fe7ae42e92bc04fcd5780464bd21d0c8ac0c599f9af020fde6ab0a7e7d1d39902f5d8fb6c614184c4c1b103fb46e94cd10a6c8a40f9991a1f28269f326435b6c50276fda6493353c650a833f724d80c7d522ba16c79f0eb61f672736b68fb8be3243d10943c4ab7028d09e76cfb5892222e38bc4d35585bf35a88cd68c73b07"
+      )
+    };
+    await client.importKey(keyName, jsonWebKey, { tracingOptions });
+  });
+
+  testTracingNodeNames(["createEcKey", "updateKeyProperties"], async function(
+    tracingOptions: OperationTracingOptions
+  ) {
+    const keyName = getKeyName(this);
+    const { version } = (await client.createEcKey(keyName, { tracingOptions })).properties;
+    await client.updateKeyProperties(keyName, version || "", { enabled: false, tracingOptions });
+    await testClient.flushKey(keyName);
+  });
+
+  testTracingNodeNames(
+    ["listPropertiesOfKeys", "listPropertiesOfKeyVersions", "listDeletedKeys"],
+    async function(tracingOptions: OperationTracingOptions) {
+      const keyName = testClient.formatName(`${keyPrefix}-${this!.test!.title}-${keySuffix}`);
+      const keyNames = [`${keyName}-0`, `${keyName}-1`];
+      for (const name of keyNames) {
+        await client.createKey(name, "RSA");
+      }
+
+      for await (const properties of client.listPropertiesOfKeys({ tracingOptions })) {
+        for await (const _version of client.listPropertiesOfKeyVersions(properties.name, {
+          tracingOptions
+        })) {
+          // Nothing to do here..
+        }
+      }
+
+      for (const name of keyNames) {
+        const poller = await client.beginDeleteKey(name, testPollerProperties);
+        await poller.pollUntilDone();
+      }
+
+      for await (const _deletedKey of client.listDeletedKeys({ tracingOptions })) {
+        // Nothing to do here..
+      }
+
+      for (const name of keyNames) {
+        await testClient.purgeKey(name);
+      }
+    }
+  );
+
+  if (isRecordMode() || isPlaybackMode()) {
+    // This test can't run live,
+    // since the purge operation currently can't be expected to finish anytime soon.
+    testTracingNodeNames(["createRsaKey", "backupKey", "restoreKeyBackup"], async function(tracingOptions: OperationTracingOptions) {
+      const keyName = getKeyName(this);
+      await client.createRsaKey(keyName, { tracingOptions });
+      const backup = await client.backupKey(keyName, { tracingOptions });
+
+      await testClient.flushKey(keyName);
+
+      // This method can't be made into a long running operation yet.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        try {
+          await client.restoreKeyBackup(backup as Uint8Array, { tracingOptions });
+          break;
+        } catch (e) {
+          console.log("Can't restore the key since it's not fully deleted:", e.message);
+          console.log("Retrying in one second...");
+          await delay(1000);
+        }
+      }
+
+      await testClient.flushKey(keyName);
+    });
+  }
+});


### PR DESCRIPTION
Here's an idea for testing tracing functionalities. I wonder if something like this could be added to core-tracing.

If this looks good at least for KeyVault, I reasonably still have to:

- Add the recordings.
- Add the same tests for certificates and secrets.

I was also thinking on using decorators instead. I don't remember if we favored decorators or not. I think they're tricky to implement correctly, but a good one could make it so that we could add the tracing testing decorator to any existing test, which means that we could confirm that tracing worked everywhere without having to add new test files, nor generate new recordings.

Decorators would also be cool to test things like to confirm that the challenge based authentication fix is effective in all of our tests without having to change the inner code of our tests.