### PR TITLE
Regenerated CS Computer Vision & Bumped Major Version

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-computervision/LICENSE.txt
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Microsoft
+Copyright (c) 2020 Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sdk/cognitiveservices/cognitiveservices-computervision/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-computervision",
   "author": "Microsoft Corporation",
   "description": "ComputerVisionClient Library with typescript type definitions for node.js and browser.",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClient.ts
@@ -354,130 +354,64 @@ class ComputerVisionClient extends ComputerVisionClientContext {
   }
 
   /**
-   * Recognize Text operation. When you use the Recognize Text interface, the response contains a
-   * field called 'Operation-Location'. The 'Operation-Location' field contains the URL that you must
-   * use for your Get Recognize Text Operation Result operation.
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
-   * @param url Publicly reachable URL of an image.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.RecognizeTextResponse>
-   */
-  recognizeText(mode: Models.TextRecognitionMode, url: string, options?: msRest.RequestOptionsBase): Promise<Models.RecognizeTextResponse>;
-  /**
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
-   * @param url Publicly reachable URL of an image.
-   * @param callback The callback
-   */
-  recognizeText(mode: Models.TextRecognitionMode, url: string, callback: msRest.ServiceCallback<void>): void;
-  /**
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
-   * @param url Publicly reachable URL of an image.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  recognizeText(mode: Models.TextRecognitionMode, url: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  recognizeText(mode: Models.TextRecognitionMode, url: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.RecognizeTextResponse> {
-    return this.sendOperationRequest(
-      {
-        mode,
-        url,
-        options
-      },
-      recognizeTextOperationSpec,
-      callback) as Promise<Models.RecognizeTextResponse>;
-  }
-
-  /**
-   * This interface is used for getting text operation result. The URL to this interface should be
-   * retrieved from 'Operation-Location' field returned from Recognize Text interface.
-   * @param operationId Id of the text operation returned in the response of the 'Recognize Text'
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetTextOperationResultResponse>
-   */
-  getTextOperationResult(operationId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetTextOperationResultResponse>;
-  /**
-   * @param operationId Id of the text operation returned in the response of the 'Recognize Text'
-   * @param callback The callback
-   */
-  getTextOperationResult(operationId: string, callback: msRest.ServiceCallback<Models.TextOperationResult>): void;
-  /**
-   * @param operationId Id of the text operation returned in the response of the 'Recognize Text'
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getTextOperationResult(operationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.TextOperationResult>): void;
-  getTextOperationResult(operationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.TextOperationResult>, callback?: msRest.ServiceCallback<Models.TextOperationResult>): Promise<Models.GetTextOperationResultResponse> {
-    return this.sendOperationRequest(
-      {
-        operationId,
-        options
-      },
-      getTextOperationResultOperationSpec,
-      callback) as Promise<Models.GetTextOperationResultResponse>;
-  }
-
-  /**
    * Use this interface to get the result of a Read operation, employing the state-of-the-art Optical
    * Character Recognition (OCR) algorithms optimized for text-heavy documents. When you use the Read
-   * File interface, the response contains a field called 'Operation-Location'. The
-   * 'Operation-Location' field contains the URL that you must use for your 'GetReadOperationResult'
-   * operation to access OCR results.​
+   * interface, the response contains a field called 'Operation-Location'. The 'Operation-Location'
+   * field contains the URL that you must use for your 'GetReadResult' operation to access OCR
+   * results.​
    * @param url Publicly reachable URL of an image.
    * @param [options] The optional parameters
-   * @returns Promise<Models.BatchReadFileResponse>
+   * @returns Promise<Models.ReadResponse>
    */
-  batchReadFile(url: string, options?: msRest.RequestOptionsBase): Promise<Models.BatchReadFileResponse>;
+  read(url: string, options?: Models.ComputerVisionClientReadOptionalParams): Promise<Models.ReadResponse>;
   /**
    * @param url Publicly reachable URL of an image.
    * @param callback The callback
    */
-  batchReadFile(url: string, callback: msRest.ServiceCallback<void>): void;
+  read(url: string, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param url Publicly reachable URL of an image.
    * @param options The optional parameters
    * @param callback The callback
    */
-  batchReadFile(url: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  batchReadFile(url: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.BatchReadFileResponse> {
+  read(url: string, options: Models.ComputerVisionClientReadOptionalParams, callback: msRest.ServiceCallback<void>): void;
+  read(url: string, options?: Models.ComputerVisionClientReadOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.ReadResponse> {
     return this.sendOperationRequest(
       {
         url,
         options
       },
-      batchReadFileOperationSpec,
-      callback) as Promise<Models.BatchReadFileResponse>;
+      readOperationSpec,
+      callback) as Promise<Models.ReadResponse>;
   }
 
   /**
    * This interface is used for getting OCR results of Read operation. The URL to this interface
-   * should be retrieved from 'Operation-Location' field returned from Batch Read File interface.
-   * @param operationId Id of read operation returned in the response of the 'Batch Read File'
-   * interface.
+   * should be retrieved from 'Operation-Location' field returned from Read interface.
+   * @param operationId Id of read operation returned in the response of the 'Read' interface.
    * @param [options] The optional parameters
-   * @returns Promise<Models.GetReadOperationResultResponse>
+   * @returns Promise<Models.GetReadResultResponse>
    */
-  getReadOperationResult(operationId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetReadOperationResultResponse>;
+  getReadResult(operationId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetReadResultResponse>;
   /**
-   * @param operationId Id of read operation returned in the response of the 'Batch Read File'
-   * interface.
+   * @param operationId Id of read operation returned in the response of the 'Read' interface.
    * @param callback The callback
    */
-  getReadOperationResult(operationId: string, callback: msRest.ServiceCallback<Models.ReadOperationResult>): void;
+  getReadResult(operationId: string, callback: msRest.ServiceCallback<Models.ReadOperationResult>): void;
   /**
-   * @param operationId Id of read operation returned in the response of the 'Batch Read File'
-   * interface.
+   * @param operationId Id of read operation returned in the response of the 'Read' interface.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getReadOperationResult(operationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ReadOperationResult>): void;
-  getReadOperationResult(operationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ReadOperationResult>, callback?: msRest.ServiceCallback<Models.ReadOperationResult>): Promise<Models.GetReadOperationResultResponse> {
+  getReadResult(operationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ReadOperationResult>): void;
+  getReadResult(operationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ReadOperationResult>, callback?: msRest.ServiceCallback<Models.ReadOperationResult>): Promise<Models.GetReadResultResponse> {
     return this.sendOperationRequest(
       {
         operationId,
         options
       },
-      getReadOperationResultOperationSpec,
-      callback) as Promise<Models.GetReadOperationResultResponse>;
+      getReadResultOperationSpec,
+      callback) as Promise<Models.GetReadResultResponse>;
   }
 
   /**
@@ -781,69 +715,35 @@ class ComputerVisionClient extends ComputerVisionClientContext {
   }
 
   /**
-   * Recognize Text operation. When you use the Recognize Text interface, the response contains a
-   * field called 'Operation-Location'. The 'Operation-Location' field contains the URL that you must
-   * use for your Get Recognize Text Operation Result operation.
-   * @param image An image stream.
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
-   * @param [options] The optional parameters
-   * @returns Promise<Models.RecognizeTextInStreamResponse>
-   */
-  recognizeTextInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, options?: msRest.RequestOptionsBase): Promise<Models.RecognizeTextInStreamResponse>;
-  /**
-   * @param image An image stream.
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
-   * @param callback The callback
-   */
-  recognizeTextInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, callback: msRest.ServiceCallback<void>): void;
-  /**
-   * @param image An image stream.
-   * @param mode Type of text to recognize. Possible values include: 'Handwritten', 'Printed'
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  recognizeTextInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  recognizeTextInStream(image: msRest.HttpRequestBody, mode: Models.TextRecognitionMode, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.RecognizeTextInStreamResponse> {
-    return this.sendOperationRequest(
-      {
-        image,
-        mode,
-        options
-      },
-      recognizeTextInStreamOperationSpec,
-      callback) as Promise<Models.RecognizeTextInStreamResponse>;
-  }
-
-  /**
-   * Use this interface to get the result of a Read Document operation, employing the
-   * state-of-the-art Optical Character Recognition (OCR) algorithms optimized for text-heavy
-   * documents. When you use the Read Document interface, the response contains a field called
-   * 'Operation-Location'. The 'Operation-Location' field contains the URL that you must use for your
-   * 'Get Read Result operation' to access OCR results.​
+   * Use this interface to get the result of a Read operation, employing the state-of-the-art Optical
+   * Character Recognition (OCR) algorithms optimized for text-heavy documents. When you use the Read
+   * interface, the response contains a field called 'Operation-Location'. The 'Operation-Location'
+   * field contains the URL that you must use for your 'GetReadResult' operation to access OCR
+   * results.​
    * @param image An image stream.
    * @param [options] The optional parameters
-   * @returns Promise<Models.BatchReadFileInStreamResponse>
+   * @returns Promise<Models.ReadInStreamResponse>
    */
-  batchReadFileInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase): Promise<Models.BatchReadFileInStreamResponse>;
+  readInStream(image: msRest.HttpRequestBody, options?: Models.ComputerVisionClientReadInStreamOptionalParams): Promise<Models.ReadInStreamResponse>;
   /**
    * @param image An image stream.
    * @param callback The callback
    */
-  batchReadFileInStream(image: msRest.HttpRequestBody, callback: msRest.ServiceCallback<void>): void;
+  readInStream(image: msRest.HttpRequestBody, callback: msRest.ServiceCallback<void>): void;
   /**
    * @param image An image stream.
    * @param options The optional parameters
    * @param callback The callback
    */
-  batchReadFileInStream(image: msRest.HttpRequestBody, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  batchReadFileInStream(image: msRest.HttpRequestBody, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.BatchReadFileInStreamResponse> {
+  readInStream(image: msRest.HttpRequestBody, options: Models.ComputerVisionClientReadInStreamOptionalParams, callback: msRest.ServiceCallback<void>): void;
+  readInStream(image: msRest.HttpRequestBody, options?: Models.ComputerVisionClientReadInStreamOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<Models.ReadInStreamResponse> {
     return this.sendOperationRequest(
       {
         image,
         options
       },
-      batchReadFileInStreamOperationSpec,
-      callback) as Promise<Models.BatchReadFileInStreamResponse>;
+      readInStreamOperationSpec,
+      callback) as Promise<Models.ReadInStreamResponse>;
   }
 }
 
@@ -1104,14 +1004,14 @@ const getAreaOfInterestOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const recognizeTextOperationSpec: msRest.OperationSpec = {
+const readOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "recognizeText",
+  path: "read/analyze",
   urlParameters: [
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.mode
+    Parameters.language0
   ],
   requestBody: {
     parameterPath: {
@@ -1124,62 +1024,19 @@ const recognizeTextOperationSpec: msRest.OperationSpec = {
   },
   responses: {
     202: {
-      headersMapper: Mappers.RecognizeTextHeaders
+      headersMapper: Mappers.ReadHeaders
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionError,
+      headersMapper: Mappers.ReadHeaders
     }
   },
   serializer
 };
 
-const getTextOperationResultOperationSpec: msRest.OperationSpec = {
+const getReadResultOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "textOperations/{operationId}",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.operationId
-  ],
-  responses: {
-    200: {
-      bodyMapper: Mappers.TextOperationResult
-    },
-    default: {
-      bodyMapper: Mappers.ComputerVisionError
-    }
-  },
-  serializer
-};
-
-const batchReadFileOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "read/core/asyncBatchAnalyze",
-  urlParameters: [
-    Parameters.endpoint
-  ],
-  requestBody: {
-    parameterPath: {
-      url: "url"
-    },
-    mapper: {
-      ...Mappers.ImageUrl,
-      required: true
-    }
-  },
-  responses: {
-    202: {
-      headersMapper: Mappers.BatchReadFileHeaders
-    },
-    default: {
-      bodyMapper: Mappers.ComputerVisionError
-    }
-  },
-  serializer
-};
-
-const getReadOperationResultOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "read/operations/{operationId}",
+  path: "read/analyzeResults/{operationId}",
   urlParameters: [
     Parameters.endpoint,
     Parameters.operationId
@@ -1449,14 +1306,14 @@ const tagImageInStreamOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const recognizeTextInStreamOperationSpec: msRest.OperationSpec = {
+const readInStreamOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "recognizeText",
+  path: "read/analyze",
   urlParameters: [
     Parameters.endpoint
   ],
   queryParameters: [
-    Parameters.mode
+    Parameters.language0
   ],
   requestBody: {
     parameterPath: "image",
@@ -1471,38 +1328,11 @@ const recognizeTextInStreamOperationSpec: msRest.OperationSpec = {
   contentType: "application/octet-stream",
   responses: {
     202: {
-      headersMapper: Mappers.RecognizeTextInStreamHeaders
+      headersMapper: Mappers.ReadInStreamHeaders
     },
     default: {
-      bodyMapper: Mappers.ComputerVisionError
-    }
-  },
-  serializer
-};
-
-const batchReadFileInStreamOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "read/core/asyncBatchAnalyze",
-  urlParameters: [
-    Parameters.endpoint
-  ],
-  requestBody: {
-    parameterPath: "image",
-    mapper: {
-      required: true,
-      serializedName: "Image",
-      type: {
-        name: "Stream"
-      }
-    }
-  },
-  contentType: "application/octet-stream",
-  responses: {
-    202: {
-      headersMapper: Mappers.BatchReadFileInStreamHeaders
-    },
-    default: {
-      bodyMapper: Mappers.ComputerVisionError
+      bodyMapper: Mappers.ComputerVisionError,
+      headersMapper: Mappers.ReadInStreamHeaders
     }
   },
   serializer

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/computerVisionClientContext.ts
@@ -11,7 +11,7 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-computervision";
-const packageVersion = "6.0.0";
+const packageVersion = "7.0.0";
 
 export class ComputerVisionClientContext extends msRest.ServiceClient {
   endpoint: string;
@@ -42,7 +42,7 @@ export class ComputerVisionClientContext extends msRest.ServiceClient {
 
     super(credentials, options);
 
-    this.baseUri = "{Endpoint}/vision/v2.1";
+    this.baseUri = "{Endpoint}/vision/v3.0";
     this.requestContentType = "application/json; charset=utf-8";
     this.endpoint = endpoint;
     this.credentials = credentials;

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/index.ts
@@ -650,9 +650,9 @@ export interface Word {
    */
   text: string;
   /**
-   * Qualitative confidence measure. Possible values include: 'High', 'Low'
+   * Qualitative confidence measure.
    */
-  confidence?: TextRecognitionResultConfidenceClass;
+  confidence: number;
 }
 
 /**
@@ -660,44 +660,53 @@ export interface Word {
  */
 export interface Line {
   /**
+   * The BCP-47 language code of the recognized text line. Only provided where the language of the
+   * line differs from the page's.
+   */
+  language?: string;
+  /**
    * Bounding box of a recognized line.
    */
-  boundingBox?: number[];
+  boundingBox: number[];
   /**
    * The text content of the line.
    */
-  text?: string;
+  text: string;
   /**
    * List of words in the text line.
    */
-  words?: Word[];
+  words: Word[];
 }
 
 /**
- * An object representing a recognized text region
+ * Text extracted from a page in the input document.
  */
-export interface TextRecognitionResult {
+export interface ReadResult {
   /**
    * The 1-based page number of the recognition result.
    */
-  page?: number;
+  page: number;
   /**
-   * The orientation of the image in degrees in the clockwise direction. Range between [0, 360).
+   * The BCP-47 language code of the recognized text page.
    */
-  clockwiseOrientation?: number;
+  language?: string;
+  /**
+   * The orientation of the image in degrees in the clockwise direction. Range between [-180, 180).
+   */
+  angle: number;
   /**
    * The width of the image in pixels or the PDF in inches.
    */
-  width?: number;
+  width: number;
   /**
    * The height of the image in pixels or the PDF in inches.
    */
-  height?: number;
+  height: number;
   /**
    * The unit used in the Width, Height and BoundingBox. For images, the unit is 'pixel'. For PDF,
    * the unit is 'inch'. Possible values include: 'pixel', 'inch'
    */
-  unit?: TextRecognitionResultDimensionUnit;
+  unit: TextRecognitionResultDimensionUnit;
   /**
    * A list of recognized text lines.
    */
@@ -705,18 +714,17 @@ export interface TextRecognitionResult {
 }
 
 /**
- * Result of recognition text operation.
+ * Analyze batch operation result.
  */
-export interface TextOperationResult {
+export interface AnalyzeResults {
   /**
-   * Status of the text operation. Possible values include: 'NotStarted', 'Running', 'Failed',
-   * 'Succeeded'
+   * Version of schema used for this result.
    */
-  status?: TextOperationStatusCodes;
+  version: string;
   /**
-   * Text recognition result of the text operation.
+   * Text extracted from the input.
    */
-  recognitionResult?: TextRecognitionResult;
+  readResults: ReadResult[];
 }
 
 /**
@@ -724,14 +732,22 @@ export interface TextOperationResult {
  */
 export interface ReadOperationResult {
   /**
-   * Status of the read operation. Possible values include: 'NotStarted', 'Running', 'Failed',
-   * 'Succeeded'
+   * Status of the read operation. Possible values include: 'notStarted', 'running', 'failed',
+   * 'succeeded'
    */
-  status?: TextOperationStatusCodes;
+  status?: OperationStatusCodes;
   /**
-   * An array of text recognition result of the read operation.
+   * Get UTC date time the batch operation was submitted.
    */
-  recognitionResults?: TextRecognitionResult[];
+  createdDateTime?: string;
+  /**
+   * Get last updated UTC date time of this batch operation.
+   */
+  lastUpdatedDateTime?: string;
+  /**
+   * Analyze batch operation result.
+   */
+  analyzeResult?: AnalyzeResults;
 }
 
 /**
@@ -846,6 +862,21 @@ export interface ComputerVisionClientGenerateThumbnailOptionalParams extends msR
 /**
  * Optional Parameters.
  */
+export interface ComputerVisionClientReadOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The BCP-47 language code of the text to be detected in the image. In future versions, when
+   * language parameter is not passed, language detection will be used to determine the language.
+   * However, in the current version, missing language parameter will cause English to be used. To
+   * ensure that your document is always parsed in English without the use of language detection in
+   * the future, pass “en” in the language parameter. Possible values include: 'en', 'es', 'fr',
+   * 'de', 'it', 'nl', 'pt'. Default value: 'en'.
+   */
+  language?: OcrDetectionLanguage;
+}
+
+/**
+ * Optional Parameters.
+ */
 export interface ComputerVisionClientAnalyzeImageInStreamOptionalParams extends msRest.RequestOptionsBase {
   /**
    * A string indicating what visual feature types to return. Multiple values should be
@@ -953,9 +984,24 @@ export interface ComputerVisionClientTagImageInStreamOptionalParams extends msRe
 }
 
 /**
- * Defines headers for RecognizeText operation.
+ * Optional Parameters.
  */
-export interface RecognizeTextHeaders {
+export interface ComputerVisionClientReadInStreamOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The BCP-47 language code of the text to be detected in the image. In future versions, when
+   * language parameter is not passed, language detection will be used to determine the language.
+   * However, in the current version, missing language parameter will cause English to be used. To
+   * ensure that your document is always parsed in English without the use of language detection in
+   * the future, pass “en” in the language parameter. Possible values include: 'en', 'es', 'fr',
+   * 'de', 'it', 'nl', 'pt'. Default value: 'en'.
+   */
+  language?: OcrDetectionLanguage;
+}
+
+/**
+ * Defines headers for Read operation.
+ */
+export interface ReadHeaders {
   /**
    * URL to query for status of the operation. The operation ID will expire in 48 hours.
    */
@@ -963,29 +1009,9 @@ export interface RecognizeTextHeaders {
 }
 
 /**
- * Defines headers for BatchReadFile operation.
+ * Defines headers for ReadInStream operation.
  */
-export interface BatchReadFileHeaders {
-  /**
-   * URL to query for status of the operation. The operation ID will expire in 48 hours.
-   */
-  operationLocation: string;
-}
-
-/**
- * Defines headers for RecognizeTextInStream operation.
- */
-export interface RecognizeTextInStreamHeaders {
-  /**
-   * URL to query for status of the operation. The operation ID will expire in 48 hours.
-   */
-  operationLocation: string;
-}
-
-/**
- * Defines headers for BatchReadFileInStream operation.
- */
-export interface BatchReadFileInStreamHeaders {
+export interface ReadInStreamHeaders {
   /**
    * URL to query for status of the operation. The operation ID will expire in 48 hours.
    */
@@ -1001,12 +1027,12 @@ export interface BatchReadFileInStreamHeaders {
 export type Gender = 'Male' | 'Female';
 
 /**
- * Defines values for TextOperationStatusCodes.
- * Possible values include: 'NotStarted', 'Running', 'Failed', 'Succeeded'
+ * Defines values for OperationStatusCodes.
+ * Possible values include: 'notStarted', 'running', 'failed', 'succeeded'
  * @readonly
  * @enum {string}
  */
-export type TextOperationStatusCodes = 'NotStarted' | 'Running' | 'Failed' | 'Succeeded';
+export type OperationStatusCodes = 'notStarted' | 'running' | 'failed' | 'succeeded';
 
 /**
  * Defines values for TextRecognitionResultDimensionUnit.
@@ -1015,14 +1041,6 @@ export type TextOperationStatusCodes = 'NotStarted' | 'Running' | 'Failed' | 'Su
  * @enum {string}
  */
 export type TextRecognitionResultDimensionUnit = 'pixel' | 'inch';
-
-/**
- * Defines values for TextRecognitionResultConfidenceClass.
- * Possible values include: 'High', 'Low'
- * @readonly
- * @enum {string}
- */
-export type TextRecognitionResultConfidenceClass = 'High' | 'Low';
 
 /**
  * Defines values for DescriptionExclude.
@@ -1052,12 +1070,12 @@ export type OcrLanguages = 'unk' | 'zh-Hans' | 'zh-Hant' | 'cs' | 'da' | 'nl' | 
 export type VisualFeatureTypes = 'ImageType' | 'Faces' | 'Adult' | 'Categories' | 'Color' | 'Tags' | 'Description' | 'Objects' | 'Brands';
 
 /**
- * Defines values for TextRecognitionMode.
- * Possible values include: 'Handwritten', 'Printed'
+ * Defines values for OcrDetectionLanguage.
+ * Possible values include: 'en', 'es', 'fr', 'de', 'it', 'nl', 'pt'
  * @readonly
  * @enum {string}
  */
-export type TextRecognitionMode = 'Handwritten' | 'Printed';
+export type OcrDetectionLanguage = 'en' | 'es' | 'fr' | 'de' | 'it' | 'nl' | 'pt';
 
 /**
  * Defines values for Details.
@@ -1318,9 +1336,9 @@ export type GetAreaOfInterestResponse = AreaOfInterestResult & {
 };
 
 /**
- * Contains response data for the recognizeText operation.
+ * Contains response data for the read operation.
  */
-export type RecognizeTextResponse = RecognizeTextHeaders & {
+export type ReadResponse = ReadHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -1328,49 +1346,14 @@ export type RecognizeTextResponse = RecognizeTextHeaders & {
       /**
        * The parsed HTTP response headers.
        */
-      parsedHeaders: RecognizeTextHeaders;
+      parsedHeaders: ReadHeaders;
     };
 };
 
 /**
- * Contains response data for the getTextOperationResult operation.
+ * Contains response data for the getReadResult operation.
  */
-export type GetTextOperationResultResponse = TextOperationResult & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: TextOperationResult;
-    };
-};
-
-/**
- * Contains response data for the batchReadFile operation.
- */
-export type BatchReadFileResponse = BatchReadFileHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The parsed HTTP response headers.
-       */
-      parsedHeaders: BatchReadFileHeaders;
-    };
-};
-
-/**
- * Contains response data for the getReadOperationResult operation.
- */
-export type GetReadOperationResultResponse = ReadOperationResult & {
+export type GetReadResultResponse = ReadOperationResult & {
   /**
    * The underlying HTTP response.
    */
@@ -1554,9 +1537,9 @@ export type TagImageInStreamResponse = TagResult & {
 };
 
 /**
- * Contains response data for the recognizeTextInStream operation.
+ * Contains response data for the readInStream operation.
  */
-export type RecognizeTextInStreamResponse = RecognizeTextInStreamHeaders & {
+export type ReadInStreamResponse = ReadInStreamHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -1564,21 +1547,6 @@ export type RecognizeTextInStreamResponse = RecognizeTextInStreamHeaders & {
       /**
        * The parsed HTTP response headers.
        */
-      parsedHeaders: RecognizeTextInStreamHeaders;
-    };
-};
-
-/**
- * Contains response data for the batchReadFileInStream operation.
- */
-export type BatchReadFileInStreamResponse = BatchReadFileInStreamHeaders & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The parsed HTTP response headers.
-       */
-      parsedHeaders: BatchReadFileInStreamHeaders;
+      parsedHeaders: ReadInStreamHeaders;
     };
 };

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/mappers.ts
@@ -1224,14 +1224,10 @@ export const Word: msRest.CompositeMapper = {
         }
       },
       confidence: {
-        nullable: true,
+        required: true,
         serializedName: "confidence",
         type: {
-          name: "Enum",
-          allowedValues: [
-            "High",
-            "Low"
-          ]
+          name: "Number"
         }
       }
     }
@@ -1244,7 +1240,14 @@ export const Line: msRest.CompositeMapper = {
     name: "Composite",
     className: "Line",
     modelProperties: {
+      language: {
+        serializedName: "language",
+        type: {
+          name: "String"
+        }
+      },
       boundingBox: {
+        required: true,
         serializedName: "boundingBox",
         type: {
           name: "Sequence",
@@ -1256,12 +1259,14 @@ export const Line: msRest.CompositeMapper = {
         }
       },
       text: {
+        required: true,
         serializedName: "text",
         type: {
           name: "String"
         }
       },
       words: {
+        required: true,
         serializedName: "words",
         type: {
           name: "Sequence",
@@ -1277,38 +1282,49 @@ export const Line: msRest.CompositeMapper = {
   }
 };
 
-export const TextRecognitionResult: msRest.CompositeMapper = {
-  serializedName: "TextRecognitionResult",
+export const ReadResult: msRest.CompositeMapper = {
+  serializedName: "ReadResult",
   type: {
     name: "Composite",
-    className: "TextRecognitionResult",
+    className: "ReadResult",
     modelProperties: {
       page: {
+        required: true,
         serializedName: "page",
         type: {
           name: "Number"
         }
       },
-      clockwiseOrientation: {
-        serializedName: "clockwiseOrientation",
+      language: {
+        serializedName: "language",
+        type: {
+          name: "String"
+        }
+      },
+      angle: {
+        required: true,
+        serializedName: "angle",
         type: {
           name: "Number"
         }
       },
       width: {
+        required: true,
         serializedName: "width",
         type: {
           name: "Number"
         }
       },
       height: {
+        required: true,
         serializedName: "height",
         type: {
           name: "Number"
         }
       },
       unit: {
-        nullable: true,
+        required: true,
+        nullable: false,
         serializedName: "unit",
         type: {
           name: "Enum",
@@ -1335,30 +1351,30 @@ export const TextRecognitionResult: msRest.CompositeMapper = {
   }
 };
 
-export const TextOperationResult: msRest.CompositeMapper = {
-  serializedName: "TextOperationResult",
+export const AnalyzeResults: msRest.CompositeMapper = {
+  serializedName: "analyzeResults",
   type: {
     name: "Composite",
-    className: "TextOperationResult",
+    className: "AnalyzeResults",
     modelProperties: {
-      status: {
-        nullable: false,
-        serializedName: "status",
+      version: {
+        required: true,
+        serializedName: "version",
         type: {
-          name: "Enum",
-          allowedValues: [
-            "NotStarted",
-            "Running",
-            "Failed",
-            "Succeeded"
-          ]
+          name: "String"
         }
       },
-      recognitionResult: {
-        serializedName: "recognitionResult",
+      readResults: {
+        required: true,
+        serializedName: "readResults",
         type: {
-          name: "Composite",
-          className: "TextRecognitionResult"
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ReadResult"
+            }
+          }
         }
       }
     }
@@ -1377,34 +1393,43 @@ export const ReadOperationResult: msRest.CompositeMapper = {
         type: {
           name: "Enum",
           allowedValues: [
-            "NotStarted",
-            "Running",
-            "Failed",
-            "Succeeded"
+            "notStarted",
+            "running",
+            "failed",
+            "succeeded"
           ]
         }
       },
-      recognitionResults: {
-        serializedName: "recognitionResults",
+      createdDateTime: {
+        nullable: false,
+        serializedName: "createdDateTime",
         type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "TextRecognitionResult"
-            }
-          }
+          name: "String"
+        }
+      },
+      lastUpdatedDateTime: {
+        nullable: false,
+        serializedName: "lastUpdatedDateTime",
+        type: {
+          name: "String"
+        }
+      },
+      analyzeResult: {
+        serializedName: "analyzeResult",
+        type: {
+          name: "Composite",
+          className: "AnalyzeResults"
         }
       }
     }
   }
 };
 
-export const RecognizeTextHeaders: msRest.CompositeMapper = {
-  serializedName: "recognizetext-headers",
+export const ReadHeaders: msRest.CompositeMapper = {
+  serializedName: "read-headers",
   type: {
     name: "Composite",
-    className: "RecognizeTextHeaders",
+    className: "ReadHeaders",
     modelProperties: {
       operationLocation: {
         serializedName: "operation-location",
@@ -1416,43 +1441,11 @@ export const RecognizeTextHeaders: msRest.CompositeMapper = {
   }
 };
 
-export const BatchReadFileHeaders: msRest.CompositeMapper = {
-  serializedName: "batchreadfile-headers",
+export const ReadInStreamHeaders: msRest.CompositeMapper = {
+  serializedName: "readinstream-headers",
   type: {
     name: "Composite",
-    className: "BatchReadFileHeaders",
-    modelProperties: {
-      operationLocation: {
-        serializedName: "operation-location",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
-export const RecognizeTextInStreamHeaders: msRest.CompositeMapper = {
-  serializedName: "recognizetextinstream-headers",
-  type: {
-    name: "Composite",
-    className: "RecognizeTextInStreamHeaders",
-    modelProperties: {
-      operationLocation: {
-        serializedName: "operation-location",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
-export const BatchReadFileInStreamHeaders: msRest.CompositeMapper = {
-  serializedName: "batchreadfileinstream-headers",
-  type: {
-    name: "Composite",
-    className: "BatchReadFileInStreamHeaders",
+    className: "ReadInStreamHeaders",
     modelProperties: {
       operationLocation: {
         serializedName: "operation-location",

--- a/sdk/cognitiveservices/cognitiveservices-computervision/src/models/parameters.ts
+++ b/sdk/cognitiveservices/cognitiveservices-computervision/src/models/parameters.ts
@@ -159,20 +159,6 @@ export const maxCandidates: msRest.OperationQueryParameter = {
     }
   }
 };
-export const mode: msRest.OperationQueryParameter = {
-  parameterPath: "mode",
-  mapper: {
-    required: true,
-    serializedName: "mode",
-    type: {
-      name: "Enum",
-      allowedValues: [
-        "Handwritten",
-        "Printed"
-      ]
-    }
-  }
-};
 export const model: msRest.OperationURLParameter = {
   parameterPath: "model",
   mapper: {
@@ -189,7 +175,7 @@ export const operationId: msRest.OperationURLParameter = {
     required: true,
     serializedName: "operationId",
     type: {
-      name: "String"
+      name: "Uuid"
     }
   }
 };


### PR DESCRIPTION
Based on request from @lmazuel, I have regenerated the Cognitive Services Computer Vision TS SDK in this PR. Command used to regenerated SDK:

```
autorest --reset && autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.4 --package-version=7.0.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/ComputerVision/readme.md
```

A few pointers to give context:

1. I have waited for the completion of this PR: https://github.com/Azure/azure-rest-api-specs/pull/8734 before regenerating. 
2. Last time, this SDK was regenerated on Sep 11, 2019. At that time ***autorest.typescript version - 4.2.2*** was used for regeneration. Now, I have used ***autorest.typescript version - 4.2.4***
3. Before this generation, the SDK was using 2.1 version of the service. After this version, the service got 3.0-preview (which we did not release) and then 3.0 (which is generated in this PR). As you can see, there are several ***breaking changes*** in the code. So, I have ***bumped*** the version to ***7.0.0***(from 6.0.0)
4. The regeneration has removed the example changes in README.md and started using the old node auth. I have discarded those changes. 

@lmazuel FYI
@ramya-rao-a Please review and approve. 