### PR TITLE
[core-http] URLBuilder incorrectly handles parametrized path with full URLs

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix issue of `SystemErrorRetryPolicy` didn't retry on errors [PR #8803](https://github.com/Azure/azure-sdk-for-js/pull/8803)
 - Add support for serialization of text media type. [PR #8977](https://github.com/Azure/azure-sdk-for-js/pull/8977)
-- Fix issue with URLBuilder incorrectly handling full URL in path. [PR #945](https://github.com/Azure/azure-sdk-for-js/pull/9245)
+- Fix issue with URLBuilder incorrectly handling full URL in path. [PR #9245](https://github.com/Azure/azure-sdk-for-js/pull/9245)
 
 ## 1.1.2 (2020-05-07)
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release History
 
-## 1.1.3 (2020-06-02)
+## 1.1.3 (2020-06-03)
 
 - Fix issue of `SystemErrorRetryPolicy` didn't retry on errors [PR #8803](https://github.com/Azure/azure-sdk-for-js/pull/8803)
 - Add support for serialization of text media type. [PR #8977](https://github.com/Azure/azure-sdk-for-js/pull/8977)
+- Fix issue with URLBuilder incorrectly handling full url in path. []()
 
 ## 1.1.2 (2020-05-07)
 

--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix issue of `SystemErrorRetryPolicy` didn't retry on errors [PR #8803](https://github.com/Azure/azure-sdk-for-js/pull/8803)
 - Add support for serialization of text media type. [PR #8977](https://github.com/Azure/azure-sdk-for-js/pull/8977)
-- Fix issue with URLBuilder incorrectly handling full url in path. []()
+- Fix issue with URLBuilder incorrectly handling full URL in path. [PR #945](https://github.com/Azure/azure-sdk-for-js/pull/9245)
 
 ## 1.1.2 (2020-05-07)
 

--- a/sdk/core/core-http/src/url.ts
+++ b/sdk/core/core-http/src/url.ts
@@ -222,8 +222,12 @@ export class URLBuilder {
     if (!path) {
       this._path = undefined;
     } else {
-      if (path.indexOf("://") !== -1) {
-        this.set(path, "SCHEME");
+      const schemeIndex = path.indexOf("://");
+      if (schemeIndex !== -1) {
+        const schemeStart = path.lastIndexOf("/", schemeIndex);
+        // Make sure to only grab the URL part of the path before setting the state back to SCHEME
+        // this will handle cases such as "/a/b/c/https://microsoft.com" => "https://microsoft.com"
+        this.set(schemeStart === -1 ? path : path.substr(schemeStart + 1), "SCHEME");
       } else {
         this.set(path, "PATH");
       }

--- a/sdk/core/core-http/test/urlTests.ts
+++ b/sdk/core/core-http/test/urlTests.ts
@@ -963,6 +963,28 @@ describe("URLBuilder", () => {
   });
 
   describe("replaceAll()", () => {
+    it("should handle parametrized path containing a full url", () => {
+      const url = URLBuilder.parse("http://localhost");
+      url.appendPath("{nextLink}");
+      url.replaceAll("{nextLink}", "http://localhost:80/paging/multiple/page/2");
+
+      assert.strictEqual(url.toString(), "http://localhost:80/paging/multiple/page/2");
+    });
+
+    it("should handle parametrized path containing a full url, when path contains parts", () => {
+      const url = URLBuilder.parse("https://localhost/formrecognizer/v2.0-preview");
+      url.appendPath("{nextLink}");
+      url.replaceAll(
+        "{nextLink}",
+        "https://localhost/formrecognizer/v2.0-preview/custom/models?nextLink=1"
+      );
+
+      assert.strictEqual(
+        url.toString(),
+        "https://localhost/formrecognizer/v2.0-preview/custom/models?nextLink=1"
+      );
+    });
+
     it(`with undefined path, "{arg}" searchValue, and "cats" replaceValue`, () => {
       const urlBuilder = new URLBuilder();
       urlBuilder.setPath(undefined);


### PR DESCRIPTION
Fixes issue #8353

Currently URLBuilder can handle the cases where a full URL is passed as a parametrized path i.e. `http://localhost/{nextLink}` and **nextLink** being `http://localhost/page/2`. Here nextLink will be the new URL

It does this by checking if the path inserting in the placeholder `{nextLink}` contains a protocol (or scheme) and re-build the URL from the path. Resulting in the URL `http://localhost/page/2`

The problem is that the current logic assumes that the baseURL will always be in the form `scheme://hostname` however there are cases where the baseURL would contain some parts such as an api version for example `http://localhost/v2/{nextLink}` and **nextLink** being `http://localhost/v2/page/2`

In this case we correctly identify the path containing a full url and try to rebuild the URL from it, however it also keeps the `/v2` part so trying to rebuild the URL from `/v2/http://localhost/v2/page/2` ends up building the wrong URL.

**Fix**
This change makes sure to only take the URL from the path when trying to re-build the new URL. So for this example:
`http://localhost/v2/{nextLink}` and **nextLink** being `http://localhost/v2/page/2`

The resulting URL is  `http://localhost/v2/page/2` instead of `/v2/http://localhost/v2/page/2` 
