### PR TITLE
Move text from method parameter to options bag

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -22,6 +22,7 @@ export interface AnalyzedTokenInfo {
 export interface AnalyzeRequest {
     analyzerName?: string;
     charFilters?: string[];
+    text: string;
     tokenFilters?: string[];
     tokenizerName?: string;
 }
@@ -1047,7 +1048,7 @@ export interface SearchIndex {
 // @public
 export class SearchIndexClient {
     constructor(endpoint: string, credential: KeyCredential, options?: SearchIndexClientOptions);
-    analyzeText(indexName: string, text: string, options: AnalyzeTextOptions): Promise<AnalyzeResult>;
+    analyzeText(indexName: string, options: AnalyzeTextOptions): Promise<AnalyzeResult>;
     readonly apiVersion: string;
     createIndex(index: SearchIndex, options?: CreateIndexOptions): Promise<SearchIndex>;
     createOrUpdateIndex(index: SearchIndex, options?: CreateOrUpdateIndexOptions): Promise<SearchIndex>;

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -568,11 +568,7 @@ export class SearchIndexClient {
    * @param text The text to break into tokens.
    * @param options Additional arguments
    */
-  public async analyzeText(
-    indexName: string,
-    text: string,
-    options: AnalyzeTextOptions
-  ): Promise<AnalyzeResult> {
+  public async analyzeText(indexName: string, options: AnalyzeTextOptions): Promise<AnalyzeResult> {
     const { operationOptions, restOptions } = utils.extractOperationOptions(options);
 
     const { span, updatedOptions } = createSpan("SearchIndexClient-analyzeText", operationOptions);
@@ -581,7 +577,6 @@ export class SearchIndexClient {
         indexName,
         {
           ...restOptions,
-          text,
           analyzer: restOptions.analyzerName,
           tokenizer: restOptions.tokenizerName
         },

--- a/sdk/search/search-documents/src/serviceModels.ts
+++ b/sdk/search/search-documents/src/serviceModels.ts
@@ -316,6 +316,10 @@ export interface DeleteDataSourceConnectionOptions extends OperationOptions {
  */
 export interface AnalyzeRequest {
   /**
+   * The text to break into tokens.
+   */
+  text: string;
+  /**
    * The name of the analyzer to use to break the given text. If this parameter is not specified,
    * you must specify a tokenizer instead. The tokenizer and analyzer parameters are mutually
    * exclusive. KnownAnalyzerNames is an enum containing known values.


### PR DESCRIPTION
This is related to PR: https://github.com/Azure/azure-sdk-for-js/issues/9318 

1. The text parameter is moved from method parameter to inside the options bag. 
2. No action is taken for the second part of the issue. A comment has been added to mention one of the analyzerename or tokenizername is required. 

@xirzec Please review and approve

@ramya-rao-a FYI...