### PR TITLE
[core-http] update mediaTypes in API review

### DIFF
--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -501,7 +501,7 @@ export interface OperationSpec {
     readonly headerParameters?: ReadonlyArray<OperationParameter>;
     readonly httpMethod: HttpMethods;
     readonly isXML?: boolean;
-    readonly mediaType?: string;
+    readonly mediaType?: "json" | "xml" | "form" | "binary" | "multipart" | "text" | "unknown" | string;
     readonly path?: string;
     readonly queryParameters?: ReadonlyArray<OperationQueryParameter>;
     readonly requestBody?: OperationParameter;


### PR DESCRIPTION
This updates the api review file in core-http to match the actual changes that were merged from #8977.
