### PR TITLE
[ai-text-analytics] Removed an errant code fence in the TA readme

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -371,8 +371,6 @@ export AZURE_LOG_LEVEL=verbose
 
 For more detailed instructions on how to enable logs, you can look at the [@azure/logger package docs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/logger).
 
-```
-
 ## Next steps
 
 Please take a look at the


### PR DESCRIPTION
This was left in and caused our README to break near the bottom.