### PR TITLE
[service-bus] T2: Enabling abort in receiveBatch and subscribe

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 7.0.0-preview.4 (Unreleased)
 
+- Adds abortSignal support throughout Sender and non-session Receivers.
+  [PR 9233](https://github.com/Azure/azure-sdk-for-js/pull/9233)
+  [PR 9284](https://github.com/Azure/azure-sdk-for-js/pull/9284)
 
 ## 7.0.0-preview.3 (2020-06-08)
 

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -332,6 +332,8 @@ export class BatchingReceiver extends MessageReceiver {
 
       const cleanupBeforeReject = (
         receiver: Receiver | undefined,
+        // fixing an eslint warning about using a variable before it's defined (note that we're called _within_ onReceiveError below)
+        // this is not circular since we don't call onReceiveError, we just need it so we can remove it from the listeners of the receiver.
         onReceiveErrorHandlerToRemove: OnAmqpEvent
       ): void => {
         if (receiver != null) {

--- a/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/batchingReceiver.ts
@@ -190,7 +190,7 @@ export class BatchingReceiver extends MessageReceiver {
         reject(translate(error));
       };
 
-      let cleanupAbortSignalFn: (() => void) | undefined = undefined;
+      let removeAbortSignalListenersFn: (() => void) | undefined = undefined;
 
       // Final action to be performed after
       // - maxMessageCount is reached or
@@ -204,9 +204,9 @@ export class BatchingReceiver extends MessageReceiver {
           clearTimeout(totalWaitTimer);
         }
 
-        if (cleanupAbortSignalFn) {
-          cleanupAbortSignalFn();
-          cleanupAbortSignalFn = undefined;
+        if (removeAbortSignalListenersFn) {
+          removeAbortSignalListenersFn();
+          removeAbortSignalListenersFn = undefined;
         }
 
         // Removing listeners, so that the next receiveMessages() call can set them again.
@@ -372,7 +372,7 @@ export class BatchingReceiver extends MessageReceiver {
         reject(error);
       };
 
-      cleanupAbortSignalFn = checkAndRegisterWithAbortSignal((err) => {
+      removeAbortSignalListenersFn = checkAndRegisterWithAbortSignal((err) => {
         cleanupBeforeReject(this._receiver, onReceiveError);
         reject(err);
       }, abortSignal);

--- a/sdk/servicebus/service-bus/src/core/messageReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/messageReceiver.ts
@@ -24,9 +24,11 @@ import * as log from "../log";
 import { LinkEntity } from "./linkEntity";
 import { ClientEntityContext } from "../clientEntityContext";
 import { DispositionType, ReceiveMode, ServiceBusMessageImpl } from "../serviceBusMessage";
-import { calculateRenewAfterDuration, getUniqueName } from "../util/utils";
+import { calculateRenewAfterDuration, getUniqueName, StandardAbortMessage } from "../util/utils";
 import { MessageHandlerOptions } from "../models";
 import { DispositionStatusOptions } from "./managementClient";
+import { AbortSignalLike } from "@azure/core-http";
+import { AbortError } from "@azure/abort-controller";
 
 /**
  * @internal
@@ -757,8 +759,17 @@ export class MessageReceiver extends LinkEntity {
    *
    * @returns {Promise<void>} Promise<void>.
    */
-  protected async _init(options?: ReceiverOptions): Promise<void> {
+  protected async _init(options?: ReceiverOptions, abortSignal?: AbortSignalLike): Promise<void> {
+    const checkAborted = (): void => {
+      if (abortSignal?.aborted) {
+        throw new AbortError(StandardAbortMessage);
+      }
+    };
+
     const connectionId = this._context.namespace.connectionId;
+
+    checkAborted();
+
     try {
       if (!this.isOpen() && !this.isConnecting) {
         if (this.wasCloseInitiated) {
@@ -781,7 +792,10 @@ export class MessageReceiver extends LinkEntity {
         }
 
         this.isConnecting = true;
+
         await this._negotiateClaim();
+        checkAborted();
+
         if (!options) {
           options = this._createReceiverOptions();
         }
@@ -794,6 +808,8 @@ export class MessageReceiver extends LinkEntity {
 
         this._receiver = await this._context.namespace.connection.createReceiver(options);
         this.isConnecting = false;
+        checkAborted();
+
         log.error(
           "[%s] Receiver '%s' with address '%s' has established itself.",
           connectionId,

--- a/sdk/servicebus/service-bus/src/core/messageSender.ts
+++ b/sdk/servicebus/service-bus/src/core/messageSender.ts
@@ -32,7 +32,7 @@ import {
 } from "../serviceBusMessage";
 import { ClientEntityContext } from "../clientEntityContext";
 import { LinkEntity } from "./linkEntity";
-import { getUniqueName, waitForTimeoutOrAbortOrResolve } from "../util/utils";
+import { getUniqueName, waitForTimeoutOrAbortOrResolve, StandardAbortMessage } from "../util/utils";
 import { throwErrorIfConnectionClosed } from "../util/errors";
 import { ServiceBusMessageBatch, ServiceBusMessageBatchImpl } from "../serviceBusMessageBatch";
 import { CreateBatchOptions } from "../models";
@@ -266,7 +266,6 @@ export class MessageSender extends LinkEntity {
           try {
             await waitForTimeoutOrAbortOrResolve({
               actionFn: () => this.open(undefined, options?.abortSignal),
-              abortMessage: "The send operation has been cancelled by the user.",
               abortSignal: options?.abortSignal,
               timeoutMs: timeoutInMs,
               timeoutMessage:
@@ -382,7 +381,7 @@ export class MessageSender extends LinkEntity {
   ): Promise<void> {
     const checkAborted = (): void => {
       if (abortSignal?.aborted) {
-        throw new AbortError("Sender creation was cancelled by the user.");
+        throw new AbortError(StandardAbortMessage);
       }
     };
 

--- a/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
+++ b/sdk/servicebus/service-bus/src/core/streamingReceiver.ts
@@ -13,7 +13,8 @@ import { ClientEntityContext } from "../clientEntityContext";
 
 import * as log from "../log";
 import { throwErrorIfConnectionClosed } from "../util/errors";
-import { RetryConfig, RetryOperationType, retry } from "@azure/core-amqp";
+import { RetryOperationType, RetryConfig, retry } from "@azure/core-amqp";
+import { OperationOptions } from "../modelsToBeSharedWithEventHubs";
 
 /**
  * @internal
@@ -75,20 +76,34 @@ export class StreamingReceiver extends MessageReceiver {
    */
   static async create(
     context: ClientEntityContext,
-    options?: ReceiveOptions
+    options?: ReceiveOptions &
+      Pick<OperationOptions, "abortSignal"> & {
+        _createStreamingReceiver?: (
+          context: ClientEntityContext,
+          options?: ReceiveOptions
+        ) => StreamingReceiver;
+      }
   ): Promise<StreamingReceiver> {
     throwErrorIfConnectionClosed(context.namespace);
     if (!options) options = {};
     if (options.autoComplete == null) options.autoComplete = true;
-    const sReceiver = new StreamingReceiver(context, options);
+
+    let sReceiver: StreamingReceiver;
+
+    if (options?._createStreamingReceiver) {
+      sReceiver = options._createStreamingReceiver(context, options);
+    } else {
+      sReceiver = new StreamingReceiver(context, options);
+    }
 
     const config: RetryConfig<void> = {
       operation: () => {
-        return sReceiver._init();
+        return sReceiver._init(undefined, options?.abortSignal);
       },
       connectionId: context.namespace.connectionId,
       operationType: RetryOperationType.receiveMessage,
-      retryOptions: options.retryOptions
+      retryOptions: options.retryOptions,
+      abortSignal: options?.abortSignal
     };
     await retry<void>(config);
     context.streamingReceiver = sReceiver;

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -23,7 +23,6 @@ import {
   retry
 } from "@azure/core-amqp";
 import { OperationOptions } from "./modelsToBeSharedWithEventHubs";
-import { AbortError } from "@azure/abort-controller";
 
 /**
  * A Sender can be used to send messages, schedule messages to be sent at a later time
@@ -260,15 +259,7 @@ export class SenderImpl implements Sender {
 
   async createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch> {
     this._throwIfSenderOrConnectionClosed();
-    try {
-      return await this._sender.createBatch(options);
-    } catch (err) {
-      if (err.name === "AbortError") {
-        throw new AbortError("The createBatch operation has been cancelled by the user.");
-      }
-
-      throw err;
-    }
+    return this._sender.createBatch(options);
   }
 
   /**

--- a/sdk/servicebus/service-bus/src/util/utils.ts
+++ b/sdk/servicebus/service-bus/src/util/utils.ts
@@ -482,6 +482,12 @@ export type EntityStatus =
   | "Unknown";
 
 /**
+ * @internal
+ * @ignore
+ */
+export const StandardAbortMessage = "The operation was aborted.";
+
+/**
  * An executor for a function that returns a Promise that obeys both a timeout and an
  * optional AbortSignal.
  * @param timeoutMs - The number of milliseconds to allow before throwing an OperationTimeoutError.
@@ -498,7 +504,6 @@ export async function waitForTimeoutOrAbortOrResolve<T>(args: {
   actionFn: () => Promise<T>;
   timeoutMs: number;
   timeoutMessage: string;
-  abortMessage: string;
   abortSignal?: AbortSignalLike;
   // these are optional and only here for testing.
   timeoutFunctions?: {
@@ -507,7 +512,7 @@ export async function waitForTimeoutOrAbortOrResolve<T>(args: {
   };
 }): Promise<T> {
   if (args.abortSignal && args.abortSignal.aborted) {
-    throw new AbortError(args.abortMessage);
+    throw new AbortError(StandardAbortMessage);
   }
 
   let timer: any | undefined = undefined;
@@ -523,7 +528,7 @@ export async function waitForTimeoutOrAbortOrResolve<T>(args: {
 
   // eslint-disable-next-line promise/param-names
   const abortOrTimeoutPromise = new Promise<T>((_resolve, reject) => {
-    clearAbortSignal = checkAndRegisterWithAbortSignal(reject, args.abortMessage, args.abortSignal);
+    clearAbortSignal = checkAndRegisterWithAbortSignal(reject, args.abortSignal);
 
     timer = (args.timeoutFunctions?.setTimeoutFn ?? setTimeout)(() => {
       reject(new OperationTimeoutError(args.timeoutMessage));
@@ -551,7 +556,6 @@ export async function waitForTimeoutOrAbortOrResolve<T>(args: {
  */
 export function checkAndRegisterWithAbortSignal(
   onAbortFn: (abortError: AbortError) => void,
-  abortMessage: string,
   abortSignal?: AbortSignalLike
 ): () => void {
   if (abortSignal == null) {
@@ -559,12 +563,12 @@ export function checkAndRegisterWithAbortSignal(
   }
 
   if (abortSignal.aborted) {
-    throw new AbortError(abortMessage);
+    throw new AbortError(StandardAbortMessage);
   }
 
   const onAbort = (): void => {
     abortSignal.removeEventListener("abort", onAbort);
-    onAbortFn(new AbortError(abortMessage));
+    onAbortFn(new AbortError(StandardAbortMessage));
   };
 
   abortSignal.addEventListener("abort", onAbort);

--- a/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/abortSignal.spec.ts
@@ -6,14 +6,17 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 const assert = chai.assert;
 
-import { ClientEntityContext } from "../../src/clientEntityContext";
 import { MessageSender } from "../../src/core/messageSender";
 import { OperationOptions } from "../../src/modelsToBeSharedWithEventHubs";
-import { DefaultDataTransformer, AccessToken } from "@azure/core-amqp";
-import { AbortSignalLike, AbortError } from "@azure/abort-controller";
 import { AwaitableSender, delay } from "rhea-promise";
 import { ServiceBusMessageBatchImpl } from "../../src/serviceBusMessageBatch";
-import { SenderImpl } from "../../src/sender";
+import { MessageReceiver, ReceiverType } from "../../src/core/messageReceiver";
+import {
+  createAbortSignalForTest,
+  createCountdownAbortSignal
+} from "../utils/abortSignalTestUtils";
+import { createClientEntityContextForTests } from "./unittestUtils";
+import { StandardAbortMessage } from "../../src/util/utils";
 
 describe("AbortSignal", () => {
   const testMessageThatDoesntMatter = {
@@ -36,24 +39,28 @@ describe("AbortSignal", () => {
         passedInOptions = options;
       };
 
+      let abortSignal = createAbortSignalForTest(false);
+
       await sender.send(testMessageThatDoesntMatter, {
-        abortSignal: createTaggedAbortSignal("passed with send", false)
+        abortSignal
       });
 
-      assert.equal((passedInOptions?.abortSignal as any).tag, "passed with send");
+      assert.equal(passedInOptions?.abortSignal, abortSignal);
+
+      abortSignal = createAbortSignalForTest(false);
 
       const batchMessage = new ServiceBusMessageBatchImpl(clientEntityContext, 1000);
       await sender.sendBatch(batchMessage, {
-        abortSignal: createTaggedAbortSignal("passed with sendBatch", false)
+        abortSignal
       });
 
-      assert.equal((passedInOptions?.abortSignal as any).tag, "passed with sendBatch");
+      assert.equal(passedInOptions?.abortSignal, abortSignal);
 
       await sender.sendMessages([testMessageThatDoesntMatter], {
-        abortSignal: createTaggedAbortSignal("passed with sendMessages", false)
+        abortSignal
       });
 
-      assert.equal((passedInOptions?.abortSignal as any).tag, "passed with sendMessages");
+      assert.equal(passedInOptions?.abortSignal, abortSignal);
     });
 
     it("_trySend with an already aborted AbortSignal", async () => {
@@ -63,7 +70,7 @@ describe("AbortSignal", () => {
         throw new Error("INIT SHOULD NEVER HAVE BEEN CALLED");
       };
 
-      const abortSignal = createTaggedAbortSignal("_trySend test", true);
+      const abortSignal = createAbortSignalForTest(true);
 
       try {
         await sender["_trySend"]({} as Buffer, true, {
@@ -71,7 +78,7 @@ describe("AbortSignal", () => {
         });
         assert.fail("AbortError should be thrown when the signal is already in an aborted state");
       } catch (err) {
-        assert.equal(err.message, "The send operation has been cancelled by the user.");
+        assert.equal(err.message, StandardAbortMessage);
 
         // we aborted in the sync part of the abort check so these event listeners are never set up
         assert.isFalse(abortSignal.addWasCalled);
@@ -79,26 +86,6 @@ describe("AbortSignal", () => {
 
         // init() doesn't get called - we abort early on this one.
         assert.isFalse(clientEntityContext.initWasCalled);
-      }
-    });
-
-    it("createBatch()", async () => {
-      const sender = new SenderImpl(createClientEntityContextForTests());
-
-      sender["_sender"] = ({
-        createBatch: async () => {
-          throw new AbortError(
-            "The error matters but this message will be ignored and made specific to the actual operation."
-          );
-        }
-      } as any) as MessageSender;
-
-      try {
-        await sender.createBatch();
-        assert.fail("AbortError should have been thrown");
-      } catch (err) {
-        assert.equal(err.message, "The createBatch operation has been cancelled by the user.");
-        assert.equal(err.name, "AbortError");
       }
     });
 
@@ -130,7 +117,7 @@ describe("AbortSignal", () => {
 
       try {
         await sender["_trySend"]({} as Buffer, true, {
-          abortSignal: createTaggedAbortSignal("not used for this test", false)
+          abortSignal: createAbortSignalForTest(false)
         });
         assert.fail("Sender should have thrown in the async portion of the abort handling");
       } catch (err) {
@@ -150,13 +137,13 @@ describe("AbortSignal", () => {
   describe("MessageSender.open() aborts after...", () => {
     it("...beforeLock", async () => {
       const sender = new MessageSender(createClientEntityContextForTests(), {});
-      const abortSignal = createTaggedAbortSignal("countdown", createCountdown(1));
+      const abortSignal = createCountdownAbortSignal(1);
 
       try {
         await sender.open(undefined, abortSignal);
         assert.fail("Should have thrown an AbortError");
       } catch (err) {
-        assert.equal(err.message, "Sender creation was cancelled by the user.");
+        assert.equal(err.message, StandardAbortMessage);
         assert.equal(err.name, "AbortError");
       }
 
@@ -165,13 +152,13 @@ describe("AbortSignal", () => {
 
     it("...afterLock", async () => {
       const sender = new MessageSender(createClientEntityContextForTests(), {});
-      const abortSignal = createTaggedAbortSignal("countdown", createCountdown(2));
+      const abortSignal = createCountdownAbortSignal(2);
 
       try {
         await sender.open(undefined, abortSignal);
         assert.fail("Should have thrown an AbortError");
       } catch (err) {
-        assert.equal(err.message, "Sender creation was cancelled by the user.");
+        assert.equal(err.message, StandardAbortMessage);
         assert.equal(err.name, "AbortError");
       }
 
@@ -180,7 +167,7 @@ describe("AbortSignal", () => {
 
     it("...negotiateClaim", async () => {
       let isAborted = false;
-      const taggedAbortSignal = createTaggedAbortSignal("a", () => isAborted);
+      const taggedAbortSignal = createAbortSignalForTest(() => isAborted);
 
       const sender = new MessageSender(
         createClientEntityContextForTests({
@@ -197,7 +184,7 @@ describe("AbortSignal", () => {
         await sender.createBatch({ abortSignal: taggedAbortSignal });
         assert.fail("Should have thrown an AbortError");
       } catch (err) {
-        assert.equal(err.message, "Sender creation was cancelled by the user.");
+        assert.equal(err.message, StandardAbortMessage);
         assert.equal(err.name, "AbortError");
       }
 
@@ -206,15 +193,12 @@ describe("AbortSignal", () => {
 
     it("...createAwaitableSender", async () => {
       let isAborted = false;
-      const taggedAbortSignal = createTaggedAbortSignal("a", () => isAborted);
-
-      const createdSenders: AwaitableSender[] = [];
+      const taggedAbortSignal = createAbortSignalForTest(() => isAborted);
 
       const sender = new MessageSender(
         createClientEntityContextForTests({
-          onCreateAwaitableSenderCalled: (sender) => {
+          onCreateAwaitableSenderCalled: () => {
             isAborted = true;
-            createdSenders.push(sender);
           }
         }),
         {}
@@ -226,105 +210,80 @@ describe("AbortSignal", () => {
         await sender.createBatch({ abortSignal: taggedAbortSignal });
         assert.fail("Should have thrown an AbortError");
       } catch (err) {
-        assert.equal(err.message, "Sender creation was cancelled by the user.");
+        assert.equal(err.message, StandardAbortMessage);
         assert.equal(err.name, "AbortError");
       }
 
       assert.isFalse(sender.isConnecting);
     });
   });
-});
 
-function createClientEntityContextForTests(options?: {
-  onCreateAwaitableSenderCalled: (createdSender: AwaitableSender) => void;
-}): ClientEntityContext & { initWasCalled: boolean } {
-  let initWasCalled = false;
-
-  const fakeClientEntityContext = {
-    entityPath: "queue",
-    sender: {
-      credit: 999
-    },
-    namespace: {
-      config: { endpoint: "my.service.bus" },
-      connectionId: "connection-id",
-      connection: {
-        createAwaitableSender: async (): Promise<AwaitableSender> => {
-          let isClosed = false;
-
-          const testAwaitableSender = ({
-            setMaxListeners: () => testAwaitableSender,
-            isOpen: () => isClosed,
-            close: async () => {
-              isClosed = true;
-            }
-          } as any) as AwaitableSender;
-
-          options?.onCreateAwaitableSenderCalled(testAwaitableSender);
-          return testAwaitableSender;
-        }
-      },
-      dataTransformer: new DefaultDataTransformer(),
-      tokenCredential: {
-        getToken() {
-          return {} as AccessToken;
-        }
-      },
-      cbsSession: {
-        cbsLock: "cbs-lock",
-        async init() {
-          initWasCalled = true;
-        }
-      }
-    },
-    initWasCalled
-  };
-
-  return (fakeClientEntityContext as any) as ReturnType<typeof createClientEntityContextForTests>;
-}
-
-function createCountdown(numTimesTillAborted: number): () => boolean {
-  return () => {
-    --numTimesTillAborted;
-
-    if (numTimesTillAborted < 0) {
-      throw new Error(
-        "We're checking abortSignal more than we thought. Our count is probably incorrect."
+  describe("MessageReceiver.open() aborts after...", () => {
+    it("...before first async call", async () => {
+      const messageReceiver = new MessageReceiver(
+        createClientEntityContextForTests(),
+        ReceiverType.streaming
       );
-    }
 
-    return numTimesTillAborted === 0;
-  };
-}
+      const abortSignal = createCountdownAbortSignal(1);
 
-function createTaggedAbortSignal(
-  tag: string,
-  isAborted: boolean | (() => boolean) = false
-): AbortSignalLike & {
-  tag: string;
-  removeWasCalled: boolean;
-  addWasCalled: boolean;
-} {
-  const removeWasCalled = false;
-  let addWasCalled = false;
-
-  const signal = {
-    addEventListener(): void {
-      addWasCalled = true;
-    },
-    removeEventListener(): void {
-      this.removeWasCalled = true;
-    },
-    tag,
-    removeWasCalled,
-    addWasCalled,
-    get aborted(): boolean {
-      if (typeof isAborted === "function") {
-        return isAborted();
+      try {
+        await messageReceiver["_init"](undefined, abortSignal);
+        assert.fail("Should have thrown an AbortError");
+      } catch (err) {
+        assert.equal(err.message, StandardAbortMessage);
+        assert.equal(err.name, "AbortError");
       }
-      return isAborted;
-    }
-  };
 
-  return signal;
-}
+      assert.isFalse(messageReceiver.isConnecting);
+    });
+
+    it("...after negotiateClaim", async () => {
+      const messageReceiver = new MessageReceiver(
+        createClientEntityContextForTests(),
+        ReceiverType.streaming
+      );
+
+      let isAborted = false;
+      const abortSignal = createAbortSignalForTest(() => isAborted);
+
+      messageReceiver["_negotiateClaim"] = async () => {
+        isAborted = true;
+      };
+
+      try {
+        await messageReceiver["_init"](undefined, abortSignal);
+        assert.fail("Should have thrown an AbortError");
+      } catch (err) {
+        assert.equal(err.message, StandardAbortMessage);
+        assert.equal(err.name, "AbortError");
+      }
+
+      assert.isFalse(messageReceiver.isConnecting);
+    });
+
+    it("...after createReceiver", async () => {
+      let isAborted = false;
+      const abortSignal = createAbortSignalForTest(() => isAborted);
+
+      const fakeContext = createClientEntityContextForTests({
+        onCreateReceiverCalled: () => {
+          isAborted = true;
+        }
+      });
+      const messageReceiver = new MessageReceiver(fakeContext, ReceiverType.streaming);
+
+      messageReceiver["_negotiateClaim"] = async () => {};
+
+      try {
+        await messageReceiver["_init"](undefined, abortSignal);
+        assert.fail("Should have thrown an AbortError");
+      } catch (err) {
+        assert.equal(err.message, StandardAbortMessage);
+        assert.equal(err.name, "AbortError");
+      }
+
+      assert.isFalse(messageReceiver.isConnecting);
+    });
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
@@ -110,8 +110,8 @@ describe("BatchingReceiver unit tests", () => {
       assert.deepEqual(listenersBeingRemoved, [
         "receiver_error",
         "message",
-        "receiver_drained",
-        "session_error"
+        "session_error",
+        "receiver_drained"
       ]);
       assert.isEmpty(callsDoneAfterAbort);
     });

--- a/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/batchingReceiver.spec.ts
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+import { BatchingReceiver } from "../../src/core/batchingReceiver";
+import { createClientEntityContextForTests } from "./unittestUtils";
+import { ReceiverImpl } from "../../src/receivers/receiver";
+import { createAbortSignalForTest } from "../utils/abortSignalTestUtils";
+import { AbortController, AbortSignalLike } from "@azure/abort-controller";
+import { ServiceBusMessageImpl, ReceiveMode } from "../../src/serviceBusMessage";
+import { Receiver as RheaReceiver, ReceiverEvents, SessionEvents } from "rhea-promise";
+import { StandardAbortMessage } from "../../src/util/utils";
+
+describe("BatchingReceiver unit tests", () => {
+  describe("AbortSignal", () => {
+    // establish that the abortSignal does get properly sent down. Now the rest of the tests
+    // will test at the BatchingReceiver level.
+    it("is plumbed into BatchingReceiver from ReceiverImpl", async () => {
+      const origAbortSignal = createAbortSignalForTest();
+      const receiver = new ReceiverImpl(createClientEntityContextForTests(), "peekLock");
+      let wasCalled = false;
+
+      receiver["_createBatchingReceiver"] = () => {
+        return {
+          async receive(
+            _maxMessageCount: number,
+            _maxWaitTimeInMs?: number,
+            abortSignal?: AbortSignalLike
+          ): Promise<ServiceBusMessageImpl[]> {
+            assert.equal(abortSignal, origAbortSignal);
+            wasCalled = true;
+            return [];
+          }
+        } as BatchingReceiver;
+      };
+
+      await receiver.receiveBatch(1000, {
+        maxWaitTimeInMs: 60 * 1000,
+        abortSignal: origAbortSignal
+      });
+
+      assert.isTrue(wasCalled, "Expected a call to BatchingReceiver.receive()");
+    });
+
+    it("abortSignal is already signalled", async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+
+      const receiver = new BatchingReceiver(createClientEntityContextForTests(), {
+        receiveMode: ReceiveMode.peekLock
+      });
+
+      try {
+        await receiver.receive(1, 60 * 1000, abortController.signal);
+        assert.fail("Should have thrown");
+      } catch (err) {
+        assert.equal(err.message, StandardAbortMessage);
+        assert.equal(err.name, "AbortError");
+      }
+    }).timeout(1000);
+
+    it("abortSignal while receive is in process", async () => {
+      const abortController = new AbortController();
+
+      const receiver = new BatchingReceiver(createClientEntityContextForTests(), {
+        receiveMode: ReceiveMode.peekLock
+      });
+
+      const listenersBeingRemoved: string[] = [];
+      const callsDoneAfterAbort: string[] = [];
+
+      receiver["_init"] = async () => {
+        // just enough of a Receiver to validate that cleanup actions
+        // are being run on abort.
+        receiver["_receiver"] = ({
+          removeListener: (eventType: ReceiverEvents) => {
+            listenersBeingRemoved.push(eventType.toString());
+          },
+          on: (eventType: ReceiverEvents) => {
+            // we definitely shouldn't be registering any new handlers if we've aborted.
+            callsDoneAfterAbort.push(eventType);
+          },
+          addCredit: () => {
+            // we definitely shouldn't be adding credits if we know we've aborted.
+            callsDoneAfterAbort.push("addCredit");
+          },
+          session: {
+            removeListener: (eventType: SessionEvents) => {
+              listenersBeingRemoved.push(eventType.toString());
+            }
+          }
+        } as any) as RheaReceiver;
+
+        abortController.abort();
+      };
+
+      try {
+        await receiver.receive(1, 60 * 1000, abortController.signal);
+        assert.fail("Should have thrown");
+      } catch (err) {
+        assert.equal(err.message, StandardAbortMessage);
+        assert.equal(err.name, "AbortError");
+      }
+
+      // order here isn't important, it just happens to be the order we call in `cleanupBeforeReject`
+      assert.deepEqual(listenersBeingRemoved, [
+        "receiver_error",
+        "message",
+        "receiver_drained",
+        "session_error"
+      ]);
+      assert.isEmpty(callsDoneAfterAbort);
+    });
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/streamingReceiver.spec.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { ReceiverImpl } from "../../src/receivers/receiver";
+import { createClientEntityContextForTests, getPromiseResolverForTest } from "./unittestUtils";
+import { ClientEntityContext } from "../../src/clientEntityContext";
+import { ReceiveOptions } from "../../src/core/messageReceiver";
+import { OperationOptions } from "../../src";
+import { StreamingReceiver } from "../../src/core/streamingReceiver";
+import { AbortController, AbortSignalLike } from "@azure/abort-controller";
+chai.use(chaiAsPromised);
+const assert = chai.assert;
+
+describe("StreamingReceiver unit tests", () => {
+  describe("AbortSignal", () => {
+    it("sanity check - abortSignal is propagated", async () => {
+      const receiverImpl = new ReceiverImpl(createClientEntityContextForTests(), "peekLock");
+
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      const { resolve, promise } = getPromiseResolverForTest();
+
+      receiverImpl["_createStreamingReceiver"] = async (
+        _context: ClientEntityContext,
+        options?: ReceiveOptions &
+          Pick<OperationOptions, "abortSignal"> & {
+            createStreamingReceiver?: (
+              context: ClientEntityContext,
+              options?: ReceiveOptions
+            ) => StreamingReceiver;
+          }
+      ) => {
+        assert.equal(abortSignal, options?.abortSignal, "abortSignal is properly passed through");
+        resolve();
+        return {} as StreamingReceiver;
+      };
+
+      const errors: string[] = [];
+
+      receiverImpl.subscribe(
+        {
+          processMessage: async () => {},
+          processError: async (err) => {
+            errors.push(err.message);
+          }
+        },
+        {
+          abortSignal
+        }
+      );
+
+      await promise;
+      assert.isEmpty(errors);
+    }).timeout(2000); // just for safety
+
+    it("sanity check - abortSignal is propagated to _init()", async () => {
+      let wasCalled = false;
+      const abortController = new AbortController();
+
+      await StreamingReceiver.create(createClientEntityContextForTests(), {
+        _createStreamingReceiver: (_context, _options) => {
+          wasCalled = true;
+          return ({
+            _init: (_ignoredOptions: any, abortSignal?: AbortSignalLike) => {
+              wasCalled = true;
+              assert.equal(
+                abortSignal,
+                abortController.signal,
+                "abortSignal passed in when created should propagate to _init()"
+              );
+              return;
+            }
+          } as any) as StreamingReceiver;
+        },
+        abortSignal: abortController.signal
+      });
+
+      assert.isTrue(wasCalled);
+    });
+  });
+});

--- a/sdk/servicebus/service-bus/test/internal/unittestUtils.ts
+++ b/sdk/servicebus/service-bus/test/internal/unittestUtils.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ClientEntityContext } from "../../src/clientEntityContext";
+import { AwaitableSender, Receiver as RheaReceiver } from "rhea-promise";
+import { DefaultDataTransformer, AccessToken } from "@azure/core-amqp";
+
+export function createClientEntityContextForTests(options?: {
+  onCreateAwaitableSenderCalled?: () => void;
+  onCreateReceiverCalled?: () => void;
+}): ClientEntityContext & { initWasCalled: boolean } {
+  let initWasCalled = false;
+
+  const fakeClientEntityContext = {
+    entityPath: "queue",
+    sender: {
+      credit: 999
+    },
+    namespace: {
+      config: { endpoint: "my.service.bus" },
+      connectionId: "connection-id",
+      connection: {
+        createAwaitableSender: async (): Promise<AwaitableSender> => {
+          if (options?.onCreateAwaitableSenderCalled) {
+            options.onCreateAwaitableSenderCalled();
+          }
+
+          const testAwaitableSender = ({
+            setMaxListeners: () => testAwaitableSender
+          } as any) as AwaitableSender;
+
+          return testAwaitableSender;
+        },
+        createReceiver: async (): Promise<RheaReceiver> => {
+          if (options?.onCreateReceiverCalled) {
+            options.onCreateReceiverCalled();
+          }
+
+          return ({} as any) as RheaReceiver;
+        }
+      },
+      dataTransformer: new DefaultDataTransformer(),
+      tokenCredential: {
+        getToken() {
+          return {} as AccessToken;
+        }
+      },
+      cbsSession: {
+        cbsLock: "cbs-lock",
+        async init() {
+          initWasCalled = true;
+        }
+      }
+    },
+    initWasCalled
+  };
+
+  return (fakeClientEntityContext as any) as ReturnType<typeof createClientEntityContextForTests>;
+}
+
+export function getPromiseResolverForTest(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: Error) => void;
+} {
+  let resolver: () => void;
+  let rejecter: (err: Error) => void;
+
+  const promise = new Promise<void>((resolve, reject) => {
+    resolver = resolve;
+    rejecter = reject;
+  });
+
+  return {
+    promise,
+    resolve: resolver!,
+    reject: rejecter!
+  };
+}

--- a/sdk/servicebus/service-bus/test/utils/abortSignalTestUtils.ts
+++ b/sdk/servicebus/service-bus/test/utils/abortSignalTestUtils.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { AbortSignalLike } from "@azure/abort-controller";
+
+/**
+ * Creates an AbortSignal that signals that it's aborted after .aborted is checked a certain
+ * number of times.
+ */
+export function createCountdownAbortSignal(
+  numTimesTillAborted: number
+): ReturnType<typeof createAbortSignalForTest> {
+  const countdownFn = () => {
+    --numTimesTillAborted;
+
+    if (numTimesTillAborted < 0) {
+      throw new Error(
+        "We're checking abortSignal more than we thought. Our count is probably incorrect."
+      );
+    }
+
+    return numTimesTillAborted === 0;
+  };
+
+  return createAbortSignalForTest(countdownFn);
+}
+
+/**
+ * Creates an AbortSignal that is already signalled or can be controlled by a
+ * custom function passed via isAborted.
+ */
+export function createAbortSignalForTest(
+  isAborted: boolean | (() => boolean) = false
+): AbortSignalLike & {
+  removeWasCalled: boolean;
+  addWasCalled: boolean;
+} {
+  const removeWasCalled = false;
+  let addWasCalled = false;
+
+  const signal = {
+    addEventListener(): void {
+      addWasCalled = true;
+    },
+    removeEventListener(): void {
+      this.removeWasCalled = true;
+    },
+    removeWasCalled,
+    addWasCalled,
+    get aborted(): boolean {
+      if (typeof isAborted === "function") {
+        return isAborted();
+      }
+      return isAborted;
+    }
+  };
+
+  return signal;
+}


### PR DESCRIPTION
- Plumbing abortSignal through so it can be used to cancel the init() call in subscribe() and any part of receiveBatch()
- Standardizing our AbortError message for all the new abortSignal work for Sender and Receiver. 

Part of #4375