### PR TITLE
[Service Bus] browse -> peek

### DIFF
--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -87,7 +87,7 @@ brings this package in line with the [Azure SDK Design Guidelines for Typescript
   });
   ```
 
-* `peekBySequenceNumber()`is removed in favor of an overload to `peek()` that would take the sequence number to start peeking from in the options.
+* `peekBySequenceNumber()`is removed in favor of an overload to `peekMessages()` that would take the sequence number to start peeking from in the options.
 
 * Subscription rule management has been moved to its own class, rather than being part of the now-removed `SubscriptionClient`
 

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -87,7 +87,7 @@ brings this package in line with the [Azure SDK Design Guidelines for Typescript
   });
   ```
 
-* `peek()`is renamed to `browseMessages()` to avoid confusion with the PeekLock mode
+* `peekBySequenceNumber()`is removed in favor of an overload to `peek()` that would take the sequence number to start peeking from in the options.
 
 * Subscription rule management has been moved to its own class, rather than being part of the now-removed `SubscriptionClient`
 

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -33,12 +33,6 @@ export type AuthorizationRule = {
 };
 
 // @public
-export interface BrowseMessagesOptions extends OperationOptions {
-    fromSequenceNumber?: Long;
-    maxMessageCount?: number;
-}
-
-// @public
 export interface CorrelationRuleFilter {
     contentType?: string;
     correlationId?: string;
@@ -183,6 +177,12 @@ export interface OperationOptions {
 }
 
 // @public
+export interface PeekMessagesOptions extends OperationOptions {
+    fromSequenceNumber?: Long;
+    maxMessageCount?: number;
+}
+
+// @public
 export interface QueueDescription {
     authorizationRules?: AuthorizationRule[];
     autoDeleteOnIdle?: string;
@@ -257,12 +257,12 @@ export interface ReceivedMessageWithLock extends ReceivedMessage {
 
 // @public
 export interface Receiver<ReceivedMessageT> {
-    browseMessages(options?: BrowseMessagesOptions): Promise<ReceivedMessage[]>;
     close(): Promise<void>;
     entityPath: string;
     getMessageIterator(options?: GetMessageIteratorOptions): AsyncIterableIterator<ReceivedMessageT>;
     isClosed: boolean;
     isReceivingMessages(): boolean;
+    peekMessages(options?: PeekMessagesOptions): Promise<ReceivedMessage[]>;
     receiveBatch(maxMessages: number, options?: ReceiveBatchOptions): Promise<ReceivedMessageT[]>;
     receiveDeferredMessage(sequenceNumber: Long, options?: OperationOptions): Promise<ReceivedMessageT | undefined>;
     receiveDeferredMessages(sequenceNumbers: Long[], options?: OperationOptions): Promise<ReceivedMessageT[]>;

--- a/sdk/servicebus/service-bus/samples/javascript/README.md
+++ b/sdk/servicebus/service-bus/samples/javascript/README.md
@@ -11,7 +11,7 @@ These sample programs show how to use the JavaScript client libraries for Azure 
 | [receiveMessagesLoop.js][receivemessagesloop]                       | uses the receiveMessages() function to receive Service Bus messages in a loop                                                  |
 | [scheduledMessages.js][scheduledmessages]                           | uses the scheduleMessage() function to schedule messages to appear on a Service Bus Queue/Subscription at a later time         |
 | [session.js][session]                                               | sends/receives messages to/from session enabled queues/subscriptions in Service Bus                                            |
-| [browseMessages.js][browsemessages]                                 | uses the browseMessages() function to browse a Service Bus                                                                     |
+| [browseMessages.js][browsemessages]                                 | uses the peekMessages() function to browse a Service Bus                                                                     |
 | [usingAadAuth.js][usingaadauth]                                     | creates a ServiceBusClient that authenticates using AAD credentials                                                            |
 | [useProxy.js][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                                  |
 | [advanced/movingMessagesToDLQ.js][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                            |

--- a/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
@@ -5,7 +5,7 @@
   **NOTE**: If you are using version 1.1.x or lower, then please use the link below:
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.5/sdk/servicebus/service-bus/samples
   
-  This sample demonstrates how the browseMessages() function can be used to browse a Service Bus message.
+  This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.
 
   See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn
   about message browsing.
@@ -31,7 +31,7 @@ async function main() {
   const queueReceiver = sbClient.createReceiver(queueName, "receiveAndDelete");
   try {
     for (let i = 0; i < 20; i++) {
-      const messages = await queueReceiver.browseMessages();
+      const messages = await queueReceiver.peekMessages();
       if (!messages.length) {
         console.log("No more messages to peek");
         break;

--- a/sdk/servicebus/service-bus/samples/typescript/README.md
+++ b/sdk/servicebus/service-bus/samples/typescript/README.md
@@ -11,7 +11,7 @@ These sample programs show how to use the TypeScript client libraries for Azure 
 | [receiveMessagesLoop.ts][receivemessagesloop]                       | uses the receiveMessages() function to receive Service Bus messages in a loop                                                  |
 | [scheduledMessages.ts][scheduledmessages]                           | uses the scheduleMessage() function to schedule messages to appear on a Service Bus Queue/Subscription at a later time         |
 | [session.ts][session]                                               | sends/receives messages to/from session enabled queues/subscriptions in Service Bus                                            |
-| [browseMessages.ts][browsemessages]                                 | uses the browseMessages() function to browse a Service Bus                                                                     |
+| [browseMessages.ts][browsemessages]                                 | uses the peekMessages() function to browse a Service Bus                                                                     |
 | [usingAadAuth.ts][usingaadauth]                                     | creates a ServiceBusClient that authenticates using AAD credentials                                                            |
 | [useProxy.ts][useproxy]                                             | creates a ServiceBusClient that uses an HTTP(S) proxy server to make requests                                                  |
 | [advanced/movingMessagesToDLQ.ts][advanced-movingmessagestodlq]     | moves a message explicitly to the dead-letter queue                                                                            |

--- a/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
@@ -6,7 +6,7 @@
   For samples using the current stable version of the package, please use the link below:
   https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.5/sdk/servicebus/service-bus/samples
   
-  This sample demonstrates how the browseMessages() function can be used to browse a Service Bus message.
+  This sample demonstrates how the peekMessages() function can be used to browse a Service Bus message.
 
   See https://docs.microsoft.com/en-us/azure/service-bus-messaging/message-browsing to learn
   about message browsing.
@@ -35,7 +35,7 @@ export async function main() {
 
   try {
     for (let i = 0; i < 20; i++) {
-      const messages = await queueReceiver.browseMessages();
+      const messages = await queueReceiver.peekMessages();
       if (!messages.length) {
         console.log("No more messages to peek");
         break;

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -16,7 +16,7 @@ export { Delivery, WebSocketImpl } from "rhea-promise";
 export { ServiceBusClientOptions } from "./constructorHelpers";
 export { CorrelationRuleFilter } from "./core/managementClient";
 export {
-  BrowseMessagesOptions,
+  PeekMessagesOptions,
   CreateBatchOptions,
   CreateSenderOptions,
   CreateSessionReceiverOptions,

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -115,16 +115,16 @@ export interface CreateSenderOptions {
 }
 
 /**
- * Describes the options passed to the `browseMessages` method on a receiver.
+ * Describes the options passed to the `peekMessages` method on a receiver.
  */
-export interface BrowseMessagesOptions extends OperationOptions {
+export interface PeekMessagesOptions extends OperationOptions {
   /**
-   * @property The maximum number of messages to browse.
+   * @property The maximum number of messages to peek.
    * Default value is 1
    */
   maxMessageCount?: number;
   /**
-   * @property The sequence number to start browsing messages from (inclusive).
+   * @property The sequence number to start peeking messages from (inclusive).
    */
   fromSequenceNumber?: Long;
 }

--- a/sdk/servicebus/service-bus/src/receivers/receiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/receiver.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import {
-  BrowseMessagesOptions,
+  PeekMessagesOptions,
   GetMessageIteratorOptions,
   MessageHandlerOptions,
   MessageHandlers,
@@ -92,16 +92,16 @@ export interface Receiver<ReceivedMessageT> {
   isReceivingMessages(): boolean;
 
   /**
-   * Browse the next batch of active messages (including deferred but not deadlettered messages) on the
+   * Peek the next batch of active messages (including deferred but not deadlettered messages) on the
    * queue or subscription without modifying them.
-   * - The first call to `browseMessages()` fetches the first active message. Each subsequent call fetches the
+   * - The first call to `peekMessages()` fetches the first active message. Each subsequent call fetches the
    * subsequent message.
-   * - Unlike a "received" message, "browsed" message is a read-only version of the message.
+   * - Unlike a "received" message, "peeked" message is a read-only version of the message.
    * It cannot be `Completed/Abandoned/Deferred/Deadlettered`.
-   * @param options Options that allow to specify the maximum number of messages to browse,
-   * the sequenceNumber to start browsing from or an abortSignal to abort the operation.
+   * @param options Options that allow to specify the maximum number of messages to peek,
+   * the sequenceNumber to start peeking from or an abortSignal to abort the operation.
    */
-  browseMessages(options?: BrowseMessagesOptions): Promise<ReceivedMessage[]>;
+  peekMessages(options?: PeekMessagesOptions): Promise<ReceivedMessage[]>;
   /**
    * Path of the entity for which the receiver has been created.
    */
@@ -410,11 +410,11 @@ export class ReceiverImpl<ReceivedMessageT extends ReceivedMessage | ReceivedMes
 
   // ManagementClient methods # Begin
 
-  async browseMessages(options: BrowseMessagesOptions = {}): Promise<ReceivedMessage[]> {
+  async peekMessages(options: PeekMessagesOptions = {}): Promise<ReceivedMessage[]> {
     this._throwIfReceiverOrConnectionClosed();
     const managementRequestOptions = {
       ...options,
-      requestName: "browseMessages",
+      requestName: "peekMessages",
       timeoutInMs: this._retryOptions?.timeoutInMs
     };
     const peekOperationPromise = async () => {

--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -10,7 +10,7 @@ import {
   SubscribeOptions
 } from "..";
 import {
-  BrowseMessagesOptions,
+  PeekMessagesOptions,
   CreateSessionReceiverOptions,
   GetMessageIteratorOptions
 } from "../models";
@@ -335,12 +335,12 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
     return retry<any>(config);
   }
 
-  async browseMessages(options: BrowseMessagesOptions = {}): Promise<ReceivedMessage[]> {
+  async peekMessages(options: PeekMessagesOptions = {}): Promise<ReceivedMessage[]> {
     this._throwIfReceiverOrConnectionClosed();
 
     const managementRequestOptions = {
       ...options,
-      requestName: "browseMessages",
+      requestName: "peekMessages",
       timeoutInMs: this._retryOptions?.timeoutInMs
     };
     const peekOperationPromise = async () => {

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -42,14 +42,14 @@ describe("invalid parameters", () => {
     });
 
     it("Peek: Invalid maxMessageCount for Queue", async function(): Promise<void> {
-      const browsedMessages = await receiver.browseMessages({ maxMessageCount: -100 });
-      should.equal(browsedMessages.length, 0);
+      const peekedMessages = await receiver.peekMessages({ maxMessageCount: -100 });
+      should.equal(peekedMessages.length, 0);
     });
 
     it("Peek: Wrong type maxMessageCount for Queue", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await receiver.browseMessages({ maxMessageCount: "somestring" as any });
+        await receiver.peekMessages({ maxMessageCount: "somestring" as any });
       } catch (error) {
         caughtError = error;
       }
@@ -61,11 +61,11 @@ describe("invalid parameters", () => {
     });
 
     it("PeekBySequenceNumber: Invalid maxMessageCount for Queue", async function(): Promise<void> {
-      const browsedMessages = await receiver.browseMessages({
+      const peekedMessages = await receiver.peekMessages({
         fromSequenceNumber: Long.ZERO,
         maxMessageCount: -100
       });
-      should.equal(browsedMessages.length, 0);
+      should.equal(peekedMessages.length, 0);
     });
 
     it("PeekBySequenceNumber: Wrong type maxMessageCount for Queue", async function(): Promise<
@@ -73,7 +73,7 @@ describe("invalid parameters", () => {
     > {
       let caughtError: Error | undefined;
       try {
-        await receiver.browseMessages({
+        await receiver.peekMessages({
           fromSequenceNumber: Long.ZERO,
           maxMessageCount: "somestring" as any
         });
@@ -92,7 +92,7 @@ describe("invalid parameters", () => {
     > {
       let caughtError: Error | undefined;
       try {
-        await receiver.browseMessages({ fromSequenceNumber: "somestring" as any });
+        await receiver.peekMessages({ fromSequenceNumber: "somestring" as any });
       } catch (error) {
         caughtError = error;
       }
@@ -127,7 +127,7 @@ describe("invalid parameters", () => {
     });
 
     it("Peek: Invalid maxMessageCount for Subscription", async function(): Promise<void> {
-      const browsedMessages = await subscriptionReceiverClient.browseMessages({
+      const browsedMessages = await subscriptionReceiverClient.peekMessages({
         maxMessageCount: -100
       });
       should.equal(browsedMessages.length, 0);
@@ -136,7 +136,7 @@ describe("invalid parameters", () => {
     it("Peek: Wrong type maxMessageCount for Subscription", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.browseMessages({ maxMessageCount: "somestring" as any });
+        await subscriptionReceiverClient.peekMessages({ maxMessageCount: "somestring" as any });
       } catch (error) {
         caughtError = error;
       }
@@ -150,7 +150,7 @@ describe("invalid parameters", () => {
     it("PeekBySequenceNumber: Invalid maxMessageCount for Subscription", async function(): Promise<
       void
     > {
-      const browsedMessages = await subscriptionReceiverClient.browseMessages({
+      const browsedMessages = await subscriptionReceiverClient.peekMessages({
         fromSequenceNumber: Long.ZERO,
         maxMessageCount: -100
       });
@@ -162,7 +162,7 @@ describe("invalid parameters", () => {
     > {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.browseMessages({
+        await subscriptionReceiverClient.peekMessages({
           fromSequenceNumber: Long.ZERO,
           maxMessageCount: "somestring" as any
         });
@@ -181,7 +181,7 @@ describe("invalid parameters", () => {
     > {
       let caughtError: Error | undefined;
       try {
-        await subscriptionReceiverClient.browseMessages({
+        await subscriptionReceiverClient.peekMessages({
           fromSequenceNumber: "somestring" as any
         });
       } catch (error) {
@@ -366,14 +366,14 @@ describe("invalid parameters", () => {
     });
 
     it("Peek: Invalid maxMessageCount in SessionReceiver", async function(): Promise<void> {
-      const browsedMessages = await receiver.browseMessages({ maxMessageCount: -100 });
-      should.equal(browsedMessages.length, 0);
+      const peekedMessages = await receiver.peekMessages({ maxMessageCount: -100 });
+      should.equal(peekedMessages.length, 0);
     });
 
     it("Peek: Wrong type maxMessageCount in SessionReceiver", async function(): Promise<void> {
       let caughtError: Error | undefined;
       try {
-        await receiver.browseMessages({ maxMessageCount: "somestring" as any });
+        await receiver.peekMessages({ maxMessageCount: "somestring" as any });
       } catch (error) {
         caughtError = error;
       }
@@ -387,11 +387,11 @@ describe("invalid parameters", () => {
     it("PeekBySequenceNumber: Invalid maxMessageCount in SessionReceiver", async function(): Promise<
       void
     > {
-      const browsedMessages = await receiver.browseMessages({
+      const peekedMessages = await receiver.peekMessages({
         fromSequenceNumber: Long.ZERO,
         maxMessageCount: -100
       });
-      should.equal(browsedMessages.length, 0);
+      should.equal(peekedMessages.length, 0);
     });
 
     it("PeekBySequenceNumber: Wrong type maxMessageCount in SessionReceiver", async function(): Promise<
@@ -399,7 +399,7 @@ describe("invalid parameters", () => {
     > {
       let caughtError: Error | undefined;
       try {
-        await receiver.browseMessages({
+        await receiver.peekMessages({
           fromSequenceNumber: Long.ZERO,
           maxMessageCount: "somestring" as any
         });
@@ -418,7 +418,7 @@ describe("invalid parameters", () => {
     > {
       let caughtError: Error | undefined;
       try {
-        await receiver.browseMessages({ fromSequenceNumber: "somestring" as any });
+        await receiver.peekMessages({ fromSequenceNumber: "somestring" as any });
       } catch (error) {
         caughtError = error;
       }

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -55,7 +55,7 @@ describe("ManagementClient - disconnects", function(): void {
     await sender.send(TestMessage.getSample());
 
     let peekedMessageCount = 0;
-    let messages = await receiver.browseMessages({ maxMessageCount: 1 });
+    let messages = await receiver.peekMessages({ maxMessageCount: 1 });
     peekedMessageCount += messages.length;
 
     peekedMessageCount.should.equal(1, "Unexpected number of peeked messages.");
@@ -76,7 +76,7 @@ describe("ManagementClient - disconnects", function(): void {
     await delay(2000);
 
     // peek additional messages
-    messages = await receiver.browseMessages({ maxMessageCount: 1 });
+    messages = await receiver.peekMessages({ maxMessageCount: 1 });
     peekedMessageCount += messages.length;
     peekedMessageCount.should.equal(2, "Unexpected number of peeked messages.");
 

--- a/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
@@ -55,9 +55,9 @@ describe("renew lock sessions", () => {
     // Hence, commenting the following code since there is no need to purge/peek into a freshly created entity
 
     // await purge(receiver);
-    // const browsedMsgs = await receiver.browseMessages();
+    // const peekedMsgs = await receiver.peekMessages();
     // const receiverEntityType = receiver.entityType;
-    // if (browsedMsgs.length) {
+    // if (peekedMsgs.length) {
     //   chai.assert.fail(`Please use an empty ${receiverEntityType} for integration testing`);
     // }
   }

--- a/sdk/servicebus/service-bus/test/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/retries.spec.ts
@@ -137,13 +137,13 @@ describe("Retries - ManagementClient", () => {
 
     it("Unpartitioned Queue: peek", async function(): Promise<void> {
       await mockManagementClientAndVerifyRetries(async () => {
-        await receiver.browseMessages();
+        await receiver.peekMessages();
       });
     });
 
     it("Unpartitioned Queue: peekBySequenceNumber", async function(): Promise<void> {
       await mockManagementClientAndVerifyRetries(async () => {
-        await receiver.browseMessages({ fromSequenceNumber: new Long(0) });
+        await receiver.peekMessages({ fromSequenceNumber: new Long(0) });
       });
     });
   });
@@ -161,13 +161,13 @@ describe("Retries - ManagementClient", () => {
 
     it("Unpartitioned Queue with Sessions: peek", async function(): Promise<void> {
       await mockManagementClientAndVerifyRetries(async () => {
-        await sessionReceiver.browseMessages();
+        await sessionReceiver.peekMessages();
       });
     });
 
     it("Unpartitioned Queue with Sessions: peekBySequenceNumber", async function(): Promise<void> {
       await mockManagementClientAndVerifyRetries(async () => {
-        await sessionReceiver.browseMessages({ fromSequenceNumber: new Long(0) });
+        await sessionReceiver.peekMessages({ fromSequenceNumber: new Long(0) });
       });
     });
 

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -617,13 +617,13 @@ describe("Errors after close()", function(): void {
     );
 
     let errorPeek: string = "";
-    await receiver.browseMessages().catch((err) => {
+    await receiver.peekMessages().catch((err) => {
       errorPeek = err.message;
     });
     should.equal(
       errorPeek,
       expectedErrorMsg,
-      "Expected error not thrown for browseMessages() from receiver"
+      "Expected error not thrown for peekMessages() from receiver"
     );
   }
 
@@ -652,7 +652,7 @@ describe("Errors after close()", function(): void {
     const sessionReceiver = receiver as SessionReceiver<ReceivedMessageWithLock>;
 
     let errorPeek: string = "";
-    await sessionReceiver.browseMessages().catch((err) => {
+    await sessionReceiver.peekMessages().catch((err) => {
       errorPeek = err.message;
     });
     should.equal(
@@ -662,7 +662,7 @@ describe("Errors after close()", function(): void {
     );
 
     let errorPeekBySequence: string = "";
-    await sessionReceiver.browseMessages({ fromSequenceNumber: Long.ZERO }).catch((err) => {
+    await sessionReceiver.peekMessages({ fromSequenceNumber: Long.ZERO }).catch((err) => {
       errorPeekBySequence = err.message;
     });
     should.equal(

--- a/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
@@ -42,9 +42,9 @@ describe("sessions tests -  requires completely clean entity for each test", () 
     // Hence, commenting the following code since there is no need to purge/peek into a freshly created entity
 
     // await purge(receiver);
-    // const browsedMsgs = await receiver.browseMessages();
+    // const peekedMsgs = await receiver.peekMessages();
     // const receiverEntityType = receiver.entityType;
-    // if (browsedMsgs.length) {
+    // if (peekedMsgs.length) {
     //   chai.assert.fail(`Please use an empty ${receiverEntityType} for integration testing`);
     // }
   }
@@ -80,17 +80,17 @@ describe("sessions tests -  requires completely clean entity for each test", () 
       });
 
       // At this point AMQP receiver link has not been established.
-      // browseMessages() will not establish the link if sessionId was provided
-      const browsedMsgs = await receiver.browseMessages();
-      should.equal(browsedMsgs.length, 1, "Unexpected number of messages browsed");
-      should.equal(browsedMsgs[0].body, testMessage.body, "MessageBody is different than expected");
+      // peekMessages() will not establish the link if sessionId was provided
+      const peekedMsgs = await receiver.peekMessages();
+      should.equal(peekedMsgs.length, 1, "Unexpected number of messages browsed");
+      should.equal(peekedMsgs[0].body, testMessage.body, "MessageBody is different than expected");
       should.equal(
-        browsedMsgs[0].messageId,
+        peekedMsgs[0].messageId,
         testMessage.messageId,
         "MessageId is different than expected"
       );
       should.equal(
-        browsedMsgs[0].sessionId,
+        peekedMsgs[0].sessionId,
         testMessage.sessionId,
         "SessionId is different than expected"
       );
@@ -281,8 +281,8 @@ describe("sessions tests -  requires completely clean entity for each test", () 
       );
       await msgs[0].complete();
 
-      const browsedMsgsInSession = await receiver.browseMessages();
-      should.equal(browsedMsgsInSession.length, 0, "Unexpected number of messages browsed");
+      const peekedMsgsInSession = await receiver.peekMessages();
+      should.equal(peekedMsgsInSession.length, 0, "Unexpected number of messages peeked");
 
       await receiver.close();
     }

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -55,9 +55,9 @@ describe("session tests", () => {
     // Hence, commenting the following code since there is no need to purge/peek into a freshly created entity
 
     // await purge(receiver);
-    // const browsedMsgs = await receiver.browseMessages();
+    // const peekedMsgs = await receiver.peekMessages();
     // const receiverEntityType = receiver.entityType;
-    // if (browsedMsgs.length) {
+    // if (peekedMsgs.length) {
     //   chai.assert.fail(`Please use an empty ${receiverEntityType} for integration testing`);
     // }
   }

--- a/sdk/servicebus/service-bus/test/smoketest.spec.ts
+++ b/sdk/servicebus/service-bus/test/smoketest.spec.ts
@@ -472,7 +472,7 @@ async function waitAndValidate(
     await delay(500);
   }
 
-  const remainingMessages = (await receiver.browseMessages()).map((m) => m.body);
+  const remainingMessages = (await receiver.peekMessages()).map((m) => m.body);
   assert.isEmpty(errors);
   assert.isEmpty(remainingMessages);
   assert.deepEqual([expectedMessage], receivedBodies);

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -155,8 +155,8 @@ describe("Streaming", () => {
       should.equal(unexpectedError, undefined, unexpectedError && unexpectedError.message);
       should.equal(receivedMsgs.length, 1, "Unexpected number of messages");
 
-      const browsedMsgs = await receiver.browseMessages();
-      should.equal(browsedMsgs.length, 0, "Unexpected number of msgs found when peeking");
+      const peekedMsgs = await receiver.peekMessages();
+      should.equal(peekedMsgs.length, 0, "Unexpected number of msgs found when peeking");
     }
 
     it("Partitioned Queue: AutoComplete removes the message", async function(): Promise<void> {

--- a/sdk/servicebus/service-bus/test/utils/testutils2.ts
+++ b/sdk/servicebus/service-bus/test/utils/testutils2.ts
@@ -468,12 +468,12 @@ export async function testPeekMsgsLength(
   peekableReceiver: Receiver<ReceivedMessage>,
   expectedPeekLength: number
 ): Promise<void> {
-  const browsedMsgs = await peekableReceiver.browseMessages({
+  const peekedMsgs = await peekableReceiver.peekMessages({
     maxMessageCount: expectedPeekLength + 1
   });
 
   should.equal(
-    browsedMsgs.length,
+    peekedMsgs.length,
     expectedPeekLength,
     "Unexpected number of msgs found when peeking"
   );


### PR DESCRIPTION
Based on recent design discussions and user studies, we have decided to revert the naming change made to the peek operation. The name `peek` is a standard term used for the operation being discussed for queues. Changing it can cause confusion or reduce clarity on what the method is meant to do.