### PR TITLE
Add OnlyIfUnchanged parameter to CreateUpdate & Delete operations

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -162,21 +162,30 @@ export type CreateIndexerOptions = OperationOptions;
 export type CreateIndexOptions = OperationOptions;
 
 // @public
-export type CreateorUpdateDataSourceOptions = OperationOptions & ETagOperationOptions;
-
-// @public
-export type CreateorUpdateIndexerOptions = OperationOptions & ETagOperationOptions;
-
-// @public
-export interface CreateOrUpdateIndexOptions extends OperationOptions, ETagOperationOptions {
-    allowIndexDowntime?: boolean;
+export interface CreateorUpdateDataSourceOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
 }
 
 // @public
-export type CreateOrUpdateSkillsetOptions = OperationOptions & ETagOperationOptions;
+export interface CreateorUpdateIndexerOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
 
 // @public
-export type CreateOrUpdateSynonymMapOptions = OperationOptions & ETagOperationOptions;
+export interface CreateOrUpdateIndexOptions extends OperationOptions {
+    allowIndexDowntime?: boolean;
+    onlyIfUnchanged?: boolean;
+}
+
+// @public
+export interface CreateOrUpdateSkillsetOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
+
+// @public
+export interface CreateOrUpdateSynonymMapOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
 
 // @public
 export type CreateSkillsetOptions = OperationOptions;
@@ -232,22 +241,32 @@ export interface DefaultCognitiveServicesAccount {
 }
 
 // @public
-export type DeleteDataSourceOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteDataSourceOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
 
 // @public
 export type DeleteDocumentsOptions = IndexDocuments;
 
 // @public
-export type DeleteIndexerOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteIndexerOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
 
 // @public
-export type DeleteIndexOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteIndexOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
 
 // @public
-export type DeleteSkillsetOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteSkillsetOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
 
 // @public
-export type DeleteSynonymMapOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteSynonymMapOptions extends OperationOptions {
+    onlyIfUnchanged?: boolean;
+}
 
 // @public
 export interface DictionaryDecompounderTokenFilter {
@@ -339,11 +358,6 @@ export interface EntityRecognitionSkill {
 
 // @public
 export type EntityRecognitionSkillLanguage = 'ar' | 'cs' | 'zh-Hans' | 'zh-Hant' | 'da' | 'nl' | 'en' | 'fi' | 'fr' | 'de' | 'el' | 'hu' | 'it' | 'ja' | 'ko' | 'no' | 'pl' | 'pt-PT' | 'pt-BR' | 'ru' | 'es' | 'sv' | 'tr';
-
-// @public
-export interface ETagOperationOptions {
-    accessCondition?: AccessCondition;
-}
 
 // @public
 export interface FacetResult {

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -49,7 +49,6 @@ export {
   Skillset,
   ListSynonymMapsOptions,
   DeleteIndexOptions,
-  ETagOperationOptions,
   AnalyzeTextOptions,
   GetIndexOptions,
   GetIndexStatisticsOptions,

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -340,10 +340,17 @@ export class SearchIndexClient {
   ): Promise<Index> {
     const { span, updatedOptions } = createSpan("SearchIndexClient-createOrUpdateIndex", options);
     try {
+      const etag = options.onlyIfUnchanged ? index.etag : undefined;
+
       const result = await this.client.indexes.createOrUpdate(
         index.name,
         utils.publicIndexToGeneratedIndex(index),
-        operationOptionsToRequestOptionsBase(updatedOptions)
+        {
+          ...operationOptionsToRequestOptionsBase(updatedOptions),
+          accessCondition: {
+            ifMatch: etag
+          }
+        }
       );
       return utils.generatedIndexToPublicIndex(result);
     } catch (e) {
@@ -371,10 +378,17 @@ export class SearchIndexClient {
       options
     );
     try {
+      const etag = options.onlyIfUnchanged ? synonymMap.etag : undefined;
+
       const result = await this.client.synonymMaps.createOrUpdate(
         synonymMap.name,
         utils.publicSynonymMapToGeneratedSynonymMap(synonymMap),
-        operationOptionsToRequestOptionsBase(updatedOptions)
+        {
+          ...operationOptionsToRequestOptionsBase(updatedOptions),
+          accessCondition: {
+            ifMatch: etag
+          }
+        }
       );
       return utils.generatedSynonymMapToPublicSynonymMap(result);
     } catch (e) {
@@ -397,11 +411,15 @@ export class SearchIndexClient {
     const { span, updatedOptions } = createSpan("SearchIndexClient-deleteIndex", options);
     try {
       const indexName: string = typeof index === "string" ? index : index.name;
+      const etag =
+        typeof index === "string" ? undefined : options.onlyIfUnchanged ? index.etag : undefined;
 
-      await this.client.indexes.deleteMethod(
-        indexName,
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      await this.client.indexes.deleteMethod(indexName, {
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        accessCondition: {
+          ifMatch: etag
+        }
+      });
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -425,11 +443,19 @@ export class SearchIndexClient {
     const { span, updatedOptions } = createSpan("SearchIndexClient-deleteSynonymMap", options);
     try {
       const synonymMapName: string = typeof synonymMap === "string" ? synonymMap : synonymMap.name;
+      const etag =
+        typeof synonymMap === "string"
+          ? undefined
+          : options.onlyIfUnchanged
+          ? synonymMap.etag
+          : undefined;
 
-      await this.client.synonymMaps.deleteMethod(
-        synonymMapName,
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      await this.client.synonymMaps.deleteMethod(synonymMapName, {
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        accessCondition: {
+          ifMatch: etag
+        }
+      });
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -453,11 +453,14 @@ export class SearchIndexerClient {
       options
     );
     try {
-      const result = await this.client.indexers.createOrUpdate(
-        indexer.name,
-        indexer,
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      const etag = options.onlyIfUnchanged ? indexer.etag : undefined;
+
+      const result = await this.client.indexers.createOrUpdate(indexer.name, indexer, {
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        accessCondition: {
+          ifMatch: etag
+        }
+      });
       return result;
     } catch (e) {
       span.setStatus({
@@ -484,11 +487,14 @@ export class SearchIndexerClient {
       options
     );
     try {
-      const result = await this.client.dataSources.createOrUpdate(
-        dataSource.name,
-        dataSource,
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      const etag = options.onlyIfUnchanged ? dataSource.etag : undefined;
+
+      const result = await this.client.dataSources.createOrUpdate(dataSource.name, dataSource, {
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        accessCondition: {
+          ifMatch: etag
+        }
+      });
       return utils.generatedDataSourceToPublicDataSource(result);
     } catch (e) {
       span.setStatus({
@@ -515,11 +521,19 @@ export class SearchIndexerClient {
       options
     );
     try {
+      const etag = options.onlyIfUnchanged ? skillset.etag : undefined;
+
       const result = await this.client.skillsets.createOrUpdate(
         skillset.name,
         utils.publicSkillsetToGeneratedSkillset(skillset),
-        operationOptionsToRequestOptionsBase(updatedOptions)
+        {
+          ...operationOptionsToRequestOptionsBase(updatedOptions),
+          accessCondition: {
+            ifMatch: etag
+          }
+        }
       );
+
       return utils.generatedSkillsetToPublicSkillset(result);
     } catch (e) {
       span.setStatus({
@@ -544,11 +558,19 @@ export class SearchIndexerClient {
     const { span, updatedOptions } = createSpan("SearchIndexerClient-deleteIndexer", options);
     try {
       const indexerName: string = typeof indexer === "string" ? indexer : indexer.name;
+      const etag =
+        typeof indexer === "string"
+          ? undefined
+          : options.onlyIfUnchanged
+          ? indexer.etag
+          : undefined;
 
-      await this.client.indexers.deleteMethod(
-        indexerName,
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      await this.client.indexers.deleteMethod(indexerName, {
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        accessCondition: {
+          ifMatch: etag
+        }
+      });
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -572,11 +594,19 @@ export class SearchIndexerClient {
     const { span, updatedOptions } = createSpan("SearchIndexerClient-deleteDataSource", options);
     try {
       const dataSourceName: string = typeof dataSource === "string" ? dataSource : dataSource.name;
+      const etag =
+        typeof dataSource === "string"
+          ? undefined
+          : options.onlyIfUnchanged
+          ? dataSource.etag
+          : undefined;
 
-      await this.client.dataSources.deleteMethod(
-        dataSourceName,
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      await this.client.dataSources.deleteMethod(dataSourceName, {
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        accessCondition: {
+          ifMatch: etag
+        }
+      });
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -600,11 +630,19 @@ export class SearchIndexerClient {
     const { span, updatedOptions } = createSpan("SearchIndexerClient-deleteSkillset", options);
     try {
       const skillsetName: string = typeof skillset === "string" ? skillset : skillset.name;
+      const etag =
+        typeof skillset === "string"
+          ? undefined
+          : options.onlyIfUnchanged
+          ? skillset.etag
+          : undefined;
 
-      await this.client.skillsets.deleteMethod(
-        skillsetName,
-        operationOptionsToRequestOptionsBase(updatedOptions)
-      );
+      await this.client.skillsets.deleteMethod(skillsetName, {
+        ...operationOptionsToRequestOptionsBase(updatedOptions),
+        accessCondition: {
+          ifMatch: etag
+        }
+      });
     } catch (e) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -3,7 +3,6 @@
 
 import { OperationOptions } from "@azure/core-http";
 import {
-  AccessCondition,
   AnalyzeRequest,
   CustomAnalyzer,
   StandardAnalyzer,
@@ -179,19 +178,9 @@ export type CreateIndexerOptions = OperationOptions;
 export type CreateDataSourceOptions = OperationOptions;
 
 /**
- * Options for all operations with etag parameters.
- */
-export interface ETagOperationOptions {
-  /**
-   * ETag parameters
-   */
-  accessCondition?: AccessCondition;
-}
-
-/**
  * Options for create/update index operation.
  */
-export interface CreateOrUpdateIndexOptions extends OperationOptions, ETagOperationOptions {
+export interface CreateOrUpdateIndexOptions extends OperationOptions {
   /**
    * Allows new analyzers, tokenizers, token filters, or char filters to be added to an index by
    * taking the index offline for at least a few seconds. This temporarily causes indexing and
@@ -199,52 +188,101 @@ export interface CreateOrUpdateIndexOptions extends OperationOptions, ETagOperat
    * several minutes after the index is updated, or longer for very large indexes.
    */
   allowIndexDowntime?: boolean;
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
 }
 
 /**
  * Options for create/update skillset operation.
  */
-export type CreateOrUpdateSkillsetOptions = OperationOptions & ETagOperationOptions;
+export interface CreateOrUpdateSkillsetOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for create/update synonymmap operation.
  */
-export type CreateOrUpdateSynonymMapOptions = OperationOptions & ETagOperationOptions;
+export interface CreateOrUpdateSynonymMapOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for create/update indexer operation.
  */
-export type CreateorUpdateIndexerOptions = OperationOptions & ETagOperationOptions;
+export interface CreateorUpdateIndexerOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for create/update datasource operation.
  */
-export type CreateorUpdateDataSourceOptions = OperationOptions & ETagOperationOptions;
+export interface CreateorUpdateDataSourceOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for delete index operation.
  */
-export type DeleteIndexOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteIndexOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for delete skillset operaion.
  */
-export type DeleteSkillsetOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteSkillsetOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for delete synonymmap operation.
  */
-export type DeleteSynonymMapOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteSynonymMapOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for delete indexer operation.
  */
-export type DeleteIndexerOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteIndexerOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for delete datasource operation.
  */
-export type DeleteDataSourceOptions = OperationOptions & ETagOperationOptions;
+export interface DeleteDataSourceOptions extends OperationOptions {
+  /**
+   * If set to true, Resource will be deleted only if the etag matches.
+   */
+  onlyIfUnchanged?: boolean;
+}
 
 /**
  * Options for analyze text operation.


### PR DESCRIPTION
**Specification for this PR**
Currently in the SDK we expose ```ETagOperationOptions``` which has ```AccessCondition```. It should be removed. We should not expose it. Instead, we need to introduce a boolean value ```OnlyIfUnchanged```. This value must be used to determine if the etag value should be sent to the server or not. 

1) For CreateOrUpdate, this is straight forward: we already take entire models that have an ETag, so you just get that and, if onlyIfUnchanged is true, pass the If-Match header.
2) For Delete, which takes stringName as inputParameter, Unconditionally delete resources.
3) For Delete, which takes the model as inputParameter, Use onlyIfUnchanged similar to CreateOrUpdate.

This is related to issue https://github.com/Azure/azure-sdk-for-js/issues/8517 


@xirzec Please review and approve
@ramya-rao-a FYI
