### PR TITLE
[FormRecognizer] rename data parameter to recognition methods.

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -209,11 +209,11 @@ export type FormPollerLike = PollerLike<PollOperationState<RecognizeFormResultRe
 // @public
 export class FormRecognizerClient {
     constructor(endpointUrl: string, credential: TokenCredential | KeyCredential, options?: FormRecognizerClientOptions);
-    beginRecognizeContent(data: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeContentOptions): Promise<ContentPollerLike>;
+    beginRecognizeContent(form: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeContentOptions): Promise<ContentPollerLike>;
     beginRecognizeContentFromUrl(formUrl: string, options?: BeginRecognizeContentOptions): Promise<ContentPollerLike>;
-    beginRecognizeCustomForms(modelId: string, data: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
+    beginRecognizeCustomForms(modelId: string, form: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeFormsOptions): Promise<FormPollerLike>;
     beginRecognizeCustomFormsFromUrl(modelId: string, formUrl: string, options?: BeginRecognizeFormsOptions): Promise<PollerLike<PollOperationState<RecognizeFormResultResponse>, RecognizeFormResultResponse>>;
-    beginRecognizeReceipts(data: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeReceiptsOptions): Promise<ReceiptPollerLike>;
+    beginRecognizeReceipts(receipt: FormRecognizerRequestBody, contentType?: FormContentType, options?: BeginRecognizeReceiptsOptions): Promise<ReceiptPollerLike>;
     beginRecognizeReceiptsFromUrl(receiptUrl: string, options?: BeginRecognizeReceiptsOptions): Promise<ReceiptPollerLike>;
     readonly endpointUrl: string;
     }

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -277,12 +277,12 @@ export class FormRecognizerClient {
    * console.log(response.pages);
    * ```
    * @summary Recognizes content/layout information from a given document
-   * @param {FormRecognizerRequestBody} data Input document
+   * @param {FormRecognizerRequestBody} form Input document
    * @param {FormContentType} contentType Content type of the input. Supported types are "application/pdf", "image/jpeg", "image/png", and "image/tiff";
    * @param {BeginRecognizeContentOptions} [options] Options to start content recognition operation
    */
   public async beginRecognizeContent(
-    data: FormRecognizerRequestBody,
+    form: FormRecognizerRequestBody,
     contentType?: FormContentType,
     options: BeginRecognizeContentOptions = {}
   ): Promise<ContentPollerLike> {
@@ -293,7 +293,7 @@ export class FormRecognizerClient {
 
     const poller = new BeginRecognizePoller<RecognizeContentResultResponse>({
       client: analyzePollerClient,
-      source: data,
+      source: form,
       contentType,
       ...options
     });
@@ -403,13 +403,13 @@ ng", and "image/tiff";
    * ```
    * @summary Recognizes form information from a given document using a custom form model.
    * @param {string} modelId Id of the custom form model to use
-   * @param {FormRecognizerRequestBody} data Input form document
+   * @param {FormRecognizerRequestBody} form Input form document
    * @param {FormContentType} contentType Content type of the input. Supported types are "application/pdf", "image/jpeg", "image/png", and "image/tiff";
    * @param {BeginRecognizeFormsOptions} [options] Options to start the form recognition operation
    */
   public async beginRecognizeCustomForms(
     modelId: string,
-    data: FormRecognizerRequestBody,
+    form: FormRecognizerRequestBody,
     contentType?: FormContentType,
     options: BeginRecognizeFormsOptions = {}
   ): Promise<FormPollerLike> {
@@ -430,7 +430,7 @@ ng", and "image/tiff";
     const poller = new BeginRecognizePoller({
       client: analyzePollerClient,
       modelId,
-      source: data,
+      source: form,
       contentType,
       ...options
     });
@@ -564,12 +564,12 @@ ng", and "image/tiff";
    * console.log(usReceipt.recognizedForm.fields["MerchantAddress"]);
    * ```
    * @summary Recognizes receipt information from a given document
-   * @param {FormRecognizerRequestBody} data Input document
+   * @param {FormRecognizerRequestBody} receipt Input document
    * @param {FormContentType} contentType Content type of the input. Supported types are "application/pdf", "image/jpeg", "image/png", and "image/tiff";
    * @param {BeginRecognizeReceiptsOptions} [options] Options to start the receipt recognition operation
    */
   public async beginRecognizeReceipts(
-    data: FormRecognizerRequestBody,
+    receipt: FormRecognizerRequestBody,
     contentType?: FormContentType,
     options: BeginRecognizeReceiptsOptions = {}
   ): Promise<ReceiptPollerLike> {
@@ -580,7 +580,7 @@ ng", and "image/tiff";
 
     const poller = new BeginRecognizePoller({
       client: analyzePollerClient,
-      source: data,
+      source: receipt,
       contentType,
       ...options
     });


### PR DESCRIPTION
The parameter to the *FromUrl() methods were already renamed. This change makes
the names more consistent.