### PR TITLE
Update dev dependency "cross-env"

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1805,15 +1805,17 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==
-  /cross-env/6.0.3:
+  /cross-env/7.0.2:
     dependencies:
       cross-spawn: 7.0.2
     dev: false
     engines:
-      node: '>=8.0'
+      node: '>=10.14'
+      npm: '>=6'
+      yarn: '>=1'
     hasBin: true
     resolution:
-      integrity: sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==
+      integrity: sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==
   /cross-spawn/4.0.2:
     dependencies:
       lru-cache: 4.1.5
@@ -7438,7 +7440,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       delay: 4.3.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -7470,7 +7472,7 @@ packages:
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
-      integrity: sha512-t1XcRg8+UYEEJb7YJ24B+SCb2L5qykaDtzq/4bL7OpRyPHDx9/dt4LIWhkGmXeQWhgmhE7HgeLEp97GxpysDnw==
+      integrity: sha512-WjbXe/KlZD7oYbWnwOC9D4jjwkzVpfgrwe3a4m0p8gU2YDODMYTQk9CdSpMlFtNv1mzcp3KZdNCm/ywezJluyA==
       tarball: 'file:projects/abort-controller.tgz'
     version: 0.0.0
   'file:projects/ai-form-recognizer.tgz':
@@ -7492,7 +7494,7 @@ packages:
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -7530,7 +7532,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
-      integrity: sha512-LXkkjHuN8X4L4SVElgtluVHntRjbvVNs9vT3oUVkDwKnZm+9+MYi+qt5/XfQderz9uvK7WcL/denlhsFbJjXJw==
+      integrity: sha512-OBOf+sSQ+2t3THBs/RhJJ7tKTQ/BAOHXirPrVqLexYFdIc61KqOPmrQT/zLs+HhEBQ0O29r9uqO02qZGTIfAVw==
       tarball: 'file:projects/ai-form-recognizer.tgz'
     version: 0.0.0
   'file:projects/ai-text-analytics.tgz':
@@ -7552,7 +7554,7 @@ packages:
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -7589,7 +7591,7 @@ packages:
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
-      integrity: sha512-PrM0aSID6lUJUBtUeM82XtWdk29vGzUWwSzSaqKR+ZyAwKGya1eWRovc1iNGITSCVh15FcVM/n4tt7V/6PPNAw==
+      integrity: sha512-WKaoCfw3F9vRqC2nblQrQxSYdYp9k4TosDrg7AKCEHT3Z9fPXIkweiEGqbDFU3FnliZe3zR1hDHB125WWbfQdw==
       tarball: 'file:projects/ai-text-analytics.tgz'
     version: 0.0.0
   'file:projects/app-configuration.tgz':
@@ -7660,7 +7662,7 @@ packages:
       buffer: 5.6.0
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       debug: 4.1.1
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
@@ -7699,7 +7701,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-wZ2B79DiSWRuixInwWdVpDd6SN76mdbTan7Zmq33U/0zCaCSM3qY8MbRiBNqgypgAZn9dwZMlUYz0ufSQcHmpA==
+      integrity: sha512-doQCRgyRhm2EbsJAXtTJuWPddZHDpN7CVFWmWjczw1UHUQgG+usgstRQMkgwj7rkuvCj2MPekZMSwntHkoDD4Q==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-arm.tgz':
@@ -7768,7 +7770,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       downlevel-dts: 0.4.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -7790,7 +7792,7 @@ packages:
     dev: false
     name: '@rush-temp/core-auth'
     resolution:
-      integrity: sha512-WSS08ALSWyt1/AD9OormY54Z9Y5/qWDL5bJUAMda3xC4FhmkzvmPacDU+kqYUJP/hfjAr1am1aVWUh+GV9LWqA==
+      integrity: sha512-sffQJZ6qejEbzPo7Q4G0RYzZJAMtVPApnBFzZYOP626AGB/FbwCNUR2CXKGDM+Mla2U7cuNRccMisXYvmdEm9w==
       tarball: 'file:projects/core-auth.tgz'
     version: 0.0.0
   'file:projects/core-http.tgz':
@@ -7820,7 +7822,7 @@ packages:
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       babel-runtime: 6.26.0
       chai: 4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       downlevel-dts: 0.4.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -7867,7 +7869,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-wh4G+ovKXBsqixZbW2ySkDJlqiLtSgA2YotxgJUh0XoUYrgVaiNFKsqsBtHgVdgApvNkeToSBJtRxPyITT6DrA==
+      integrity: sha512-0SvlXEzP9jLBvEQ+VJvWWvkg0Xs1qo+JvWO5GFTP292btCtP46e3uR9vQZe5TqkVhsyPN2vYTyBDckBjmE1Rog==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-https.tgz':
@@ -7885,7 +7887,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       chai: 4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       downlevel-dts: 0.4.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -7918,7 +7920,7 @@ packages:
     dev: false
     name: '@rush-temp/core-https'
     resolution:
-      integrity: sha512-XII+YvK/L7DKm9b3v+a/IJU1dNSJPL7lAdYQ8z7Nz3gwgHo2fNt4zJSeJXDSL7jti++zWZIcGTGua+3+ewKz2A==
+      integrity: sha512-V/tvdimTlQ+LQDL8lE8AJs6FyzqrBmvCF4xjeE8rvhZKF07MzewimGaRvqZ4B8hrU2pdGZN7BFsZXWdM1KpGnQ==
       tarball: 'file:projects/core-https.tgz'
     version: 0.0.0
   'file:projects/core-lro.tgz':
@@ -8007,7 +8009,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
       eslint-plugin-no-null: 1.0.2_eslint@6.8.0
@@ -8028,7 +8030,7 @@ packages:
     dev: false
     name: '@rush-temp/core-tracing'
     resolution:
-      integrity: sha512-IuteqrtocEmF/QOMvZxlcBw0Fvx7kdb46AzB13k9dXXMCnYfpjIFdPtdaZtqvfAKf4dcCpeoCD8mzj+4fNDD+A==
+      integrity: sha512-yG9pQRIp0c/H009Ccmi6bk/69JAzoUs9PjzoIfdKux4AOJYCqfRog2X5Yd0hut5j4OKtTUUhcZeCgEYk4My1Ow==
       tarball: 'file:projects/core-tracing.tgz'
     version: 0.0.0
   'file:projects/cosmos.tgz':
@@ -8051,7 +8053,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/eslint-plugin-tslint': 2.34.0_fecc5d28141122f1c31d1ed9d728f517
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       debug: 4.1.1
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
@@ -8089,7 +8091,7 @@ packages:
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-1BwLzP45Dx370L1kri3W/g0OdsGdk0jtHo7umYqhiZIfDgB2akrdEz6Rs+kzYWobvhRTHQFxhmDdYWJxdyWHKw==
+      integrity: sha512-5Uz9geFHa+r8790KtJZ897Nk+es60wxr16e8j0x3kQT+mYXtv1CRe7qPCCueREEcP0Rc0QpMI9ke65C/FjYcCQ==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/eslint-plugin-azure-sdk.tgz':
@@ -8155,7 +8157,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       debug: 4.1.1
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
@@ -8200,7 +8202,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-tCDq+8c9DgoaF/oMMcDUzX//7K2HnmeglOueqqDJ6k8XqpkLCoJC6Fe6uZROnk3R3BYAVzLMr0WPycQp9REqOg==
+      integrity: sha512-i9h03x29yp8Q3f71c2JLfZCbTHE524BBoMVKvvOMykd6yZuoIasZNWDZMFWK6yT8/f2hXLfHJhA/41CAw7egsQ==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -8230,7 +8232,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       debug: 4.1.1
       dotenv: 8.2.0
       eslint: 6.8.0
@@ -8257,7 +8259,7 @@ packages:
     dev: false
     name: '@rush-temp/event-processor-host'
     resolution:
-      integrity: sha512-q74mXqMCDs+ToOyaLjI/hoj+IRNB6nUSV5j8DLDrlCDMkiTBE+hlXQGi561UOCzkgdw6lFaYLeAPmZ658KFkjw==
+      integrity: sha512-Ny9dQ2oRS9uJ5B5oX3Jbb2qiM+pc11RjfKgGVW1Ae3GmCOCm9HF976v4LkoTpqNGzCDDE8vnWCl6VMpDijJOJg==
       tarball: 'file:projects/event-processor-host.tgz'
     version: 0.0.0
   'file:projects/eventhubs-checkpointstore-blob.tgz':
@@ -8281,7 +8283,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-string: 1.5.0_chai@4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       debug: 4.1.1
       dotenv: 8.2.0
       eslint: 6.8.0
@@ -8321,7 +8323,7 @@ packages:
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
     resolution:
-      integrity: sha512-7lafTfvgZ3n+OK6lh7zPr4zu/f1vDtpddqiSrp4o2DcPbzmUUmS0cf9ub/8cb6/OSJ7tek34TrOKJc96jJ3evw==
+      integrity: sha512-fk6/0ySv7R7JcdhG3p0S7p1e0WPMgd5amWeUoLbup75X0axziRxLtj6i19CRj0fQVIIYuAPtXyLNvSrz1zw97A==
       tarball: 'file:projects/eventhubs-checkpointstore-blob.tgz'
     version: 0.0.0
   'file:projects/identity.tgz':
@@ -8343,7 +8345,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       eslint: 6.8.0
       events: 3.1.0
       express: 4.17.1
@@ -8377,7 +8379,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-6doG7KCHqDzmQ9upBfcWeL10S3kzOlegsWv5NvR86JJXwQRLixmAlbz13Xe0JzSyLV0fkcXDjA7fk/L7A2liWw==
+      integrity: sha512-L7snTRRCbwCvJ/vwDhYUYRzbNzY/tb1ZmJt2al/YgUC0SbVM+wvEfeuNH0aRPy/G1p4Wup7Rt+I1fj/mXQCfiQ==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -8400,7 +8402,7 @@ packages:
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -8443,7 +8445,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-881prvUQH4Zn5g0oNGGnPMfMdlCexugbkY5pM5X6D7zhIhn7Dq7D7eLVRvJQ0/tW6I9CBZhDqRvH3vKOPXESSw==
+      integrity: sha512-KhSN01G7f9/8jJas7wQ43hSvzsBzzkkDv4T4kEFqFmYy9UctBtAjKAoQDgWlMeLvzpK4wZrXFIQzw9GOATeimw==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
@@ -8466,7 +8468,7 @@ packages:
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -8509,7 +8511,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-IRirl3e+en5UQizgQjUTVDbbb5C+/42l0lBYqQa6mjUOwluDW8amBc1XJVeVJA+HE+WIkfuVu0I8MLTIaapHmA==
+      integrity: sha512-Qbx/IXYUopHVNXpR32sOdPI6LX3UWate2IvgYFhGS2PtOrsFD1bNNYtDXJWGblZDjFQdxmV3blsVxEceZClWpQ==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -8532,7 +8534,7 @@ packages:
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -8575,7 +8577,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-fz4iLbyUJ9gVvc/OgZRrsT9zSJnT017JzSHZLHp9YvNhf0bSXwztwaOnngZY7R8gztlPcZFUib7m1QVSh8yedQ==
+      integrity: sha512-rq5AGczst2+yIvrLm1EEoEzr25iYO4m+D4CWAg8TRoTNzrM8bI9m2+P0vgMPWWxYIjspKTL2S7vQFpsEQreHZQ==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/logger.tgz':
@@ -8593,7 +8595,7 @@ packages:
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
       chai: 4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       delay: 4.3.0
       dotenv: 8.2.0
       eslint: 6.8.0
@@ -8628,7 +8630,7 @@ packages:
     dev: false
     name: '@rush-temp/logger'
     resolution:
-      integrity: sha512-Gj42cVp3Sp7Nb3o2Mu9SHebQ/o5XbK/9mZJk8xYoShp6wR6UFAMmuyRYLzbIQB7ivWxgRMQ/y2AdVH9Xu+Gkqw==
+      integrity: sha512-pBOO+Y1HfZGpsmaxZrWyCG0XVt2pDD4++i/+l+cwKdPsKKEc53mM7XNdFBEiQHisdXXe1cBICGSDZBT7UffERg==
       tarball: 'file:projects/logger.tgz'
     version: 0.0.0
   'file:projects/search-documents.tgz':
@@ -8648,7 +8650,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       chai: 4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
@@ -8687,7 +8689,7 @@ packages:
     dev: false
     name: '@rush-temp/search-documents'
     resolution:
-      integrity: sha512-Bd52s1lY1edFe52fKCfD70mUvOC0pCQ8iXMXYr+FBuNlsfHytx0Tw1+nwYc48o2ZkWdUhJOhSi8e40w9VEZWBw==
+      integrity: sha512-8Vj9SdqQVoRs491St/C43kPnPUP+C9ABA/UuRp2HYVaY+uBMiQhoQM9VCtpf1y7+w4BetP2fcj19rdDbbOtBmw==
       tarball: 'file:projects/search-documents.tgz'
     version: 0.0.0
   'file:projects/service-bus.tgz':
@@ -8718,7 +8720,7 @@ packages:
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       chai-exclude: 2.0.2_chai@4.2.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       debug: 4.1.1
       delay: 4.3.0
       dotenv: 8.2.0
@@ -8765,7 +8767,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-ke+nCNTUawY2wx1u7xLOUc6+g7Prs7j5zeyISpiAnIFfM6EaiKkkJb6wyj0ErhIA1sr/qF58NUcj5zFR6QTXrQ==
+      integrity: sha512-MxvoAXIxfXedntJHa4+hQ0ibGqTjy4SFeoZDdiAkR8vObu/1YQbp5MMRQ7qPc6NPM5zlNmXYcqymGoKORvro4g==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
@@ -8782,7 +8784,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
@@ -8826,7 +8828,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-J2NKl7le7y+G2vb/4R2nTuPc5gSbJPC3FPNMmm46z0mhsm3SyVfdFAAQperyUMFGa0wXIs4WHjiX8ER311FcsA==
+      integrity: sha512-GsYLVscSsQKi4cDOCAPJYLQccVrPZNMXwPiIsseQr7kM/4T40vccQLDXmB+HIPJwmNMjpKhjATZy2Go8vTFrzg==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file-datalake.tgz':
@@ -8846,7 +8848,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
@@ -8895,7 +8897,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-3LwgEkOd8PB3AEF3hn+LTcwPvIk3uy45atiS1Kh/49lj1aFxiJRiqHy4qQwKiNo6PjTjKjQIvu5EWdi2sZUq6A==
+      integrity: sha512-MBRefMDWkcMrz++RPfU8HTo3//VjsCjgBMtJBqOnKFrQT12u8TuN/Lxovt1kgJPiS6SngTbQuO7AOJRUT/wA/A==
       tarball: 'file:projects/storage-file-datalake.tgz'
     version: 0.0.0
   'file:projects/storage-file-share.tgz':
@@ -8912,7 +8914,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
@@ -8956,7 +8958,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-tiAGD/genpH1Djv+XLlpd/nOtNvvMo+w8OkzQ3yprV/vp9KfOHI5Oz3mvlt1W9J/y1D2e7SmdU9mbr7yhcpOWQ==
+      integrity: sha512-1z6Gy0Crd1MEfUUs72/eJI4I7YV9tBbD26BRtE8MCs3tF5mSe/GI184WMrORhbWeKXMr1jN5hPtAUqK8Go7iwA==
       tarball: 'file:projects/storage-file-share.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -8973,7 +8975,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       dotenv: 8.2.0
       downlevel-dts: 0.4.0
       es6-promise: 4.2.8
@@ -9016,7 +9018,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-rmEQ4gbwbRC71hvew/oEQg8wINtSsMxc9hRWrXehyVRVrTqaZrzd8CnrWOG8CyB/u0WmSGOCM4dcEIxxNH2dgw==
+      integrity: sha512-NuiHATe/q/XUEknF8OV8jX/yVmxdXSahJQ+ruAzHtyrV8XNUP4R2+HeoJlx2HStu112Dvdj46odmrGjbuz/npA==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':
@@ -9033,7 +9035,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 2.34.0_fbe180e5e50b8ec89ec2be5e2ce5513b
       '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.8.3
       assert: 1.5.0
-      cross-env: 6.0.3
+      cross-env: 7.0.2
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
       eslint-plugin-no-null: 1.0.2_eslint@6.8.0
@@ -9066,7 +9068,7 @@ packages:
     dev: false
     name: '@rush-temp/template'
     resolution:
-      integrity: sha512-RLiUQzQu1wd/1xzd02rJBN57vwOmVlagI70FdO1clDc/n7wR1f1ZMVRCjyVUbpR4L96A5N0CgWaQsm6iG1Hl8Q==
+      integrity: sha512-i9KV+kjdyV2SE/CwAm52TLHAnLJFqI/Jt6O0nUFwAIHPM4as2Y+4G+H7oYhNp9MaOCGSPvq4lN8CMqxJPcfsEQ==
       tarball: 'file:projects/template.tgz'
     version: 0.0.0
   'file:projects/test-utils-perfstress.tgz':

--- a/sdk/core/abort-controller/package.json
+++ b/sdk/core/abort-controller/package.json
@@ -77,7 +77,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "delay": "^4.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -112,7 +112,7 @@
     "assert": "^1.4.1",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",

--- a/sdk/core/core-auth/package.json
+++ b/sdk/core/core-auth/package.json
@@ -84,7 +84,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -165,7 +165,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "babel-runtime": "^6.26.0",
     "chai": "^4.2.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/core/core-https/package.json
+++ b/sdk/core/core-https/package.json
@@ -88,7 +88,7 @@
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "chai": "^4.2.0",
     "downlevel-dts": "~0.4.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",

--- a/sdk/core/core-tracing/package.json
+++ b/sdk/core/core-tracing/package.json
@@ -72,7 +72,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -84,7 +84,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "delay": "^4.2.0",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -110,7 +110,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/eslint-plugin-tslint": "^2.8.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -123,7 +123,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "eslint": "^6.1.0",

--- a/sdk/eventhub/event-processor-host/package.json
+++ b/sdk/eventhub/event-processor-host/package.json
@@ -97,7 +97,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
+++ b/sdk/eventhub/eventhubs-checkpointstore-blob/package.json
@@ -86,7 +86,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-string": "^1.5.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -104,7 +104,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -106,7 +106,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "eslint": "^6.1.0",
     "express": "^4.16.3",
     "inherits": "^2.0.3",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -113,7 +113,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -112,7 +112,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -115,7 +115,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
     "chai": "^4.2.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -98,7 +98,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "chai": "^4.2.0",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -125,7 +125,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-exclude": "^2.0.2",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "delay": "^4.2.0",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -119,7 +119,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -120,7 +120,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -122,7 +122,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -119,7 +119,7 @@
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "downlevel-dts": "~0.4.0",
     "es6-promise": "^4.2.5",

--- a/sdk/template/template/package.json
+++ b/sdk/template/template/package.json
@@ -79,7 +79,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0",
     "assert": "^1.4.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-no-null": "^1.0.2",

--- a/sdk/textanalytics/ai-text-analytics/package.json
+++ b/sdk/textanalytics/ai-text-analytics/package.json
@@ -99,7 +99,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "cross-env": "^6.0.3",
+    "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "eslint": "^6.1.0",
     "eslint-config-prettier": "^6.0.0",


### PR DESCRIPTION
Node 8 support was officially dropped in `7.0.0`, but I suspect it will continue to work.

https://github.com/kentcdodds/cross-env/releases/tag/v7.0.0

Blocked by #9172