### PR TITLE
[core-amqp] ensure sendRequest timeout is cleared for all responses

### DIFF
--- a/sdk/core/core-amqp/CHANGELOG.md
+++ b/sdk/core/core-amqp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.1.4 (Unreleased)
 
+- Fixes issue [9287](https://github.com/Azure/azure-sdk-for-js/issues/9287)
+  where operations that used the `RequestResponseLink` and encountered an error
+  would fail to cleanup their internal timer.
+  This caused exiting the process to be delayed until the timer reached its timeout.
 
 ## 1.1.3 (2020-06-02)
 

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -171,10 +171,10 @@ export class RequestResponseLink implements ReqResLink {
 
         // remove the event listeners as they will be registered next time when someone makes a request.
         this.receiver.removeListener(ReceiverEvents.message, messageCallback);
+        if (!timeOver) {
+          clearTimeout(waitTimer);
+        }
         if (info.statusCode > 199 && info.statusCode < 300) {
-          if (!timeOver) {
-            clearTimeout(waitTimer);
-          }
           logger.verbose(
             "[%s] request-messageId | '%s' == '%s' | response-correlationId.",
             this.connection.id,

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -14,6 +14,16 @@ import { Connection, Message } from "rhea-promise";
 import { stub } from "sinon";
 import EventEmitter from "events";
 import { AbortController, AbortSignalLike } from "@azure/abort-controller";
+interface Window {}
+declare let self: Window & typeof globalThis;
+
+function getGlobal() {
+  if (typeof global !== "undefined") {
+    return global;
+  } else {
+    return self;
+  }
+}
 
 describe("RequestResponseLink", function() {
   it("should send a request and receive a response correctly", async function() {
@@ -398,5 +408,118 @@ describe("RequestResponseLink", function() {
         `Incorrect error received "${err.message}"`
       );
     }
+  });
+
+  describe("sendRequest clears timeout", () => {
+    const _global = getGlobal();
+    const originalClearTimeout = clearTimeout;
+    afterEach(() => {
+      _global.clearTimeout = originalClearTimeout;
+    });
+
+    it("sendRequest clears timeout after error message", async function() {
+      let wasClearTimeoutCalled = false;
+      _global.clearTimeout = (tid) => {
+        wasClearTimeoutCalled = true;
+        return originalClearTimeout(tid);
+      };
+      const connectionStub = stub(new Connection());
+      const rcvr = new EventEmitter();
+      let req: any = {};
+      connectionStub.createSession.resolves({
+        connection: {
+          id: "connection-1"
+        },
+        createSender: () => {
+          return Promise.resolve({
+            send: (request: any) => {
+              req = request;
+            }
+          });
+        },
+        createReceiver: () => {
+          return Promise.resolve(rcvr);
+        }
+      } as any);
+      const sessionStub = await connectionStub.createSession();
+      const senderStub = await sessionStub.createSender();
+      const receiverStub = await sessionStub.createReceiver();
+      const link = new RequestResponseLink(sessionStub as any, senderStub, receiverStub);
+      const request: AmqpMessage = {
+        body: "Hello World!!"
+      };
+      const testFailureMessage = "Test failure";
+      setTimeout(() => {
+        rcvr.emit("message", {
+          message: {
+            correlation_id: req.message_id,
+            application_properties: {
+              statusCode: 400,
+              errorCondition: null,
+              statusDescription: null,
+              "com.microsoft:tracking-id": null
+            },
+            body: "I should throw an error!"
+          }
+        });
+      }, 0);
+      try {
+        await link.sendRequest(request, { timeoutInMs: 120000, requestName: "foo" });
+        throw new Error(testFailureMessage);
+      } catch (err) {
+        assert.notEqual(err.message, "Test failure");
+      }
+      assert.isTrue(wasClearTimeoutCalled, "clearTimeout wasn't called.");
+    });
+
+    it("sendRequest clears timeout after successful message", async function() {
+      let wasClearTimeoutCalled = false;
+      _global.clearTimeout = (tid) => {
+        wasClearTimeoutCalled = true;
+        return originalClearTimeout(tid);
+      };
+      const connectionStub = stub(new Connection());
+      const rcvr = new EventEmitter();
+      let req: any = {};
+      connectionStub.createSession.resolves({
+        connection: {
+          id: "connection-1"
+        },
+        createSender: () => {
+          return Promise.resolve({
+            send: (request: any) => {
+              req = request;
+            }
+          });
+        },
+        createReceiver: () => {
+          return Promise.resolve(rcvr);
+        }
+      } as any);
+      const sessionStub = await connectionStub.createSession();
+      const senderStub = await sessionStub.createSender();
+      const receiverStub = await sessionStub.createReceiver();
+      const link = new RequestResponseLink(sessionStub as any, senderStub, receiverStub);
+      const request: AmqpMessage = {
+        body: "Hello World!!"
+      };
+      setTimeout(() => {
+        rcvr.emit("message", {
+          message: {
+            correlation_id: req.message_id,
+            application_properties: {
+              statusCode: 200,
+              errorCondition: null,
+              statusDescription: null,
+              "com.microsoft:tracking-id": null
+            },
+            body: "I work!"
+          }
+        });
+      }, 0);
+
+      await link.sendRequest(request, { timeoutInMs: 120000, requestName: "foo" });
+      assert.isTrue(wasClearTimeoutCalled, "clearTimeout wasn't called.");
+    });
   });
 });

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -467,7 +467,7 @@ describe("RequestResponseLink", function() {
         await link.sendRequest(request, { timeoutInMs: 120000, requestName: "foo" });
         throw new Error(testFailureMessage);
       } catch (err) {
-        assert.notEqual(err.message, "Test failure");
+        assert.notEqual(err.message, testFailureMessage);
       }
       assert.isTrue(wasClearTimeoutCalled, "clearTimeout wasn't called.");
     });

--- a/sdk/core/core-amqp/test/requestResponse.spec.ts
+++ b/sdk/core/core-amqp/test/requestResponse.spec.ts
@@ -413,16 +413,21 @@ describe("RequestResponseLink", function() {
   describe("sendRequest clears timeout", () => {
     const _global = getGlobal();
     const originalClearTimeout = clearTimeout;
+    let clearTimeoutCalledCount = 0;
+
+    beforeEach(() => {
+      clearTimeoutCalledCount = 0;
+      _global.clearTimeout = (tid) => {
+        clearTimeoutCalledCount++;
+        return originalClearTimeout(tid);
+      };
+    });
+
     afterEach(() => {
       _global.clearTimeout = originalClearTimeout;
     });
 
     it("sendRequest clears timeout after error message", async function() {
-      let wasClearTimeoutCalled = false;
-      _global.clearTimeout = (tid) => {
-        wasClearTimeoutCalled = true;
-        return originalClearTimeout(tid);
-      };
       const connectionStub = stub(new Connection());
       const rcvr = new EventEmitter();
       let req: any = {};
@@ -469,15 +474,10 @@ describe("RequestResponseLink", function() {
       } catch (err) {
         assert.notEqual(err.message, testFailureMessage);
       }
-      assert.isTrue(wasClearTimeoutCalled, "clearTimeout wasn't called.");
+      assert.equal(clearTimeoutCalledCount, 1, "Expected clearTimeout to be called once.");
     });
 
     it("sendRequest clears timeout after successful message", async function() {
-      let wasClearTimeoutCalled = false;
-      _global.clearTimeout = (tid) => {
-        wasClearTimeoutCalled = true;
-        return originalClearTimeout(tid);
-      };
       const connectionStub = stub(new Connection());
       const rcvr = new EventEmitter();
       let req: any = {};
@@ -519,7 +519,7 @@ describe("RequestResponseLink", function() {
       }, 0);
 
       await link.sendRequest(request, { timeoutInMs: 120000, requestName: "foo" });
-      assert.isTrue(wasClearTimeoutCalled, "clearTimeout wasn't called.");
+      assert.equal(clearTimeoutCalledCount, 1, "Expected clearTimeout to be called once.");
     });
   });
 });


### PR DESCRIPTION
Fixes #9287.

In `core-amqp`, the `sendRequest` method on `RequestResponseLink` has a timeout that can be specified by the user.

Currently when a message is received with a successful status code, the timer is cleared. However, it is not cleared if a message is received with an error status code. This caused the timer to remain active until the operation timeout was reached, preventing the node.js process from exiting.

This change moves the clearTimeout call right above where we check the status code of the message so that it is applied for all messages.