### PR TITLE
[Event Hubs] Use consumer & producer client in disconnects.spec.ts

### DIFF
--- a/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
+++ b/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
@@ -6,12 +6,10 @@ const should = chai.should();
 import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 import { EnvVarKeys, getEnvVars } from "../utils/testUtils";
-import { EventHubClient } from "../../src/impl/eventHubClient";
-import { EventHubConsumerClient, EventHubProducerClient } from "../../src/index";
+import { EventHubConsumerClient, EventHubProducerClient, Subscription } from "../../src";
 const env = getEnvVars();
 
 describe("disconnected", function() {
-  let client: EventHubClient;
   const service = {
     connectionString: env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
     path: env[EnvVarKeys.EVENTHUB_NAME]
@@ -27,16 +25,10 @@ describe("disconnected", function() {
     );
   });
 
-  afterEach("close the connection", async function(): Promise<void> {
-    if (client) {
-      await client.close();
-    }
-  });
-
-  describe("HubRuntime", function() {
-    it("operations work after disconnect", async () => {
-      client = new EventHubClient(service.connectionString, service.path);
-      const clientConnectionContext = client["_context"];
+  describe("EventHubConsumerClient", function() {
+    it("runtimeInfo work after disconnect", async () => {
+      const client = new EventHubConsumerClient(EventHubConsumerClient.defaultConsumerGroupName, service.connectionString, service.path);
+      const clientConnectionContext = client["_eventHubClient"]["_context"];
 
       await client.getPartitionIds({});
       const originalConnectionId = clientConnectionContext.connectionId;
@@ -49,35 +41,71 @@ describe("disconnected", function() {
 
       should.not.equal(originalConnectionId, newConnectionId);
       partitionIds.length.should.greaterThan(0, "Invalid number of partition ids returned.");
+
+      await client.close();
+    });
+
+    it("should receive after a disconnect", async () => {
+      const client = new EventHubConsumerClient(EventHubConsumerClient.defaultConsumerGroupName, service.connectionString, service.path);
+      const partitionId = "0";
+      const partitionProperties = await client.getPartitionProperties(partitionId);
+      const clientConnectionContext = client["_eventHubClient"]["_context"];
+
+      let subscription: Subscription | undefined;
+      let originalConnectionId: string;
+
+      await new Promise((resolve, reject) => {
+        subscription = client.subscribe(
+          partitionId,
+          {
+            processEvents: async (data) => {
+              should.exist(data);
+              should.equal(data.length, 0);
+              if (!originalConnectionId) {
+                originalConnectionId = clientConnectionContext.connectionId;
+                // Trigger a disconnect on the underlying connection.
+                clientConnectionContext.connection["_connection"].idle();
+              } else {
+                const newConnectionId = clientConnectionContext.connectionId;
+                should.not.equal(originalConnectionId, newConnectionId);
+                resolve();
+              }
+            },
+            processError: async (err) => {
+              reject(err);
+            }
+          },
+          {
+            startPosition: { sequenceNumber: partitionProperties.lastEnqueuedSequenceNumber },
+            maxWaitTimeInSeconds: 2
+          }
+        );
+      });
+      await subscription!.close();
+      await client.close();
     });
   });
 
-  describe("Receiver", function() {
-    it("should receive after a disconnect", async () => {
-      client = new EventHubClient(service.connectionString, service.path);
-      const partitionId = "0";
-      const partitionProperties = await client.getPartitionProperties(partitionId);
-      const receiver = client.createConsumer(EventHubConsumerClient.defaultConsumerGroupName, "0", {
-        sequenceNumber: partitionProperties.lastEnqueuedSequenceNumber
-      });
-      const clientConnectionContext = receiver["_context"];
+  describe("EventHubProducerClient", function() {
+    it("runtimeInfo work after disconnect", async () => {
+      const client = new EventHubProducerClient(service.connectionString, service.path);
+      const clientConnectionContext = client["_client"]["_context"];
 
-      await receiver.receiveBatch(1, 1);
+      await client.getPartitionIds({});
       const originalConnectionId = clientConnectionContext.connectionId;
 
       // Trigger a disconnect on the underlying connection.
       clientConnectionContext.connection["_connection"].idle();
 
-      await receiver.receiveBatch(1, 2);
+      const partitionIds = await client.getPartitionIds({});
       const newConnectionId = clientConnectionContext.connectionId;
 
       should.not.equal(originalConnectionId, newConnectionId);
+      partitionIds.length.should.greaterThan(0, "Invalid number of partition ids returned.");
 
-      await receiver.close();
+      await client.close();
     });
-  });
 
-  describe("Sender", function() {
     it("should send after a disconnect", async () => {
       const client = new EventHubProducerClient(service.connectionString, service.path);
       const clientConnectionContext = client["_client"]["_context"];


### PR DESCRIPTION
This PR updates the tests in disconnects.spec.ts file to use the public `EventHubConsumerClient` and `EventHubProducerClient` instead of the internal `EventHubClient`

This is part of a multiple series of code changes required to 
- have tests depend on public api surface where possible
- reduce internal dependency on `EventHubClient` so that it can be eventually removed altogether