### PR TITLE
[search-documents] Make listIndexes and listIndexesNames pageable.

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -584,6 +584,12 @@ export interface IndexingSchedule {
 }
 
 // @public
+export type IndexIterator = PagedAsyncIterableIterator<Index, Index[], {}>;
+
+// @public
+export type IndexNameIterator = PagedAsyncIterableIterator<string, string[], {}>;
+
+// @public
 export interface InputFieldMappingEntry {
     inputs?: InputFieldMappingEntry[];
     name: string;
@@ -1151,8 +1157,8 @@ export class SearchIndexClient {
     getIndexStatistics(indexName: string, options?: GetIndexStatisticsOptions): Promise<GetIndexStatisticsResult>;
     getServiceStatistics(options?: GetServiceStatisticsOptions): Promise<ServiceStatistics>;
     getSynonymMap(synonymMapName: string, options?: GetSynonymMapsOptions): Promise<SynonymMap>;
-    listIndexes(options?: ListIndexesOptions): Promise<Array<Index>>;
-    listIndexesNames(options?: ListIndexesOptions): Promise<Array<string>>;
+    listIndexes(options?: ListIndexesOptions): IndexIterator;
+    listIndexesNames(options?: ListIndexesOptions): IndexNameIterator;
     listSynonymMaps(options?: ListSynonymMapsOptions): Promise<Array<SynonymMap>>;
     listSynonymMapsNames(options?: ListSynonymMapsOptions): Promise<Array<string>>;
 }

--- a/sdk/search/search-documents/src/index.ts
+++ b/sdk/search/search-documents/src/index.ts
@@ -84,7 +84,9 @@ export {
   DataSource,
   DataChangeDetectionPolicy,
   DataDeletionDetectionPolicy,
-  GetServiceStatisticsOptions
+  GetServiceStatisticsOptions,
+  IndexIterator,
+  IndexNameIterator
 } from "./serviceModels";
 export { default as GeographyPoint } from "./geographyPoint";
 export { odata } from "./odata";

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -76,6 +76,7 @@ import {
   DataSourceCredentials,
   DataContainer
 } from "./generated/service/models";
+import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
 /**
  * Options for a list skillsets operation.
@@ -647,6 +648,20 @@ export interface SynonymMap {
    */
   etag?: string;
 }
+
+/**
+ * An iterator for listing the indexes that exist in the Search service. Will make requests
+ * as needed during iteration. Use .byPage() to make one request to the server
+ * per iteration.
+ */
+export type IndexIterator = PagedAsyncIterableIterator<Index, Index[], {}>;
+
+/**
+ * An iterator for listing the indexes that exist in the Search service. Will make requests
+ * as needed during iteration. Use .byPage() to make one request to the server
+ * per iteration.
+ */
+export type IndexNameIterator = PagedAsyncIterableIterator<string, string[], {}>;
 
 /**
  * Represents a search index definition, which describes the fields and search behavior of an


### PR DESCRIPTION
Per other languages, we're making listing indexes a pageable operation, even though today its an atomically returned array so that the service can later move to a paging model without breaking.

Since there is no continuation token or support for page size at the moment, I removed the paging options from byPage to avoid conflicts with whatever support we add in later.

Fixes #8484