### PR TITLE
[core-http] use # as the charkey in xml parsers

### DIFF
--- a/sdk/core/core-http/review/core-http.api.md
+++ b/sdk/core/core-http/review/core-http.api.md
@@ -953,6 +953,12 @@ export interface WebResourceLike {
     withCredentials: boolean;
 }
 
+// @public
+export const XML_ATTRKEY = "$";
+
+// @public
+export const XML_CHARKEY = "#";
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -125,3 +125,4 @@ export { TopicCredentials } from "./credentials/topicCredentials";
 export { Authenticator } from "./credentials/credentials";
 
 export { parseXML, stringifyXML } from "./util/xml";
+export { XML_ATTRKEY, XML_CHARKEY } from './util/xml.common';

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -4,6 +4,7 @@
 
 import * as base64 from "./util/base64";
 import * as utils from "./util/utils";
+import { XML_ATTRKEY, XML_CHARKEY } from './util/xml.common';
 
 export class Serializer {
   constructor(
@@ -210,11 +211,11 @@ export class Serializer {
       if (this.isXML) {
         /**
          * If the mapper specifies this as a non-composite type value but the responseBody contains
-         * both header ("$") and body ("_") properties, then just reduce the responseBody value to
-         * the body ("_") property.
+         * both header ("$" i.e., XML2JS_ATTRKEY) and body ("#" i.e., XML2JS_CHARKEY) properties,
+         * then just reduce the responseBody value to the body ("#" i.e., XML2JS_CHARKEY) property.
          */
-        if (responseBody["$"] != undefined && responseBody["_"] != undefined) {
-          responseBody = responseBody["_"];
+        if (responseBody[XML_ATTRKEY] != undefined && responseBody[XML_CHARKEY] != undefined) {
+          responseBody = responseBody[XML_CHARKEY];
         }
       }
 
@@ -750,7 +751,7 @@ function getXmlObjectValue(propertyMapper: Mapper, serializedValue: any, isXml: 
 }
 
 function isSpecialXmlProperty(propertyName: string): boolean {
-  return ["$", "_"].includes(propertyName);
+  return [XML_ATTRKEY, XML_CHARKEY].includes(propertyName);
 }
 
 function deserializeCompositeType(

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -60,6 +60,7 @@ import { DefaultKeepAliveOptions, keepAlivePolicy } from "./policies/keepAlivePo
 import { tracingPolicy } from "./policies/tracingPolicy";
 import { disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
 import { ndJsonPolicy } from "./policies/ndJsonPolicy";
+import { XML_ATTRKEY, XML_CHARKEY } from "./util/xml.common";
 
 /**
  * Options to configure a proxy for outgoing requests (Node.js only).
@@ -639,7 +640,10 @@ function getXmlValueWithNamespace(
   // Composite and Sequence schemas already got their root namespace set during serialization
   // We just need to add xmlns to the other schema types
   if (xmlNamespace && !["Composite", "Sequence", "Dictionary"].includes(typeName)) {
-    return { _: serializedValue, $: { [xmlnsKey]: xmlNamespace } };
+    const result: any = {};
+    result[XML_CHARKEY] = serializedValue;
+    result[XML_ATTRKEY] = { [xmlnsKey]: xmlNamespace };
+    return result;
   }
 
   return serializedValue;

--- a/sdk/core/core-http/src/util/xml.browser.ts
+++ b/sdk/core/core-http/src/util/xml.browser.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { XML_ATTRKEY, XML_CHARKEY } from './xml.common';
+
 // tslint:disable-next-line:no-null-keyword
 const doc = document.implementation.createDocument(null, null, null);
 
@@ -67,15 +69,15 @@ function domToObject(node: Node): any {
 
   const elementWithAttributes: Element | undefined = asElementWithAttributes(node);
   if (elementWithAttributes) {
-    result["$"] = {};
+    result[XML_ATTRKEY] = {};
 
     for (let i = 0; i < elementWithAttributes.attributes.length; i++) {
       const attr = elementWithAttributes.attributes[i];
-      result["$"][attr.nodeName] = attr.nodeValue;
+      result[XML_ATTRKEY][attr.nodeName] = attr.nodeValue;
     }
 
     if (onlyChildTextValue) {
-      result["_"] = onlyChildTextValue;
+      result[XML_CHARKEY] = onlyChildTextValue;
     }
   } else if (childNodeCount === 0) {
     result = "";
@@ -145,11 +147,11 @@ function buildNode(obj: any, elementName: string): Node[] {
   } else if (typeof obj === "object") {
     const elem = doc.createElement(elementName);
     for (const key of Object.keys(obj)) {
-      if (key === "$") {
+      if (key === XML_ATTRKEY) {
         for (const attr of buildAttributes(obj[key])) {
           elem.attributes.setNamedItem(attr);
         }
-      } else if (key === "_") {
+      } else if (key === XML_CHARKEY) {
         elem.textContent = obj[key].toString();
       } else {
         for (const child of buildNode(obj[key], key)) {

--- a/sdk/core/core-http/src/util/xml.common.ts
+++ b/sdk/core/core-http/src/util/xml.common.ts
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+
+/**
+ * Key that is used to access the XML attributes.
+ */
 export const XML_ATTRKEY = "$";
+/**
+ * Key that is used to access the XML value content.
+ */
 export const XML_CHARKEY = "#";

--- a/sdk/core/core-http/src/util/xml.common.ts
+++ b/sdk/core/core-http/src/util/xml.common.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const XML_ATTRKEY = "$";
+export const XML_CHARKEY = "#";

--- a/sdk/core/core-http/src/util/xml.ts
+++ b/sdk/core/core-http/src/util/xml.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as xml2js from "xml2js";
+import { XML_ATTRKEY, XML_CHARKEY } from './xml.common';
 
 // Note: The reason we re-define all of the xml2js default settings (version 2.0) here is because the default settings object exposed
 // by the xm2js library is mutable. See https://github.com/Leonidas-from-XIV/node-xml2js/issues/536
@@ -12,8 +13,8 @@ const xml2jsDefaultOptionsV2 = {
   trim: false,
   normalize: false,
   normalizeTags: false,
-  attrkey: "$",
-  charkey: "_",
+  attrkey: XML_ATTRKEY,
+  charkey: XML_CHARKEY,
   explicitArray: true,
   ignoreAttrs: false,
   mergeAttrs: false,

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -170,7 +170,7 @@ describe("deserializationPolicy", function() {
           $: {
             tasty: "yes"
           },
-          _: "3"
+          "#": "3"
         }
       });
       assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
@@ -372,7 +372,7 @@ describe("deserializationPolicy", function() {
           $: {
             taste: "good"
           },
-          _: "3"
+          "#": "3"
         }
       });
       assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
@@ -406,7 +406,7 @@ describe("deserializationPolicy", function() {
           $: {
             taste: "good"
           },
-          _: "3"
+          "#": "3"
         }
       });
       assert.strictEqual(deserializedResponse.parsedHeaders, undefined);
@@ -495,7 +495,7 @@ describe("deserializationPolicy", function() {
           $: {
             type: "text"
           },
-          _: "testQueuePath"
+          "#": "testQueuePath"
         },
         updated: "2018-10-09T19:56:35Z"
       });

--- a/sdk/core/core-http/test/xmlTests.ts
+++ b/sdk/core/core-http/test/xmlTests.ts
@@ -75,7 +75,7 @@ describe("XML serializer", function() {
         $: {
           healthy: "true"
         },
-        _: "yum"
+        "#": "yum"
       });
     });
 
@@ -111,7 +111,7 @@ describe("XML serializer", function() {
           $: {
             tasty: "true"
           },
-          _: "yum"
+          "#": "yum"
         }
       });
     });
@@ -175,7 +175,7 @@ describe("XML serializer", function() {
           $: {
             healthy: "true"
           },
-          _: "yum"
+          "#": "yum"
         }
       });
     });
@@ -218,7 +218,7 @@ describe("XML serializer", function() {
           $: {
             tasty: "true"
           },
-          _: "yum"
+          "#": "yum"
         }
       });
     });
@@ -293,7 +293,7 @@ describe("XML serializer", function() {
             $: {
               healthy: "true"
             },
-            _: "yum"
+            "#": "yum"
           }
         },
         { rootName: "fruits" }
@@ -311,7 +311,7 @@ describe("XML serializer", function() {
             $: {
               healthy: "true"
             },
-            _: "yum"
+            "#": "yum"
           }
         },
         { rootName: "fruits" }
@@ -374,7 +374,7 @@ describe("XML serializer", function() {
             $: {
               tasty: "true"
             },
-            _: "yum"
+            "#": "yum"
           }
         },
         { rootName: "fruits" }

--- a/sdk/servicebus/service-bus/src/util/constants.ts
+++ b/sdk/servicebus/service-bus/src/util/constants.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
+import { XML_ATTRKEY, XML_CHARKEY } from "@azure/core-http";
+
 /**
  * @internal
  * @ignore
@@ -345,7 +347,7 @@ export const ODATA_ERROR_MESSAGE_VALUE = "value";
  * @internal
  * @ignore
  */
-export const XML_METADATA_MARKER = "$";
+export const XML_METADATA_MARKER = XML_ATTRKEY;
 
 /**
  * Marker for atom value.
@@ -353,7 +355,7 @@ export const XML_METADATA_MARKER = "$";
  * @internal
  * @ignore
  */
-export const XML_VALUE_MARKER = "_";
+export const XML_VALUE_MARKER = XML_CHARKEY;
 
 /**
  * Constant representing the property where the atom default elements are stored.
@@ -361,7 +363,7 @@ export const XML_VALUE_MARKER = "_";
  * @internal
  * @ignore
  */
-export const ATOM_METADATA_MARKER = "_";
+export const ATOM_METADATA_MARKER = XML_CHARKEY;
 
 /**
  * Known HTTP status codes as documented and referenced in ATOM based management API feature


### PR DESCRIPTION
We were using '\_' as charkey in xml2js parser settings. It is the key used to
access the value content of xml elements.  This caused issues like
#9171 where '_' cannot be used as a blob metadata key. The fix is
switching to use '#' as the charkey.  '#' is an invalid character for
blob metadata key names and for identifer names in most programming
languages so it should be safe to use.

Consumers of our libraries are not impacted as this key is only used internally in core-http/Service Bus.