### PR TITLE
[service-bus] Fixing some issues with the samples

### DIFF
--- a/sdk/servicebus/service-bus/samples/javascript/useProxy.js
+++ b/sdk/servicebus/service-bus/samples/javascript/useProxy.js
@@ -18,6 +18,7 @@ require("dotenv").config();
 
 // Define connection string for your Service Bus instance here
 const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {
   const proxyInfo = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
@@ -36,14 +37,18 @@ async function main() {
       // No need to pass the `WebSocket` from "ws" package if you're in the browser
       // in which case the `window.WebSocket` is used by the library.
       webSocket: WebSocket,
-      webSocketConstructorOptions: { agent: proxyAgent }
-    }
+      webSocketConstructorOptions: { agent: proxyAgent },
+    },
   });
 
-  /*
-     Refer to other samples, and place your code here
-     to create queue clients, and to send/receive messages
-    */
+  const sender = sbClient.createSender(queueName);
+
+  console.log(`Sending message using proxy server ${proxyInfo}`);
+
+  await sender.send({
+    body: "sample message",
+  });
+
   await sbClient.close();
 }
 

--- a/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
@@ -12,7 +12,7 @@
 
 import { ServiceBusClient } from "@azure/service-bus";
 import WebSocket from "ws";
-import HttpsProxyAgent from "https-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
 
 // Load the .env file if it exists
 import * as dotenv from "dotenv";
@@ -20,9 +20,11 @@ dotenv.config();
 
 // Define connection string for your Service Bus instance here
 const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {
   const proxyInfo = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+
   if (!proxyInfo) {
     console.error(
       "Error: Proxy information not provided, but it is required to run this sample. Exiting."
@@ -38,14 +40,18 @@ export async function main() {
       // No need to pass the `WebSocket` from "ws" package if you're in the browser
       // in which case the `window.WebSocket` is used by the library.
       webSocket: WebSocket,
-      webSocketConstructorOptions: { agent: proxyAgent }
-    }
+      webSocketConstructorOptions: { agent: proxyAgent },
+    },
   });
 
-  /*
-   Refer to other samples, and place your code here
-   to create queue clients, and to send/receive messages
-  */
+  const sender = sbClient.createSender(queueName);
+
+  console.log(`Sending message using proxy server ${proxyInfo}`);
+
+  await sender.send({
+    body: "sample message",
+  });
+
   await sbClient.close();
 }
 

--- a/sdk/servicebus/service-bus/samples/typescript/tsconfig.json
+++ b/sdk/servicebus/service-bus/samples/typescript/tsconfig.json
@@ -4,8 +4,8 @@
     "target": "ES2015",
     "moduleResolution": "node",
 
-    "allowSyntheticDefaultImports": true,
-
+    "esModuleInterop": true,
+    "lib": ["ESNext.AsyncIterable"],
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
Fixing some issues with the samples:

- Needed to add in AsyncIterable
- `useProxy.ts` was incorrectly importing ws, causing it to not actually use a proxy.
- `useProxy.ts` wasn't compiling against later versions of https-proxy-agent

Fixes #9371 