### PR TITLE
[appconfig] Updating optimisticConcurrencyViaETag to include changes from #9451.

### DIFF
--- a/sdk/appconfiguration/app-configuration/samples/javascript/optimisticConcurrencyViaEtag.js
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/optimisticConcurrencyViaEtag.js
@@ -44,18 +44,14 @@ async function main() {
 
   // Since both of Alpha and Beta will attempt to update at the same time
   // they'll have to coordinate this. This is when they use the etag.
+
   // For our example we'll have Beta update first
-  const betaUpdatedSetting = await client.setConfigurationSetting(
-    {
-      key: key,
-      value: "Beta has updated the value"
-    },
-    {
-      // onlyIfUnchanged allows Beta to say "only update the setting if the _current_ etag matches my etag"
-      // which is true for Beta since nobody has modified it since Beta got it.
-      onlyIfUnchanged: true
-    }
-  );
+  betaSetting.value = "Beta has updated the value";
+  const betaUpdatedSetting = await client.setConfigurationSetting(betaSetting, {
+    // onlyIfUnchanged allows Beta to say "only update the setting if the _current_ etag matches my etag"
+    // which is true for Beta since nobody has modified it since Beta got it.
+    onlyIfUnchanged: true
+  });
 
   console.log(`Beta has updated the setting. The setting's etag is now ${betaUpdatedSetting.etag}`);
 
@@ -66,21 +62,16 @@ async function main() {
   );
 
   try {
-    await client.setConfigurationSetting(
-      {
-        key: key,
-        value: "Alpha is attempting to update the value but will fail"
-      },
-      {
-        // in this case Alpha's etag is out of date - there's no way to update it
-        // without retrieving the setting again. This allows Alpha a chance to
-        // potentially incorporate Beta's update into their own _or_ to just overwrite
-        // it.
-        //
-        // the 'catch' below will now incorporate the update
-        onlyIfUnchanged: true
-      }
-    );
+    alphaSetting.value = "Alpha is attempting to update the value but will fail";
+    await client.setConfigurationSetting(alphaSetting, {
+      // in this case Alpha's etag is out of date - there's no way to update it
+      // without retrieving the setting again. This allows Alpha a chance to
+      // potentially incorporate Beta's update into their own _or_ to just overwrite
+      // it.
+      //
+      // the 'catch' below will now incorporate the update
+      onlyIfUnchanged: true
+    });
   } catch (err) {
     if (err.statusCode === 412) {
       // precondition failed
@@ -105,6 +96,12 @@ async function main() {
   // and now that the dust has settled the value has been updated
   const finalSetting = await client.getConfigurationSetting({ key: key });
   console.log(`Final value with Alpha and Beta's updates: ${finalSetting.value}`);
+
+  if (
+    finalSetting.value !== "Beta has updated the value and Alpha has updated the setting as well"
+  ) {
+    throw new Error("SAMPLE FAILURE: Setting was not properly updated");
+  }
 
   await cleanupSampleValues([key], client);
 }

--- a/sdk/appconfiguration/app-configuration/samples/javascript/package.json
+++ b/sdk/appconfiguration/app-configuration/samples/javascript/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/app-configuration": "next",
+    "@azure/app-configuration": "^1.0.0",
     "dotenv": "^8.2.0"
   },
   "devDependencies": {

--- a/sdk/appconfiguration/app-configuration/samples/typescript/src/optimisticConcurrencyViaEtag.ts
+++ b/sdk/appconfiguration/app-configuration/samples/typescript/src/optimisticConcurrencyViaEtag.ts
@@ -47,15 +47,12 @@ export async function main() {
   // they'll have to coordinate this. This is when they use the etag.
 
   // For our example we'll have Beta update first
-  betaSetting.value = "Beta has updated the value"
-  const betaUpdatedSetting = await client.setConfigurationSetting(
-    betaSetting,
-    {
-      // onlyIfUnchanged allows Beta to say "only update the setting if the _current_ etag matches my etag"
-      // which is true for Beta since nobody has modified it since Beta got it.
-      onlyIfUnchanged: true
-    }
-  );
+  betaSetting.value = "Beta has updated the value";
+  const betaUpdatedSetting = await client.setConfigurationSetting(betaSetting, {
+    // onlyIfUnchanged allows Beta to say "only update the setting if the _current_ etag matches my etag"
+    // which is true for Beta since nobody has modified it since Beta got it.
+    onlyIfUnchanged: true
+  });
 
   console.log(`Beta has updated the setting. The setting's etag is now ${betaUpdatedSetting.etag}`);
 
@@ -67,18 +64,15 @@ export async function main() {
 
   try {
     alphaSetting.value = "Alpha is attempting to update the value but will fail";
-    await client.setConfigurationSetting(
-      alphaSetting,
-      {
-        // in this case Alpha's etag is out of date - there's no way to update it
-        // without retrieving the setting again. This allows Alpha a chance to
-        // potentially incorporate Beta's update into their own _or_ to just overwrite
-        // it.
-        //
-        // the 'catch' below will now incorporate the update
-        onlyIfUnchanged: true
-      }
-    );
+    await client.setConfigurationSetting(alphaSetting, {
+      // in this case Alpha's etag is out of date - there's no way to update it
+      // without retrieving the setting again. This allows Alpha a chance to
+      // potentially incorporate Beta's update into their own _or_ to just overwrite
+      // it.
+      //
+      // the 'catch' below will now incorporate the update
+      onlyIfUnchanged: true
+    });
   } catch (err) {
     if (err.statusCode === 412) {
       // precondition failed
@@ -103,6 +97,12 @@ export async function main() {
   // and now that the dust has settled the value has been updated
   const finalSetting = await client.getConfigurationSetting({ key: key });
   console.log(`Final value with Alpha and Beta's updates: ${finalSetting.value}`);
+
+  if (
+    finalSetting.value !== "Beta has updated the value and Alpha has updated the setting as well"
+  ) {
+    throw new Error("SAMPLE FAILURE: Setting was not properly updated");
+  }
 
   await cleanupSampleValues([key], client);
 }


### PR DESCRIPTION
- Adding in a check that'll at least print when the results are incorrect so we don't run into this again.
- Fixing package.json - we don't have a next tag now that AppConfig is GA.