### PR TITLE
[event-hubs] fix EventHubConsumerClient waiting 1 min before exit

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Fixes issue [#9289](https://github.com/Azure/azure-sdk-for-js/issues/9289)
   where calling `await subscription.close()` inside of a subscription's `processError`
   handler would cause the subscription to deadlock.
+- Fixes issue [8598](https://github.com/Azure/azure-sdk-for-js/issues/8598)
+  where the EventHubConsumerClient would remain open in the background beyond
+  when `subscription.close()` was called. This would prevent the process from
+  exiting until the `maxWaitTimeInSeconds` (default 60) was reached.
 
 ## 5.2.1 (2020-06-08)
 

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -8,7 +8,7 @@ import { EventHubClient } from "./impl/eventHubClient";
 import { EventPosition } from "./eventPosition";
 import { PartitionProcessor } from "./partitionProcessor";
 import { EventHubConsumer } from "./receiver";
-import { AbortController } from "@azure/abort-controller";
+import { AbortController, AbortSignalLike } from "@azure/abort-controller";
 import { MessagingError } from "@azure/core-amqp";
 import { OperationOptions, getParentSpan } from "./util/operationOptions";
 import { getTracer } from "@azure/core-tracing";
@@ -33,12 +33,13 @@ export class PartitionPump {
     eventHubClient: EventHubClient,
     partitionProcessor: PartitionProcessor,
     private readonly _startPosition: EventPosition,
+    parentAbortSignal: AbortSignalLike,
     options: CommonEventProcessorOptions
   ) {
     this._eventHubClient = eventHubClient;
     this._partitionProcessor = partitionProcessor;
     this._processorOptions = options;
-    this._abortController = new AbortController();
+    this._abortController = new AbortController(parentAbortSignal);
   }
 
   public get isReceiving(): boolean {

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -45,13 +45,18 @@ export class PartitionPump {
     this._partitionProcessor = partitionProcessor;
     this._processorOptions = options;
     this._abortController = new AbortController();
+
+    // React to the parent cancellation signal emitting.
     this._onParentSignalCancelled = () => {
       // Clean up the event listener.
       parentAbortSignal.removeEventListener("abort", this._onParentSignalCancelled);
       this.stop(CloseReason.Shutdown);
     };
     parentAbortSignal.addEventListener("abort", this._onParentSignalCancelled);
+
+    // Handle the edge case where the parent signal was already cancelled.
     if (parentAbortSignal.aborted) {
+      this._isStopped = true;
       this._abortController.abort();
     }
   }

--- a/sdk/eventhub/event-hubs/src/pumpManager.ts
+++ b/sdk/eventhub/event-hubs/src/pumpManager.ts
@@ -134,6 +134,7 @@ export class PumpManagerImpl implements PumpManager {
       eventHubClient,
       partitionProcessor,
       startPosition,
+      abortSignal,
       this._options
     );
 

--- a/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
+++ b/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
@@ -150,6 +150,7 @@ describe("PartitionPump", () => {
       { maxBatchSize: 1, maxWaitTimeInSeconds: 1 }
     );
 
+    pump["_isStopped"].should.equal(false, "The pump should not be stopped yet.");
     const waitForCancellation = new Promise<any>((resolve) => {
       // The PartitionPump has its own AbortController to cancel requests if it is stopped.
       // The internal AbortController should listen to the abort signal passed to the pump.
@@ -161,5 +162,6 @@ describe("PartitionPump", () => {
 
     const event = await waitForCancellation;
     event.type.should.equal("abort");
+    pump["_isStopped"].should.equal(true, "The pump should have been stopped.");
   });
 });

--- a/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
+++ b/sdk/eventhub/event-hubs/test/partitionPump.spec.ts
@@ -127,7 +127,7 @@ describe("PartitionPump", () => {
     });
   });
 
-  it("can be cancelled", async () => {
+  it.only("can be cancelled", async () => {
     const mockPartitionProcessor = new PartitionProcessor(
       {
         async processError() {
@@ -163,5 +163,32 @@ describe("PartitionPump", () => {
     const event = await waitForCancellation;
     event.type.should.equal("abort");
     pump["_isStopped"].should.equal(true, "The pump should have been stopped.");
+  });
+
+  it.only("can be cancelled by already cancelled signal", async () => {
+    const mockPartitionProcessor = new PartitionProcessor(
+      {
+        async processError() {
+          /* no-op for test */
+        },
+        async processEvents() {
+          /* no-op for test */
+        }
+      },
+      {} as any,
+      { partitionId: "0" } as any
+    );
+
+    const testAbortController = new AbortController();
+    testAbortController.abort();
+    const pump = new PartitionPump(
+      {} as any,
+      mockPartitionProcessor,
+      { enqueuedOn: new Date() },
+      testAbortController.signal,
+      { maxBatchSize: 1, maxWaitTimeInSeconds: 1 }
+    );
+
+    pump["_isStopped"].should.equal(true, "The pump should be stopped.");
   });
 });


### PR DESCRIPTION
## Description
Fixes #8598
This change fixes the bug where calling `subscription.close()` would not immediately cancel any in-flight `receiveBatch` calls.

## Background
The `EventProcessor` creates and holds onto an `AbortController`, and is meant to pass the `signal` to any async operations. When the user calls `subscription.close()`, the signal fires the `abort` event so that any currently running async code is immediately cancelled.
https://github.com/Azure/azure-sdk-for-js/blob/a5292aecc9885f657b5cf8783b6f16e69f5432e6/sdk/eventhub/event-hubs/src/eventProcessor.ts#L497-L504
https://github.com/Azure/azure-sdk-for-js/blob/a5292aecc9885f657b5cf8783b6f16e69f5432e6/sdk/eventhub/event-hubs/src/eventProcessor.ts#L533-L538

## So why wasn't that cancelling the in-flight receiveBatch requests?
Each partition that the subscription is reading from is assigned a [PartitionPump](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/event-hubs_5.2.1/sdk/eventhub/event-hubs/src/partitionPump.ts) that is in charge of calling the user's subscription handlers and getting the actual events.

The `PartitionPump` creates its own `AbortController` so that it can have greater control over when `receiveBatch` operations should be cancelled.
https://github.com/Azure/azure-sdk-for-js/blob/a5292aecc9885f657b5cf8783b6f16e69f5432e6/sdk/eventhub/event-hubs/src/partitionPump.ts#L41

The problem was, the PartitionPump didn't know about the EventProcessor's abort signal.

## So how does this fix the problem?
The PartitionPump now accepts the abort signal from the EventProcessor. When the EventProcessor's abort signal emits the abort event, it will call `stop()` which in turn will call the PartitionPump's abort controller.

Now when subscription.close() is called, the EventProcessor's abort signal tells the PartitionPump to stop, which in turn cancels the `receiveBatch` call.

## How do we make sure this doesn't break in the future?
I've added unit-tests that test that the PartitionPump can be cancelled using an external abort signal. There are existing tests that ensure that a `receiveBatch` operation can be cancelled.

### Wouldn't it be better to test that the process exits after the subscription is closed?
Ideally, yes. However this is very difficult to capture in a test because there's no way from user-code to detect the still-running timeout in receiveBatch while inside a test framework. (There are tricks we could do in a stand-alone script for node.js, but not in a test runner.) In this case I judged that ensuring the PartitionPump could be cancelled was enough given the tests we already have for cancelling `receiveBatch`.