### PR TITLE
[abort-controller] Fixing typos

### DIFF
--- a/sdk/core/abort-controller/README.md
+++ b/sdk/core/abort-controller/README.md
@@ -10,7 +10,7 @@ in an Azure SDK that accept a parameter of type `AbortSignalLike`.
 
 ### Installation
 
-Install this libray using npm as follows
+Install this library using npm as follows
 
 ```
 npm install @azure/abort-controller


### PR DESCRIPTION
I found one typo in the abort-controller 🌞

I was able to detect these by using [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) on VSCode.