### PR TITLE
[service-bus] T2 - revert back to lazy-initialization model for .createSender()

### DIFF
--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Breaking Changes
 
-- `Sender` now has an `open()` method to proactively initialize the connection. In addition `ServiceBusClient.createSender()` is no longer an `async` method.
+- `ServiceBusClient.createSender()` which was made async in the previous preview to include the link initialization is no longer async. Instead, the sender now has an `open()` method that can be used to proactively initialize the link. 
   [PR 9302](https://github.com/Azure/azure-sdk-for-js/pull/9302)
 
 ## 7.0.0-preview.2 (2020-05-05)

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Improves the performance of the `ServiceBusMessageBatch.tryAdd` method.
   [PR 8772](https://github.com/Azure/azure-sdk-for-js/pull/8772)
+- `Sender` now has an `open()` method to proactively initialize the connection. In addition `ServiceBusClient.createSender()` is no longer an `async` method.
+  [PR 9302](https://github.com/Azure/azure-sdk-for-js/pull/9302)
 
 ## 7.0.0-preview.2 (2020-05-05)
 

--- a/sdk/servicebus/service-bus/CHANGELOG.md
+++ b/sdk/servicebus/service-bus/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Improves the performance of the `ServiceBusMessageBatch.tryAdd` method.
   [PR 8772](https://github.com/Azure/azure-sdk-for-js/pull/8772)
+
+### Breaking Changes
+
 - `Sender` now has an `open()` method to proactively initialize the connection. In addition `ServiceBusClient.createSender()` is no longer an `async` method.
   [PR 9302](https://github.com/Azure/azure-sdk-for-js/pull/9302)
 

--- a/sdk/servicebus/service-bus/README.md
+++ b/sdk/servicebus/service-bus/README.md
@@ -102,7 +102,7 @@ using the [createSender][sbclient_createsender] method.
 This gives you a sender which you can use to [send][sender_send] messages.
 
 ```javascript
-const sender = await serviceBusClient.createSender("my-queue");
+const sender = serviceBusClient.createSender("my-queue");
 
 // sending a single message
 await sender.send({
@@ -189,7 +189,7 @@ When sending the message, set the `sessionId` property in the message to ensure
 your message lands in the right session.
 
 ```javascript
-const sender = await serviceBusClient.createSender("my-session-queue");
+const sender = serviceBusClient.createSender("my-session-queue");
 await sender.send({
   body: "my-message-body",
   sessionId: "my-session"

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -108,7 +108,8 @@ brings this package in line with the [Azure SDK Design Guidelines for Typescript
   ruleManager.removeRule();
   ```
 
-* createSessionReceiver() is now an async method and initialize the connection
+* createSessionReceiver() is now an async method. The promise returned by this method
+is resolved when a receiver link has been initialized with a session in the service.
 
 Prior to v7 `createSessionReceiver()` worked using lazy-initialization, where the
 AMQP connection would only be initialized on first send or receiving of a message.

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -109,11 +109,10 @@ brings this package in line with the [Azure SDK Design Guidelines for Typescript
   ```
 
 * createSessionReceiver() is now an async method. The promise returned by this method
-is resolved when a receiver link has been initialized with a session in the service.
+  is resolved when a receiver link has been initialized with a session in the service.
 
 Prior to v7 `createSessionReceiver()` worked using lazy-initialization, where the
-AMQP connection would only be initialized on first send or receiving of a message.
-
-The connection and link are now initialized after calling `createSessionReceiver`.
+receiver link to the session was only initialized when the async methods on the `SessionReceiver`
+were first called.
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fservicebus%2Fservice-bus%2FMIGRATIONGUIDE.png)

--- a/sdk/servicebus/service-bus/migrationguide.md
+++ b/sdk/servicebus/service-bus/migrationguide.md
@@ -1,4 +1,4 @@
-# Guide to migrate from @azure/service-bus v1 to v7.preview.2
+# Guide to migrate from @azure/service-bus v1 to v7.preview.3
 
 This document is intended for users that would like to try out preview 7
 for @azure/service-bus. As the package is in preview, these details might
@@ -108,11 +108,11 @@ brings this package in line with the [Azure SDK Design Guidelines for Typescript
   ruleManager.removeRule();
   ```
 
-* createSender() and createSessionReceiver() are now async methods and initialize the connection
+* createSessionReceiver() is now an async method and initialize the connection
 
-Prior to v7 `createSender()` and `createSessionReceiver()` worked using lazy-initialization, where the
+Prior to v7 `createSessionReceiver()` worked using lazy-initialization, where the
 AMQP connection would only be initialized on first send or receiving of a message.
 
-The connection and link are now initialized after calling either method.
+The connection and link are now initialized after calling `createSessionReceiver`.
 
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fservicebus%2Fservice-bus%2FMIGRATIONGUIDE.png)

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -63,11 +63,6 @@ export type CreateQueueResponse = QueueResponse;
 export type CreateRuleResponse = RuleResponse;
 
 // @public
-export interface CreateSenderOptions {
-    abortSignal?: AbortSignalLike;
-}
-
-// @public
 export interface CreateSessionReceiverOptions extends SessionReceiverOptions, OperationOptions {
 }
 
@@ -175,6 +170,11 @@ export interface MessageHandlers<ReceivedMessageT> {
 }
 
 export { MessagingError }
+
+// @public
+export interface OpenOptions {
+    abortSignal?: AbortSignalLike;
+}
 
 // @public
 export interface OperationOptions {
@@ -292,6 +292,7 @@ export interface Sender {
     createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch>;
     entityPath: string;
     isClosed: boolean;
+    open(options?: OpenOptions): Promise<void>;
     scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage, options?: OperationOptions): Promise<Long>;
     scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[], options?: OperationOptions): Promise<Long[]>;
     send(message: ServiceBusMessage, options?: OperationOptions): Promise<void>;
@@ -312,7 +313,7 @@ export class ServiceBusClient {
     createReceiver(queueName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
     createReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock"): Receiver<ReceivedMessageWithLock>;
     createReceiver(topicName: string, subscriptionName: string, receiveMode: "receiveAndDelete"): Receiver<ReceivedMessage>;
-    createSender(queueOrTopicName: string, options?: CreateSenderOptions): Promise<Sender>;
+    createSender(queueOrTopicName: string): Sender;
     createSessionReceiver(queueName: string, receiveMode: "peekLock", options?: CreateSessionReceiverOptions): Promise<SessionReceiver<ReceivedMessageWithLock>>;
     createSessionReceiver(queueName: string, receiveMode: "receiveAndDelete", options?: CreateSessionReceiverOptions): Promise<SessionReceiver<ReceivedMessage>>;
     createSessionReceiver(topicName: string, subscriptionName: string, receiveMode: "peekLock", options?: CreateSessionReceiverOptions): Promise<SessionReceiver<ReceivedMessageWithLock>>;

--- a/sdk/servicebus/service-bus/review/service-bus.api.md
+++ b/sdk/servicebus/service-bus/review/service-bus.api.md
@@ -172,11 +172,6 @@ export interface MessageHandlers<ReceivedMessageT> {
 export { MessagingError }
 
 // @public
-export interface OpenOptions {
-    abortSignal?: AbortSignalLike;
-}
-
-// @public
 export interface OperationOptions {
     abortSignal?: AbortSignalLike;
     tracingOptions?: OperationTracingOptions;
@@ -292,12 +287,17 @@ export interface Sender {
     createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch>;
     entityPath: string;
     isClosed: boolean;
-    open(options?: OpenOptions): Promise<void>;
+    open(options?: SenderOpenOptions): Promise<void>;
     scheduleMessage(scheduledEnqueueTimeUtc: Date, message: ServiceBusMessage, options?: OperationOptions): Promise<Long>;
     scheduleMessages(scheduledEnqueueTimeUtc: Date, messages: ServiceBusMessage[], options?: OperationOptions): Promise<Long[]>;
     send(message: ServiceBusMessage, options?: OperationOptions): Promise<void>;
     send(messages: ServiceBusMessage[], options?: OperationOptions): Promise<void>;
     send(messageBatch: ServiceBusMessageBatch, options?: OperationOptions): Promise<void>;
+}
+
+// @public
+export interface SenderOpenOptions {
+    abortSignal?: AbortSignalLike;
 }
 
 // @public

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/deferral.js
@@ -32,7 +32,7 @@ async function main() {
 async function sendMessages() {
   const sbClient = new ServiceBusClient(connectionString);
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const data = [
     { step: 1, title: "Shop" },

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/movingMessagesToDLQ.js
@@ -35,7 +35,7 @@ async function main() {
 
 async function sendMessage() {
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: {

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/processMessageFromDLQ.js
@@ -55,7 +55,7 @@ async function processDeadletterMessageQueue() {
 // Send repaired message back to the current queue / topic
 async function fixAndResendMessage(oldMessage) {
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   // Inspect given message and make any changes if necessary
   const repairedMessage = { ...oldMessage };

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionState.js
@@ -86,7 +86,7 @@ async function getSessionState(sessionId) {
 }
 async function sendMessagesForSession(shoppingEvents, sessionId) {
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(userEventsQueueName);
+  const sender = sbClient.createSender(userEventsQueueName);
   for (let index = 0; index < shoppingEvents.length; index++) {
     const message = {
       sessionId: sessionId,

--- a/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/scheduledMessages.js
@@ -47,7 +47,7 @@ async function main() {
 // Scheduling messages to be sent after 10 seconds from now
 async function sendScheduledMessages(sbClient) {
   // createSender() handles sending to a queue or a topic
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const messages = listOfScientists.map((scientist) => ({
     body: `${scientist.firstName} ${scientist.lastName}`,

--- a/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/sendMessages.js
@@ -37,7 +37,7 @@ async function main() {
   const sbClient = new ServiceBusClient(connectionString);
 
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   try {
     for (let index = 0; index < listOfScientists.length; index++) {

--- a/sdk/servicebus/service-bus/samples/javascript/session.js
+++ b/sdk/servicebus/service-bus/samples/javascript/session.js
@@ -60,7 +60,7 @@ async function main() {
 
 async function sendMessage(sbClient, scientist, sessionId) {
   // createSender() also works with topics
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: `${scientist.firstName} ${scientist.lastName}`,

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/deferral.ts
@@ -34,7 +34,7 @@ export async function main() {
 async function sendMessages() {
   const sbClient = new ServiceBusClient(connectionString);
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const data = [
     { step: 1, title: "Shop" },

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/movingMessagesToDLQ.ts
@@ -37,7 +37,7 @@ export async function main() {
 
 async function sendMessage() {
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: {

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/processMessageFromDLQ.ts
@@ -57,7 +57,7 @@ async function processDeadletterMessageQueue() {
 // Send repaired message back to the current queue / topic
 async function fixAndResendMessage(oldMessage: ServiceBusMessage) {
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   // Inspect given message and make any changes if necessary
   const repairedMessage = { ...oldMessage };

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionState.ts
@@ -101,7 +101,7 @@ async function getSessionState(sessionId: string) {
 
 async function sendMessagesForSession(shoppingEvents: any[], sessionId: string) {
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(userEventsQueueName);
+  const sender = sbClient.createSender(userEventsQueueName);
 
   for (let index = 0; index < shoppingEvents.length; index++) {
     const message = {

--- a/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/scheduledMessages.ts
@@ -50,7 +50,7 @@ export async function main() {
 // Scheduling messages to be sent after 10 seconds from now
 async function sendScheduledMessages(sbClient: ServiceBusClient) {
   // createSender() handles sending to a queue or a topic
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const messages: ServiceBusMessage[] = listOfScientists.map((scientist) => ({
     body: `${scientist.firstName} ${scientist.lastName}`,

--- a/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/sendMessages.ts
@@ -40,7 +40,7 @@ export async function main() {
   const sbClient = new ServiceBusClient(connectionString);
 
   // createSender() can also be used to create a sender for a topic.
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   try {
     for (let index = 0; index < listOfScientists.length; index++) {

--- a/sdk/servicebus/service-bus/samples/typescript/src/session.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/session.ts
@@ -64,7 +64,7 @@ export async function main() {
 
 async function sendMessage(sbClient: ServiceBusClient, scientist: any, sessionId: string) {
   // createSender() also works with topics
-  const sender = await sbClient.createSender(queueName);
+  const sender = sbClient.createSender(queueName);
 
   const message = {
     body: `${scientist.firstName} ${scientist.lastName}`,

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -18,7 +18,7 @@ export { CorrelationRuleFilter } from "./core/managementClient";
 export {
   BrowseMessagesOptions,
   CreateBatchOptions,
-  OpenOptions,
+  SenderOpenOptions,
   CreateSessionReceiverOptions,
   GetMessageIteratorOptions,
   MessageHandlerOptions,

--- a/sdk/servicebus/service-bus/src/index.ts
+++ b/sdk/servicebus/service-bus/src/index.ts
@@ -18,7 +18,7 @@ export { CorrelationRuleFilter } from "./core/managementClient";
 export {
   BrowseMessagesOptions,
   CreateBatchOptions,
-  CreateSenderOptions,
+  OpenOptions,
   CreateSessionReceiverOptions,
   GetMessageIteratorOptions,
   MessageHandlerOptions,

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -107,7 +107,7 @@ export interface CreateSessionReceiverOptions extends SessionReceiverOptions, Op
 /**
  * Describes the options passed to the `open` method on a `Sender`.
  */
-export interface OpenOptions {
+export interface SenderOpenOptions {
   /**
    * The signal which can be used to abort requests.
    */

--- a/sdk/servicebus/service-bus/src/models.ts
+++ b/sdk/servicebus/service-bus/src/models.ts
@@ -105,9 +105,9 @@ export interface MessageHandlerOptions {
 export interface CreateSessionReceiverOptions extends SessionReceiverOptions, OperationOptions {}
 
 /**
- * Describes the options passed to the `createSender` method on `ServiceBusClient`.
+ * Describes the options passed to the `open` method on a `Sender`.
  */
-export interface CreateSenderOptions {
+export interface OpenOptions {
   /**
    * The signal which can be used to abort requests.
    */

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -14,7 +14,7 @@ import {
   throwTypeErrorIfParameterNotLongArray
 } from "./util/errors";
 import { ServiceBusMessageBatch } from "./serviceBusMessageBatch";
-import { CreateBatchOptions, OpenOptions } from "./models";
+import { CreateBatchOptions, SenderOpenOptions } from "./models";
 import {
   MessagingError,
   RetryConfig,
@@ -99,7 +99,7 @@ export interface Sender {
    *
    * @param options - Options bag to pass an abort signal.
    */
-  open(options?: OpenOptions): Promise<void>;
+  open(options?: SenderOpenOptions): Promise<void>;
 
   /**
    * @property Returns `true` if either the sender or the client that created it has been closed
@@ -413,7 +413,7 @@ export class SenderImpl implements Sender {
     return retry<void>(config);
   }
 
-  async open(options?: OpenOptions): Promise<void> {
+  async open(options?: SenderOpenOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
 
     const config: RetryConfig<void> = {

--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -14,7 +14,7 @@ import {
   throwTypeErrorIfParameterNotLongArray
 } from "./util/errors";
 import { ServiceBusMessageBatch } from "./serviceBusMessageBatch";
-import { CreateBatchOptions, CreateSenderOptions } from "./models";
+import { CreateBatchOptions, OpenOptions } from "./models";
 import {
   MessagingError,
   RetryConfig,
@@ -89,6 +89,17 @@ export interface Sender {
    * @throws Error if the underlying connection or sender has been closed.
    */
   createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch>;
+
+  /**
+   * Opens the AMQP link to Azure Service Bus from the sender.
+   *
+   * It is not necessary to call this method in order to use the sender. It is
+   * recommended to call this before your first send() or sendBatch() call if you
+   * want to front load the work of setting up the AMQP link to the service.
+   *
+   * @param options - Options bag to pass an abort signal.
+   */
+  open(options?: OpenOptions): Promise<void>;
 
   /**
    * @property Returns `true` if either the sender or the client that created it has been closed
@@ -402,7 +413,7 @@ export class SenderImpl implements Sender {
     return retry<void>(config);
   }
 
-  async open(options?: CreateSenderOptions): Promise<void> {
+  async open(options?: OpenOptions): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
 
     const config: RetryConfig<void> = {

--- a/sdk/servicebus/service-bus/src/serviceBusClient.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusClient.ts
@@ -11,7 +11,7 @@ import {
 import { ConnectionContext } from "./connectionContext";
 import { ClientEntityContext } from "./clientEntityContext";
 import { Sender, SenderImpl } from "./sender";
-import { CreateSenderOptions, CreateSessionReceiverOptions } from "./models";
+import { CreateSessionReceiverOptions } from "./models";
 import { Receiver, ReceiverImpl } from "./receivers/receiver";
 import { SessionReceiver, SessionReceiverImpl } from "./receivers/sessionReceiver";
 import { ReceivedMessage, ReceivedMessageWithLock } from "./serviceBusMessage";
@@ -310,17 +310,14 @@ export class ServiceBusClient {
    * Creates a Sender which can be used to send messages, schedule messages to be
    * sent at a later time and cancel such scheduled messages.
    * @param queueOrTopicName The name of a queue or topic to send messages to.
-   * @param options Options for creating a sender.
    */
-  async createSender(queueOrTopicName: string, options?: CreateSenderOptions): Promise<Sender> {
+  createSender(queueOrTopicName: string): Sender {
     const clientEntityContext = ClientEntityContext.create(
       queueOrTopicName,
       this._connectionContext,
       `${queueOrTopicName}/${generate_uuid()}`
     );
-    const sender = new SenderImpl(clientEntityContext, this._clientOptions.retryOptions);
-    await sender.open(options);
-    return sender;
+    return new SenderImpl(clientEntityContext, this._clientOptions.retryOptions);
   }
 
   // /**

--- a/sdk/servicebus/service-bus/test/backupMessageSettlement.spec.ts
+++ b/sdk/servicebus/service-bus/test/backupMessageSettlement.spec.ts
@@ -39,7 +39,7 @@ describe("Backup message settlement - Through ManagementLink", () => {
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     deadLetterReceiver = serviceBusClient.test.createDeadLetterReceiver(entityNames);

--- a/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/batchReceiver.spec.ts
@@ -44,7 +44,7 @@ describe("batchReceiver", () => {
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     deadLetterReceiver = serviceBusClient.test.createDeadLetterReceiver(entityNames);
@@ -1033,7 +1033,7 @@ describe("Batching - disconnects", function(): void {
     }
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
@@ -14,7 +14,6 @@ import { TestClientType } from "./utils/testUtils";
 import { SenderImpl } from "../src/sender";
 import { AbortController } from "@azure/abort-controller";
 
-const should = chai.should();
 chai.use(chaiAsPromised);
 
 describe("controlled connection initialization", () => {
@@ -47,12 +46,9 @@ describe("controlled connection initialization", () => {
     await serviceBusClient.test.after();
   });
 
-  it("createSender() is no longer lazy", async () => {
-    assert.isTrue(sender["_context"].sender?.isOpen());
-    await checkThatInitializationDoesntReoccur(sender);
-  });
-
   it("open() early exits if the connection is already open (avoid taking unnecessary lock)", async () => {
+    await sender.open();
+
     // open uses a lock (at the sender level) that helps us not to have overlapping open() calls.
     await defaultLock.acquire(sender["_context"]!.sender!["openLock"], async () => {
       // the connection is _already_ open so it doesn't attempt to take a lock
@@ -125,42 +121,4 @@ describe("controlled connection initialization", () => {
 function delayThatReturns999(): Promise<void> | Promise<number> {
   const ac = new AbortController();
   return delay(1000, ac.signal, "ignored", 999);
-}
-
-/**
- * Checks that calling open() on the sender at this point doesn't reopen it
- * NOTE: this does change the underlying sender so you won't be able to use it
- * again afterwards.
- */
-async function checkThatInitializationDoesntReoccur(sender: SenderImpl) {
-  // make sure the private details haven't shifted out from underneath me.
-  should.exist(sender["_context"].sender!["_negotiateClaim"]);
-  assert.isTrue(sender["_context"].sender!["isOpen"](), "The connection is actually open()");
-
-  // stub out the `MessageSender` methods that handle initializing the
-  // connection - now that everything is up we should always see that it
-  // takes the "early exit" path when it sees that the connection is open
-  let negotiateClaimWasCalled = false;
-
-  // now we'll just fake the rest
-  let isOpenWasCalled = false;
-
-  sender["_context"].sender!["isOpen"] = () => {
-    isOpenWasCalled = true;
-    return true;
-  };
-
-  sender["_context"].sender!["_negotiateClaim"] = async () => {
-    negotiateClaimWasCalled = true;
-  };
-
-  await sender.send({
-    body: "sending another message just to prove the connection checks work"
-  });
-
-  assert.isTrue(isOpenWasCalled, "we should have checked that the connection was open");
-  assert.isFalse(
-    negotiateClaimWasCalled,
-    "we should NOT have tried to _negotiateClaim since the connection was open"
-  );
 }

--- a/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
+++ b/sdk/servicebus/service-bus/test/connectionManagement.spec.ts
@@ -37,7 +37,7 @@ describe("controlled connection initialization", () => {
 
     // casting because I need access to 'open' and the return type of createSender() is an
     // interface.
-    sender = (await serviceBusClient.createSender(queue!)) as SenderImpl;
+    sender = serviceBusClient.createSender(queue!) as SenderImpl;
     senderEntityPath = queue!;
   });
 

--- a/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
+++ b/sdk/servicebus/service-bus/test/deferredMessage.spec.ts
@@ -32,7 +32,7 @@ describe("deferred messages", () => {
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     deadLetterReceiver = serviceBusClient.test.createDeadLetterReceiver(entityNames);

--- a/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
+++ b/sdk/servicebus/service-bus/test/invalidParameters.spec.ts
@@ -309,7 +309,7 @@ describe("invalid parameters", () => {
       );
 
       sender = serviceBusClient.test.addToCleanup(
-        await serviceBusClient.createSender(entityNames.queue!)
+        serviceBusClient.createSender(entityNames.queue!)
       );
 
       receiver = await serviceBusClient.test.getSessionPeekLockReceiver(entityNames, {
@@ -526,7 +526,7 @@ describe("invalid parameters", () => {
       );
 
       sender = serviceBusClient.test.addToCleanup(
-        await serviceBusClient.createSender(entityNames.queue!)
+        serviceBusClient.createSender(entityNames.queue!)
       );
 
       receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
@@ -668,7 +668,7 @@ describe("invalid parameters", () => {
       );
 
       // const clients = await getSenderReceiverClients(TestClientType.PartitionedQueue, "peekLock");
-      sender = serviceBusClient.test.addToCleanup(await serviceBusClient.createSender(queue!));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(queue!));
     });
 
     after(() => {

--- a/sdk/servicebus/service-bus/test/managementClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/managementClient.spec.ts
@@ -20,7 +20,7 @@ describe("ManagementClient - disconnects", function(): void {
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
   before(() => {

--- a/sdk/servicebus/service-bus/test/perf/rhea-promise/send.ts
+++ b/sdk/servicebus/service-bus/test/perf/rhea-promise/send.ts
@@ -71,7 +71,7 @@ async function RunTest(
   } as ConnectionOptions);
   await connection.open();
 
-  const sender = await connection.createSender({
+  const sender = connection.createSender({
     name: "sender-1",
     target: {
       address: entityPath

--- a/sdk/servicebus/service-bus/test/propsToModify.spec.ts
+++ b/sdk/servicebus/service-bus/test/propsToModify.spec.ts
@@ -31,7 +31,7 @@ describe("dead lettering", () => {
 
     // send a test message with the body being the title of the test (for something unique)
     const sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue)
+      serviceBusClient.createSender(entityNames.queue)
     );
 
     await sender.send({
@@ -181,7 +181,7 @@ describe("abandoning", () => {
 
     // send a test message with the body being the title of the test (for something unique)
     const sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue)
+      serviceBusClient.createSender(entityNames.queue)
     );
 
     await sender.send({
@@ -302,7 +302,7 @@ describe("deferring", () => {
 
     // send a test message with the body being the title of the test (for something unique)
     const sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue)
+      serviceBusClient.createSender(entityNames.queue)
     );
 
     await sender.send({

--- a/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
+++ b/sdk/servicebus/service-bus/test/receiveAndDeleteMode.spec.ts
@@ -42,7 +42,7 @@ describe("receive and delete", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
     if (receiveMode === "peekLock") {
       receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);

--- a/sdk/servicebus/service-bus/test/renewLock.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLock.spec.ts
@@ -30,7 +30,7 @@ describe("renew lock", () => {
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/renewLockSessions.spec.ts
@@ -35,7 +35,7 @@ describe("renew lock sessions", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     sessionId = Date.now().toString();

--- a/sdk/servicebus/service-bus/test/retries.spec.ts
+++ b/sdk/servicebus/service-bus/test/retries.spec.ts
@@ -41,7 +41,7 @@ describe("Retries - ManagementClient", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
     // subscriptionRuleManager = serviceBusClient.test.addToCleanup(
@@ -252,7 +252,7 @@ describe("Retries - MessageSender", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 
@@ -453,7 +453,7 @@ describe("Retries - onDetached", () => {
     const entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
   }

--- a/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendAndSchedule.spec.ts
@@ -36,7 +36,7 @@ describe("send scheduled messages", () => {
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/sendBatch.spec.ts
+++ b/sdk/servicebus/service-bus/test/sendBatch.spec.ts
@@ -33,7 +33,7 @@ describe("Send Batch", () => {
     entityNames = await serviceBusClient.test.createTestEntities(entityType);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
+++ b/sdk/servicebus/service-bus/test/serviceBusClient.spec.ts
@@ -63,7 +63,7 @@ describe("Random scheme in the endpoint from connection string", function(): voi
     sbClientWithRelaxedEndPoint = new ServiceBusClient(
       getEnvVars().SERVICEBUS_CONNECTION_STRING.replace("sb://", "CheeseBurger://")
     );
-    sender = await sbClientWithRelaxedEndPoint.createSender(entities.queue!);
+    sender = sbClientWithRelaxedEndPoint.createSender(entities.queue!);
     receiver = !entities.usesSessions
       ? sbClientWithRelaxedEndPoint.createReceiver(entities.queue!, "peekLock")
       : await sbClientWithRelaxedEndPoint.createSessionReceiver(entities.queue!, "peekLock", {
@@ -142,19 +142,6 @@ describe("Errors with non existing Namespace", function(): void {
     }
   };
 
-  it("throws error when create a sender for a non existing namespace", async function(): Promise<
-    void
-  > {
-    try {
-      await sbClient.createSender("some-queue");
-      should.fail("Should have thrown");
-    } catch (err) {
-      testError(err);
-    }
-
-    should.equal(errorWasThrown, true, "Error thrown flag must be true");
-  });
-
   it("throws error when receiving batch data to a non existing namespace", async function(): Promise<
     void
   > {
@@ -216,12 +203,6 @@ describe("Errors with non existing Queue/Topic/Subscription", async function(): 
       errorWasThrown = true;
     }
   };
-
-  it("throws error when opening a sender to a non-existent queue", async function(): Promise<void> {
-    await sbClient.createSender("some-name").catch((err) => testError(err, "some-name"));
-
-    should.equal(errorWasThrown, true, "Error thrown flag must be true");
-  });
 
   it("throws error when receiving batch data from a non existing queue", async function(): Promise<
     void
@@ -301,7 +282,7 @@ describe("Test ServiceBusClient creation", function(): void {
   const serviceBusEndpoint = (env.SERVICEBUS_CONNECTION_STRING.match(
     "Endpoint=sb://((.*).servicebus.windows.net)"
   ) || "")[1];
-  
+
   // `keytar` being used in `@azure/identity` is causing the build to fail when imported for the tests.
   // /**
   //  * Utility to create EnvironmentCredential using `@azure/identity`
@@ -409,7 +390,7 @@ describe("Errors after close()", function(): void {
     entityName = await sbClient.test.createTestEntities(entityType);
 
     sender = sbClient.test.addToCleanup(
-      await sbClient.createSender(entityName.queue ?? entityName.topic!)
+      sbClient.createSender(entityName.queue ?? entityName.topic!)
     );
     receiver = await sbClient.test.getPeekLockReceiver(entityName);
 
@@ -556,7 +537,7 @@ describe("Errors after close()", function(): void {
   async function testCreateSender(expectedErrorMsg: string): Promise<void> {
     let errorNewSender: string = "";
     try {
-      await sbClient.createSender(entityName.queue ?? entityName.topic!);
+      sbClient.createSender(entityName.queue ?? entityName.topic!);
     } catch (err) {
       errorNewSender = err.message;
     }
@@ -808,7 +789,7 @@ describe("entityPath on sender and receiver", async () => {
   });
   it("UnpartitionedQueue", async () => {
     const entityName = await sbClient.test.createTestEntities(TestClientType.UnpartitionedQueue);
-    const sender = sbClient.test.addToCleanup(await sbClient.createSender(entityName.queue!));
+    const sender = sbClient.test.addToCleanup(sbClient.createSender(entityName.queue!));
     const receiver = sbClient.test.addToCleanup(
       sbClient.createReceiver(entityName.queue!, "receiveAndDelete")
     );
@@ -832,7 +813,7 @@ describe("entityPath on sender and receiver", async () => {
     const entityName = await sbClient.test.createTestEntities(
       TestClientType.PartitionedSubscriptionWithSessions
     );
-    const sender = sbClient.test.addToCleanup(await sbClient.createSender(entityName.topic!));
+    const sender = sbClient.test.addToCleanup(sbClient.createSender(entityName.topic!));
     const receiver = sbClient.test.addToCleanup(
       await sbClient.createSessionReceiver(
         entityName.topic!,

--- a/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsRequiredCleanEntityTests.spec.ts
@@ -29,7 +29,7 @@ describe("sessions tests -  requires completely clean entity for each test", () 
     const entityNames = await serviceBusClient.test.createTestEntities(testClientType);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     // Observation -

--- a/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
+++ b/sdk/servicebus/service-bus/test/sessionsTests.spec.ts
@@ -42,7 +42,7 @@ describe("session tests", () => {
     });
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     // Observation -
@@ -405,7 +405,7 @@ describe.skip("SessionReceiver - disconnects", function(): void {
       sessionId: testMessage.sessionId,
       autoRenewLockDurationInMs: 10000 // Lower this value so that test can complete in time.
     });
-    const sender = await serviceBusClient.createSender(entityName.queue!);
+    const sender = serviceBusClient.createSender(entityName.queue!);
     // Send a message so we can be sure when the receiver is open and active.
     await sender.send(testMessage);
     const receivedErrors: any[] = [];

--- a/sdk/servicebus/service-bus/test/smoketest.spec.ts
+++ b/sdk/servicebus/service-bus/test/smoketest.spec.ts
@@ -35,7 +35,7 @@ describe("Sample scenarios for track 2", () => {
     });
 
     beforeEach(async () => {
-      sender = serviceBusClient.test.addToCleanup(await serviceBusClient.createSender(queueName));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(queueName));
     });
 
     afterEach(async () => {
@@ -192,7 +192,7 @@ describe("Sample scenarios for track 2", () => {
     });
 
     beforeEach(async () => {
-      sender = serviceBusClient.test.addToCleanup(await serviceBusClient.createSender(topic));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(topic));
     });
 
     afterEach(async () => {
@@ -332,7 +332,7 @@ describe("Sample scenarios for track 2", () => {
         TestClientType.UnpartitionedQueueWithSessions
       );
       queue = entities.queue!;
-      sender = serviceBusClient.test.addToCleanup(await serviceBusClient.createSender(queue));
+      sender = serviceBusClient.test.addToCleanup(serviceBusClient.createSender(queue));
     });
 
     it("Queue, next unlocked session, sessions", async () => {

--- a/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiver.spec.ts
@@ -67,7 +67,7 @@ describe("Streaming", () => {
       receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
     }
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     deadLetterReceiver = serviceBusClient.test.createDeadLetterReceiver(entityNames);
@@ -1144,7 +1144,7 @@ describe("Streaming - onDetached", function(): void {
       receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
     }
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     errorWasThrown = false;
@@ -1324,7 +1324,7 @@ describe("Streaming - disconnects", function(): void {
     const entityNames = await serviceBusClient.test.createTestEntities(testClientType);
     receiver = await serviceBusClient.test.getPeekLockReceiver(entityNames);
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
   }
 

--- a/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
+++ b/sdk/servicebus/service-bus/test/streamingReceiverSessions.spec.ts
@@ -52,7 +52,7 @@ describe("Streaming with sessions", () => {
     const entityNames = await createReceiverForTests(testClientType, receiveMode);
 
     sender = serviceBusClient.test.addToCleanup(
-      await serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
+      serviceBusClient.createSender(entityNames.queue ?? entityNames.topic!)
     );
 
     deadLetterReceiver = serviceBusClient.test.createDeadLetterReceiver(entityNames);

--- a/sdk/servicebus/service-bus/test/topicFilters.spec.ts
+++ b/sdk/servicebus/service-bus/test/topicFilters.spec.ts
@@ -47,7 +47,7 @@
 
 //     subscriptionClient = await serviceBusClient.test.getPeekLockReceiver(entityNames);
 //     topicClient = serviceBusClient.test.addToCleanup(
-//       await serviceBusClient.createSender(entityNames.topic!)
+//       serviceBusClient.createSender(entityNames.topic!)
 //     );
 
 //     subscriptionRuleManager = subscriptionRuleManager = serviceBusClient.test.addToCleanup(


### PR DESCRIPTION
This PR reverts the change we made to make createSender() an async method.

Originally the plan was to change all the create*() methods on ServiceBusClient to be async, forcing the connection and link to be fully initialized before the Sender or Receiver was returned to the caller.

For session receivers this step was necessary to provide the user a guarantee that if they had a SessionReceiver that it would be usable since we'd have already done the work of acquiring the session lock (named session) or were able to acquire an available session (ie, user did not specify a session id).

We've decided to go a different route for the Sender and expose an .open() method (basically what we did in track 1). The benefit to the user is that they can now choose between lazy initialization (do not explicitly call open()) and non-lazy initialization (call open()).