### PR TITLE
[KeyVault Certificates] Making sure updateCertificateProperties properly passes the certificate attributes to the underlying generated method

### DIFF
--- a/sdk/keyvault/keyvault-certificates/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-certificates/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `KVPollerLike` is now an alias of `PollerLike`.
 - `KVPollerLike` is considered deprecated. Use `PollerLike`.
 - Fixed [bug 8378](https://github.com/Azure/azure-sdk-for-js/issues/8378), which caused the challenge based authentication to re-authenticate on every new request.
+- Fixed [bug 9020](https://github.com/Azure/azure-sdk-for-js/issues/9020), which caused updateCertificateProperties to not properly send the certificate attributes to the service.
 
 ## 4.0.1 (2020-05-13)
 

--- a/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate.json
+++ b/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate.json
@@ -1,0 +1,798 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/create",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"Request is missing a Bearer or PoP token.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "87",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:03 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "401",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.windows.net/azure_tenant_id\", resource=\"https://vault.azure.net\"",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "42f3af0a-e6cc-4762-8e95-2481a5789f36",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1315",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:02 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.10620.11 - SCUS ProdSlices",
+    "x-ms-request-id": "107f6279-b061-4008-8b27-323dd1ae1400"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/create",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": "{\"policy\":{\"key_props\":{},\"secret_props\":{},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{}},\"issuer\":{\"name\":\"Self\"},\"attributes\":{}},\"attributes\":{}}",
+   "status": 202,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:04 GMT",
+    "expires": "-1",
+    "location": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending?api-version=7.1-preview&request_id=e22e74332ca24528ba5a057284bf2013",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "202",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "bc1a0fa5-1f97-4390-bf1c-f86563c6571a",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:04 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "a4bd38df-b0d3-4640-a1b4-3c03032b1fee",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:04 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "448ab1c9-2a15-4b8b-87b3-b210519dbaa7",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:06 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "6dc160cb-8472-4ca3-9aa0-619a524ecc4e",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:08 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "58f7428e-b60a-4048-879e-832e126c9650",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:10 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "329b5624-e851-4cd4-bfe7-cba4d68089b2",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:12 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "1bf5000c-bd57-47b0-9253-4e4885a75b27",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:14 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "d09bcaf0-2b80-46b4-a0c6-cd3decf4c731",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:16 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "afc7dc95-d265-4c67-bc31-d2adb979b2c1",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:18 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "3ddf39b1-260c-4627-8ffc-4ff77a11450a",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1340",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:20 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "c54537e8-78a3-42b6-bcc4-5766cd671404",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAytMudPd4xKlECxl48T16fUsm0H1DGNrei3kUUGCARU7/JQR9s0uxQmhCc0BergwZYKCUgLCB7anIzvG52I5/Dz4HXoRGBru+BssXVvTQ+bkVdx3RhQKz9Hlw/k8fKAAYRx5L/TBcrijvYzBSfcfHpFF3j11dQvj9B95AZUtuanKYdfgoa/vvodakFfEcJL8MFTq4SwAyiaLyaLWc7acBINzw7uoHXn6xFewTf2LfDAxPagQmlFVw9Am4N1zcVXXOvUEdXsBvZOnqEcEsBcL4xXr8i1TcOiyzj3ankiUktsxlMkHAVn8aB0SK33zSBqfNocqbyFVSc6FnMPFJEGcqqQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAK5rrrzMx+prINd7YgoRGwhqk7KFja6MOgj8MKlFQJxrBJRYr4wcOwRHnNgm1kEKf21hSfdISJzShlboSR75RgTLTbbX2x+Nv3EX4vzOEvDw9qpDBihGDKQe3knL/9CFl2EhwJyW+C8GntSQTSVsOpKeDZuvv1narndQCdhAq2kKVXRCZ8WmGeMhXqWabdjaGG0kKIi2zfKEC6SUuSKarCBtidV2Tt3YIyOLrbqwOPI2wkL0xJu9645ZazOrPDGr5nlFVT6cMzpKK3fYdn91zUzCeoP4WzOSPLrjer5mDKWNjPu+N6osTdHAJm12WaNQcQE3r3yuQHVSz3HOu5lg4kk=\",\"cancellation_requested\":false,\"status\":\"completed\",\"target\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-\",\"request_id\":\"e22e74332ca24528ba5a057284bf2013\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1307",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:22 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "97e52ddf-666f-439f-8eac-74074affe3ee",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"x5t\":\"SAs2q2eqxu0yf3GLra66Q5R_BRg\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQK4lHJzObSK+6Y9IDPyoIwjANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDIxWhcNMjEwNTI3MTMyMDIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDK0y5093jEqUQLGXjxPXp9SybQfUMY2t6LeRRQYIBFTv8lBH2zS7FCaEJzQF6uDBlgoJSAsIHtqcjO8bnYjn8PPgdehEYGu74GyxdW9ND5uRV3HdGFArP0eXD+Tx8oABhHHkv9MFyuKO9jMFJ9x8ekUXePXV1C+P0H3kBlS25qcph1+Chr+++h1qQV8RwkvwwVOrhLADKJovJotZztpwEg3PDu6gdefrEV7BN/Yt8MDE9qBCaUVXD0Cbg3XNxVdc69QR1ewG9k6eoRwSwFwvjFevyLVNw6LLOPdqeSJSS2zGUyQcBWfxoHRIrffNIGp82hypvIVVJzoWcw8UkQZyqpAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQLvO5HKRafyQAfae1XheZF4SxsYzAdBgNVHQ4EFgQUC7zuRykWn8kAH2ntV4XmReEsbGMwDQYJKoZIhvcNAQELBQADggEBACV9CuJB+Q7IJusvg3lw0u/G7twTsZRnwaf2wUexRmAeoi6cHOY4yXIpJxzc3acRPypuJv4jfnLRf8No1N+EeOwYwxOOWDZGFiqq6EzRUSpMxeFfbmd9BbERS0Fn6h8LDfFpjHxs+2QlRGXledoE8tHw2GBr7aukTxzz3GcBrChAanMFc4ARb5CPtJvTemiHHcgMKFc2LClSA82zFN7mBViWqZrNj8n1sCEzohiygX02z2/zKAqIJRxcbI/9sPJt36LwYwpFX1knGB7NVYD4tBP1P3POGedHIbiBoH9pwtsUTvcTzJIhPkX3HlqI+xYaR8GQVk+yqZ3nlLmYvFG/Riw=\",\"attributes\":{\"enabled\":true,\"nbf\":1590585021,\"exp\":1622121621,\"created\":1590585621,\"updated\":1590585621,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585604,\"updated\":1590585604}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2590",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:22 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "0aabbded-8325-4c33-b70a-156d8e8b24aa",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "PATCH",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": "{\"attributes\":{\"enabled\":false}}",
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"x5t\":\"SAs2q2eqxu0yf3GLra66Q5R_BRg\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQK4lHJzObSK+6Y9IDPyoIwjANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDIxWhcNMjEwNTI3MTMyMDIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDK0y5093jEqUQLGXjxPXp9SybQfUMY2t6LeRRQYIBFTv8lBH2zS7FCaEJzQF6uDBlgoJSAsIHtqcjO8bnYjn8PPgdehEYGu74GyxdW9ND5uRV3HdGFArP0eXD+Tx8oABhHHkv9MFyuKO9jMFJ9x8ekUXePXV1C+P0H3kBlS25qcph1+Chr+++h1qQV8RwkvwwVOrhLADKJovJotZztpwEg3PDu6gdefrEV7BN/Yt8MDE9qBCaUVXD0Cbg3XNxVdc69QR1ewG9k6eoRwSwFwvjFevyLVNw6LLOPdqeSJSS2zGUyQcBWfxoHRIrffNIGp82hypvIVVJzoWcw8UkQZyqpAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQLvO5HKRafyQAfae1XheZF4SxsYzAdBgNVHQ4EFgQUC7zuRykWn8kAH2ntV4XmReEsbGMwDQYJKoZIhvcNAQELBQADggEBACV9CuJB+Q7IJusvg3lw0u/G7twTsZRnwaf2wUexRmAeoi6cHOY4yXIpJxzc3acRPypuJv4jfnLRf8No1N+EeOwYwxOOWDZGFiqq6EzRUSpMxeFfbmd9BbERS0Fn6h8LDfFpjHxs+2QlRGXledoE8tHw2GBr7aukTxzz3GcBrChAanMFc4ARb5CPtJvTemiHHcgMKFc2LClSA82zFN7mBViWqZrNj8n1sCEzohiygX02z2/zKAqIJRxcbI/9sPJt36LwYwpFX1knGB7NVYD4tBP1P3POGedHIbiBoH9pwtsUTvcTzJIhPkX3HlqI+xYaR8GQVk+yqZ3nlLmYvFG/Riw=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585021,\"exp\":1622121621,\"created\":1590585621,\"updated\":1590585623,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585604,\"updated\":1590585604}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2591",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:22 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "98b6a02a-d18e-4125-9edc-8d992cc88440",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"x5t\":\"SAs2q2eqxu0yf3GLra66Q5R_BRg\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQK4lHJzObSK+6Y9IDPyoIwjANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDIxWhcNMjEwNTI3MTMyMDIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDK0y5093jEqUQLGXjxPXp9SybQfUMY2t6LeRRQYIBFTv8lBH2zS7FCaEJzQF6uDBlgoJSAsIHtqcjO8bnYjn8PPgdehEYGu74GyxdW9ND5uRV3HdGFArP0eXD+Tx8oABhHHkv9MFyuKO9jMFJ9x8ekUXePXV1C+P0H3kBlS25qcph1+Chr+++h1qQV8RwkvwwVOrhLADKJovJotZztpwEg3PDu6gdefrEV7BN/Yt8MDE9qBCaUVXD0Cbg3XNxVdc69QR1ewG9k6eoRwSwFwvjFevyLVNw6LLOPdqeSJSS2zGUyQcBWfxoHRIrffNIGp82hypvIVVJzoWcw8UkQZyqpAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQLvO5HKRafyQAfae1XheZF4SxsYzAdBgNVHQ4EFgQUC7zuRykWn8kAH2ntV4XmReEsbGMwDQYJKoZIhvcNAQELBQADggEBACV9CuJB+Q7IJusvg3lw0u/G7twTsZRnwaf2wUexRmAeoi6cHOY4yXIpJxzc3acRPypuJv4jfnLRf8No1N+EeOwYwxOOWDZGFiqq6EzRUSpMxeFfbmd9BbERS0Fn6h8LDfFpjHxs+2QlRGXledoE8tHw2GBr7aukTxzz3GcBrChAanMFc4ARb5CPtJvTemiHHcgMKFc2LClSA82zFN7mBViWqZrNj8n1sCEzohiygX02z2/zKAqIJRxcbI/9sPJt36LwYwpFX1knGB7NVYD4tBP1P3POGedHIbiBoH9pwtsUTvcTzJIhPkX3HlqI+xYaR8GQVk+yqZ3nlLmYvFG/Riw=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585021,\"exp\":1622121621,\"created\":1590585621,\"updated\":1590585623,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585604,\"updated\":1590585604}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2591",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:22 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "d6357de2-4661-471b-a07c-43514d80c93b",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-\",\"deletedDate\":1590585623,\"scheduledPurgeDate\":1598361623,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"x5t\":\"SAs2q2eqxu0yf3GLra66Q5R_BRg\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQK4lHJzObSK+6Y9IDPyoIwjANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDIxWhcNMjEwNTI3MTMyMDIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDK0y5093jEqUQLGXjxPXp9SybQfUMY2t6LeRRQYIBFTv8lBH2zS7FCaEJzQF6uDBlgoJSAsIHtqcjO8bnYjn8PPgdehEYGu74GyxdW9ND5uRV3HdGFArP0eXD+Tx8oABhHHkv9MFyuKO9jMFJ9x8ekUXePXV1C+P0H3kBlS25qcph1+Chr+++h1qQV8RwkvwwVOrhLADKJovJotZztpwEg3PDu6gdefrEV7BN/Yt8MDE9qBCaUVXD0Cbg3XNxVdc69QR1ewG9k6eoRwSwFwvjFevyLVNw6LLOPdqeSJSS2zGUyQcBWfxoHRIrffNIGp82hypvIVVJzoWcw8UkQZyqpAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQLvO5HKRafyQAfae1XheZF4SxsYzAdBgNVHQ4EFgQUC7zuRykWn8kAH2ntV4XmReEsbGMwDQYJKoZIhvcNAQELBQADggEBACV9CuJB+Q7IJusvg3lw0u/G7twTsZRnwaf2wUexRmAeoi6cHOY4yXIpJxzc3acRPypuJv4jfnLRf8No1N+EeOwYwxOOWDZGFiqq6EzRUSpMxeFfbmd9BbERS0Fn6h8LDfFpjHxs+2QlRGXledoE8tHw2GBr7aukTxzz3GcBrChAanMFc4ARb5CPtJvTemiHHcgMKFc2LClSA82zFN7mBViWqZrNj8n1sCEzohiygX02z2/zKAqIJRxcbI/9sPJt36LwYwpFX1knGB7NVYD4tBP1P3POGedHIbiBoH9pwtsUTvcTzJIhPkX3HlqI+xYaR8GQVk+yqZ3nlLmYvFG/Riw=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585021,\"exp\":1622121621,\"created\":1590585621,\"updated\":1590585623,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585604,\"updated\":1590585604}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2791",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:22 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "0b20de93-80e1-44c4-bae5-9bd9d78040e7",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:22 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "6f9336ee-c414-433d-bb12-c6c907b2e021",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:22 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "87df494c-15d2-410a-989a-1812bb7a9509",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:25 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "7a3c607f-06e3-43ce-965e-0b7ff22fc5c8",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:27 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "19fddc1b-b2b3-436f-a8cc-4126531eac8a",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:29 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "7a5aeab8-f539-46c8-91c3-e3b87df9b0f0",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:31 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "37a8a515-7931-417b-9636-24cc02d7b6f6",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:33 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "f02a6bfd-75fe-47ae-93e5-4c40604287c5",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:35 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "6b4e87be-f6ed-4dfd-93d9-e8b941fac39b",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificate-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "148",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:37 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "c6467322-0aa9-4e4d-8a72-f91979eb1aaf",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-\",\"deletedDate\":1590585623,\"scheduledPurgeDate\":1598361623,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ab2cbba510b24499873fe188975b784c\",\"x5t\":\"SAs2q2eqxu0yf3GLra66Q5R_BRg\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQK4lHJzObSK+6Y9IDPyoIwjANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDIxWhcNMjEwNTI3MTMyMDIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDK0y5093jEqUQLGXjxPXp9SybQfUMY2t6LeRRQYIBFTv8lBH2zS7FCaEJzQF6uDBlgoJSAsIHtqcjO8bnYjn8PPgdehEYGu74GyxdW9ND5uRV3HdGFArP0eXD+Tx8oABhHHkv9MFyuKO9jMFJ9x8ekUXePXV1C+P0H3kBlS25qcph1+Chr+++h1qQV8RwkvwwVOrhLADKJovJotZztpwEg3PDu6gdefrEV7BN/Yt8MDE9qBCaUVXD0Cbg3XNxVdc69QR1ewG9k6eoRwSwFwvjFevyLVNw6LLOPdqeSJSS2zGUyQcBWfxoHRIrffNIGp82hypvIVVJzoWcw8UkQZyqpAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQLvO5HKRafyQAfae1XheZF4SxsYzAdBgNVHQ4EFgQUC7zuRykWn8kAH2ntV4XmReEsbGMwDQYJKoZIhvcNAQELBQADggEBACV9CuJB+Q7IJusvg3lw0u/G7twTsZRnwaf2wUexRmAeoi6cHOY4yXIpJxzc3acRPypuJv4jfnLRf8No1N+EeOwYwxOOWDZGFiqq6EzRUSpMxeFfbmd9BbERS0Fn6h8LDfFpjHxs+2QlRGXledoE8tHw2GBr7aukTxzz3GcBrChAanMFc4ARb5CPtJvTemiHHcgMKFc2LClSA82zFN7mBViWqZrNj8n1sCEzohiygX02z2/zKAqIJRxcbI/9sPJt36LwYwpFX1knGB7NVYD4tBP1P3POGedHIbiBoH9pwtsUTvcTzJIhPkX3HlqI+xYaR8GQVk+yqZ3nlLmYvFG/Riw=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585021,\"exp\":1622121621,\"created\":1590585621,\"updated\":1590585623,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585604,\"updated\":1590585604}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2791",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:39 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "d9b25e8a-7954-42bc-8a9b-96243bcb3d9d",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "date": "Wed, 27 May 2020 13:20:39 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "204",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "9580f6f1-76d4-47a5-9ee1-ecb9bf78f934",
+    "x-powered-by": "ASP.NET"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "dc6a461082bdeae7db210cbfa3031db0"
+}

--- a/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate_version.json
+++ b/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate_version.json
@@ -1,0 +1,743 @@
+{
+ "recordings": [
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/create",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": "",
+   "status": 401,
+   "response": "{\"error\":{\"code\":\"Unauthorized\",\"message\":\"Request is missing a Bearer or PoP token.\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "87",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:39 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "401",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "www-authenticate": "Bearer authorization=\"https://login.windows.net/azure_tenant_id\", resource=\"https://vault.azure.net\"",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "0afc7ea7-c44e-44e5-a63a-5063eb49e570",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://login.microsoftonline.com/azure_tenant_id/oauth2/v2.0/token",
+   "query": {},
+   "requestBody": "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default",
+   "status": 200,
+   "response": "{\"token_type\":\"Bearer\",\"expires_in\":86399,\"ext_expires_in\":86399,\"access_token\":\"access_token\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache, no-store",
+    "content-length": "1315",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:39 GMT",
+    "expires": "-1",
+    "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
+    "pragma": "no-cache",
+    "referrer-policy": "strict-origin-when-cross-origin",
+    "strict-transport-security": "max-age=31536000; includeSubDomains",
+    "x-content-type-options": "nosniff",
+    "x-ms-ests-server": "2.1.10620.11 - SCUS ProdSlices",
+    "x-ms-request-id": "2fa850d9-9601-4ad4-a6fc-855f97111500"
+   }
+  },
+  {
+   "method": "POST",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/create",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": "{\"policy\":{\"key_props\":{},\"secret_props\":{},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{}},\"issuer\":{\"name\":\"Self\"},\"attributes\":{}},\"attributes\":{}}",
+   "status": 202,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:40 GMT",
+    "expires": "-1",
+    "location": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending?api-version=7.1-preview&request_id=bd20b951a0a34fb1a8b0829a68a55ddd",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "202",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "9cc2200f-1ec2-43b9-8dbe-4c1e4c32997c",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:40 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "f03671c7-b347-4785-b9f1-d9052f6da99b",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:40 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "66e06585-3db3-4552-bd0e-6bf63b58ef95",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:42 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "fad078b0-4ea0-42e6-8705-431f25ea374b",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:44 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "82adb507-66cc-49ed-bcee-72aac33602cf",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:46 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "04cbc280-1185-4dbc-83ac-98c583b4510b",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:49 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "435fabfd-a595-4a47-af42-adf72f8445bb",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:51 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "bca225cc-78cf-4369-bec2-f724e35a33b0",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:53 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "7bc2bcbc-d8e5-4166-af95-3b559ad79dee",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1345",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:55 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "retry-after": "10",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "f436371a-ea2c-4f59-bac8-0e394a1db996",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsPS79Vch1WFIF56N3VzNKq2/nN3p7aHGUt+/1H3+qgonLiQBbU1oqPdyZfbQB2e5P78SX3uVYqF5br8ucHhW3rDfWj9PubEqvySlCDLEKwDIsGjGAN8ulsbi/ce+vWe3vKl2ZgJgPySCP0C3Jj/N5WP79L9WBWoPBMkbjQoAXDQ3dko++FPtkj8wNf/YkLJ7ha2DbmFp0covzM+X5mSZP47DLEia6G1nRlCjC99lrNXelHyApH6/3rFQEU87Tb3m/SPNIPNa8Vih63cmfaXNxw4yOEoe3l2WlY/guRm5ZvaYUA9xny6LqZJRpCdjG5unAP9dS37uAJnzCNdhNtNyNQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAJiFwXUw/DfkwfgBCc8AEn7mlDPkHIdA1WNTv4Zd+1C+x3AriXugnxrOhvwWKMRQvZCSek5oPLgSfI2c8yLyP21i9Y8OujG4khV/+ZtwnT4oKk65+x1dGVFPI1EEsI+8551iBZSfgvbQMCrj8u4E8FMXoih1EOJY736EyO69NvFRbcp+GLROeQeJ4Ahw0SXE1UbsOjl9G/PSxzY9T7xGvyeEMvM0A0ESh0aE7WfJDLIHL0PO8hl/j7oKTg9VDCHxCOgjK9xmlDvJsVEnb1pszGpUpTAK1ww/XAPXESbPrJaR2NiD+yx5dGLW5C655XdIwo8nDDS6immVudkZYXrAKeY=\",\"cancellation_requested\":false,\"status\":\"completed\",\"target\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-\",\"request_id\":\"bd20b951a0a34fb1a8b0829a68a55ddd\"}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1317",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:56 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "896a1cec-2c74-434c-9337-36271822ea2b",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"x5t\":\"79j3HP5IszZKuqMz_rRHltlaNBs\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQU/ThA1drSN+xUI36Uvf4XDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDU0WhcNMjEwNTI3MTMyMDU0WjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw9Lv1VyHVYUgXno3dXM0qrb+c3entocZS37/Uff6qCicuJAFtTWio93Jl9tAHZ7k/vxJfe5VioXluvy5weFbesN9aP0+5sSq/JKUIMsQrAMiwaMYA3y6WxuL9x769Z7e8qXZmAmA/JII/QLcmP83lY/v0v1YFag8EyRuNCgBcNDd2Sj74U+2SPzA1/9iQsnuFrYNuYWnRyi/Mz5fmZJk/jsMsSJrobWdGUKML32Ws1d6UfICkfr/esVARTztNveb9I80g81rxWKHrdyZ9pc3HDjI4Sh7eXZaVj+C5Gblm9phQD3GfLoupklGkJ2Mbm6cA/11Lfu4AmfMI12E203I1AgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSQM58EpHMCl43Ewq0GS8xQYhaKqDAdBgNVHQ4EFgQUkDOfBKRzApeNxMKtBkvMUGIWiqgwDQYJKoZIhvcNAQELBQADggEBAD3rfLPjg/DbEwxlhw55BDXT+gyHLR2PHgvJNvZpB9AOrTJOTZCt+kinPgj3DcscgTNx6ITMG9fbLoUsRO4WVQNlHJxdRIkK0+y+WO+An2PyZvzxMqzNdQDPhkO1SQ36FXokgtRJRVif66HvML+6fOgoVTsYDyQOagSnIya+28WlUWha+1Jp8ALdctWGGMJHlQVdvQS4le8In6xWvwq90zkhNRznk70E/aHRHr6veOi6D8MgMX3XOFWh6asYahv9Eh84d4cwsNMnagSlFixQnss9hqv6YHe/H3FAAlEKSygGciEVYP80cbXqmZ9xMYlIjJbMKDxQJNUm3NEqPDpFyy4=\",\"attributes\":{\"enabled\":true,\"nbf\":1590585054,\"exp\":1622121654,\"created\":1590585655,\"updated\":1590585655,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585640,\"updated\":1590585640}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2615",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:56 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "00f75525-b4cc-4cb7-be13-9cec5fe33ff4",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "PATCH",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": "{\"attributes\":{\"enabled\":false}}",
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"x5t\":\"79j3HP5IszZKuqMz_rRHltlaNBs\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQU/ThA1drSN+xUI36Uvf4XDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDU0WhcNMjEwNTI3MTMyMDU0WjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw9Lv1VyHVYUgXno3dXM0qrb+c3entocZS37/Uff6qCicuJAFtTWio93Jl9tAHZ7k/vxJfe5VioXluvy5weFbesN9aP0+5sSq/JKUIMsQrAMiwaMYA3y6WxuL9x769Z7e8qXZmAmA/JII/QLcmP83lY/v0v1YFag8EyRuNCgBcNDd2Sj74U+2SPzA1/9iQsnuFrYNuYWnRyi/Mz5fmZJk/jsMsSJrobWdGUKML32Ws1d6UfICkfr/esVARTztNveb9I80g81rxWKHrdyZ9pc3HDjI4Sh7eXZaVj+C5Gblm9phQD3GfLoupklGkJ2Mbm6cA/11Lfu4AmfMI12E203I1AgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSQM58EpHMCl43Ewq0GS8xQYhaKqDAdBgNVHQ4EFgQUkDOfBKRzApeNxMKtBkvMUGIWiqgwDQYJKoZIhvcNAQELBQADggEBAD3rfLPjg/DbEwxlhw55BDXT+gyHLR2PHgvJNvZpB9AOrTJOTZCt+kinPgj3DcscgTNx6ITMG9fbLoUsRO4WVQNlHJxdRIkK0+y+WO+An2PyZvzxMqzNdQDPhkO1SQ36FXokgtRJRVif66HvML+6fOgoVTsYDyQOagSnIya+28WlUWha+1Jp8ALdctWGGMJHlQVdvQS4le8In6xWvwq90zkhNRznk70E/aHRHr6veOi6D8MgMX3XOFWh6asYahv9Eh84d4cwsNMnagSlFixQnss9hqv6YHe/H3FAAlEKSygGciEVYP80cbXqmZ9xMYlIjJbMKDxQJNUm3NEqPDpFyy4=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585054,\"exp\":1622121654,\"created\":1590585655,\"updated\":1590585657,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1938",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:57 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "6c3f48a6-8851-44b8-a1ef-0f869e4cfb64",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"x5t\":\"79j3HP5IszZKuqMz_rRHltlaNBs\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQU/ThA1drSN+xUI36Uvf4XDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDU0WhcNMjEwNTI3MTMyMDU0WjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw9Lv1VyHVYUgXno3dXM0qrb+c3entocZS37/Uff6qCicuJAFtTWio93Jl9tAHZ7k/vxJfe5VioXluvy5weFbesN9aP0+5sSq/JKUIMsQrAMiwaMYA3y6WxuL9x769Z7e8qXZmAmA/JII/QLcmP83lY/v0v1YFag8EyRuNCgBcNDd2Sj74U+2SPzA1/9iQsnuFrYNuYWnRyi/Mz5fmZJk/jsMsSJrobWdGUKML32Ws1d6UfICkfr/esVARTztNveb9I80g81rxWKHrdyZ9pc3HDjI4Sh7eXZaVj+C5Gblm9phQD3GfLoupklGkJ2Mbm6cA/11Lfu4AmfMI12E203I1AgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSQM58EpHMCl43Ewq0GS8xQYhaKqDAdBgNVHQ4EFgQUkDOfBKRzApeNxMKtBkvMUGIWiqgwDQYJKoZIhvcNAQELBQADggEBAD3rfLPjg/DbEwxlhw55BDXT+gyHLR2PHgvJNvZpB9AOrTJOTZCt+kinPgj3DcscgTNx6ITMG9fbLoUsRO4WVQNlHJxdRIkK0+y+WO+An2PyZvzxMqzNdQDPhkO1SQ36FXokgtRJRVif66HvML+6fOgoVTsYDyQOagSnIya+28WlUWha+1Jp8ALdctWGGMJHlQVdvQS4le8In6xWvwq90zkhNRznk70E/aHRHr6veOi6D8MgMX3XOFWh6asYahv9Eh84d4cwsNMnagSlFixQnss9hqv6YHe/H3FAAlEKSygGciEVYP80cbXqmZ9xMYlIjJbMKDxQJNUm3NEqPDpFyy4=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585054,\"exp\":1622121654,\"created\":1590585655,\"updated\":1590585657,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "1785",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:57 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "ee494cb9-ab95-4b04-b5dd-fdab183e94b1",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-\",\"deletedDate\":1590585657,\"scheduledPurgeDate\":1598361657,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"x5t\":\"79j3HP5IszZKuqMz_rRHltlaNBs\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQU/ThA1drSN+xUI36Uvf4XDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDU0WhcNMjEwNTI3MTMyMDU0WjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw9Lv1VyHVYUgXno3dXM0qrb+c3entocZS37/Uff6qCicuJAFtTWio93Jl9tAHZ7k/vxJfe5VioXluvy5weFbesN9aP0+5sSq/JKUIMsQrAMiwaMYA3y6WxuL9x769Z7e8qXZmAmA/JII/QLcmP83lY/v0v1YFag8EyRuNCgBcNDd2Sj74U+2SPzA1/9iQsnuFrYNuYWnRyi/Mz5fmZJk/jsMsSJrobWdGUKML32Ws1d6UfICkfr/esVARTztNveb9I80g81rxWKHrdyZ9pc3HDjI4Sh7eXZaVj+C5Gblm9phQD3GfLoupklGkJ2Mbm6cA/11Lfu4AmfMI12E203I1AgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSQM58EpHMCl43Ewq0GS8xQYhaKqDAdBgNVHQ4EFgQUkDOfBKRzApeNxMKtBkvMUGIWiqgwDQYJKoZIhvcNAQELBQADggEBAD3rfLPjg/DbEwxlhw55BDXT+gyHLR2PHgvJNvZpB9AOrTJOTZCt+kinPgj3DcscgTNx6ITMG9fbLoUsRO4WVQNlHJxdRIkK0+y+WO+An2PyZvzxMqzNdQDPhkO1SQ36FXokgtRJRVif66HvML+6fOgoVTsYDyQOagSnIya+28WlUWha+1Jp8ALdctWGGMJHlQVdvQS4le8In6xWvwq90zkhNRznk70E/aHRHr6veOi6D8MgMX3XOFWh6asYahv9Eh84d4cwsNMnagSlFixQnss9hqv6YHe/H3FAAlEKSygGciEVYP80cbXqmZ9xMYlIjJbMKDxQJNUm3NEqPDpFyy4=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585054,\"exp\":1622121654,\"created\":1590585655,\"updated\":1590585657,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585640,\"updated\":1590585640}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2821",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:57 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "96d24685-dde2-44b9-a4ae-9c0536c8a87e",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:57 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "06b9897d-d878-479d-8eae-8cde5d38673e",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:57 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "6adb71df-1b97-41f3-81d6-7ed374e22ce7",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:20:59 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "288b6b8b-0a55-4b50-8b95-9b9f586958c2",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:21:01 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "fa7657ba-b328-4b22-9a04-ca6069651f7f",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:21:03 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "4351f580-b8c9-4c12-b9cb-5a27d322fac4",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:21:05 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "16c4f609-b6c9-476c-96ad-9628c40e988a",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:21:08 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "06a374c5-eae5-48f7-a8a7-45d6764dfe22",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 404,
+   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "153",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:21:09 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "404",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "06221ad3-5594-4d18-b235-514d146f5fc8",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "GET",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 200,
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-\",\"deletedDate\":1590585657,\"scheduledPurgeDate\":1598361657,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"kid\":\"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"sid\":\"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/9213925b8ea64685b417d0c6b99bf3ec\",\"x5t\":\"79j3HP5IszZKuqMz_rRHltlaNBs\",\"cer\":\"MIIDKDCCAhCgAwIBAgIQU/ThA1drSN+xUI36Uvf4XDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMxMDU0WhcNMjEwNTI3MTMyMDU0WjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCw9Lv1VyHVYUgXno3dXM0qrb+c3entocZS37/Uff6qCicuJAFtTWio93Jl9tAHZ7k/vxJfe5VioXluvy5weFbesN9aP0+5sSq/JKUIMsQrAMiwaMYA3y6WxuL9x769Z7e8qXZmAmA/JII/QLcmP83lY/v0v1YFag8EyRuNCgBcNDd2Sj74U+2SPzA1/9iQsnuFrYNuYWnRyi/Mz5fmZJk/jsMsSJrobWdGUKML32Ws1d6UfICkfr/esVARTztNveb9I80g81rxWKHrdyZ9pc3HDjI4Sh7eXZaVj+C5Gblm9phQD3GfLoupklGkJ2Mbm6cA/11Lfu4AmfMI12E203I1AgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSQM58EpHMCl43Ewq0GS8xQYhaKqDAdBgNVHQ4EFgQUkDOfBKRzApeNxMKtBkvMUGIWiqgwDQYJKoZIhvcNAQELBQADggEBAD3rfLPjg/DbEwxlhw55BDXT+gyHLR2PHgvJNvZpB9AOrTJOTZCt+kinPgj3DcscgTNx6ITMG9fbLoUsRO4WVQNlHJxdRIkK0+y+WO+An2PyZvzxMqzNdQDPhkO1SQ36FXokgtRJRVif66HvML+6fOgoVTsYDyQOagSnIya+28WlUWha+1Jp8ALdctWGGMJHlQVdvQS4le8In6xWvwq90zkhNRznk70E/aHRHr6veOi6D8MgMX3XOFWh6asYahv9Eh84d4cwsNMnagSlFixQnss9hqv6YHe/H3FAAlEKSygGciEVYP80cbXqmZ9xMYlIjJbMKDxQJNUm3NEqPDpFyy4=\",\"attributes\":{\"enabled\":false,\"nbf\":1590585054,\"exp\":1622121654,\"created\":1590585655,\"updated\":1590585657,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590585640,\"updated\":1590585640}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending\"}}",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "content-length": "2821",
+    "content-type": "application/json; charset=utf-8",
+    "date": "Wed, 27 May 2020 13:21:11 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "200",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "7fc57516-dee9-4958-a420-760d54a487d7",
+    "x-powered-by": "ASP.NET"
+   }
+  },
+  {
+   "method": "DELETE",
+   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-",
+   "query": {
+    "api-version": "7.1-preview"
+   },
+   "requestBody": null,
+   "status": 204,
+   "response": "",
+   "responseHeaders": {
+    "cache-control": "no-cache",
+    "date": "Wed, 27 May 2020 13:21:12 GMT",
+    "expires": "-1",
+    "pragma": "no-cache",
+    "status": "204",
+    "strict-transport-security": "max-age=31536000;includeSubDomains",
+    "x-aspnet-version": "4.0.30319",
+    "x-content-type-options": "nosniff",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-region": "westus",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "33fc98ca-a6cf-4da4-9bcc-a945256e9be8",
+    "x-powered-by": "ASP.NET"
+   }
+  }
+ ],
+ "uniqueTestInfo": {
+  "uniqueName": {},
+  "newDate": {}
+ },
+ "hash": "9e136291d49054d5d1549f5678670816"
+}

--- a/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_update_certificate_with_requestoptions_timeout.json
+++ b/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_update_certificate_with_requestoptions_timeout.json
@@ -4,5 +4,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "ee26e3ba3709c5e698d14a3a7de8ae8c"
+ "hash": "4e2de66bd216e6b04a01e029aeb8d3dc"
 }

--- a/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_update_the_tags_of_a_certificate.json
+++ b/sdk/keyvault/keyvault-certificates/recordings/browsers/certificates_client__create_read_update_and_delete/recording_can_update_the_tags_of_a_certificate.json
@@ -13,19 +13,18 @@
     "cache-control": "no-cache",
     "content-length": "87",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:20 GMT",
+    "date": "Wed, 27 May 2020 15:05:14 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "401",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "www-authenticate": "Bearer authorization=\"https://login.windows.net/azure_tenant_id\", resource=\"https://vault.azure.net\"",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "1a7c1070-b252-4733-85ab-09acc9ba66af",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "2d853811-0420-405f-af69-61c536202bed",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -40,15 +39,15 @@
     "cache-control": "no-cache, no-store",
     "content-length": "1315",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:20 GMT",
+    "date": "Wed, 27 May 2020 15:05:14 GMT",
     "expires": "-1",
     "p3p": "CP=\"DSP CUR OTPi IND OTRi ONL FIN\"",
     "pragma": "no-cache",
     "referrer-policy": "strict-origin-when-cross-origin",
     "strict-transport-security": "max-age=31536000; includeSubDomains",
     "x-content-type-options": "nosniff",
-    "x-ms-ests-server": "2.1.10433.14 - EUS ProdSlices",
-    "x-ms-request-id": "f19a06ef-e2a2-4e15-8411-9353b514af00"
+    "x-ms-ests-server": "2.1.10620.11 - EUS ProdSlices",
+    "x-ms-request-id": "cf7115d9-8f96-42e2-8bcd-7edd30641800"
    }
   },
   {
@@ -59,25 +58,24 @@
    },
    "requestBody": "{\"policy\":{\"key_props\":{},\"secret_props\":{},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{}},\"issuer\":{\"name\":\"Self\"},\"attributes\":{}},\"attributes\":{}}",
    "status": 202,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtAUfNG9gZXkrQ+DxQjc777YZSb9GiFwDfNrantahpqMbDplKuTSQLwrjA6UbcovgVJL8ImKrl5JdZCI7oYKb3MtlnxkZlNp6Sy6gq4wc5N/l2xq1UAM3tTyShpzL1pP+0d3MlNu24bFIo7uTPG9bmnY6yqIncImUlEE8ObDnzkjwHVK3TZswT9UxU50kEkakvr25aHOeuSvuaStlg5uLYSWv0ZUH66VS0gZlvaqwLqd3ZPl8SzBuWHTccJHIy/UOLzMA3kEPZ2DL/ti6xht1/d7NTMZ/wG3w74DZ3MiO9b8dELhe6JnY7aPiah28WYAnwzSEzEy0XXbzUWr22ZXtFQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAEqacsquldDua1iMfCg1d/ROxJYTuBAGwmjiulNbrMvcyVdPDCVB0WjR8Q7GQ4MR0APoC5qTLW0v/sCM7PY3dtSyJJ9bCVQiWdY6BfdWTK65yClJBnL7C4OiC2UDoy1wczFypj62KxcamDxNykFRVg9k6CDmqL+TTe/yAtuTwj9jH6rqQC0h1BSbEA7l77hbvfinHAnDN214ERkD09vZxWG80F9Oh7lvaJ6vVvo/Gs0HCCvLDyJ/nA4C/Wsau+aGX39C13lwqoEuAAnw5l8QzG3sSVj8bc4Nc3bzJle1z5IwusUzJI8GHEdoKKb94BfmNxeQiIWJX8LCJIAbWVmvqgc=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"a0538bd948c04a42b6e9ceee4dea7d92\"}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsoTfjZOlo83NG+5oV1Q4GmXFZbjeN78M8Kth3hTE2kpDtWHohOe8wPWpqKsVjvxmLp+crPlfi20dkamE2AfDSlWqrCZbjRGCxAc5VmljjaQi3MLNCg9wr1wvUGWsIjWvRthQX6civkvsdr5BlYwNsFZXdixsi9Gdr4hU6fmCm3sPUh9pm732B5TtusH7uB7ovMLS6bs15BbHFBX80al5AIiW7il3+9NNYPU28o+B23Lg2DIU48oY32c3g150qie1ar0RoJpMuSJNQ++EChHZApCDfZw6H6hsbB4JKzNWir5XScZx6JDMeP5q/KWoQpivIivHIabbjBnE+1N0CFMQrQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGt/+gBl5uv/OxvKhSVzV9B04GIsCbQidK8xGiFlXupD4hrZnoc45mmoA1EXyvohprrnjubUKf2CyNfjNvr1MxxfZ79HD1SsWuss5815uYSY/YfltyTOnWrD55MtIK8KpG5wvLpsTdKsyrFnBCkvS8rcORFQd9mhqSx6bUohR8DwbPFDmRUhgAaj8YSXoaaa6SjEzYj6fW6L3RFUep3zKHdGlMJTypkRdqrR58tzLhE9VlMnb3jPzhIGhjB9M6ECLQquexl8cqW7tK3QLfcI9Xbv5Ptp7Nk7t6cFlxyuc49hbdubZVMqIfLx5jcoAp2x7mZElYM7k3AdfRF5E7+YW2g=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"f420b7b34aba46b4b32c7b0b6992cf57\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1347",
+    "content-length": "1346",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:22 GMT",
+    "date": "Wed, 27 May 2020 15:05:15 GMT",
     "expires": "-1",
-    "location": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending?api-version=7.1-preview&request_id=a0538bd948c04a42b6e9ceee4dea7d92",
+    "location": "https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending?api-version=7.1-preview&request_id=f420b7b34aba46b4b32c7b0b6992cf57",
     "pragma": "no-cache",
     "retry-after": "10",
-    "server": "Microsoft-IIS/10.0",
     "status": "202",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "3bddf01c-be2e-4278-879f-d1954d3c473a",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "99797a8a-fe4e-498f-8542-3b4a13c3e4da",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -89,24 +87,23 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtAUfNG9gZXkrQ+DxQjc777YZSb9GiFwDfNrantahpqMbDplKuTSQLwrjA6UbcovgVJL8ImKrl5JdZCI7oYKb3MtlnxkZlNp6Sy6gq4wc5N/l2xq1UAM3tTyShpzL1pP+0d3MlNu24bFIo7uTPG9bmnY6yqIncImUlEE8ObDnzkjwHVK3TZswT9UxU50kEkakvr25aHOeuSvuaStlg5uLYSWv0ZUH66VS0gZlvaqwLqd3ZPl8SzBuWHTccJHIy/UOLzMA3kEPZ2DL/ti6xht1/d7NTMZ/wG3w74DZ3MiO9b8dELhe6JnY7aPiah28WYAnwzSEzEy0XXbzUWr22ZXtFQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAEqacsquldDua1iMfCg1d/ROxJYTuBAGwmjiulNbrMvcyVdPDCVB0WjR8Q7GQ4MR0APoC5qTLW0v/sCM7PY3dtSyJJ9bCVQiWdY6BfdWTK65yClJBnL7C4OiC2UDoy1wczFypj62KxcamDxNykFRVg9k6CDmqL+TTe/yAtuTwj9jH6rqQC0h1BSbEA7l77hbvfinHAnDN214ERkD09vZxWG80F9Oh7lvaJ6vVvo/Gs0HCCvLDyJ/nA4C/Wsau+aGX39C13lwqoEuAAnw5l8QzG3sSVj8bc4Nc3bzJle1z5IwusUzJI8GHEdoKKb94BfmNxeQiIWJX8LCJIAbWVmvqgc=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"a0538bd948c04a42b6e9ceee4dea7d92\"}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\",\"issuer\":{\"name\":\"Self\"},\"csr\":\"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsoTfjZOlo83NG+5oV1Q4GmXFZbjeN78M8Kth3hTE2kpDtWHohOe8wPWpqKsVjvxmLp+crPlfi20dkamE2AfDSlWqrCZbjRGCxAc5VmljjaQi3MLNCg9wr1wvUGWsIjWvRthQX6civkvsdr5BlYwNsFZXdixsi9Gdr4hU6fmCm3sPUh9pm732B5TtusH7uB7ovMLS6bs15BbHFBX80al5AIiW7il3+9NNYPU28o+B23Lg2DIU48oY32c3g150qie1ar0RoJpMuSJNQ++EChHZApCDfZw6H6hsbB4JKzNWir5XScZx6JDMeP5q/KWoQpivIivHIabbjBnE+1N0CFMQrQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGt/+gBl5uv/OxvKhSVzV9B04GIsCbQidK8xGiFlXupD4hrZnoc45mmoA1EXyvohprrnjubUKf2CyNfjNvr1MxxfZ79HD1SsWuss5815uYSY/YfltyTOnWrD55MtIK8KpG5wvLpsTdKsyrFnBCkvS8rcORFQd9mhqSx6bUohR8DwbPFDmRUhgAaj8YSXoaaa6SjEzYj6fW6L3RFUep3zKHdGlMJTypkRdqrR58tzLhE9VlMnb3jPzhIGhjB9M6ECLQquexl8cqW7tK3QLfcI9Xbv5Ptp7Nk7t6cFlxyuc49hbdubZVMqIfLx5jcoAp2x7mZElYM7k3AdfRF5E7+YW2g=\",\"cancellation_requested\":false,\"status\":\"inProgress\",\"status_details\":\"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.\",\"request_id\":\"f420b7b34aba46b4b32c7b0b6992cf57\"}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1347",
+    "content-length": "1346",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:23 GMT",
+    "date": "Wed, 27 May 2020 15:05:15 GMT",
     "expires": "-1",
     "pragma": "no-cache",
     "retry-after": "10",
-    "server": "Microsoft-IIS/10.0",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "88b7230b-6ea2-4f7e-b544-776c6325362f",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "4854c0dd-4ea7-48d2-90c3-b053f81aa197",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -116,25 +113,24 @@
    "query": {
     "api-version": "7.1-preview"
    },
-   "requestBody": "{\"tags\":{\"customTag\":\"value\"}}",
+   "requestBody": "{\"attributes\":{},\"tags\":{\"customTag\":\"value\"}}",
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/b8ecd117cf2540b5b76b2edc780fa9a2\",\"attributes\":{\"enabled\":false,\"nbf\":1588197921,\"exp\":1619734521,\"created\":1588198521,\"updated\":1588198523,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1588198521,\"updated\":1588198521}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/93cb49ab678540eaa432ef3819a75980\",\"attributes\":{\"enabled\":false,\"nbf\":1590591315,\"exp\":1622127915,\"created\":1590591915,\"updated\":1590591916,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590591915,\"updated\":1590591915}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1201",
+    "content-length": "1198",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:23 GMT",
+    "date": "Wed, 27 May 2020 15:05:15 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "49b4f5d5-da0b-4843-bbad-c6550f9e48c5",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "fc519dc4-6d25-4c78-bb51-3bc671221d88",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -146,23 +142,22 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/b8ecd117cf2540b5b76b2edc780fa9a2\",\"attributes\":{\"enabled\":false,\"nbf\":1588197921,\"exp\":1619734521,\"created\":1588198521,\"updated\":1588198523,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1588198521,\"updated\":1588198521}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
+   "response": "{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/93cb49ab678540eaa432ef3819a75980\",\"attributes\":{\"enabled\":false,\"nbf\":1590591315,\"exp\":1622127915,\"created\":1590591915,\"updated\":1590591916,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590591915,\"updated\":1590591915}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1201",
+    "content-length": "1198",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:23 GMT",
+    "date": "Wed, 27 May 2020 15:05:15 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "2f72745b-9a4b-4a76-8df5-007f0117d20c",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "e8bc9785-8466-4dd5-8d49-eedc970126a1",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -174,23 +169,22 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-\",\"deletedDate\":1588198524,\"scheduledPurgeDate\":1595974524,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/b8ecd117cf2540b5b76b2edc780fa9a2\",\"attributes\":{\"enabled\":false,\"nbf\":1588197921,\"exp\":1619734521,\"created\":1588198521,\"updated\":1588198523,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1588198521,\"updated\":1588198521}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-\",\"deletedDate\":1590591916,\"scheduledPurgeDate\":1598367916,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/93cb49ab678540eaa432ef3819a75980\",\"attributes\":{\"enabled\":false,\"nbf\":1590591315,\"exp\":1622127915,\"created\":1590591915,\"updated\":1590591916,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590591915,\"updated\":1590591915}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1408",
+    "content-length": "1404",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:23 GMT",
+    "date": "Wed, 27 May 2020 15:05:15 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "7a5e769f-de05-4e18-8d74-f0033806f8b3",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "57e0dee8-ca38-4905-8db1-6d5ac3d9f56b",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -205,20 +199,19 @@
    "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "155",
+    "content-length": "154",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:23 GMT",
+    "date": "Wed, 27 May 2020 15:05:15 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "404",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "1aad89e9-9ab6-468c-aa2d-326bcdd2e2ba",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "ef12c88b-b8e1-4734-a23c-1c1151255120",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -233,20 +226,19 @@
    "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "155",
+    "content-length": "154",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:23 GMT",
+    "date": "Wed, 27 May 2020 15:05:15 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "404",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "519395c2-809f-488a-86de-d104f577ccb7",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "66a3e534-9a9d-4be8-aeb8-fd6111420b1b",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -261,20 +253,19 @@
    "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "155",
+    "content-length": "154",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:25 GMT",
+    "date": "Wed, 27 May 2020 15:05:18 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "404",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "bc8d2e36-1040-42ad-acd7-026b36a292c3",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "8ecb88fd-69bd-40cc-a765-7235f85142b5",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -289,20 +280,19 @@
    "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "155",
+    "content-length": "154",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:27 GMT",
+    "date": "Wed, 27 May 2020 15:05:20 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "404",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "c8862c3f-30aa-4229-b12e-ba9777979c51",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "49a120b0-c42b-4a7d-80ae-90674e1238dd",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -317,20 +307,19 @@
    "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "155",
+    "content-length": "154",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:29 GMT",
+    "date": "Wed, 27 May 2020 15:05:22 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "404",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "19bbd0d9-d22c-4292-9033-8777f49dfbed",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "a14c9963-ff64-42a1-8b2e-c7dd6b0752ec",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -345,1280 +334,19 @@
    "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "155",
+    "content-length": "154",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:32 GMT",
+    "date": "Wed, 27 May 2020 15:05:24 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "404",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "0a7dc4a3-9e79-4381-9581-eeaf3d897610",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:34 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "1dccab3a-bb61-47a7-b4c6-f94f6a872d49",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:36 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "62be7ea0-f176-49f8-818c-de4d5363b35d",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:38 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "42d51362-10c2-49ca-8877-2ec23a919c78",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:40 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "1e8e03c6-fe05-4150-9165-b348f7fe5d8c",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:42 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "fb86ba67-0cda-40b4-ac9b-938c0f9e9976",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:44 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "142e2689-bcd7-4d7d-a142-7faf8af5365f",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:46 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "95c2758f-c5a1-41cc-a04d-cb9910fd6f0d",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:48 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "e0cb927a-2f21-4a90-8318-ee66bf04284c",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:50 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "b1b7b53f-e111-48fa-85ea-b2c2606c8967",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:52 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "68799483-1375-4356-8e8a-5a3c7876718e",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:54 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "2745823f-635a-4905-8360-53f0ce2b3d73",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:56 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "65383fe2-a064-4b30-9c50-249306adb875",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:15:58 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "f64b88e0-6e47-4a80-8447-68f5fd5d09c2",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:00 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "26861dce-0a46-474b-8a8c-0a3504afc134",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:02 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "ce3c0ecc-6081-4261-8056-edc1ccaa9063",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:05 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "d470eaa7-44a6-4042-9d01-f5667f0cefe6",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:07 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "3afecadd-3255-4622-a196-e591eccace19",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:09 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "4e5827b7-05fe-4478-99f2-569f9a0cf78e",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:11 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "e9d9220c-0afd-4a7d-94bc-0a48a3fd4510",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:13 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "17f44e52-98f1-4dce-aa78-49daa6fab3d5",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:15 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "52f6d362-cdda-4c19-ae52-0f3960093aa6",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:17 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "81819258-95ca-4881-ae2d-194ffbe6ec49",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:19 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "c659c647-36f4-46f1-8912-6104b52f6e4e",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:21 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "a4b7376b-7bc7-40d4-a2aa-3d4d06f092d9",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:23 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "7bbc719e-500b-4b56-aa30-3b4b6f6bb113",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:25 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "c66a5a89-cf9f-401c-8a41-5bdc18fca5f1",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:27 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "073e2fb7-bf2f-4a46-ad00-0dc5f34a2e00",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:29 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "405a82a4-ffb6-4ac1-81ef-69112b820a87",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:31 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "b17d1d06-906f-43b0-9827-73c7a48b7f2b",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:33 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "19a3efef-6f90-42e0-bf60-8a9a4b4182dd",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:36 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "45a30182-42e4-4d83-8897-f8547c601de1",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:38 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "eeb48bda-847a-4cac-9351-1d8dcc17195f",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:40 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "4e04ef33-8714-4d57-bfe3-37790ade26c0",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:42 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "e92609ae-6d09-4913-af13-7438b04b1f3c",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:44 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "8040e812-b73f-4631-b7b0-a6998a31cb0d",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:46 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "6d65122a-84e5-4922-bbed-02f7891435f4",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:48 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "a352bdfd-fd4b-45d2-9de9-0f9f71eb04d5",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:50 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "a37c12aa-adf9-49f0-87bd-4a6c5e1920b4",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:52 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "0f93a8c5-4e98-4784-a60c-341f29802585",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:54 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "29f9a61e-b282-4462-a6ff-18fb8931f623",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:56 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "68e9bc22-e2f6-473c-91ce-01005a111aa2",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:16:58 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "4ab733db-57aa-4184-82b5-ece5d32aead5",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:17:00 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "4604934b-b9d3-4437-b209-c45f58cc2aac",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:17:02 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "d2de71ab-8786-4465-a120-ecb6ddea4064",
-    "x-powered-by": "ASP.NET"
-   }
-  },
-  {
-   "method": "GET",
-   "url": "https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-",
-   "query": {
-    "api-version": "7.1-preview"
-   },
-   "requestBody": null,
-   "status": 404,
-   "response": "{\"error\":{\"code\":\"CertificateNotFound\",\"message\":\"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-\"}}",
-   "responseHeaders": {
-    "cache-control": "no-cache",
-    "content-length": "155",
-    "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:17:04 GMT",
-    "expires": "-1",
-    "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
-    "status": "404",
-    "strict-transport-security": "max-age=31536000;includeSubDomains",
-    "x-aspnet-version": "4.0.30319",
-    "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
-    "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "450ec548-a2a5-45bf-a6d2-087d5960c0ba",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "24249fb3-34ba-4908-866a-230e913b278c",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -1630,23 +358,22 @@
    },
    "requestBody": null,
    "status": 200,
-   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-\",\"deletedDate\":1588198524,\"scheduledPurgeDate\":1595974524,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/b8ecd117cf2540b5b76b2edc780fa9a2\",\"attributes\":{\"enabled\":false,\"nbf\":1588197921,\"exp\":1619734521,\"created\":1588198521,\"updated\":1588198523,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1588198521,\"updated\":1588198521}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
+   "response": "{\"recoveryId\":\"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-\",\"deletedDate\":1590591916,\"scheduledPurgeDate\":1598367916,\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/93cb49ab678540eaa432ef3819a75980\",\"attributes\":{\"enabled\":false,\"nbf\":1590591315,\"exp\":1622127915,\"created\":1590591915,\"updated\":1590591916,\"recoveryLevel\":\"Recoverable+Purgeable\",\"recoverableDays\":90},\"tags\":{\"customTag\":\"value\"},\"policy\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy\",\"key_props\":{\"exportable\":true,\"kty\":\"RSA\",\"key_size\":2048,\"reuse_key\":false},\"secret_props\":{\"contentType\":\"application/x-pkcs12\"},\"x509_props\":{\"subject\":\"cn=MyCert\",\"sans\":{},\"ekus\":[\"1.3.6.1.5.5.7.3.1\",\"1.3.6.1.5.5.7.3.2\"],\"key_usage\":[\"digitalSignature\",\"keyEncipherment\"],\"validity_months\":12,\"basic_constraints\":{\"ca\":false}},\"lifetime_actions\":[{\"trigger\":{\"lifetime_percentage\":80},\"action\":{\"action_type\":\"AutoRenew\"}}],\"issuer\":{\"name\":\"Self\"},\"attributes\":{\"enabled\":true,\"created\":1590591915,\"updated\":1590591915}},\"pending\":{\"id\":\"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending\"}}",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "content-length": "1408",
+    "content-length": "1404",
     "content-type": "application/json; charset=utf-8",
-    "date": "Wed, 29 Apr 2020 22:17:06 GMT",
+    "date": "Wed, 27 May 2020 15:05:26 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "200",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "38237c56-067b-460e-82f2-383d5c9afa85",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "a12d7891-a3c1-42d3-ab29-dad705026538",
     "x-powered-by": "ASP.NET"
    }
   },
@@ -1661,18 +388,17 @@
    "response": "",
    "responseHeaders": {
     "cache-control": "no-cache",
-    "date": "Wed, 29 Apr 2020 22:17:06 GMT",
+    "date": "Wed, 27 May 2020 15:05:26 GMT",
     "expires": "-1",
     "pragma": "no-cache",
-    "server": "Microsoft-IIS/10.0",
     "status": "204",
     "strict-transport-security": "max-age=31536000;includeSubDomains",
     "x-aspnet-version": "4.0.30319",
     "x-content-type-options": "nosniff",
-    "x-ms-keyvault-network-info": "addr=51.141.174.130;act_addr_fam=InterNetwork;",
+    "x-ms-keyvault-network-info": "conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;",
     "x-ms-keyvault-region": "westus",
-    "x-ms-keyvault-service-version": "1.1.0.898",
-    "x-ms-request-id": "701cb500-9245-48de-97b9-a3cd1f68e9c7",
+    "x-ms-keyvault-service-version": "1.1.5.0",
+    "x-ms-request-id": "7d066121-3cbc-4219-96ec-66b817af20c3",
     "x-powered-by": "ASP.NET"
    }
   }
@@ -1681,5 +407,5 @@
   "uniqueName": {},
   "newDate": {}
  },
- "hash": "07d5d6f962357f9d42e3a6d6d4489a51"
+ "hash": "fb6fc7121879e408171ce6c3c0e95a8e"
 }

--- a/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate.js
+++ b/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate.js
@@ -1,0 +1,1014 @@
+let nock = require('nock');
+
+module.exports.hash = "292818f01c5ac558f9a432982a7bfae2";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/certificates/recoverCertificateName-candisableacertificate-/create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'a46c6281-e0ec-4e14-a9a4-9dc95186f8ac',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:01 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  'ac7be9c3-c96c-4071-be94-01c39ce30900',
+  'x-ms-ests-server',
+  '2.1.10656.5 - WUS2 ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=As2SNxyetS1Evpi27lOew8M_aSJHAQAAAIlfYNYOAAAA; expires=Fri, 26-Jun-2020 13:18:02 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Wed, 27 May 2020 13:18:01 GMT',
+  'Content-Length',
+  '1315'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/certificates/recoverCertificateName-candisableacertificate-/create', {"policy":{"key_props":{},"secret_props":{},"x509_props":{"subject":"cn=MyCert","sans":{}},"issuer":{"name":"Self"},"attributes":{}},"attributes":{}})
+  .query(true)
+  .reply(202, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Location',
+  'https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending?api-version=7.1-preview&request_id=e37f677a9b354a139c378071673d6e13',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'bc21e71a-0048-4a3c-804f-005ae71f92d3',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:02 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '7f73593d-0d42-4195-8cf9-347311ddbfe5',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:02 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '8abbf2ac-0dd0-4218-908b-9accc9f114a6',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:02 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '1531378e-4970-48a3-a54b-e663285f2710',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:04 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'f09bb5ca-2ccc-4f3f-8fdb-40f80bf5296c',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:06 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'b18eda00-dd81-40a2-bfa8-6dbbb0d62908',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:08 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'bce8e50e-bf10-4c0c-82cf-dca3b3821279',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:10 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '68998ebe-8d7a-4d9b-bd85-e147cf3d259c',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:12 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'b2c2c0ed-aa1c-4d02-b09e-651a6e3db238',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:15 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '059be727-aebc-4c15-bf1b-c1356c0fbca6',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:17 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '669982e6-4236-4a6f-91bf-be82a244a678',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:19 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'c2505610-5309-4d45-8737-2522c9af3817',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:21 GMT',
+  'Content-Length',
+  '1338'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuOda2PUv4OOLSXUqi764t5zKRl5a8hFeV7iDGC/lcgWY356QZe9DlbCuHWZsTQ8X9CJa0puDHRQQ7r7Ac50qalwSgT9NtEjoXoNoe5Ir0vYCpfFToHtYWWV8pQmRE96DrHgl8wXyECZvrF1OUtdL1xyrtT6lXyAEqEFgrBilu4JZW3PVfLlJSd69wK/JKaw/JfLv4uyS8MlWeMh2BIq03H5tUGesZelFM2zeOJgpLJJYJ3kYfM468Y5qf9eR2A7FU362Kuko4TpZwh5NLvcQ7O6zNMuS/qJgfXaXRKXUhHIDENq2amj5Selft2bFj7As1rlytdzaD7QzRZnBMiQDmwIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAHErgRW0yrpr0AAsCsJcHiLx20ML50NKJy0rvzFSS8fvwtvOlMAkUHJSmxp93HuDZB67t+ibVxHq6p5qju4yZS7cs6fP9uua2RYoKLnx05MgLuhvrPej5VGicNob8LTA+GlSjKrl09l8BKXUItPZmtxMdv0grD4Cq+NLELwyv3f0VE5oeo4bst9Om4BoeCgruCsJD530KP+5Z3PiOE6VRXaouIpAK9MGgVcBTNYlTHUXX4HPEYRgNWMtd6Qv+dfyOrIdHxM2bUgz7Bi9a4PdvbYXlz/NrSpVXd5Co7NjKe7TBxnlhYcjVXfxjtQbTNb0rbfdWDMCoQBxvTddlCHhJPk=","cancellation_requested":false,"status":"completed","target":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-","request_id":"e37f677a9b354a139c378071673d6e13"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '83885339-b9c6-47a2-bcf3-849715854d56',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:23 GMT',
+  'Content-Length',
+  '1303'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","x5t":"rnjuw18TqWex92xvwqYfH71iC_o","cer":"MIIDKDCCAhCgAwIBAgIQf1JriRdtT4yQl2Am3+f8EDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODIxWhcNMjEwNTI3MTMxODIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC451rY9S/g44tJdSqLvri3nMpGXlryEV5XuIMYL+VyBZjfnpBl70OVsK4dZmxNDxf0IlrSm4MdFBDuvsBznSpqXBKBP020SOheg2h7kivS9gKl8VOge1hZZXylCZET3oOseCXzBfIQJm+sXU5S10vXHKu1PqVfIASoQWCsGKW7gllbc9V8uUlJ3r3Ar8kprD8l8u/i7JLwyVZ4yHYEirTcfm1QZ6xl6UUzbN44mCksklgneRh8zjrxjmp/15HYDsVTfrYq6SjhOlnCHk0u9xDs7rM0y5L+omB9dpdEpdSEcgMQ2rZqaPlJ6V+3ZsWPsCzWuXK13NoPtDNFmcEyJAObAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQs86BZlbIcjpyRkpkYuEpRduV4WjAdBgNVHQ4EFgQULPOgWZWyHI6ckZKZGLhKUXbleFowDQYJKoZIhvcNAQELBQADggEBAKGu5VU7H9/108y+IgCcdtlaXjf67ljW1a5S2kIH91OKIU9ah2qHTI+lVI1DCSsSXlwsYVCFbPAXES/g7MSmFBU/7B1utZvcFjg3ZCpIOsl59RCqcO/tZFl9+DNgzY3k21FB6sK0H2ZmELoSYMrmy5FRFybNrQkJS4UrrjmLocFXAZMTKZfVjx+O+H7v9ttZ2YvfBCEc8xAuWybpdMMOMAElf9FA7wZjuEyWYkPbUXPXted0XRWcvu23iQirUXzOcCIFFMqEDlviZzGx5FYFS5BjkLhuTgZDZWRGCq2GEUpsaiOoTUYQS8apMQEj4fBaIaWKyjnveXbf4gcjKERyq/M=","attributes":{"enabled":true,"nbf":1590584901,"exp":1622121501,"created":1590585501,"updated":1590585501,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585482,"updated":1590585482}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '7559b87e-4e43-4290-9108-8e8b18dc6272',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:23 GMT',
+  'Content-Length',
+  '2580'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .patch('/certificates/recoverCertificateName-candisableacertificate-/', {"attributes":{"enabled":false}})
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","x5t":"rnjuw18TqWex92xvwqYfH71iC_o","cer":"MIIDKDCCAhCgAwIBAgIQf1JriRdtT4yQl2Am3+f8EDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODIxWhcNMjEwNTI3MTMxODIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC451rY9S/g44tJdSqLvri3nMpGXlryEV5XuIMYL+VyBZjfnpBl70OVsK4dZmxNDxf0IlrSm4MdFBDuvsBznSpqXBKBP020SOheg2h7kivS9gKl8VOge1hZZXylCZET3oOseCXzBfIQJm+sXU5S10vXHKu1PqVfIASoQWCsGKW7gllbc9V8uUlJ3r3Ar8kprD8l8u/i7JLwyVZ4yHYEirTcfm1QZ6xl6UUzbN44mCksklgneRh8zjrxjmp/15HYDsVTfrYq6SjhOlnCHk0u9xDs7rM0y5L+omB9dpdEpdSEcgMQ2rZqaPlJ6V+3ZsWPsCzWuXK13NoPtDNFmcEyJAObAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQs86BZlbIcjpyRkpkYuEpRduV4WjAdBgNVHQ4EFgQULPOgWZWyHI6ckZKZGLhKUXbleFowDQYJKoZIhvcNAQELBQADggEBAKGu5VU7H9/108y+IgCcdtlaXjf67ljW1a5S2kIH91OKIU9ah2qHTI+lVI1DCSsSXlwsYVCFbPAXES/g7MSmFBU/7B1utZvcFjg3ZCpIOsl59RCqcO/tZFl9+DNgzY3k21FB6sK0H2ZmELoSYMrmy5FRFybNrQkJS4UrrjmLocFXAZMTKZfVjx+O+H7v9ttZ2YvfBCEc8xAuWybpdMMOMAElf9FA7wZjuEyWYkPbUXPXted0XRWcvu23iQirUXzOcCIFFMqEDlviZzGx5FYFS5BjkLhuTgZDZWRGCq2GEUpsaiOoTUYQS8apMQEj4fBaIaWKyjnveXbf4gcjKERyq/M=","attributes":{"enabled":false,"nbf":1590584901,"exp":1622121501,"created":1590585501,"updated":1590585503,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585482,"updated":1590585482}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '10e1720c-a461-49b6-b9ec-8fc37a1e0e7c',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:23 GMT',
+  'Content-Length',
+  '2581'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificate-/')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","x5t":"rnjuw18TqWex92xvwqYfH71iC_o","cer":"MIIDKDCCAhCgAwIBAgIQf1JriRdtT4yQl2Am3+f8EDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODIxWhcNMjEwNTI3MTMxODIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC451rY9S/g44tJdSqLvri3nMpGXlryEV5XuIMYL+VyBZjfnpBl70OVsK4dZmxNDxf0IlrSm4MdFBDuvsBznSpqXBKBP020SOheg2h7kivS9gKl8VOge1hZZXylCZET3oOseCXzBfIQJm+sXU5S10vXHKu1PqVfIASoQWCsGKW7gllbc9V8uUlJ3r3Ar8kprD8l8u/i7JLwyVZ4yHYEirTcfm1QZ6xl6UUzbN44mCksklgneRh8zjrxjmp/15HYDsVTfrYq6SjhOlnCHk0u9xDs7rM0y5L+omB9dpdEpdSEcgMQ2rZqaPlJ6V+3ZsWPsCzWuXK13NoPtDNFmcEyJAObAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQs86BZlbIcjpyRkpkYuEpRduV4WjAdBgNVHQ4EFgQULPOgWZWyHI6ckZKZGLhKUXbleFowDQYJKoZIhvcNAQELBQADggEBAKGu5VU7H9/108y+IgCcdtlaXjf67ljW1a5S2kIH91OKIU9ah2qHTI+lVI1DCSsSXlwsYVCFbPAXES/g7MSmFBU/7B1utZvcFjg3ZCpIOsl59RCqcO/tZFl9+DNgzY3k21FB6sK0H2ZmELoSYMrmy5FRFybNrQkJS4UrrjmLocFXAZMTKZfVjx+O+H7v9ttZ2YvfBCEc8xAuWybpdMMOMAElf9FA7wZjuEyWYkPbUXPXted0XRWcvu23iQirUXzOcCIFFMqEDlviZzGx5FYFS5BjkLhuTgZDZWRGCq2GEUpsaiOoTUYQS8apMQEj4fBaIaWKyjnveXbf4gcjKERyq/M=","attributes":{"enabled":false,"nbf":1590584901,"exp":1622121501,"created":1590585501,"updated":1590585503,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585482,"updated":1590585482}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'ac930158-5105-4a85-9850-f32425f61eb8',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:23 GMT',
+  'Content-Length',
+  '2581'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/certificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-","deletedDate":1590585503,"scheduledPurgeDate":1598361503,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","x5t":"rnjuw18TqWex92xvwqYfH71iC_o","cer":"MIIDKDCCAhCgAwIBAgIQf1JriRdtT4yQl2Am3+f8EDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODIxWhcNMjEwNTI3MTMxODIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC451rY9S/g44tJdSqLvri3nMpGXlryEV5XuIMYL+VyBZjfnpBl70OVsK4dZmxNDxf0IlrSm4MdFBDuvsBznSpqXBKBP020SOheg2h7kivS9gKl8VOge1hZZXylCZET3oOseCXzBfIQJm+sXU5S10vXHKu1PqVfIASoQWCsGKW7gllbc9V8uUlJ3r3Ar8kprD8l8u/i7JLwyVZ4yHYEirTcfm1QZ6xl6UUzbN44mCksklgneRh8zjrxjmp/15HYDsVTfrYq6SjhOlnCHk0u9xDs7rM0y5L+omB9dpdEpdSEcgMQ2rZqaPlJ6V+3ZsWPsCzWuXK13NoPtDNFmcEyJAObAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQs86BZlbIcjpyRkpkYuEpRduV4WjAdBgNVHQ4EFgQULPOgWZWyHI6ckZKZGLhKUXbleFowDQYJKoZIhvcNAQELBQADggEBAKGu5VU7H9/108y+IgCcdtlaXjf67ljW1a5S2kIH91OKIU9ah2qHTI+lVI1DCSsSXlwsYVCFbPAXES/g7MSmFBU/7B1utZvcFjg3ZCpIOsl59RCqcO/tZFl9+DNgzY3k21FB6sK0H2ZmELoSYMrmy5FRFybNrQkJS4UrrjmLocFXAZMTKZfVjx+O+H7v9ttZ2YvfBCEc8xAuWybpdMMOMAElf9FA7wZjuEyWYkPbUXPXted0XRWcvu23iQirUXzOcCIFFMqEDlviZzGx5FYFS5BjkLhuTgZDZWRGCq2GEUpsaiOoTUYQS8apMQEj4fBaIaWKyjnveXbf4gcjKERyq/M=","attributes":{"enabled":false,"nbf":1590584901,"exp":1622121501,"created":1590585501,"updated":1590585503,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585482,"updated":1590585482}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '8884925d-7149-48f3-8fe5-b79ee2b6a224',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:23 GMT',
+  'Content-Length',
+  '2779'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '32137119-7da2-4851-b1ec-a5f90d2f6ab3',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:23 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '2e8df743-c46f-4ad7-909d-3ed8c21238cf',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:23 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '6e2e2cb5-a722-4e9e-8904-24401ae1cf55',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:25 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '1c7fbf97-8bcc-4cff-9e37-6ff3e74530d7',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:27 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '856a47a6-77e9-406e-9555-2f447fe4ed07',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:29 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '1ae6a15e-2b7b-441a-a5ca-85861eafcda9',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:31 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '6bb142ec-b128-4876-ad47-f3249aadbd4c',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:33 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificate-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '146',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '33680e76-4a65-49ec-84a6-635ed64fcc6f',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:35 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificate-","deletedDate":1590585503,"scheduledPurgeDate":1598361503,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificate-/ca74d2a4dafa43209b004505f397e86a","x5t":"rnjuw18TqWex92xvwqYfH71iC_o","cer":"MIIDKDCCAhCgAwIBAgIQf1JriRdtT4yQl2Am3+f8EDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODIxWhcNMjEwNTI3MTMxODIxWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC451rY9S/g44tJdSqLvri3nMpGXlryEV5XuIMYL+VyBZjfnpBl70OVsK4dZmxNDxf0IlrSm4MdFBDuvsBznSpqXBKBP020SOheg2h7kivS9gKl8VOge1hZZXylCZET3oOseCXzBfIQJm+sXU5S10vXHKu1PqVfIASoQWCsGKW7gllbc9V8uUlJ3r3Ar8kprD8l8u/i7JLwyVZ4yHYEirTcfm1QZ6xl6UUzbN44mCksklgneRh8zjrxjmp/15HYDsVTfrYq6SjhOlnCHk0u9xDs7rM0y5L+omB9dpdEpdSEcgMQ2rZqaPlJ6V+3ZsWPsCzWuXK13NoPtDNFmcEyJAObAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBQs86BZlbIcjpyRkpkYuEpRduV4WjAdBgNVHQ4EFgQULPOgWZWyHI6ckZKZGLhKUXbleFowDQYJKoZIhvcNAQELBQADggEBAKGu5VU7H9/108y+IgCcdtlaXjf67ljW1a5S2kIH91OKIU9ah2qHTI+lVI1DCSsSXlwsYVCFbPAXES/g7MSmFBU/7B1utZvcFjg3ZCpIOsl59RCqcO/tZFl9+DNgzY3k21FB6sK0H2ZmELoSYMrmy5FRFybNrQkJS4UrrjmLocFXAZMTKZfVjx+O+H7v9ttZ2YvfBCEc8xAuWybpdMMOMAElf9FA7wZjuEyWYkPbUXPXted0XRWcvu23iQirUXzOcCIFFMqEDlviZzGx5FYFS5BjkLhuTgZDZWRGCq2GEUpsaiOoTUYQS8apMQEj4fBaIaWKyjnveXbf4gcjKERyq/M=","attributes":{"enabled":false,"nbf":1590584901,"exp":1622121501,"created":1590585501,"updated":1590585503,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585482,"updated":1590585482}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificate-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'a033ff8c-de45-4f64-8fcf-154a6cd8c06d',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:38 GMT',
+  'Content-Length',
+  '2779'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedcertificates/recoverCertificateName-candisableacertificate-')
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'ab80d433-f499-4203-bbda-6710444c2019',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:38 GMT'
+]);

--- a/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate_version.js
+++ b/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_disable_a_certificate_version.js
@@ -1,0 +1,906 @@
+let nock = require('nock');
+
+module.exports.hash = "6642b148547d702a60858c62054b7edb";
+
+module.exports.testInfo = {"uniqueName":{},"newDate":{}}
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/certificates/recoverCertificateName-candisableacertificateversion-/create')
+  .query(true)
+  .reply(401, {"error":{"code":"Unauthorized","message":"Request is missing a Bearer or PoP token."}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '87',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'WWW-Authenticate',
+  'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '2c01b3f7-063d-4285-a94e-d654041e831b',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:38 GMT'
+]);
+
+nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
+  .post('/azure_tenant_id/oauth2/v2.0/token', "response_type=token&grant_type=client_credentials&client_id=azure_client_id&client_secret=azure_client_secret&scope=https%3A%2F%2Fvault.azure.net%2F.default")
+  .reply(200, {"token_type":"Bearer","expires_in":86399,"ext_expires_in":86399,"access_token":"access_token"}, [
+  'Cache-Control',
+  'no-cache, no-store',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Strict-Transport-Security',
+  'max-age=31536000; includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'x-ms-request-id',
+  'ac7be9c3-c96c-4071-be94-01c377e80900',
+  'x-ms-ests-server',
+  '2.1.10656.5 - WUS2 ProdSlices',
+  'P3P',
+  'CP="DSP CUR OTPi IND OTRi ONL FIN"',
+  'Set-Cookie',
+  'fpc=ArnHxfp2qxZHjMg8-lfYXCA_aSJHAQAAAK5fYNYOAAAA; expires=Fri, 26-Jun-2020 13:18:38 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'Set-Cookie',
+  'x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly',
+  'Set-Cookie',
+  'stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly',
+  'Date',
+  'Wed, 27 May 2020 13:18:38 GMT',
+  'Content-Length',
+  '1310'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .post('/certificates/recoverCertificateName-candisableacertificateversion-/create', {"policy":{"key_props":{},"secret_props":{},"x509_props":{"subject":"cn=MyCert","sans":{}},"issuer":{"name":"Self"},"attributes":{}},"attributes":{}})
+  .query(true)
+  .reply(202, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Location',
+  'https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending?api-version=7.1-preview&request_id=6b53d972e3ce4395b05c4c2728e77a4b',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'a90496f2-6bfa-48fd-b564-6b11608130f9',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:39 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '0e387b24-0127-4b81-92b7-42e587250825',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:39 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'dc941c1a-319a-4ed9-87f1-14e1a41ce3af',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:39 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '44b6acf2-8630-4a45-967b-713d2eaceb08',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:41 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'd62b3e92-13fe-46f2-a808-693ec1a93660',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:42 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '3b3b7ed5-ad78-4707-912a-7fcfca3930b9',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:45 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '76f50107-cab3-418b-a42e-bf4e73772d58',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:47 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'a533b10b-3f6e-421d-94b0-f485ae60712f',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:49 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'Retry-After',
+  '10',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '257ac7e3-7603-4cd9-97a8-3ca7ef37149a',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:51 GMT',
+  'Content-Length',
+  '1346'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/pending')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA3vgH5rX6LySq6O+imhpvdLAMs9kfVPQmbZHSpDWcS2rKVgk4wA/warOCqhaOhV0kEfIHgKIvkklCEK5x40VSK5E84HlQ7/yFuo/OGTkIxtfSe5p/KY3etmRukAchAo/flERry3yty8cFBmXLcAOJrgHM4V1AsJk2NL3V3EUWJtgr4Sl5fpKnJOBIkdK78KOKYqmsO4i8gWfNQYhzbiY4lRNl1QvcoEAOyw8ExmQDwzox7eFxU/YAir1Ol2eTwCZPW6Qgep1fStc/crZXSwnhwj64RyjWN4hjIqIxAhshA+f5x9W1PsSdH+sznPshTJLlxkyH/0zfd8K8xs7X1ViPpQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAGChujG1zgYfiyG8bI7I9e7b+kS7vi4LEI+iRoC44v/WkzueDeopz2VEMIg3eqxyc+PB3df9SzBbivfQnaA053B6P2aDOseRIifXCGPbhqPl+9Cw9MmjPP5MTRagpasl4a46H/74Jm00PM7KAEtwTgjO8vBO9KusReSdK9WzCX2O5gtkWBFZ0KivBczmKHN3dq1Go5J+jxH57bot9CDYZDz27YqrWVJjLg9tV1p9DddJBg6YH9FUlQ0BHTvjDpLRor5PsHvjQ/NQqn5w9DLw4CsB820GPXQAdAxODK+WuWhV5+Ggk/qMH/y6mrRTBVYWtH/cHK2qH9lbL21T28Cwixw=","cancellation_requested":false,"status":"completed","target":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-","request_id":"6b53d972e3ce4395b05c4c2728e77a4b"}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '791ceda0-8888-4d62-9a31-089fc876c922',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:53 GMT',
+  'Content-Length',
+  '1319'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","x5t":"VTgf6LvLaVgtK9Rm5vdvaOE9J5c","cer":"MIIDKDCCAhCgAwIBAgIQR55D2LCIRhaeV7mhDd2DGDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODUyWhcNMjEwNTI3MTMxODUyWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDe+AfmtfovJKro76KaGm90sAyz2R9U9CZtkdKkNZxLaspWCTjAD/Bqs4KqFo6FXSQR8geAoi+SSUIQrnHjRVIrkTzgeVDv/IW6j84ZOQjG19J7mn8pjd62ZG6QByECj9+URGvLfK3LxwUGZctwA4muAczhXUCwmTY0vdXcRRYm2CvhKXl+kqck4EiR0rvwo4piqaw7iLyBZ81BiHNuJjiVE2XVC9ygQA7LDwTGZAPDOjHt4XFT9gCKvU6XZ5PAJk9bpCB6nV9K1z9ytldLCeHCPrhHKNY3iGMiojECGyED5/nH1bU+xJ0f6zOc+yFMkuXGTIf/TN93wrzGztfVWI+lAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSKGdSvpdcm6pwBb4T03vuDJP466zAdBgNVHQ4EFgQUihnUr6XXJuqcAW+E9N77gyT+OuswDQYJKoZIhvcNAQELBQADggEBAK+4DMHb7vnyz5rtYJjHh5bwNPKYm/K4FG7QLS+W/c3W9fnkQdhuJCXJ6LsPbWbwZdir4QRdJTlGNnlUH8NGSrBxzlDfoHYd9XmpjfZB3nThq6Lc6KvbBNS0Da8l6C3kokUFffno/CoedRiDDNbSlD3eXMalZLQliY8S/Q1+7D4HgcKuJFKDVCku/45zGQPg9k+55uCTX9hOKwO5BS/99wq/sQ5B9vKIfrXlj84f724z9ipgmTUDVWqZ4MjT+G25vI2Gitz3t+KPwiY3dowx8wAEtHxQCvAzm0bZGucyrXYMnb4v+bC3TQpufamXL+OM1aFPGp6xjFgOEkx3Fl87w1A=","attributes":{"enabled":true,"nbf":1590584932,"exp":1622121532,"created":1590585532,"updated":1590585532,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585519,"updated":1590585519}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '6841c490-9666-42c4-8107-d74f74a67401',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:53 GMT',
+  'Content-Length',
+  '2620'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .patch('/certificates/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0', {"attributes":{"enabled":false}})
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","x5t":"VTgf6LvLaVgtK9Rm5vdvaOE9J5c","cer":"MIIDKDCCAhCgAwIBAgIQR55D2LCIRhaeV7mhDd2DGDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODUyWhcNMjEwNTI3MTMxODUyWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDe+AfmtfovJKro76KaGm90sAyz2R9U9CZtkdKkNZxLaspWCTjAD/Bqs4KqFo6FXSQR8geAoi+SSUIQrnHjRVIrkTzgeVDv/IW6j84ZOQjG19J7mn8pjd62ZG6QByECj9+URGvLfK3LxwUGZctwA4muAczhXUCwmTY0vdXcRRYm2CvhKXl+kqck4EiR0rvwo4piqaw7iLyBZ81BiHNuJjiVE2XVC9ygQA7LDwTGZAPDOjHt4XFT9gCKvU6XZ5PAJk9bpCB6nV9K1z9ytldLCeHCPrhHKNY3iGMiojECGyED5/nH1bU+xJ0f6zOc+yFMkuXGTIf/TN93wrzGztfVWI+lAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSKGdSvpdcm6pwBb4T03vuDJP466zAdBgNVHQ4EFgQUihnUr6XXJuqcAW+E9N77gyT+OuswDQYJKoZIhvcNAQELBQADggEBAK+4DMHb7vnyz5rtYJjHh5bwNPKYm/K4FG7QLS+W/c3W9fnkQdhuJCXJ6LsPbWbwZdir4QRdJTlGNnlUH8NGSrBxzlDfoHYd9XmpjfZB3nThq6Lc6KvbBNS0Da8l6C3kokUFffno/CoedRiDDNbSlD3eXMalZLQliY8S/Q1+7D4HgcKuJFKDVCku/45zGQPg9k+55uCTX9hOKwO5BS/99wq/sQ5B9vKIfrXlj84f724z9ipgmTUDVWqZ4MjT+G25vI2Gitz3t+KPwiY3dowx8wAEtHxQCvAzm0bZGucyrXYMnb4v+bC3TQpufamXL+OM1aFPGp6xjFgOEkx3Fl87w1A=","attributes":{"enabled":false,"nbf":1590584932,"exp":1622121532,"created":1590585532,"updated":1590585534,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'ac56b114-6b8b-4780-96db-b5d81808f626',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:53 GMT',
+  'Content-Length',
+  '1942'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/certificates/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0')
+  .query(true)
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","x5t":"VTgf6LvLaVgtK9Rm5vdvaOE9J5c","cer":"MIIDKDCCAhCgAwIBAgIQR55D2LCIRhaeV7mhDd2DGDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODUyWhcNMjEwNTI3MTMxODUyWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDe+AfmtfovJKro76KaGm90sAyz2R9U9CZtkdKkNZxLaspWCTjAD/Bqs4KqFo6FXSQR8geAoi+SSUIQrnHjRVIrkTzgeVDv/IW6j84ZOQjG19J7mn8pjd62ZG6QByECj9+URGvLfK3LxwUGZctwA4muAczhXUCwmTY0vdXcRRYm2CvhKXl+kqck4EiR0rvwo4piqaw7iLyBZ81BiHNuJjiVE2XVC9ygQA7LDwTGZAPDOjHt4XFT9gCKvU6XZ5PAJk9bpCB6nV9K1z9ytldLCeHCPrhHKNY3iGMiojECGyED5/nH1bU+xJ0f6zOc+yFMkuXGTIf/TN93wrzGztfVWI+lAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSKGdSvpdcm6pwBb4T03vuDJP466zAdBgNVHQ4EFgQUihnUr6XXJuqcAW+E9N77gyT+OuswDQYJKoZIhvcNAQELBQADggEBAK+4DMHb7vnyz5rtYJjHh5bwNPKYm/K4FG7QLS+W/c3W9fnkQdhuJCXJ6LsPbWbwZdir4QRdJTlGNnlUH8NGSrBxzlDfoHYd9XmpjfZB3nThq6Lc6KvbBNS0Da8l6C3kokUFffno/CoedRiDDNbSlD3eXMalZLQliY8S/Q1+7D4HgcKuJFKDVCku/45zGQPg9k+55uCTX9hOKwO5BS/99wq/sQ5B9vKIfrXlj84f724z9ipgmTUDVWqZ4MjT+G25vI2Gitz3t+KPwiY3dowx8wAEtHxQCvAzm0bZGucyrXYMnb4v+bC3TQpufamXL+OM1aFPGp6xjFgOEkx3Fl87w1A=","attributes":{"enabled":false,"nbf":1590584932,"exp":1622121532,"created":1590585532,"updated":1590585534,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'eaa5580c-5360-4747-a346-716455c48db7',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:53 GMT',
+  'Content-Length',
+  '1788'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/certificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-","deletedDate":1590585534,"scheduledPurgeDate":1598361534,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","x5t":"VTgf6LvLaVgtK9Rm5vdvaOE9J5c","cer":"MIIDKDCCAhCgAwIBAgIQR55D2LCIRhaeV7mhDd2DGDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODUyWhcNMjEwNTI3MTMxODUyWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDe+AfmtfovJKro76KaGm90sAyz2R9U9CZtkdKkNZxLaspWCTjAD/Bqs4KqFo6FXSQR8geAoi+SSUIQrnHjRVIrkTzgeVDv/IW6j84ZOQjG19J7mn8pjd62ZG6QByECj9+URGvLfK3LxwUGZctwA4muAczhXUCwmTY0vdXcRRYm2CvhKXl+kqck4EiR0rvwo4piqaw7iLyBZ81BiHNuJjiVE2XVC9ygQA7LDwTGZAPDOjHt4XFT9gCKvU6XZ5PAJk9bpCB6nV9K1z9ytldLCeHCPrhHKNY3iGMiojECGyED5/nH1bU+xJ0f6zOc+yFMkuXGTIf/TN93wrzGztfVWI+lAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSKGdSvpdcm6pwBb4T03vuDJP466zAdBgNVHQ4EFgQUihnUr6XXJuqcAW+E9N77gyT+OuswDQYJKoZIhvcNAQELBQADggEBAK+4DMHb7vnyz5rtYJjHh5bwNPKYm/K4FG7QLS+W/c3W9fnkQdhuJCXJ6LsPbWbwZdir4QRdJTlGNnlUH8NGSrBxzlDfoHYd9XmpjfZB3nThq6Lc6KvbBNS0Da8l6C3kokUFffno/CoedRiDDNbSlD3eXMalZLQliY8S/Q1+7D4HgcKuJFKDVCku/45zGQPg9k+55uCTX9hOKwO5BS/99wq/sQ5B9vKIfrXlj84f724z9ipgmTUDVWqZ4MjT+G25vI2Gitz3t+KPwiY3dowx8wAEtHxQCvAzm0bZGucyrXYMnb4v+bC3TQpufamXL+OM1aFPGp6xjFgOEkx3Fl87w1A=","attributes":{"enabled":false,"nbf":1590584932,"exp":1622121532,"created":1590585532,"updated":1590585534,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585519,"updated":1590585519}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'e521a09a-8915-46e7-b40e-599a2e351ded',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:53 GMT',
+  'Content-Length',
+  '2827'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'a7796335-9aa6-417b-bac6-515461608212',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:53 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '54b886a6-2b29-4966-baf2-698fca9853b7',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:53 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'a5b17ae7-5519-48eb-9c8a-81165681e2d1',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:55 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'ddbe3c6f-aa31-431a-ad3a-4ed09e3fd7ae',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:18:58 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'c18a2dc7-adf1-4c8d-bff2-bd784db5e479',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:19:00 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '8375ca83-a8c2-4d63-b0ac-e8014782197c',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:19:02 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'bb20a977-408b-4c95-a63f-c32ebf511b60',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:19:04 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-candisableacertificateversion-"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Length',
+  '154',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  '3bce1d32-d371-40d2-a602-e5ce8b109a84',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:19:07 GMT'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .get('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-candisableacertificateversion-","deletedDate":1590585534,"scheduledPurgeDate":1598361534,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","kid":"https://keyvault_name.vault.azure.net/keys/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","sid":"https://keyvault_name.vault.azure.net/secrets/recoverCertificateName-candisableacertificateversion-/a27358f95acc445bb78cc6eb3d3ce4a0","x5t":"VTgf6LvLaVgtK9Rm5vdvaOE9J5c","cer":"MIIDKDCCAhCgAwIBAgIQR55D2LCIRhaeV7mhDd2DGDANBgkqhkiG9w0BAQsFADARMQ8wDQYDVQQDEwZNeUNlcnQwHhcNMjAwNTI3MTMwODUyWhcNMjEwNTI3MTMxODUyWjARMQ8wDQYDVQQDEwZNeUNlcnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDe+AfmtfovJKro76KaGm90sAyz2R9U9CZtkdKkNZxLaspWCTjAD/Bqs4KqFo6FXSQR8geAoi+SSUIQrnHjRVIrkTzgeVDv/IW6j84ZOQjG19J7mn8pjd62ZG6QByECj9+URGvLfK3LxwUGZctwA4muAczhXUCwmTY0vdXcRRYm2CvhKXl+kqck4EiR0rvwo4piqaw7iLyBZ81BiHNuJjiVE2XVC9ygQA7LDwTGZAPDOjHt4XFT9gCKvU6XZ5PAJk9bpCB6nV9K1z9ytldLCeHCPrhHKNY3iGMiojECGyED5/nH1bU+xJ0f6zOc+yFMkuXGTIf/TN93wrzGztfVWI+lAgMBAAGjfDB6MA4GA1UdDwEB/wQEAwIFoDAJBgNVHRMEAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAfBgNVHSMEGDAWgBSKGdSvpdcm6pwBb4T03vuDJP466zAdBgNVHQ4EFgQUihnUr6XXJuqcAW+E9N77gyT+OuswDQYJKoZIhvcNAQELBQADggEBAK+4DMHb7vnyz5rtYJjHh5bwNPKYm/K4FG7QLS+W/c3W9fnkQdhuJCXJ6LsPbWbwZdir4QRdJTlGNnlUH8NGSrBxzlDfoHYd9XmpjfZB3nThq6Lc6KvbBNS0Da8l6C3kokUFffno/CoedRiDDNbSlD3eXMalZLQliY8S/Q1+7D4HgcKuJFKDVCku/45zGQPg9k+55uCTX9hOKwO5BS/99wq/sQ5B9vKIfrXlj84f724z9ipgmTUDVWqZ4MjT+G25vI2Gitz3t+KPwiY3dowx8wAEtHxQCvAzm0bZGucyrXYMnb4v+bC3TQpufamXL+OM1aFPGp6xjFgOEkx3Fl87w1A=","attributes":{"enabled":false,"nbf":1590584932,"exp":1622121532,"created":1590585532,"updated":1590585534,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590585519,"updated":1590585519}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-candisableacertificateversion-/pending"}}, [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Content-Type',
+  'application/json; charset=utf-8',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'd1b7543e-69f5-4a08-89ce-075ebc70ffce',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:19:09 GMT',
+  'Content-Length',
+  '2827'
+]);
+
+nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
+  .delete('/deletedcertificates/recoverCertificateName-candisableacertificateversion-')
+  .query(true)
+  .reply(204, "", [
+  'Cache-Control',
+  'no-cache',
+  'Pragma',
+  'no-cache',
+  'Expires',
+  '-1',
+  'x-ms-keyvault-region',
+  'westus',
+  'x-ms-request-id',
+  'c21f9274-408a-4712-b627-614744942887',
+  'x-ms-keyvault-service-version',
+  '1.1.5.0',
+  'x-ms-keyvault-network-info',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
+  'X-AspNet-Version',
+  '4.0.30319',
+  'X-Powered-By',
+  'ASP.NET',
+  'Strict-Transport-Security',
+  'max-age=31536000;includeSubDomains',
+  'X-Content-Type-Options',
+  'nosniff',
+  'Date',
+  'Wed, 27 May 2020 13:19:09 GMT'
+]);

--- a/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_update_the_tags_of_a_certificate.js
+++ b/sdk/keyvault/keyvault-certificates/recordings/node/certificates_client__create_read_update_and_delete/recording_can_update_the_tags_of_a_certificate.js
@@ -18,18 +18,16 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'WWW-Authenticate',
   'Bearer authorization="https://login.windows.net/azure_tenant_id", resource="https://vault.azure.net"',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '1e2adc49-688b-495b-a709-df9604abd4f0',
+  '32615cae-1f80-4a9e-b55c-b0eeaa35763a',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -39,7 +37,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:48 GMT'
+  'Wed, 27 May 2020 15:04:23 GMT'
 ]);
 
 nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
@@ -58,19 +56,19 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'x-ms-request-id',
-  'ac2b3571-3c5a-4c56-9e73-7b5468aa0700',
+  '1647191f-fc41-4f66-94c8-0d57ccb31700',
   'x-ms-ests-server',
-  '2.1.10433.14 - EUS ProdSlices',
+  '2.1.10620.11 - EUS ProdSlices',
   'P3P',
   'CP="DSP CUR OTPi IND OTRi ONL FIN"',
   'Set-Cookie',
-  'fpc=Ani8mC5EM2JCsERNuNhjkBQ_aSJHAQAAAOC4OdYOAAAA; expires=Thu, 28-May-2020 05:40:49 GMT; path=/; secure; HttpOnly; SameSite=None',
+  'fpc=AvrQdu_2QcpKhBAcaVoI2Jw_aSJHAQAAAHd4YNYOAAAA; expires=Fri, 26-Jun-2020 15:04:24 GMT; path=/; secure; HttpOnly; SameSite=None',
   'Set-Cookie',
   'x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly',
   'Set-Cookie',
   'stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly',
   'Date',
-  'Tue, 28 Apr 2020 05:40:48 GMT',
+  'Wed, 27 May 2020 15:04:23 GMT',
   'Content-Length',
   '1315'
 ]);
@@ -78,7 +76,7 @@ nock('https://login.microsoftonline.com:443', {"encodedQueryParams":true})
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .post('/certificates/recoverCertificateName-canupdatethetagsofacertificate-/create', {"policy":{"key_props":{},"secret_props":{},"x509_props":{"subject":"cn=MyCert","sans":{}},"issuer":{"name":"Self"},"attributes":{}},"attributes":{}})
   .query(true)
-  .reply(202, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAixAA5opOGBWRbITOxM/lR/TyHMxMLeNvtahQTcWbY/javFk/mmsgIkfgABi8TT4qNfTtVPKP2XiWkhBLLGEoeqZ56ap9Ea57uP/m+3ZOM2GBN/5+DjFHsWMK6HAtMrehVWiGb9NuOJ6EmwROCCqrURvX5CXRMtAfHve+mFpXeH0fEy6Z87RZh1Z86Hw7ih+x9X0sxBKkUbQUXnDuzED67zdM8n/EIL5/L5pXW4vM7Ys7o3YsKtGB6ShkKMwSqt+QMoMz9XI9kVdeZTtRFibeRoUuKHXcDwnN2QnkdRWHJqP9yLPWoNTU830vBRnXAqZZtdXtULVdS/Yf3nGB0Kk7TQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAEJh/MFE9afffBdgwTW7zcx04Y027Bs/B18KNK34tE9ZQgMBYz+xtTCP1Q1dWzOiSAenxFHqNR6arPhYo0jylx81GqHXRfTJTcjmMQfoILR2vZUL77r5cDpJ0/4pQIcyYIbGg9AtlsVr0Ie9Qp0TbJQO7AXuEX4erl/lOYvjIzDkPemTJl1FyfzhwszFwcKxFtN5VmrZj+9tC/6qUkOmINnXSFpgLX75axe6fVHQOqhhU6FAzqwznWMsmOwihk7c0IKFpH3HKg/C8qQCSXlDllUpgGDdLtyzvnCxHRyzOAFpgZUyHps0CMDN2OhwYSduXU+IQaTKvDDp3cbHk4WIaCM=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"427f91944ee64db0b85d940dc37e3653"}, [
+  .reply(202, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzC1uQc4JhMZme+h3xgWkdAZHaCIhV+OCLMSc+8dqg6fYL9W4Bjc90mK8s88GDAb1gn8ch8IGVldmFJ9brPLs4Jad+gx3hdewKBugKMacPyqHrHIG+v49p1kdPwCq848XCQWgI1p663Pua8taSHnsSnZvONPqdmCi3e/b50vb7gEODBpt0PdQ1CUgEIUSLxSWiKaVsim2TpfJXhAuev8rqCd5ApCqKzLzgJ1OBySmZifFEiTmxuo3kSR7hUjdK2f4cB9myEJawqxqBLO/qDyd4XGwQzLNO6QaTc9WP+Jq5hyeJ+ZkpgjZymDysCtlkGmZaMTe0WuQsOBqzqfJCf3r8wIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAA8/jTcYv8kuR/52ZG6EOgOEsA2yxZd+TRNXw9BgU6s//MR1Vli5wpayPZIXIdMgE9n8sSkIuIRupGybLjnJieKOWwvhxwl5COubcPxYe+/lNk5YSHSlr3UTBF+PO+eksBcGobmb9wY5Cjj5+VPVhFYgZ1XxxgZIWjAkPtzjIoLxM/vzg9WUrMaytmUFWBfai+v/yIs6P5UYXcCeV5edWFNfv3WOlyZTEnNMQo2LVpDxu5moAwJ5ho9IjuYYGQ7w7LbG5NTAw09tf61P64HokbnfPS2cHwt4+IaToVvPe7AWiLOaWWChL/ujLzRtKMc/JvD5YtOWPRLwvwUmDWYl8Vo=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"a8b3796d3b5240f685a3b350e5f2f07c"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -88,19 +86,17 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Expires',
   '-1',
   'Location',
-  'https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending?api-version=7.1-preview&request_id=427f91944ee64db0b85d940dc37e3653',
+  'https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending?api-version=7.1-preview&request_id=a8b3796d3b5240f685a3b350e5f2f07c',
   'Retry-After',
   '10',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '26e05b29-cef3-4425-a52f-7985598748d8',
+  'a5196634-dd97-418e-a683-cd3360de4adc',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -110,15 +106,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:50 GMT',
+  'Wed, 27 May 2020 15:04:24 GMT',
   'Content-Length',
-  '1347'
+  '1346'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending')
   .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAixAA5opOGBWRbITOxM/lR/TyHMxMLeNvtahQTcWbY/javFk/mmsgIkfgABi8TT4qNfTtVPKP2XiWkhBLLGEoeqZ56ap9Ea57uP/m+3ZOM2GBN/5+DjFHsWMK6HAtMrehVWiGb9NuOJ6EmwROCCqrURvX5CXRMtAfHve+mFpXeH0fEy6Z87RZh1Z86Hw7ih+x9X0sxBKkUbQUXnDuzED67zdM8n/EIL5/L5pXW4vM7Ys7o3YsKtGB6ShkKMwSqt+QMoMz9XI9kVdeZTtRFibeRoUuKHXcDwnN2QnkdRWHJqP9yLPWoNTU830vBRnXAqZZtdXtULVdS/Yf3nGB0Kk7TQIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAEJh/MFE9afffBdgwTW7zcx04Y027Bs/B18KNK34tE9ZQgMBYz+xtTCP1Q1dWzOiSAenxFHqNR6arPhYo0jylx81GqHXRfTJTcjmMQfoILR2vZUL77r5cDpJ0/4pQIcyYIbGg9AtlsVr0Ie9Qp0TbJQO7AXuEX4erl/lOYvjIzDkPemTJl1FyfzhwszFwcKxFtN5VmrZj+9tC/6qUkOmINnXSFpgLX75axe6fVHQOqhhU6FAzqwznWMsmOwihk7c0IKFpH3HKg/C8qQCSXlDllUpgGDdLtyzvnCxHRyzOAFpgZUyHps0CMDN2OhwYSduXU+IQaTKvDDp3cbHk4WIaCM=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"427f91944ee64db0b85d940dc37e3653"}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending","issuer":{"name":"Self"},"csr":"MIICoTCCAYkCAQAwETEPMA0GA1UEAxMGTXlDZXJ0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzC1uQc4JhMZme+h3xgWkdAZHaCIhV+OCLMSc+8dqg6fYL9W4Bjc90mK8s88GDAb1gn8ch8IGVldmFJ9brPLs4Jad+gx3hdewKBugKMacPyqHrHIG+v49p1kdPwCq848XCQWgI1p663Pua8taSHnsSnZvONPqdmCi3e/b50vb7gEODBpt0PdQ1CUgEIUSLxSWiKaVsim2TpfJXhAuev8rqCd5ApCqKzLzgJ1OBySmZifFEiTmxuo3kSR7hUjdK2f4cB9myEJawqxqBLO/qDyd4XGwQzLNO6QaTc9WP+Jq5hyeJ+ZkpgjZymDysCtlkGmZaMTe0WuQsOBqzqfJCf3r8wIDAQABoEswSQYJKoZIhvcNAQkOMTwwOjAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBAA8/jTcYv8kuR/52ZG6EOgOEsA2yxZd+TRNXw9BgU6s//MR1Vli5wpayPZIXIdMgE9n8sSkIuIRupGybLjnJieKOWwvhxwl5COubcPxYe+/lNk5YSHSlr3UTBF+PO+eksBcGobmb9wY5Cjj5+VPVhFYgZ1XxxgZIWjAkPtzjIoLxM/vzg9WUrMaytmUFWBfai+v/yIs6P5UYXcCeV5edWFNfv3WOlyZTEnNMQo2LVpDxu5moAwJ5ho9IjuYYGQ7w7LbG5NTAw09tf61P64HokbnfPS2cHwt4+IaToVvPe7AWiLOaWWChL/ujLzRtKMc/JvD5YtOWPRLwvwUmDWYl8Vo=","cancellation_requested":false,"status":"inProgress","status_details":"Pending certificate created. Certificate request is in progress. This may take some time based on the issuer provider. Please check again later.","request_id":"a8b3796d3b5240f685a3b350e5f2f07c"}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -129,16 +125,14 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   '-1',
   'Retry-After',
   '10',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  'effc1fd7-020d-4fa0-afff-b0023d368b3c',
+  'b2350e61-b694-4ec9-8dd5-7469f13efc3d',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -148,15 +142,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:50 GMT',
+  'Wed, 27 May 2020 15:04:24 GMT',
   'Content-Length',
-  '1347'
+  '1346'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .patch('/certificates/recoverCertificateName-canupdatethetagsofacertificate-/', {"tags":{"customTag":"value"}})
+  .patch('/certificates/recoverCertificateName-canupdatethetagsofacertificate-/', {"attributes":{},"tags":{"customTag":"value"}})
   .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/84f3531c3e2548ed84aece9d033c2ade","attributes":{"enabled":false,"nbf":1588051849,"exp":1619588449,"created":1588052449,"updated":1588052450,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1588052449,"updated":1588052449}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/a005245c0d7945e7a56201021c894cbd","attributes":{"enabled":false,"nbf":1590591264,"exp":1622127864,"created":1590591864,"updated":1590591865,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590591864,"updated":1590591864}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -165,16 +159,14 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  'c415443a-3c0c-4f4a-8723-056c473eb021',
+  '9ce02114-3057-42bd-86d8-4046f20f89cc',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -184,15 +176,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:50 GMT',
+  'Wed, 27 May 2020 15:04:25 GMT',
   'Content-Length',
-  '1201'
+  '1198'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/certificates/recoverCertificateName-canupdatethetagsofacertificate-/')
   .query(true)
-  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/84f3531c3e2548ed84aece9d033c2ade","attributes":{"enabled":false,"nbf":1588051849,"exp":1619588449,"created":1588052449,"updated":1588052450,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1588052449,"updated":1588052449}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
+  .reply(200, {"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/a005245c0d7945e7a56201021c894cbd","attributes":{"enabled":false,"nbf":1590591264,"exp":1622127864,"created":1590591864,"updated":1590591865,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590591864,"updated":1590591864}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -201,16 +193,14 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '8b0df78d-dbdf-41dd-96da-7f17c63f84fe',
+  '8795cf57-64e4-4470-a299-7679ca7d9b62',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -220,15 +210,15 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:50 GMT',
+  'Wed, 27 May 2020 15:04:25 GMT',
   'Content-Length',
-  '1201'
+  '1198'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .delete('/certificates/recoverCertificateName-canupdatethetagsofacertificate-')
   .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-","deletedDate":1588052450,"scheduledPurgeDate":1595828450,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/84f3531c3e2548ed84aece9d033c2ade","attributes":{"enabled":false,"nbf":1588051849,"exp":1619588449,"created":1588052449,"updated":1588052450,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1588052449,"updated":1588052449}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-","deletedDate":1590591865,"scheduledPurgeDate":1598367865,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/a005245c0d7945e7a56201021c894cbd","attributes":{"enabled":false,"nbf":1590591264,"exp":1622127864,"created":1590591864,"updated":1590591865,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590591864,"updated":1590591864}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -237,16 +227,14 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '5f324396-0418-4124-85db-c54aaf56823d',
+  '12515b46-182b-4b26-b2fb-bb9fa9e41359',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -256,9 +244,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:50 GMT',
+  'Wed, 27 May 2020 15:04:25 GMT',
   'Content-Length',
-  '1408'
+  '1404'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -270,21 +258,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '4e4bdf85-c2a8-4304-9d07-061b072a7604',
+  '4b63931e-9ecf-45bd-89ac-9956c8e1c7b4',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -294,7 +280,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:50 GMT'
+  'Wed, 27 May 2020 15:04:25 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -306,21 +292,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '8fa6d507-5dac-44cd-8630-c2d04fada22e',
+  'd389edc4-1348-4661-a53a-4bc688583fec',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -330,7 +314,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:50 GMT'
+  'Wed, 27 May 2020 15:04:25 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -342,21 +326,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '5e34e15f-b2e1-47a1-99e1-1c3455bb244b',
+  '76f701c9-f6fa-4589-81ef-ee908dfd0d0f',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -366,7 +348,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:52 GMT'
+  'Wed, 27 May 2020 15:04:27 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -378,21 +360,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  'c0a27123-aec6-4ea3-822d-bc5352e34139',
+  'a3a618bd-e097-42ab-b411-1fc43af52c09',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -402,7 +382,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:54 GMT'
+  'Wed, 27 May 2020 15:04:29 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -414,21 +394,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  'ffb08db6-9b08-43e0-84a9-f9a20737e080',
+  '95b098df-444a-4963-b1a3-f4ebafd8565a',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -438,7 +416,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:56 GMT'
+  'Wed, 27 May 2020 15:04:31 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -450,21 +428,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '127b3bc9-6e8f-43f0-b5d7-11039965ee19',
+  '0c382576-d925-49ed-9619-e0d0791a20f1',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -474,7 +450,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:40:58 GMT'
+  'Wed, 27 May 2020 15:04:33 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -486,21 +462,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '8c5cf06e-e5c7-4cd9-83a2-aeae8a80d997',
+  '198d0eac-1631-48a0-bd22-46aee265b352',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -510,7 +484,7 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:41:00 GMT'
+  'Wed, 27 May 2020 15:04:35 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -522,21 +496,19 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'Pragma',
   'no-cache',
   'Content-Length',
-  '155',
+  '154',
   'Content-Type',
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '50b85dea-5ec8-4d15-869f-edbc5a10ca2a',
+  '8f532fe3-f416-4702-85e2-b2d57a3168ec',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -546,805 +518,13 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:41:02 GMT'
+  'Wed, 27 May 2020 15:04:37 GMT'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
   .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '3c404501-ee62-451f-8bdf-29f9ca34d8f5',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:04 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'c779269c-6ebd-40e2-8a21-d46e50370f6c',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:06 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'e7f43ee2-c50d-4a2f-99b9-028443d16d66',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:08 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '1a2c06ce-4019-4cc2-aa4a-083986c357bb',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:11 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '11b36587-21f2-4a95-9640-53587b1c6f27',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:13 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'ad0f382b-018c-4669-b22f-4be41608719b',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:15 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'b382a07b-9c60-46c9-859d-01c247bb4723',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:17 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '516958c2-a81c-4db3-a18e-ef3e6326ee1d',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:19 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '84fe5425-df21-4cdb-8066-9c342397fd70',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:21 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'e58da587-7b86-454e-b9b0-d9ba7be99aa7',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:23 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '8e18828d-b8a5-40f2-b155-fdee30aa7a42',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:25 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'a6d68812-21ef-40ef-8bc9-a132d8466fc9',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:27 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '527b1f1e-6dae-42b8-8230-761ea8884933',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:29 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '37fee5ce-3d68-4637-b22c-134bc0de04db',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:31 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '93a970a0-5612-4ba5-b2ff-0e17a383bdce',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:33 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'fc9184a5-6962-4064-8b52-414853456a17',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:35 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'cfd7d947-38e2-42d0-892b-4f20e0cc8857',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:38 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'ad5e123d-6530-4e7a-99f5-3125ec15007f',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:41 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'e2b603cb-3c8a-4106-a54a-facad1b85662',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:43 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  '9819806c-0559-4a46-8a32-9052b8fbe863',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:45 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'd3b6f5c8-e885-405a-a71f-425ecb645ee3',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:46 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(404, {"error":{"code":"CertificateNotFound","message":"Deleted Certificate not found: recoverCertificateName-canupdatethetagsofacertificate-"}}, [
-  'Cache-Control',
-  'no-cache',
-  'Pragma',
-  'no-cache',
-  'Content-Length',
-  '155',
-  'Content-Type',
-  'application/json; charset=utf-8',
-  'Expires',
-  '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
-  'x-ms-keyvault-region',
-  'westus',
-  'x-ms-request-id',
-  'c9be7d7c-0426-4ee1-acad-343b4ad49577',
-  'x-ms-keyvault-service-version',
-  '1.1.0.898',
-  'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
-  'X-AspNet-Version',
-  '4.0.30319',
-  'X-Powered-By',
-  'ASP.NET',
-  'Strict-Transport-Security',
-  'max-age=31536000;includeSubDomains',
-  'X-Content-Type-Options',
-  'nosniff',
-  'Date',
-  'Tue, 28 Apr 2020 05:41:48 GMT'
-]);
-
-nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
-  .get('/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-')
-  .query(true)
-  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-","deletedDate":1588052450,"scheduledPurgeDate":1595828450,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/84f3531c3e2548ed84aece9d033c2ade","attributes":{"enabled":false,"nbf":1588051849,"exp":1619588449,"created":1588052449,"updated":1588052450,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1588052449,"updated":1588052449}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
+  .reply(200, {"recoveryId":"https://keyvault_name.vault.azure.net/deletedcertificates/recoverCertificateName-canupdatethetagsofacertificate-","deletedDate":1590591865,"scheduledPurgeDate":1598367865,"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/a005245c0d7945e7a56201021c894cbd","attributes":{"enabled":false,"nbf":1590591264,"exp":1622127864,"created":1590591864,"updated":1590591865,"recoveryLevel":"Recoverable+Purgeable","recoverableDays":90},"tags":{"customTag":"value"},"policy":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/policy","key_props":{"exportable":true,"kty":"RSA","key_size":2048,"reuse_key":false},"secret_props":{"contentType":"application/x-pkcs12"},"x509_props":{"subject":"cn=MyCert","sans":{},"ekus":["1.3.6.1.5.5.7.3.1","1.3.6.1.5.5.7.3.2"],"key_usage":["digitalSignature","keyEncipherment"],"validity_months":12,"basic_constraints":{"ca":false}},"lifetime_actions":[{"trigger":{"lifetime_percentage":80},"action":{"action_type":"AutoRenew"}}],"issuer":{"name":"Self"},"attributes":{"enabled":true,"created":1590591864,"updated":1590591864}},"pending":{"id":"https://keyvault_name.vault.azure.net/certificates/recoverCertificateName-canupdatethetagsofacertificate-/pending"}}, [
   'Cache-Control',
   'no-cache',
   'Pragma',
@@ -1353,16 +533,14 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'application/json; charset=utf-8',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  '9bd16744-568f-45bd-9e8e-bd32c090b88e',
+  'ef3dbd8d-523b-4ecc-b663-f53b598d4db8',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -1372,9 +550,9 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:41:50 GMT',
+  'Wed, 27 May 2020 15:04:39 GMT',
   'Content-Length',
-  '1408'
+  '1404'
 ]);
 
 nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
@@ -1387,16 +565,14 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'no-cache',
   'Expires',
   '-1',
-  'Server',
-  'Microsoft-IIS/10.0',
   'x-ms-keyvault-region',
   'westus',
   'x-ms-request-id',
-  'b0d26b0d-3e94-465d-a7b2-194dad8d5e31',
+  'f2f2dd71-53b9-4fb5-8872-a3c130587240',
   'x-ms-keyvault-service-version',
-  '1.1.0.898',
+  '1.1.5.0',
   'x-ms-keyvault-network-info',
-  'addr=52.247.203.156;act_addr_fam=InterNetwork;',
+  'conn_type=Ipv4;addr=52.233.72.51;act_addr_fam=InterNetwork;',
   'X-AspNet-Version',
   '4.0.30319',
   'X-Powered-By',
@@ -1406,5 +582,5 @@ nock('https://keyvault_name.vault.azure.net:443', {"encodedQueryParams":true})
   'X-Content-Type-Options',
   'nosniff',
   'Date',
-  'Tue, 28 Apr 2020 05:41:51 GMT'
+  'Wed, 27 May 2020 15:04:39 GMT'
 ]);

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -1438,7 +1438,10 @@ export class CertificateClient {
         this.vaultUrl,
         certificateName,
         version,
-        this.setParentSpan(span, requestOptions)
+        {
+          ...this.setParentSpan(span, requestOptions),
+          certificateAttributes: toCoreAttributes(options)
+        }
       );
     } finally {
       span.end();

--- a/sdk/keyvault/keyvault-certificates/test/CRUD.test.ts
+++ b/sdk/keyvault/keyvault-certificates/test/CRUD.test.ts
@@ -136,6 +136,54 @@ describe("Certificates client - create, read, update and delete", () => {
     await testClient.flushCertificate(certificateName);
   });
 
+  it("can disable a certificate", async function() {
+    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+
+    const poller = await client.beginCreateCertificate(
+      certificateName,
+      basicCertificatePolicy,
+      testPollerProperties
+    );
+
+    let result = await poller.pollUntilDone();
+    assert.equal(result.properties.enabled, true);
+
+    result = await client.updateCertificateProperties(certificateName, "", {
+      enabled: false
+    });
+    assert.equal(result.properties.enabled, false);
+
+    result = await client.getCertificate(certificateName);
+    assert.equal(result.properties.enabled, false);
+
+    await testClient.flushCertificate(certificateName);
+  });
+
+  it("can disable a certificate version", async function() {
+    const certificateName = testClient.formatName(`${prefix}-${this!.test!.title}-${suffix}`);
+
+    const poller = await client.beginCreateCertificate(
+      certificateName,
+      basicCertificatePolicy,
+      testPollerProperties
+    );
+
+    let result = await poller.pollUntilDone();
+
+    const version = result.properties.version!;
+    assert.equal(result.properties.enabled, true);
+
+    result = await client.updateCertificateProperties(certificateName, version, {
+      enabled: false
+    });
+    assert.equal(result.properties.enabled, false);
+
+    result = await client.getCertificateVersion(certificateName, version);
+    assert.equal(result.properties.enabled, false);
+
+    await testClient.flushCertificate(certificateName);
+  });
+
   // On playback mode, the tests happen too fast for the timeout to work
   it("can update certificate with requestOptions timeout", async function() {
     recorder.skip(undefined, "Timeout tests don't work on playback mode.");


### PR DESCRIPTION
This PR addresses the bug reported on #9020

The bug is that: updateCertificateProperties is not correctly passing the attributes required by the underlying method.

I will be adding these changes to my current 4.0.2 hotfix PR https://github.com/Azure/azure-sdk-for-js/pull/9122