### PR TITLE
[Event Hubs] Update startingFromHere helper to stop using EventHubClient

### DIFF
--- a/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
+++ b/sdk/eventhub/event-hubs/test/eventProcessor.spec.ts
@@ -617,7 +617,7 @@ describe("Event Processor", function(): void {
     const {
       subscriptionEventHandler,
       startPosition
-    } = await SubscriptionHandlerForTests.startingFromHere(client);
+    } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
 
     const processor = new EventProcessor(
       EventHubConsumerClient.defaultConsumerGroupName,
@@ -682,7 +682,7 @@ describe("Event Processor", function(): void {
     const {
       subscriptionEventHandler,
       startPosition
-    } = await SubscriptionHandlerForTests.startingFromHere(client);
+    } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
     const partitionLoadBalancer = new GreedyPartitionLoadBalancer();
 
     const processor = new EventProcessor(
@@ -736,7 +736,7 @@ describe("Event Processor", function(): void {
       const {
         subscriptionEventHandler,
         startPosition
-      } = await SubscriptionHandlerForTests.startingFromHere(client);
+      } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
 
       const processor = new EventProcessor(
         EventHubConsumerClient.defaultConsumerGroupName,
@@ -1443,7 +1443,7 @@ describe("Event Processor", function(): void {
     it("should have lastEnqueuedEventProperties populated when trackLastEnqueuedEventProperties is set to true", async function(): Promise<
       void
     > {
-      const { startPosition } = await SubscriptionHandlerForTests.startingFromHere(client);
+      const { startPosition } = await SubscriptionHandlerForTests.startingFromHere(producerClient);
       const partitionIds = await client.getPartitionIds({});
       for (const partitionId of partitionIds) {
         await producerClient.sendBatch([{ body: `Hello world - ${partitionId}` }], { partitionId });

--- a/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
+++ b/sdk/eventhub/event-hubs/test/utils/subscriptionHandlerForTests.ts
@@ -1,18 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { delay } from "@azure/core-amqp";
+import chai from "chai";
+import {
+  CloseReason,
+  EventHubConsumerClient,
+  EventHubProducerClient,
+  EventPosition,
+  ReceivedEventData
+} from "../../src";
 import {
   PartitionContext,
   SubscriptionEventHandlers
 } from "../../src/eventHubConsumerClientModels";
-import { EventHubConsumerClient } from "../../src/eventHubConsumerClient";
-import { EventHubProducerClient } from "../../src/eventHubProducerClient";
-import { EventHubClient } from "../../src/impl/eventHubClient";
-import { CloseReason, EventPosition, ReceivedEventData } from "../../src";
 import { loggerForTest } from "./logHelpers";
 import { loopUntil } from "./testUtils";
-import { delay } from "@azure/core-amqp";
-import chai from "chai";
 const should = chai.should();
 
 export interface HandlerAndPositions {
@@ -25,7 +28,7 @@ export class SubscriptionHandlerForTests implements Required<SubscriptionEventHa
   private _timeBetweenChecksMs = 1000;
 
   static async startingFromHere(
-    client: EventHubClient | EventHubProducerClient | EventHubConsumerClient
+    client: EventHubProducerClient | EventHubConsumerClient
   ): Promise<HandlerAndPositions> {
     const partitionIds = await client.getPartitionIds({});
     const startPosition: { [partitionId: string]: EventPosition } = {};


### PR DESCRIPTION
This PR updates the `startingFromHere()` helper method to no longer support `EventHubClient`.

This is part of a multiple series of code changes required to 
- have tests depend on public api surface where possible
- reduce internal dependency on `EventHubClient` so that it can be eventually removed altogether