### PR TITLE
[Identity] Make credentials and DAC list public

### DIFF
--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -38,6 +38,13 @@ export class AuthorizationCodeCredential implements TokenCredential {
     }
 
 // @public
+export class AzureCliCredential implements TokenCredential {
+    constructor();
+    protected getAzureCliAccessToken(resource: string): Promise<unknown>;
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+}
+
+// @public
 export type BrowserLoginStyle = "redirect" | "popup";
 
 // @public
@@ -61,7 +68,6 @@ export class ClientSecretCredential implements TokenCredential {
 // @public
 export class DefaultAzureCredential extends ChainedTokenCredential {
     constructor(tokenCredentialOptions?: TokenCredentialOptions);
-    // (undocumented)
     static credentials(tokenCredentialOptions?: TokenCredentialOptions): TokenCredential[];
 }
 
@@ -149,6 +155,12 @@ export interface TokenCredentialOptions extends PipelineOptions {
 // @public
 export class UsernamePasswordCredential implements TokenCredential {
     constructor(tenantIdOrName: string, clientId: string, username: string, password: string, options?: TokenCredentialOptions);
+    getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
+    }
+
+// @public
+export class VSCodeCredential implements TokenCredential {
+    constructor(options?: TokenCredentialOptions);
     getToken(scopes: string | string[], options?: GetTokenOptions): Promise<AccessToken | null>;
     }
 

--- a/sdk/identity/identity/review/identity.api.md
+++ b/sdk/identity/identity/review/identity.api.md
@@ -61,6 +61,8 @@ export class ClientSecretCredential implements TokenCredential {
 // @public
 export class DefaultAzureCredential extends ChainedTokenCredential {
     constructor(tokenCredentialOptions?: TokenCredentialOptions);
+    // (undocumented)
+    static credentials(tokenCredentialOptions?: TokenCredentialOptions): TokenCredential[];
 }
 
 // @public

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -7,6 +7,7 @@ import { EnvironmentCredential } from "./environmentCredential";
 import { ManagedIdentityCredential } from "./managedIdentityCredential";
 import { AzureCliCredential } from "./azureCliCredential";
 import { VSCodeCredential } from "./vscodeCredential";
+import { TokenCredential } from "@azure/core-http";
 
 /**
  * Provides a default {@link ChainedTokenCredential} configuration for
@@ -20,12 +21,7 @@ import { VSCodeCredential } from "./vscodeCredential";
  * on how they attempt authentication.
  */
 export class DefaultAzureCredential extends ChainedTokenCredential {
-  /**
-   * Creates an instance of the DefaultAzureCredential class.
-   *
-   * @param options Options for configuring the client which makes the authentication request.
-   */
-  constructor(tokenCredentialOptions?: TokenCredentialOptions) {
+  static credentials(tokenCredentialOptions?: TokenCredentialOptions): TokenCredential[] {
     let credentials = [];
     credentials.push(new EnvironmentCredential(tokenCredentialOptions));
     credentials.push(new ManagedIdentityCredential(tokenCredentialOptions));
@@ -35,6 +31,15 @@ export class DefaultAzureCredential extends ChainedTokenCredential {
     credentials.push(new AzureCliCredential());
     credentials.push(new VSCodeCredential(tokenCredentialOptions));
 
+    return credentials;
+  }
+  /**
+   * Creates an instance of the DefaultAzureCredential class.
+   *
+   * @param options Options for configuring the client which makes the authentication request.
+   */
+  constructor(tokenCredentialOptions?: TokenCredentialOptions) {
+    let credentials = DefaultAzureCredential.credentials(tokenCredentialOptions);
     super(
       ...credentials
     );

--- a/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
+++ b/sdk/identity/identity/src/credentials/defaultAzureCredential.ts
@@ -21,6 +21,11 @@ import { TokenCredential } from "@azure/core-http";
  * on how they attempt authentication.
  */
 export class DefaultAzureCredential extends ChainedTokenCredential {
+  /**
+   * Returns the list of credentials DefaultAzureCredential will use to authenticate.
+   *
+   * @param options Options for configuring the client which makes the authentication request.
+   */
   static credentials(tokenCredentialOptions?: TokenCredentialOptions): TokenCredential[] {
     let credentials = [];
     credentials.push(new EnvironmentCredential(tokenCredentialOptions));

--- a/sdk/identity/identity/src/credentials/vscodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/vscodeCredential.ts
@@ -31,10 +31,8 @@ export class VSCodeCredential implements TokenCredential {
   }
 
   /**
-   * Returns the first access token returned by one of the chained
-   * `TokenCredential` implementations.  Throws an {@link AggregateAuthenticationError}
-   * when one or more credentials throws an {@link AuthenticationError} and
-   * no credentials have returned an access token.
+   * Returns the token found by searching VSCode's authentication cache or
+   * returns null if no token could be found.
    *
    * @param scopes The list of scopes for which the token will have access.
    * @param options The options used to configure any requests this

--- a/sdk/identity/identity/src/credentials/vscodeCredential.ts
+++ b/sdk/identity/identity/src/credentials/vscodeCredential.ts
@@ -19,12 +19,27 @@ const VSCodeUserName = 'VS Code Azure';
 export class VSCodeCredential implements TokenCredential {
   private identityClient: IdentityClient;
 
+  /**
+   * Creates an instance of VSCodeCredential to use for automatically authenicating via VSCode.
+   * 
+   * @param options Options for configuring the client which makes the authentication request. 
+   */
   constructor(
     options?: TokenCredentialOptions
   ) {
     this.identityClient = new IdentityClient(options);
   }
 
+  /**
+   * Returns the first access token returned by one of the chained
+   * `TokenCredential` implementations.  Throws an {@link AggregateAuthenticationError}
+   * when one or more credentials throws an {@link AuthenticationError} and
+   * no credentials have returned an access token.
+   *
+   * @param scopes The list of scopes for which the token will have access.
+   * @param options The options used to configure any requests this
+   *                `TokenCredential` implementation might make.
+   */
   public async getToken(
     scopes: string | string[],
     options?: GetTokenOptions

--- a/sdk/identity/identity/src/index.ts
+++ b/sdk/identity/identity/src/index.ts
@@ -10,6 +10,9 @@ export { EnvironmentCredential } from "./credentials/environmentCredential";
 export { ClientSecretCredential } from "./credentials/clientSecretCredential";
 export { ClientCertificateCredential } from "./credentials/clientCertificateCredential";
 export { InteractiveBrowserCredential } from "./credentials/interactiveBrowserCredential";
+export { VSCodeCredential } from "./credentials/vscodeCredential";
+export { AzureCliCredential } from "./credentials/azureCliCredential";
+
 export {
   InteractiveBrowserCredentialOptions,
   BrowserLoginStyle


### PR DESCRIPTION
This makes a few changes to adjust to the current DAC recommendation:

* VSCodeCredential and AzureCliCredential are now publicly exported so devs can get to them directly
* We also expose a helper method on DefaultAzureCredential which will return the same chain of credentials that DAC will create by default. This will allow users to explore them and learn from them as they see fit.

In addition to these changes, we should also include running the manual tests against a ChainedTokenCredential built from this new DAC helper