### PR TITLE
[core] fix browser mapping

### DIFF
--- a/sdk/core/core-http/CHANGELOG.md
+++ b/sdk/core/core-http/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Release History
 
 ## 1.1.4 (Unreleased)
+
 - Fix issue with flattened model serialization, where constant properties are being dropped [PR#8658](https://github.com/Azure/azure-sdk-for-js/pull/8658)
+
+- Fixed an issue that caused browser bundlers that don't honor `module` mapping
+  to fail to find the package entry point.
 
 ## 1.1.3 (2020-06-03)
 

--- a/sdk/core/core-http/package.json
+++ b/sdk/core/core-http/package.json
@@ -48,6 +48,7 @@
     "LICENSE"
   ],
   "browser": {
+    "./dist/coreHttp.node.js": "./es/src/coreHttp.js",
     "./es/src/policies/msRestUserAgentPolicy.js": "./es/src/policies/msRestUserAgentPolicy.browser.js",
     "./es/src/policies/disableResponseDecompressionPolicy.js": "./es/src/policies/disableResponseDecompressionPolicy.browser.js",
     "./es/src/policies/proxyPolicy.js": "./es/src/policies/proxyPolicy.browser.js",

--- a/sdk/core/logger/CHANGELOG.md
+++ b/sdk/core/logger/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.0.1 (Unreleased)
 
+- Fixed an issue that caused browser bundlers that don't honor `module` mapping
+  to fail to find the package entry point.
+
 ## 1.0.0 (2019-10-29)
 
 This release marks the general availability of the `@azure/logging` package.

--- a/sdk/core/logger/package.json
+++ b/sdk/core/logger/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/src/logger.js",
   "browser": {
+    "./dist/index.js": "./dist-esm/src/logger.js",
     "./dist-esm/src/log.js": "./dist-esm/src/log.browser.js",
     "process": false
   },


### PR DESCRIPTION
This change updates the browser field mappings for `core-http` and `logger`.

In both of these packages, we correctly specify the `main` field for node.js, and the `module` field for bundlers that support it (this helps with tree-shaking).

We also have a `browser` mapping in package.json that generally maps a node.js-specific es2015 js file to a browser-specific es2015 js file.

This all works great as long as the bundler being used supports reading  the `module` field in package.json. For bundlers that only support the `browser` field, we also need to include a mapping from `main` to the browser entry point.

I discovered this while using karma-typescript with the autorest typescript package, since that honors `browser` mappings but not `module`. I suspect there are other bundlers that this might benefit as well.