### PR TITLE
[Service Bus] Fix abortSignal test failure for sendBatch

### DIFF
--- a/sdk/servicebus/service-bus/test/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/abortSignal.spec.ts
@@ -11,8 +11,8 @@ import { MessageSender } from "../src/core/messageSender";
 import { OperationOptions } from "../src/modelsToBeSharedWithEventHubs";
 import { DefaultDataTransformer } from "@azure/core-amqp";
 import { AbortSignalLike } from "@azure/abort-controller";
-import { ServiceBusMessageBatch } from "../src/serviceBusMessageBatch";
 import { delay, AwaitableSender } from "rhea-promise";
+import { ServiceBusMessageBatchImpl } from "../src/serviceBusMessageBatch";
 
 describe("AbortSignal", () => {
   const testMessageThatDoesntMatter = {
@@ -41,7 +41,8 @@ describe("AbortSignal", () => {
 
       assert.equal((passedInOptions?.abortSignal as any).tag, "passed with send");
 
-      await sender.sendBatch({} as ServiceBusMessageBatch, {
+      const batchMessage = new ServiceBusMessageBatchImpl(clientEntityContext, 1000);
+      await sender.sendBatch(batchMessage, {
         abortSignal: createTaggedAbortSignal("passed with sendBatch", false)
       });
 


### PR DESCRIPTION
This test seemed to start failing after the sendBatch update, not sure why it didn't fail on that PR itself.

Test failed because the batchMessage being passed is invalid.
![image](https://user-images.githubusercontent.com/10452642/81973972-c09a4900-95d9-11ea-9994-1ddffb72a44e.png)

Not updating the MessageSender's sendBatch with any sort of validations since the Sender's methods have the validations already and the user won't use the MessageSender directly.