### PR TITLE
[event-hubs] fix subscription deadlock

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 5.2.2 (Unreleased)
 
+- Fixes issue [#9289](https://github.com/Azure/azure-sdk-for-js/issues/9289)
+  where calling `await subscription.close()` inside of a subscription's `processError`
+  handler would cause the subscription to deadlock.
 
 ## 5.2.1 (2020-06-08)
 


### PR DESCRIPTION
## Background
Fixes #9289 
The EventHubConsumerClient subscription could deadlock if the user's `processError` handler was invoked with a non partition-specific error (e.g. unable to get partition ids) __and__ the user awaited `subscription.close()` within `processError`.

## What was the root cause?
This behavior is being caused because we have some circular awaits in this scenario. Here's what's happening:

1. EventProcessor loop begins.
2. Call to get partition ids fail due to bad eventHubName, enter catch block in loop.
3. Inside catch block, we await processError.
4. User's processError awaits subscription.close().
5. subscription.close() waits for the EventProcessor loop to exit before yielding.

It's at this point that we've reached a holding pattern, since processError won't yield to the loop until the loop has closed...which it can't do until processError yields!

## What's the change?
This change adds a `cancelLoopPromise` that resolves once the EventProcessor loop is cancelled. This happens when the user calls subscription.close().

Then in the `catch` block of the EventProcessor loop, we put a `Promise.race` around the `cancelLoopPromise` and the call to the user's `processError`.

## How does that help?
When the user calls `subscription.close()` inside `processError`, the `Promise.race` will resolve. The EventProcessor loop exits because its abortSignal.aborted now returns true (due to the `close()`).

Inside the `processError` handler that has called `await subscription.close()`, now that the EventProcessor loop has exited, control is yielded back to the handler.

## Is it safe to exit the loop before the user's `processError` yields?
With this change, the loop still only exits if the subscription is closed. If the user is calling `subscription.close()` inside of their handlers, then it should be expected that the subscription may close immediately.

## This fixes the issue for `processError`, can anything else cause this deadlock?
The `processError` handler is the only user-provided handler that is awaited inside the EventProcessor loop, so this is the only place that this deadlock can occur.

There can be a delay between when subscription.close() is called, and when the loop exits if `listOwnership` is in-flight, but this delay should just be the amount of time it takes to get a response from the checkpointstore. We should consider updating our CheckpointStore to also accept an optional abortSignal for its methods to minimize any delays.

Edit: #9492 logged to add cancellation support to CheckpointStore methods.
