### PR TITLE
[event-hubs] fix flaky disconnect test

### DIFF
--- a/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
+++ b/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
@@ -56,7 +56,7 @@ describe("disconnected", function() {
     it("should receive after a disconnect", async () => {
       client = new EventHubClient(service.connectionString, service.path);
       const receiver = client.createConsumer(EventHubConsumerClient.defaultConsumerGroupName, "0", {
-        sequenceNumber: 0
+        enqueuedOn: Date.now()
       });
       const clientConnectionContext = receiver["_context"];
 
@@ -66,7 +66,7 @@ describe("disconnected", function() {
       // Trigger a disconnect on the underlying connection.
       clientConnectionContext.connection["_connection"].idle();
 
-      await receiver.receiveBatch(1, 1);
+      await receiver.receiveBatch(1, 2);
       const newConnectionId = clientConnectionContext.connectionId;
 
       should.not.equal(originalConnectionId, newConnectionId);


### PR DESCRIPTION
This should guard against either of the two reasons the receiver disconnect test may be flaky:
https://github.com/Azure/azure-sdk-for-js/pull/9343#issuecomment-639891210

1. It sets the event position to the current time rather than the start of the event hub, so it should not receive any messages.
2. The 2nd receiveBatch takes 2 seconds instead of 1 second to run now. We know that rhea's idle method waits 1 second before closing the socket, so this should guard against a race condition where receiveBatch returns before idle completes its work.