### PR TITLE
[core-auth] target ES5

### DIFF
--- a/sdk/core/core-auth/tsconfig.json
+++ b/sdk/core/core-auth/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../tsconfig.package",
   "compilerOptions": {
     "declarationDir": "./types",
+    "target": "es5",
     "outDir": "./dist-esm"
   }
 }


### PR DESCRIPTION
because storage packages still need to target ES5.