### PR TITLE
Incorrect comment in Containers.createIfNotExists()

### DIFF
--- a/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Container/Containers.ts
@@ -172,8 +172,8 @@ export class Containers {
       throw new Error("body parameter must be an object with an id property");
     }
     /*
-      1. Attempt to read the Database (based on an assumption that most databases will already exist, so its faster)
-      2. If it fails with NotFound error, attempt to create the db. Else, return the read results.
+      1. Attempt to read the Container (based on an assumption that most containers will already exist, so its faster)
+      2. If it fails with NotFound error, attempt to create the container. Else, return the read results.
     */
     try {
       const readResponse = await this.database.container(body.id).read(options);


### PR DESCRIPTION
The content of the comment in the method is the same as that described in `Databases.createIfNotExists()`, and it does not match the content of `Containers.createIfNotExists()`, so it was corrected.