### PR TITLE
Update pnpm to v5

### DIFF
--- a/eng/pipelines/templates/steps/use-node-test-version.yml
+++ b/eng/pipelines/templates/steps/use-node-test-version.yml
@@ -11,19 +11,19 @@ steps:
       $KeytarSymlinkPath = "common/temp/node_modules/.pnpm/node_modules/keytar"
 
       # Map from the symlink path to the target path (npm has issues installing into symlink dirs)
-      # Example: common/temp/node_modules/.pnpm/registry.npmjs.org/keytar/5.4.0/node_modules/keytar
+      # Example: common/temp/node_modules/.pnpm/keytar@5.6.0/node_modules/keytar
       $KeytarTargetPath = (Get-Item $KeytarSymlinkPath).Target
 
       # Need to run "npm install" at path containing "node_modules" folder
-      # Example: common/temp/node_modules/.pnpm/registry.npmjs.org/keytar/5.4.0
+      # Example: common/temp/node_modules/.pnpm/keytar@5.6.0
       $KeytarInstallPath = Join-Path $KeytarTargetPath "../.."
 
-      # The version is the leaf node of the path
-      # Example: 5.4.0
-      $KeytarVersion = Split-Path -Leaf $KeytarInstallPath
+      # <pkg>@<version> is the leaf node of the path
+      # Example: keytar@5.4.0
+      $KeytarPackageAtVersion = Split-Path -Leaf $KeytarInstallPath
 
       Set-Location $KeytarInstallPath
 
       # Install matching version of package
-      npm install --no-package-lock keytar@$KeytarVersion
+      npm install --no-package-lock $KeytarPackageAtVersion
     displayName: Reinstall native dependencies

--- a/eng/pipelines/templates/steps/use-node-test-version.yml
+++ b/eng/pipelines/templates/steps/use-node-test-version.yml
@@ -19,7 +19,7 @@ steps:
       $KeytarInstallPath = Join-Path $KeytarTargetPath "../.."
 
       # <pkg>@<version> is the leaf node of the path
-      # Example: keytar@5.4.0
+      # Example: keytar@5.6.0
       $KeytarPackageAtVersion = Split-Path -Leaf $KeytarInstallPath
 
       Set-Location $KeytarInstallPath

--- a/rush.json
+++ b/rush.json
@@ -24,7 +24,7 @@
    * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
    * for details about these alternatives.
    */
-  "pnpmVersion": "4.14.2",
+  "pnpmVersion": "5.1.8",
   // "npmVersion": "4.5.0",
   // "yarnVersion": "1.9.4",
   /**


### PR DESCRIPTION
Adds the following warnings during `rush install`, though these seem harmless and there appears to be no way to configure rush to prevent these warnings:

```
WARN  Deprecated options: 'lock', 'resolution-strategy'
```