### PR TITLE
[FormRecognizer] fix JavaScript copy model sample

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/copyModel.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/copyModel.js
@@ -11,7 +11,7 @@ const { FormTrainingClient, AzureKeyCredential } = require("@azure/ai-form-recog
 // Load the .env file if it exists
 require("dotenv").config();
 
-export async function main() {
+async function main() {
   // You will need to set these environment variables or edit the following values
   // information about the source Form Recognizer resource
   const endpoint = process.env["FORM_RECOGNIZER_SOURCE_ENDPOINT"] || "<source cognitive services endpoint>";


### PR DESCRIPTION
to remove the TypeScript keyword from copy-n-paste