### PR TITLE
Update rush

### DIFF
--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -292,8 +292,8 @@ function _cleanInstallFolder(rushTempFolder, packageInstallFolder) {
         }
         const nodeModulesFolder = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME);
         if (fs.existsSync(nodeModulesFolder)) {
-            const rushRecyclerFolder = _ensureAndJoinPath(rushTempFolder, 'rush-recycler', `install-run-${Date.now().toString()}`);
-            fs.renameSync(nodeModulesFolder, rushRecyclerFolder);
+            const rushRecyclerFolder = _ensureAndJoinPath(rushTempFolder, 'rush-recycler');
+            fs.renameSync(nodeModulesFolder, path.join(rushRecyclerFolder, `install-run-${Date.now().toString()}`));
         }
     }
     catch (e) {

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -6,9 +6,9 @@ parameters:
       OSVmImage: "ubuntu-18.04"
       NodeTestVersion: "8.x"
       TestType: "node"
-    Windows_Node10:
+    Windows_Node8:
       OSVmImage: "windows-2019"
-      NodeTestVersion: "10.x"
+      NodeTestVersion: "8.x"
       TestType: "node"
     macOS_Node12:
       OSVmImage: "macOS-10.15"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -2,22 +2,22 @@ parameters:
   Artifacts: []
   ServiceDirectory: not-specified
   Matrix:
-    Linux_Node8:
-      OSVmImage: "ubuntu-18.04"
+    # Linux_Node8:
+    #   OSVmImage: "ubuntu-18.04"
+    #   NodeTestVersion: "8.x"
+    #   TestType: "node"
+    Windows_Node8:
+      OSVmImage: "windows-2019"
       NodeTestVersion: "8.x"
       TestType: "node"
-    Windows_Node10:
-      OSVmImage: "windows-2019"
-      NodeTestVersion: "10.x"
-      TestType: "node"
-    macOS_Node12:
-      OSVmImage: "macOS-10.15"
-      NodeTestVersion: "12.x"
-      TestType: "node"
-    Browser_Linux_Node12:
-      OSVmImage: "ubuntu-18.04"
-      NodeTestVersion: "12.x"
-      TestType: "browser"
+    # macOS_Node12:
+    #   OSVmImage: "macOS-10.15"
+    #   NodeTestVersion: "12.x"
+    #   TestType: "node"
+    # Browser_Linux_Node12:
+    #   OSVmImage: "ubuntu-18.04"
+    #   NodeTestVersion: "12.x"
+    #   TestType: "browser"
 
 jobs:
   - job: "Build"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -6,9 +6,9 @@ parameters:
       OSVmImage: "ubuntu-18.04"
       NodeTestVersion: "8.x"
       TestType: "node"
-    Windows_Node8:
+    Windows_Node10:
       OSVmImage: "windows-2019"
-      NodeTestVersion: "8.x"
+      NodeTestVersion: "10.x"
       TestType: "node"
     macOS_Node12:
       OSVmImage: "macOS-10.15"

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -2,22 +2,22 @@ parameters:
   Artifacts: []
   ServiceDirectory: not-specified
   Matrix:
-    # Linux_Node8:
-    #   OSVmImage: "ubuntu-18.04"
-    #   NodeTestVersion: "8.x"
-    #   TestType: "node"
-    Windows_Node8:
-      OSVmImage: "windows-2019"
+    Linux_Node8:
+      OSVmImage: "ubuntu-18.04"
       NodeTestVersion: "8.x"
       TestType: "node"
-    # macOS_Node12:
-    #   OSVmImage: "macOS-10.15"
-    #   NodeTestVersion: "12.x"
-    #   TestType: "node"
-    # Browser_Linux_Node12:
-    #   OSVmImage: "ubuntu-18.04"
-    #   NodeTestVersion: "12.x"
-    #   TestType: "browser"
+    Windows_Node10:
+      OSVmImage: "windows-2019"
+      NodeTestVersion: "10.x"
+      TestType: "node"
+    macOS_Node12:
+      OSVmImage: "macOS-10.15"
+      NodeTestVersion: "12.x"
+      TestType: "node"
+    Browser_Linux_Node12:
+      OSVmImage: "ubuntu-18.04"
+      NodeTestVersion: "12.x"
+      TestType: "browser"
 
 jobs:
   - job: "Build"

--- a/eng/pipelines/templates/steps/use-node-test-version.yml
+++ b/eng/pipelines/templates/steps/use-node-test-version.yml
@@ -29,9 +29,3 @@ steps:
       # Install matching version of package
       npm install --no-package-lock keytar@$KeytarVersion
     displayName: Reinstall native dependencies
-
-  # After changing Node versions, Rush will attempt to reinstall itself, but will be blocked on
-  # Windows due to issue microsoft/rushstack#1878.  A workaround is to manually delete the Rush
-  # install folder.
-  - pwsh: Remove-Item -Recurse -Force common/temp/install-run
-    displayName: Delete Rush install folder

--- a/rush.json
+++ b/rush.json
@@ -15,7 +15,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.23.3",
+  "rushVersion": "5.24.0",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process


### PR DESCRIPTION
- Remove workaround for rush reinstall

Validation build forcing Windows to use Node 8 (Windows normally uses Node 10 so the issue does not repro): https://dev.azure.com/azure-sdk/public/_build/results?buildId=409687&view=results