### PR TITLE
Update dev dependency "puppeteer"

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -641,10 +641,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-JN8OVL/wiDlCWTPzplsgMPu0uE9Q6blwp68rYsfk2G8aokRUQ8XD9MEhZwihfAiQvoyE+m31m6i3GFXwYWomKQ==
-  /@types/mime-types/2.1.0:
-    dev: false
-    resolution:
-      integrity: sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
   /@types/mime/2.0.2:
     dev: false
     resolution:
@@ -785,6 +781,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
+  /@types/yauzl/2.9.1:
+    dependencies:
+      '@types/node': 14.0.4
+    dev: false
+    optional: true
+    resolution:
+      integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
   /@typescript-eslint/eslint-plugin-tslint/2.34.0_a41b4b021727de5dc0e615e83abafe21:
     dependencies:
       '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.3
@@ -1724,17 +1727,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
-  /concat-stream/1.6.2:
-    dependencies:
-      buffer-from: 1.1.1
-      inherits: 2.0.4
-      readable-stream: 2.3.7
-      typedarray: 0.0.6
-    dev: false
-    engines:
-      '0': node >= 0.8
-    resolution:
-      integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
   /connect/3.7.0:
     dependencies:
       debug: 2.6.9
@@ -2617,16 +2609,19 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
-  /extract-zip/1.7.0:
+  /extract-zip/2.0.1:
     dependencies:
-      concat-stream: 1.6.2
-      debug: 2.6.9
-      mkdirp: 0.5.5
+      debug: 4.1.1
+      get-stream: 5.1.0
       yauzl: 2.10.0
     dev: false
+    engines:
+      node: '>= 10.17.0'
     hasBin: true
+    optionalDependencies:
+      '@types/yauzl': 2.9.1
     resolution:
-      integrity: sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
+      integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
   /extsprintf/1.3.0:
     dev: false
     engines:
@@ -5472,24 +5467,24 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==
-  /puppeteer/2.1.1:
+  /puppeteer/3.3.0:
     dependencies:
-      '@types/mime-types': 2.1.0
       debug: 4.1.1
-      extract-zip: 1.7.0
+      extract-zip: 2.0.1
       https-proxy-agent: 4.0.0
       mime: 2.4.5
-      mime-types: 2.1.27
       progress: 2.0.3
       proxy-from-env: 1.1.0
-      rimraf: 2.7.1
-      ws: 6.2.1
+      rimraf: 3.0.2
+      tar-fs: 2.1.0
+      unbzip2-stream: 1.4.3
+      ws: 7.3.0
     dev: false
     engines:
-      node: '>=8.16.0'
+      node: '>=10.18.1'
     requiresBuild: true
     resolution:
-      integrity: sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==
+      integrity: sha512-23zNqRltZ1PPoK28uRefWJ/zKb5Jhnzbbwbpcna2o5+QMn17F0khq5s1bdH3vPlyj+J36pubccR8wiNA/VE0Vw==
   /qjobs/1.2.0:
     dev: false
     engines:
@@ -6951,10 +6946,6 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
-  /typedarray/0.0.6:
-    dev: false
-    resolution:
-      integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
   /typedoc-default-themes/0.6.3:
     dependencies:
       backbone: 1.4.0
@@ -7019,6 +7010,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+  /unbzip2-stream/1.4.3:
+    dependencies:
+      buffer: 5.6.0
+      through: 2.3.8
+    dev: false
+    resolution:
+      integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==
   /underscore/1.10.2:
     dev: false
     resolution:
@@ -7296,12 +7294,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
-  /ws/6.2.1:
-    dependencies:
-      async-limiter: 1.0.1
-    dev: false
-    resolution:
-      integrity: sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   /ws/7.3.0:
     dev: false
     engines:
@@ -7741,7 +7733,7 @@ packages:
       nyc: 14.1.1
       prettier: 1.19.1
       process: 0.11.10
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       rhea: 1.0.21
       rhea-promise: 1.0.0
       rimraf: 3.0.2
@@ -7760,7 +7752,7 @@ packages:
     dev: false
     name: '@rush-temp/core-amqp'
     resolution:
-      integrity: sha512-t5zZGhW0aN9s2TdikMx7ZIGKkUX/0c4O82um+i7ZyaZzoV/aNN9MRwua7l7dKdXhcRvwmFkgR5aPMlvSi6ctUA==
+      integrity: sha512-vQuyRkXvsxNXFld08NdABYHJ7GykKzizzfXA/PjeGjlzVQGSkdycxTAG8iu/g+/IAw04CWNIvgo0UODO79lOdQ==
       tarball: 'file:projects/core-amqp.tgz'
     version: 0.0.0
   'file:projects/core-arm.tgz':
@@ -7907,7 +7899,7 @@ packages:
       nyc: 14.1.1
       prettier: 1.19.1
       process: 0.11.10
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       regenerator-runtime: 0.13.5
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -7928,7 +7920,7 @@ packages:
     dev: false
     name: '@rush-temp/core-http'
     resolution:
-      integrity: sha512-aqPdnBm1dboZOzV1LYMs5Z72XM3dVaEP2X0YEDcyRGIqOtGhu3qRvQzKM5YCm4ybJ/twn5NGzMz6vjWxhiuUPg==
+      integrity: sha512-B2ZGxHSjobksvIEc9HpR0NPX6fxxUOVIMKcioUy4z8EfgKCS4SCTWkeHgPPXa7fDG4CHitae+VmTzpnD5q/pWQ==
       tarball: 'file:projects/core-http.tgz'
     version: 0.0.0
   'file:projects/core-https.tgz':
@@ -8250,7 +8242,7 @@ packages:
       nyc: 14.1.1
       prettier: 1.19.1
       process: 0.11.10
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       rhea-promise: 1.0.0
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8266,7 +8258,7 @@ packages:
     dev: false
     name: '@rush-temp/event-hubs'
     resolution:
-      integrity: sha512-BqGB+gqJcFIkxyyHngkUl4CiPqP7DLWC4/kDidSyxpfm7j3g9Atq61P5leJZBn/iGsODzUQLLGf/YUCtVWgY5g==
+      integrity: sha512-J7EZ5qh4xzw3vYG95t2MkavJiaq9ViaD2YHAkFDOjjaLuh8MEc+lF3ocZQOcfnTYyh/IPPxHvbugQ4FEyS12sQ==
       tarball: 'file:projects/event-hubs.tgz'
     version: 0.0.0
   'file:projects/event-processor-host.tgz':
@@ -8429,7 +8421,7 @@ packages:
       msal: 1.3.1
       open: 7.0.4
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       qs: 6.9.4
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8443,7 +8435,7 @@ packages:
     dev: false
     name: '@rush-temp/identity'
     resolution:
-      integrity: sha512-2TG4TN3k9e0NXi0bpJSc0MZO+tzq9amaej0VNzczpDvGUy9ElCl6xL1gOljF1LBuKHNHnahcDdznu6GmK8joJA==
+      integrity: sha512-CkIN2Ipd9woAinYzfwgONBGFRPN4H1uANREOcTDT+tcKzT2+OR4jArnbnTX1KDygfPu7mrsGEOcNt/PYhyvGXw==
       tarball: 'file:projects/identity.tgz'
     version: 0.0.0
   'file:projects/keyvault-certificates.tgz':
@@ -8492,7 +8484,7 @@ packages:
       mocha-junit-reporter: 1.23.3_mocha@7.1.2
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       query-string: 5.1.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8509,7 +8501,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-certificates'
     resolution:
-      integrity: sha512-5+XIk7Ad+0FCc2LXbIeiiNEtmzqJFeWr7i8ec9yEg8sluaTIJyaghK5riUJcNHlBJeibewCH1NH0W5TBI0C3Bw==
+      integrity: sha512-Z1PeLBZEpC6G6hzlKont/PQ8OKj0dzr31deJdnOXSN1mebC6JtMo7Pl79Qzl6F+FjAcxSBUAWbHaxW7WTQJN7A==
       tarball: 'file:projects/keyvault-certificates.tgz'
     version: 0.0.0
   'file:projects/keyvault-keys.tgz':
@@ -8558,7 +8550,7 @@ packages:
       mocha-junit-reporter: 1.23.3_mocha@7.1.2
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       query-string: 5.1.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8575,7 +8567,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-keys'
     resolution:
-      integrity: sha512-WHKLo1tnotMnAk2QnZlRrm9Zo1ajG8QkWWluxI02Esv1YrJ+4+/UY6DsGoLVrDPpPDqc8QWbbnrVrK7qW5JJMw==
+      integrity: sha512-Rm8+Z6FjPz3tGtRCyfMzMFwwYbeCSM9P2C/kKDvpSNDXfegvLr4AXnj3XGkUhh8nJT10FGxtpOqX12ZXcbBAPA==
       tarball: 'file:projects/keyvault-keys.tgz'
     version: 0.0.0
   'file:projects/keyvault-secrets.tgz':
@@ -8624,7 +8616,7 @@ packages:
       mocha-junit-reporter: 1.23.3_mocha@7.1.2
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       query-string: 5.1.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8641,7 +8633,7 @@ packages:
     dev: false
     name: '@rush-temp/keyvault-secrets'
     resolution:
-      integrity: sha512-g1WgZjTfUKDURDbNYbJ1sV1e0K7V1yLxejf+9pb4fVYfio0fZJJVa2ttYoEnqFMrxf+ncaiN+HLmX7zvNAKO7Q==
+      integrity: sha512-aUW6Ha5QeBesanZehFAF26ykukKgLITTSfO0KvlsN4H7PUeMqdoXfIKleqZKq5QUTiZUDP72MALnqra9doD1fg==
       tarball: 'file:projects/keyvault-secrets.tgz'
     version: 0.0.0
   'file:projects/logger.tgz':
@@ -8682,7 +8674,7 @@ packages:
       mocha-junit-reporter: 1.23.3_mocha@7.1.2
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
@@ -8694,7 +8686,7 @@ packages:
     dev: false
     name: '@rush-temp/logger'
     resolution:
-      integrity: sha512-rLDi/JSwxD4gokXFFYTlZZaYyTwrZEA2S9D3Ecy54ocKQfZ7Rn8lG8e7yWcSX29n5MejFH4AANgaaqO6Ndq0Gw==
+      integrity: sha512-DeR/cH/+CueWgvrfb5NOhy4FZD6drOOP9/u7zHTT8UHDEOVrPfE3VHbz5ZgXY5HjbMrs46qRmy/UbZ/gQifGGg==
       tarball: 'file:projects/logger.tgz'
     version: 0.0.0
   'file:projects/search-documents.tgz':
@@ -8817,7 +8809,7 @@ packages:
       prettier: 1.19.1
       process: 0.11.10
       promise: 8.1.0
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       rhea-promise: 1.0.0
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8831,7 +8823,7 @@ packages:
     dev: false
     name: '@rush-temp/service-bus'
     resolution:
-      integrity: sha512-ZqmmSt5qWToQkLIVsXuHhjeLLl6+RvZLFSTvXazte1b2El0yXufQlMNw9sUEu7Y4csiqNUYVcj4GTAFxB3qN+Q==
+      integrity: sha512-wvwki9VUk1OBa5vOKDNUtNv48hISwA4O1yQGklLVg3K/WdRmz/a7r4stTezbEKbjTk0mOYSU2hX3HgUSssIisA==
       tarball: 'file:projects/service-bus.tgz'
     version: 0.0.0
   'file:projects/storage-blob.tgz':
@@ -8877,7 +8869,7 @@ packages:
       mocha-junit-reporter: 1.23.3_mocha@7.1.2
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-shim: 1.0.0
@@ -8892,7 +8884,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-blob'
     resolution:
-      integrity: sha512-BU5UqBr82IbGa5oSJBN0SEXo6vLx0VnaoAd7X6UdxIxqpnK5Fswz3PsZ1zb5TpG8vELJTD6ZOyuHTFaFC4kBRQ==
+      integrity: sha512-X5SpvKqUvP2trk070l4e4dFQPQJmfl5dTbJsXHfr2/KWnjsi2h0HwbzrugwGrfcO5z3LntB5cXnkvPYCooLbkQ==
       tarball: 'file:projects/storage-blob.tgz'
     version: 0.0.0
   'file:projects/storage-file-datalake.tgz':
@@ -8945,7 +8937,7 @@ packages:
       nock: 11.9.1
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       query-string: 5.1.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8961,7 +8953,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-datalake'
     resolution:
-      integrity: sha512-EfUW/qtbla6OtMboCAtObOVBdQeknPimvUjJJwz/k+vCVJYW0sMJU/i+orcx/pulYDEjDB/4y9D1wxHwjpOORQ==
+      integrity: sha512-+5A/p1Sz5BnPMXppQ+6CGY6vD+UtG0X93WoPzcmUjX4zlbtPZ1GGut1tEMMqoVtVO6DrbTWAfG1RqcZeQ4NnWw==
       tarball: 'file:projects/storage-file-datalake.tgz'
     version: 0.0.0
   'file:projects/storage-file-share.tgz':
@@ -9007,7 +8999,7 @@ packages:
       mocha-junit-reporter: 1.23.3_mocha@7.1.2
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-shim: 1.0.0
@@ -9022,7 +9014,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-file-share'
     resolution:
-      integrity: sha512-o/3Y+SLF/xdIC7P56dy3vgZ6wsKpNFBfEXVShRXpvJO/I8p/g2fj8Hzpm0NXVYsfPPvIl+bA2aiDS8X8jwlnqw==
+      integrity: sha512-+grl8U9yaRX3UGYxkRfmey6oX4gRB/IiUff3B44r+s0ulNndZDPlBLj9zzDu5e7TEfl9kSZayeDdy4ufKwRFSg==
       tarball: 'file:projects/storage-file-share.tgz'
     version: 0.0.0
   'file:projects/storage-queue.tgz':
@@ -9067,7 +9059,7 @@ packages:
       mocha-junit-reporter: 1.23.3_mocha@7.1.2
       nyc: 14.1.1
       prettier: 1.19.1
-      puppeteer: 2.1.1
+      puppeteer: 3.3.0
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-shim: 1.0.0
@@ -9082,7 +9074,7 @@ packages:
     dev: false
     name: '@rush-temp/storage-queue'
     resolution:
-      integrity: sha512-9/fZzOuxw85XU17N1FGaA6dZzjoDM0PHcf8i7Vd301hPYkHwFDvtEMCtyHFi+BQ5d9kwIWPgKUMxKvtcpc3ITw==
+      integrity: sha512-E6ImWiOuPf5pQGhAIZQazY04aR9GAiR0cFUblCT5s5f346DmloID1VfAsleww7nyzDtj1iRdUaWMzy/rpVYlMw==
       tarball: 'file:projects/storage-queue.tgz'
     version: 0.0.0
   'file:projects/template.tgz':

--- a/sdk/core/core-amqp/package.json
+++ b/sdk/core/core-amqp/package.json
@@ -126,7 +126,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -188,7 +188,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "regenerator-runtime": "^0.13.3",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -107,7 +107,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-sourcemaps": "^0.4.2",

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -144,7 +144,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",

--- a/sdk/identity/identity/package.json
+++ b/sdk/identity/identity/package.json
@@ -122,7 +122,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "open": "^7.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-sourcemaps": "^0.4.2",

--- a/sdk/keyvault/keyvault-certificates/package.json
+++ b/sdk/keyvault/keyvault-certificates/package.json
@@ -139,7 +139,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "query-string": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",

--- a/sdk/keyvault/keyvault-keys/package.json
+++ b/sdk/keyvault/keyvault-keys/package.json
@@ -138,7 +138,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "query-string": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",

--- a/sdk/keyvault/keyvault-secrets/package.json
+++ b/sdk/keyvault/keyvault-secrets/package.json
@@ -141,7 +141,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "query-string": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -152,7 +152,7 @@
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
     "promise": "^8.0.3",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -147,7 +147,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "@rollup/plugin-commonjs": "11.0.2",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -149,7 +149,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "query-string": "^5.0.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -150,7 +150,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -147,7 +147,7 @@
     "mocha-junit-reporter": "^1.18.0",
     "nyc": "^14.0.0",
     "prettier": "^1.16.4",
-    "puppeteer": "^2.0.0",
+    "puppeteer": "^3.3.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.16.3",
     "rollup-plugin-shim": "^1.0.0",


### PR DESCRIPTION
Node 8 is no longer supported, however `puppeteer` is only used for browser testing where we use Node 10 or higher.

https://github.com/puppeteer/puppeteer/releases/tag/v3.0.0
https://github.com/puppeteer/puppeteer/pull/5365