### PR TITLE
[app-configuration] Fix minor typo in test readme for app configuration

### DIFF
--- a/sdk/appconfiguration/app-configuration/test/README.md
+++ b/sdk/appconfiguration/app-configuration/test/README.md
@@ -6,7 +6,7 @@ You can use existing Azure resources for the live tests, or generate new ones by
 
 The Azure resource that is used by the tests in this project is:
 
-- An [Azure App Configuration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview). Your Azure application needs to be assigned as the **owner** of this Azure Key Vault. The steps are provided [below](#AAD-based-authentication).
+- An [Azure App Configuration](https://docs.microsoft.com/en-us/azure/azure-app-configuration/overview). Your Azure application needs to be assigned as the **owner** of this Azure App Configuration resource. The steps are provided [below](#AAD-based-authentication).
 
 To run the live tests, you will also need to set the below environment variables:
 


### PR DESCRIPTION
In the course of validating #8257 I found a small typo. 

Other than that, all the instructions appear accurate and I was able to bootstrap just fine using the variables specified. :)

Fixes #8527