### PR TITLE
Code changes to add select to List Skillsets operation

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -845,7 +845,9 @@ export interface ListSearchResultsPageSettings {
 }
 
 // @public
-export type ListSkillsetsOptions = OperationOptions;
+export interface ListSkillsetsOptions<Fields> extends OperationOptions {
+    select?: Fields[];
+}
 
 // @public
 export interface ListSynonymMapsOptions<Fields> extends OperationOptions {
@@ -1200,7 +1202,7 @@ export class SearchServiceClient {
     listDataSources<Fields extends keyof DataSource>(options?: ListDataSourcesOptions<Fields>): Promise<Array<Pick<DataSource, Fields>>>;
     listIndexers<Fields extends keyof Indexer>(options?: ListIndexersOptions<Fields>): Promise<Array<Pick<Indexer, Fields>>>;
     listIndexes<Fields extends keyof Index>(options?: ListIndexesOptions<Fields>): Promise<Array<Pick<Index, Fields>>>;
-    listSkillsets(options?: ListSkillsetsOptions): Promise<Skillset[]>;
+    listSkillsets<Fields extends keyof Skillset>(options?: ListSkillsetsOptions<Fields>): Promise<Array<Pick<Skillset, Fields>>>;
     listSynonymMaps<Fields extends keyof SynonymMap>(options?: ListSynonymMapsOptions<Fields>): Promise<Array<Pick<SynonymMap, Fields>>>;
     resetIndexer(indexerName: string, options?: ResetIndexerOptions): Promise<void>;
     runIndexer(indexerName: string, options?: RunIndexerOptions): Promise<void>;

--- a/sdk/search/search-documents/src/searchServiceClient.ts
+++ b/sdk/search/search-documents/src/searchServiceClient.ts
@@ -216,12 +216,15 @@ export class SearchServiceClient {
    * Retrieves a list of existing Skillsets in the service.
    * @param options Options to the list Skillsets operation.
    */
-  public async listSkillsets(options: ListSkillsetsOptions = {}): Promise<Skillset[]> {
+  public async listSkillsets<Fields extends keyof Skillset>(
+    options: ListSkillsetsOptions<Fields> = {}
+  ): Promise<Array<Pick<Skillset, Fields>>> {
     const { span, updatedOptions } = createSpan("SearchServiceClient-listSkillsets", options);
     try {
-      const result = await this.client.skillsets.list(
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      const result = await this.client.skillsets.list({
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        select: updatedOptions.select?.join(",")
+      });
       return result.skillsets.map(utils.generatedSkillsetToPublicSkillset);
     } catch (e) {
       span.setStatus({

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -81,7 +81,14 @@ import {
 /**
  * Options for a list skillsets operation.
  */
-export type ListSkillsetsOptions = OperationOptions;
+export interface ListSkillsetsOptions<Fields> extends OperationOptions {
+  /**
+   * Selects which top-level properties of the synonym maps to retrieve. Specified as a
+   * comma-separated list of JSON property names, or '*' for all properties. The default is all
+   * properties.
+   */
+  select?: Fields[];
+}
 
 /**
  * Options for a list synonymMaps operation.

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -42,6 +42,10 @@ import {
 } from "./serviceModels";
 
 export function convertSkillsToPublic(skills: SkillUnion[]): Skill[] {
+  if (!skills) {
+    return skills;
+  }
+
   const result: Skill[] = [];
   for (const skill of skills) {
     if (skill.odatatype !== "Skill") {
@@ -122,6 +126,10 @@ export function convertAnalyzersToPublic(analyzers?: AnalyzerUnion[]): Analyzer[
 }
 
 export function convertFieldsToPublic(fields: GeneratedField[]): Field[] {
+  if (!fields) {
+    return fields;
+  }
+
   return fields.map<Field>((field) => {
     let result: Field;
     if (field.type === "Collection(Edm.ComplexType)" || field.type === "Edm.ComplexType") {


### PR DESCRIPTION
The List Skillsets operation does have a select fields (even though the docs say otherwise). The swagger document [here](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/search/data-plane/Azure.Search/stable/2019-05-06/searchservice.json#L759) can be used for reference. 


```ts
import { SearchServiceClient, AzureKeyCredential, Skillset, odata, SynonymMap, Index }  from "@azure/search-documents";

const client: SearchServiceClient = new SearchServiceClient(
  "xyz",
  new AzureKeyCredential("abc")
);


async function main(): Promise<void> {
  const listOfSkillSets = await client.listSkillsets({
    select: ['name', 'skills']
  })
  listOfSkillSets.forEach((sk, index) => {
    console.log(`Name: ${sk.name}`);
    console.log(`Name: ${sk.skills}`);
  });
}

main();
```

@xirzec Please review and approve
@ramya-rao-a FYI