### PR TITLE
[ai-text-analytics] Some tweaks to readme files

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -2,6 +2,8 @@
 
 [Azure TextAnalytics](https://azure.microsoft.com/services/cognitive-services/text-analytics/) is a cloud-based service that provides advanced natural language processing over raw text, and includes six main functions:
 
+__Note:__ This SDK targets Azure Text Analytics service API version 3.0.
+
 - Language Detection
 - Sentiment Analysis
 - Key Phrase Extraction

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -35,7 +35,7 @@ Use the client library to:
 If you use the Azure CLI, replace `<your-resource-group-name>` and `<your-resource-name>` with your own unique names:
 
 ```PowerShell
-az cognitiveservices account create --kind TextAnalytics --resource-group <your-resource-group-name> --name <your-resource-name>
+az cognitiveservices account create --kind TextAnalytics --resource-group <your-resource-group-name> --name <your-resource-name> --sku <your-sku-name> --location <your-location>
 ```
 
 ### Install the `@azure/ai-text-analytics` package
@@ -326,15 +326,15 @@ const client = new TextAnalyticsClient(
 const documents = [
   "This is written in English.",
   "Il documento scritto in italiano.",
-  "Dies ist in englischer Sprache verfasst."
+  "Dies ist in deutscher Sprache verfasst."
 ];
 
 async function main() {
   const results = await client.detectLanguage(documents, "none");
 
   for (const result of results) {
-    const { primaryLanguage } = result;
     if (result.error === undefined) {
+      const { primaryLanguage } = result;
       console.log(
         "Input #",
         result.id,

--- a/sdk/textanalytics/ai-text-analytics/test/README.md
+++ b/sdk/textanalytics/ai-text-analytics/test/README.md
@@ -15,7 +15,7 @@ To run the live tests, you will also need to set the below environment variables
 - `TEXT_ANALYTICS_API_KEY_ALT` (optional): The secondary API key of the Text Analytics API in your Azure Cognitive Services account.
 - `ENDPOINT`: The endpoint of your Text Analytics API in your Azure Cognitive Services account.
 
-In addition to the environment variables above, an Azure Active Directoryidentity configuration is required. See the [README file for the @azure/identity package](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity) for more details on how to configure an identity for local testing. The test configuration uses the `DefaultAzureCredential` to request an authentication token, so any authentication method that is exposed by `DefaultAzureCredential` will be sufficient to run the tests. The next section will explain how to grant access to your Cognitive Services account to the user or application you wish to use for testing.
+In addition to the environment variables above, an Azure Active Directory identity configuration is required. See the [README file for the @azure/identity package](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity) for more details on how to configure an identity for local testing. The test configuration uses the `DefaultAzureCredential` to request an authentication token, so any authentication method that is exposed by `DefaultAzureCredential` will be sufficient to run the tests. The next section will explain how to grant access to your Cognitive Services account to the user or application you wish to use for testing.
 
 ## AAD-based Authentication
 

--- a/sdk/textanalytics/ai-text-analytics/test/README.md
+++ b/sdk/textanalytics/ai-text-analytics/test/README.md
@@ -15,6 +15,34 @@ To run the live tests, you will also need to set the below environment variables
 - `TEXT_ANALYTICS_API_KEY_ALT` (optional): The secondary API key of the Text Analytics API in your Azure Cognitive Services account.
 - `ENDPOINT`: The endpoint of your Text Analytics API in your Azure Cognitive Services account.
 
-The live tests in this project will create collections in the provided Azure Cognitive Services account.
+In addition to the environment variables above, an Azure Active Directoryidentity configuration is required. See the [README file for the @azure/identity package](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity) for more details on how to configure an identity for local testing. The test configuration uses the `DefaultAzureCredential` to request an authentication token, so any authentication method that is exposed by `DefaultAzureCredential` will be sufficient to run the tests. The next section will explain how to grant access to your Cognitive Services account to the user or application you wish to use for testing.
+
+## AAD-based Authentication
+
+In order to use Azure Active Directory to run the live tests, you will need to configure a role assignment within your AAD tenant.
+
+### Using an App Registration (Service Principal)
+
+- Follow [Documentation to register a new application](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) in the Azure Active Directory (in the Azure portal).
+- Note the Client ID and Tenant ID.
+- In the "Certificates & Secrets" tab, create a secret and note that down.
+- Ensure the following environment variables are set:
+  - `AZURE_TENANT_ID="<your tenant ID>"`
+  - `AZURE_CLIENT_ID="<your client ID>"`
+  - `AZURE_CLIENT_SECRET="<the client secret>"`
+
+### Using a User Account
+
+As an alternative to creating a service principal, you can use a simple user account. This is not recommended for production, but may be useful for development and testing. Using a User Account requires either the Azure CLI or Visual Studio Code with the [Azure Account extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.azure-account).
+
+- Create an account in your Azure Active Directory tenant (or use the default account associated with your Microsoft account)
+- Log in to the account, either using the Azure CLI (`az login` command) or though the VS Code Azure Account extension.
+
+Once you are logged in, the `DefaultAzureCredential` will use the identity of the account when communicating with the Cognitive Services endpoint.
+
+### Assign owner role to the registered application
+
+- In the Azure portal, go to your Cognitive Services resource and assign the **Cognitive Services User** role to the registered application (if using an Application Service Principal) or to your user account.
+  - This can be done from `Role assignment` section of `Access control (IAM)` tab (in the left-side-navbar of your Cognitive Services resource in the Azure portal)<br>_Doing this will allow anyone with your application or user's credentials and/or access token to utilize the endpoint resources._
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Ftextanalytics%2Fai-text-analytics%2Ftest%2FREADME.png)

--- a/sdk/textanalytics/ai-text-analytics/test/README.md
+++ b/sdk/textanalytics/ai-text-analytics/test/README.md
@@ -40,9 +40,11 @@ As an alternative to creating a service principal, you can use a simple user acc
 
 Once you are logged in, the `DefaultAzureCredential` will use the identity of the account when communicating with the Cognitive Services endpoint.
 
-### Assign owner role to the registered application
+### Assign the Cognitive Services User role to your user
 
 - In the Azure portal, go to your Cognitive Services resource and assign the **Cognitive Services User** role to the registered application (if using an Application Service Principal) or to your user account.
   - This can be done from `Role assignment` section of `Access control (IAM)` tab (in the left-side-navbar of your Cognitive Services resource in the Azure portal)<br>_Doing this will allow anyone with your application or user's credentials and/or access token to utilize the endpoint resources._
+
+After configuring your account's permissions and setting up the authenticated environment, you should be able to run the live tests.
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Ftextanalytics%2Fai-text-analytics%2Ftest%2FREADME.png)


### PR DESCRIPTION
Addresses #8390 and contains a first stab at instructions for using AAD in TextAnalytics's testing README ( #8463 )

CC @sadasant I think the README content on how to use AAD here is maybe a little long, so I'd like to extract it to a separate location if we know where that should live right now. Otherwise, let me know what you think of the content.