### PR TITLE
[service-bus] Fix formatting of samples

### DIFF
--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -60,7 +60,7 @@
     "execute:ts-samples": "node ../../../common/scripts/run-samples.js samples/typescript/dist/samples/typescript/src/",
     "execute:samples": "echo skipped",
     "extract-api": "tsc -p . && api-extractor run --local",
-    "format": "prettier --write --config ../../.prettierrc.json \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
+    "format": "prettier --write --config ../../.prettierrc.json \"samples/**/*.{ts,js}\" \"src/**/*.ts\" \"test/**/*.ts\" \"*.{js,json}\"",
     "integration-test:browser": "karma start --single-run",
     "integration-test:node": "nyc mocha -r esm --require source-map-support/register --reporter ../../../common/tools/mocha-multi-reporter.js --timeout 120000 --full-trace dist-esm/test/*.spec.js dist-esm/test/**/*.spec.js",
     "integration-test": "npm run integration-test:node && npm run integration-test:browser",

--- a/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
+++ b/sdk/servicebus/service-bus/samples/javascript/advanced/sessionRoundRobin.js
@@ -15,7 +15,7 @@ const { AbortController } = require("@azure/abort-controller");
 dotenv.config();
 
 const serviceBusConnectionString =
-process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
 // NOTE: this sample uses a queue but would also work a session enabled subscription.
 const queueName = process.env.QUEUE_NAME || "<queue name>";

--- a/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
+++ b/sdk/servicebus/service-bus/samples/javascript/browseMessages.js
@@ -19,8 +19,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 require("dotenv").config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 async function main() {
@@ -44,6 +43,6 @@ async function main() {
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesLoop.js
@@ -14,8 +14,7 @@ const { ServiceBusClient } = require("@azure/service-bus");
 // Load the .env file if it exists
 require("dotenv").config();
 // Define connection string and related Service Bus entity names here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 async function main() {
   const sbClient = new ServiceBusClient(connectionString);
@@ -45,6 +44,6 @@ async function main() {
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
+++ b/sdk/servicebus/service-bus/samples/javascript/receiveMessagesStreaming.js
@@ -16,8 +16,7 @@ const { delay, ServiceBusClient } = require("@azure/service-bus");
 // Load the .env file if it exists
 require("dotenv").config();
 // Define connection string and related Service Bus entity names here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 async function main() {
   const sbClient = new ServiceBusClient(connectionString);
@@ -26,12 +25,12 @@ async function main() {
   // - See session.ts for how to receive using sessions.
   const receiver = sbClient.createReceiver(queueName, "peekLock");
 
-  const processMessage = async brokeredMessage => {
+  const processMessage = async (brokeredMessage) => {
     console.log(`Received message: ${brokeredMessage.body}`);
     await brokeredMessage.complete();
   };
 
-  const processError = async err => {
+  const processError = async (err) => {
     console.log("Error occurred: ", err);
   };
 
@@ -55,6 +54,6 @@ async function main() {
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/javascript/useProxy.js
+++ b/sdk/servicebus/service-bus/samples/javascript/useProxy.js
@@ -37,8 +37,8 @@ async function main() {
       // No need to pass the `WebSocket` from "ws" package if you're in the browser
       // in which case the `window.WebSocket` is used by the library.
       webSocket: WebSocket,
-      webSocketConstructorOptions: { agent: proxyAgent },
-    },
+      webSocketConstructorOptions: { agent: proxyAgent }
+    }
   });
 
   const sender = sbClient.createSender(queueName);
@@ -46,7 +46,7 @@ async function main() {
   console.log(`Sending message using proxy server ${proxyInfo}`);
 
   await sender.send({
-    body: "sample message",
+    body: "sample message"
   });
 
   await sbClient.close();

--- a/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
+++ b/sdk/servicebus/service-bus/samples/javascript/usingAadAuth.js
@@ -29,8 +29,7 @@ require("dotenv").config();
 
 // Define Service Bus Endpoint here and related entity names here
 const serviceBusEndpoint =
-  process.env.SERVICE_BUS_ENDPOINT ||
-  "<your-servicebus-namespace>.servicebus.windows.net";
+  process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here
 const clientId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
@@ -47,6 +46,6 @@ async function main() {
   await sbClient.close();
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/advanced/sessionRoundRobin.ts
@@ -21,7 +21,7 @@ import { AbortController } from "@azure/abort-controller";
 dotenv.config();
 
 const serviceBusConnectionString =
-process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 
 // NOTE: this sample uses a queue but would also work a session enabled subscription.
 const queueName = process.env.QUEUE_NAME || "<queue name>";

--- a/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/browseMessages.ts
@@ -21,8 +21,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {
@@ -48,6 +47,6 @@ export async function main() {
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesLoop.ts
@@ -19,8 +19,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {
@@ -52,6 +51,6 @@ export async function main() {
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/receiveMessagesStreaming.ts
@@ -19,8 +19,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // Define connection string and related Service Bus entity names here
-const connectionString =
-  process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
+const connectionString = process.env.SERVICE_BUS_CONNECTION_STRING || "<connection string>";
 const queueName = process.env.QUEUE_NAME || "<queue name>";
 
 export async function main() {
@@ -31,11 +30,11 @@ export async function main() {
   // - See session.ts for how to receive using sessions.
   const receiver = sbClient.createReceiver(queueName, "peekLock");
 
-  const processMessage = async brokeredMessage => {
+  const processMessage = async (brokeredMessage) => {
     console.log(`Received message: ${brokeredMessage.body}`);
     await brokeredMessage.complete();
   };
-  const processError = async err => {
+  const processError = async (err) => {
     console.log("Error occurred: ", err);
   };
 
@@ -59,6 +58,6 @@ export async function main() {
   }
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });

--- a/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/useProxy.ts
@@ -40,8 +40,8 @@ export async function main() {
       // No need to pass the `WebSocket` from "ws" package if you're in the browser
       // in which case the `window.WebSocket` is used by the library.
       webSocket: WebSocket,
-      webSocketConstructorOptions: { agent: proxyAgent },
-    },
+      webSocketConstructorOptions: { agent: proxyAgent }
+    }
   });
 
   const sender = sbClient.createSender(queueName);
@@ -49,7 +49,7 @@ export async function main() {
   console.log(`Sending message using proxy server ${proxyInfo}`);
 
   await sender.send({
-    body: "sample message",
+    body: "sample message"
   });
 
   await sbClient.close();

--- a/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
+++ b/sdk/servicebus/service-bus/samples/typescript/src/usingAadAuth.ts
@@ -31,8 +31,7 @@ dotenv.config();
 
 // Define Service Bus Endpoint here and related entity names here
 const serviceBusEndpoint =
-  process.env.SERVICE_BUS_ENDPOINT ||
-  "<your-servicebus-namespace>.servicebus.windows.net";
+  process.env.SERVICE_BUS_ENDPOINT || "<your-servicebus-namespace>.servicebus.windows.net";
 
 // Define CLIENT_ID, TENANT_ID and SECRET of your AAD application here
 const clientId = process.env.AZURE_TENANT_ID || "<azure tenant id>";
@@ -50,6 +49,6 @@ export async function main() {
   await sbClient.close();
 }
 
-main().catch(err => {
+main().catch((err) => {
   console.log("Error occurred: ", err);
 });


### PR DESCRIPTION
Fixing formatting using the current prettier version and adding the samples to the `format` target for Service Bus.

(This was purely a `npm run format` run)