### PR TITLE
[Identity] IDENTITY_ENDPOINT and IDENTITY_SECRET support

### DIFF
--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.1.0-preview.4 (Unreleased)
 
+- Added support for the `IDENTITY_ENDPOINT` and `IDENTITY_SECRET` environment variables.
+
 ## 1.1.0-preview.3 (2020-05-05)
 
 - Add ability to read AZURE_AUTHORITY_HOST from environment ([PR #8226](https://github.com/Azure/azure-sdk-for-js/pull/8226) [PR #8343](https://github.com/Azure/azure-sdk-for-js/pull/8343))

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0-preview.4 (Unreleased)
 
-- Added support for the `IDENTITY_ENDPOINT` and `IDENTITY_SECRET` environment variables.
+- Added support for the `IDENTITY_ENDPOINT` and `IDENTITY_SECRET` environment variables on the `ManagedIdentityCredential`.
 
 ## 1.1.0-preview.3 (2020-05-05)
 

--- a/sdk/identity/identity/CHANGELOG.md
+++ b/sdk/identity/identity/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0-preview.4 (Unreleased)
 
-- Added support for the `IDENTITY_ENDPOINT` and `IDENTITY_SECRET` environment variables on the `ManagedIdentityCredential`.
+- Added support for the `IDENTITY_ENDPOINT` and `IDENTITY_SECRET` environment variables when using `ManagedIdentityCredential` on Azure App Service.
 
 ## 1.1.0-preview.3 (2020-05-05)
 

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -120,12 +120,12 @@ export class ManagedIdentityCredential implements TokenCredential {
     }
 
     return {
-      url: process.env.MSI_ENDPOINT || process.env.IDENTITY_ENDPOINT,
+      url: process.env.IDENTITY_ENDPOINT || process.env.MSI_ENDPOINT,
       method: "GET",
       queryParameters,
       headers: {
         Accept: "application/json",
-        secret: process.env.MSI_SECRET || process.env.IDENTITY_SECRET
+        secret: process.env.IDENTITY_SECRET || process.env.MSI_SECRET
       }
     };
   }
@@ -143,7 +143,7 @@ export class ManagedIdentityCredential implements TokenCredential {
     }
 
     return {
-      url: process.env.MSI_ENDPOINT || process.env.IDENTITY_ENDPOINT,
+      url: process.env.IDENTITY_ENDPOINT || process.env.MSI_ENDPOINT,
       method: "POST",
       body: qs.stringify(body),
       headers: {
@@ -231,8 +231,8 @@ export class ManagedIdentityCredential implements TokenCredential {
 
     try {
       // Detect which type of environment we are running in
-      if (process.env.MSI_ENDPOINT || process.env.IDENTITY_ENDPOINT) {
-        if (process.env.MSI_SECRET || process.env.IDENTITY_SECRET) {
+      if (process.env.IDENTITY_ENDPOINT || process.env.MSI_ENDPOINT) {
+        if (process.env.IDENTITY_SECRET || process.env.MSI_SECRET) {
           // Running in App Service
           authRequestOptions = this.createAppServiceMsiAuthRequest(resource, clientId);
           expiresInParser = (requestBody: any) => {

--- a/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
+++ b/sdk/identity/identity/src/credentials/managedIdentityCredential.ts
@@ -120,12 +120,12 @@ export class ManagedIdentityCredential implements TokenCredential {
     }
 
     return {
-      url: process.env.MSI_ENDPOINT,
+      url: process.env.MSI_ENDPOINT || process.env.IDENTITY_ENDPOINT,
       method: "GET",
       queryParameters,
       headers: {
         Accept: "application/json",
-        secret: process.env.MSI_SECRET
+        secret: process.env.MSI_SECRET || process.env.IDENTITY_SECRET
       }
     };
   }
@@ -143,7 +143,7 @@ export class ManagedIdentityCredential implements TokenCredential {
     }
 
     return {
-      url: process.env.MSI_ENDPOINT,
+      url: process.env.MSI_ENDPOINT || process.env.IDENTITY_ENDPOINT,
       method: "POST",
       body: qs.stringify(body),
       headers: {
@@ -231,8 +231,8 @@ export class ManagedIdentityCredential implements TokenCredential {
 
     try {
       // Detect which type of environment we are running in
-      if (process.env.MSI_ENDPOINT) {
-        if (process.env.MSI_SECRET) {
+      if (process.env.MSI_ENDPOINT || process.env.IDENTITY_ENDPOINT) {
+        if (process.env.MSI_SECRET || process.env.IDENTITY_SECRET) {
           // Running in App Service
           authRequestOptions = this.createAppServiceMsiAuthRequest(resource, clientId);
           expiresInParser = (requestBody: any) => {


### PR DESCRIPTION
The latest documentation available by the identity docs show that the Azure resources are moving from `MSI_ENDPOINT` and `MSI_SECRET` to `IDENTITY_ENDPOINT` and `IDENTITY_SECRET`. Here's an example:

https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=javascript#obtain-tokens-for-azure-resources

Fixes #9408