### PR TITLE
Removing "fs-extra" from the repository

### DIFF
--- a/sdk/test-utils/recorder/package.json
+++ b/sdk/test-utils/recorder/package.json
@@ -65,7 +65,6 @@
   "dependencies": {
     "@azure/core-http": "^1.2.0",
     "@opentelemetry/api": "^0.10.2",
-    "fs-extra": "^8.1.0",
     "nise": "^4.0.3",
     "nock": "^12.0.3",
     "tslib": "^2.0.0",
@@ -78,7 +77,6 @@
     "@rollup/plugin-multi-entry": "^3.0.0",
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@rollup/plugin-replace": "^2.2.0",
-    "@types/fs-extra": "^8.0.0",
     "@types/chai": "^4.1.6",
     "@types/md5": "^2.2.0",
     "@types/mocha": "^7.0.2",

--- a/sdk/test-utils/recorder/src/basekarma.conf.ts
+++ b/sdk/test-utils/recorder/src/basekarma.conf.ts
@@ -1,5 +1,6 @@
 import { isRecordMode } from "./utils";
-import fs from "fs-extra";
+import { createFolderForRecording } from "./utils/recordings";
+import fs from "fs";
 
 // - jsonToFileReporter filters the JSON strings in console.logs.
 // - Console logs with `.writeFile` property are captured and are written to a file(recordings).
@@ -31,7 +32,7 @@ export const jsonRecordingFilterFunction = function(browserRecordingJsonObject: 
       // Create the directories recursively incase they don't exist
       try {
         // Stripping away the filename from the file path and retaining the directory structure
-        fs.ensureDirSync(
+        createFolderForRecording(
           browserRecordingJsonObject.path.substring(
             0,
             browserRecordingJsonObject.path.lastIndexOf("/") + 1

--- a/sdk/test-utils/recorder/src/createRecorder.ts
+++ b/sdk/test-utils/recorder/src/createRecorder.ts
@@ -3,10 +3,10 @@
 
 import { BaseRecorder } from "./baseRecorder";
 import { RecorderEnvironmentSetup, isRecordMode, isPlaybackMode } from "./utils";
-import { nodeRequireRecordingIfExists } from "./utils/recordings";
+import { createFolderForRecording, nodeRequireRecordingIfExists } from "./utils/recordings";
 
 import { config as readEnvFile } from "dotenv";
-import fs from "fs-extra";
+import fs from "fs";
 import { Definition } from "nock";
 
 let nock: typeof import("nock");
@@ -58,7 +58,7 @@ export class NockRecorder extends BaseRecorder {
       // Create the directories recursively incase they don't exist
       try {
         // Stripping away the filename from the filepath and retaining the directory structure
-        fs.ensureDirSync(
+        createFolderForRecording(
           "./recordings/" +
             this.relativeTestRecordingFilePath.substring(
               0,

--- a/sdk/test-utils/recorder/src/utils/index.ts
+++ b/sdk/test-utils/recorder/src/utils/index.ts
@@ -3,7 +3,7 @@
 
 import { URLBuilder } from "@azure/core-http";
 
-export { testHasChanged } from "./recordings";
+export { testHasChanged, createFolderForRecording } from "./recordings";
 
 export { generateTestRecordingFilePath } from "./recordingPath";
 

--- a/sdk/test-utils/recorder/src/utils/index.ts
+++ b/sdk/test-utils/recorder/src/utils/index.ts
@@ -3,7 +3,7 @@
 
 import { URLBuilder } from "@azure/core-http";
 
-export { testHasChanged, createFolderForRecording } from "./recordings";
+export { testHasChanged } from "./recordings";
 
 export { generateTestRecordingFilePath } from "./recordingPath";
 

--- a/sdk/test-utils/recorder/src/utils/recordings.ts
+++ b/sdk/test-utils/recorder/src/utils/recordings.ts
@@ -3,7 +3,7 @@
 
 import { generateTestRecordingFilePath } from "./recordingPath";
 
-import fs from "fs-extra";
+import fs from "fs";
 import path from "path";
 
 /**
@@ -109,4 +109,39 @@ export function testHasChanged(
   }
 
   return previousHash !== currentHash;
+}
+
+/**
+ * ONLY WORKS IN THE NODE.JS ENVIRONMENT
+ *
+ * Meant to be called before saving the recording, this ensures that the folder path exists for the recording to be saved.
+ *
+ * Example for `dirPath` : "./recordings/node/utils/"
+ * @export
+ * @param {string} dirPath
+ */
+export function createFolderForRecording(dirPath: string) {
+  let path = require("path");
+  if (fs.existsSync(dirPath)) {
+    // Nothing to do if the path exists
+    return;
+  } else {
+    try {
+      // Stripping the tailing slash "/"
+      dirPath = dirPath.endsWith("/") ? dirPath.substr(0, dirPath.length - 1) : dirPath;
+
+      // "fs" doesn't let creating folders recursively,
+      // split the path and create folders at each level instead
+      let subDirs = dirPath.split("/");
+      let currentPath = subDirs[0];
+      for (let index = 1; index < subDirs.length; index++) {
+        currentPath = path.resolve(currentPath, subDirs[index]);
+        if (!fs.existsSync(currentPath)) {
+          fs.mkdirSync(currentPath);
+        }
+      }
+    } catch (err) {
+      throw new Error(`Unable to create the folder for recording \n ${err}`);
+    }
+  }
 }

--- a/sdk/test-utils/recorder/test/node/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/node/utils.spec.ts
@@ -3,12 +3,11 @@ import {
   isBrowser,
   testHasChanged,
   isContentTypeInNockFixture,
-  decodeHexEncodingIfExistsInNockFixture,
-  createFolderForRecording
+  decodeHexEncodingIfExistsInNockFixture
 } from "../../src/utils";
 import fs from "fs";
 
-import { nodeRequireRecordingIfExists, findRecordingsFolderPath } from "../../src/utils/recordings";
+import { nodeRequireRecordingIfExists, findRecordingsFolderPath, createFolderForRecording } from "../../src/utils/recordings";
 
 import chai, { expect } from "chai";
 

--- a/sdk/test-utils/recorder/test/node/utils.spec.ts
+++ b/sdk/test-utils/recorder/test/node/utils.spec.ts
@@ -3,8 +3,10 @@ import {
   isBrowser,
   testHasChanged,
   isContentTypeInNockFixture,
-  decodeHexEncodingIfExistsInNockFixture
+  decodeHexEncodingIfExistsInNockFixture,
+  createFolderForRecording
 } from "../../src/utils";
+import fs from "fs";
 
 import { nodeRequireRecordingIfExists, findRecordingsFolderPath } from "../../src/utils/recordings";
 
@@ -392,6 +394,17 @@ describe("NodeJS utils", () => {
           }`
         );
       });
+    });
+  });
+
+  describe("fs helpers", () => {
+    it("should be able to create a folder if doesn't exists", function() {
+      createFolderForRecording("./tmp/temp/temporary");
+      createFolderForRecording("./tmp/temp/temporary2/");
+      fs.rmdirSync("./tmp/temp/temporary");
+      fs.rmdirSync("./tmp/temp/temporary2");
+      fs.rmdirSync("./tmp/temp");
+      fs.rmdirSync("./tmp");
     });
   });
 });


### PR DESCRIPTION
Reference - #9052 

This PR attempts to remove the "fs-extra" library, leverage "fs" instead.

TO DO
- [x] Remove dependency on "fs-extra" for all the SDKs by leveraging "fs"
- [x] Alternate helper methods wherever required
   - [x] Add tests
- [x] Make sure "saving the recording files" works properly for both node and browser
  - [x] Windows
  - [ ] Linux
- [ ] Both the commands should work
  - [ ] integration-test command
  - [x] unit-test command