### PR TITLE
[FormRecognizer] rename includeTextDetails to includeTextContent

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.0-preview.4 (Unreleased)
 
+- [Breaking] Rename `includeTextDetails` to `includeTextContent` in custom form and receipt recognition options to be consistent with other languages.
 
 ## 1.0.0-preview.3 (2020-06-10)
 

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -521,7 +521,7 @@ export interface RecognizedReceiptArray extends Array<RecognizedReceipt> {
 
 // @public
 export type RecognizeFormsOptions = FormRecognizerOperationOptions & {
-    includeTextDetails?: boolean;
+    includeTextContent?: boolean;
 };
 
 // @public
@@ -534,7 +534,7 @@ export type RecognizeReceiptPollerClient = {
 
 // @public
 export type RecognizeReceiptsOptions = FormRecognizerOperationOptions & {
-    includeTextDetails?: boolean;
+    includeTextContent?: boolean;
 };
 
 export { RestResponse }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceiptFromUrl.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/recognizeReceiptFromUrl.js
@@ -20,7 +20,7 @@ async function main() {
     "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/contoso-allinone.jpg";
 
   const poller = await client.beginRecognizeReceiptsFromUrl(url, {
-    includeTextDetails: true,
+    includeTextContent: true,
     onProgress: (state) => {
       console.log(`analyzing status: ${state.status}`);
     }

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceiptFromUrl.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/recognizeReceiptFromUrl.ts
@@ -20,7 +20,7 @@ export async function main() {
     "https://raw.githubusercontent.com/Azure-Samples/cognitive-services-REST-api-samples/master/curl/form-recognizer/contoso-allinone.jpg";
 
   const poller = await client.beginRecognizeReceiptsFromUrl(url, {
-    includeTextDetails: true,
+    includeTextContent: true,
     onProgress: (state) => {
       console.log(`analyzing status: ${state.status}`);
     }

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -124,7 +124,7 @@ export type RecognizeFormsOptions = FormRecognizerOperationOptions & {
   /**
    * Specifies whether to include text lines and element references in the result
    */
-  includeTextDetails?: boolean;
+  includeTextContent?: boolean;
 };
 
 /**
@@ -165,7 +165,7 @@ export type RecognizeReceiptsOptions = FormRecognizerOperationOptions & {
   /**
    * Specifies whether to include text lines and element references in the result
    */
-  includeTextDetails?: boolean;
+  includeTextContent?: boolean;
 };
 
 /**
@@ -646,7 +646,7 @@ ng", and "image/tiff";
    * const client = new FormRecognizerClient(endpoint, new AzureKeyCredential(apiKey));
    * const poller = await client.beginRecognizeReceiptsFromUrl(
    *   url, {
-   *     includeTextDetails: true,
+   *     includeTextContent: true,
    *     onProgress: (state) => { console.log(`analyzing status: ${state.status}`); }
    * });
    * await poller.pollUntilDone();
@@ -789,7 +789,10 @@ async function recognizeCustomFormInternal(
   options: RecognizeFormsOptions = {},
   modelId?: string
 ): Promise<AnalyzeWithCustomModelResponseModel> {
-  const { span, updatedOptions: finalOptions } = createSpan("analyzeCustomFormInternal", options);
+  const { span, updatedOptions: finalOptions } = createSpan("analyzeCustomFormInternal", {
+    ...options,
+    includeTextDetails: options.includeTextContent
+  });
   const requestBody = await toRequestBody(body);
   const requestContentType = contentType ? contentType : await getContentType(requestBody);
 
@@ -827,8 +830,11 @@ async function recognizeReceiptInternal(
   options?: RecognizeReceiptsOptions,
   _modelId?: string
 ): Promise<AnalyzeReceiptAsyncResponseModel> {
-  const realOptions = options || { includeTextDetails: false };
-  const { span, updatedOptions: finalOptions } = createSpan("analyzeReceiptInternal", realOptions);
+  const realOptions = options || { includeTextContent: false };
+  const { span, updatedOptions: finalOptions } = createSpan("analyzeReceiptInternal", {
+    ...realOptions,
+    includeTextDetails: realOptions.includeTextContent
+  });
   const requestBody = await toRequestBody(body);
   const requestContentType =
     contentType !== undefined ? contentType : await getContentType(requestBody);

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -152,7 +152,7 @@ export interface FormTableCell {
    */
   confidence: number;
   /**
-   * When includeTextDetails is set to true, a list of references to the text elements constituting this table cell.
+   * When includeTextContent is set to true, a list of references to the text elements constituting this table cell.
    */
   textContent?: FormContent[];
   /**
@@ -208,7 +208,7 @@ export interface FieldText {
    */
   boundingBox?: Point2D[];
   /**
-   * When includeTextDetails is set to true, a list of references to the text elements constituting this name or value.
+   * When includeTextContent is set to true, a list of references to the text elements constituting this name or value.
    */
   textContent?: FormContent[];
   /**
@@ -294,7 +294,7 @@ export interface FormPage {
    */
   // language?: Language;
   /**
-   * When includeTextDetails is set to true, a list of recognized text lines. The maximum number of
+   * When includeTextContent is set to true, a list of recognized text lines. The maximum number of
    * lines returned is 300 per page. The lines are sorted top to bottom, left to right, although in
    * certain cases proximity is treated with higher priority. As the sorting order depends on the
    * detected text, it may change across images and OCR version updates. Thus, business logic
@@ -356,7 +356,7 @@ export interface CommonFieldValue {
    */
   confidence?: number;
   /**
-   * When includeTextDetails is set to true, a list of references to the text elements constituting
+   * When includeTextContent is set to true, a list of references to the text elements constituting
    * this field.
    */
   textContent?: FormContent[];

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formrecognizerclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formrecognizerclient.spec.ts
@@ -173,7 +173,7 @@ describe("FormRecognizerClient NodeJS only", () => {
     const stream = fs.createReadStream(filePath);
 
     const poller = await client.beginRecognizeReceipts(stream, "application/pdf", {
-      includeTextDetails: true
+      includeTextContent: true
     });
     await poller.pollUntilDone();
     const receipts = poller.getResult();


### PR DESCRIPTION
in the custom form/receipt recognition options.  This was missed in the
consistency push.