### PR TITLE
[service-bus] Remove unused dev dependency "@types/async-lock"

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -111,7 +111,6 @@
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",
-    "@types/async-lock": "^1.1.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/debug": "^4.1.4",


### PR DESCRIPTION
- No runtime or dev dependency on "async-lock"

Live tests for `servicebus` passed.