### PR TITLE
[core-http] support text media type serialization

### DIFF
--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -501,6 +501,7 @@ export interface OperationSpec {
     readonly headerParameters?: ReadonlyArray<OperationParameter>;
     readonly httpMethod: HttpMethods;
     readonly isXML?: boolean;
+    readonly mediaType?: string;
     readonly path?: string;
     readonly queryParameters?: ReadonlyArray<OperationQueryParameter>;
     readonly requestBody?: OperationParameter;

--- a/sdk/core/core-http/src/operationSpec.ts
+++ b/sdk/core/core-http/src/operationSpec.ts
@@ -47,7 +47,15 @@ export interface OperationSpec {
    * The media type of the request body.
    * This value can be used to aide in serialization if it is provided.
    */
-  readonly mediaType?: string;
+  readonly mediaType?:
+    | "json"
+    | "xml"
+    | "form"
+    | "binary"
+    | "multipart"
+    | "text"
+    | "unknown"
+    | string;
   /**
    * The parameter that will be used to construct the HTTP request's body.
    */

--- a/sdk/core/core-http/src/operationSpec.ts
+++ b/sdk/core/core-http/src/operationSpec.ts
@@ -44,6 +44,11 @@ export interface OperationSpec {
   readonly contentType?: string;
 
   /**
+   * The media type of the request body.
+   * This value can be used to aide in serialization if it is provided.
+   */
+  readonly mediaType?: string;
+  /**
    * The parameter that will be used to construct the HTTP request's body.
    */
   readonly requestBody?: OperationParameter;

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -563,7 +563,7 @@ export function serializeRequestBody(
           }
         } else if (
           typeName === MapperType.String &&
-          operationSpec.contentType?.match("text/plain")
+          (operationSpec.contentType?.match("text/plain") || operationSpec.mediaType === "text")
         ) {
           // the String serializer has validated that request body is a string
           // so just send the string.

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -653,6 +653,34 @@ describe("ServiceClient", function() {
       );
       assert.strictEqual(httpRequest.body, "body value");
     });
+
+    it("should serialize a string send with the mediaType 'text' as just a string", () => {
+      const httpRequest = new WebResource();
+      serializeRequestBody(
+        new ServiceClient(),
+        httpRequest,
+        {
+          bodyArg: "body value"
+        },
+        {
+          httpMethod: "POST",
+          mediaType: "text",
+          requestBody: {
+            parameterPath: "bodyArg",
+            mapper: {
+              required: true,
+              serializedName: "bodyArg",
+              type: {
+                name: MapperType.String
+              }
+            }
+          },
+          responses: { 200: {} },
+          serializer: new Serializer()
+        }
+      );
+      assert.strictEqual(httpRequest.body, "body value");
+    });
   });
 
   describe("getOperationArgumentValueFromParameterPath()", () => {


### PR DESCRIPTION
## Description
This change adds a `mediaType` field to the `OperationSpec` interface.
This field can then be used to determine how a request body should be serialized.

This is related to the work in #7963

## What is mediaType?
`mediaType` describes the type of the request body in a more generic way than contentType.
For example, some valid values for mediaTypes would be "binary", "xml", "json", "text".

This change adds a check to see if the `mediaType` is `text`, and serializes the request body the same as if it had the contentType `text/plain`.

## Why can't we just use contentType?
Multiple contentType values can be treated the same way. For example, imagine an operation that supports `text/plain` or `text/markdown`. Both of these contentTypes would map to the `text` mediaType. If we rely on the contentType value rather than mediaType, we will need to maintain a list of contentTypes that should be treated as strings when serialized in core-http.

## Other changes needed?
`@autorest/typescript` will need to be updated to populate the `mediaType` field on OperationSpecs. It already has the concept of `mediaType`, so this update to core-http will allow us to plumb it through.

/cc @bterlson @joheredi 