### PR TITLE
[core-http] Remove unused dev dependency "ts-loader"

### DIFF
--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -196,7 +196,6 @@
     "rollup-plugin-visualizer": "^3.1.1",
     "shx": "^0.3.2",
     "sinon": "^9.0.2",
-    "ts-loader": "^6.0.4",
     "ts-node": "^8.3.0",
     "typescript": "~3.9.3",
     "uglify-js": "^3.4.9",


### PR DESCRIPTION
Dev dependency `ts-loader` appears to be unused.  The only package which depends on it is `core-http`, and there are no other references to `ts-loader` in `package.json` or the source code.

https://github.com/Azure/azure-sdk-for-js/search?q=ts-loader&unscoped_q=ts-loader