### PR TITLE
Bugfix ResourceManagementClient Example Wrong ApiVersion

### DIFF
--- a/sdk/resources/arm-resources/README.md
+++ b/sdk/resources/arm-resources/README.md
@@ -35,6 +35,7 @@ const subscriptionId = process.env["AZURE_SUBSCRIPTION_ID"];
 
 msRestNodeAuth.interactiveLogin().then((creds) => {
   const client = new ResourceManagementClient(creds, subscriptionId);
+  client.apiVersion = '2015-01-01';
   client.operations.list().then((result) => {
     console.log("The result is:");
     console.log(result);


### PR DESCRIPTION
Current behavior:
The example errors with the following error:
`The resource type 'operations' could not be found in the namespace 'Microsoft.Resources' for api version '2019-07-01'. The supported api-versions are '2015-01-01'.`

This can be fixed by setting the required api-version upfront:
` client.apiVersion = '2015-01-01';`
