### PR TITLE
[storage-file-datalake] Remove unused dev dependency "nock"

### DIFF
--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -147,11 +147,6 @@
     "karma-remap-istanbul": "^0.6.0",
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^1.18.0",
-<<<<<<< HEAD
-    "nock": "^11.7.0",
-=======
-    "nise": "^1.4.10",
->>>>>>> [storage-file-datalake] Remove unused dev dependency "nock"
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
     "puppeteer": "^2.0.0",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -147,7 +147,11 @@
     "karma-remap-istanbul": "^0.6.0",
     "mocha": "^7.1.1",
     "mocha-junit-reporter": "^1.18.0",
+<<<<<<< HEAD
     "nock": "^11.7.0",
+=======
+    "nise": "^1.4.10",
+>>>>>>> [storage-file-datalake] Remove unused dev dependency "nock"
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
     "puppeteer": "^2.0.0",


### PR DESCRIPTION
Dependency was added in #6337 but it appears to be unused. I do not see any references to `nock` in the `storage-file-datalake` sources (except for the test recordings, which I believe are a special case and do not require a dev dependency in the runtime package).