### PR TITLE
[ai-text-analytics] add caveat note about TS 3.1

### DIFF
--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -147,7 +147,7 @@ const results = await client.analyzeSentiment(documents);
 const onlySuccessful = results.filter((result) => result.error === undefined);
 ```
 
-**Note**: TypeScript users can benefit from better type-checking of result and error objects if `compilerOptions.strictNullChecks` is set to `true` in their `tsconfig.json` configuration. For example:
+**Note**: TypeScript users can benefit from better type-checking of result and error objects if `compilerOptions.strictNullChecks` is set to `true` in the `tsconfig.json` configuration. For example:
 
 ```typescript
 const [result] = await client.analyzeSentiment(["Hello world!"]);
@@ -158,6 +158,16 @@ if (result.error !== undefined) {
   // the tsconfig.json
 
   console.log(result.error);
+}
+```
+
+This feature was introduced in TypeScript 3.2, so users of TypeScript 3.1 **must** cast result values to their corresponding success variant as follows:
+
+```typescript
+const [result] = await client.detectLanguage(["Hello world!"]);
+
+if (result.error === undefined) {
+  const { primaryLanguage } = result as DetectLanguageSuccessResult;
 }
 ```
 

--- a/sdk/textanalytics/ai-text-analytics/README.md
+++ b/sdk/textanalytics/ai-text-analytics/README.md
@@ -161,7 +161,7 @@ if (result.error !== undefined) {
 }
 ```
 
-This feature was introduced in TypeScript 3.2, so users of TypeScript 3.1 **must** cast result values to their corresponding success variant as follows:
+This capability was introduced in TypeScript 3.2, so users of TypeScript 3.1 must cast result values to their corresponding success variant as follows:
 
 ```typescript
 const [result] = await client.detectLanguage(["Hello world!"]);


### PR DESCRIPTION
The ability to use `undefined` as a union discriminant wasn't added until TS 3.2, so I've added a note to the error-handling docs in the README showing explaining that 3.1 users will have to cast, and showing how to do it.