### PR TITLE
[core-http] fix browser tests on Firefox

### DIFF
--- a/sdk/core/core-http/test/msRestUserAgentPolicyTests.browser.ts
+++ b/sdk/core/core-http/test/msRestUserAgentPolicyTests.browser.ts
@@ -60,10 +60,10 @@ describe("MsRestUserAgentPolicy (browser)", () => {
         userAgentHeader.should.be.equal(customUserAgent);
       });
 
-      it("should be space delimited and contain two fields", async () => {
+      it("should be space delimited and contain at least two fields", async () => {
         const userAgent = await getUserAgent();
         const userAgentParts = userAgent.split(" ");
-        userAgentParts.length.should.be.equal(2);
+        userAgentParts.length.should.be.greaterThan(1);
       });
 
       it("should contain runtime information", async () => {

--- a/sdk/core/core-http/test/serializationTests.ts
+++ b/sdk/core/core-http/test/serializationTests.ts
@@ -286,9 +286,9 @@ describe("msrest", function() {
         required: false,
         serializedName: "DateTimeRfc1123"
       };
-      const rfc = new Date("Mon, 01 Jan 0001 00:00:00 GMT");
+      const rfc = new Date("Thu, 01 Jan 3001 00:00:00 GMT");
       const serializedDateString = Serializer.serialize(mapper, rfc, "dateTimeObj");
-      serializedDateString.should.equal("Mon, 01 Jan 2001 00:00:00 GMT");
+      serializedDateString.should.equal("Thu, 01 Jan 3001 00:00:00 GMT");
       done();
     });
 

--- a/sdk/core/core-http/test/serializationTests.ts
+++ b/sdk/core/core-http/test/serializationTests.ts
@@ -286,9 +286,9 @@ describe("msrest", function() {
         required: false,
         serializedName: "DateTimeRfc1123"
       };
-      const rfc = new Date("Thu, 01 Jan 3001 00:00:00 GMT");
+      const rfc = new Date("Wed, 01 Jan 2020 00:00:00 GMT");
       const serializedDateString = Serializer.serialize(mapper, rfc, "dateTimeObj");
-      serializedDateString.should.equal("Thu, 01 Jan 3001 00:00:00 GMT");
+      serializedDateString.should.equal("Wed, 01 Jan 2020 00:00:00 GMT");
       done();
     });
 

--- a/sdk/core/core-http/test/xmlTests.ts
+++ b/sdk/core/core-http/test/xmlTests.ts
@@ -9,20 +9,22 @@ describe("XML serializer", function() {
   describe("parseXML(string)", function() {
     it("with undefined", async function() {
       const error: Error = await msAssert.throwsAsync(parseXML(undefined as any));
-      assert.notStrictEqual(
-        error.message.indexOf("Document is empty"),
-        -1,
-        `error.message ("${error.message}") should have contained "Document is empty"`
+      assert.ok(
+        error.message.indexOf("Document is empty") !== -1 || // Chrome
+        (error.message.startsWith("XML Parsing Error: syntax error") &&
+          error.message.indexOf("undefined") !== -1), // Firefox
+        `error.message ("${error.message}") should have contained "Document is empty" or "undefined"`
       );
     });
 
     it("with null", async function() {
       // tslint:disable-next-line:no-null-keyword
       const error: Error = await msAssert.throwsAsync(parseXML(null as any));
-      assert.notStrictEqual(
-        error.message.indexOf("Document is empty"),
-        -1,
-        `error.message ("${error.message}") should have contained "Document is empty"`
+      assert.ok(
+        error.message.indexOf("Document is empty") !== -1 || // Chrome
+        (error.message.startsWith("XML Parsing Error: syntax error") &&
+          error.message.indexOf("null") !== -1), // Firefox
+        `error.message ("${error.message}") should have contained "Document is empty" or "null"`
       );
     });
 


### PR DESCRIPTION
Issue 1) on Firefox user agent string contains more than two
fields:

  "core-http/1.1.3 OS/WindowsNT 10.0; Win64; x64"

while on Chrome it has just two:

  "core-http/1.1.3 OS/Win32"

Changed to verify it has at least two fields.

Issue 2) Most likely either Chrome has a bug, or behavior of dates
before January 1, 1970 is not well defined. For the date Tue, Jan 1
0001 00:00:00 GMT, Chrome sets the year to be 2001, while Firefox
keeps the year as 0001.

Changed to use another date in the test.

Issue 3) The error message when parsing xml with an input of undefined
or null is different between Chrome and Firefox.

Changed to pass on either one.