### PR TITLE
[Cosmos] Use constants for auth headers returned by generateHeaders function

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Release History
 
-## 3.7.0 (Unreleased)
+## 3.7.0 (2020-6-08)
 
 - BUGFIX: Support crypto functions in Internet Explorer browser
+- BUGFIX: Incorrect key casing in object returned by `setAuthorizationHeader`
 - FEATURE: Adds `readOffer` methods to container and database
 - FEATURE: Allows string value `partitionKey` parameter when creating containers
 

--- a/sdk/cosmosdb/cosmos/src/utils/headers.ts
+++ b/sdk/cosmosdb/cosmos/src/utils/headers.ts
@@ -1,5 +1,5 @@
 import { hmac } from "./hmac";
-import { HTTPMethod, ResourceType } from "../common";
+import { HTTPMethod, ResourceType, Constants } from "../common";
 
 export async function generateHeaders(
   masterKey: string,
@@ -11,8 +11,8 @@ export async function generateHeaders(
   const sig = await signature(masterKey, method, resourceType, resourceId, date);
 
   return {
-    Authorization: sig,
-    "x-ms-date": date.toUTCString()
+    [Constants.HttpHeaders.Authorization]: sig,
+    [Constants.HttpHeaders.XDate]: date.toUTCString()
   };
 }
 


### PR DESCRIPTION
This is causing a downstream portal bug where Firefox is not properly setting the auth header due to the incorrect casing.