### PR TITLE
[core-http] change browser telemetry header key to x-ms-useragent

### DIFF
--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.browser.ts
@@ -14,7 +14,7 @@ interface NavigatorEx extends Navigator {
 }
 
 export function getDefaultUserAgentKey(): string {
-  return "x-ms-command-name";
+  return "x-ms-useragent";
 }
 
 export function getPlatformSpecificData(): TelemetryInfo[] {

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -135,7 +135,7 @@ export interface ServiceClientOptions {
   deserializationContentTypes?: DeserializationContentTypes;
   /**
    * The header name to use for the telemetry header while sending the request. If this is not
-   * specified, then "User-Agent" will be used when running on Node.js and "x-ms-command-name" will
+   * specified, then "User-Agent" will be used when running on Node.js and "x-ms-useragent" will
    * be used when running in a browser.
    */
   userAgentHeaderName?: string | ((defaultUserAgentHeaderName: string) => string);

--- a/sdk/core/core-http/test/msRestUserAgentPolicyTests.browser.ts
+++ b/sdk/core/core-http/test/msRestUserAgentPolicyTests.browser.ts
@@ -10,7 +10,7 @@ import { userAgentPolicy } from "../src/policies/userAgentPolicy";
 
 describe("MsRestUserAgentPolicy (browser)", () => {
   describe("for browser", function() {
-    const userAgentHeaderKey = "x-ms-command-name";
+    const userAgentHeaderKey = "x-ms-useragent";
 
     const emptyRequestPolicy: RequestPolicy = {
       sendRequest(request: WebResource): Promise<HttpOperationResponse> {

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -389,7 +389,7 @@ describe("ServiceClient", function() {
 
     assert.strictEqual(response._response.status, 200);
     assert.strictEqual(
-      response._response.request.headers.get(isNode ? "user-agent" : "x-ms-command-name"),
+      response._response.request.headers.get(isNode ? "user-agent" : "x-ms-useragent"),
       "blah blah"
     );
   });
@@ -418,7 +418,7 @@ describe("ServiceClient", function() {
 
     assert.strictEqual(response._response.status, 200);
     const userAgentHeaderValue: string | undefined = response._response.request.headers.get(
-      isNode ? "user-agent" : "x-ms-command-name"
+      isNode ? "user-agent" : "x-ms-useragent"
     );
     assert(userAgentHeaderValue);
     assert(userAgentHeaderValue!.startsWith("core-http/"));
@@ -449,7 +449,7 @@ describe("ServiceClient", function() {
 
     assert.strictEqual(response._response.status, 200);
     assert.strictEqual(
-      response._response.request.headers.get(isNode ? "user-agent" : "x-ms-command-name"),
+      response._response.request.headers.get(isNode ? "user-agent" : "x-ms-useragent"),
       "blah blah 2"
     );
   });


### PR DESCRIPTION
Based on the analysis at https://github.com/Azure/azure-sdk-for-js/issues/6530#issuecomment-642326789

* KeyVault service doesn't support CORS yet which means no browser support
* Storage doesn't send x-ms-command-name or x-ms-useragent for browsers as they
are not using core-http user agent policy
* Event Hubs/Service Bus don't use http
* Rest of services allows the x-ms-useragent header key

it is safe to change the header key for browser user agent information from
`x-ms-command-name` to `x-ms-useragent` in core-http.

Updates to AppConfiguration and Storage libraries will be in separate PRs.