### PR TITLE
Regenerated CS Custom Vision - Prediction & Training & Bumped Major Version

### DIFF
--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/LICENSE.txt
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Microsoft
+Copyright (c) 2020 Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/README.md
@@ -22,6 +22,7 @@ The following sample predicts and classifies the given image based on your custo
 
 ```typescript
 import { PredictionAPIClient } from "@azure/cognitiveservices-customvision-prediction";
+import { CognitiveServicesCredentials } from "@azure/ms-rest-azure-js";
 
 async function main(): Promise<void> {
   const customVisionPredictionKey =
@@ -31,13 +32,11 @@ async function main(): Promise<void> {
     "<customVisionPredictionEndPoint>";
   const projectId = process.env["projectId"] || "<projectId>";
 
+  const cognitiveServiceCredentials = new CognitiveServicesCredentials(customVisionPredictionKey);
+  const client = new PredictionAPIClient(cognitiveServiceCredentials, customVisionPredictionEndPoint);
+
   const imageURL =
     "https://www.atlantatrails.com/wp-content/uploads/2019/02/north-georgia-waterfalls-1024x683.jpg";
-
-  const client = new PredictionAPIClient(
-    customVisionPredictionKey,
-    customVisionPredictionEndPoint
-  );
 
   client
     .classifyImageUrl(projectId, "Iteration1", { url: imageURL })
@@ -71,12 +70,17 @@ main();
       const customVisionPredictionEndPoint =
         "<YOUR_CUSTOM_VISION_PREDICTION_ENDPOINT>";
       const projectId = "<YOUR_CUSTOM_VISION_PREDICTION_PROJECTID>";
+      const cognitiveServiceCredentials = new msRest.ApiKeyCredentials({
+        inHeader: {
+          "Ocp-Apim-Subscription-Key": customVisionPredictionKey
+        }
+      });
 
       const imageURL =
         "https://www.atlantatrails.com/wp-content/uploads/2019/02/north-georgia-waterfalls-1024x683.jpg";
 
       const client = new Azure.CognitiveservicesCustomvisionPrediction.PredictionAPIClient(
-        customVisionPredictionKey,
+        cognitiveServiceCredentials,
         customVisionPredictionEndPoint
       );
 

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-customvision-prediction",
   "author": "Microsoft Corporation",
   "description": "PredictionAPIClient Library with typescript type definitions for node.js and browser.",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/models/parameters.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/models/parameters.ts
@@ -10,16 +10,6 @@
 
 import * as msRest from "@azure/ms-rest-js";
 
-export const apiKey: msRest.OperationParameter = {
-  parameterPath: "apiKey",
-  mapper: {
-    required: true,
-    serializedName: "Prediction-Key",
-    type: {
-      name: "String"
-    }
-  }
-};
 export const application: msRest.OperationQueryParameter = {
   parameterPath: [
     "options",

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClient.ts
@@ -17,12 +17,12 @@ import { PredictionAPIClientContext } from "./predictionAPIClientContext";
 class PredictionAPIClient extends PredictionAPIClientContext {
   /**
    * Initializes a new instance of the PredictionAPIClient class.
-   * @param apiKey API key.
    * @param endpoint Supported Cognitive Services endpoints.
+   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(apiKey: string, endpoint: string, options?: msRest.ServiceClientOptions) {
-    super(apiKey, endpoint, options);
+  constructor(credentials: msRest.ServiceClientCredentials, endpoint: string, options?: msRest.ServiceClientOptions) {
+    super(credentials, endpoint, options);
   }
 
   /**
@@ -345,9 +345,6 @@ const classifyImageUrlOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.application
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   requestBody: {
     parameterPath: "imageUrl",
     mapper: {
@@ -377,9 +374,6 @@ const classifyImageOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.application
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   formDataParameters: [
     Parameters.imageData
   ],
@@ -405,9 +399,6 @@ const classifyImageUrlWithNoStoreOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.application
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   requestBody: {
     parameterPath: "imageUrl",
@@ -438,9 +429,6 @@ const classifyImageWithNoStoreOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.application
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   formDataParameters: [
     Parameters.imageData
   ],
@@ -466,9 +454,6 @@ const detectImageUrlOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.application
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   requestBody: {
     parameterPath: "imageUrl",
@@ -499,9 +484,6 @@ const detectImageOperationSpec: msRest.OperationSpec = {
   queryParameters: [
     Parameters.application
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   formDataParameters: [
     Parameters.imageData
   ],
@@ -527,9 +509,6 @@ const detectImageUrlWithNoStoreOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.application
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   requestBody: {
     parameterPath: "imageUrl",
@@ -559,9 +538,6 @@ const detectImageWithNoStoreOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.application
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   formDataParameters: [
     Parameters.imageData

--- a/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-prediction/src/predictionAPIClientContext.ts
@@ -11,24 +11,24 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-customvision-prediction";
-const packageVersion = "4.0.0";
+const packageVersion = "5.0.0";
 
 export class PredictionAPIClientContext extends msRest.ServiceClient {
-  apiKey: string;
   endpoint: string;
+  credentials: msRest.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the PredictionAPIClientContext class.
-   * @param apiKey API key.
    * @param endpoint Supported Cognitive Services endpoints.
+   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(apiKey: string, endpoint: string, options?: msRest.ServiceClientOptions) {
-    if (apiKey == undefined) {
-      throw new Error("'apiKey' cannot be null.");
-    }
+  constructor(credentials: msRest.ServiceClientCredentials, endpoint: string, options?: msRest.ServiceClientOptions) {
     if (endpoint == undefined) {
       throw new Error("'endpoint' cannot be null.");
+    }
+    if (credentials == undefined) {
+      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -40,11 +40,11 @@ export class PredictionAPIClientContext extends msRest.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(undefined, options);
+    super(credentials, options);
 
     this.baseUri = "{Endpoint}/customvision/v3.0/prediction";
     this.requestContentType = "application/json; charset=utf-8";
-    this.apiKey = apiKey;
     this.endpoint = endpoint;
+    this.credentials = credentials;
   }
 }

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/LICENSE.txt
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Microsoft
+Copyright (c) 2020 Microsoft
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/README.md
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/README.md
@@ -25,6 +25,7 @@ import {
   TrainingAPIClient,
   TrainingAPIModels
 } from "@azure/cognitiveservices-customvision-training";
+import { CognitiveServicesCredentials } from "@azure/ms-rest-azure-js";
 
 async function main(): Promise<void> {
   const customVisionTrainingKey =
@@ -35,13 +36,11 @@ async function main(): Promise<void> {
   const projectId = process.env["projectId"] || "<projectId>";
   const iterationId = process.env["iterationId"] || "<iterationId>";
 
+  const cognitiveServiceCredentials = new CognitiveServicesCredentials(customVisionTrainingKey);
+  const client = new TrainingAPIClient(cognitiveServiceCredentials, customVisionTrainingEndPoint);
+
   const imageURL =
     "https://www.atlantatrails.com/wp-content/uploads/2019/02/north-georgia-waterfalls-1024x683.jpg";
-
-  const client = new TrainingAPIClient(
-    customVisionTrainingKey,
-    customVisionTrainingEndPoint
-  );
 
   const options: TrainingAPIModels.TrainingAPIClientQuickTestImageUrlOptionalParams = {
     iterationId: iterationId
@@ -86,12 +85,17 @@ main();
         "<YOUR_CUSTOM_VISION_TRAINING_ENDPOINT>";
       const projectId = "<YOUR_PROJECT_ID>";
       const iterationId = "<YOUR_ITERATION_ID>";
+      const cognitiveServiceCredentials = new msRest.ApiKeyCredentials({
+        inHeader: {
+          "Ocp-Apim-Subscription-Key": customVisionTrainingKey
+        }
+      });
 
       const imageURL =
         "https://www.atlantatrails.com/wp-content/uploads/2019/02/north-georgia-waterfalls-1024x683.jpg";
 
       const client = new Azure.CognitiveservicesCustomvisionTraining.TrainingAPIClient(
-        customVisionTrainingKey,
+        cognitiveServiceCredentials,
         customVisionTrainingEndPoint
       );
 

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/package.json
@@ -2,7 +2,7 @@
   "name": "@azure/cognitiveservices-customvision-training",
   "author": "Microsoft Corporation",
   "description": "TrainingAPIClient Library with typescript type definitions for node.js and browser.",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "dependencies": {
     "@azure/ms-rest-js": "^2.0.4",
     "tslib": "^1.10.0"

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/index.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/index.ts
@@ -10,6 +10,94 @@
 import * as msRest from "@azure/ms-rest-js";
 
 /**
+ * Bounding box that defines a region of an image.
+ */
+export interface BoundingBox {
+  /**
+   * Coordinate of the left boundary.
+   */
+  left: number;
+  /**
+   * Coordinate of the top boundary.
+   */
+  top: number;
+  /**
+   * Width.
+   */
+  width: number;
+  /**
+   * Height.
+   */
+  height: number;
+}
+
+/**
+ * An interface representing CustomVisionError.
+ */
+export interface CustomVisionError {
+  /**
+   * The error code. Possible values include: 'NoError', 'BadRequest',
+   * 'BadRequestExceededBatchSize', 'BadRequestNotSupported', 'BadRequestInvalidIds',
+   * 'BadRequestProjectName', 'BadRequestProjectNameNotUnique', 'BadRequestProjectDescription',
+   * 'BadRequestProjectUnknownDomain', 'BadRequestProjectUnknownClassification',
+   * 'BadRequestProjectUnsupportedDomainTypeChange', 'BadRequestProjectUnsupportedExportPlatform',
+   * 'BadRequestProjectImagePreprocessingSettings', 'BadRequestProjectDuplicated',
+   * 'BadRequestIterationName', 'BadRequestIterationNameNotUnique',
+   * 'BadRequestIterationDescription', 'BadRequestIterationIsNotTrained',
+   * 'BadRequestIterationValidationFailed', 'BadRequestWorkspaceCannotBeModified',
+   * 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName', 'BadRequestTagNameNotUnique',
+   * 'BadRequestTagDescription', 'BadRequestTagType', 'BadRequestMultipleNegativeTag',
+   * 'BadRequestImageTags', 'BadRequestImageRegions', 'BadRequestNegativeAndRegularTagOnSameImage',
+   * 'BadRequestRequiredParamIsNull', 'BadRequestIterationIsPublished',
+   * 'BadRequestInvalidPublishName', 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed',
+   * 'BadRequestIterationNotPublished', 'BadRequestSubscriptionApi',
+   * 'BadRequestExceedProjectLimit', 'BadRequestExceedIterationPerProjectLimit',
+   * 'BadRequestExceedTagPerProjectLimit', 'BadRequestExceedTagPerImageLimit',
+   * 'BadRequestExceededQuota', 'BadRequestCannotMigrateProjectWithName',
+   * 'BadRequestNotLimitedTrial', 'BadRequestImageBatch', 'BadRequestImageStream',
+   * 'BadRequestImageUrl', 'BadRequestImageFormat', 'BadRequestImageSizeBytes',
+   * 'BadRequestImageExceededCount', 'BadRequestTrainingNotNeeded',
+   * 'BadRequestTrainingNotNeededButTrainingPipelineUpdated', 'BadRequestTrainingValidationFailed',
+   * 'BadRequestClassificationTrainingValidationFailed',
+   * 'BadRequestMultiClassClassificationTrainingValidationFailed',
+   * 'BadRequestMultiLabelClassificationTrainingValidationFailed',
+   * 'BadRequestDetectionTrainingValidationFailed', 'BadRequestTrainingAlreadyInProgress',
+   * 'BadRequestDetectionTrainingNotAllowNegativeTag', 'BadRequestInvalidEmailAddress',
+   * 'BadRequestDomainNotSupportedForAdvancedTraining',
+   * 'BadRequestExportPlatformNotSupportedForAdvancedTraining',
+   * 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining',
+   * 'BadRequestExportValidationFailed', 'BadRequestExportAlreadyInProgress',
+   * 'BadRequestPredictionIdsMissing', 'BadRequestPredictionIdsExceededCount',
+   * 'BadRequestPredictionTagsExceededCount', 'BadRequestPredictionResultsExceededCount',
+   * 'BadRequestPredictionInvalidApplicationName', 'BadRequestPredictionInvalidQueryParameters',
+   * 'BadRequestInvalidImportToken', 'BadRequestExportWhileTraining', 'BadRequestInvalid',
+   * 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser', 'ForbiddenUserResource',
+   * 'ForbiddenUserSignupDisabled', 'ForbiddenUserSignupAllowanceExceeded',
+   * 'ForbiddenUserDoesNotExist', 'ForbiddenUserDisabled', 'ForbiddenUserInsufficientCapability',
+   * 'ForbiddenDRModeEnabled', 'ForbiddenInvalid', 'NotFound', 'NotFoundProject',
+   * 'NotFoundProjectDefaultIteration', 'NotFoundIteration', 'NotFoundIterationPerformance',
+   * 'NotFoundTag', 'NotFoundImage', 'NotFoundDomain', 'NotFoundApimSubscription',
+   * 'NotFoundInvalid', 'Conflict', 'ConflictInvalid', 'ErrorUnknown', 'ErrorIterationCopyFailed',
+   * 'ErrorPreparePerformanceMigrationFailed', 'ErrorProjectInvalidWorkspace',
+   * 'ErrorProjectInvalidPipelineConfiguration', 'ErrorProjectInvalidDomain',
+   * 'ErrorProjectTrainingRequestFailed', 'ErrorProjectImportRequestFailed',
+   * 'ErrorProjectExportRequestFailed', 'ErrorFeaturizationServiceUnavailable',
+   * 'ErrorFeaturizationQueueTimeout', 'ErrorFeaturizationInvalidFeaturizer',
+   * 'ErrorFeaturizationAugmentationUnavailable', 'ErrorFeaturizationUnrecognizedJob',
+   * 'ErrorFeaturizationAugmentationError', 'ErrorExporterInvalidPlatform',
+   * 'ErrorExporterInvalidFeaturizer', 'ErrorExporterInvalidClassifier',
+   * 'ErrorPredictionServiceUnavailable', 'ErrorPredictionModelNotFound',
+   * 'ErrorPredictionModelNotCached', 'ErrorPrediction', 'ErrorPredictionStorage',
+   * 'ErrorRegionProposal', 'ErrorInvalid'
+   */
+  code: CustomVisionErrorCodes;
+  /**
+   * A message explaining the error reported by the service.
+   */
+  message: string;
+}
+
+/**
  * An interface representing Domain.
  */
 export interface Domain {
@@ -37,124 +125,40 @@ export interface Domain {
 }
 
 /**
- * Entry associating a tag to an image.
+ * An interface representing ExportModel.
  */
-export interface ImageTagCreateEntry {
+export interface ExportModel {
   /**
-   * Id of the image.
-   */
-  imageId?: string;
-  /**
-   * Id of the tag.
-   */
-  tagId?: string;
-}
-
-/**
- * Batch of image tags.
- */
-export interface ImageTagCreateBatch {
-  /**
-   * Image Tag entries to include in this batch.
-   */
-  tags?: ImageTagCreateEntry[];
-}
-
-/**
- * An interface representing ImageTagCreateSummary.
- */
-export interface ImageTagCreateSummary {
-  created?: ImageTagCreateEntry[];
-  duplicated?: ImageTagCreateEntry[];
-  exceeded?: ImageTagCreateEntry[];
-}
-
-/**
- * Entry associating a region to an image.
- */
-export interface ImageRegionCreateEntry {
-  /**
-   * Id of the image.
-   */
-  imageId: string;
-  /**
-   * Id of the tag associated with this region.
-   */
-  tagId: string;
-  /**
-   * Coordinate of the left boundary.
-   */
-  left: number;
-  /**
-   * Coordinate of the top boundary.
-   */
-  top: number;
-  /**
-   * Width.
-   */
-  width: number;
-  /**
-   * Height.
-   */
-  height: number;
-}
-
-/**
- * Batch of image region information to create.
- */
-export interface ImageRegionCreateBatch {
-  regions?: ImageRegionCreateEntry[];
-}
-
-/**
- * An interface representing ImageRegionCreateResult.
- */
-export interface ImageRegionCreateResult {
-  /**
+   * Platform of the export. Possible values include: 'CoreML', 'TensorFlow', 'DockerFile', 'ONNX',
+   * 'VAIDK'
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly imageId?: string;
+  readonly platform?: ExportPlatform;
   /**
+   * Status of the export. Possible values include: 'Exporting', 'Failed', 'Done'
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly regionId?: string;
+  readonly status?: ExportStatus;
   /**
+   * URI used to download the model.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly tagName?: string;
+  readonly downloadUri?: string;
   /**
+   * Flavor of the export. These are specializations of the export platform.
+   * Docker platform has valid flavors: Linux, Windows, ARM.
+   * Tensorflow platform has valid flavors: TensorFlowNormal, TensorFlowLite.
+   * ONNX platform has valid flavors: ONNX10, ONNX12. Possible values include: 'Linux', 'Windows',
+   * 'ONNX10', 'ONNX12', 'ARM', 'TensorFlowNormal', 'TensorFlowLite'
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly created?: Date;
+  readonly flavor?: ExportFlavor;
   /**
-   * Id of the tag associated with this region.
+   * Indicates an updated version of the export package is available and should be re-exported for
+   * the latest changes.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  tagId: string;
-  /**
-   * Coordinate of the left boundary.
-   */
-  left: number;
-  /**
-   * Coordinate of the top boundary.
-   */
-  top: number;
-  /**
-   * Width.
-   */
-  width: number;
-  /**
-   * Height.
-   */
-  height: number;
-}
-
-/**
- * An interface representing ImageRegionCreateSummary.
- */
-export interface ImageRegionCreateSummary {
-  created?: ImageRegionCreateResult[];
-  duplicated?: ImageRegionCreateEntry[];
-  exceeded?: ImageRegionCreateEntry[];
+  readonly newerVersionAvailable?: boolean;
 }
 
 /**
@@ -349,26 +353,6 @@ export interface ImageFileCreateBatch {
 }
 
 /**
- * An interface representing ImageUrlCreateEntry.
- */
-export interface ImageUrlCreateEntry {
-  /**
-   * Url of the image.
-   */
-  url: string;
-  tagIds?: string[];
-  regions?: Region[];
-}
-
-/**
- * An interface representing ImageUrlCreateBatch.
- */
-export interface ImageUrlCreateBatch {
-  images?: ImageUrlCreateEntry[];
-  tagIds?: string[];
-}
-
-/**
  * An interface representing ImageIdCreateEntry.
  */
 export interface ImageIdCreateEntry {
@@ -389,9 +373,129 @@ export interface ImageIdCreateBatch {
 }
 
 /**
- * Bounding box that defines a region of an image.
+ * Prediction result.
  */
-export interface BoundingBox {
+export interface Prediction {
+  /**
+   * Probability of the tag.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly probability?: number;
+  /**
+   * Id of the predicted tag.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly tagId?: string;
+  /**
+   * Name of the predicted tag.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly tagName?: string;
+  /**
+   * Bounding box of the prediction.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly boundingBox?: BoundingBox;
+}
+
+/**
+ * Image performance model.
+ */
+export interface ImagePerformance {
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly predictions?: Prediction[];
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly id?: string;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly created?: Date;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly width?: number;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly height?: number;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly imageUri?: string;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly thumbnailUri?: string;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly tags?: ImageTag[];
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly regions?: ImageRegion[];
+}
+
+/**
+ * Result of an image prediction request.
+ */
+export interface ImagePrediction {
+  /**
+   * Prediction Id.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly id?: string;
+  /**
+   * Project Id.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly project?: string;
+  /**
+   * Iteration Id.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly iteration?: string;
+  /**
+   * Date this prediction was created.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly created?: Date;
+  /**
+   * List of predictions.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly predictions?: Prediction[];
+}
+
+/**
+ * Represents image preprocessing settings used by image augmentation.
+ */
+export interface ImageProcessingSettings {
+  /**
+   * Gets or sets enabled image transforms. The key corresponds to the transform name. If value is
+   * set to true, then correspondent transform is enabled. Otherwise this transform will not be
+   * used.
+   * Augmentation will be uniformly distributed among enabled transforms.
+   */
+  augmentationMethods?: { [propertyName: string]: boolean };
+}
+
+/**
+ * Entry associating a region to an image.
+ */
+export interface ImageRegionCreateEntry {
+  /**
+   * Id of the image.
+   */
+  imageId: string;
+  /**
+   * Id of the tag associated with this region.
+   */
+  tagId: string;
   /**
    * Coordinate of the left boundary.
    */
@@ -408,6 +512,64 @@ export interface BoundingBox {
    * Height.
    */
   height: number;
+}
+
+/**
+ * Batch of image region information to create.
+ */
+export interface ImageRegionCreateBatch {
+  regions?: ImageRegionCreateEntry[];
+}
+
+/**
+ * An interface representing ImageRegionCreateResult.
+ */
+export interface ImageRegionCreateResult {
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly imageId?: string;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly regionId?: string;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly tagName?: string;
+  /**
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly created?: Date;
+  /**
+   * Id of the tag associated with this region.
+   */
+  tagId: string;
+  /**
+   * Coordinate of the left boundary.
+   */
+  left: number;
+  /**
+   * Coordinate of the top boundary.
+   */
+  top: number;
+  /**
+   * Width.
+   */
+  width: number;
+  /**
+   * Height.
+   */
+  height: number;
+}
+
+/**
+ * An interface representing ImageRegionCreateSummary.
+ */
+export interface ImageRegionCreateSummary {
+  created?: ImageRegionCreateResult[];
+  duplicated?: ImageRegionCreateEntry[];
+  exceeded?: ImageRegionCreateEntry[];
 }
 
 /**
@@ -443,6 +605,39 @@ export interface ImageRegionProposal {
 }
 
 /**
+ * Entry associating a tag to an image.
+ */
+export interface ImageTagCreateEntry {
+  /**
+   * Id of the image.
+   */
+  imageId?: string;
+  /**
+   * Id of the tag.
+   */
+  tagId?: string;
+}
+
+/**
+ * Batch of image tags.
+ */
+export interface ImageTagCreateBatch {
+  /**
+   * Image Tag entries to include in this batch.
+   */
+  tags?: ImageTagCreateEntry[];
+}
+
+/**
+ * An interface representing ImageTagCreateSummary.
+ */
+export interface ImageTagCreateSummary {
+  created?: ImageTagCreateEntry[];
+  duplicated?: ImageTagCreateEntry[];
+  exceeded?: ImageTagCreateEntry[];
+}
+
+/**
  * Image url.
  */
 export interface ImageUrl {
@@ -453,161 +648,109 @@ export interface ImageUrl {
 }
 
 /**
- * Prediction result.
+ * An interface representing ImageUrlCreateEntry.
  */
-export interface Prediction {
+export interface ImageUrlCreateEntry {
   /**
-   * Probability of the tag.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   * Url of the image.
    */
-  readonly probability?: number;
-  /**
-   * Id of the predicted tag.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly tagId?: string;
-  /**
-   * Name of the predicted tag.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly tagName?: string;
-  /**
-   * Bounding box of the prediction.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly boundingBox?: BoundingBox;
+  url: string;
+  tagIds?: string[];
+  regions?: Region[];
 }
 
 /**
- * Result of an image prediction request.
+ * An interface representing ImageUrlCreateBatch.
  */
-export interface ImagePrediction {
+export interface ImageUrlCreateBatch {
+  images?: ImageUrlCreateEntry[];
+  tagIds?: string[];
+}
+
+/**
+ * Iteration model to be sent over JSON.
+ */
+export interface Iteration {
   /**
-   * Prediction Id.
+   * Gets the id of the iteration.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly id?: string;
   /**
-   * Project Id.
+   * Gets or sets the name of the iteration.
+   */
+  name: string;
+  /**
+   * Gets the current iteration status.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly project?: string;
+  readonly status?: string;
   /**
-   * Iteration Id.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly iteration?: string;
-  /**
-   * Date this prediction was created.
+   * Gets the time this iteration was completed.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly created?: Date;
   /**
-   * List of predictions.
+   * Gets the time this iteration was last modified.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly predictions?: Prediction[];
-}
-
-/**
- * An interface representing PredictionQueryTag.
- */
-export interface PredictionQueryTag {
+  readonly lastModified?: Date;
   /**
+   * Gets the time this iteration was last modified.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly id?: string;
+  readonly trainedAt?: Date;
   /**
+   * Gets the project id of the iteration.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly minThreshold?: number;
+  readonly projectId?: string;
   /**
+   * Whether the iteration can be exported to another format for download.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly maxThreshold?: number;
-}
-
-/**
- * An interface representing PredictionQueryToken.
- */
-export interface PredictionQueryToken {
-  session?: string;
-  continuation?: string;
-  maxCount?: number;
+  readonly exportable?: boolean;
   /**
-   * Possible values include: 'Newest', 'Oldest', 'Suggested'
-   */
-  orderBy?: OrderBy;
-  tags?: PredictionQueryTag[];
-  iterationId?: string;
-  startTime?: Date;
-  endTime?: Date;
-  application?: string;
-}
-
-/**
- * result of an image classification request.
- */
-export interface StoredImagePrediction {
-  /**
-   * The URI to the (resized) prediction image.
+   * A set of platforms this iteration can export to.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly resizedImageUri?: string;
+  readonly exportableTo?: string[];
   /**
-   * The URI to the thumbnail of the original prediction image.
+   * Get or sets a guid of the domain the iteration has been trained on.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly thumbnailUri?: string;
+  readonly domainId?: string;
   /**
-   * The URI to the original prediction image.
+   * Gets the classification type of the project. Possible values include: 'Multiclass',
+   * 'Multilabel'
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly originalImageUri?: string;
+  readonly classificationType?: Classifier;
   /**
-   * Domain used for the prediction.
+   * Gets the training type of the iteration. Possible values include: 'Regular', 'Advanced'
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly domain?: string;
+  readonly trainingType?: TrainingType;
   /**
-   * Prediction Id.
+   * Gets the reserved advanced training budget for the iteration.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly id?: string;
+  readonly reservedBudgetInHours?: number;
   /**
-   * Project Id.
+   * Gets the training time for the iteration.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly project?: string;
+  readonly trainingTimeInMinutes?: number;
   /**
-   * Iteration Id.
+   * Name of the published model.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly iteration?: string;
+  readonly publishName?: string;
   /**
-   * Date this prediction was created.
+   * Resource Provider Id this iteration was originally published to.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly created?: Date;
-  /**
-   * List of predictions.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly predictions?: Prediction[];
-}
-
-/**
- * An interface representing PredictionQueryResult.
- */
-export interface PredictionQueryResult {
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly token?: PredictionQueryToken;
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly results?: StoredImagePrediction[];
+  readonly originalPublishResourceId?: string;
 }
 
 /**
@@ -686,45 +829,96 @@ export interface IterationPerformance {
 }
 
 /**
- * Image performance model.
+ * An interface representing PredictionQueryTag.
  */
-export interface ImagePerformance {
+export interface PredictionQueryTag {
+  id?: string;
+  minThreshold?: number;
+  maxThreshold?: number;
+}
+
+/**
+ * An interface representing PredictionQueryToken.
+ */
+export interface PredictionQueryToken {
+  session?: string;
+  continuation?: string;
+  maxCount?: number;
   /**
+   * Possible values include: 'Newest', 'Oldest', 'Suggested'
+   */
+  orderBy?: OrderBy;
+  tags?: PredictionQueryTag[];
+  iterationId?: string;
+  startTime?: Date;
+  endTime?: Date;
+  application?: string;
+}
+
+/**
+ * Result of an image prediction request.
+ */
+export interface StoredImagePrediction {
+  /**
+   * The URI to the (resized) prediction image.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly predictions?: Prediction[];
+  readonly resizedImageUri?: string;
   /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly created?: Date;
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly width?: number;
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly height?: number;
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly imageUri?: string;
-  /**
+   * The URI to the thumbnail of the original prediction image.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly thumbnailUri?: string;
   /**
+   * The URI to the original prediction image.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly tags?: ImageTag[];
+  readonly originalImageUri?: string;
   /**
+   * Domain used for the prediction.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly regions?: ImageRegion[];
+  readonly domain?: string;
+  /**
+   * Prediction Id.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly id?: string;
+  /**
+   * Project Id.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly project?: string;
+  /**
+   * Iteration Id.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly iteration?: string;
+  /**
+   * Date this prediction was created.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly created?: Date;
+  /**
+   * List of predictions.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly predictions?: Prediction[];
+}
+
+/**
+ * Query result of the prediction images that were sent to your prediction endpoint.
+ */
+export interface PredictionQueryResult {
+  /**
+   * Prediction Query Token.
+   */
+  token?: PredictionQueryToken;
+  /**
+   * Result of an prediction request.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly results?: StoredImagePrediction[];
 }
 
 /**
@@ -744,6 +938,20 @@ export interface ProjectSettings {
    * A list of ExportPlatform that the trained model should be able to support.
    */
   targetExportPlatforms?: string[];
+  /**
+   * Indicates if negative set is being used.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly useNegativeSet?: boolean;
+  /**
+   * Detection parameters in use, if any.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly detectionParameters?: string;
+  /**
+   * Gets or sets image preprocessing settings.
+   */
+  imageProcessingSettings?: ImageProcessingSettings;
 }
 
 /**
@@ -783,124 +991,206 @@ export interface Project {
    */
   readonly thumbnailUri?: string;
   /**
-   * Gets if the DR mode is on.
+   * Gets if the Disaster Recovery (DR) mode is on, indicating the project is temporarily
+   * read-only.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly drModeEnabled?: boolean;
+  /**
+   * Gets the status of the project. Possible values include: 'Succeeded', 'Importing', 'Failed'
+   */
+  status?: ProjectStatus;
 }
 
 /**
- * Iteration model to be sent over JSON.
+ * Represents information about a project export.
  */
-export interface Iteration {
+export interface ProjectExport {
   /**
-   * Gets the id of the iteration.
+   * Count of iterations that will be exported.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly iterationCount?: number;
+  /**
+   * Count of images that will be exported.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly imageCount?: number;
+  /**
+   * Count of tags that will be exported.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly tagCount?: number;
+  /**
+   * Count of regions that will be exported.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly regionCount?: number;
+  /**
+   * Estimated time this project will take to import, can change based on network connectivity and
+   * load between
+   * source and destination regions.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly estimatedImportTimeInMS?: number;
+  /**
+   * Opaque token that should be passed to ImportProject to perform the import. This token grants
+   * access to import this
+   * project to all that have the token.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly token?: string;
+}
+
+/**
+ * Result of a suggested tags and regions request of the untagged image.
+ */
+export interface StoredSuggestedTagAndRegion {
+  /**
+   * Width of the resized image.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly width?: number;
+  /**
+   * Height of the resized image.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly height?: number;
+  /**
+   * The URI to the (resized) prediction image.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly resizedImageUri?: string;
+  /**
+   * The URI to the thumbnail of the original prediction image.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly thumbnailUri?: string;
+  /**
+   * The URI to the original prediction image.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly originalImageUri?: string;
+  /**
+   * Domain used for the prediction.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly domain?: string;
+  /**
+   * Prediction Id.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly id?: string;
   /**
-   * Gets or sets the name of the iteration.
-   */
-  name: string;
-  /**
-   * Gets the current iteration status.
+   * Project Id.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly status?: string;
+  readonly project?: string;
   /**
-   * Gets the time this iteration was completed.
+   * Iteration Id.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly iteration?: string;
+  /**
+   * Date this prediction was created.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly created?: Date;
   /**
-   * Gets the time this iteration was last modified.
+   * List of predictions.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly lastModified?: Date;
+  readonly predictions?: Prediction[];
   /**
-   * Gets the time this iteration was last modified.
+   * Uncertainty (entropy) of suggested tags or regions per image.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly trainedAt?: Date;
-  /**
-   * Gets the project id of the iteration.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly projectId?: string;
-  /**
-   * Whether the iteration can be exported to another format for download.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly exportable?: boolean;
-  /**
-   * A set of platforms this iteration can export to.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly exportableTo?: string[];
-  /**
-   * Get or sets a guid of the domain the iteration has been trained on.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly domainId?: string;
-  /**
-   * Gets the classification type of the project. Possible values include: 'Multiclass',
-   * 'Multilabel'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly classificationType?: Classifier;
-  /**
-   * Gets the training type of the iteration. Possible values include: 'Regular', 'Advanced'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly trainingType?: TrainingType;
-  /**
-   * Gets the reserved advanced training budget for the iteration.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly reservedBudgetInHours?: number;
-  /**
-   * Name of the published model.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly publishName?: string;
-  /**
-   * Resource Provider Id this iteration was originally published to.
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly originalPublishResourceId?: string;
+  readonly predictionUncertainty?: number;
 }
 
 /**
- * An interface representing ExportModel.
+ * Result of a suggested tags and regions request.
  */
-export interface ExportModel {
+export interface SuggestedTagAndRegion {
   /**
-   * Platform of the export. Possible values include: 'CoreML', 'TensorFlow', 'DockerFile', 'ONNX',
-   * 'VAIDK'
+   * Prediction Id.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly platform?: ExportPlatform;
+  readonly id?: string;
   /**
-   * Status of the export. Possible values include: 'Exporting', 'Failed', 'Done'
+   * Project Id.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly status?: ExportStatus;
+  readonly project?: string;
   /**
-   * URI used to download the model.
+   * Iteration Id.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly downloadUri?: string;
+  readonly iteration?: string;
   /**
-   * Flavor of the export. Possible values include: 'Linux', 'Windows', 'ONNX10', 'ONNX12', 'ARM'
+   * Date this prediction was created.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly flavor?: ExportFlavor;
+  readonly created?: Date;
   /**
-   * Indicates an updated version of the export package is available and should be re-exported for
-   * the latest changes.
+   * List of predictions.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly newerVersionAvailable?: boolean;
+  readonly predictions?: Prediction[];
+  /**
+   * Uncertainty (entropy) of suggested tags or regions per image.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly predictionUncertainty?: number;
+}
+
+/**
+ * Contains properties we need to fetch suggested tags for. For the first call, Session and
+ * continuation set to null.
+ * Then on subsequent calls, uses the session/continuation from the previous
+ * SuggestedTagAndRegionQuery result to fetch additional results.
+ */
+export interface SuggestedTagAndRegionQueryToken {
+  /**
+   * Existing TagIds in project to filter suggested tags on.
+   */
+  tagIds?: string[];
+  /**
+   * Confidence threshold to filter suggested tags on.
+   */
+  threshold?: number;
+  /**
+   * SessionId for database query. Initially set to null but later used to paginate.
+   */
+  session?: string;
+  /**
+   * Continuation Id for database pagination. Initially null but later used to paginate.
+   */
+  continuation?: string;
+  /**
+   * Maximum number of results you want to be returned in the response.
+   */
+  maxCount?: number;
+  /**
+   * OrderBy. Ordering mechanism for your results. Possible values include: 'UncertaintyAscending',
+   * 'UncertaintyDescending'
+   */
+  sortBy?: SortBy;
+}
+
+/**
+ * The array of result images and token containing session and continuation Ids for the next query.
+ */
+export interface SuggestedTagAndRegionQuery {
+  /**
+   * Contains properties we need to fetch suggested tags for.
+   */
+  token?: SuggestedTagAndRegionQueryToken;
+  /**
+   * Result of a suggested tags and regions request of the untagged image.
+   * **NOTE: This property will not be serialized. It can only be populated by the server.**
+   */
+  readonly results?: StoredSuggestedTagAndRegion[];
 }
 
 /**
@@ -932,78 +1222,59 @@ export interface Tag {
 }
 
 /**
- * An interface representing CustomVisionError.
+ * Model that query for counting of images whose suggested tags match given tags and their
+ * probability are greater than or equal to the given threshold.
  */
-export interface CustomVisionError {
+export interface TagFilter {
   /**
-   * The error code. Possible values include: 'NoError', 'BadRequest',
-   * 'BadRequestExceededBatchSize', 'BadRequestNotSupported', 'BadRequestInvalidIds',
-   * 'BadRequestProjectName', 'BadRequestProjectNameNotUnique', 'BadRequestProjectDescription',
-   * 'BadRequestProjectUnknownDomain', 'BadRequestProjectUnknownClassification',
-   * 'BadRequestProjectUnsupportedDomainTypeChange', 'BadRequestProjectUnsupportedExportPlatform',
-   * 'BadRequestIterationName', 'BadRequestIterationNameNotUnique',
-   * 'BadRequestIterationDescription', 'BadRequestIterationIsNotTrained',
-   * 'BadRequestWorkspaceCannotBeModified', 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName',
-   * 'BadRequestTagNameNotUnique', 'BadRequestTagDescription', 'BadRequestTagType',
-   * 'BadRequestMultipleNegativeTag', 'BadRequestImageTags', 'BadRequestImageRegions',
-   * 'BadRequestNegativeAndRegularTagOnSameImage', 'BadRequestRequiredParamIsNull',
-   * 'BadRequestIterationIsPublished', 'BadRequestInvalidPublishName',
-   * 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed',
-   * 'BadRequestIterationNotPublished', 'BadRequestSubscriptionApi',
-   * 'BadRequestExceedProjectLimit', 'BadRequestExceedIterationPerProjectLimit',
-   * 'BadRequestExceedTagPerProjectLimit', 'BadRequestExceedTagPerImageLimit',
-   * 'BadRequestExceededQuota', 'BadRequestCannotMigrateProjectWithName',
-   * 'BadRequestNotLimitedTrial', 'BadRequestImageBatch', 'BadRequestImageStream',
-   * 'BadRequestImageUrl', 'BadRequestImageFormat', 'BadRequestImageSizeBytes',
-   * 'BadRequestImageExceededCount', 'BadRequestTrainingNotNeeded',
-   * 'BadRequestTrainingNotNeededButTrainingPipelineUpdated', 'BadRequestTrainingValidationFailed',
-   * 'BadRequestClassificationTrainingValidationFailed',
-   * 'BadRequestMultiClassClassificationTrainingValidationFailed',
-   * 'BadRequestMultiLabelClassificationTrainingValidationFailed',
-   * 'BadRequestDetectionTrainingValidationFailed', 'BadRequestTrainingAlreadyInProgress',
-   * 'BadRequestDetectionTrainingNotAllowNegativeTag', 'BadRequestInvalidEmailAddress',
-   * 'BadRequestDomainNotSupportedForAdvancedTraining',
-   * 'BadRequestExportPlatformNotSupportedForAdvancedTraining',
-   * 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining',
-   * 'BadRequestExportValidationFailed', 'BadRequestExportAlreadyInProgress',
-   * 'BadRequestPredictionIdsMissing', 'BadRequestPredictionIdsExceededCount',
-   * 'BadRequestPredictionTagsExceededCount', 'BadRequestPredictionResultsExceededCount',
-   * 'BadRequestPredictionInvalidApplicationName', 'BadRequestPredictionInvalidQueryParameters',
-   * 'BadRequestInvalid', 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser',
-   * 'ForbiddenUserResource', 'ForbiddenUserSignupDisabled',
-   * 'ForbiddenUserSignupAllowanceExceeded', 'ForbiddenUserDoesNotExist', 'ForbiddenUserDisabled',
-   * 'ForbiddenUserInsufficientCapability', 'ForbiddenDRModeEnabled', 'ForbiddenInvalid',
-   * 'NotFound', 'NotFoundProject', 'NotFoundProjectDefaultIteration', 'NotFoundIteration',
-   * 'NotFoundIterationPerformance', 'NotFoundTag', 'NotFoundImage', 'NotFoundDomain',
-   * 'NotFoundApimSubscription', 'NotFoundInvalid', 'Conflict', 'ConflictInvalid', 'ErrorUnknown',
-   * 'ErrorProjectInvalidWorkspace', 'ErrorProjectInvalidPipelineConfiguration',
-   * 'ErrorProjectInvalidDomain', 'ErrorProjectTrainingRequestFailed',
-   * 'ErrorProjectExportRequestFailed', 'ErrorFeaturizationServiceUnavailable',
-   * 'ErrorFeaturizationQueueTimeout', 'ErrorFeaturizationInvalidFeaturizer',
-   * 'ErrorFeaturizationAugmentationUnavailable', 'ErrorFeaturizationUnrecognizedJob',
-   * 'ErrorFeaturizationAugmentationError', 'ErrorExporterInvalidPlatform',
-   * 'ErrorExporterInvalidFeaturizer', 'ErrorExporterInvalidClassifier',
-   * 'ErrorPredictionServiceUnavailable', 'ErrorPredictionModelNotFound',
-   * 'ErrorPredictionModelNotCached', 'ErrorPrediction', 'ErrorPredictionStorage',
-   * 'ErrorRegionProposal', 'ErrorInvalid'
+   * Existing TagIds in project to get suggested tags count for.
    */
-  code: CustomVisionErrorCodes;
+  tagIds?: string[];
   /**
-   * A message explaining the error reported by the service.
+   * Confidence threshold to filter suggested tags on.
    */
-  message: string;
+  threshold?: number;
+}
+
+/**
+ * Parameters used for training.
+ */
+export interface TrainingParameters {
+  /**
+   * List of tags selected for this training session, other tags in the project will be ignored.
+   */
+  selectedTags?: string[];
 }
 
 /**
  * Optional Parameters.
  */
-export interface TrainingAPIClientGetTaggedImageCountOptionalParams extends msRest.RequestOptionsBase {
+export interface TrainingAPIClientCreateProjectOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * The iteration id. Defaults to workspace.
+   * The description of the project.
    */
-  iterationId?: string;
+  description?: string;
   /**
-   * A list of tags ids to filter the images to count. Defaults to all tags when null.
+   * The id of the domain to use for this project. Defaults to General.
+   */
+  domainId?: string;
+  /**
+   * The type of classifier to create for this project. Possible values include: 'Multiclass',
+   * 'Multilabel'
+   */
+  classificationType?: ClassificationType;
+  /**
+   * List of platforms the trained model is intending exporting to.
+   */
+  targetExportPlatforms?: string[];
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface TrainingAPIClientCreateImagesFromDataOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The tags ids with which to tag each image. Limited to 20.
    */
   tagIds?: string[];
 }
@@ -1011,7 +1282,31 @@ export interface TrainingAPIClientGetTaggedImageCountOptionalParams extends msRe
 /**
  * Optional Parameters.
  */
-export interface TrainingAPIClientGetUntaggedImageCountOptionalParams extends msRest.RequestOptionsBase {
+export interface TrainingAPIClientDeleteImagesOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Ids of the images to be deleted. Limited to 256 images per batch.
+   */
+  imageIds?: string[];
+  /**
+   * Flag to specify delete all images, specify this flag or a list of images. Using this flag will
+   * return a 202 response to indicate the images are being deleted.
+   */
+  allImages?: boolean;
+  /**
+   * Removes these images from all iterations, not just the current workspace. Using this flag will
+   * return a 202 response to indicate the images are being deleted.
+   */
+  allIterations?: boolean;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface TrainingAPIClientGetImagesByIdsOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The list of image ids to retrieve. Limited to 256.
+   */
+  imageIds?: string[];
   /**
    * The iteration id. Defaults to workspace.
    */
@@ -1048,6 +1343,20 @@ export interface TrainingAPIClientGetTaggedImagesOptionalParams extends msRest.R
 /**
  * Optional Parameters.
  */
+export interface TrainingAPIClientGetTaggedImageCountOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The iteration id. Defaults to workspace.
+   */
+  iterationId?: string;
+  /**
+   * A list of tags ids to filter the images to count. Defaults to all tags when null.
+   */
+  tagIds?: string[];
+}
+
+/**
+ * Optional Parameters.
+ */
 export interface TrainingAPIClientGetUntaggedImagesOptionalParams extends msRest.RequestOptionsBase {
   /**
    * The iteration id. Defaults to workspace.
@@ -1070,11 +1379,7 @@ export interface TrainingAPIClientGetUntaggedImagesOptionalParams extends msRest
 /**
  * Optional Parameters.
  */
-export interface TrainingAPIClientGetImagesByIdsOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * The list of image ids to retrieve. Limited to 256.
-   */
-  imageIds?: string[];
+export interface TrainingAPIClientGetUntaggedImageCountOptionalParams extends msRest.RequestOptionsBase {
   /**
    * The iteration id. Defaults to workspace.
    */
@@ -1084,33 +1389,12 @@ export interface TrainingAPIClientGetImagesByIdsOptionalParams extends msRest.Re
 /**
  * Optional Parameters.
  */
-export interface TrainingAPIClientCreateImagesFromDataOptionalParams extends msRest.RequestOptionsBase {
+export interface TrainingAPIClientExportIterationOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * The tags ids with which to tag each image. Limited to 20.
+   * The flavor of the target platform. Possible values include: 'Linux', 'Windows', 'ONNX10',
+   * 'ONNX12', 'ARM', 'TensorFlowNormal', 'TensorFlowLite'
    */
-  tagIds?: string[];
-}
-
-/**
- * Optional Parameters.
- */
-export interface TrainingAPIClientQuickTestImageUrlOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * Optional. Specifies the id of a particular iteration to evaluate against.
-   * The default iteration for the project will be used when not specified.
-   */
-  iterationId?: string;
-}
-
-/**
- * Optional Parameters.
- */
-export interface TrainingAPIClientQuickTestImageOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * Optional. Specifies the id of a particular iteration to evaluate against.
-   * The default iteration for the project will be used when not specified.
-   */
-  iterationId?: string;
+  flavor?: Flavor;
 }
 
 /**
@@ -1163,69 +1447,33 @@ export interface TrainingAPIClientGetImagePerformanceCountOptionalParams extends
 /**
  * Optional Parameters.
  */
-export interface TrainingAPIClientCreateProjectOptionalParams extends msRest.RequestOptionsBase {
+export interface TrainingAPIClientQuickTestImageOptionalParams extends msRest.RequestOptionsBase {
   /**
-   * The description of the project.
-   */
-  description?: string;
-  /**
-   * The id of the domain to use for this project. Defaults to General.
-   */
-  domainId?: string;
-  /**
-   * The type of classifier to create for this project. Possible values include: 'Multiclass',
-   * 'Multilabel'
-   */
-  classificationType?: ClassificationType;
-  /**
-   * List of platforms the trained model is intending exporting to.
-   */
-  targetExportPlatforms?: string[];
-}
-
-/**
- * Optional Parameters.
- */
-export interface TrainingAPIClientTrainProjectOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * The type of training to use to train the project (default: Regular). Possible values include:
-   * 'Regular', 'Advanced'
-   */
-  trainingType?: TrainingType1;
-  /**
-   * The number of hours reserved as budget for training (if applicable). Default value: 0.
-   */
-  reservedBudgetInHours?: number;
-  /**
-   * Whether to force train even if dataset and configuration does not change (default: false).
-   * Default value: false.
-   */
-  forceTrain?: boolean;
-  /**
-   * The email address to send notification to when training finishes (default: null).
-   */
-  notificationEmailAddress?: string;
-}
-
-/**
- * Optional Parameters.
- */
-export interface TrainingAPIClientExportIterationOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * The flavor of the target platform. Possible values include: 'Linux', 'Windows', 'ONNX10',
-   * 'ONNX12', 'ARM'
-   */
-  flavor?: Flavor;
-}
-
-/**
- * Optional Parameters.
- */
-export interface TrainingAPIClientGetTagOptionalParams extends msRest.RequestOptionsBase {
-  /**
-   * The iteration to retrieve this tag from. Optional, defaults to current training set.
+   * Optional. Specifies the id of a particular iteration to evaluate against.
+   * The default iteration for the project will be used when not specified.
    */
   iterationId?: string;
+  /**
+   * Optional. Specifies whether or not to store the result of this prediction. The default is
+   * true, to store. Default value: true.
+   */
+  store?: boolean;
+}
+
+/**
+ * Optional Parameters.
+ */
+export interface TrainingAPIClientQuickTestImageUrlOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * Optional. Specifies the id of a particular iteration to evaluate against.
+   * The default iteration for the project will be used when not specified.
+   */
+  iterationId?: string;
+  /**
+   * Optional. Specifies whether or not to store the result of this prediction. The default is
+   * true, to store. Default value: true.
+   */
+  store?: boolean;
 }
 
 /**
@@ -1253,78 +1501,42 @@ export interface TrainingAPIClientCreateTagOptionalParams extends msRest.Request
 }
 
 /**
- * Defines values for DomainType.
- * Possible values include: 'Classification', 'ObjectDetection'
- * @readonly
- * @enum {string}
+ * Optional Parameters.
  */
-export type DomainType = 'Classification' | 'ObjectDetection';
+export interface TrainingAPIClientGetTagOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The iteration to retrieve this tag from. Optional, defaults to current training set.
+   */
+  iterationId?: string;
+}
 
 /**
- * Defines values for ImageCreateStatus.
- * Possible values include: 'OK', 'OKDuplicate', 'ErrorSource', 'ErrorImageFormat',
- * 'ErrorImageSize', 'ErrorStorage', 'ErrorLimitExceed', 'ErrorTagLimitExceed',
- * 'ErrorRegionLimitExceed', 'ErrorUnknown', 'ErrorNegativeAndRegularTagOnSameImage'
- * @readonly
- * @enum {string}
+ * Optional Parameters.
  */
-export type ImageCreateStatus = 'OK' | 'OKDuplicate' | 'ErrorSource' | 'ErrorImageFormat' | 'ErrorImageSize' | 'ErrorStorage' | 'ErrorLimitExceed' | 'ErrorTagLimitExceed' | 'ErrorRegionLimitExceed' | 'ErrorUnknown' | 'ErrorNegativeAndRegularTagOnSameImage';
-
-/**
- * Defines values for OrderBy.
- * Possible values include: 'Newest', 'Oldest', 'Suggested'
- * @readonly
- * @enum {string}
- */
-export type OrderBy = 'Newest' | 'Oldest' | 'Suggested';
-
-/**
- * Defines values for Classifier.
- * Possible values include: 'Multiclass', 'Multilabel'
- * @readonly
- * @enum {string}
- */
-export type Classifier = 'Multiclass' | 'Multilabel';
-
-/**
- * Defines values for TrainingType.
- * Possible values include: 'Regular', 'Advanced'
- * @readonly
- * @enum {string}
- */
-export type TrainingType = 'Regular' | 'Advanced';
-
-/**
- * Defines values for ExportPlatform.
- * Possible values include: 'CoreML', 'TensorFlow', 'DockerFile', 'ONNX', 'VAIDK'
- * @readonly
- * @enum {string}
- */
-export type ExportPlatform = 'CoreML' | 'TensorFlow' | 'DockerFile' | 'ONNX' | 'VAIDK';
-
-/**
- * Defines values for ExportStatus.
- * Possible values include: 'Exporting', 'Failed', 'Done'
- * @readonly
- * @enum {string}
- */
-export type ExportStatus = 'Exporting' | 'Failed' | 'Done';
-
-/**
- * Defines values for ExportFlavor.
- * Possible values include: 'Linux', 'Windows', 'ONNX10', 'ONNX12', 'ARM'
- * @readonly
- * @enum {string}
- */
-export type ExportFlavor = 'Linux' | 'Windows' | 'ONNX10' | 'ONNX12' | 'ARM';
-
-/**
- * Defines values for TagType.
- * Possible values include: 'Regular', 'Negative'
- * @readonly
- * @enum {string}
- */
-export type TagType = 'Regular' | 'Negative';
+export interface TrainingAPIClientTrainProjectOptionalParams extends msRest.RequestOptionsBase {
+  /**
+   * The type of training to use to train the project (default: Regular). Possible values include:
+   * 'Regular', 'Advanced'
+   */
+  trainingType?: TrainingType1;
+  /**
+   * The number of hours reserved as budget for training (if applicable). Default value: 0.
+   */
+  reservedBudgetInHours?: number;
+  /**
+   * Whether to force train even if dataset and configuration does not change (default: false).
+   * Default value: false.
+   */
+  forceTrain?: boolean;
+  /**
+   * The email address to send notification to when training finishes (default: null).
+   */
+  notificationEmailAddress?: string;
+  /**
+   * Additional training parameters passed in to control how the project is trained.
+   */
+  trainingParameters?: TrainingParameters;
+}
 
 /**
  * Defines values for CustomVisionErrorCodes.
@@ -1333,13 +1545,15 @@ export type TagType = 'Regular' | 'Negative';
  * 'BadRequestProjectNameNotUnique', 'BadRequestProjectDescription',
  * 'BadRequestProjectUnknownDomain', 'BadRequestProjectUnknownClassification',
  * 'BadRequestProjectUnsupportedDomainTypeChange', 'BadRequestProjectUnsupportedExportPlatform',
+ * 'BadRequestProjectImagePreprocessingSettings', 'BadRequestProjectDuplicated',
  * 'BadRequestIterationName', 'BadRequestIterationNameNotUnique', 'BadRequestIterationDescription',
- * 'BadRequestIterationIsNotTrained', 'BadRequestWorkspaceCannotBeModified',
- * 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName', 'BadRequestTagNameNotUnique',
- * 'BadRequestTagDescription', 'BadRequestTagType', 'BadRequestMultipleNegativeTag',
- * 'BadRequestImageTags', 'BadRequestImageRegions', 'BadRequestNegativeAndRegularTagOnSameImage',
- * 'BadRequestRequiredParamIsNull', 'BadRequestIterationIsPublished',
- * 'BadRequestInvalidPublishName', 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed',
+ * 'BadRequestIterationIsNotTrained', 'BadRequestIterationValidationFailed',
+ * 'BadRequestWorkspaceCannotBeModified', 'BadRequestWorkspaceNotDeletable', 'BadRequestTagName',
+ * 'BadRequestTagNameNotUnique', 'BadRequestTagDescription', 'BadRequestTagType',
+ * 'BadRequestMultipleNegativeTag', 'BadRequestImageTags', 'BadRequestImageRegions',
+ * 'BadRequestNegativeAndRegularTagOnSameImage', 'BadRequestRequiredParamIsNull',
+ * 'BadRequestIterationIsPublished', 'BadRequestInvalidPublishName',
+ * 'BadRequestInvalidPublishTarget', 'BadRequestUnpublishFailed',
  * 'BadRequestIterationNotPublished', 'BadRequestSubscriptionApi', 'BadRequestExceedProjectLimit',
  * 'BadRequestExceedIterationPerProjectLimit', 'BadRequestExceedTagPerProjectLimit',
  * 'BadRequestExceedTagPerImageLimit', 'BadRequestExceededQuota',
@@ -1359,26 +1573,128 @@ export type TagType = 'Regular' | 'Negative';
  * 'BadRequestPredictionIdsMissing', 'BadRequestPredictionIdsExceededCount',
  * 'BadRequestPredictionTagsExceededCount', 'BadRequestPredictionResultsExceededCount',
  * 'BadRequestPredictionInvalidApplicationName', 'BadRequestPredictionInvalidQueryParameters',
- * 'BadRequestInvalid', 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser',
- * 'ForbiddenUserResource', 'ForbiddenUserSignupDisabled', 'ForbiddenUserSignupAllowanceExceeded',
+ * 'BadRequestInvalidImportToken', 'BadRequestExportWhileTraining', 'BadRequestInvalid',
+ * 'UnsupportedMediaType', 'Forbidden', 'ForbiddenUser', 'ForbiddenUserResource',
+ * 'ForbiddenUserSignupDisabled', 'ForbiddenUserSignupAllowanceExceeded',
  * 'ForbiddenUserDoesNotExist', 'ForbiddenUserDisabled', 'ForbiddenUserInsufficientCapability',
  * 'ForbiddenDRModeEnabled', 'ForbiddenInvalid', 'NotFound', 'NotFoundProject',
  * 'NotFoundProjectDefaultIteration', 'NotFoundIteration', 'NotFoundIterationPerformance',
  * 'NotFoundTag', 'NotFoundImage', 'NotFoundDomain', 'NotFoundApimSubscription', 'NotFoundInvalid',
- * 'Conflict', 'ConflictInvalid', 'ErrorUnknown', 'ErrorProjectInvalidWorkspace',
+ * 'Conflict', 'ConflictInvalid', 'ErrorUnknown', 'ErrorIterationCopyFailed',
+ * 'ErrorPreparePerformanceMigrationFailed', 'ErrorProjectInvalidWorkspace',
  * 'ErrorProjectInvalidPipelineConfiguration', 'ErrorProjectInvalidDomain',
- * 'ErrorProjectTrainingRequestFailed', 'ErrorProjectExportRequestFailed',
- * 'ErrorFeaturizationServiceUnavailable', 'ErrorFeaturizationQueueTimeout',
- * 'ErrorFeaturizationInvalidFeaturizer', 'ErrorFeaturizationAugmentationUnavailable',
- * 'ErrorFeaturizationUnrecognizedJob', 'ErrorFeaturizationAugmentationError',
- * 'ErrorExporterInvalidPlatform', 'ErrorExporterInvalidFeaturizer',
- * 'ErrorExporterInvalidClassifier', 'ErrorPredictionServiceUnavailable',
- * 'ErrorPredictionModelNotFound', 'ErrorPredictionModelNotCached', 'ErrorPrediction',
- * 'ErrorPredictionStorage', 'ErrorRegionProposal', 'ErrorInvalid'
+ * 'ErrorProjectTrainingRequestFailed', 'ErrorProjectImportRequestFailed',
+ * 'ErrorProjectExportRequestFailed', 'ErrorFeaturizationServiceUnavailable',
+ * 'ErrorFeaturizationQueueTimeout', 'ErrorFeaturizationInvalidFeaturizer',
+ * 'ErrorFeaturizationAugmentationUnavailable', 'ErrorFeaturizationUnrecognizedJob',
+ * 'ErrorFeaturizationAugmentationError', 'ErrorExporterInvalidPlatform',
+ * 'ErrorExporterInvalidFeaturizer', 'ErrorExporterInvalidClassifier',
+ * 'ErrorPredictionServiceUnavailable', 'ErrorPredictionModelNotFound',
+ * 'ErrorPredictionModelNotCached', 'ErrorPrediction', 'ErrorPredictionStorage',
+ * 'ErrorRegionProposal', 'ErrorInvalid'
  * @readonly
  * @enum {string}
  */
-export type CustomVisionErrorCodes = 'NoError' | 'BadRequest' | 'BadRequestExceededBatchSize' | 'BadRequestNotSupported' | 'BadRequestInvalidIds' | 'BadRequestProjectName' | 'BadRequestProjectNameNotUnique' | 'BadRequestProjectDescription' | 'BadRequestProjectUnknownDomain' | 'BadRequestProjectUnknownClassification' | 'BadRequestProjectUnsupportedDomainTypeChange' | 'BadRequestProjectUnsupportedExportPlatform' | 'BadRequestIterationName' | 'BadRequestIterationNameNotUnique' | 'BadRequestIterationDescription' | 'BadRequestIterationIsNotTrained' | 'BadRequestWorkspaceCannotBeModified' | 'BadRequestWorkspaceNotDeletable' | 'BadRequestTagName' | 'BadRequestTagNameNotUnique' | 'BadRequestTagDescription' | 'BadRequestTagType' | 'BadRequestMultipleNegativeTag' | 'BadRequestImageTags' | 'BadRequestImageRegions' | 'BadRequestNegativeAndRegularTagOnSameImage' | 'BadRequestRequiredParamIsNull' | 'BadRequestIterationIsPublished' | 'BadRequestInvalidPublishName' | 'BadRequestInvalidPublishTarget' | 'BadRequestUnpublishFailed' | 'BadRequestIterationNotPublished' | 'BadRequestSubscriptionApi' | 'BadRequestExceedProjectLimit' | 'BadRequestExceedIterationPerProjectLimit' | 'BadRequestExceedTagPerProjectLimit' | 'BadRequestExceedTagPerImageLimit' | 'BadRequestExceededQuota' | 'BadRequestCannotMigrateProjectWithName' | 'BadRequestNotLimitedTrial' | 'BadRequestImageBatch' | 'BadRequestImageStream' | 'BadRequestImageUrl' | 'BadRequestImageFormat' | 'BadRequestImageSizeBytes' | 'BadRequestImageExceededCount' | 'BadRequestTrainingNotNeeded' | 'BadRequestTrainingNotNeededButTrainingPipelineUpdated' | 'BadRequestTrainingValidationFailed' | 'BadRequestClassificationTrainingValidationFailed' | 'BadRequestMultiClassClassificationTrainingValidationFailed' | 'BadRequestMultiLabelClassificationTrainingValidationFailed' | 'BadRequestDetectionTrainingValidationFailed' | 'BadRequestTrainingAlreadyInProgress' | 'BadRequestDetectionTrainingNotAllowNegativeTag' | 'BadRequestInvalidEmailAddress' | 'BadRequestDomainNotSupportedForAdvancedTraining' | 'BadRequestExportPlatformNotSupportedForAdvancedTraining' | 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining' | 'BadRequestExportValidationFailed' | 'BadRequestExportAlreadyInProgress' | 'BadRequestPredictionIdsMissing' | 'BadRequestPredictionIdsExceededCount' | 'BadRequestPredictionTagsExceededCount' | 'BadRequestPredictionResultsExceededCount' | 'BadRequestPredictionInvalidApplicationName' | 'BadRequestPredictionInvalidQueryParameters' | 'BadRequestInvalid' | 'UnsupportedMediaType' | 'Forbidden' | 'ForbiddenUser' | 'ForbiddenUserResource' | 'ForbiddenUserSignupDisabled' | 'ForbiddenUserSignupAllowanceExceeded' | 'ForbiddenUserDoesNotExist' | 'ForbiddenUserDisabled' | 'ForbiddenUserInsufficientCapability' | 'ForbiddenDRModeEnabled' | 'ForbiddenInvalid' | 'NotFound' | 'NotFoundProject' | 'NotFoundProjectDefaultIteration' | 'NotFoundIteration' | 'NotFoundIterationPerformance' | 'NotFoundTag' | 'NotFoundImage' | 'NotFoundDomain' | 'NotFoundApimSubscription' | 'NotFoundInvalid' | 'Conflict' | 'ConflictInvalid' | 'ErrorUnknown' | 'ErrorProjectInvalidWorkspace' | 'ErrorProjectInvalidPipelineConfiguration' | 'ErrorProjectInvalidDomain' | 'ErrorProjectTrainingRequestFailed' | 'ErrorProjectExportRequestFailed' | 'ErrorFeaturizationServiceUnavailable' | 'ErrorFeaturizationQueueTimeout' | 'ErrorFeaturizationInvalidFeaturizer' | 'ErrorFeaturizationAugmentationUnavailable' | 'ErrorFeaturizationUnrecognizedJob' | 'ErrorFeaturizationAugmentationError' | 'ErrorExporterInvalidPlatform' | 'ErrorExporterInvalidFeaturizer' | 'ErrorExporterInvalidClassifier' | 'ErrorPredictionServiceUnavailable' | 'ErrorPredictionModelNotFound' | 'ErrorPredictionModelNotCached' | 'ErrorPrediction' | 'ErrorPredictionStorage' | 'ErrorRegionProposal' | 'ErrorInvalid';
+export type CustomVisionErrorCodes = 'NoError' | 'BadRequest' | 'BadRequestExceededBatchSize' | 'BadRequestNotSupported' | 'BadRequestInvalidIds' | 'BadRequestProjectName' | 'BadRequestProjectNameNotUnique' | 'BadRequestProjectDescription' | 'BadRequestProjectUnknownDomain' | 'BadRequestProjectUnknownClassification' | 'BadRequestProjectUnsupportedDomainTypeChange' | 'BadRequestProjectUnsupportedExportPlatform' | 'BadRequestProjectImagePreprocessingSettings' | 'BadRequestProjectDuplicated' | 'BadRequestIterationName' | 'BadRequestIterationNameNotUnique' | 'BadRequestIterationDescription' | 'BadRequestIterationIsNotTrained' | 'BadRequestIterationValidationFailed' | 'BadRequestWorkspaceCannotBeModified' | 'BadRequestWorkspaceNotDeletable' | 'BadRequestTagName' | 'BadRequestTagNameNotUnique' | 'BadRequestTagDescription' | 'BadRequestTagType' | 'BadRequestMultipleNegativeTag' | 'BadRequestImageTags' | 'BadRequestImageRegions' | 'BadRequestNegativeAndRegularTagOnSameImage' | 'BadRequestRequiredParamIsNull' | 'BadRequestIterationIsPublished' | 'BadRequestInvalidPublishName' | 'BadRequestInvalidPublishTarget' | 'BadRequestUnpublishFailed' | 'BadRequestIterationNotPublished' | 'BadRequestSubscriptionApi' | 'BadRequestExceedProjectLimit' | 'BadRequestExceedIterationPerProjectLimit' | 'BadRequestExceedTagPerProjectLimit' | 'BadRequestExceedTagPerImageLimit' | 'BadRequestExceededQuota' | 'BadRequestCannotMigrateProjectWithName' | 'BadRequestNotLimitedTrial' | 'BadRequestImageBatch' | 'BadRequestImageStream' | 'BadRequestImageUrl' | 'BadRequestImageFormat' | 'BadRequestImageSizeBytes' | 'BadRequestImageExceededCount' | 'BadRequestTrainingNotNeeded' | 'BadRequestTrainingNotNeededButTrainingPipelineUpdated' | 'BadRequestTrainingValidationFailed' | 'BadRequestClassificationTrainingValidationFailed' | 'BadRequestMultiClassClassificationTrainingValidationFailed' | 'BadRequestMultiLabelClassificationTrainingValidationFailed' | 'BadRequestDetectionTrainingValidationFailed' | 'BadRequestTrainingAlreadyInProgress' | 'BadRequestDetectionTrainingNotAllowNegativeTag' | 'BadRequestInvalidEmailAddress' | 'BadRequestDomainNotSupportedForAdvancedTraining' | 'BadRequestExportPlatformNotSupportedForAdvancedTraining' | 'BadRequestReservedBudgetInHoursNotEnoughForAdvancedTraining' | 'BadRequestExportValidationFailed' | 'BadRequestExportAlreadyInProgress' | 'BadRequestPredictionIdsMissing' | 'BadRequestPredictionIdsExceededCount' | 'BadRequestPredictionTagsExceededCount' | 'BadRequestPredictionResultsExceededCount' | 'BadRequestPredictionInvalidApplicationName' | 'BadRequestPredictionInvalidQueryParameters' | 'BadRequestInvalidImportToken' | 'BadRequestExportWhileTraining' | 'BadRequestInvalid' | 'UnsupportedMediaType' | 'Forbidden' | 'ForbiddenUser' | 'ForbiddenUserResource' | 'ForbiddenUserSignupDisabled' | 'ForbiddenUserSignupAllowanceExceeded' | 'ForbiddenUserDoesNotExist' | 'ForbiddenUserDisabled' | 'ForbiddenUserInsufficientCapability' | 'ForbiddenDRModeEnabled' | 'ForbiddenInvalid' | 'NotFound' | 'NotFoundProject' | 'NotFoundProjectDefaultIteration' | 'NotFoundIteration' | 'NotFoundIterationPerformance' | 'NotFoundTag' | 'NotFoundImage' | 'NotFoundDomain' | 'NotFoundApimSubscription' | 'NotFoundInvalid' | 'Conflict' | 'ConflictInvalid' | 'ErrorUnknown' | 'ErrorIterationCopyFailed' | 'ErrorPreparePerformanceMigrationFailed' | 'ErrorProjectInvalidWorkspace' | 'ErrorProjectInvalidPipelineConfiguration' | 'ErrorProjectInvalidDomain' | 'ErrorProjectTrainingRequestFailed' | 'ErrorProjectImportRequestFailed' | 'ErrorProjectExportRequestFailed' | 'ErrorFeaturizationServiceUnavailable' | 'ErrorFeaturizationQueueTimeout' | 'ErrorFeaturizationInvalidFeaturizer' | 'ErrorFeaturizationAugmentationUnavailable' | 'ErrorFeaturizationUnrecognizedJob' | 'ErrorFeaturizationAugmentationError' | 'ErrorExporterInvalidPlatform' | 'ErrorExporterInvalidFeaturizer' | 'ErrorExporterInvalidClassifier' | 'ErrorPredictionServiceUnavailable' | 'ErrorPredictionModelNotFound' | 'ErrorPredictionModelNotCached' | 'ErrorPrediction' | 'ErrorPredictionStorage' | 'ErrorRegionProposal' | 'ErrorInvalid';
+
+/**
+ * Defines values for DomainType.
+ * Possible values include: 'Classification', 'ObjectDetection'
+ * @readonly
+ * @enum {string}
+ */
+export type DomainType = 'Classification' | 'ObjectDetection';
+
+/**
+ * Defines values for ExportPlatform.
+ * Possible values include: 'CoreML', 'TensorFlow', 'DockerFile', 'ONNX', 'VAIDK'
+ * @readonly
+ * @enum {string}
+ */
+export type ExportPlatform = 'CoreML' | 'TensorFlow' | 'DockerFile' | 'ONNX' | 'VAIDK';
+
+/**
+ * Defines values for ExportStatus.
+ * Possible values include: 'Exporting', 'Failed', 'Done'
+ * @readonly
+ * @enum {string}
+ */
+export type ExportStatus = 'Exporting' | 'Failed' | 'Done';
+
+/**
+ * Defines values for ExportFlavor.
+ * Possible values include: 'Linux', 'Windows', 'ONNX10', 'ONNX12', 'ARM', 'TensorFlowNormal',
+ * 'TensorFlowLite'
+ * @readonly
+ * @enum {string}
+ */
+export type ExportFlavor = 'Linux' | 'Windows' | 'ONNX10' | 'ONNX12' | 'ARM' | 'TensorFlowNormal' | 'TensorFlowLite';
+
+/**
+ * Defines values for ImageCreateStatus.
+ * Possible values include: 'OK', 'OKDuplicate', 'ErrorSource', 'ErrorImageFormat',
+ * 'ErrorImageSize', 'ErrorStorage', 'ErrorLimitExceed', 'ErrorTagLimitExceed',
+ * 'ErrorRegionLimitExceed', 'ErrorUnknown', 'ErrorNegativeAndRegularTagOnSameImage'
+ * @readonly
+ * @enum {string}
+ */
+export type ImageCreateStatus = 'OK' | 'OKDuplicate' | 'ErrorSource' | 'ErrorImageFormat' | 'ErrorImageSize' | 'ErrorStorage' | 'ErrorLimitExceed' | 'ErrorTagLimitExceed' | 'ErrorRegionLimitExceed' | 'ErrorUnknown' | 'ErrorNegativeAndRegularTagOnSameImage';
+
+/**
+ * Defines values for Classifier.
+ * Possible values include: 'Multiclass', 'Multilabel'
+ * @readonly
+ * @enum {string}
+ */
+export type Classifier = 'Multiclass' | 'Multilabel';
+
+/**
+ * Defines values for TrainingType.
+ * Possible values include: 'Regular', 'Advanced'
+ * @readonly
+ * @enum {string}
+ */
+export type TrainingType = 'Regular' | 'Advanced';
+
+/**
+ * Defines values for OrderBy.
+ * Possible values include: 'Newest', 'Oldest', 'Suggested'
+ * @readonly
+ * @enum {string}
+ */
+export type OrderBy = 'Newest' | 'Oldest' | 'Suggested';
+
+/**
+ * Defines values for ProjectStatus.
+ * Possible values include: 'Succeeded', 'Importing', 'Failed'
+ * @readonly
+ * @enum {string}
+ */
+export type ProjectStatus = 'Succeeded' | 'Importing' | 'Failed';
+
+/**
+ * Defines values for SortBy.
+ * Possible values include: 'UncertaintyAscending', 'UncertaintyDescending'
+ * @readonly
+ * @enum {string}
+ */
+export type SortBy = 'UncertaintyAscending' | 'UncertaintyDescending';
+
+/**
+ * Defines values for TagType.
+ * Possible values include: 'Regular', 'Negative'
+ * @readonly
+ * @enum {string}
+ */
+export type TagType = 'Regular' | 'Negative';
+
+/**
+ * Defines values for ClassificationType.
+ * Possible values include: 'Multiclass', 'Multilabel'
+ * @readonly
+ * @enum {string}
+ */
+export type ClassificationType = 'Multiclass' | 'Multilabel';
 
 /**
  * Defines values for OrderBy1.
@@ -1397,6 +1713,15 @@ export type OrderBy1 = 'Newest' | 'Oldest';
 export type OrderBy2 = 'Newest' | 'Oldest';
 
 /**
+ * Defines values for Flavor.
+ * Possible values include: 'Linux', 'Windows', 'ONNX10', 'ONNX12', 'ARM', 'TensorFlowNormal',
+ * 'TensorFlowLite'
+ * @readonly
+ * @enum {string}
+ */
+export type Flavor = 'Linux' | 'Windows' | 'ONNX10' | 'ONNX12' | 'ARM' | 'TensorFlowNormal' | 'TensorFlowLite';
+
+/**
  * Defines values for OrderBy3.
  * Possible values include: 'Newest', 'Oldest'
  * @readonly
@@ -1405,12 +1730,12 @@ export type OrderBy2 = 'Newest' | 'Oldest';
 export type OrderBy3 = 'Newest' | 'Oldest';
 
 /**
- * Defines values for ClassificationType.
- * Possible values include: 'Multiclass', 'Multilabel'
+ * Defines values for Type.
+ * Possible values include: 'Regular', 'Negative'
  * @readonly
  * @enum {string}
  */
-export type ClassificationType = 'Multiclass' | 'Multilabel';
+export type Type = 'Regular' | 'Negative';
 
 /**
  * Defines values for TrainingType1.
@@ -1419,22 +1744,6 @@ export type ClassificationType = 'Multiclass' | 'Multilabel';
  * @enum {string}
  */
 export type TrainingType1 = 'Regular' | 'Advanced';
-
-/**
- * Defines values for Flavor.
- * Possible values include: 'Linux', 'Windows', 'ONNX10', 'ONNX12', 'ARM'
- * @readonly
- * @enum {string}
- */
-export type Flavor = 'Linux' | 'Windows' | 'ONNX10' | 'ONNX12' | 'ARM';
-
-/**
- * Defines values for Type.
- * Possible values include: 'Regular', 'Negative'
- * @readonly
- * @enum {string}
- */
-export type Type = 'Regular' | 'Negative';
 
 /**
  * Defines values for Platform.
@@ -1481,381 +1790,6 @@ export type GetDomainResponse = Domain & {
        * The response body as parsed JSON or XML
        */
       parsedBody: Domain;
-    };
-};
-
-/**
- * Contains response data for the getTaggedImageCount operation.
- */
-export type GetTaggedImageCountResponse = {
-  /**
-   * The parsed response body.
-   */
-  body: number;
-
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: number;
-    };
-};
-
-/**
- * Contains response data for the getUntaggedImageCount operation.
- */
-export type GetUntaggedImageCountResponse = {
-  /**
-   * The parsed response body.
-   */
-  body: number;
-
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: number;
-    };
-};
-
-/**
- * Contains response data for the createImageTags operation.
- */
-export type CreateImageTagsResponse = ImageTagCreateSummary & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImageTagCreateSummary;
-    };
-};
-
-/**
- * Contains response data for the createImageRegions operation.
- */
-export type CreateImageRegionsResponse = ImageRegionCreateSummary & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImageRegionCreateSummary;
-    };
-};
-
-/**
- * Contains response data for the getTaggedImages operation.
- */
-export type GetTaggedImagesResponse = Array<Image> & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Image[];
-    };
-};
-
-/**
- * Contains response data for the getUntaggedImages operation.
- */
-export type GetUntaggedImagesResponse = Array<Image> & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Image[];
-    };
-};
-
-/**
- * Contains response data for the getImagesByIds operation.
- */
-export type GetImagesByIdsResponse = Array<Image> & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: Image[];
-    };
-};
-
-/**
- * Contains response data for the createImagesFromData operation.
- */
-export type CreateImagesFromDataResponse = ImageCreateSummary & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImageCreateSummary;
-    };
-};
-
-/**
- * Contains response data for the createImagesFromFiles operation.
- */
-export type CreateImagesFromFilesResponse = ImageCreateSummary & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImageCreateSummary;
-    };
-};
-
-/**
- * Contains response data for the createImagesFromUrls operation.
- */
-export type CreateImagesFromUrlsResponse = ImageCreateSummary & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImageCreateSummary;
-    };
-};
-
-/**
- * Contains response data for the createImagesFromPredictions operation.
- */
-export type CreateImagesFromPredictionsResponse = ImageCreateSummary & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImageCreateSummary;
-    };
-};
-
-/**
- * Contains response data for the getImageRegionProposals operation.
- */
-export type GetImageRegionProposalsResponse = ImageRegionProposal & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImageRegionProposal;
-    };
-};
-
-/**
- * Contains response data for the quickTestImageUrl operation.
- */
-export type QuickTestImageUrlResponse = ImagePrediction & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImagePrediction;
-    };
-};
-
-/**
- * Contains response data for the quickTestImage operation.
- */
-export type QuickTestImageResponse = ImagePrediction & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImagePrediction;
-    };
-};
-
-/**
- * Contains response data for the queryPredictions operation.
- */
-export type QueryPredictionsResponse = PredictionQueryResult & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: PredictionQueryResult;
-    };
-};
-
-/**
- * Contains response data for the getIterationPerformance operation.
- */
-export type GetIterationPerformanceResponse = IterationPerformance & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: IterationPerformance;
-    };
-};
-
-/**
- * Contains response data for the getImagePerformances operation.
- */
-export type GetImagePerformancesResponse = Array<ImagePerformance> & {
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: ImagePerformance[];
-    };
-};
-
-/**
- * Contains response data for the getImagePerformanceCount operation.
- */
-export type GetImagePerformanceCountResponse = {
-  /**
-   * The parsed response body.
-   */
-  body: number;
-
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: number;
     };
 };
 
@@ -1940,9 +1874,9 @@ export type UpdateProjectResponse = Project & {
 };
 
 /**
- * Contains response data for the trainProject operation.
+ * Contains response data for the exportProject operation.
  */
-export type TrainProjectResponse = Iteration & {
+export type ExportProjectResponse = ProjectExport & {
   /**
    * The underlying HTTP response.
    */
@@ -1955,7 +1889,302 @@ export type TrainProjectResponse = Iteration & {
       /**
        * The response body as parsed JSON or XML
        */
-      parsedBody: Iteration;
+      parsedBody: ProjectExport;
+    };
+};
+
+/**
+ * Contains response data for the createImagesFromData operation.
+ */
+export type CreateImagesFromDataResponse = ImageCreateSummary & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImageCreateSummary;
+    };
+};
+
+/**
+ * Contains response data for the getImageRegionProposals operation.
+ */
+export type GetImageRegionProposalsResponse = ImageRegionProposal & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImageRegionProposal;
+    };
+};
+
+/**
+ * Contains response data for the createImagesFromFiles operation.
+ */
+export type CreateImagesFromFilesResponse = ImageCreateSummary & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImageCreateSummary;
+    };
+};
+
+/**
+ * Contains response data for the getImagesByIds operation.
+ */
+export type GetImagesByIdsResponse = Array<Image> & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Image[];
+    };
+};
+
+/**
+ * Contains response data for the createImagesFromPredictions operation.
+ */
+export type CreateImagesFromPredictionsResponse = ImageCreateSummary & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImageCreateSummary;
+    };
+};
+
+/**
+ * Contains response data for the createImageRegions operation.
+ */
+export type CreateImageRegionsResponse = ImageRegionCreateSummary & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImageRegionCreateSummary;
+    };
+};
+
+/**
+ * Contains response data for the querySuggestedImages operation.
+ */
+export type QuerySuggestedImagesResponse = SuggestedTagAndRegionQuery & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SuggestedTagAndRegionQuery;
+    };
+};
+
+/**
+ * Contains response data for the querySuggestedImageCount operation.
+ */
+export type QuerySuggestedImageCountResponse = {
+  /**
+   * The response body properties.
+   */
+  [propertyName: string]: number;
+} & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: { [propertyName: string]: number };
+    };
+};
+
+/**
+ * Contains response data for the getTaggedImages operation.
+ */
+export type GetTaggedImagesResponse = Array<Image> & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Image[];
+    };
+};
+
+/**
+ * Contains response data for the getTaggedImageCount operation.
+ */
+export type GetTaggedImageCountResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: number;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: number;
+    };
+};
+
+/**
+ * Contains response data for the createImageTags operation.
+ */
+export type CreateImageTagsResponse = ImageTagCreateSummary & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImageTagCreateSummary;
+    };
+};
+
+/**
+ * Contains response data for the getUntaggedImages operation.
+ */
+export type GetUntaggedImagesResponse = Array<Image> & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Image[];
+    };
+};
+
+/**
+ * Contains response data for the getUntaggedImageCount operation.
+ */
+export type GetUntaggedImageCountResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: number;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: number;
+    };
+};
+
+/**
+ * Contains response data for the createImagesFromUrls operation.
+ */
+export type CreateImagesFromUrlsResponse = ImageCreateSummary & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImageCreateSummary;
     };
 };
 
@@ -2020,31 +2249,6 @@ export type UpdateIterationResponse = Iteration & {
 };
 
 /**
- * Contains response data for the publishIteration operation.
- */
-export type PublishIterationResponse = {
-  /**
-   * The parsed response body.
-   */
-  body: boolean;
-
-  /**
-   * The underlying HTTP response.
-   */
-  _response: msRest.HttpResponse & {
-      /**
-       * The response body as text (string format)
-       */
-      bodyAsText: string;
-
-      /**
-       * The response body as parsed JSON or XML
-       */
-      parsedBody: boolean;
-    };
-};
-
-/**
  * Contains response data for the getExports operation.
  */
 export type GetExportsResponse = Array<ExportModel> & {
@@ -2081,6 +2285,196 @@ export type ExportIterationResponse = ExportModel & {
        * The response body as parsed JSON or XML
        */
       parsedBody: ExportModel;
+    };
+};
+
+/**
+ * Contains response data for the getIterationPerformance operation.
+ */
+export type GetIterationPerformanceResponse = IterationPerformance & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: IterationPerformance;
+    };
+};
+
+/**
+ * Contains response data for the getImagePerformances operation.
+ */
+export type GetImagePerformancesResponse = Array<ImagePerformance> & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImagePerformance[];
+    };
+};
+
+/**
+ * Contains response data for the getImagePerformanceCount operation.
+ */
+export type GetImagePerformanceCountResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: number;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: number;
+    };
+};
+
+/**
+ * Contains response data for the publishIteration operation.
+ */
+export type PublishIterationResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: boolean;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: boolean;
+    };
+};
+
+/**
+ * Contains response data for the queryPredictions operation.
+ */
+export type QueryPredictionsResponse = PredictionQueryResult & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: PredictionQueryResult;
+    };
+};
+
+/**
+ * Contains response data for the quickTestImage operation.
+ */
+export type QuickTestImageResponse = ImagePrediction & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImagePrediction;
+    };
+};
+
+/**
+ * Contains response data for the quickTestImageUrl operation.
+ */
+export type QuickTestImageUrlResponse = ImagePrediction & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: ImagePrediction;
+    };
+};
+
+/**
+ * Contains response data for the getTags operation.
+ */
+export type GetTagsResponse = Array<Tag> & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Tag[];
+    };
+};
+
+/**
+ * Contains response data for the createTag operation.
+ */
+export type CreateTagResponse = Tag & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Tag;
     };
 };
 
@@ -2125,9 +2519,9 @@ export type UpdateTagResponse = Tag & {
 };
 
 /**
- * Contains response data for the getTags operation.
+ * Contains response data for the suggestTagsAndRegions operation.
  */
-export type GetTagsResponse = Array<Tag> & {
+export type SuggestTagsAndRegionsResponse = Array<SuggestedTagAndRegion> & {
   /**
    * The underlying HTTP response.
    */
@@ -2140,14 +2534,14 @@ export type GetTagsResponse = Array<Tag> & {
       /**
        * The response body as parsed JSON or XML
        */
-      parsedBody: Tag[];
+      parsedBody: SuggestedTagAndRegion[];
     };
 };
 
 /**
- * Contains response data for the createTag operation.
+ * Contains response data for the trainProject operation.
  */
-export type CreateTagResponse = Tag & {
+export type TrainProjectResponse = Iteration & {
   /**
    * The underlying HTTP response.
    */
@@ -2160,6 +2554,26 @@ export type CreateTagResponse = Tag & {
       /**
        * The response body as parsed JSON or XML
        */
-      parsedBody: Tag;
+      parsedBody: Iteration;
+    };
+};
+
+/**
+ * Contains response data for the importProject operation.
+ */
+export type ImportProjectResponse = Project & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: msRest.HttpResponse & {
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
+
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Project;
     };
 };

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/mappers.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/mappers.ts
@@ -9,6 +9,72 @@
 import * as msRest from "@azure/ms-rest-js";
 
 
+export const BoundingBox: msRest.CompositeMapper = {
+  serializedName: "BoundingBox",
+  type: {
+    name: "Composite",
+    className: "BoundingBox",
+    modelProperties: {
+      left: {
+        required: true,
+        nullable: false,
+        serializedName: "left",
+        type: {
+          name: "Number"
+        }
+      },
+      top: {
+        required: true,
+        nullable: false,
+        serializedName: "top",
+        type: {
+          name: "Number"
+        }
+      },
+      width: {
+        required: true,
+        nullable: false,
+        serializedName: "width",
+        type: {
+          name: "Number"
+        }
+      },
+      height: {
+        required: true,
+        nullable: false,
+        serializedName: "height",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const CustomVisionError: msRest.CompositeMapper = {
+  serializedName: "CustomVisionError",
+  type: {
+    name: "Composite",
+    className: "CustomVisionError",
+    modelProperties: {
+      code: {
+        required: true,
+        serializedName: "code",
+        type: {
+          name: "String"
+        }
+      },
+      message: {
+        required: true,
+        serializedName: "message",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
 export const Domain: msRest.CompositeMapper = {
   serializedName: "Domain",
   type: {
@@ -59,44 +125,246 @@ export const Domain: msRest.CompositeMapper = {
   }
 };
 
-export const ImageTagCreateEntry: msRest.CompositeMapper = {
-  serializedName: "ImageTagCreateEntry",
+export const ExportModel: msRest.CompositeMapper = {
+  serializedName: "Export",
   type: {
     name: "Composite",
-    className: "ImageTagCreateEntry",
+    className: "ExportModel",
     modelProperties: {
-      imageId: {
+      platform: {
         nullable: false,
-        serializedName: "imageId",
+        readOnly: true,
+        serializedName: "platform",
         type: {
-          name: "Uuid"
+          name: "String"
         }
       },
-      tagId: {
+      status: {
         nullable: false,
-        serializedName: "tagId",
+        readOnly: true,
+        serializedName: "status",
         type: {
-          name: "Uuid"
+          name: "String"
+        }
+      },
+      downloadUri: {
+        readOnly: true,
+        serializedName: "downloadUri",
+        type: {
+          name: "String"
+        }
+      },
+      flavor: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "flavor",
+        type: {
+          name: "String"
+        }
+      },
+      newerVersionAvailable: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "newerVersionAvailable",
+        type: {
+          name: "Boolean"
         }
       }
     }
   }
 };
 
-export const ImageTagCreateBatch: msRest.CompositeMapper = {
-  serializedName: "ImageTagCreateBatch",
+export const ImageTag: msRest.CompositeMapper = {
+  serializedName: "ImageTag",
   type: {
     name: "Composite",
-    className: "ImageTagCreateBatch",
+    className: "ImageTag",
     modelProperties: {
+      tagId: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "tagId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      tagName: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "tagName",
+        type: {
+          name: "String"
+        }
+      },
+      created: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "created",
+        type: {
+          name: "DateTime"
+        }
+      }
+    }
+  }
+};
+
+export const ImageRegion: msRest.CompositeMapper = {
+  serializedName: "ImageRegion",
+  type: {
+    name: "Composite",
+    className: "ImageRegion",
+    modelProperties: {
+      regionId: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "regionId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      tagName: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "tagName",
+        type: {
+          name: "String"
+        }
+      },
+      created: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "created",
+        type: {
+          name: "DateTime"
+        }
+      },
+      tagId: {
+        required: true,
+        nullable: false,
+        serializedName: "tagId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      left: {
+        required: true,
+        nullable: false,
+        serializedName: "left",
+        type: {
+          name: "Number"
+        }
+      },
+      top: {
+        required: true,
+        nullable: false,
+        serializedName: "top",
+        type: {
+          name: "Number"
+        }
+      },
+      width: {
+        required: true,
+        nullable: false,
+        serializedName: "width",
+        type: {
+          name: "Number"
+        }
+      },
+      height: {
+        required: true,
+        nullable: false,
+        serializedName: "height",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const Image: msRest.CompositeMapper = {
+  serializedName: "Image",
+  type: {
+    name: "Composite",
+    className: "Image",
+    modelProperties: {
+      id: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "id",
+        type: {
+          name: "Uuid"
+        }
+      },
+      created: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "created",
+        type: {
+          name: "DateTime"
+        }
+      },
+      width: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "width",
+        type: {
+          name: "Number"
+        }
+      },
+      height: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "height",
+        type: {
+          name: "Number"
+        }
+      },
+      resizedImageUri: {
+        readOnly: true,
+        serializedName: "resizedImageUri",
+        type: {
+          name: "String"
+        }
+      },
+      thumbnailUri: {
+        readOnly: true,
+        serializedName: "thumbnailUri",
+        type: {
+          name: "String"
+        }
+      },
+      originalImageUri: {
+        readOnly: true,
+        serializedName: "originalImageUri",
+        type: {
+          name: "String"
+        }
+      },
       tags: {
+        nullable: true,
+        readOnly: true,
         serializedName: "tags",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "ImageTagCreateEntry"
+              className: "ImageTag"
+            }
+          }
+        }
+      },
+      regions: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "regions",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImageRegion"
             }
           }
         }
@@ -105,47 +373,483 @@ export const ImageTagCreateBatch: msRest.CompositeMapper = {
   }
 };
 
-export const ImageTagCreateSummary: msRest.CompositeMapper = {
-  serializedName: "ImageTagCreateSummary",
+export const ImageCreateResult: msRest.CompositeMapper = {
+  serializedName: "ImageCreateResult",
   type: {
     name: "Composite",
-    className: "ImageTagCreateSummary",
+    className: "ImageCreateResult",
     modelProperties: {
-      created: {
+      sourceUrl: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "sourceUrl",
+        type: {
+          name: "String"
+        }
+      },
+      status: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "status",
+        type: {
+          name: "String"
+        }
+      },
+      image: {
+        readOnly: true,
+        serializedName: "image",
+        type: {
+          name: "Composite",
+          className: "Image"
+        }
+      }
+    }
+  }
+};
+
+export const ImageCreateSummary: msRest.CompositeMapper = {
+  serializedName: "ImageCreateSummary",
+  type: {
+    name: "Composite",
+    className: "ImageCreateSummary",
+    modelProperties: {
+      isBatchSuccessful: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "isBatchSuccessful",
+        type: {
+          name: "Boolean"
+        }
+      },
+      images: {
+        readOnly: true,
+        serializedName: "images",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImageCreateResult"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const Region: msRest.CompositeMapper = {
+  serializedName: "Region",
+  type: {
+    name: "Composite",
+    className: "Region",
+    modelProperties: {
+      tagId: {
+        required: true,
+        nullable: false,
+        serializedName: "tagId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      left: {
+        required: true,
+        nullable: false,
+        serializedName: "left",
+        type: {
+          name: "Number"
+        }
+      },
+      top: {
+        required: true,
+        nullable: false,
+        serializedName: "top",
+        type: {
+          name: "Number"
+        }
+      },
+      width: {
+        required: true,
+        nullable: false,
+        serializedName: "width",
+        type: {
+          name: "Number"
+        }
+      },
+      height: {
+        required: true,
+        nullable: false,
+        serializedName: "height",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const ImageFileCreateEntry: msRest.CompositeMapper = {
+  serializedName: "ImageFileCreateEntry",
+  type: {
+    name: "Composite",
+    className: "ImageFileCreateEntry",
+    modelProperties: {
+      name: {
+        nullable: false,
+        serializedName: "name",
+        type: {
+          name: "String"
+        }
+      },
+      contents: {
+        serializedName: "contents",
+        type: {
+          name: "ByteArray"
+        }
+      },
+      tagIds: {
+        serializedName: "tagIds",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Uuid"
+            }
+          }
+        }
+      },
+      regions: {
+        serializedName: "regions",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Region"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const ImageFileCreateBatch: msRest.CompositeMapper = {
+  serializedName: "ImageFileCreateBatch",
+  type: {
+    name: "Composite",
+    className: "ImageFileCreateBatch",
+    modelProperties: {
+      images: {
+        serializedName: "images",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImageFileCreateEntry"
+            }
+          }
+        }
+      },
+      tagIds: {
+        serializedName: "tagIds",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Uuid"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const ImageIdCreateEntry: msRest.CompositeMapper = {
+  serializedName: "ImageIdCreateEntry",
+  type: {
+    name: "Composite",
+    className: "ImageIdCreateEntry",
+    modelProperties: {
+      id: {
+        nullable: false,
+        serializedName: "id",
+        type: {
+          name: "Uuid"
+        }
+      },
+      tagIds: {
+        serializedName: "tagIds",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Uuid"
+            }
+          }
+        }
+      },
+      regions: {
+        serializedName: "regions",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Region"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const ImageIdCreateBatch: msRest.CompositeMapper = {
+  serializedName: "ImageIdCreateBatch",
+  type: {
+    name: "Composite",
+    className: "ImageIdCreateBatch",
+    modelProperties: {
+      images: {
+        serializedName: "images",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImageIdCreateEntry"
+            }
+          }
+        }
+      },
+      tagIds: {
+        serializedName: "tagIds",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Uuid"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const Prediction: msRest.CompositeMapper = {
+  serializedName: "Prediction",
+  type: {
+    name: "Composite",
+    className: "Prediction",
+    modelProperties: {
+      probability: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "probability",
+        type: {
+          name: "Number"
+        }
+      },
+      tagId: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "tagId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      tagName: {
         nullable: true,
+        readOnly: true,
+        serializedName: "tagName",
+        type: {
+          name: "String"
+        }
+      },
+      boundingBox: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "boundingBox",
+        type: {
+          name: "Composite",
+          className: "BoundingBox"
+        }
+      }
+    }
+  }
+};
+
+export const ImagePerformance: msRest.CompositeMapper = {
+  serializedName: "ImagePerformance",
+  type: {
+    name: "Composite",
+    className: "ImagePerformance",
+    modelProperties: {
+      predictions: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "predictions",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Prediction"
+            }
+          }
+        }
+      },
+      id: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "id",
+        type: {
+          name: "Uuid"
+        }
+      },
+      created: {
+        nullable: false,
+        readOnly: true,
         serializedName: "created",
         type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "ImageTagCreateEntry"
-            }
-          }
+          name: "DateTime"
         }
       },
-      duplicated: {
+      width: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "width",
+        type: {
+          name: "Number"
+        }
+      },
+      height: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "height",
+        type: {
+          name: "Number"
+        }
+      },
+      imageUri: {
+        readOnly: true,
+        serializedName: "imageUri",
+        type: {
+          name: "String"
+        }
+      },
+      thumbnailUri: {
+        readOnly: true,
+        serializedName: "thumbnailUri",
+        type: {
+          name: "String"
+        }
+      },
+      tags: {
         nullable: true,
-        serializedName: "duplicated",
+        readOnly: true,
+        serializedName: "tags",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "ImageTagCreateEntry"
+              className: "ImageTag"
             }
           }
         }
       },
-      exceeded: {
+      regions: {
         nullable: true,
-        serializedName: "exceeded",
+        readOnly: true,
+        serializedName: "regions",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "ImageTagCreateEntry"
+              className: "ImageRegion"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const ImagePrediction: msRest.CompositeMapper = {
+  serializedName: "ImagePrediction",
+  type: {
+    name: "Composite",
+    className: "ImagePrediction",
+    modelProperties: {
+      id: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "id",
+        type: {
+          name: "Uuid"
+        }
+      },
+      project: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "project",
+        type: {
+          name: "Uuid"
+        }
+      },
+      iteration: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "iteration",
+        type: {
+          name: "Uuid"
+        }
+      },
+      created: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "created",
+        type: {
+          name: "DateTime"
+        }
+      },
+      predictions: {
+        readOnly: true,
+        serializedName: "predictions",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Prediction"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const ImageProcessingSettings: msRest.CompositeMapper = {
+  serializedName: "ImageProcessingSettings",
+  type: {
+    name: "Composite",
+    className: "ImageProcessingSettings",
+    modelProperties: {
+      augmentationMethods: {
+        nullable: true,
+        serializedName: "augmentationMethods",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "Boolean"
             }
           }
         }
@@ -365,200 +1069,158 @@ export const ImageRegionCreateSummary: msRest.CompositeMapper = {
   }
 };
 
-export const ImageTag: msRest.CompositeMapper = {
-  serializedName: "ImageTag",
+export const RegionProposal: msRest.CompositeMapper = {
+  serializedName: "RegionProposal",
   type: {
     name: "Composite",
-    className: "ImageTag",
+    className: "RegionProposal",
     modelProperties: {
-      tagId: {
+      confidence: {
         nullable: false,
         readOnly: true,
-        serializedName: "tagId",
+        serializedName: "confidence",
         type: {
-          name: "Uuid"
+          name: "Number"
         }
       },
-      tagName: {
-        nullable: false,
+      boundingBox: {
         readOnly: true,
-        serializedName: "tagName",
+        serializedName: "boundingBox",
         type: {
-          name: "String"
-        }
-      },
-      created: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "created",
-        type: {
-          name: "DateTime"
+          name: "Composite",
+          className: "BoundingBox"
         }
       }
     }
   }
 };
 
-export const ImageRegion: msRest.CompositeMapper = {
-  serializedName: "ImageRegion",
+export const ImageRegionProposal: msRest.CompositeMapper = {
+  serializedName: "ImageRegionProposal",
   type: {
     name: "Composite",
-    className: "ImageRegion",
+    className: "ImageRegionProposal",
     modelProperties: {
-      regionId: {
+      projectId: {
         nullable: false,
         readOnly: true,
-        serializedName: "regionId",
+        serializedName: "projectId",
         type: {
           name: "Uuid"
         }
       },
-      tagName: {
+      imageId: {
         nullable: false,
         readOnly: true,
-        serializedName: "tagName",
-        type: {
-          name: "String"
-        }
-      },
-      created: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "created",
-        type: {
-          name: "DateTime"
-        }
-      },
-      tagId: {
-        required: true,
-        nullable: false,
-        serializedName: "tagId",
+        serializedName: "imageId",
         type: {
           name: "Uuid"
         }
       },
-      left: {
-        required: true,
-        nullable: false,
-        serializedName: "left",
+      proposals: {
+        readOnly: true,
+        serializedName: "proposals",
         type: {
-          name: "Number"
-        }
-      },
-      top: {
-        required: true,
-        nullable: false,
-        serializedName: "top",
-        type: {
-          name: "Number"
-        }
-      },
-      width: {
-        required: true,
-        nullable: false,
-        serializedName: "width",
-        type: {
-          name: "Number"
-        }
-      },
-      height: {
-        required: true,
-        nullable: false,
-        serializedName: "height",
-        type: {
-          name: "Number"
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "RegionProposal"
+            }
+          }
         }
       }
     }
   }
 };
 
-export const Image: msRest.CompositeMapper = {
-  serializedName: "Image",
+export const ImageTagCreateEntry: msRest.CompositeMapper = {
+  serializedName: "ImageTagCreateEntry",
   type: {
     name: "Composite",
-    className: "Image",
+    className: "ImageTagCreateEntry",
     modelProperties: {
-      id: {
+      imageId: {
         nullable: false,
-        readOnly: true,
-        serializedName: "id",
+        serializedName: "imageId",
         type: {
           name: "Uuid"
         }
       },
-      created: {
+      tagId: {
         nullable: false,
-        readOnly: true,
-        serializedName: "created",
+        serializedName: "tagId",
         type: {
-          name: "DateTime"
+          name: "Uuid"
         }
-      },
-      width: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "width",
-        type: {
-          name: "Number"
-        }
-      },
-      height: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "height",
-        type: {
-          name: "Number"
-        }
-      },
-      resizedImageUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "resizedImageUri",
-        type: {
-          name: "String"
-        }
-      },
-      thumbnailUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "thumbnailUri",
-        type: {
-          name: "String"
-        }
-      },
-      originalImageUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "originalImageUri",
-        type: {
-          name: "String"
-        }
-      },
+      }
+    }
+  }
+};
+
+export const ImageTagCreateBatch: msRest.CompositeMapper = {
+  serializedName: "ImageTagCreateBatch",
+  type: {
+    name: "Composite",
+    className: "ImageTagCreateBatch",
+    modelProperties: {
       tags: {
-        nullable: true,
-        readOnly: true,
         serializedName: "tags",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "ImageTag"
+              className: "ImageTagCreateEntry"
             }
           }
         }
-      },
-      regions: {
+      }
+    }
+  }
+};
+
+export const ImageTagCreateSummary: msRest.CompositeMapper = {
+  serializedName: "ImageTagCreateSummary",
+  type: {
+    name: "Composite",
+    className: "ImageTagCreateSummary",
+    modelProperties: {
+      created: {
         nullable: true,
-        readOnly: true,
-        serializedName: "regions",
+        serializedName: "created",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "ImageRegion"
+              className: "ImageTagCreateEntry"
+            }
+          }
+        }
+      },
+      duplicated: {
+        nullable: true,
+        serializedName: "duplicated",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImageTagCreateEntry"
+            }
+          }
+        }
+      },
+      exceeded: {
+        nullable: true,
+        serializedName: "exceeded",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImageTagCreateEntry"
             }
           }
         }
@@ -567,196 +1229,18 @@ export const Image: msRest.CompositeMapper = {
   }
 };
 
-export const ImageCreateResult: msRest.CompositeMapper = {
-  serializedName: "ImageCreateResult",
+export const ImageUrl: msRest.CompositeMapper = {
+  serializedName: "ImageUrl",
   type: {
     name: "Composite",
-    className: "ImageCreateResult",
+    className: "ImageUrl",
     modelProperties: {
-      sourceUrl: {
+      url: {
+        required: true,
         nullable: false,
-        readOnly: true,
-        serializedName: "sourceUrl",
+        serializedName: "url",
         type: {
           name: "String"
-        }
-      },
-      status: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "status",
-        type: {
-          name: "String"
-        }
-      },
-      image: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "image",
-        type: {
-          name: "Composite",
-          className: "Image"
-        }
-      }
-    }
-  }
-};
-
-export const ImageCreateSummary: msRest.CompositeMapper = {
-  serializedName: "ImageCreateSummary",
-  type: {
-    name: "Composite",
-    className: "ImageCreateSummary",
-    modelProperties: {
-      isBatchSuccessful: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "isBatchSuccessful",
-        type: {
-          name: "Boolean"
-        }
-      },
-      images: {
-        readOnly: true,
-        serializedName: "images",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "ImageCreateResult"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const Region: msRest.CompositeMapper = {
-  serializedName: "Region",
-  type: {
-    name: "Composite",
-    className: "Region",
-    modelProperties: {
-      tagId: {
-        required: true,
-        nullable: false,
-        serializedName: "tagId",
-        type: {
-          name: "Uuid"
-        }
-      },
-      left: {
-        required: true,
-        nullable: false,
-        serializedName: "left",
-        type: {
-          name: "Number"
-        }
-      },
-      top: {
-        required: true,
-        nullable: false,
-        serializedName: "top",
-        type: {
-          name: "Number"
-        }
-      },
-      width: {
-        required: true,
-        nullable: false,
-        serializedName: "width",
-        type: {
-          name: "Number"
-        }
-      },
-      height: {
-        required: true,
-        nullable: false,
-        serializedName: "height",
-        type: {
-          name: "Number"
-        }
-      }
-    }
-  }
-};
-
-export const ImageFileCreateEntry: msRest.CompositeMapper = {
-  serializedName: "ImageFileCreateEntry",
-  type: {
-    name: "Composite",
-    className: "ImageFileCreateEntry",
-    modelProperties: {
-      name: {
-        nullable: false,
-        serializedName: "name",
-        type: {
-          name: "String"
-        }
-      },
-      contents: {
-        nullable: false,
-        serializedName: "contents",
-        type: {
-          name: "ByteArray"
-        }
-      },
-      tagIds: {
-        serializedName: "tagIds",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Uuid"
-            }
-          }
-        }
-      },
-      regions: {
-        serializedName: "regions",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "Region"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const ImageFileCreateBatch: msRest.CompositeMapper = {
-  serializedName: "ImageFileCreateBatch",
-  type: {
-    name: "Composite",
-    className: "ImageFileCreateBatch",
-    modelProperties: {
-      images: {
-        serializedName: "images",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "ImageFileCreateEntry"
-            }
-          }
-        }
-      },
-      tagIds: {
-        serializedName: "tagIds",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Uuid"
-            }
-          }
         }
       }
     }
@@ -837,154 +1321,60 @@ export const ImageUrlCreateBatch: msRest.CompositeMapper = {
   }
 };
 
-export const ImageIdCreateEntry: msRest.CompositeMapper = {
-  serializedName: "ImageIdCreateEntry",
+export const Iteration: msRest.CompositeMapper = {
+  serializedName: "Iteration",
   type: {
     name: "Composite",
-    className: "ImageIdCreateEntry",
+    className: "Iteration",
     modelProperties: {
       id: {
         nullable: false,
+        readOnly: true,
         serializedName: "id",
         type: {
           name: "Uuid"
         }
       },
-      tagIds: {
-        serializedName: "tagIds",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Uuid"
-            }
-          }
-        }
-      },
-      regions: {
-        serializedName: "regions",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "Region"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const ImageIdCreateBatch: msRest.CompositeMapper = {
-  serializedName: "ImageIdCreateBatch",
-  type: {
-    name: "Composite",
-    className: "ImageIdCreateBatch",
-    modelProperties: {
-      images: {
-        serializedName: "images",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "ImageIdCreateEntry"
-            }
-          }
-        }
-      },
-      tagIds: {
-        serializedName: "tagIds",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Uuid"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const BoundingBox: msRest.CompositeMapper = {
-  serializedName: "BoundingBox",
-  type: {
-    name: "Composite",
-    className: "BoundingBox",
-    modelProperties: {
-      left: {
+      name: {
         required: true,
         nullable: false,
-        serializedName: "left",
+        serializedName: "name",
         type: {
-          name: "Number"
+          name: "String"
         }
       },
-      top: {
-        required: true,
-        nullable: false,
-        serializedName: "top",
-        type: {
-          name: "Number"
-        }
-      },
-      width: {
-        required: true,
-        nullable: false,
-        serializedName: "width",
-        type: {
-          name: "Number"
-        }
-      },
-      height: {
-        required: true,
-        nullable: false,
-        serializedName: "height",
-        type: {
-          name: "Number"
-        }
-      }
-    }
-  }
-};
-
-export const RegionProposal: msRest.CompositeMapper = {
-  serializedName: "RegionProposal",
-  type: {
-    name: "Composite",
-    className: "RegionProposal",
-    modelProperties: {
-      confidence: {
+      status: {
         nullable: false,
         readOnly: true,
-        serializedName: "confidence",
+        serializedName: "status",
         type: {
-          name: "Number"
+          name: "String"
         }
       },
-      boundingBox: {
+      created: {
         nullable: false,
         readOnly: true,
-        serializedName: "boundingBox",
+        serializedName: "created",
         type: {
-          name: "Composite",
-          className: "BoundingBox"
+          name: "DateTime"
         }
-      }
-    }
-  }
-};
-
-export const ImageRegionProposal: msRest.CompositeMapper = {
-  serializedName: "ImageRegionProposal",
-  type: {
-    name: "Composite",
-    className: "ImageRegionProposal",
-    modelProperties: {
+      },
+      lastModified: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "lastModified",
+        type: {
+          name: "DateTime"
+        }
+      },
+      trainedAt: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "trainedAt",
+        type: {
+          name: "DateTime"
+        }
+      },
       projectId: {
         nullable: false,
         readOnly: true,
@@ -993,372 +1383,80 @@ export const ImageRegionProposal: msRest.CompositeMapper = {
           name: "Uuid"
         }
       },
-      imageId: {
+      exportable: {
         nullable: false,
         readOnly: true,
-        serializedName: "imageId",
+        serializedName: "exportable",
         type: {
-          name: "Uuid"
+          name: "Boolean"
         }
       },
-      proposals: {
+      exportableTo: {
         readOnly: true,
-        serializedName: "proposals",
+        serializedName: "exportableTo",
         type: {
           name: "Sequence",
           element: {
             type: {
-              name: "Composite",
-              className: "RegionProposal"
+              name: "String"
             }
           }
         }
-      }
-    }
-  }
-};
-
-export const ImageUrl: msRest.CompositeMapper = {
-  serializedName: "ImageUrl",
-  type: {
-    name: "Composite",
-    className: "ImageUrl",
-    modelProperties: {
-      url: {
-        required: true,
-        nullable: false,
-        serializedName: "url",
+      },
+      domainId: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "domainId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      classificationType: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "classificationType",
         type: {
           name: "String"
         }
-      }
-    }
-  }
-};
-
-export const Prediction: msRest.CompositeMapper = {
-  serializedName: "Prediction",
-  type: {
-    name: "Composite",
-    className: "Prediction",
-    modelProperties: {
-      probability: {
+      },
+      trainingType: {
         nullable: false,
         readOnly: true,
-        serializedName: "probability",
+        serializedName: "trainingType",
+        type: {
+          name: "String"
+        }
+      },
+      reservedBudgetInHours: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "reservedBudgetInHours",
         type: {
           name: "Number"
         }
       },
-      tagId: {
+      trainingTimeInMinutes: {
         nullable: false,
         readOnly: true,
-        serializedName: "tagId",
-        type: {
-          name: "Uuid"
-        }
-      },
-      tagName: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "tagName",
-        type: {
-          name: "String"
-        }
-      },
-      boundingBox: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "boundingBox",
-        type: {
-          name: "Composite",
-          className: "BoundingBox"
-        }
-      }
-    }
-  }
-};
-
-export const ImagePrediction: msRest.CompositeMapper = {
-  serializedName: "ImagePrediction",
-  type: {
-    name: "Composite",
-    className: "ImagePrediction",
-    modelProperties: {
-      id: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "id",
-        type: {
-          name: "Uuid"
-        }
-      },
-      project: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "project",
-        type: {
-          name: "Uuid"
-        }
-      },
-      iteration: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "iteration",
-        type: {
-          name: "Uuid"
-        }
-      },
-      created: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "created",
-        type: {
-          name: "DateTime"
-        }
-      },
-      predictions: {
-        readOnly: true,
-        serializedName: "predictions",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "Prediction"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const PredictionQueryTag: msRest.CompositeMapper = {
-  serializedName: "PredictionQueryTag",
-  type: {
-    name: "Composite",
-    className: "PredictionQueryTag",
-    modelProperties: {
-      id: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "id",
-        type: {
-          name: "Uuid"
-        }
-      },
-      minThreshold: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "minThreshold",
+        serializedName: "trainingTimeInMinutes",
         type: {
           name: "Number"
         }
       },
-      maxThreshold: {
+      publishName: {
         nullable: false,
         readOnly: true,
-        serializedName: "maxThreshold",
-        type: {
-          name: "Number"
-        }
-      }
-    }
-  }
-};
-
-export const PredictionQueryToken: msRest.CompositeMapper = {
-  serializedName: "PredictionQueryToken",
-  type: {
-    name: "Composite",
-    className: "PredictionQueryToken",
-    modelProperties: {
-      session: {
-        nullable: false,
-        serializedName: "session",
+        serializedName: "publishName",
         type: {
           name: "String"
         }
       },
-      continuation: {
+      originalPublishResourceId: {
         nullable: false,
-        serializedName: "continuation",
+        readOnly: true,
+        serializedName: "originalPublishResourceId",
         type: {
           name: "String"
-        }
-      },
-      maxCount: {
-        nullable: false,
-        serializedName: "maxCount",
-        type: {
-          name: "Number"
-        }
-      },
-      orderBy: {
-        nullable: false,
-        serializedName: "orderBy",
-        type: {
-          name: "String"
-        }
-      },
-      tags: {
-        serializedName: "tags",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "PredictionQueryTag"
-            }
-          }
-        }
-      },
-      iterationId: {
-        nullable: true,
-        serializedName: "iterationId",
-        type: {
-          name: "Uuid"
-        }
-      },
-      startTime: {
-        nullable: true,
-        serializedName: "startTime",
-        type: {
-          name: "DateTime"
-        }
-      },
-      endTime: {
-        nullable: true,
-        serializedName: "endTime",
-        type: {
-          name: "DateTime"
-        }
-      },
-      application: {
-        nullable: false,
-        serializedName: "application",
-        type: {
-          name: "String"
-        }
-      }
-    }
-  }
-};
-
-export const StoredImagePrediction: msRest.CompositeMapper = {
-  serializedName: "StoredImagePrediction",
-  type: {
-    name: "Composite",
-    className: "StoredImagePrediction",
-    modelProperties: {
-      resizedImageUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "resizedImageUri",
-        type: {
-          name: "String"
-        }
-      },
-      thumbnailUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "thumbnailUri",
-        type: {
-          name: "String"
-        }
-      },
-      originalImageUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "originalImageUri",
-        type: {
-          name: "String"
-        }
-      },
-      domain: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "domain",
-        type: {
-          name: "Uuid"
-        }
-      },
-      id: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "id",
-        type: {
-          name: "Uuid"
-        }
-      },
-      project: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "project",
-        type: {
-          name: "Uuid"
-        }
-      },
-      iteration: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "iteration",
-        type: {
-          name: "Uuid"
-        }
-      },
-      created: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "created",
-        type: {
-          name: "DateTime"
-        }
-      },
-      predictions: {
-        readOnly: true,
-        serializedName: "predictions",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "Prediction"
-            }
-          }
-        }
-      }
-    }
-  }
-};
-
-export const PredictionQueryResult: msRest.CompositeMapper = {
-  serializedName: "PredictionQueryResult",
-  type: {
-    name: "Composite",
-    className: "PredictionQueryResult",
-    modelProperties: {
-      token: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "token",
-        type: {
-          name: "Composite",
-          className: "PredictionQueryToken"
-        }
-      },
-      results: {
-        readOnly: true,
-        serializedName: "results",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "StoredImagePrediction"
-            }
-          }
         }
       }
     }
@@ -1494,30 +1592,170 @@ export const IterationPerformance: msRest.CompositeMapper = {
   }
 };
 
-export const ImagePerformance: msRest.CompositeMapper = {
-  serializedName: "ImagePerformance",
+export const PredictionQueryTag: msRest.CompositeMapper = {
+  serializedName: "PredictionQueryTag",
   type: {
     name: "Composite",
-    className: "ImagePerformance",
+    className: "PredictionQueryTag",
     modelProperties: {
-      predictions: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "predictions",
+      id: {
+        nullable: false,
+        serializedName: "id",
+        type: {
+          name: "Uuid"
+        }
+      },
+      minThreshold: {
+        nullable: false,
+        serializedName: "minThreshold",
+        type: {
+          name: "Number"
+        }
+      },
+      maxThreshold: {
+        nullable: false,
+        serializedName: "maxThreshold",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const PredictionQueryToken: msRest.CompositeMapper = {
+  serializedName: "PredictionQueryToken",
+  type: {
+    name: "Composite",
+    className: "PredictionQueryToken",
+    modelProperties: {
+      session: {
+        nullable: false,
+        serializedName: "session",
+        type: {
+          name: "String"
+        }
+      },
+      continuation: {
+        nullable: false,
+        serializedName: "continuation",
+        type: {
+          name: "String"
+        }
+      },
+      maxCount: {
+        nullable: false,
+        serializedName: "maxCount",
+        type: {
+          name: "Number"
+        }
+      },
+      orderBy: {
+        nullable: false,
+        serializedName: "orderBy",
+        type: {
+          name: "String"
+        }
+      },
+      tags: {
+        serializedName: "tags",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "Prediction"
+              className: "PredictionQueryTag"
             }
           }
+        }
+      },
+      iterationId: {
+        nullable: true,
+        serializedName: "iterationId",
+        type: {
+          name: "Uuid"
+        }
+      },
+      startTime: {
+        nullable: true,
+        serializedName: "startTime",
+        type: {
+          name: "DateTime"
+        }
+      },
+      endTime: {
+        nullable: true,
+        serializedName: "endTime",
+        type: {
+          name: "DateTime"
+        }
+      },
+      application: {
+        nullable: false,
+        serializedName: "application",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const StoredImagePrediction: msRest.CompositeMapper = {
+  serializedName: "StoredImagePrediction",
+  type: {
+    name: "Composite",
+    className: "StoredImagePrediction",
+    modelProperties: {
+      resizedImageUri: {
+        readOnly: true,
+        serializedName: "resizedImageUri",
+        type: {
+          name: "String"
+        }
+      },
+      thumbnailUri: {
+        readOnly: true,
+        serializedName: "thumbnailUri",
+        type: {
+          name: "String"
+        }
+      },
+      originalImageUri: {
+        readOnly: true,
+        serializedName: "originalImageUri",
+        type: {
+          name: "String"
+        }
+      },
+      domain: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "domain",
+        type: {
+          name: "Uuid"
         }
       },
       id: {
         nullable: false,
         readOnly: true,
         serializedName: "id",
+        type: {
+          name: "Uuid"
+        }
+      },
+      project: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "project",
+        type: {
+          name: "Uuid"
+        }
+      },
+      iteration: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "iteration",
         type: {
           name: "Uuid"
         }
@@ -1530,62 +1768,45 @@ export const ImagePerformance: msRest.CompositeMapper = {
           name: "DateTime"
         }
       },
-      width: {
-        nullable: false,
+      predictions: {
         readOnly: true,
-        serializedName: "width",
-        type: {
-          name: "Number"
-        }
-      },
-      height: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "height",
-        type: {
-          name: "Number"
-        }
-      },
-      imageUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "imageUri",
-        type: {
-          name: "String"
-        }
-      },
-      thumbnailUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "thumbnailUri",
-        type: {
-          name: "String"
-        }
-      },
-      tags: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "tags",
+        serializedName: "predictions",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "ImageTag"
+              className: "Prediction"
             }
           }
         }
+      }
+    }
+  }
+};
+
+export const PredictionQueryResult: msRest.CompositeMapper = {
+  serializedName: "PredictionQueryResult",
+  type: {
+    name: "Composite",
+    className: "PredictionQueryResult",
+    modelProperties: {
+      token: {
+        serializedName: "token",
+        type: {
+          name: "Composite",
+          className: "PredictionQueryToken"
+        }
       },
-      regions: {
-        nullable: true,
+      results: {
         readOnly: true,
-        serializedName: "regions",
+        serializedName: "results",
         type: {
           name: "Sequence",
           element: {
             type: {
               name: "Composite",
-              className: "ImageRegion"
+              className: "StoredImagePrediction"
             }
           }
         }
@@ -1624,6 +1845,29 @@ export const ProjectSettings: msRest.CompositeMapper = {
             }
           }
         }
+      },
+      useNegativeSet: {
+        nullable: true,
+        readOnly: true,
+        serializedName: "useNegativeSet",
+        type: {
+          name: "Boolean"
+        }
+      },
+      detectionParameters: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "detectionParameters",
+        type: {
+          name: "String"
+        }
+      },
+      imageProcessingSettings: {
+        serializedName: "imageProcessingSettings",
+        type: {
+          name: "Composite",
+          className: "ImageProcessingSettings"
+        }
       }
     }
   }
@@ -1653,7 +1897,7 @@ export const Project: msRest.CompositeMapper = {
       },
       description: {
         required: true,
-        nullable: false,
+        nullable: true,
         serializedName: "description",
         type: {
           name: "String"
@@ -1661,7 +1905,6 @@ export const Project: msRest.CompositeMapper = {
       },
       settings: {
         required: true,
-        nullable: false,
         serializedName: "settings",
         type: {
           name: "Composite",
@@ -1685,7 +1928,6 @@ export const Project: msRest.CompositeMapper = {
         }
       },
       thumbnailUri: {
-        nullable: false,
         readOnly: true,
         serializedName: "thumbnailUri",
         type: {
@@ -1699,17 +1941,127 @@ export const Project: msRest.CompositeMapper = {
         type: {
           name: "Boolean"
         }
+      },
+      status: {
+        nullable: false,
+        serializedName: "status",
+        type: {
+          name: "String"
+        }
       }
     }
   }
 };
 
-export const Iteration: msRest.CompositeMapper = {
-  serializedName: "Iteration",
+export const ProjectExport: msRest.CompositeMapper = {
+  serializedName: "ProjectExport",
   type: {
     name: "Composite",
-    className: "Iteration",
+    className: "ProjectExport",
     modelProperties: {
+      iterationCount: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "iterationCount",
+        type: {
+          name: "Number"
+        }
+      },
+      imageCount: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "imageCount",
+        type: {
+          name: "Number"
+        }
+      },
+      tagCount: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "tagCount",
+        type: {
+          name: "Number"
+        }
+      },
+      regionCount: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "regionCount",
+        type: {
+          name: "Number"
+        }
+      },
+      estimatedImportTimeInMS: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "estimatedImportTimeInMS",
+        type: {
+          name: "Number"
+        }
+      },
+      token: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "token",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const StoredSuggestedTagAndRegion: msRest.CompositeMapper = {
+  serializedName: "StoredSuggestedTagAndRegion",
+  type: {
+    name: "Composite",
+    className: "StoredSuggestedTagAndRegion",
+    modelProperties: {
+      width: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "width",
+        type: {
+          name: "Number"
+        }
+      },
+      height: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "height",
+        type: {
+          name: "Number"
+        }
+      },
+      resizedImageUri: {
+        readOnly: true,
+        serializedName: "resizedImageUri",
+        type: {
+          name: "String"
+        }
+      },
+      thumbnailUri: {
+        readOnly: true,
+        serializedName: "thumbnailUri",
+        type: {
+          name: "String"
+        }
+      },
+      originalImageUri: {
+        readOnly: true,
+        serializedName: "originalImageUri",
+        type: {
+          name: "String"
+        }
+      },
+      domain: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "domain",
+        type: {
+          name: "Uuid"
+        }
+      },
       id: {
         nullable: false,
         readOnly: true,
@@ -1718,20 +2070,20 @@ export const Iteration: msRest.CompositeMapper = {
           name: "Uuid"
         }
       },
-      name: {
-        required: true,
-        nullable: false,
-        serializedName: "name",
-        type: {
-          name: "String"
-        }
-      },
-      status: {
+      project: {
         nullable: false,
         readOnly: true,
-        serializedName: "status",
+        serializedName: "project",
         type: {
-          name: "String"
+          name: "Uuid"
+        }
+      },
+      iteration: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "iteration",
+        type: {
+          name: "Uuid"
         }
       },
       created: {
@@ -1742,94 +2094,142 @@ export const Iteration: msRest.CompositeMapper = {
           name: "DateTime"
         }
       },
-      lastModified: {
-        nullable: false,
+      predictions: {
         readOnly: true,
-        serializedName: "lastModified",
-        type: {
-          name: "DateTime"
-        }
-      },
-      trainedAt: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "trainedAt",
-        type: {
-          name: "DateTime"
-        }
-      },
-      projectId: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "projectId",
-        type: {
-          name: "Uuid"
-        }
-      },
-      exportable: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "exportable",
-        type: {
-          name: "Boolean"
-        }
-      },
-      exportableTo: {
-        readOnly: true,
-        serializedName: "exportableTo",
+        serializedName: "predictions",
         type: {
           name: "Sequence",
           element: {
             type: {
-              name: "String"
+              name: "Composite",
+              className: "Prediction"
             }
           }
         }
       },
-      domainId: {
-        nullable: true,
+      predictionUncertainty: {
+        nullable: false,
         readOnly: true,
-        serializedName: "domainId",
+        serializedName: "predictionUncertainty",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const SuggestedTagAndRegion: msRest.CompositeMapper = {
+  serializedName: "SuggestedTagAndRegion",
+  type: {
+    name: "Composite",
+    className: "SuggestedTagAndRegion",
+    modelProperties: {
+      id: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "id",
         type: {
           name: "Uuid"
         }
       },
-      classificationType: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "classificationType",
-        type: {
-          name: "String"
-        }
-      },
-      trainingType: {
+      project: {
         nullable: false,
         readOnly: true,
-        serializedName: "trainingType",
+        serializedName: "project",
         type: {
-          name: "String"
+          name: "Uuid"
         }
       },
-      reservedBudgetInHours: {
+      iteration: {
         nullable: false,
         readOnly: true,
-        serializedName: "reservedBudgetInHours",
+        serializedName: "iteration",
+        type: {
+          name: "Uuid"
+        }
+      },
+      created: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "created",
+        type: {
+          name: "DateTime"
+        }
+      },
+      predictions: {
+        readOnly: true,
+        serializedName: "predictions",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Prediction"
+            }
+          }
+        }
+      },
+      predictionUncertainty: {
+        nullable: false,
+        readOnly: true,
+        serializedName: "predictionUncertainty",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const SuggestedTagAndRegionQueryToken: msRest.CompositeMapper = {
+  serializedName: "SuggestedTagAndRegionQueryToken",
+  type: {
+    name: "Composite",
+    className: "SuggestedTagAndRegionQueryToken",
+    modelProperties: {
+      tagIds: {
+        serializedName: "tagIds",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Uuid"
+            }
+          }
+        }
+      },
+      threshold: {
+        nullable: false,
+        serializedName: "threshold",
         type: {
           name: "Number"
         }
       },
-      publishName: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "publishName",
+      session: {
+        nullable: false,
+        serializedName: "session",
         type: {
           name: "String"
         }
       },
-      originalPublishResourceId: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "originalPublishResourceId",
+      continuation: {
+        nullable: false,
+        serializedName: "continuation",
+        type: {
+          name: "String"
+        }
+      },
+      maxCount: {
+        nullable: false,
+        serializedName: "maxCount",
+        type: {
+          name: "Number"
+        }
+      },
+      sortBy: {
+        nullable: false,
+        serializedName: "sortBy",
         type: {
           name: "String"
         }
@@ -1838,50 +2238,30 @@ export const Iteration: msRest.CompositeMapper = {
   }
 };
 
-export const ExportModel: msRest.CompositeMapper = {
-  serializedName: "Export",
+export const SuggestedTagAndRegionQuery: msRest.CompositeMapper = {
+  serializedName: "SuggestedTagAndRegionQuery",
   type: {
     name: "Composite",
-    className: "ExportModel",
+    className: "SuggestedTagAndRegionQuery",
     modelProperties: {
-      platform: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "platform",
+      token: {
+        serializedName: "token",
         type: {
-          name: "String"
+          name: "Composite",
+          className: "SuggestedTagAndRegionQueryToken"
         }
       },
-      status: {
-        nullable: false,
+      results: {
         readOnly: true,
-        serializedName: "status",
+        serializedName: "results",
         type: {
-          name: "String"
-        }
-      },
-      downloadUri: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "downloadUri",
-        type: {
-          name: "String"
-        }
-      },
-      flavor: {
-        nullable: true,
-        readOnly: true,
-        serializedName: "flavor",
-        type: {
-          name: "String"
-        }
-      },
-      newerVersionAvailable: {
-        nullable: false,
-        readOnly: true,
-        serializedName: "newerVersionAvailable",
-        type: {
-          name: "Boolean"
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "StoredSuggestedTagAndRegion"
+            }
+          }
         }
       }
     }
@@ -1912,7 +2292,7 @@ export const Tag: msRest.CompositeMapper = {
       },
       description: {
         required: true,
-        nullable: false,
+        nullable: true,
         serializedName: "description",
         type: {
           name: "String"
@@ -1938,24 +2318,49 @@ export const Tag: msRest.CompositeMapper = {
   }
 };
 
-export const CustomVisionError: msRest.CompositeMapper = {
-  serializedName: "CustomVisionError",
+export const TagFilter: msRest.CompositeMapper = {
+  serializedName: "TagFilter",
   type: {
     name: "Composite",
-    className: "CustomVisionError",
+    className: "TagFilter",
     modelProperties: {
-      code: {
-        required: true,
-        serializedName: "code",
+      tagIds: {
+        serializedName: "tagIds",
         type: {
-          name: "String"
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Uuid"
+            }
+          }
         }
       },
-      message: {
-        required: true,
-        serializedName: "message",
+      threshold: {
+        nullable: false,
+        serializedName: "threshold",
         type: {
-          name: "String"
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const TrainingParameters: msRest.CompositeMapper = {
+  serializedName: "TrainingParameters",
+  type: {
+    name: "Composite",
+    className: "TrainingParameters",
+    modelProperties: {
+      selectedTags: {
+        serializedName: "selectedTags",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Uuid"
+            }
+          }
         }
       }
     }

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/parameters.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/models/parameters.ts
@@ -10,13 +10,27 @@
 
 import * as msRest from "@azure/ms-rest-js";
 
-export const apiKey: msRest.OperationParameter = {
-  parameterPath: "apiKey",
+export const allImages: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "allImages"
+  ],
   mapper: {
-    required: true,
-    serializedName: "Training-Key",
+    serializedName: "allImages",
     type: {
-      name: "String"
+      name: "Boolean"
+    }
+  }
+};
+export const allIterations: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "allIterations"
+  ],
+  mapper: {
+    serializedName: "allIterations",
+    type: {
+      name: "Boolean"
     }
   }
 };
@@ -144,26 +158,6 @@ export const imageId: msRest.OperationURLParameter = {
   }
 };
 export const imageIds0: msRest.OperationQueryParameter = {
-  parameterPath: "imageIds",
-  mapper: {
-    required: true,
-    serializedName: "imageIds",
-    constraints: {
-      MaxItems: 64,
-      MinItems: 0
-    },
-    type: {
-      name: "Sequence",
-      element: {
-        type: {
-          name: "Uuid"
-        }
-      }
-    }
-  },
-  collectionFormat: msRest.QueryCollectionFormat.Csv
-};
-export const imageIds1: msRest.OperationQueryParameter = {
   parameterPath: [
     "options",
     "imageIds"
@@ -185,13 +179,13 @@ export const imageIds1: msRest.OperationQueryParameter = {
   },
   collectionFormat: msRest.QueryCollectionFormat.Csv
 };
-export const imageIds2: msRest.OperationQueryParameter = {
+export const imageIds1: msRest.OperationQueryParameter = {
   parameterPath: "imageIds",
   mapper: {
     required: true,
     serializedName: "imageIds",
     constraints: {
-      MaxItems: 256,
+      MaxItems: 64,
       MinItems: 0
     },
     type: {
@@ -217,7 +211,7 @@ export const iterationId0: msRest.OperationQueryParameter = {
     }
   }
 };
-export const iterationId1: msRest.OperationURLParameter = {
+export const iterationId1: msRest.OperationQueryParameter = {
   parameterPath: "iterationId",
   mapper: {
     required: true,
@@ -359,6 +353,19 @@ export const skip: msRest.OperationQueryParameter = {
     }
   }
 };
+export const store: msRest.OperationQueryParameter = {
+  parameterPath: [
+    "options",
+    "store"
+  ],
+  mapper: {
+    serializedName: "store",
+    defaultValue: true,
+    type: {
+      name: "Boolean"
+    }
+  }
+};
 export const tagId: msRest.OperationURLParameter = {
   parameterPath: "tagId",
   mapper: {
@@ -376,22 +383,6 @@ export const tagIds0: msRest.OperationQueryParameter = {
   ],
   mapper: {
     serializedName: "tagIds",
-    type: {
-      name: "Sequence",
-      element: {
-        type: {
-          name: "Uuid"
-        }
-      }
-    }
-  },
-  collectionFormat: msRest.QueryCollectionFormat.Csv
-};
-export const tagIds1: msRest.OperationQueryParameter = {
-  parameterPath: "tagIds",
-  mapper: {
-    required: true,
-    serializedName: "tagIds",
     constraints: {
       MaxItems: 20,
       MinItems: 0
@@ -407,12 +398,28 @@ export const tagIds1: msRest.OperationQueryParameter = {
   },
   collectionFormat: msRest.QueryCollectionFormat.Csv
 };
-export const tagIds2: msRest.OperationQueryParameter = {
+export const tagIds1: msRest.OperationQueryParameter = {
   parameterPath: [
     "options",
     "tagIds"
   ],
   mapper: {
+    serializedName: "tagIds",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "Uuid"
+        }
+      }
+    }
+  },
+  collectionFormat: msRest.QueryCollectionFormat.Csv
+};
+export const tagIds2: msRest.OperationQueryParameter = {
+  parameterPath: "tagIds",
+  mapper: {
+    required: true,
     serializedName: "tagIds",
     constraints: {
       MaxItems: 20,
@@ -473,6 +480,16 @@ export const threshold: msRest.OperationQueryParameter = {
     serializedName: "threshold",
     type: {
       name: "Number"
+    }
+  }
+};
+export const token: msRest.OperationQueryParameter = {
+  parameterPath: "token",
+  mapper: {
+    required: true,
+    serializedName: "token",
+    type: {
+      name: "String"
     }
   }
 };

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClient.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClient.ts
@@ -17,12 +17,12 @@ import { TrainingAPIClientContext } from "./trainingAPIClientContext";
 class TrainingAPIClient extends TrainingAPIClientContext {
   /**
    * Initializes a new instance of the TrainingAPIClient class.
-   * @param apiKey API key.
    * @param endpoint Supported Cognitive Services endpoints.
+   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(apiKey: string, endpoint: string, options?: msRest.ServiceClientOptions) {
-    super(apiKey, endpoint, options);
+  constructor(credentials: msRest.ServiceClientCredentials, endpoint: string, options?: msRest.ServiceClientOptions) {
+    super(credentials, endpoint, options);
   }
 
   /**
@@ -75,743 +75,6 @@ class TrainingAPIClient extends TrainingAPIClientContext {
       },
       getDomainOperationSpec,
       callback) as Promise<Models.GetDomainResponse>;
-  }
-
-  /**
-   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
-   * "Dog" and
-   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
-   * @summary Gets the number of images tagged with the provided {tagIds}.
-   * @param projectId The project id.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetTaggedImageCountResponse>
-   */
-  getTaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetTaggedImageCountOptionalParams): Promise<Models.GetTaggedImageCountResponse>;
-  /**
-   * @param projectId The project id.
-   * @param callback The callback
-   */
-  getTaggedImageCount(projectId: string, callback: msRest.ServiceCallback<number>): void;
-  /**
-   * @param projectId The project id.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getTaggedImageCount(projectId: string, options: Models.TrainingAPIClientGetTaggedImageCountOptionalParams, callback: msRest.ServiceCallback<number>): void;
-  getTaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetTaggedImageCountOptionalParams | msRest.ServiceCallback<number>, callback?: msRest.ServiceCallback<number>): Promise<Models.GetTaggedImageCountResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        options
-      },
-      getTaggedImageCountOperationSpec,
-      callback) as Promise<Models.GetTaggedImageCountResponse>;
-  }
-
-  /**
-   * This API returns the images which have no tags for a given project and optionally an iteration.
-   * If no iteration is specified the
-   * current workspace is used.
-   * @summary Gets the number of untagged images.
-   * @param projectId The project id.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetUntaggedImageCountResponse>
-   */
-  getUntaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImageCountOptionalParams): Promise<Models.GetUntaggedImageCountResponse>;
-  /**
-   * @param projectId The project id.
-   * @param callback The callback
-   */
-  getUntaggedImageCount(projectId: string, callback: msRest.ServiceCallback<number>): void;
-  /**
-   * @param projectId The project id.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getUntaggedImageCount(projectId: string, options: Models.TrainingAPIClientGetUntaggedImageCountOptionalParams, callback: msRest.ServiceCallback<number>): void;
-  getUntaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImageCountOptionalParams | msRest.ServiceCallback<number>, callback?: msRest.ServiceCallback<number>): Promise<Models.GetUntaggedImageCountResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        options
-      },
-      getUntaggedImageCountOperationSpec,
-      callback) as Promise<Models.GetUntaggedImageCountResponse>;
-  }
-
-  /**
-   * @summary Associate a set of images with a set of tags.
-   * @param projectId The project id.
-   * @param batch Batch of image tags. Limited to 128 tags per batch.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.CreateImageTagsResponse>
-   */
-  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImageTagsResponse>;
-  /**
-   * @param projectId The project id.
-   * @param batch Batch of image tags. Limited to 128 tags per batch.
-   * @param callback The callback
-   */
-  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, callback: msRest.ServiceCallback<Models.ImageTagCreateSummary>): void;
-  /**
-   * @param projectId The project id.
-   * @param batch Batch of image tags. Limited to 128 tags per batch.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageTagCreateSummary>): void;
-  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageTagCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageTagCreateSummary>): Promise<Models.CreateImageTagsResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        batch,
-        options
-      },
-      createImageTagsOperationSpec,
-      callback) as Promise<Models.CreateImageTagsResponse>;
-  }
-
-  /**
-   * @summary Remove a set of tags from a set of images.
-   * @param projectId The project id.
-   * @param imageIds Image ids. Limited to 64 images.
-   * @param tagIds Tags to be deleted from the specified images. Limited to 20 tags.
-   * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
-   */
-  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
-  /**
-   * @param projectId The project id.
-   * @param imageIds Image ids. Limited to 64 images.
-   * @param tagIds Tags to be deleted from the specified images. Limited to 20 tags.
-   * @param callback The callback
-   */
-  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], callback: msRest.ServiceCallback<void>): void;
-  /**
-   * @param projectId The project id.
-   * @param imageIds Image ids. Limited to 64 images.
-   * @param tagIds Tags to be deleted from the specified images. Limited to 20 tags.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        imageIds,
-        tagIds,
-        options
-      },
-      deleteImageTagsOperationSpec,
-      callback);
-  }
-
-  /**
-   * This API accepts a batch of image regions, and optionally tags, to update existing images with
-   * region information.
-   * There is a limit of 64 entries in the batch.
-   * @summary Create a set of image regions.
-   * @param projectId The project id.
-   * @param batch Batch of image regions which include a tag and bounding box. Limited to 64.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.CreateImageRegionsResponse>
-   */
-  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImageRegionsResponse>;
-  /**
-   * @param projectId The project id.
-   * @param batch Batch of image regions which include a tag and bounding box. Limited to 64.
-   * @param callback The callback
-   */
-  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, callback: msRest.ServiceCallback<Models.ImageRegionCreateSummary>): void;
-  /**
-   * @param projectId The project id.
-   * @param batch Batch of image regions which include a tag and bounding box. Limited to 64.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageRegionCreateSummary>): void;
-  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageRegionCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageRegionCreateSummary>): Promise<Models.CreateImageRegionsResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        batch,
-        options
-      },
-      createImageRegionsOperationSpec,
-      callback) as Promise<Models.CreateImageRegionsResponse>;
-  }
-
-  /**
-   * @summary Delete a set of image regions.
-   * @param projectId The project id.
-   * @param regionIds Regions to delete. Limited to 64.
-   * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
-   */
-  deleteImageRegions(projectId: string, regionIds: string[], options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
-  /**
-   * @param projectId The project id.
-   * @param regionIds Regions to delete. Limited to 64.
-   * @param callback The callback
-   */
-  deleteImageRegions(projectId: string, regionIds: string[], callback: msRest.ServiceCallback<void>): void;
-  /**
-   * @param projectId The project id.
-   * @param regionIds Regions to delete. Limited to 64.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  deleteImageRegions(projectId: string, regionIds: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteImageRegions(projectId: string, regionIds: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        regionIds,
-        options
-      },
-      deleteImageRegionsOperationSpec,
-      callback);
-  }
-
-  /**
-   * This API supports batching and range selection. By default it will only return first 50 images
-   * matching images.
-   * Use the {take} and {skip} parameters to control how many images to return in a given batch.
-   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
-   * "Dog" and
-   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
-   * @summary Get tagged images for a given project iteration.
-   * @param projectId The project id.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetTaggedImagesResponse>
-   */
-  getTaggedImages(projectId: string, options?: Models.TrainingAPIClientGetTaggedImagesOptionalParams): Promise<Models.GetTaggedImagesResponse>;
-  /**
-   * @param projectId The project id.
-   * @param callback The callback
-   */
-  getTaggedImages(projectId: string, callback: msRest.ServiceCallback<Models.Image[]>): void;
-  /**
-   * @param projectId The project id.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getTaggedImages(projectId: string, options: Models.TrainingAPIClientGetTaggedImagesOptionalParams, callback: msRest.ServiceCallback<Models.Image[]>): void;
-  getTaggedImages(projectId: string, options?: Models.TrainingAPIClientGetTaggedImagesOptionalParams | msRest.ServiceCallback<Models.Image[]>, callback?: msRest.ServiceCallback<Models.Image[]>): Promise<Models.GetTaggedImagesResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        options
-      },
-      getTaggedImagesOperationSpec,
-      callback) as Promise<Models.GetTaggedImagesResponse>;
-  }
-
-  /**
-   * This API supports batching and range selection. By default it will only return first 50 images
-   * matching images.
-   * Use the {take} and {skip} parameters to control how many images to return in a given batch.
-   * @summary Get untagged images for a given project iteration.
-   * @param projectId The project id.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetUntaggedImagesResponse>
-   */
-  getUntaggedImages(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImagesOptionalParams): Promise<Models.GetUntaggedImagesResponse>;
-  /**
-   * @param projectId The project id.
-   * @param callback The callback
-   */
-  getUntaggedImages(projectId: string, callback: msRest.ServiceCallback<Models.Image[]>): void;
-  /**
-   * @param projectId The project id.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getUntaggedImages(projectId: string, options: Models.TrainingAPIClientGetUntaggedImagesOptionalParams, callback: msRest.ServiceCallback<Models.Image[]>): void;
-  getUntaggedImages(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImagesOptionalParams | msRest.ServiceCallback<Models.Image[]>, callback?: msRest.ServiceCallback<Models.Image[]>): Promise<Models.GetUntaggedImagesResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        options
-      },
-      getUntaggedImagesOperationSpec,
-      callback) as Promise<Models.GetUntaggedImagesResponse>;
-  }
-
-  /**
-   * This API will return a set of Images for the specified tags and optionally iteration. If no
-   * iteration is specified the
-   * current workspace is used.
-   * @summary Get images by id for a given project iteration.
-   * @param projectId The project id.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetImagesByIdsResponse>
-   */
-  getImagesByIds(projectId: string, options?: Models.TrainingAPIClientGetImagesByIdsOptionalParams): Promise<Models.GetImagesByIdsResponse>;
-  /**
-   * @param projectId The project id.
-   * @param callback The callback
-   */
-  getImagesByIds(projectId: string, callback: msRest.ServiceCallback<Models.Image[]>): void;
-  /**
-   * @param projectId The project id.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getImagesByIds(projectId: string, options: Models.TrainingAPIClientGetImagesByIdsOptionalParams, callback: msRest.ServiceCallback<Models.Image[]>): void;
-  getImagesByIds(projectId: string, options?: Models.TrainingAPIClientGetImagesByIdsOptionalParams | msRest.ServiceCallback<Models.Image[]>, callback?: msRest.ServiceCallback<Models.Image[]>): Promise<Models.GetImagesByIdsResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        options
-      },
-      getImagesByIdsOperationSpec,
-      callback) as Promise<Models.GetImagesByIdsResponse>;
-  }
-
-  /**
-   * This API accepts body content as multipart/form-data and application/octet-stream. When using
-   * multipart
-   * multiple image files can be sent at once, with a maximum of 64 files
-   * @summary Add the provided images to the set of training images.
-   * @param projectId The project id.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 6MB.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.CreateImagesFromDataResponse>
-   */
-  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientCreateImagesFromDataOptionalParams): Promise<Models.CreateImagesFromDataResponse>;
-  /**
-   * @param projectId The project id.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 6MB.
-   * @param callback The callback
-   */
-  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  /**
-   * @param projectId The project id.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 6MB.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, options: Models.TrainingAPIClientCreateImagesFromDataOptionalParams, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientCreateImagesFromDataOptionalParams | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromDataResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        imageData,
-        options
-      },
-      createImagesFromDataOperationSpec,
-      callback) as Promise<Models.CreateImagesFromDataResponse>;
-  }
-
-  /**
-   * @summary Delete images from the set of training images.
-   * @param projectId The project id.
-   * @param imageIds Ids of the images to be deleted. Limited to 256 images per batch.
-   * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
-   */
-  deleteImages(projectId: string, imageIds: string[], options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
-  /**
-   * @param projectId The project id.
-   * @param imageIds Ids of the images to be deleted. Limited to 256 images per batch.
-   * @param callback The callback
-   */
-  deleteImages(projectId: string, imageIds: string[], callback: msRest.ServiceCallback<void>): void;
-  /**
-   * @param projectId The project id.
-   * @param imageIds Ids of the images to be deleted. Limited to 256 images per batch.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  deleteImages(projectId: string, imageIds: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deleteImages(projectId: string, imageIds: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        imageIds,
-        options
-      },
-      deleteImagesOperationSpec,
-      callback);
-  }
-
-  /**
-   * This API accepts a batch of files, and optionally tags, to create images. There is a limit of 64
-   * images and 20 tags.
-   * @summary Add the provided batch of images to the set of training images.
-   * @param projectId The project id.
-   * @param batch The batch of image files to add. Limited to 64 images and 20 tags per batch.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.CreateImagesFromFilesResponse>
-   */
-  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromFilesResponse>;
-  /**
-   * @param projectId The project id.
-   * @param batch The batch of image files to add. Limited to 64 images and 20 tags per batch.
-   * @param callback The callback
-   */
-  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  /**
-   * @param projectId The project id.
-   * @param batch The batch of image files to add. Limited to 64 images and 20 tags per batch.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromFilesResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        batch,
-        options
-      },
-      createImagesFromFilesOperationSpec,
-      callback) as Promise<Models.CreateImagesFromFilesResponse>;
-  }
-
-  /**
-   * This API accepts a batch of urls, and optionally tags, to create images. There is a limit of 64
-   * images and 20 tags.
-   * @summary Add the provided images urls to the set of training images.
-   * @param projectId The project id.
-   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.CreateImagesFromUrlsResponse>
-   */
-  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromUrlsResponse>;
-  /**
-   * @param projectId The project id.
-   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
-   * @param callback The callback
-   */
-  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  /**
-   * @param projectId The project id.
-   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromUrlsResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        batch,
-        options
-      },
-      createImagesFromUrlsOperationSpec,
-      callback) as Promise<Models.CreateImagesFromUrlsResponse>;
-  }
-
-  /**
-   * This API creates a batch of images from predicted images specified. There is a limit of 64
-   * images and 20 tags.
-   * @summary Add the specified predicted images to the set of training images.
-   * @param projectId The project id.
-   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.CreateImagesFromPredictionsResponse>
-   */
-  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromPredictionsResponse>;
-  /**
-   * @param projectId The project id.
-   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
-   * @param callback The callback
-   */
-  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  /**
-   * @param projectId The project id.
-   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
-  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromPredictionsResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        batch,
-        options
-      },
-      createImagesFromPredictionsOperationSpec,
-      callback) as Promise<Models.CreateImagesFromPredictionsResponse>;
-  }
-
-  /**
-   * This API will get region proposals for an image along with confidences for the region. It
-   * returns an empty array if no proposals are found.
-   * @summary Get region proposals for an image. Returns empty array if no proposals are found.
-   * @param projectId The project id.
-   * @param imageId The image id.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetImageRegionProposalsResponse>
-   */
-  getImageRegionProposals(projectId: string, imageId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetImageRegionProposalsResponse>;
-  /**
-   * @param projectId The project id.
-   * @param imageId The image id.
-   * @param callback The callback
-   */
-  getImageRegionProposals(projectId: string, imageId: string, callback: msRest.ServiceCallback<Models.ImageRegionProposal>): void;
-  /**
-   * @param projectId The project id.
-   * @param imageId The image id.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getImageRegionProposals(projectId: string, imageId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageRegionProposal>): void;
-  getImageRegionProposals(projectId: string, imageId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageRegionProposal>, callback?: msRest.ServiceCallback<Models.ImageRegionProposal>): Promise<Models.GetImageRegionProposalsResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        imageId,
-        options
-      },
-      getImageRegionProposalsOperationSpec,
-      callback) as Promise<Models.GetImageRegionProposalsResponse>;
-  }
-
-  /**
-   * @summary Delete a set of predicted images and their associated prediction results.
-   * @param projectId The project id.
-   * @param ids The prediction ids. Limited to 64.
-   * @param [options] The optional parameters
-   * @returns Promise<msRest.RestResponse>
-   */
-  deletePrediction(projectId: string, ids: string[], options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
-  /**
-   * @param projectId The project id.
-   * @param ids The prediction ids. Limited to 64.
-   * @param callback The callback
-   */
-  deletePrediction(projectId: string, ids: string[], callback: msRest.ServiceCallback<void>): void;
-  /**
-   * @param projectId The project id.
-   * @param ids The prediction ids. Limited to 64.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  deletePrediction(projectId: string, ids: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  deletePrediction(projectId: string, ids: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        ids,
-        options
-      },
-      deletePredictionOperationSpec,
-      callback);
-  }
-
-  /**
-   * @summary Quick test an image url.
-   * @param projectId The project to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.QuickTestImageUrlResponse>
-   */
-  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, options?: Models.TrainingAPIClientQuickTestImageUrlOptionalParams): Promise<Models.QuickTestImageUrlResponse>;
-  /**
-   * @param projectId The project to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param callback The callback
-   */
-  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  /**
-   * @param projectId The project to evaluate against.
-   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, options: Models.TrainingAPIClientQuickTestImageUrlOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, options?: Models.TrainingAPIClientQuickTestImageUrlOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.QuickTestImageUrlResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        imageUrl,
-        options
-      },
-      quickTestImageUrlOperationSpec,
-      callback) as Promise<Models.QuickTestImageUrlResponse>;
-  }
-
-  /**
-   * @summary Quick test an image.
-   * @param projectId The project id.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 6MB.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.QuickTestImageResponse>
-   */
-  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientQuickTestImageOptionalParams): Promise<Models.QuickTestImageResponse>;
-  /**
-   * @param projectId The project id.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 6MB.
-   * @param callback The callback
-   */
-  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  /**
-   * @param projectId The project id.
-   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
-   * images up to 6MB.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, options: Models.TrainingAPIClientQuickTestImageOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
-  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientQuickTestImageOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.QuickTestImageResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        imageData,
-        options
-      },
-      quickTestImageOperationSpec,
-      callback) as Promise<Models.QuickTestImageResponse>;
-  }
-
-  /**
-   * @summary Get images that were sent to your prediction endpoint.
-   * @param projectId The project id.
-   * @param query Parameters used to query the predictions. Limited to combining 2 tags.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.QueryPredictionsResponse>
-   */
-  queryPredictions(projectId: string, query: Models.PredictionQueryToken, options?: msRest.RequestOptionsBase): Promise<Models.QueryPredictionsResponse>;
-  /**
-   * @param projectId The project id.
-   * @param query Parameters used to query the predictions. Limited to combining 2 tags.
-   * @param callback The callback
-   */
-  queryPredictions(projectId: string, query: Models.PredictionQueryToken, callback: msRest.ServiceCallback<Models.PredictionQueryResult>): void;
-  /**
-   * @param projectId The project id.
-   * @param query Parameters used to query the predictions. Limited to combining 2 tags.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  queryPredictions(projectId: string, query: Models.PredictionQueryToken, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PredictionQueryResult>): void;
-  queryPredictions(projectId: string, query: Models.PredictionQueryToken, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PredictionQueryResult>, callback?: msRest.ServiceCallback<Models.PredictionQueryResult>): Promise<Models.QueryPredictionsResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        query,
-        options
-      },
-      queryPredictionsOperationSpec,
-      callback) as Promise<Models.QueryPredictionsResponse>;
-  }
-
-  /**
-   * @summary Get detailed performance information about an iteration.
-   * @param projectId The id of the project the iteration belongs to.
-   * @param iterationId The id of the iteration to get.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetIterationPerformanceResponse>
-   */
-  getIterationPerformance(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetIterationPerformanceOptionalParams): Promise<Models.GetIterationPerformanceResponse>;
-  /**
-   * @param projectId The id of the project the iteration belongs to.
-   * @param iterationId The id of the iteration to get.
-   * @param callback The callback
-   */
-  getIterationPerformance(projectId: string, iterationId: string, callback: msRest.ServiceCallback<Models.IterationPerformance>): void;
-  /**
-   * @param projectId The id of the project the iteration belongs to.
-   * @param iterationId The id of the iteration to get.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getIterationPerformance(projectId: string, iterationId: string, options: Models.TrainingAPIClientGetIterationPerformanceOptionalParams, callback: msRest.ServiceCallback<Models.IterationPerformance>): void;
-  getIterationPerformance(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetIterationPerformanceOptionalParams | msRest.ServiceCallback<Models.IterationPerformance>, callback?: msRest.ServiceCallback<Models.IterationPerformance>): Promise<Models.GetIterationPerformanceResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        iterationId,
-        options
-      },
-      getIterationPerformanceOperationSpec,
-      callback) as Promise<Models.GetIterationPerformanceResponse>;
-  }
-
-  /**
-   * This API supports batching and range selection. By default it will only return first 50 images
-   * matching images.
-   * Use the {take} and {skip} parameters to control how many images to return in a given batch.
-   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
-   * "Dog" and
-   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
-   * @summary Get image with its prediction for a given project iteration.
-   * @param projectId The project id.
-   * @param iterationId The iteration id. Defaults to workspace.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetImagePerformancesResponse>
-   */
-  getImagePerformances(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformancesOptionalParams): Promise<Models.GetImagePerformancesResponse>;
-  /**
-   * @param projectId The project id.
-   * @param iterationId The iteration id. Defaults to workspace.
-   * @param callback The callback
-   */
-  getImagePerformances(projectId: string, iterationId: string, callback: msRest.ServiceCallback<Models.ImagePerformance[]>): void;
-  /**
-   * @param projectId The project id.
-   * @param iterationId The iteration id. Defaults to workspace.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getImagePerformances(projectId: string, iterationId: string, options: Models.TrainingAPIClientGetImagePerformancesOptionalParams, callback: msRest.ServiceCallback<Models.ImagePerformance[]>): void;
-  getImagePerformances(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformancesOptionalParams | msRest.ServiceCallback<Models.ImagePerformance[]>, callback?: msRest.ServiceCallback<Models.ImagePerformance[]>): Promise<Models.GetImagePerformancesResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        iterationId,
-        options
-      },
-      getImagePerformancesOperationSpec,
-      callback) as Promise<Models.GetImagePerformancesResponse>;
-  }
-
-  /**
-   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
-   * "Dog" and
-   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
-   * @summary Gets the number of images tagged with the provided {tagIds} that have prediction
-   * results from
-   * training for the provided iteration {iterationId}.
-   * @param projectId The project id.
-   * @param iterationId The iteration id. Defaults to workspace.
-   * @param [options] The optional parameters
-   * @returns Promise<Models.GetImagePerformanceCountResponse>
-   */
-  getImagePerformanceCount(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformanceCountOptionalParams): Promise<Models.GetImagePerformanceCountResponse>;
-  /**
-   * @param projectId The project id.
-   * @param iterationId The iteration id. Defaults to workspace.
-   * @param callback The callback
-   */
-  getImagePerformanceCount(projectId: string, iterationId: string, callback: msRest.ServiceCallback<number>): void;
-  /**
-   * @param projectId The project id.
-   * @param iterationId The iteration id. Defaults to workspace.
-   * @param options The optional parameters
-   * @param callback The callback
-   */
-  getImagePerformanceCount(projectId: string, iterationId: string, options: Models.TrainingAPIClientGetImagePerformanceCountOptionalParams, callback: msRest.ServiceCallback<number>): void;
-  getImagePerformanceCount(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformanceCountOptionalParams | msRest.ServiceCallback<number>, callback?: msRest.ServiceCallback<number>): Promise<Models.GetImagePerformanceCountResponse> {
-    return this.sendOperationRequest(
-      {
-        projectId,
-        iterationId,
-        options
-      },
-      getImagePerformanceCountOperationSpec,
-      callback) as Promise<Models.GetImagePerformanceCountResponse>;
   }
 
   /**
@@ -955,31 +218,604 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
-   * @summary Queues project for training.
-   * @param projectId The project id.
+   * @summary Exports a project.
+   * @param projectId The project id of the project to export.
    * @param [options] The optional parameters
-   * @returns Promise<Models.TrainProjectResponse>
+   * @returns Promise<Models.ExportProjectResponse>
    */
-  trainProject(projectId: string, options?: Models.TrainingAPIClientTrainProjectOptionalParams): Promise<Models.TrainProjectResponse>;
+  exportProject(projectId: string, options?: msRest.RequestOptionsBase): Promise<Models.ExportProjectResponse>;
   /**
-   * @param projectId The project id.
+   * @param projectId The project id of the project to export.
    * @param callback The callback
    */
-  trainProject(projectId: string, callback: msRest.ServiceCallback<Models.Iteration>): void;
+  exportProject(projectId: string, callback: msRest.ServiceCallback<Models.ProjectExport>): void;
   /**
-   * @param projectId The project id.
+   * @param projectId The project id of the project to export.
    * @param options The optional parameters
    * @param callback The callback
    */
-  trainProject(projectId: string, options: Models.TrainingAPIClientTrainProjectOptionalParams, callback: msRest.ServiceCallback<Models.Iteration>): void;
-  trainProject(projectId: string, options?: Models.TrainingAPIClientTrainProjectOptionalParams | msRest.ServiceCallback<Models.Iteration>, callback?: msRest.ServiceCallback<Models.Iteration>): Promise<Models.TrainProjectResponse> {
+  exportProject(projectId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ProjectExport>): void;
+  exportProject(projectId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ProjectExport>, callback?: msRest.ServiceCallback<Models.ProjectExport>): Promise<Models.ExportProjectResponse> {
     return this.sendOperationRequest(
       {
         projectId,
         options
       },
-      trainProjectOperationSpec,
-      callback) as Promise<Models.TrainProjectResponse>;
+      exportProjectOperationSpec,
+      callback) as Promise<Models.ExportProjectResponse>;
+  }
+
+  /**
+   * This API accepts body content as multipart/form-data and application/octet-stream. When using
+   * multipart
+   * multiple image files can be sent at once, with a maximum of 64 files
+   * @summary Add the provided images to the set of training images.
+   * @param projectId The project id.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 6MB.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.CreateImagesFromDataResponse>
+   */
+  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientCreateImagesFromDataOptionalParams): Promise<Models.CreateImagesFromDataResponse>;
+  /**
+   * @param projectId The project id.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 6MB.
+   * @param callback The callback
+   */
+  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  /**
+   * @param projectId The project id.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 6MB.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, options: Models.TrainingAPIClientCreateImagesFromDataOptionalParams, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  createImagesFromData(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientCreateImagesFromDataOptionalParams | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromDataResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        imageData,
+        options
+      },
+      createImagesFromDataOperationSpec,
+      callback) as Promise<Models.CreateImagesFromDataResponse>;
+  }
+
+  /**
+   * @summary Delete images from the set of training images.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<msRest.RestResponse>
+   */
+  deleteImages(projectId: string, options?: Models.TrainingAPIClientDeleteImagesOptionalParams): Promise<msRest.RestResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  deleteImages(projectId: string, callback: msRest.ServiceCallback<void>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  deleteImages(projectId: string, options: Models.TrainingAPIClientDeleteImagesOptionalParams, callback: msRest.ServiceCallback<void>): void;
+  deleteImages(projectId: string, options?: Models.TrainingAPIClientDeleteImagesOptionalParams | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      deleteImagesOperationSpec,
+      callback);
+  }
+
+  /**
+   * This API will get region proposals for an image along with confidences for the region. It
+   * returns an empty array if no proposals are found.
+   * @summary Get region proposals for an image. Returns empty array if no proposals are found.
+   * @param projectId The project id.
+   * @param imageId The image id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetImageRegionProposalsResponse>
+   */
+  getImageRegionProposals(projectId: string, imageId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetImageRegionProposalsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param imageId The image id.
+   * @param callback The callback
+   */
+  getImageRegionProposals(projectId: string, imageId: string, callback: msRest.ServiceCallback<Models.ImageRegionProposal>): void;
+  /**
+   * @param projectId The project id.
+   * @param imageId The image id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getImageRegionProposals(projectId: string, imageId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageRegionProposal>): void;
+  getImageRegionProposals(projectId: string, imageId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageRegionProposal>, callback?: msRest.ServiceCallback<Models.ImageRegionProposal>): Promise<Models.GetImageRegionProposalsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        imageId,
+        options
+      },
+      getImageRegionProposalsOperationSpec,
+      callback) as Promise<Models.GetImageRegionProposalsResponse>;
+  }
+
+  /**
+   * This API accepts a batch of files, and optionally tags, to create images. There is a limit of 64
+   * images and 20 tags.
+   * @summary Add the provided batch of images to the set of training images.
+   * @param projectId The project id.
+   * @param batch The batch of image files to add. Limited to 64 images and 20 tags per batch.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.CreateImagesFromFilesResponse>
+   */
+  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromFilesResponse>;
+  /**
+   * @param projectId The project id.
+   * @param batch The batch of image files to add. Limited to 64 images and 20 tags per batch.
+   * @param callback The callback
+   */
+  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  /**
+   * @param projectId The project id.
+   * @param batch The batch of image files to add. Limited to 64 images and 20 tags per batch.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  createImagesFromFiles(projectId: string, batch: Models.ImageFileCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromFilesResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        batch,
+        options
+      },
+      createImagesFromFilesOperationSpec,
+      callback) as Promise<Models.CreateImagesFromFilesResponse>;
+  }
+
+  /**
+   * This API will return a set of Images for the specified tags and optionally iteration. If no
+   * iteration is specified the
+   * current workspace is used.
+   * @summary Get images by id for a given project iteration.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetImagesByIdsResponse>
+   */
+  getImagesByIds(projectId: string, options?: Models.TrainingAPIClientGetImagesByIdsOptionalParams): Promise<Models.GetImagesByIdsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getImagesByIds(projectId: string, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getImagesByIds(projectId: string, options: Models.TrainingAPIClientGetImagesByIdsOptionalParams, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  getImagesByIds(projectId: string, options?: Models.TrainingAPIClientGetImagesByIdsOptionalParams | msRest.ServiceCallback<Models.Image[]>, callback?: msRest.ServiceCallback<Models.Image[]>): Promise<Models.GetImagesByIdsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getImagesByIdsOperationSpec,
+      callback) as Promise<Models.GetImagesByIdsResponse>;
+  }
+
+  /**
+   * This API creates a batch of images from predicted images specified. There is a limit of 64
+   * images and 20 tags.
+   * @summary Add the specified predicted images to the set of training images.
+   * @param projectId The project id.
+   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.CreateImagesFromPredictionsResponse>
+   */
+  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromPredictionsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param callback The callback
+   */
+  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  /**
+   * @param projectId The project id.
+   * @param batch Image and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  createImagesFromPredictions(projectId: string, batch: Models.ImageIdCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromPredictionsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        batch,
+        options
+      },
+      createImagesFromPredictionsOperationSpec,
+      callback) as Promise<Models.CreateImagesFromPredictionsResponse>;
+  }
+
+  /**
+   * This API accepts a batch of image regions, and optionally tags, to update existing images with
+   * region information.
+   * There is a limit of 64 entries in the batch.
+   * @summary Create a set of image regions.
+   * @param projectId The project id.
+   * @param batch Batch of image regions which include a tag and bounding box. Limited to 64.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.CreateImageRegionsResponse>
+   */
+  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImageRegionsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param batch Batch of image regions which include a tag and bounding box. Limited to 64.
+   * @param callback The callback
+   */
+  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, callback: msRest.ServiceCallback<Models.ImageRegionCreateSummary>): void;
+  /**
+   * @param projectId The project id.
+   * @param batch Batch of image regions which include a tag and bounding box. Limited to 64.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageRegionCreateSummary>): void;
+  createImageRegions(projectId: string, batch: Models.ImageRegionCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageRegionCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageRegionCreateSummary>): Promise<Models.CreateImageRegionsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        batch,
+        options
+      },
+      createImageRegionsOperationSpec,
+      callback) as Promise<Models.CreateImageRegionsResponse>;
+  }
+
+  /**
+   * @summary Delete a set of image regions.
+   * @param projectId The project id.
+   * @param regionIds Regions to delete. Limited to 64.
+   * @param [options] The optional parameters
+   * @returns Promise<msRest.RestResponse>
+   */
+  deleteImageRegions(projectId: string, regionIds: string[], options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  /**
+   * @param projectId The project id.
+   * @param regionIds Regions to delete. Limited to 64.
+   * @param callback The callback
+   */
+  deleteImageRegions(projectId: string, regionIds: string[], callback: msRest.ServiceCallback<void>): void;
+  /**
+   * @param projectId The project id.
+   * @param regionIds Regions to delete. Limited to 64.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  deleteImageRegions(projectId: string, regionIds: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  deleteImageRegions(projectId: string, regionIds: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        regionIds,
+        options
+      },
+      deleteImageRegionsOperationSpec,
+      callback);
+  }
+
+  /**
+   * This API will fetch untagged images filtered by suggested tags Ids. It returns an empty array if
+   * no images are found.
+   * @summary Get untagged images whose suggested tags match given tags. Returns empty array if no
+   * images are found.
+   * @param projectId The project id.
+   * @param iterationId IterationId to use for the suggested tags and regions.
+   * @param query Contains properties we need to query suggested images.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.QuerySuggestedImagesResponse>
+   */
+  querySuggestedImages(projectId: string, iterationId: string, query: Models.SuggestedTagAndRegionQueryToken, options?: msRest.RequestOptionsBase): Promise<Models.QuerySuggestedImagesResponse>;
+  /**
+   * @param projectId The project id.
+   * @param iterationId IterationId to use for the suggested tags and regions.
+   * @param query Contains properties we need to query suggested images.
+   * @param callback The callback
+   */
+  querySuggestedImages(projectId: string, iterationId: string, query: Models.SuggestedTagAndRegionQueryToken, callback: msRest.ServiceCallback<Models.SuggestedTagAndRegionQuery>): void;
+  /**
+   * @param projectId The project id.
+   * @param iterationId IterationId to use for the suggested tags and regions.
+   * @param query Contains properties we need to query suggested images.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  querySuggestedImages(projectId: string, iterationId: string, query: Models.SuggestedTagAndRegionQueryToken, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.SuggestedTagAndRegionQuery>): void;
+  querySuggestedImages(projectId: string, iterationId: string, query: Models.SuggestedTagAndRegionQueryToken, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.SuggestedTagAndRegionQuery>, callback?: msRest.ServiceCallback<Models.SuggestedTagAndRegionQuery>): Promise<Models.QuerySuggestedImagesResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        iterationId,
+        query,
+        options
+      },
+      querySuggestedImagesOperationSpec,
+      callback) as Promise<Models.QuerySuggestedImagesResponse>;
+  }
+
+  /**
+   * This API takes in tagIds to get count of untagged images per suggested tags for a given
+   * threshold.
+   * @summary Get count of images whose suggested tags match given tags and their probabilities are
+   * greater than or equal to the given threshold. Returns count as 0 if none found.
+   * @param projectId The project id.
+   * @param iterationId IterationId to use for the suggested tags and regions.
+   * @param query Model that contains tagIds, threshold and projectType to query by.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.QuerySuggestedImageCountResponse>
+   */
+  querySuggestedImageCount(projectId: string, iterationId: string, query: Models.TagFilter, options?: msRest.RequestOptionsBase): Promise<Models.QuerySuggestedImageCountResponse>;
+  /**
+   * @param projectId The project id.
+   * @param iterationId IterationId to use for the suggested tags and regions.
+   * @param query Model that contains tagIds, threshold and projectType to query by.
+   * @param callback The callback
+   */
+  querySuggestedImageCount(projectId: string, iterationId: string, query: Models.TagFilter, callback: msRest.ServiceCallback<{ [propertyName: string]: number }>): void;
+  /**
+   * @param projectId The project id.
+   * @param iterationId IterationId to use for the suggested tags and regions.
+   * @param query Model that contains tagIds, threshold and projectType to query by.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  querySuggestedImageCount(projectId: string, iterationId: string, query: Models.TagFilter, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<{ [propertyName: string]: number }>): void;
+  querySuggestedImageCount(projectId: string, iterationId: string, query: Models.TagFilter, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<{ [propertyName: string]: number }>, callback?: msRest.ServiceCallback<{ [propertyName: string]: number }>): Promise<Models.QuerySuggestedImageCountResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        iterationId,
+        query,
+        options
+      },
+      querySuggestedImageCountOperationSpec,
+      callback) as Promise<Models.QuerySuggestedImageCountResponse>;
+  }
+
+  /**
+   * This API supports batching and range selection. By default it will only return first 50 images
+   * matching images.
+   * Use the {take} and {skip} parameters to control how many images to return in a given batch.
+   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
+   * "Dog" and
+   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
+   * @summary Get tagged images for a given project iteration.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetTaggedImagesResponse>
+   */
+  getTaggedImages(projectId: string, options?: Models.TrainingAPIClientGetTaggedImagesOptionalParams): Promise<Models.GetTaggedImagesResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getTaggedImages(projectId: string, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getTaggedImages(projectId: string, options: Models.TrainingAPIClientGetTaggedImagesOptionalParams, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  getTaggedImages(projectId: string, options?: Models.TrainingAPIClientGetTaggedImagesOptionalParams | msRest.ServiceCallback<Models.Image[]>, callback?: msRest.ServiceCallback<Models.Image[]>): Promise<Models.GetTaggedImagesResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getTaggedImagesOperationSpec,
+      callback) as Promise<Models.GetTaggedImagesResponse>;
+  }
+
+  /**
+   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
+   * "Dog" and
+   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
+   * @summary Gets the number of images tagged with the provided {tagIds}.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetTaggedImageCountResponse>
+   */
+  getTaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetTaggedImageCountOptionalParams): Promise<Models.GetTaggedImageCountResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getTaggedImageCount(projectId: string, callback: msRest.ServiceCallback<number>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getTaggedImageCount(projectId: string, options: Models.TrainingAPIClientGetTaggedImageCountOptionalParams, callback: msRest.ServiceCallback<number>): void;
+  getTaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetTaggedImageCountOptionalParams | msRest.ServiceCallback<number>, callback?: msRest.ServiceCallback<number>): Promise<Models.GetTaggedImageCountResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getTaggedImageCountOperationSpec,
+      callback) as Promise<Models.GetTaggedImageCountResponse>;
+  }
+
+  /**
+   * @summary Associate a set of images with a set of tags.
+   * @param projectId The project id.
+   * @param batch Batch of image tags. Limited to 128 tags per batch.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.CreateImageTagsResponse>
+   */
+  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImageTagsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param batch Batch of image tags. Limited to 128 tags per batch.
+   * @param callback The callback
+   */
+  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, callback: msRest.ServiceCallback<Models.ImageTagCreateSummary>): void;
+  /**
+   * @param projectId The project id.
+   * @param batch Batch of image tags. Limited to 128 tags per batch.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageTagCreateSummary>): void;
+  createImageTags(projectId: string, batch: Models.ImageTagCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageTagCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageTagCreateSummary>): Promise<Models.CreateImageTagsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        batch,
+        options
+      },
+      createImageTagsOperationSpec,
+      callback) as Promise<Models.CreateImageTagsResponse>;
+  }
+
+  /**
+   * @summary Remove a set of tags from a set of images.
+   * @param projectId The project id.
+   * @param imageIds Image ids. Limited to 64 images.
+   * @param tagIds Tags to be deleted from the specified images. Limited to 20 tags.
+   * @param [options] The optional parameters
+   * @returns Promise<msRest.RestResponse>
+   */
+  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
+  /**
+   * @param projectId The project id.
+   * @param imageIds Image ids. Limited to 64 images.
+   * @param tagIds Tags to be deleted from the specified images. Limited to 20 tags.
+   * @param callback The callback
+   */
+  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], callback: msRest.ServiceCallback<void>): void;
+  /**
+   * @param projectId The project id.
+   * @param imageIds Image ids. Limited to 64 images.
+   * @param tagIds Tags to be deleted from the specified images. Limited to 20 tags.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  deleteImageTags(projectId: string, imageIds: string[], tagIds: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        imageIds,
+        tagIds,
+        options
+      },
+      deleteImageTagsOperationSpec,
+      callback);
+  }
+
+  /**
+   * This API supports batching and range selection. By default it will only return first 50 images
+   * matching images.
+   * Use the {take} and {skip} parameters to control how many images to return in a given batch.
+   * @summary Get untagged images for a given project iteration.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetUntaggedImagesResponse>
+   */
+  getUntaggedImages(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImagesOptionalParams): Promise<Models.GetUntaggedImagesResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getUntaggedImages(projectId: string, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getUntaggedImages(projectId: string, options: Models.TrainingAPIClientGetUntaggedImagesOptionalParams, callback: msRest.ServiceCallback<Models.Image[]>): void;
+  getUntaggedImages(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImagesOptionalParams | msRest.ServiceCallback<Models.Image[]>, callback?: msRest.ServiceCallback<Models.Image[]>): Promise<Models.GetUntaggedImagesResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getUntaggedImagesOperationSpec,
+      callback) as Promise<Models.GetUntaggedImagesResponse>;
+  }
+
+  /**
+   * This API returns the images which have no tags for a given project and optionally an iteration.
+   * If no iteration is specified the
+   * current workspace is used.
+   * @summary Gets the number of untagged images.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetUntaggedImageCountResponse>
+   */
+  getUntaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImageCountOptionalParams): Promise<Models.GetUntaggedImageCountResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getUntaggedImageCount(projectId: string, callback: msRest.ServiceCallback<number>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getUntaggedImageCount(projectId: string, options: Models.TrainingAPIClientGetUntaggedImageCountOptionalParams, callback: msRest.ServiceCallback<number>): void;
+  getUntaggedImageCount(projectId: string, options?: Models.TrainingAPIClientGetUntaggedImageCountOptionalParams | msRest.ServiceCallback<number>, callback?: msRest.ServiceCallback<number>): Promise<Models.GetUntaggedImageCountResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getUntaggedImageCountOperationSpec,
+      callback) as Promise<Models.GetUntaggedImageCountResponse>;
+  }
+
+  /**
+   * This API accepts a batch of urls, and optionally tags, to create images. There is a limit of 64
+   * images and 20 tags.
+   * @summary Add the provided images urls to the set of training images.
+   * @param projectId The project id.
+   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.CreateImagesFromUrlsResponse>
+   */
+  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, options?: msRest.RequestOptionsBase): Promise<Models.CreateImagesFromUrlsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param callback The callback
+   */
+  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  /**
+   * @param projectId The project id.
+   * @param batch Image urls and tag ids. Limited to 64 images and 20 tags per batch.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ImageCreateSummary>): void;
+  createImagesFromUrls(projectId: string, batch: Models.ImageUrlCreateBatch, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ImageCreateSummary>, callback?: msRest.ServiceCallback<Models.ImageCreateSummary>): Promise<Models.CreateImagesFromUrlsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        batch,
+        options
+      },
+      createImagesFromUrlsOperationSpec,
+      callback) as Promise<Models.CreateImagesFromUrlsResponse>;
   }
 
   /**
@@ -1111,6 +947,184 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
+   * @summary Get the list of exports for a specific iteration.
+   * @param projectId The project id.
+   * @param iterationId The iteration id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetExportsResponse>
+   */
+  getExports(projectId: string, iterationId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetExportsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id.
+   * @param callback The callback
+   */
+  getExports(projectId: string, iterationId: string, callback: msRest.ServiceCallback<Models.ExportModel[]>): void;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getExports(projectId: string, iterationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ExportModel[]>): void;
+  getExports(projectId: string, iterationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ExportModel[]>, callback?: msRest.ServiceCallback<Models.ExportModel[]>): Promise<Models.GetExportsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        iterationId,
+        options
+      },
+      getExportsOperationSpec,
+      callback) as Promise<Models.GetExportsResponse>;
+  }
+
+  /**
+   * @summary Export a trained iteration.
+   * @param projectId The project id.
+   * @param iterationId The iteration id.
+   * @param platform The target platform. Possible values include: 'CoreML', 'TensorFlow',
+   * 'DockerFile', 'ONNX', 'VAIDK'
+   * @param [options] The optional parameters
+   * @returns Promise<Models.ExportIterationResponse>
+   */
+  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, options?: Models.TrainingAPIClientExportIterationOptionalParams): Promise<Models.ExportIterationResponse>;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id.
+   * @param platform The target platform. Possible values include: 'CoreML', 'TensorFlow',
+   * 'DockerFile', 'ONNX', 'VAIDK'
+   * @param callback The callback
+   */
+  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, callback: msRest.ServiceCallback<Models.ExportModel>): void;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id.
+   * @param platform The target platform. Possible values include: 'CoreML', 'TensorFlow',
+   * 'DockerFile', 'ONNX', 'VAIDK'
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, options: Models.TrainingAPIClientExportIterationOptionalParams, callback: msRest.ServiceCallback<Models.ExportModel>): void;
+  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, options?: Models.TrainingAPIClientExportIterationOptionalParams | msRest.ServiceCallback<Models.ExportModel>, callback?: msRest.ServiceCallback<Models.ExportModel>): Promise<Models.ExportIterationResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        iterationId,
+        platform,
+        options
+      },
+      exportIterationOperationSpec,
+      callback) as Promise<Models.ExportIterationResponse>;
+  }
+
+  /**
+   * @summary Get detailed performance information about an iteration.
+   * @param projectId The id of the project the iteration belongs to.
+   * @param iterationId The id of the iteration to get.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetIterationPerformanceResponse>
+   */
+  getIterationPerformance(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetIterationPerformanceOptionalParams): Promise<Models.GetIterationPerformanceResponse>;
+  /**
+   * @param projectId The id of the project the iteration belongs to.
+   * @param iterationId The id of the iteration to get.
+   * @param callback The callback
+   */
+  getIterationPerformance(projectId: string, iterationId: string, callback: msRest.ServiceCallback<Models.IterationPerformance>): void;
+  /**
+   * @param projectId The id of the project the iteration belongs to.
+   * @param iterationId The id of the iteration to get.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getIterationPerformance(projectId: string, iterationId: string, options: Models.TrainingAPIClientGetIterationPerformanceOptionalParams, callback: msRest.ServiceCallback<Models.IterationPerformance>): void;
+  getIterationPerformance(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetIterationPerformanceOptionalParams | msRest.ServiceCallback<Models.IterationPerformance>, callback?: msRest.ServiceCallback<Models.IterationPerformance>): Promise<Models.GetIterationPerformanceResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        iterationId,
+        options
+      },
+      getIterationPerformanceOperationSpec,
+      callback) as Promise<Models.GetIterationPerformanceResponse>;
+  }
+
+  /**
+   * This API supports batching and range selection. By default it will only return first 50 images
+   * matching images.
+   * Use the {take} and {skip} parameters to control how many images to return in a given batch.
+   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
+   * "Dog" and
+   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
+   * @summary Get image with its prediction for a given project iteration.
+   * @param projectId The project id.
+   * @param iterationId The iteration id. Defaults to workspace.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetImagePerformancesResponse>
+   */
+  getImagePerformances(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformancesOptionalParams): Promise<Models.GetImagePerformancesResponse>;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id. Defaults to workspace.
+   * @param callback The callback
+   */
+  getImagePerformances(projectId: string, iterationId: string, callback: msRest.ServiceCallback<Models.ImagePerformance[]>): void;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id. Defaults to workspace.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getImagePerformances(projectId: string, iterationId: string, options: Models.TrainingAPIClientGetImagePerformancesOptionalParams, callback: msRest.ServiceCallback<Models.ImagePerformance[]>): void;
+  getImagePerformances(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformancesOptionalParams | msRest.ServiceCallback<Models.ImagePerformance[]>, callback?: msRest.ServiceCallback<Models.ImagePerformance[]>): Promise<Models.GetImagePerformancesResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        iterationId,
+        options
+      },
+      getImagePerformancesOperationSpec,
+      callback) as Promise<Models.GetImagePerformancesResponse>;
+  }
+
+  /**
+   * The filtering is on an and/or relationship. For example, if the provided tag ids are for the
+   * "Dog" and
+   * "Cat" tags, then only images tagged with Dog and/or Cat will be returned
+   * @summary Gets the number of images tagged with the provided {tagIds} that have prediction
+   * results from
+   * training for the provided iteration {iterationId}.
+   * @param projectId The project id.
+   * @param iterationId The iteration id. Defaults to workspace.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetImagePerformanceCountResponse>
+   */
+  getImagePerformanceCount(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformanceCountOptionalParams): Promise<Models.GetImagePerformanceCountResponse>;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id. Defaults to workspace.
+   * @param callback The callback
+   */
+  getImagePerformanceCount(projectId: string, iterationId: string, callback: msRest.ServiceCallback<number>): void;
+  /**
+   * @param projectId The project id.
+   * @param iterationId The iteration id. Defaults to workspace.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getImagePerformanceCount(projectId: string, iterationId: string, options: Models.TrainingAPIClientGetImagePerformanceCountOptionalParams, callback: msRest.ServiceCallback<number>): void;
+  getImagePerformanceCount(projectId: string, iterationId: string, options?: Models.TrainingAPIClientGetImagePerformanceCountOptionalParams | msRest.ServiceCallback<number>, callback?: msRest.ServiceCallback<number>): Promise<Models.GetImagePerformanceCountResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        iterationId,
+        options
+      },
+      getImagePerformanceCountOperationSpec,
+      callback) as Promise<Models.GetImagePerformanceCountResponse>;
+  }
+
+  /**
    * @summary Publish a specific iteration.
    * @param projectId The project id.
    * @param iterationId The iteration id.
@@ -1183,74 +1197,194 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
-   * @summary Get the list of exports for a specific iteration.
+   * @summary Delete a set of predicted images and their associated prediction results.
    * @param projectId The project id.
-   * @param iterationId The iteration id.
+   * @param ids The prediction ids. Limited to 64.
    * @param [options] The optional parameters
-   * @returns Promise<Models.GetExportsResponse>
+   * @returns Promise<msRest.RestResponse>
    */
-  getExports(projectId: string, iterationId: string, options?: msRest.RequestOptionsBase): Promise<Models.GetExportsResponse>;
+  deletePrediction(projectId: string, ids: string[], options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
   /**
    * @param projectId The project id.
-   * @param iterationId The iteration id.
+   * @param ids The prediction ids. Limited to 64.
    * @param callback The callback
    */
-  getExports(projectId: string, iterationId: string, callback: msRest.ServiceCallback<Models.ExportModel[]>): void;
+  deletePrediction(projectId: string, ids: string[], callback: msRest.ServiceCallback<void>): void;
   /**
    * @param projectId The project id.
-   * @param iterationId The iteration id.
+   * @param ids The prediction ids. Limited to 64.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getExports(projectId: string, iterationId: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.ExportModel[]>): void;
-  getExports(projectId: string, iterationId: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.ExportModel[]>, callback?: msRest.ServiceCallback<Models.ExportModel[]>): Promise<Models.GetExportsResponse> {
+  deletePrediction(projectId: string, ids: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  deletePrediction(projectId: string, ids: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<void>, callback?: msRest.ServiceCallback<void>): Promise<msRest.RestResponse> {
     return this.sendOperationRequest(
       {
         projectId,
-        iterationId,
+        ids,
         options
       },
-      getExportsOperationSpec,
-      callback) as Promise<Models.GetExportsResponse>;
+      deletePredictionOperationSpec,
+      callback);
   }
 
   /**
-   * @summary Export a trained iteration.
+   * @summary Get images that were sent to your prediction endpoint.
    * @param projectId The project id.
-   * @param iterationId The iteration id.
-   * @param platform The target platform. Possible values include: 'CoreML', 'TensorFlow',
-   * 'DockerFile', 'ONNX', 'VAIDK'
+   * @param query Parameters used to query the predictions. Limited to combining 2 tags.
    * @param [options] The optional parameters
-   * @returns Promise<Models.ExportIterationResponse>
+   * @returns Promise<Models.QueryPredictionsResponse>
    */
-  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, options?: Models.TrainingAPIClientExportIterationOptionalParams): Promise<Models.ExportIterationResponse>;
+  queryPredictions(projectId: string, query: Models.PredictionQueryToken, options?: msRest.RequestOptionsBase): Promise<Models.QueryPredictionsResponse>;
   /**
    * @param projectId The project id.
-   * @param iterationId The iteration id.
-   * @param platform The target platform. Possible values include: 'CoreML', 'TensorFlow',
-   * 'DockerFile', 'ONNX', 'VAIDK'
+   * @param query Parameters used to query the predictions. Limited to combining 2 tags.
    * @param callback The callback
    */
-  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, callback: msRest.ServiceCallback<Models.ExportModel>): void;
+  queryPredictions(projectId: string, query: Models.PredictionQueryToken, callback: msRest.ServiceCallback<Models.PredictionQueryResult>): void;
   /**
    * @param projectId The project id.
-   * @param iterationId The iteration id.
-   * @param platform The target platform. Possible values include: 'CoreML', 'TensorFlow',
-   * 'DockerFile', 'ONNX', 'VAIDK'
+   * @param query Parameters used to query the predictions. Limited to combining 2 tags.
    * @param options The optional parameters
    * @param callback The callback
    */
-  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, options: Models.TrainingAPIClientExportIterationOptionalParams, callback: msRest.ServiceCallback<Models.ExportModel>): void;
-  exportIteration(projectId: string, iterationId: string, platform: Models.Platform, options?: Models.TrainingAPIClientExportIterationOptionalParams | msRest.ServiceCallback<Models.ExportModel>, callback?: msRest.ServiceCallback<Models.ExportModel>): Promise<Models.ExportIterationResponse> {
+  queryPredictions(projectId: string, query: Models.PredictionQueryToken, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.PredictionQueryResult>): void;
+  queryPredictions(projectId: string, query: Models.PredictionQueryToken, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.PredictionQueryResult>, callback?: msRest.ServiceCallback<Models.PredictionQueryResult>): Promise<Models.QueryPredictionsResponse> {
     return this.sendOperationRequest(
       {
         projectId,
-        iterationId,
-        platform,
+        query,
         options
       },
-      exportIterationOperationSpec,
-      callback) as Promise<Models.ExportIterationResponse>;
+      queryPredictionsOperationSpec,
+      callback) as Promise<Models.QueryPredictionsResponse>;
+  }
+
+  /**
+   * @summary Quick test an image.
+   * @param projectId The project id.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 6MB.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.QuickTestImageResponse>
+   */
+  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientQuickTestImageOptionalParams): Promise<Models.QuickTestImageResponse>;
+  /**
+   * @param projectId The project id.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 6MB.
+   * @param callback The callback
+   */
+  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  /**
+   * @param projectId The project id.
+   * @param imageData Binary image data. Supported formats are JPEG, GIF, PNG, and BMP. Supports
+   * images up to 6MB.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, options: Models.TrainingAPIClientQuickTestImageOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  quickTestImage(projectId: string, imageData: msRest.HttpRequestBody, options?: Models.TrainingAPIClientQuickTestImageOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.QuickTestImageResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        imageData,
+        options
+      },
+      quickTestImageOperationSpec,
+      callback) as Promise<Models.QuickTestImageResponse>;
+  }
+
+  /**
+   * @summary Quick test an image url.
+   * @param projectId The project to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.QuickTestImageUrlResponse>
+   */
+  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, options?: Models.TrainingAPIClientQuickTestImageUrlOptionalParams): Promise<Models.QuickTestImageUrlResponse>;
+  /**
+   * @param projectId The project to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param callback The callback
+   */
+  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  /**
+   * @param projectId The project to evaluate against.
+   * @param imageUrl An ImageUrl that contains the url of the image to be evaluated.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, options: Models.TrainingAPIClientQuickTestImageUrlOptionalParams, callback: msRest.ServiceCallback<Models.ImagePrediction>): void;
+  quickTestImageUrl(projectId: string, imageUrl: Models.ImageUrl, options?: Models.TrainingAPIClientQuickTestImageUrlOptionalParams | msRest.ServiceCallback<Models.ImagePrediction>, callback?: msRest.ServiceCallback<Models.ImagePrediction>): Promise<Models.QuickTestImageUrlResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        imageUrl,
+        options
+      },
+      quickTestImageUrlOperationSpec,
+      callback) as Promise<Models.QuickTestImageUrlResponse>;
+  }
+
+  /**
+   * @summary Get the tags for a given project and iteration.
+   * @param projectId The project id.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.GetTagsResponse>
+   */
+  getTags(projectId: string, options?: Models.TrainingAPIClientGetTagsOptionalParams): Promise<Models.GetTagsResponse>;
+  /**
+   * @param projectId The project id.
+   * @param callback The callback
+   */
+  getTags(projectId: string, callback: msRest.ServiceCallback<Models.Tag[]>): void;
+  /**
+   * @param projectId The project id.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  getTags(projectId: string, options: Models.TrainingAPIClientGetTagsOptionalParams, callback: msRest.ServiceCallback<Models.Tag[]>): void;
+  getTags(projectId: string, options?: Models.TrainingAPIClientGetTagsOptionalParams | msRest.ServiceCallback<Models.Tag[]>, callback?: msRest.ServiceCallback<Models.Tag[]>): Promise<Models.GetTagsResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        options
+      },
+      getTagsOperationSpec,
+      callback) as Promise<Models.GetTagsResponse>;
+  }
+
+  /**
+   * @summary Create a tag for the project.
+   * @param projectId The project id.
+   * @param name The tag name.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.CreateTagResponse>
+   */
+  createTag(projectId: string, name: string, options?: Models.TrainingAPIClientCreateTagOptionalParams): Promise<Models.CreateTagResponse>;
+  /**
+   * @param projectId The project id.
+   * @param name The tag name.
+   * @param callback The callback
+   */
+  createTag(projectId: string, name: string, callback: msRest.ServiceCallback<Models.Tag>): void;
+  /**
+   * @param projectId The project id.
+   * @param name The tag name.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  createTag(projectId: string, name: string, options: Models.TrainingAPIClientCreateTagOptionalParams, callback: msRest.ServiceCallback<Models.Tag>): void;
+  createTag(projectId: string, name: string, options?: Models.TrainingAPIClientCreateTagOptionalParams | msRest.ServiceCallback<Models.Tag>, callback?: msRest.ServiceCallback<Models.Tag>): Promise<Models.CreateTagResponse> {
+    return this.sendOperationRequest(
+      {
+        projectId,
+        name,
+        options
+      },
+      createTagOperationSpec,
+      callback) as Promise<Models.CreateTagResponse>;
   }
 
   /**
@@ -1354,63 +1488,102 @@ class TrainingAPIClient extends TrainingAPIClientContext {
   }
 
   /**
-   * @summary Get the tags for a given project and iteration.
+   * This API will get suggested tags and regions for an array/batch of untagged images along with
+   * confidences for the tags. It returns an empty array if no tags are found.
+   * There is a limit of 64 images in the batch.
+   * @summary Suggest tags and regions for an array/batch of untagged images. Returns empty array if
+   * no tags are found.
    * @param projectId The project id.
+   * @param iterationId IterationId to use for tag and region suggestion.
+   * @param imageIds Array of image ids tag suggestion are needed for. Use GetUntaggedImages API to
+   * get imageIds.
    * @param [options] The optional parameters
-   * @returns Promise<Models.GetTagsResponse>
+   * @returns Promise<Models.SuggestTagsAndRegionsResponse>
    */
-  getTags(projectId: string, options?: Models.TrainingAPIClientGetTagsOptionalParams): Promise<Models.GetTagsResponse>;
+  suggestTagsAndRegions(projectId: string, iterationId: string, imageIds: string[], options?: msRest.RequestOptionsBase): Promise<Models.SuggestTagsAndRegionsResponse>;
   /**
    * @param projectId The project id.
+   * @param iterationId IterationId to use for tag and region suggestion.
+   * @param imageIds Array of image ids tag suggestion are needed for. Use GetUntaggedImages API to
+   * get imageIds.
    * @param callback The callback
    */
-  getTags(projectId: string, callback: msRest.ServiceCallback<Models.Tag[]>): void;
+  suggestTagsAndRegions(projectId: string, iterationId: string, imageIds: string[], callback: msRest.ServiceCallback<Models.SuggestedTagAndRegion[]>): void;
   /**
    * @param projectId The project id.
+   * @param iterationId IterationId to use for tag and region suggestion.
+   * @param imageIds Array of image ids tag suggestion are needed for. Use GetUntaggedImages API to
+   * get imageIds.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getTags(projectId: string, options: Models.TrainingAPIClientGetTagsOptionalParams, callback: msRest.ServiceCallback<Models.Tag[]>): void;
-  getTags(projectId: string, options?: Models.TrainingAPIClientGetTagsOptionalParams | msRest.ServiceCallback<Models.Tag[]>, callback?: msRest.ServiceCallback<Models.Tag[]>): Promise<Models.GetTagsResponse> {
+  suggestTagsAndRegions(projectId: string, iterationId: string, imageIds: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.SuggestedTagAndRegion[]>): void;
+  suggestTagsAndRegions(projectId: string, iterationId: string, imageIds: string[], options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.SuggestedTagAndRegion[]>, callback?: msRest.ServiceCallback<Models.SuggestedTagAndRegion[]>): Promise<Models.SuggestTagsAndRegionsResponse> {
     return this.sendOperationRequest(
       {
         projectId,
+        iterationId,
+        imageIds,
         options
       },
-      getTagsOperationSpec,
-      callback) as Promise<Models.GetTagsResponse>;
+      suggestTagsAndRegionsOperationSpec,
+      callback) as Promise<Models.SuggestTagsAndRegionsResponse>;
   }
 
   /**
-   * @summary Create a tag for the project.
+   * @summary Queues project for training.
    * @param projectId The project id.
-   * @param name The tag name.
    * @param [options] The optional parameters
-   * @returns Promise<Models.CreateTagResponse>
+   * @returns Promise<Models.TrainProjectResponse>
    */
-  createTag(projectId: string, name: string, options?: Models.TrainingAPIClientCreateTagOptionalParams): Promise<Models.CreateTagResponse>;
+  trainProject(projectId: string, options?: Models.TrainingAPIClientTrainProjectOptionalParams): Promise<Models.TrainProjectResponse>;
   /**
    * @param projectId The project id.
-   * @param name The tag name.
    * @param callback The callback
    */
-  createTag(projectId: string, name: string, callback: msRest.ServiceCallback<Models.Tag>): void;
+  trainProject(projectId: string, callback: msRest.ServiceCallback<Models.Iteration>): void;
   /**
    * @param projectId The project id.
-   * @param name The tag name.
    * @param options The optional parameters
    * @param callback The callback
    */
-  createTag(projectId: string, name: string, options: Models.TrainingAPIClientCreateTagOptionalParams, callback: msRest.ServiceCallback<Models.Tag>): void;
-  createTag(projectId: string, name: string, options?: Models.TrainingAPIClientCreateTagOptionalParams | msRest.ServiceCallback<Models.Tag>, callback?: msRest.ServiceCallback<Models.Tag>): Promise<Models.CreateTagResponse> {
+  trainProject(projectId: string, options: Models.TrainingAPIClientTrainProjectOptionalParams, callback: msRest.ServiceCallback<Models.Iteration>): void;
+  trainProject(projectId: string, options?: Models.TrainingAPIClientTrainProjectOptionalParams | msRest.ServiceCallback<Models.Iteration>, callback?: msRest.ServiceCallback<Models.Iteration>): Promise<Models.TrainProjectResponse> {
     return this.sendOperationRequest(
       {
         projectId,
-        name,
         options
       },
-      createTagOperationSpec,
-      callback) as Promise<Models.CreateTagResponse>;
+      trainProjectOperationSpec,
+      callback) as Promise<Models.TrainProjectResponse>;
+  }
+
+  /**
+   * @summary Imports a project.
+   * @param token Token generated from the export project call.
+   * @param [options] The optional parameters
+   * @returns Promise<Models.ImportProjectResponse>
+   */
+  importProject(token: string, options?: msRest.RequestOptionsBase): Promise<Models.ImportProjectResponse>;
+  /**
+   * @param token Token generated from the export project call.
+   * @param callback The callback
+   */
+  importProject(token: string, callback: msRest.ServiceCallback<Models.Project>): void;
+  /**
+   * @param token Token generated from the export project call.
+   * @param options The optional parameters
+   * @param callback The callback
+   */
+  importProject(token: string, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Project>): void;
+  importProject(token: string, options?: msRest.RequestOptionsBase | msRest.ServiceCallback<Models.Project>, callback?: msRest.ServiceCallback<Models.Project>): Promise<Models.ImportProjectResponse> {
+    return this.sendOperationRequest(
+      {
+        token,
+        options
+      },
+      importProjectOperationSpec,
+      callback) as Promise<Models.ImportProjectResponse>;
   }
 }
 
@@ -1421,9 +1594,6 @@ const getDomainsOperationSpec: msRest.OperationSpec = {
   path: "domains",
   urlParameters: [
     Parameters.endpoint
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   responses: {
     200: {
@@ -1454,645 +1624,9 @@ const getDomainOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint,
     Parameters.domainId0
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   responses: {
     200: {
       bodyMapper: Mappers.Domain
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getTaggedImageCountOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/images/tagged/count",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.iterationId0,
-    Parameters.tagIds0
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Number"
-        }
-      }
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getUntaggedImageCountOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/images/untagged/count",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.iterationId0
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Number"
-        }
-      }
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const createImageTagsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/images/tags",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  requestBody: {
-    parameterPath: "batch",
-    mapper: {
-      ...Mappers.ImageTagCreateBatch,
-      required: true
-    }
-  },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImageTagCreateSummary
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const deleteImageTagsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "DELETE",
-  path: "projects/{projectId}/images/tags",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.imageIds0,
-    Parameters.tagIds1
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    204: {},
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const createImageRegionsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/images/regions",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  requestBody: {
-    parameterPath: "batch",
-    mapper: {
-      ...Mappers.ImageRegionCreateBatch,
-      required: true
-    }
-  },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImageRegionCreateSummary
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const deleteImageRegionsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "DELETE",
-  path: "projects/{projectId}/images/regions",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.regionIds
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    204: {},
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getTaggedImagesOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/images/tagged",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.iterationId0,
-    Parameters.tagIds2,
-    Parameters.orderBy,
-    Parameters.take,
-    Parameters.skip
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "Image"
-            }
-          }
-        }
-      }
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getUntaggedImagesOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/images/untagged",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.iterationId0,
-    Parameters.orderBy,
-    Parameters.take,
-    Parameters.skip
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "Image"
-            }
-          }
-        }
-      }
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getImagesByIdsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/images/id",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.imageIds1,
-    Parameters.iterationId0
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "Image"
-            }
-          }
-        }
-      }
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const createImagesFromDataOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/images",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.tagIds2
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  formDataParameters: [
-    Parameters.imageData
-  ],
-  contentType: "multipart/form-data",
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImageCreateSummary
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const deleteImagesOperationSpec: msRest.OperationSpec = {
-  httpMethod: "DELETE",
-  path: "projects/{projectId}/images",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.imageIds2
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    204: {},
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const createImagesFromFilesOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/images/files",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  requestBody: {
-    parameterPath: "batch",
-    mapper: {
-      ...Mappers.ImageFileCreateBatch,
-      required: true
-    }
-  },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImageCreateSummary
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const createImagesFromUrlsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/images/urls",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  requestBody: {
-    parameterPath: "batch",
-    mapper: {
-      ...Mappers.ImageUrlCreateBatch,
-      required: true
-    }
-  },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImageCreateSummary
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const createImagesFromPredictionsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/images/predictions",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  requestBody: {
-    parameterPath: "batch",
-    mapper: {
-      ...Mappers.ImageIdCreateBatch,
-      required: true
-    }
-  },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImageCreateSummary
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getImageRegionProposalsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/images/{imageId}/regionproposals",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.imageId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImageRegionProposal
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const deletePredictionOperationSpec: msRest.OperationSpec = {
-  httpMethod: "DELETE",
-  path: "projects/{projectId}/predictions",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.ids
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    204: {},
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const quickTestImageUrlOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/quicktest/url",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.iterationId0
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  requestBody: {
-    parameterPath: "imageUrl",
-    mapper: {
-      ...Mappers.ImageUrl,
-      required: true
-    }
-  },
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImagePrediction
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const quickTestImageOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/quicktest/image",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  queryParameters: [
-    Parameters.iterationId0
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  formDataParameters: [
-    Parameters.imageData
-  ],
-  contentType: "multipart/form-data",
-  responses: {
-    200: {
-      bodyMapper: Mappers.ImagePrediction
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const queryPredictionsOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/predictions/query",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  requestBody: {
-    parameterPath: "query",
-    mapper: {
-      ...Mappers.PredictionQueryToken,
-      required: true
-    }
-  },
-  responses: {
-    200: {
-      bodyMapper: Mappers.PredictionQueryResult
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getIterationPerformanceOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/iterations/{iterationId}/performance",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.iterationId1
-  ],
-  queryParameters: [
-    Parameters.threshold,
-    Parameters.overlapThreshold
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: Mappers.IterationPerformance
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getImagePerformancesOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/iterations/{iterationId}/performance/images",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.iterationId1
-  ],
-  queryParameters: [
-    Parameters.tagIds2,
-    Parameters.orderBy,
-    Parameters.take,
-    Parameters.skip
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Sequence",
-          element: {
-            type: {
-              name: "Composite",
-              className: "ImagePerformance"
-            }
-          }
-        }
-      }
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const getImagePerformanceCountOperationSpec: msRest.OperationSpec = {
-  httpMethod: "GET",
-  path: "projects/{projectId}/iterations/{iterationId}/performance/images/count",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.iterationId1
-  ],
-  queryParameters: [
-    Parameters.tagIds0
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Number"
-        }
-      }
     },
     default: {
       bodyMapper: Mappers.CustomVisionError
@@ -2106,9 +1640,6 @@ const getProjectsOperationSpec: msRest.OperationSpec = {
   path: "projects",
   urlParameters: [
     Parameters.endpoint
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   responses: {
     200: {
@@ -2145,9 +1676,6 @@ const createProjectOperationSpec: msRest.OperationSpec = {
     Parameters.classificationType,
     Parameters.targetExportPlatforms
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   responses: {
     200: {
       bodyMapper: Mappers.Project
@@ -2165,9 +1693,6 @@ const getProjectOperationSpec: msRest.OperationSpec = {
   urlParameters: [
     Parameters.endpoint,
     Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   responses: {
     200: {
@@ -2187,9 +1712,6 @@ const deleteProjectOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint,
     Parameters.projectId
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   responses: {
     204: {},
     default: {
@@ -2205,9 +1727,6 @@ const updateProjectOperationSpec: msRest.OperationSpec = {
   urlParameters: [
     Parameters.endpoint,
     Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   requestBody: {
     parameterPath: "updatedProject",
@@ -2227,25 +1746,469 @@ const updateProjectOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const trainProjectOperationSpec: msRest.OperationSpec = {
+const exportProjectOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/export",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  responses: {
+    200: {
+      bodyMapper: Mappers.ProjectExport
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const createImagesFromDataOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
-  path: "projects/{projectId}/train",
+  path: "projects/{projectId}/images",
   urlParameters: [
     Parameters.endpoint,
     Parameters.projectId
   ],
   queryParameters: [
-    Parameters.trainingType,
-    Parameters.reservedBudgetInHours,
-    Parameters.forceTrain,
-    Parameters.notificationEmailAddress
+    Parameters.tagIds0
   ],
-  headerParameters: [
-    Parameters.apiKey
+  formDataParameters: [
+    Parameters.imageData
+  ],
+  contentType: "multipart/form-data",
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImageCreateSummary
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const deleteImagesOperationSpec: msRest.OperationSpec = {
+  httpMethod: "DELETE",
+  path: "projects/{projectId}/images",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.imageIds0,
+    Parameters.allImages,
+    Parameters.allIterations
+  ],
+  responses: {
+    202: {},
+    204: {},
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getImageRegionProposalsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/{imageId}/regionproposals",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.imageId
   ],
   responses: {
     200: {
-      bodyMapper: Mappers.Iteration
+      bodyMapper: Mappers.ImageRegionProposal
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const createImagesFromFilesOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/files",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  requestBody: {
+    parameterPath: "batch",
+    mapper: {
+      ...Mappers.ImageFileCreateBatch,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImageCreateSummary
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getImagesByIdsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/images/id",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.imageIds0,
+    Parameters.iterationId0
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Image"
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const createImagesFromPredictionsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/predictions",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  requestBody: {
+    parameterPath: "batch",
+    mapper: {
+      ...Mappers.ImageIdCreateBatch,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImageCreateSummary
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const createImageRegionsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/regions",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  requestBody: {
+    parameterPath: "batch",
+    mapper: {
+      ...Mappers.ImageRegionCreateBatch,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImageRegionCreateSummary
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const deleteImageRegionsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "DELETE",
+  path: "projects/{projectId}/images/regions",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.regionIds
+  ],
+  responses: {
+    204: {},
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const querySuggestedImagesOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/suggested",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId1
+  ],
+  requestBody: {
+    parameterPath: "query",
+    mapper: {
+      ...Mappers.SuggestedTagAndRegionQueryToken,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.SuggestedTagAndRegionQuery
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const querySuggestedImageCountOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/suggested/count",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId1
+  ],
+  requestBody: {
+    parameterPath: "query",
+    mapper: {
+      ...Mappers.TagFilter,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "Number"
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getTaggedImagesOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/images/tagged",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0,
+    Parameters.tagIds0,
+    Parameters.orderBy,
+    Parameters.take,
+    Parameters.skip
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Image"
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getTaggedImageCountOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/images/tagged/count",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0,
+    Parameters.tagIds1
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Number"
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const createImageTagsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/tags",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  requestBody: {
+    parameterPath: "batch",
+    mapper: {
+      ...Mappers.ImageTagCreateBatch,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImageTagCreateSummary
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const deleteImageTagsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "DELETE",
+  path: "projects/{projectId}/images/tags",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.imageIds1,
+    Parameters.tagIds2
+  ],
+  responses: {
+    204: {},
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getUntaggedImagesOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/images/untagged",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0,
+    Parameters.orderBy,
+    Parameters.take,
+    Parameters.skip
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "Image"
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getUntaggedImageCountOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/images/untagged/count",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Number"
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const createImagesFromUrlsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/images/urls",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  requestBody: {
+    parameterPath: "batch",
+    mapper: {
+      ...Mappers.ImageUrlCreateBatch,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImageCreateSummary
     },
     default: {
       bodyMapper: Mappers.CustomVisionError
@@ -2260,9 +2223,6 @@ const getIterationsOperationSpec: msRest.OperationSpec = {
   urlParameters: [
     Parameters.endpoint,
     Parameters.projectId
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   responses: {
     200: {
@@ -2294,9 +2254,6 @@ const getIterationOperationSpec: msRest.OperationSpec = {
     Parameters.projectId,
     Parameters.iterationId1
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   responses: {
     200: {
       bodyMapper: Mappers.Iteration
@@ -2316,9 +2273,6 @@ const deleteIterationOperationSpec: msRest.OperationSpec = {
     Parameters.projectId,
     Parameters.iterationId1
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   responses: {
     204: {},
     default: {
@@ -2335,9 +2289,6 @@ const updateIterationOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint,
     Parameters.projectId,
     Parameters.iterationId1
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   requestBody: {
     parameterPath: "updatedIteration",
@@ -2357,57 +2308,6 @@ const updateIterationOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const publishIterationOperationSpec: msRest.OperationSpec = {
-  httpMethod: "POST",
-  path: "projects/{projectId}/iterations/{iterationId}/publish",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.iterationId1
-  ],
-  queryParameters: [
-    Parameters.publishName,
-    Parameters.predictionId
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    200: {
-      bodyMapper: {
-        serializedName: "parsedResponse",
-        type: {
-          name: "Boolean"
-        }
-      }
-    },
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
-const unpublishIterationOperationSpec: msRest.OperationSpec = {
-  httpMethod: "DELETE",
-  path: "projects/{projectId}/iterations/{iterationId}/publish",
-  urlParameters: [
-    Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.iterationId1
-  ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
-  responses: {
-    204: {},
-    default: {
-      bodyMapper: Mappers.CustomVisionError
-    }
-  },
-  serializer
-};
-
 const getExportsOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "projects/{projectId}/iterations/{iterationId}/export",
@@ -2415,9 +2315,6 @@ const getExportsOperationSpec: msRest.OperationSpec = {
     Parameters.endpoint,
     Parameters.projectId,
     Parameters.iterationId1
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   responses: {
     200: {
@@ -2453,9 +2350,6 @@ const exportIterationOperationSpec: msRest.OperationSpec = {
     Parameters.platform,
     Parameters.flavor
   ],
-  headerParameters: [
-    Parameters.apiKey
-  ],
   responses: {
     200: {
       bodyMapper: Mappers.ExportModel
@@ -2467,23 +2361,21 @@ const exportIterationOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const getTagOperationSpec: msRest.OperationSpec = {
+const getIterationPerformanceOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
-  path: "projects/{projectId}/tags/{tagId}",
+  path: "projects/{projectId}/iterations/{iterationId}/performance",
   urlParameters: [
     Parameters.endpoint,
     Parameters.projectId,
-    Parameters.tagId
+    Parameters.iterationId1
   ],
   queryParameters: [
-    Parameters.iterationId0
-  ],
-  headerParameters: [
-    Parameters.apiKey
+    Parameters.threshold,
+    Parameters.overlapThreshold
   ],
   responses: {
     200: {
-      bodyMapper: Mappers.Tag
+      bodyMapper: Mappers.IterationPerformance
     },
     default: {
       bodyMapper: Mappers.CustomVisionError
@@ -2492,16 +2384,104 @@ const getTagOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const deleteTagOperationSpec: msRest.OperationSpec = {
-  httpMethod: "DELETE",
-  path: "projects/{projectId}/tags/{tagId}",
+const getImagePerformancesOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/iterations/{iterationId}/performance/images",
   urlParameters: [
     Parameters.endpoint,
     Parameters.projectId,
-    Parameters.tagId
+    Parameters.iterationId1
   ],
-  headerParameters: [
-    Parameters.apiKey
+  queryParameters: [
+    Parameters.tagIds0,
+    Parameters.orderBy,
+    Parameters.take,
+    Parameters.skip
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "ImagePerformance"
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getImagePerformanceCountOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/iterations/{iterationId}/performance/images/count",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.iterationId1
+  ],
+  queryParameters: [
+    Parameters.tagIds1
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Number"
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const publishIterationOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/iterations/{iterationId}/publish",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.iterationId1
+  ],
+  queryParameters: [
+    Parameters.publishName,
+    Parameters.predictionId
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Boolean"
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const unpublishIterationOperationSpec: msRest.OperationSpec = {
+  httpMethod: "DELETE",
+  path: "projects/{projectId}/iterations/{iterationId}/publish",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.iterationId1
   ],
   responses: {
     204: {},
@@ -2512,27 +2492,97 @@ const deleteTagOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-const updateTagOperationSpec: msRest.OperationSpec = {
-  httpMethod: "PATCH",
-  path: "projects/{projectId}/tags/{tagId}",
+const deletePredictionOperationSpec: msRest.OperationSpec = {
+  httpMethod: "DELETE",
+  path: "projects/{projectId}/predictions",
   urlParameters: [
     Parameters.endpoint,
-    Parameters.projectId,
-    Parameters.tagId
+    Parameters.projectId
   ],
-  headerParameters: [
-    Parameters.apiKey
+  queryParameters: [
+    Parameters.ids
+  ],
+  responses: {
+    204: {},
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const queryPredictionsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/predictions/query",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
   ],
   requestBody: {
-    parameterPath: "updatedTag",
+    parameterPath: "query",
     mapper: {
-      ...Mappers.Tag,
+      ...Mappers.PredictionQueryToken,
       required: true
     }
   },
   responses: {
     200: {
-      bodyMapper: Mappers.Tag
+      bodyMapper: Mappers.PredictionQueryResult
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const quickTestImageOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/quicktest/image",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0,
+    Parameters.store
+  ],
+  formDataParameters: [
+    Parameters.imageData
+  ],
+  contentType: "multipart/form-data",
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImagePrediction
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const quickTestImageUrlOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/quicktest/url",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId0,
+    Parameters.store
+  ],
+  requestBody: {
+    parameterPath: "imageUrl",
+    mapper: {
+      ...Mappers.ImageUrl,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.ImagePrediction
     },
     default: {
       bodyMapper: Mappers.CustomVisionError
@@ -2550,9 +2600,6 @@ const getTagsOperationSpec: msRest.OperationSpec = {
   ],
   queryParameters: [
     Parameters.iterationId0
-  ],
-  headerParameters: [
-    Parameters.apiKey
   ],
   responses: {
     200: {
@@ -2588,12 +2635,158 @@ const createTagOperationSpec: msRest.OperationSpec = {
     Parameters.description,
     Parameters.type
   ],
-  headerParameters: [
-    Parameters.apiKey
+  responses: {
+    200: {
+      bodyMapper: Mappers.Tag
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const getTagOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "projects/{projectId}/tags/{tagId}",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.tagId
+  ],
+  queryParameters: [
+    Parameters.iterationId0
   ],
   responses: {
     200: {
       bodyMapper: Mappers.Tag
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const deleteTagOperationSpec: msRest.OperationSpec = {
+  httpMethod: "DELETE",
+  path: "projects/{projectId}/tags/{tagId}",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.tagId
+  ],
+  responses: {
+    204: {},
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const updateTagOperationSpec: msRest.OperationSpec = {
+  httpMethod: "PATCH",
+  path: "projects/{projectId}/tags/{tagId}",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId,
+    Parameters.tagId
+  ],
+  requestBody: {
+    parameterPath: "updatedTag",
+    mapper: {
+      ...Mappers.Tag,
+      required: true
+    }
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.Tag
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const suggestTagsAndRegionsOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/tagsandregions/suggestions",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.iterationId1,
+    Parameters.imageIds1
+  ],
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "SuggestedTagAndRegion"
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const trainProjectOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/{projectId}/train",
+  urlParameters: [
+    Parameters.endpoint,
+    Parameters.projectId
+  ],
+  queryParameters: [
+    Parameters.trainingType,
+    Parameters.reservedBudgetInHours,
+    Parameters.forceTrain,
+    Parameters.notificationEmailAddress
+  ],
+  requestBody: {
+    parameterPath: [
+      "options",
+      "trainingParameters"
+    ],
+    mapper: Mappers.TrainingParameters
+  },
+  responses: {
+    200: {
+      bodyMapper: Mappers.Iteration
+    },
+    default: {
+      bodyMapper: Mappers.CustomVisionError
+    }
+  },
+  serializer
+};
+
+const importProjectOperationSpec: msRest.OperationSpec = {
+  httpMethod: "POST",
+  path: "projects/import",
+  urlParameters: [
+    Parameters.endpoint
+  ],
+  queryParameters: [
+    Parameters.token
+  ],
+  responses: {
+    200: {
+      bodyMapper: Mappers.Project
     },
     default: {
       bodyMapper: Mappers.CustomVisionError

--- a/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClientContext.ts
+++ b/sdk/cognitiveservices/cognitiveservices-customvision-training/src/trainingAPIClientContext.ts
@@ -11,24 +11,24 @@
 import * as msRest from "@azure/ms-rest-js";
 
 const packageName = "@azure/cognitiveservices-customvision-training";
-const packageVersion = "4.0.0";
+const packageVersion = "5.0.0";
 
 export class TrainingAPIClientContext extends msRest.ServiceClient {
-  apiKey: string;
   endpoint: string;
+  credentials: msRest.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the TrainingAPIClientContext class.
-   * @param apiKey API key.
    * @param endpoint Supported Cognitive Services endpoints.
+   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(apiKey: string, endpoint: string, options?: msRest.ServiceClientOptions) {
-    if (apiKey == undefined) {
-      throw new Error("'apiKey' cannot be null.");
-    }
+  constructor(credentials: msRest.ServiceClientCredentials, endpoint: string, options?: msRest.ServiceClientOptions) {
     if (endpoint == undefined) {
       throw new Error("'endpoint' cannot be null.");
+    }
+    if (credentials == undefined) {
+      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -40,11 +40,11 @@ export class TrainingAPIClientContext extends msRest.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(undefined, options);
+    super(credentials, options);
 
-    this.baseUri = "{Endpoint}/customvision/v3.0/training";
+    this.baseUri = "{Endpoint}/customvision/v3.2/training";
     this.requestContentType = "application/json; charset=utf-8";
-    this.apiKey = apiKey;
     this.endpoint = endpoint;
+    this.credentials = credentials;
   }
 }


### PR DESCRIPTION
Based on request from @zikalino, I have regenerated the Cognitive Services Custom Vision Prediction & Training TS SDKs in this PR. Command used to regenerated SDK:

**Prediction**
```
autorest --reset && autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.4 --package-version=5.0.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/2c3bdf02d5f714174ed160fcfade02d5e5669bce/specification/cognitiveservices/data-plane/CustomVision/Prediction/readme.md
```

**Training**
```
autorest --reset && autorest --typescript --license-header=MICROSOFT_MIT_NO_VERSION --typescript-sdks-folder=/Users/saranganrajamanickam/Projects/azure-sdk-for-js --use=@microsoft.azure/autorest.typescript@4.2.4 --package-version=5.0.0 https://raw.githubusercontent.com/Azure/azure-rest-api-specs/2c3bdf02d5f714174ed160fcfade02d5e5669bce/specification/cognitiveservices/data-plane/CustomVision/Training/readme.md
```

A few pointers to give context:
1. Last time, these SDKs were regenerated on Sep 11, 2019. At that time ***autorest.typescript version - 4.2.2*** was used for regeneration. Now, I have used ***autorest.typescript version - 4.2.4***
2. As you can see, both the SDKs have ***breaking changes***. So, I bumped the version from from ***4.0.0*** to ***5.0.0*** to both of them. 
3. The regeneration has removed the example changes in README.md and started using the old node auth. I have discarded those changes. 

@zikalino FYI...
@ramya-rao-a Please review and approve