### PR TITLE
[cosmos] Update dev dependency "typedoc"

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1256,12 +1256,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
-  /backbone/1.4.0:
-    dependencies:
-      underscore: 1.10.2
-    dev: false
-    resolution:
-      integrity: sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
   /backo2/1.0.2:
     dev: false
     resolution:
@@ -3271,10 +3265,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
-  /highlight.js/9.18.1:
+  /highlight.js/10.0.3:
     dev: false
     resolution:
-      integrity: sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+      integrity: sha512-9FG7SSzv9yOY5CGGxfI6NDm7xLYtMOjKtPBxw7Zff3t5UcRcUNTGEeS8lNjhceL34KeetLMoGMFTGoaa83HwyQ==
   /homedir-polyfill/1.0.3:
     dependencies:
       parse-passwd: 1.0.0
@@ -3857,10 +3851,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-o6vicYryQaKykE+EpiWXDzia4yo=
-  /jquery/3.5.1:
-    dev: false
-    resolution:
-      integrity: sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
   /js-tokens/4.0.0:
     dev: false
     resolution:
@@ -4434,13 +4424,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
-  /marked/0.8.2:
+  /marked/1.0.0:
     dev: false
     engines:
       node: '>= 8.16.2'
     hasBin: true
     resolution:
-      integrity: sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
+      integrity: sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
   /matched/1.0.2:
     dependencies:
       arr-union: 3.1.0
@@ -6963,36 +6953,35 @@ packages:
     dev: false
     resolution:
       integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-  /typedoc-default-themes/0.6.3:
+  /typedoc-default-themes/0.10.1:
     dependencies:
-      backbone: 1.4.0
-      jquery: 3.5.1
       lunr: 2.3.8
-      underscore: 1.10.2
     dev: false
     engines:
       node: '>= 8'
     resolution:
-      integrity: sha512-rouf0TcIA4M2nOQFfC7Zp4NEwoYiEX4vX/ZtudJWU9IHA29MPC+PPgSXYLPESkUo7FuB//GxigO3mk9Qe1xp3Q==
-  /typedoc/0.15.8:
+      integrity: sha512-SuqAQI0CkwhqSJ2kaVTgl37cWs733uy9UGUqwtcds8pkFK8oRF4rZmCq+FXTGIb9hIUOu40rf5Kojg0Ha6akeg==
+  /typedoc/0.17.7_typescript@3.9.3:
     dependencies:
-      '@types/minimatch': 3.0.3
       fs-extra: 8.1.0
       handlebars: 4.7.6
-      highlight.js: 9.18.1
+      highlight.js: 10.0.3
       lodash: 4.17.15
-      marked: 0.8.2
+      lunr: 2.3.8
+      marked: 1.0.0
       minimatch: 3.0.4
       progress: 2.0.3
       shelljs: 0.8.4
-      typedoc-default-themes: 0.6.3
-      typescript: 3.7.5
+      typedoc-default-themes: 0.10.1
+      typescript: 3.9.3
     dev: false
     engines:
-      node: '>= 6.0.0'
+      node: '>= 8.0.0'
     hasBin: true
+    peerDependencies:
+      typescript: '>=3.8.3'
     resolution:
-      integrity: sha512-a0zypcvfIFsS7Gqpf2MkC1+jNND3K1Om38pbDdy/gYWX01NuJZhC5+O0HkIp0oRIZOo7PWrA5+fC24zkANY28Q==
+      integrity: sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==
   /typescript/3.7.5:
     dev: false
     engines:
@@ -7936,7 +7925,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-HD7wTCJGKbLGCja6W3H/FS1Av/nGt35Bd8CRE7zXPwtsHJV0WJeYzc9VCNcBAfoTMV7aA4QC60KJdQk7ktRKrQ==
+      integrity: sha512-Aavb1OtBbj8OIGbhBBJjPIrb5jnfDrUUDpvd+Ojj2rOlgnNaFbaCuQI6ydOK5GTmn1WNmoEf9lYyFRSrNJNHDw==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-https.tgz':
@@ -8157,13 +8146,13 @@ packages:
       tslib: 1.13.0
       tslint: 5.20.1_typescript@3.9.3
       tslint-config-prettier: 1.18.0
-      typedoc: 0.15.8
+      typedoc: 0.17.7_typescript@3.9.3
       typescript: 3.9.3
       uuid: 8.1.0
     dev: false
     name: '@rush-temp/cosmos'
     resolution:
-      integrity: sha512-Zo1Qoju2wFzOL9yDQ8T3hDUlYSiO4M53jPKMmZtZu2czMBgpudw+MYx3D7D8Qtd/wAcQXuNmqDy9u/HoftBr5w==
+      integrity: sha512-6aw+44dTWJbSiuGWHPkFVfp1+8YEQaS3INsauBifdI+6xSxhvhDY2sICnYxIoiZSXQIu9UrOrkSiqel4f1a8Zw==
       tarball: 'file:projects/cosmos.tgz'
     version: 0.0.0
   'file:projects/eslint-plugin-azure-sdk.tgz':
@@ -8274,7 +8263,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-xbTUoiBl0HEj7vWxBV3xPQQqa22nagQobiVAKQUYVrtI/hreADQtCZYsyivcXYVooJaCOXnnLofTbFIYQAIMlA==
+      integrity: sha512-QI2JHGXrGYaynRz7GFX0V0tRSZgeJSgoP6tNtTwBXO+dY5bdo4eyKuuf3HDWiMPADgyZH7a+xvLsJJlQb1CE3w==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -8839,7 +8828,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-bXMcdF+Bu/7/oHstS0Ppx0tAby8qfZmemqeboHF66xc23mSRDZ6OQC5zyN6FQSzLeTKK1ItWxsl7iWTukpH8XA==
+      integrity: sha512-W48NAAVhOpKsh4KcHtdPXs4dtS7NBjc2XmwBxHGObQU1dsbQ6ld7z4u3YAwd2Eb95LMbkcDa93bh7lw2LfpLEg==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':

--- a/sdk/cosmosdb/cosmos/package.json
+++ b/sdk/cosmosdb/cosmos/package.json
@@ -134,7 +134,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.0.0",
     "tslint-config-prettier": "^1.14.0",
-    "typedoc": "^0.15.0",
+    "typedoc": "^0.17.7",
     "typescript": "~3.9.3"
   }
 }


### PR DESCRIPTION
Script `npm run docs` completes without error, but I'm not sure if the doc content needs to be verified as well.

```
D:\Git\js-mh\sdk\cosmosdb\cosmos>npm run docs

> @azure/cosmos@3.7.0 docs D:\Git\js-mh\sdk\cosmosdb\cosmos
> typedoc --excludePrivate --mode file --out ./dist/docs ./src


Using TypeScript 3.9.3 from D:\Git\js-mh\common\temp\node_modules\.pnpm\registry.npmjs.org\typescript\3.9.3\node_modules\typescript\lib
Rendering [========================================] 100%

Documentation generated at D:\Git\js-mh\sdk\cosmosdb\cosmos\dist\docs
```

Also, this is the only package in the repo which has a dev dependency on `typedoc`.  Docs for other packages are generated via a dedicated pipeline and tool which depends on `typedoc`:

https://github.com/Azure/azure-sdk-for-js/tree/de8499ebef11d32836dc652bd1ef6e71323d1bc8/eng/tools/generate-doc
https://github.com/Azure/azure-sdk-for-js/blob/de8499ebef11d32836dc652bd1ef6e71323d1bc8/eng/pipelines/docs.yml

Does `cosmos` use this doc pipeline yet?  If so, maybe the `typedoc` dev dependency could be removed?

CC: @KarishmaGhiya, @willmtemple 