### PR TITLE
Make @azure/template a client library so it participates in dev versioning

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -470,7 +470,7 @@
     {
       "packageName": "@azure/template",
       "projectFolder": "sdk/template/template",
-      "versionPolicyName": "utility"
+      "versionPolicyName": "client"
     },
     {
       "packageName": "@azure/eslint-plugin-azure-sdk",


### PR DESCRIPTION
This PR changes ```@azure/template``` from being designated a ```utility``` to being ```client``` in the Rush configuration. The reason for this is that the template pipeline is failing in the Integration stage on the nightly runs because it doesn't have a dev suffix.

In other repos we actually do release our template package and use it as a bit of a canary for when we are making engineering systems changes (it allows us to bump the version and test releases end-to-end). Even though it means we are publishing a useless package, there are some benefits around having this canary mechanism.

Without doing this we would need to adjust all the scripts which work with client packages to make sure that they know to skip ```@azure/template``` for whatever they do.

It does appear that ```@azure/template``` is already published in the github.io docs, which probably wasn't intentional but useful as a validation that it works.

Thoughts? Note this is different to the track 1/track 2 conversation I started earlier since template is supposed to be a track 2 template and should be treated as a track 2 client library.

/cc @KarishmaGhiya @mikeharder @ramya-rao-a 