### PR TITLE
[Event Hubs] Remove EventHubClient dependency in ProducerClient

### DIFF
--- a/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubProducerClient.ts
@@ -274,7 +274,7 @@ export class EventHubProducerClient {
    * @throws Error if the underlying connection has been closed, create a new EventHubProducerClient.
    * @throws AbortError if the operation is cancelled via the abortSignal.
    */
-  async getEventHubProperties(
+  getEventHubProperties(
     options: GetEventHubPropertiesOptions = {}
   ): Promise<EventHubProperties> {
     return this._context.managementSession!.getEventHubProperties({
@@ -291,12 +291,13 @@ export class EventHubProducerClient {
    * @throws Error if the underlying connection has been closed, create a new EventHubProducerClient.
    * @throws AbortError if the operation is cancelled via the abortSignal.
    */
-  async getPartitionIds(options: GetPartitionIdsOptions = {}): Promise<Array<string>> {
-    const eventHubProperties = await this._context.managementSession!.getEventHubProperties({
+  getPartitionIds(options: GetPartitionIdsOptions = {}): Promise<Array<string>> {
+    return this._context.managementSession!.getEventHubProperties({
       ...options,
       retryOptions: this._clientOptions.retryOptions
+    }).then(eventHubProperties => {
+      return eventHubProperties.partitionIds;
     });
-    return eventHubProperties.partitionIds;
   }
 
   /**
@@ -307,7 +308,7 @@ export class EventHubProducerClient {
    * @throws Error if the underlying connection has been closed, create a new EventHubProducerClient.
    * @throws AbortError if the operation is cancelled via the abortSignal.
    */
-  async getPartitionProperties(
+  getPartitionProperties(
     partitionId: string,
     options: GetPartitionPropertiesOptions = {}
   ): Promise<PartitionProperties> {

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { logErrorStackTrace, logger } from "../log";
 import {
   ConnectionConfig,
   EventHubConnectionConfig,
@@ -16,13 +15,8 @@ import {
 import { ConnectionContext } from "../connectionContext";
 import { EventHubProperties, PartitionProperties } from "../managementClient";
 import { EventPosition } from "../eventPosition";
-import { EventHubProducer } from "../sender";
 import { EventHubConsumer } from "../receiver";
 import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "../util/error";
-import { getTracer } from "@azure/core-tracing";
-import { CanonicalCode, Span, SpanContext, SpanKind } from "@opentelemetry/api";
-import { getParentSpan } from "../util/operationOptions";
-import { EventHubProducerOptions, OperationNames } from "../models/private";
 import {
   EventHubClientOptions,
   GetEventHubPropertiesOptions,
@@ -147,86 +141,20 @@ export class EventHubClient {
     credentialOrOptions?: TokenCredential | EventHubClientOptions,
     options?: EventHubClientOptions
   ) {
-    let connectionString;
-    let config;
-    let credential: TokenCredential | SharedKeyCredential;
-    hostOrConnectionString = String(hostOrConnectionString);
-
-    if (!isTokenCredential(credentialOrOptions)) {
-      const parsedCS = parseConnectionString<EventHubConnectionStringModel>(hostOrConnectionString);
-      if (
-        !(
-          parsedCS.EntityPath ||
-          (typeof eventHubNameOrOptions === "string" && eventHubNameOrOptions)
-        )
-      ) {
-        throw new TypeError(
-          `Either provide "eventHubName" or the "connectionString": "${hostOrConnectionString}", ` +
-            `must contain "EntityPath=<your-event-hub-name>".`
-        );
-      }
-      if (
-        parsedCS.EntityPath &&
-        typeof eventHubNameOrOptions === "string" &&
-        eventHubNameOrOptions &&
-        parsedCS.EntityPath !== eventHubNameOrOptions
-      ) {
-        throw new TypeError(
-          `The entity path "${parsedCS.EntityPath}" in connectionString: "${hostOrConnectionString}" ` +
-            `doesn't match with eventHubName: "${eventHubNameOrOptions}".`
-        );
-      }
-      connectionString = hostOrConnectionString;
-      if (typeof eventHubNameOrOptions !== "string") {
-        // connectionstring and/or options were passed to constructor
-        config = EventHubConnectionConfig.create(connectionString);
-        options = eventHubNameOrOptions;
-      } else {
-        // connectionstring, eventHubName and/or options were passed to constructor
-        const eventHubName = eventHubNameOrOptions;
-        config = EventHubConnectionConfig.create(connectionString, eventHubName);
-        options = credentialOrOptions;
-      }
-      // Since connectionstring was passed, create a SharedKeyCredential
-      credential = new SharedKeyCredential(config.sharedAccessKeyName, config.sharedAccessKey);
+    this._context = createConnectionContext(
+      hostOrConnectionString,
+      eventHubNameOrOptions,
+      credentialOrOptions,
+      options
+    );
+    this.endpoint = this._context.config.endpoint;
+    if (typeof eventHubNameOrOptions !== "string") {
+      this._clientOptions = eventHubNameOrOptions || {};
+    } else if (!isTokenCredential(credentialOrOptions)) {
+      this._clientOptions = credentialOrOptions || {};
     } else {
-      // host, eventHubName, a TokenCredential and/or options were passed to constructor
-      const eventHubName = eventHubNameOrOptions;
-      let host = hostOrConnectionString;
-      credential = credentialOrOptions;
-      if (!eventHubName) {
-        throw new TypeError(`"eventHubName" is missing`);
-      }
-
-      if (!host.endsWith("/")) host += "/";
-      connectionString = `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;SharedAccessKey=defaultKeyValue;EntityPath=${eventHubName}`;
-      config = EventHubConnectionConfig.create(connectionString);
+      this._clientOptions = options || {};
     }
-
-    ConnectionConfig.validate(config);
-
-    this.endpoint = config.endpoint;
-
-    this._clientOptions = options || {};
-    this._context = ConnectionContext.create(config, credential, this._clientOptions);
-  }
-
-  private _createClientSpan(
-    operationName: OperationNames,
-    parentSpan?: Span | SpanContext | null,
-    internal: boolean = false
-  ): Span {
-    const tracer = getTracer();
-    const span = tracer.startSpan(`Azure.EventHubs.${operationName}`, {
-      kind: internal ? SpanKind.INTERNAL : SpanKind.CLIENT,
-      parent: parentSpan
-    });
-
-    span.setAttribute("az.namespace", "Microsoft.EventHub");
-    span.setAttribute("message_bus.destination", this.eventHubName);
-    span.setAttribute("peer.address", this.endpoint);
-
-    return span;
   }
 
   /**
@@ -236,66 +164,7 @@ export class EventHubClient {
    * @throws Error if the underlying connection encounters an error while closing.
    */
   async close(): Promise<void> {
-    try {
-      if (this._context.connection.isOpen()) {
-        // Close all the senders.
-        for (const senderName of Object.keys(this._context.senders)) {
-          await this._context.senders[senderName].close();
-        }
-        // Close all the receivers.
-        for (const receiverName of Object.keys(this._context.receivers)) {
-          await this._context.receivers[receiverName].close();
-        }
-        // Close the cbs session;
-        await this._context.cbsSession.close();
-        // Close the management session
-        await this._context.managementSession!.close();
-        await this._context.connection.close();
-        this._context.wasConnectionCloseCalled = true;
-        logger.info("Closed the amqp connection '%s' on the client.", this._context.connectionId);
-      }
-    } catch (err) {
-      err = err instanceof Error ? err : JSON.stringify(err);
-      logger.warning(
-        `An error occurred while closing the connection "${this._context.connectionId}":\n${err}`
-      );
-      logErrorStackTrace(err);
-      throw err;
-    }
-  }
-
-  /**
-   * Creates an Event Hub producer that can send events to the Event Hub.
-   * If `partitionId` is specified in the `options`, all event data sent using the producer
-   * will be sent to the specified partition.
-   * Otherwise, they are automatically routed to an available partition by the Event Hubs service.
-   *
-   * Automatic routing of partitions is recommended because:
-   *  - The sending of events will be highly available.
-   *  - The event data will be evenly distributed among all available partitions.
-   *
-   * @param options The set of options to apply when creating the producer.
-   * - `partitionId`  : The identifier of the partition that the producer can be bound to.
-   * - `retryOptions` : The retry options used to govern retry attempts when an issue is encountered while sending events.
-   * A simple usage can be `{ "maxRetries": 4 }`.
-   *
-   * @throws Error if the underlying connection has been closed, create a new EventHubClient.
-   * @returns EventHubProducer
-   */
-  createProducer(options?: EventHubProducerOptions): EventHubProducer {
-    if (!options) {
-      options = {};
-    }
-    if (!options.retryOptions) {
-      options.retryOptions = this._clientOptions.retryOptions;
-    }
-    throwErrorIfConnectionClosed(this._context);
-    return new EventHubProducer(
-      this.eventHubName,
-      this.fullyQualifiedNamespace,
-      this._context,
-      options
-    );
+    return this._context.close();
   }
 
   /**
@@ -364,29 +233,10 @@ export class EventHubClient {
    * @throws AbortError if the operation is cancelled via the abortSignal3.
    */
   async getProperties(options: GetEventHubPropertiesOptions = {}): Promise<EventHubProperties> {
-    throwErrorIfConnectionClosed(this._context);
-    const clientSpan = this._createClientSpan(
-      "getEventHubProperties",
-      getParentSpan(options.tracingOptions)
-    );
-    try {
-      const result = await this._context.managementSession!.getHubRuntimeInformation({
-        retryOptions: this._clientOptions.retryOptions,
-        abortSignal: options.abortSignal
-      });
-      clientSpan.setStatus({ code: CanonicalCode.OK });
-      return result;
-    } catch (err) {
-      clientSpan.setStatus({
-        code: CanonicalCode.UNKNOWN,
-        message: err.message
-      });
-      logger.warning("An error occurred while getting the hub runtime information: %O", err);
-      logErrorStackTrace(err);
-      throw err;
-    } finally {
-      clientSpan.end();
-    }
+    return this._context.managementSession!.getEventHubProperties({
+      retryOptions: this._clientOptions.retryOptions,
+      abortSignal: options.abortSignal
+    });
   }
 
   /**
@@ -397,34 +247,8 @@ export class EventHubClient {
    * @throws AbortError if the operation is cancelled via the abortSignal.
    */
   async getPartitionIds(options: GetPartitionIdsOptions): Promise<Array<string>> {
-    throwErrorIfConnectionClosed(this._context);
-    const clientSpan = this._createClientSpan(
-      "getPartitionIds",
-      getParentSpan(options.tracingOptions),
-      true
-    );
-    try {
-      const runtimeInfo = await this.getProperties({
-        ...options,
-        tracingOptions: {
-          spanOptions: {
-            parent: clientSpan.context()
-          }
-        }
-      });
-      clientSpan.setStatus({ code: CanonicalCode.OK });
-      return runtimeInfo.partitionIds;
-    } catch (err) {
-      clientSpan.setStatus({
-        code: CanonicalCode.UNKNOWN,
-        message: err.message
-      });
-      logger.warning("An error occurred while getting the partition ids: %O", err);
-      logErrorStackTrace(err);
-      throw err;
-    } finally {
-      clientSpan.end();
-    }
+    const properties = await this.getProperties(options);
+    return properties.partitionIds;
   }
 
   /**
@@ -439,35 +263,73 @@ export class EventHubClient {
     partitionId: string,
     options: GetPartitionPropertiesOptions = {}
   ): Promise<PartitionProperties> {
-    throwErrorIfConnectionClosed(this._context);
-    throwTypeErrorIfParameterMissing(
-      this._context.connectionId,
-      "getPartitionProperties",
-      "partitionId",
-      partitionId
-    );
-    partitionId = String(partitionId);
-    const clientSpan = this._createClientSpan(
-      "getPartitionProperties",
-      getParentSpan(options.tracingOptions)
-    );
-    try {
-      const result = await this._context.managementSession!.getPartitionProperties(partitionId, {
-        retryOptions: this._clientOptions.retryOptions,
-        abortSignal: options.abortSignal
-      });
-      clientSpan.setStatus({ code: CanonicalCode.OK });
-      return result;
-    } catch (err) {
-      clientSpan.setStatus({
-        code: CanonicalCode.UNKNOWN,
-        message: err.message
-      });
-      logger.warning("An error occurred while getting the partition information: %O", err);
-      logErrorStackTrace(err);
-      throw err;
-    } finally {
-      clientSpan.end();
-    }
+    return this._context.managementSession!.getPartitionProperties(partitionId, {
+      retryOptions: this._clientOptions.retryOptions,
+      abortSignal: options.abortSignal
+    });
   }
+}
+
+export function createConnectionContext(
+  hostOrConnectionString: string,
+  eventHubNameOrOptions?: string | EventHubClientOptions,
+  credentialOrOptions?: TokenCredential | EventHubClientOptions,
+  options?: EventHubClientOptions
+): ConnectionContext {
+  let connectionString;
+  let config;
+  let credential: TokenCredential | SharedKeyCredential;
+  hostOrConnectionString = String(hostOrConnectionString);
+
+  if (!isTokenCredential(credentialOrOptions)) {
+    const parsedCS = parseConnectionString<EventHubConnectionStringModel>(hostOrConnectionString);
+    if (
+      !(parsedCS.EntityPath || (typeof eventHubNameOrOptions === "string" && eventHubNameOrOptions))
+    ) {
+      throw new TypeError(
+        `Either provide "eventHubName" or the "connectionString": "${hostOrConnectionString}", ` +
+          `must contain "EntityPath=<your-event-hub-name>".`
+      );
+    }
+    if (
+      parsedCS.EntityPath &&
+      typeof eventHubNameOrOptions === "string" &&
+      eventHubNameOrOptions &&
+      parsedCS.EntityPath !== eventHubNameOrOptions
+    ) {
+      throw new TypeError(
+        `The entity path "${parsedCS.EntityPath}" in connectionString: "${hostOrConnectionString}" ` +
+          `doesn't match with eventHubName: "${eventHubNameOrOptions}".`
+      );
+    }
+    connectionString = hostOrConnectionString;
+    if (typeof eventHubNameOrOptions !== "string") {
+      // connectionstring and/or options were passed to constructor
+      config = EventHubConnectionConfig.create(connectionString);
+      options = eventHubNameOrOptions;
+    } else {
+      // connectionstring, eventHubName and/or options were passed to constructor
+      const eventHubName = eventHubNameOrOptions;
+      config = EventHubConnectionConfig.create(connectionString, eventHubName);
+      options = credentialOrOptions;
+    }
+    // Since connectionstring was passed, create a SharedKeyCredential
+    credential = new SharedKeyCredential(config.sharedAccessKeyName, config.sharedAccessKey);
+  } else {
+    // host, eventHubName, a TokenCredential and/or options were passed to constructor
+    const eventHubName = eventHubNameOrOptions;
+    let host = hostOrConnectionString;
+    credential = credentialOrOptions;
+    if (!eventHubName) {
+      throw new TypeError(`"eventHubName" is missing`);
+    }
+
+    if (!host.endsWith("/")) host += "/";
+    connectionString = `Endpoint=sb://${host};SharedAccessKeyName=defaultKeyName;SharedAccessKey=defaultKeyValue;EntityPath=${eventHubName}`;
+    config = EventHubConnectionConfig.create(connectionString);
+  }
+
+  ConnectionConfig.validate(config);
+
+  return ConnectionContext.create(config, credential, options);
 }

--- a/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
+++ b/sdk/eventhub/event-hubs/src/impl/eventHubClient.ts
@@ -235,7 +235,7 @@ export class EventHubClient {
   async getProperties(options: GetEventHubPropertiesOptions = {}): Promise<EventHubProperties> {
     return this._context.managementSession!.getEventHubProperties({
       retryOptions: this._clientOptions.retryOptions,
-      abortSignal: options.abortSignal
+      ...options
     });
   }
 
@@ -265,7 +265,7 @@ export class EventHubClient {
   ): Promise<PartitionProperties> {
     return this._context.managementSession!.getPartitionProperties(partitionId, {
       retryOptions: this._clientOptions.retryOptions,
-      abortSignal: options.abortSignal
+      ...options
     });
   }
 }

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -28,6 +28,11 @@ import { LinkEntity } from "./linkEntity";
 import { logErrorStackTrace, logger } from "./log";
 import { getRetryAttemptTimeoutInMs } from "./util/retries";
 import { AbortError, AbortSignalLike } from "@azure/abort-controller";
+import { throwErrorIfConnectionClosed, throwTypeErrorIfParameterMissing } from "./util/error";
+import { OperationNames } from "./models/private";
+import { Span, SpanContext, SpanKind, CanonicalCode } from "@opentelemetry/api";
+import { getParentSpan, OperationOptions } from "./util/operationOptions";
+import { getTracer } from "@azure/core-tracing";
 /**
  * Describes the runtime information of an Event Hub.
  */
@@ -158,48 +163,52 @@ export class ManagementClient extends LinkEntity {
    * @param connection - The established amqp connection
    * @returns
    */
-  async getHubRuntimeInformation(options?: {
-    retryOptions?: RetryOptions;
-    abortSignal?: AbortSignalLike;
-  }): Promise<EventHubProperties> {
-    if (!options) {
-      options = {};
+  async getEventHubProperties(
+    options: OperationOptions & { retryOptions?: RetryOptions } = {}
+  ): Promise<EventHubProperties> {
+    throwErrorIfConnectionClosed(this._context);
+    const clientSpan = this._createClientSpan(
+      "getEventHubProperties",
+      getParentSpan(options.tracingOptions)
+    );
+    try {
+      const securityToken = await this.getSecurityToken();
+      const request: Message = {
+        body: Buffer.from(JSON.stringify([])),
+        message_id: uuid(),
+        reply_to: this.replyTo,
+        application_properties: {
+          operation: Constants.readOperation,
+          name: this.entityPath as string,
+          type: `${Constants.vendorString}:${Constants.eventHub}`,
+          security_token: securityToken?.token
+        }
+      };
+
+      const info: any = await this._makeManagementRequest(request, {
+        ...options,
+        requestName: "getHubRuntimeInformation"
+      });
+      const runtimeInfo: EventHubProperties = {
+        name: info.name,
+        createdOn: new Date(info.created_at),
+        partitionIds: info.partition_ids
+      };
+      logger.verbose("[%s] The hub runtime info is: %O", this._context.connectionId, runtimeInfo);
+
+      clientSpan.setStatus({ code: CanonicalCode.OK });
+      return runtimeInfo;
+    } catch (error) {
+      clientSpan.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: error.message
+      });
+      logger.warning("An error occurred while getting the hub runtime information: %O", error);
+      logErrorStackTrace(error);
+      throw error;
+    } finally {
+      clientSpan.end();
     }
-    const securityToken = await this.getSecurityToken();
-    const request: Message = {
-      body: Buffer.from(JSON.stringify([])),
-      message_id: uuid(),
-      reply_to: this.replyTo,
-      application_properties: {
-        operation: Constants.readOperation,
-        name: this.entityPath as string,
-        type: `${Constants.vendorString}:${Constants.eventHub}`,
-        security_token: securityToken?.token
-      }
-    };
-
-    const info: any = await this._makeManagementRequest(request, {
-      ...options,
-      requestName: "getHubRuntimeInformation"
-    });
-    const runtimeInfo: EventHubProperties = {
-      name: info.name,
-      createdOn: new Date(info.created_at),
-      partitionIds: info.partition_ids
-    };
-    logger.verbose("[%s] The hub runtime info is: %O", this._context.connectionId, runtimeInfo);
-    return runtimeInfo;
-  }
-
-  /**
-   * Provides an array of partitionIds.
-   * @ignore
-   * @param connection - The established amqp connection
-   * @returns
-   */
-  async getPartitionIds(): Promise<Array<string>> {
-    const runtimeInfo = await this.getHubRuntimeInformation();
-    return runtimeInfo.partitionIds;
   }
 
   /**
@@ -210,41 +219,67 @@ export class ManagementClient extends LinkEntity {
    */
   async getPartitionProperties(
     partitionId: string,
-    options?: { retryOptions?: RetryOptions; abortSignal?: AbortSignalLike }
+    options: OperationOptions & { retryOptions?: RetryOptions } = {}
   ): Promise<PartitionProperties> {
-    if (!options) {
-      options = {};
+    throwErrorIfConnectionClosed(this._context);
+    throwTypeErrorIfParameterMissing(
+      this._context.connectionId,
+      "getPartitionProperties",
+      "partitionId",
+      partitionId
+    );
+    partitionId = String(partitionId);
+
+    const clientSpan = this._createClientSpan(
+      "getPartitionProperties",
+      getParentSpan(options.tracingOptions)
+    );
+
+    try {
+      const securityToken = await this.getSecurityToken();
+      const request: Message = {
+        body: Buffer.from(JSON.stringify([])),
+        message_id: uuid(),
+        reply_to: this.replyTo,
+        application_properties: {
+          operation: Constants.readOperation,
+          name: this.entityPath as string,
+          type: `${Constants.vendorString}:${Constants.partition}`,
+          partition: `${partitionId}`,
+          security_token: securityToken?.token
+        }
+      };
+
+      const info: any = await this._makeManagementRequest(request, {
+        ...options,
+        requestName: "getPartitionInformation"
+      });
+
+      const partitionInfo: PartitionProperties = {
+        beginningSequenceNumber: info.begin_sequence_number,
+        eventHubName: info.name,
+        lastEnqueuedOffset: info.last_enqueued_offset,
+        lastEnqueuedOnUtc: new Date(info.last_enqueued_time_utc),
+        lastEnqueuedSequenceNumber: info.last_enqueued_sequence_number,
+        partitionId: info.partition,
+        isEmpty: info.is_partition_empty
+      };
+      logger.verbose("[%s] The partition info is: %O.", this._context.connectionId, partitionInfo);
+
+      clientSpan.setStatus({ code: CanonicalCode.OK });
+
+      return partitionInfo;
+    } catch (error) {
+      clientSpan.setStatus({
+        code: CanonicalCode.UNKNOWN,
+        message: error.message
+      });
+      logger.warning("An error occurred while getting the partition information: %O", error);
+      logErrorStackTrace(error);
+      throw error;
+    } finally {
+      clientSpan.end();
     }
-    const securityToken = await this.getSecurityToken();
-    const request: Message = {
-      body: Buffer.from(JSON.stringify([])),
-      message_id: uuid(),
-      reply_to: this.replyTo,
-      application_properties: {
-        operation: Constants.readOperation,
-        name: this.entityPath as string,
-        type: `${Constants.vendorString}:${Constants.partition}`,
-        partition: `${partitionId}`,
-        security_token: securityToken?.token
-      }
-    };
-
-    const info: any = await this._makeManagementRequest(request, {
-      ...options,
-      requestName: "getPartitionInformation"
-    });
-
-    const partitionInfo: PartitionProperties = {
-      beginningSequenceNumber: info.begin_sequence_number,
-      eventHubName: info.name,
-      lastEnqueuedOffset: info.last_enqueued_offset,
-      lastEnqueuedOnUtc: new Date(info.last_enqueued_time_utc),
-      lastEnqueuedSequenceNumber: info.last_enqueued_sequence_number,
-      partitionId: info.partition,
-      isEmpty: info.is_partition_empty
-    };
-    logger.verbose("[%s] The partition info is: %O.", this._context.connectionId, partitionInfo);
-    return partitionInfo;
   }
 
   /**
@@ -470,5 +505,23 @@ export class ManagementClient extends LinkEntity {
 
   private _isMgmtRequestResponseLinkOpen(): boolean {
     return this._mgmtReqResLink! && this._mgmtReqResLink!.isOpen();
+  }
+
+  private _createClientSpan(
+    operationName: OperationNames,
+    parentSpan?: Span | SpanContext | null,
+    internal: boolean = false
+  ): Span {
+    const tracer = getTracer();
+    const span = tracer.startSpan(`Azure.EventHubs.${operationName}`, {
+      kind: internal ? SpanKind.INTERNAL : SpanKind.CLIENT,
+      parent: parentSpan
+    });
+
+    span.setAttribute("az.namespace", "Microsoft.EventHub");
+    span.setAttribute("message_bus.destination", this._context.config.entityPath);
+    span.setAttribute("peer.address", this._context.config.endpoint);
+
+    return span;
   }
 }

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -160,8 +160,6 @@ export class ManagementClient extends LinkEntity {
   /**
    * Provides the eventhub runtime information.
    * @ignore
-   * @param connection - The established amqp connection
-   * @returns
    */
   async getEventHubProperties(
     options: OperationOptions & { retryOptions?: RetryOptions } = {}
@@ -214,7 +212,6 @@ export class ManagementClient extends LinkEntity {
   /**
    * Provides information about the specified partition.
    * @ignore
-   * @param connection - The established amqp connection
    * @param partitionId Partition ID for which partition information is required.
    */
   async getPartitionProperties(

--- a/sdk/eventhub/event-hubs/src/sender.ts
+++ b/sdk/eventhub/event-hubs/src/sender.ts
@@ -68,8 +68,6 @@ export class EventHubProducer {
    * @ignore
    */
   constructor(
-    eventHubName: string,
-    fullyQualifiedNamespace: string,
     context: ConnectionContext,
     options?: EventHubProducerOptions
   ) {
@@ -80,8 +78,8 @@ export class EventHubProducer {
         ? String(this._senderOptions.partitionId)
         : undefined;
     this._eventHubSender = EventHubSender.create(this._context, partitionId);
-    this._eventHubName = eventHubName;
-    this._fullyQualifiedNamespace = fullyQualifiedNamespace;
+    this._eventHubName = this._context.config.entityPath;
+    this._fullyQualifiedNamespace = this._context.config.host;
   }
 
   /**

--- a/sdk/eventhub/event-hubs/test/client.spec.ts
+++ b/sdk/eventhub/event-hubs/test/client.spec.ts
@@ -492,7 +492,7 @@ describe("EventHubProducerClient User Agent String", function(): void {
       env[EnvVarKeys.EVENTHUB_CONNECTION_STRING],
       env[EnvVarKeys.EVENTHUB_NAME]
     );
-    testUserAgentString(producerClient["_client"]["_context"]);
+    testUserAgentString(producerClient["_context"]);
     await producerClient.close();
   });
 
@@ -503,7 +503,7 @@ describe("EventHubProducerClient User Agent String", function(): void {
       env[EnvVarKeys.EVENTHUB_NAME],
       { userAgent: customUserAgent }
     );
-    testUserAgentString(producerClient["_client"]["_context"], customUserAgent);
+    testUserAgentString(producerClient["_context"], customUserAgent);
     await producerClient.close();
   });
 });

--- a/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
+++ b/sdk/eventhub/event-hubs/test/hubruntime.spec.ts
@@ -116,13 +116,8 @@ describe("RuntimeInformation", function(): void {
             name: rootSpan.name,
             children: [
               {
-                name: "Azure.EventHubs.getPartitionIds",
-                children: [
-                  {
-                    name: "Azure.EventHubs.getEventHubProperties",
-                    children: []
-                  }
-                ]
+                name: "Azure.EventHubs.getEventHubProperties",
+                children: []
               }
             ]
           }
@@ -158,13 +153,8 @@ describe("RuntimeInformation", function(): void {
             name: rootSpan.name,
             children: [
               {
-                name: "Azure.EventHubs.getPartitionIds",
-                children: [
-                  {
-                    name: "Azure.EventHubs.getEventHubProperties",
-                    children: []
-                  }
-                ]
+                name: "Azure.EventHubs.getEventHubProperties",
+                children: []
               }
             ]
           }

--- a/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
+++ b/sdk/eventhub/event-hubs/test/node/disconnects.spec.ts
@@ -89,7 +89,7 @@ describe("disconnected", function() {
   describe("EventHubProducerClient", function() {
     it("runtimeInfo work after disconnect", async () => {
       const client = new EventHubProducerClient(service.connectionString, service.path);
-      const clientConnectionContext = client["_client"]["_context"];
+      const clientConnectionContext = client["_context"];
 
       await client.getPartitionIds({});
       const originalConnectionId = clientConnectionContext.connectionId;
@@ -108,7 +108,7 @@ describe("disconnected", function() {
 
     it("should send after a disconnect", async () => {
       const client = new EventHubProducerClient(service.connectionString, service.path);
-      const clientConnectionContext = client["_client"]["_context"];
+      const clientConnectionContext = client["_context"];
 
       await client.sendBatch([{ body: "test" }]);
       const originalConnectionId = clientConnectionContext.connectionId;
@@ -126,7 +126,7 @@ describe("disconnected", function() {
 
     it("should not throw an uncaught exception", async () => {
       const client = new EventHubProducerClient(service.connectionString, service.path);
-      const clientConnectionContext = client["_client"]["_context"];
+      const clientConnectionContext = client["_context"];
 
       // Send an event to open the connection.
       await client.sendBatch([{ body: "test" }]);


### PR DESCRIPTION
This PR has changes to make the class `EventHubProducerClient` no longer dependent on the internal `EventHubClient` class. This gets us one step closer to our goals in #6505

Noteworthy changes:
- The code in `EventHubClient.close()` is moved to `ConnectionContext.close()` so that it can be re-used in `EventHubProducerClient.close()`
- The code in the `EventHubClient` constructor to create the connection context is moved to a helper method so that it is re-usable in `EventHubProducerClient`
- `EventHubClient.createProducer()` is removed in favor of instantiating the `EventHubProducer` class directly in `EventHubProducerClient`. This method was needed when `EventHubClient` was the public facing client.
- `EventHubProducer` constructor does not need event hub name and namespace to be passed in. We can get them from the connection context
- The tracing related code for the operations on the $management link is moved into the `ManagementClient` class where the implementation for these operations live
- `getPartitionIds` is essentially the same as `getEventHubProperties`, but returns partial data. So, removed the intermediate tracing step that does not add any value
