### PR TITLE
[KeyVault] Fix build warnings

### DIFF
--- a/sdk/keyvault/keyvault-certificates/tsconfig.json
+++ b/sdk/keyvault/keyvault-certificates/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
+    "lib": ["dom", "esnext.asynciterable"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "./types/**/*.d.ts", "./samples/**/*.ts"],

--- a/sdk/keyvault/keyvault-keys/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
+    "lib": ["dom", "esnext.asynciterable"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "./types/**/*.d.ts", "./samples/**/*.ts"],

--- a/sdk/keyvault/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
+    "lib": ["dom", "esnext.asynciterable"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "./types/**/*.d.ts", "./samples/**/*.ts"],


### PR DESCRIPTION
My latest PR standardizing the tsconfig.json files disregarded the warnings around our use of Async Iterators on the KeyVault projects. This PR introduces the most minimal change to fix the build warnings.