### PR TITLE
Pin dev dependency "follow-redirects"

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -16,6 +16,7 @@
      * instead of the latest version.
      */
     // "some-library": "1.2.3"
+    "follow-redirects": "1.11.0"
   },
   /**
    * When set to true, for all projects in the repo, all dependencies will be automatically added as preferredVersions,
@@ -41,7 +42,9 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/ms-rest-js": ["^2.0.0"],
+    "@azure/ms-rest-js": [
+      "^2.0.0"
+    ],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):
@@ -50,8 +53,12 @@
     //   "~2.4.0"
     // ]
     // Following is required to allow for backward compatibility with Event Processor Host Track 1
-    "@azure/event-hubs": ["^2.1.4"],
+    "@azure/event-hubs": [
+      "^2.1.4"
+    ],
     // Allow packages to continue to use old eslint-plugin-azure-sdk until they can adapt to 3.0.0
-    "@azure/eslint-plugin-azure-sdk": ["^2.0.1"]
+    "@azure/eslint-plugin-azure-sdk": [
+      "^2.0.1"
+    ]
   }
 }

--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -42,9 +42,7 @@
    * This design avoids unnecessary churn in this file.
    */
   "allowedAlternativeVersions": {
-    "@azure/ms-rest-js": [
-      "^2.0.0"
-    ],
+    "@azure/ms-rest-js": ["^2.0.0"],
     /**
      * For example, allow some projects to use an older TypeScript compiler
      * (in addition to whatever "usual" version is being used by other projects in the repo):
@@ -53,12 +51,8 @@
     //   "~2.4.0"
     // ]
     // Following is required to allow for backward compatibility with Event Processor Host Track 1
-    "@azure/event-hubs": [
-      "^2.1.4"
-    ],
+    "@azure/event-hubs": ["^2.1.4"],
     // Allow packages to continue to use old eslint-plugin-azure-sdk until they can adapt to 3.0.0
-    "@azure/eslint-plugin-azure-sdk": [
-      "^2.0.1"
-    ]
+    "@azure/eslint-plugin-azure-sdk": ["^2.0.1"]
   }
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -33,6 +33,7 @@ dependencies:
   '@rush-temp/test-utils-perfstress': 'file:projects/test-utils-perfstress.tgz'
   '@rush-temp/test-utils-recorder': 'file:projects/test-utils-recorder.tgz'
   '@rush-temp/testhub': 'file:projects/testhub.tgz'
+  follow-redirects: 1.11.0
 lockfileVersion: 5.1
 packages:
   /@azure/amqp-common/1.0.0-preview.9:
@@ -47,7 +48,7 @@ packages:
       is-buffer: 2.0.4
       jssha: 2.4.2
       process: 0.11.10
-      rhea: 1.0.21
+      rhea: 1.0.22
       rhea-promise: 0.1.15
       stream-browserify: 2.0.2
       tslib: 1.13.0
@@ -66,11 +67,11 @@ packages:
       integrity: sha512-ZKUpCd7Dlyfn7bdc+/zC/sf0aRIaNQMDuSj2RhYRFe3p70hVAnYGp3TX4cnG2yoEALp/LTj/XnZGQ8Xzf6Ja/Q==
   /@azure/eslint-plugin-azure-sdk/2.0.1_984cbb313f9ea271f36cadd8f9814e06:
     dependencies:
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       eslint: 6.8.0
       fast-levenshtein: 2.0.6
       glob: 7.1.6
-      typescript: 3.8.3
+      typescript: 3.9.5
     deprecated: 'This package is now a private implementation detail of https://github.com/Azure/azure-sdk-for-js'
     dev: false
     engines:
@@ -125,22 +126,22 @@ packages:
     dev: false
     resolution:
       integrity: sha512-aFHRw/IHhg3I9ZJW+Va4L+sCirFHMVIu6B7lFdL5mGLfG3xC5vDIdd957LRXFgy2OiKFRUC0QaKknd0YCsQIqA==
-  /@babel/code-frame/7.8.3:
+  /@babel/code-frame/7.10.1:
     dependencies:
-      '@babel/highlight': 7.9.0
+      '@babel/highlight': 7.10.1
     dev: false
     resolution:
-      integrity: sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
-  /@babel/core/7.9.6:
+      integrity: sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==
+  /@babel/core/7.10.2:
     dependencies:
-      '@babel/code-frame': 7.8.3
-      '@babel/generator': 7.9.6
-      '@babel/helper-module-transforms': 7.9.0
-      '@babel/helpers': 7.9.6
-      '@babel/parser': 7.9.6
-      '@babel/template': 7.8.6
-      '@babel/traverse': 7.9.6
-      '@babel/types': 7.9.6
+      '@babel/code-frame': 7.10.1
+      '@babel/generator': 7.10.2
+      '@babel/helper-module-transforms': 7.10.1
+      '@babel/helpers': 7.10.1
+      '@babel/parser': 7.10.2
+      '@babel/template': 7.10.1
+      '@babel/traverse': 7.10.1
+      '@babel/types': 7.10.2
       convert-source-map: 1.7.0
       debug: 4.1.1
       gensync: 1.0.0-beta.1
@@ -153,139 +154,139 @@ packages:
     engines:
       node: '>=6.9.0'
     resolution:
-      integrity: sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==
-  /@babel/generator/7.9.6:
+      integrity: sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==
+  /@babel/generator/7.10.2:
     dependencies:
-      '@babel/types': 7.9.6
+      '@babel/types': 7.10.2
       jsesc: 2.5.2
       lodash: 4.17.15
       source-map: 0.5.7
     dev: false
     resolution:
-      integrity: sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==
-  /@babel/helper-function-name/7.9.5:
+      integrity: sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==
+  /@babel/helper-function-name/7.10.1:
     dependencies:
-      '@babel/helper-get-function-arity': 7.8.3
-      '@babel/template': 7.8.6
-      '@babel/types': 7.9.6
+      '@babel/helper-get-function-arity': 7.10.1
+      '@babel/template': 7.10.1
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
-  /@babel/helper-get-function-arity/7.8.3:
+      integrity: sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==
+  /@babel/helper-get-function-arity/7.10.1:
     dependencies:
-      '@babel/types': 7.9.6
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
-  /@babel/helper-member-expression-to-functions/7.8.3:
+      integrity: sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==
+  /@babel/helper-member-expression-to-functions/7.10.1:
     dependencies:
-      '@babel/types': 7.9.6
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
-  /@babel/helper-module-imports/7.8.3:
+      integrity: sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==
+  /@babel/helper-module-imports/7.10.1:
     dependencies:
-      '@babel/types': 7.9.6
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
-  /@babel/helper-module-transforms/7.9.0:
+      integrity: sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==
+  /@babel/helper-module-transforms/7.10.1:
     dependencies:
-      '@babel/helper-module-imports': 7.8.3
-      '@babel/helper-replace-supers': 7.9.6
-      '@babel/helper-simple-access': 7.8.3
-      '@babel/helper-split-export-declaration': 7.8.3
-      '@babel/template': 7.8.6
-      '@babel/types': 7.9.6
+      '@babel/helper-module-imports': 7.10.1
+      '@babel/helper-replace-supers': 7.10.1
+      '@babel/helper-simple-access': 7.10.1
+      '@babel/helper-split-export-declaration': 7.10.1
+      '@babel/template': 7.10.1
+      '@babel/types': 7.10.2
       lodash: 4.17.15
     dev: false
     resolution:
-      integrity: sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
-  /@babel/helper-optimise-call-expression/7.8.3:
+      integrity: sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==
+  /@babel/helper-optimise-call-expression/7.10.1:
     dependencies:
-      '@babel/types': 7.9.6
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
-  /@babel/helper-replace-supers/7.9.6:
+      integrity: sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==
+  /@babel/helper-replace-supers/7.10.1:
     dependencies:
-      '@babel/helper-member-expression-to-functions': 7.8.3
-      '@babel/helper-optimise-call-expression': 7.8.3
-      '@babel/traverse': 7.9.6
-      '@babel/types': 7.9.6
+      '@babel/helper-member-expression-to-functions': 7.10.1
+      '@babel/helper-optimise-call-expression': 7.10.1
+      '@babel/traverse': 7.10.1
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==
-  /@babel/helper-simple-access/7.8.3:
+      integrity: sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==
+  /@babel/helper-simple-access/7.10.1:
     dependencies:
-      '@babel/template': 7.8.6
-      '@babel/types': 7.9.6
+      '@babel/template': 7.10.1
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
-  /@babel/helper-split-export-declaration/7.8.3:
+      integrity: sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==
+  /@babel/helper-split-export-declaration/7.10.1:
     dependencies:
-      '@babel/types': 7.9.6
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
-  /@babel/helper-validator-identifier/7.9.5:
+      integrity: sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==
+  /@babel/helper-validator-identifier/7.10.1:
     dev: false
     resolution:
-      integrity: sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
-  /@babel/helpers/7.9.6:
+      integrity: sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
+  /@babel/helpers/7.10.1:
     dependencies:
-      '@babel/template': 7.8.6
-      '@babel/traverse': 7.9.6
-      '@babel/types': 7.9.6
+      '@babel/template': 7.10.1
+      '@babel/traverse': 7.10.1
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==
-  /@babel/highlight/7.9.0:
+      integrity: sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==
+  /@babel/highlight/7.10.1:
     dependencies:
-      '@babel/helper-validator-identifier': 7.9.5
+      '@babel/helper-validator-identifier': 7.10.1
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: false
     resolution:
-      integrity: sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
-  /@babel/parser/7.9.6:
+      integrity: sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==
+  /@babel/parser/7.10.2:
     dev: false
     engines:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
-  /@babel/template/7.8.6:
+      integrity: sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
+  /@babel/template/7.10.1:
     dependencies:
-      '@babel/code-frame': 7.8.3
-      '@babel/parser': 7.9.6
-      '@babel/types': 7.9.6
+      '@babel/code-frame': 7.10.1
+      '@babel/parser': 7.10.2
+      '@babel/types': 7.10.2
     dev: false
     resolution:
-      integrity: sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
-  /@babel/traverse/7.9.6:
+      integrity: sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==
+  /@babel/traverse/7.10.1:
     dependencies:
-      '@babel/code-frame': 7.8.3
-      '@babel/generator': 7.9.6
-      '@babel/helper-function-name': 7.9.5
-      '@babel/helper-split-export-declaration': 7.8.3
-      '@babel/parser': 7.9.6
-      '@babel/types': 7.9.6
+      '@babel/code-frame': 7.10.1
+      '@babel/generator': 7.10.2
+      '@babel/helper-function-name': 7.10.1
+      '@babel/helper-split-export-declaration': 7.10.1
+      '@babel/parser': 7.10.2
+      '@babel/types': 7.10.2
       debug: 4.1.1
       globals: 11.12.0
       lodash: 4.17.15
     dev: false
     resolution:
-      integrity: sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
-  /@babel/types/7.9.6:
+      integrity: sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==
+  /@babel/types/7.10.2:
     dependencies:
-      '@babel/helper-validator-identifier': 7.9.5
+      '@babel/helper-validator-identifier': 7.10.1
       lodash: 4.17.15
       to-fast-properties: 2.0.0
     dev: false
     resolution:
-      integrity: sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
+      integrity: sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
   /@bahmutov/data-driven/1.0.0:
     dependencies:
       check-more-types: 2.24.0
@@ -349,9 +350,9 @@ packages:
       integrity: sha512-5bHhlTBBq82ti3qPT15TRxkYTFPPQWbnkkQkmHPtqiS1XcTB69cEKd3Jm7Cfi/vkPoyxapmePE9tyA7EzLt8SQ==
   /@rollup/plugin-commonjs/11.0.2_rollup@1.32.1:
     dependencies:
-      '@rollup/pluginutils': 3.0.10_rollup@1.32.1
+      '@rollup/pluginutils': 3.1.0_rollup@1.32.1
       estree-walker: 1.0.1
-      is-reference: 1.1.4
+      is-reference: 1.2.0
       magic-string: 0.25.7
       resolve: 1.17.0
       rollup: 1.32.1
@@ -364,7 +365,7 @@ packages:
       integrity: sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
   /@rollup/plugin-inject/4.0.2_rollup@1.32.1:
     dependencies:
-      '@rollup/pluginutils': 3.0.10_rollup@1.32.1
+      '@rollup/pluginutils': 3.1.0_rollup@1.32.1
       estree-walker: 1.0.1
       magic-string: 0.25.7
       rollup: 1.32.1
@@ -373,15 +374,15 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
       integrity: sha512-TSLMA8waJ7Dmgmoc8JfPnwUwVZgLjjIAM6MqeIFqPO2ODK36JqE0Cf2F54UTgCUuW8da93Mvoj75a6KAVWgylw==
-  /@rollup/plugin-json/4.0.3_rollup@1.32.1:
+  /@rollup/plugin-json/4.1.0_rollup@1.32.1:
     dependencies:
-      '@rollup/pluginutils': 3.0.10_rollup@1.32.1
+      '@rollup/pluginutils': 3.1.0_rollup@1.32.1
       rollup: 1.32.1
     dev: false
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
-      integrity: sha512-QMUT0HZNf4CX17LMdwaslzlYHUKTYGuuk34yYIgZrNdu+pMEfqMS55gck7HEeHBKXHM4cz5Dg1OVwythDdbbuQ==
+      integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
   /@rollup/plugin-multi-entry/3.0.1_rollup@1.32.1:
     dependencies:
       matched: 1.0.2
@@ -391,9 +392,9 @@ packages:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
       integrity: sha512-Gcp9E8y68Kx+Jo8zy/ZpiiAkb0W01cSqnxOz6h9bPR7MU3gaoTEdRf7xXYplwli1SBFEswXX588ESj+50Brfxw==
-  /@rollup/plugin-node-resolve/8.0.0_rollup@1.32.1:
+  /@rollup/plugin-node-resolve/8.0.1_rollup@1.32.1:
     dependencies:
-      '@rollup/pluginutils': 3.0.10_rollup@1.32.1
+      '@rollup/pluginutils': 3.1.0_rollup@1.32.1
       '@types/resolve': 0.0.8
       builtin-modules: 3.1.0
       deep-freeze: 0.0.1
@@ -407,18 +408,18 @@ packages:
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     resolution:
-      integrity: sha512-5poJCChrkVggXXND/sQ7yNqwjUNT4fP31gpRWCnSNnlXuUXTCMHT33xZrTGxgjm5Rl18MHj7iEzlCT8rYWwQSA==
-  /@rollup/plugin-replace/2.3.2_rollup@1.32.1:
+      integrity: sha512-KIeAmueDDaYMqMBnUngLVVZhURwxA12nq/YB6nGm5/JpVyOMwI1fCVU3oL/dAnnLBG7oiPXntO5LHOiMrfNXCA==
+  /@rollup/plugin-replace/2.3.3_rollup@1.32.1:
     dependencies:
-      '@rollup/pluginutils': 3.0.10_rollup@1.32.1
+      '@rollup/pluginutils': 3.1.0_rollup@1.32.1
       magic-string: 0.25.7
       rollup: 1.32.1
     dev: false
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     resolution:
-      integrity: sha512-KEEL7V2tMNOsbAoNMKg91l1sNXBDoiP31GFlqXVOuV5691VQKzKBh91+OKKOG4uQWYqcFskcjFyh1d5YnZd0Zw==
-  /@rollup/pluginutils/3.0.10_rollup@1.32.1:
+      integrity: sha512-XPmVXZ7IlaoWaJLkSCDaa0Y6uVo5XQYHhiMFzOd5qSv5rE+t/UJToPIOE56flKIxBFQI27ONsxb7dqHnwSsjKQ==
+  /@rollup/pluginutils/3.1.0_rollup@1.32.1:
     dependencies:
       '@types/estree': 0.0.39
       estree-walker: 1.0.1
@@ -430,7 +431,7 @@ packages:
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     resolution:
-      integrity: sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
+      integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
   /@rushstack/node-core-library/3.19.6:
     dependencies:
       '@types/node': 10.17.13
@@ -463,13 +464,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
-  /@sinonjs/formatio/3.2.2:
-    dependencies:
-      '@sinonjs/commons': 1.8.0
-      '@sinonjs/samsam': 3.3.3
-    dev: false
-    resolution:
-      integrity: sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
   /@sinonjs/formatio/5.0.1:
     dependencies:
       '@sinonjs/commons': 1.8.0
@@ -477,14 +471,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
-  /@sinonjs/samsam/3.3.3:
-    dependencies:
-      '@sinonjs/commons': 1.8.0
-      array-from: 2.1.1
-      lodash: 4.17.15
-    dev: false
-    resolution:
-      integrity: sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
   /@sinonjs/samsam/5.0.3:
     dependencies:
       '@sinonjs/commons': 1.8.0
@@ -512,7 +498,7 @@ packages:
   /@types/body-parser/1.19.0:
     dependencies:
       '@types/connect': 3.4.33
-      '@types/node': 14.0.4
+      '@types/node': 8.10.61
     dev: false
     resolution:
       integrity: sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
@@ -538,7 +524,7 @@ packages:
       integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
   /@types/connect/3.4.33:
     dependencies:
-      '@types/node': 14.0.4
+      '@types/node': 8.10.61
     dev: false
     resolution:
       integrity: sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==
@@ -553,7 +539,7 @@ packages:
   /@types/eslint/4.16.8:
     dependencies:
       '@types/estree': 0.0.39
-      '@types/json-schema': 7.0.4
+      '@types/json-schema': 7.0.5
     dev: false
     resolution:
       integrity: sha512-n0ZvaIpPeBxproRvV+tZoCHRxIoNAk+k+XMvQefKgx3qM3IundoogQBAwiNEnqW0GDP1j1ATe5lFy9xxutFAHg==
@@ -565,13 +551,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-iaIVzr+w2ZJ5HkidlZ3EJM8VTZb2MJLCjw3V+505yVts0gRC4UMvjw0d1HPtGqI/HQC/KdsYtayfzl+AXY2R8g==
-  /@types/events/3.0.0:
-    dev: false
-    resolution:
-      integrity: sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
   /@types/express-serve-static-core/4.17.7:
     dependencies:
-      '@types/node': 14.0.4
+      '@types/node': 8.10.61
       '@types/qs': 6.9.3
       '@types/range-parser': 1.2.3
     dev: false
@@ -596,49 +578,36 @@ packages:
     dev: false
     resolution:
       integrity: sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
-  /@types/glob/7.1.1:
+  /@types/glob/7.1.2:
     dependencies:
-      '@types/events': 3.0.0
       '@types/minimatch': 3.0.3
       '@types/node': 8.10.61
     dev: false
     resolution:
-      integrity: sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
+      integrity: sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==
   /@types/is-buffer/2.0.0:
     dependencies:
       '@types/node': 8.10.61
     dev: false
     resolution:
       integrity: sha512-0f7N/e3BAz32qDYvgB4d2cqv1DqUwvGxHkXsrucICn8la1Vb6Yl6Eg8mPScGwUiqHJeE7diXlzaK+QMA9m4Gxw==
-  /@types/json-schema/7.0.4:
+  /@types/json-schema/7.0.5:
     dev: false
     resolution:
-      integrity: sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
-  /@types/jssha/2.0.0:
-    dev: false
-    resolution:
-      integrity: sha512-oBnY3csYnXfqZXDRBJwP1nDDJCW/+VMJ88UHT4DCy0deSXpJIQvMCwYlnmdW4M+u7PiSfQc44LmiFcUbJ8hLEw==
+      integrity: sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
   /@types/jws/3.2.2:
     dependencies:
       '@types/node': 8.10.61
     dev: false
     resolution:
       integrity: sha512-S0ohSSX8ioT65zu8KbG99xKyFV3InIjbM3c8roYqWy4+5HpYPyUHLYykfhM6MEI5B/3s7KSZPGFyCzCrZ2TOZA==
-  /@types/karma/3.0.9:
-    dependencies:
-      '@types/bluebird': 3.5.32
-      '@types/node': 8.10.61
-      log4js: 4.5.1
-    dev: false
-    resolution:
-      integrity: sha512-GEhyutKIjZstOI1o9HHu58ApHLdgpyvihiUzLaPK3Ig5LIjRTagtSB5RbwKsmfKjmoh0qPNOCmZTYL37VTTcbA==
   /@types/long/4.0.1:
     dev: false
     resolution:
       integrity: sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
   /@types/md5/2.2.0:
     dependencies:
-      '@types/node': 14.0.4
+      '@types/node': 8.10.61
     dev: false
     resolution:
       integrity: sha512-JN8OVL/wiDlCWTPzplsgMPu0uE9Q6blwp68rYsfk2G8aokRUQ8XD9MEhZwihfAiQvoyE+m31m6i3GFXwYWomKQ==
@@ -685,10 +654,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
-  /@types/node/14.0.4:
-    dev: false
-    resolution:
-      integrity: sha512-k3NqigXWRzQZVBDS5D1U70A5E8Qk4Kh+Ha/x4M8Bt9pF0X05eggfnC9+63Usc9Q928hRUIpIhTQaXsZwZBl4Ew==
   /@types/node/8.10.61:
     dev: false
     resolution:
@@ -711,7 +676,7 @@ packages:
       integrity: sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
   /@types/resolve/0.0.8:
     dependencies:
-      '@types/node': 14.0.4
+      '@types/node': 10.17.13
     dev: false
     resolution:
       integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
@@ -742,7 +707,7 @@ packages:
       integrity: sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
   /@types/tunnel/0.0.0:
     dependencies:
-      '@types/node': 14.0.4
+      '@types/node': 8.10.61
     dev: false
     resolution:
       integrity: sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==
@@ -760,12 +725,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==
-  /@types/ws/7.2.4:
+  /@types/ws/7.2.5:
     dependencies:
-      '@types/node': 14.0.4
+      '@types/node': 8.10.61
     dev: false
     resolution:
-      integrity: sha512-9S6Ask71vujkVyeEXKxjBSUV8ZUB0mjL5la4IncBoheu04bDaYyUKErh1BQcY9+WzOUOiKqz/OnpJHYckbMfNg==
+      integrity: sha512-4UEih9BI1nBKii385G9id1oFrSkLcClbwtDfcYj8HJLQqZVAtb/42vXVrYvRWCcufNF/a+rZD3MxNwghA7UmCg==
   /@types/xml2js/0.4.5:
     dependencies:
       '@types/node': 8.10.61
@@ -784,18 +749,18 @@ packages:
       integrity: sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
   /@types/yauzl/2.9.1:
     dependencies:
-      '@types/node': 14.0.4
+      '@types/node': 8.10.61
     dev: false
     optional: true
     resolution:
       integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
-  /@typescript-eslint/eslint-plugin-tslint/2.34.0_a41b4b021727de5dc0e615e83abafe21:
+  /@typescript-eslint/eslint-plugin-tslint/2.34.0_81790f39504d9fb1ae55c5faec13eab0:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.5
       eslint: 6.8.0
       lodash: 4.17.15
-      tslint: 5.20.1_typescript@3.9.3
-      typescript: 3.9.3
+      tslint: 5.20.1_typescript@3.9.5
+      typescript: 3.9.5
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -805,15 +770,15 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-sCPCbFm1qRTzloeMUlHEKfgQH/2u9bUcW7tX5wjzRw1LWzsr+iNXS8I+2or9ep8mlqqE0Vy6hsMm4vVF82M2jw==
-  /@typescript-eslint/eslint-plugin/2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d:
+  /@typescript-eslint/eslint-plugin/2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb:
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.3
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.5
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       eslint: 6.8.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.1.0
-      tsutils: 3.17.1_typescript@3.9.3
-      typescript: 3.9.3
+      tsutils: 3.17.1_typescript@3.9.5
+      typescript: 3.9.5
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -826,14 +791,14 @@ packages:
         optional: true
     resolution:
       integrity: sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
-  /@typescript-eslint/experimental-utils/2.34.0_eslint@6.8.0+typescript@3.9.3:
+  /@typescript-eslint/experimental-utils/2.34.0_eslint@6.8.0+typescript@3.9.5:
     dependencies:
-      '@types/json-schema': 7.0.4
-      '@typescript-eslint/typescript-estree': 2.34.0_typescript@3.9.3
+      '@types/json-schema': 7.0.5
+      '@typescript-eslint/typescript-estree': 2.34.0_typescript@3.9.5
       eslint: 6.8.0
-      eslint-scope: 5.0.0
-      eslint-utils: 2.0.0
-      typescript: 3.9.3
+      eslint-scope: 5.1.0
+      eslint-utils: 2.1.0
+      typescript: 3.9.5
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -842,14 +807,14 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
-  /@typescript-eslint/parser/2.34.0_eslint@6.8.0+typescript@3.9.3:
+  /@typescript-eslint/parser/2.34.0_eslint@6.8.0+typescript@3.9.5:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.3
-      '@typescript-eslint/typescript-estree': 2.34.0_typescript@3.9.3
+      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.5
+      '@typescript-eslint/typescript-estree': 2.34.0_typescript@3.9.5
       eslint: 6.8.0
-      eslint-visitor-keys: 1.1.0
-      typescript: 3.9.3
+      eslint-visitor-keys: 1.2.0
+      typescript: 3.9.5
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -861,16 +826,16 @@ packages:
         optional: true
     resolution:
       integrity: sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
-  /@typescript-eslint/typescript-estree/2.34.0_typescript@3.9.3:
+  /@typescript-eslint/typescript-estree/2.34.0_typescript@3.9.5:
     dependencies:
       debug: 4.1.1
-      eslint-visitor-keys: 1.1.0
+      eslint-visitor-keys: 1.2.0
       glob: 7.1.6
       is-glob: 4.0.1
       lodash: 4.17.15
       semver: 7.3.2
-      tsutils: 3.17.1_typescript@3.9.3
-      typescript: 3.9.3
+      tsutils: 3.17.1_typescript@3.9.5
+      typescript: 3.9.5
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -894,21 +859,21 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
-  /acorn-jsx/5.2.0_acorn@7.2.0:
+  /acorn-jsx/5.2.0_acorn@7.3.1:
     dependencies:
-      acorn: 7.2.0
+      acorn: 7.3.1
     dev: false
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0
     resolution:
       integrity: sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
-  /acorn/7.2.0:
+  /acorn/7.3.1:
     dev: false
     engines:
       node: '>=0.4.0'
     hasBin: true
     resolution:
-      integrity: sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+      integrity: sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
   /adal-node/0.1.28:
     dependencies:
       '@types/node': 8.10.61
@@ -961,7 +926,7 @@ packages:
       integrity: sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==
   /ajv/6.12.2:
     dependencies:
-      fast-deep-equal: 3.1.1
+      fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.2.2
@@ -1121,10 +1086,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
-  /array-from/2.1.1:
-    dev: false
-    resolution:
-      integrity: sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
   /array-uniq/1.0.3:
     dev: false
     engines:
@@ -1225,10 +1186,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
-  /aws4/1.9.1:
+  /aws4/1.10.0:
     dev: false
     resolution:
-      integrity: sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+      integrity: sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==
   /axios/0.19.2:
     dependencies:
       follow-redirects: 1.5.10
@@ -1308,10 +1269,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
-  /big.js/5.2.2:
-    dev: false
-    resolution:
-      integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
   /binary-extensions/2.0.0:
     dev: false
     engines:
@@ -1808,7 +1765,7 @@ packages:
       integrity: sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==
   /cross-env/7.0.2:
     dependencies:
-      cross-spawn: 7.0.2
+      cross-spawn: 7.0.3
     dev: false
     engines:
       node: '>=10.14'
@@ -1836,7 +1793,7 @@ packages:
       node: '>=4.8'
     resolution:
       integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
-  /cross-spawn/7.0.2:
+  /cross-spawn/7.0.3:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -1845,7 +1802,7 @@ packages:
     engines:
       node: '>= 8'
     resolution:
-      integrity: sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==
+      integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
   /crypt/0.0.2:
     dev: false
     resolution:
@@ -1916,7 +1873,7 @@ packages:
       integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   /debug/3.2.6:
     dependencies:
-      ms: 2.1.1
+      ms: 2.1.2
     dev: false
     resolution:
       integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -1993,7 +1950,7 @@ packages:
   /degenerator/1.0.4:
     dependencies:
       ast-types: 0.13.3
-      escodegen: 1.14.1
+      escodegen: 1.14.2
       esprima: 3.1.3
     dev: false
     resolution:
@@ -2087,7 +2044,7 @@ packages:
   /downlevel-dts/0.4.0:
     dependencies:
       shelljs: 0.8.4
-      typescript: 3.8.3
+      typescript: 3.9.5
     dev: false
     hasBin: true
     resolution:
@@ -2127,12 +2084,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
-  /emojis-list/3.0.0:
-    dev: false
-    engines:
-      node: '>= 4'
-    resolution:
-      integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
   /encodeurl/1.0.2:
     dev: false
     engines:
@@ -2182,54 +2133,37 @@ packages:
     dev: false
     resolution:
       integrity: sha512-+VlKzHzMhaU+GsCIg4AoXF1UdDFjHHwMmMKqMJNDNLlUlejz58FCy4LBqB2YVJskHGYl06BatYWKP2TVdVXE5w==
-  /enhanced-resolve/4.1.1:
-    dependencies:
-      graceful-fs: 4.2.4
-      memory-fs: 0.5.0
-      tapable: 1.1.3
-    dev: false
-    engines:
-      node: '>=6.9.0'
-    resolution:
-      integrity: sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==
   /ent/2.2.0:
     dev: false
     resolution:
       integrity: sha1-6WQhkyWiHQX0RGai9obtbOX13R0=
-  /errno/0.1.7:
-    dependencies:
-      prr: 1.0.1
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
   /error-ex/1.3.2:
     dependencies:
       is-arrayish: 0.2.1
     dev: false
     resolution:
       integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
-  /es-abstract/1.17.5:
+  /es-abstract/1.17.6:
     dependencies:
       es-to-primitive: 1.2.1
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.1
-      is-callable: 1.1.5
-      is-regex: 1.0.5
+      is-callable: 1.2.0
+      is-regex: 1.1.0
       object-inspect: 1.7.0
       object-keys: 1.1.1
       object.assign: 4.1.0
-      string.prototype.trimleft: 2.1.2
-      string.prototype.trimright: 2.1.2
+      string.prototype.trimend: 1.0.1
+      string.prototype.trimstart: 1.0.1
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
+      integrity: sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
   /es-to-primitive/1.2.1:
     dependencies:
-      is-callable: 1.1.5
+      is-callable: 1.2.0
       is-date-object: 1.0.2
       is-symbol: 1.0.3
     dev: false
@@ -2277,7 +2211,7 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
-  /escodegen/1.14.1:
+  /escodegen/1.14.2:
     dependencies:
       esprima: 4.0.1
       estraverse: 4.3.0
@@ -2290,7 +2224,7 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
     resolution:
-      integrity: sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==
+      integrity: sha512-InuOIiKk8wwuOFg6x9BQXbzjrQhtyXh46K9bqVTPzSo2FnyMBaYGBMC6PhQy7yxxil9vIedFBweQBMK74/7o8A==
   /escodegen/1.8.1:
     dependencies:
       esprima: 2.7.3
@@ -2337,7 +2271,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
-  /eslint-scope/5.0.0:
+  /eslint-scope/5.1.0:
     dependencies:
       esrecurse: 4.2.1
       estraverse: 4.3.0
@@ -2345,40 +2279,40 @@ packages:
     engines:
       node: '>=8.0.0'
     resolution:
-      integrity: sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+      integrity: sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
   /eslint-utils/1.4.3:
     dependencies:
-      eslint-visitor-keys: 1.1.0
+      eslint-visitor-keys: 1.2.0
     dev: false
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
-  /eslint-utils/2.0.0:
+  /eslint-utils/2.1.0:
     dependencies:
-      eslint-visitor-keys: 1.1.0
+      eslint-visitor-keys: 1.2.0
     dev: false
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
-  /eslint-visitor-keys/1.1.0:
+      integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  /eslint-visitor-keys/1.2.0:
     dev: false
     engines:
       node: '>=4'
     resolution:
-      integrity: sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+      integrity: sha512-WFb4ihckKil6hu3Dp798xdzSfddwKKU3+nGniKF6HfeW6OLd2OUDEPP7TcHtB5+QXOKg2s6B2DaMPE1Nn/kxKQ==
   /eslint/6.8.0:
     dependencies:
-      '@babel/code-frame': 7.8.3
+      '@babel/code-frame': 7.10.1
       ajv: 6.12.2
       chalk: 2.4.2
       cross-spawn: 6.0.5
       debug: 4.1.1
       doctrine: 3.0.0
-      eslint-scope: 5.0.0
+      eslint-scope: 5.1.0
       eslint-utils: 1.4.3
-      eslint-visitor-keys: 1.1.0
+      eslint-visitor-keys: 1.2.0
       espree: 6.2.1
       esquery: 1.3.1
       esutils: 2.0.3
@@ -2389,9 +2323,9 @@ packages:
       ignore: 4.0.6
       import-fresh: 3.2.1
       imurmurhash: 0.1.4
-      inquirer: 7.1.0
+      inquirer: 7.2.0
       is-glob: 4.0.1
-      js-yaml: 3.13.1
+      js-yaml: 3.14.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.3.0
       lodash: 4.17.15
@@ -2406,7 +2340,7 @@ packages:
       strip-json-comments: 3.1.0
       table: 5.4.6
       text-table: 0.2.0
-      v8-compile-cache: 2.1.0
+      v8-compile-cache: 2.1.1
     dev: false
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
@@ -2421,9 +2355,9 @@ packages:
       integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
   /espree/6.2.1:
     dependencies:
-      acorn: 7.2.0
-      acorn-jsx: 5.2.0_acorn@7.2.0
-      eslint-visitor-keys: 1.1.0
+      acorn: 7.3.1
+      acorn-jsx: 5.2.0_acorn@7.3.1
+      eslint-visitor-keys: 1.2.0
     dev: false
     engines:
       node: '>=6.0.0'
@@ -2530,7 +2464,7 @@ packages:
       integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
   /execa/3.4.0:
     dependencies:
-      cross-spawn: 7.0.2
+      cross-spawn: 7.0.3
       get-stream: 5.1.0
       human-signals: 1.1.1
       is-stream: 2.0.0
@@ -2640,10 +2574,10 @@ packages:
       node: '>= 0.10'
     resolution:
       integrity: sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==
-  /fast-deep-equal/3.1.1:
+  /fast-deep-equal/3.1.3:
     dev: false
     resolution:
-      integrity: sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+      integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
   /fast-json-stable-stringify/2.1.0:
     dev: false
     resolution:
@@ -3150,7 +3084,7 @@ packages:
       node: '>=0.4.7'
     hasBin: true
     optionalDependencies:
-      uglify-js: 3.9.3
+      uglify-js: 3.9.4
     resolution:
       integrity: sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
   /har-schema/2.0.0:
@@ -3442,7 +3376,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
-  /inquirer/7.1.0:
+  /inquirer/7.2.0:
     dependencies:
       ansi-escapes: 4.3.1
       chalk: 3.0.0
@@ -3459,15 +3393,15 @@ packages:
       through: 2.3.8
     dev: false
     engines:
-      node: '>=6.0.0'
+      node: '>=8.0.0'
     resolution:
-      integrity: sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
-  /interpret/1.2.0:
+      integrity: sha512-E0c4rPwr9ByePfNlTIB8z51kK1s2n6jrHuJeEHENl/sbq2G/S1auvibgEwNR4uSyiU+PiYHqSwsgGiXjG8p5ZQ==
+  /interpret/1.4.0:
     dev: false
     engines:
       node: '>= 0.10'
     resolution:
-      integrity: sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
+      integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
   /ip/1.1.5:
     dev: false
     resolution:
@@ -3506,12 +3440,12 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
-  /is-callable/1.1.5:
+  /is-callable/1.2.0:
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+      integrity: sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
   /is-ci/2.0.0:
     dependencies:
       ci-info: 2.0.0
@@ -3595,20 +3529,20 @@ packages:
       node: '>=0.12.0'
     resolution:
       integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-  /is-reference/1.1.4:
+  /is-reference/1.2.0:
     dependencies:
-      '@types/estree': 0.0.39
+      '@types/estree': 0.0.44
     dev: false
     resolution:
-      integrity: sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==
-  /is-regex/1.0.5:
+      integrity: sha512-ZVxq+5TkOx6GQdnoMm2aRdCKADdcrOWXLGzGT+vIA8DMpqEJaRk5AL1bS80zJ2bjHunVmjdzfCt0e4BymIEqKQ==
+  /is-regex/1.1.0:
     dependencies:
-      has: 1.0.3
+      has-symbols: 1.0.1
     dev: false
     engines:
       node: '>= 0.4'
     resolution:
-      integrity: sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+      integrity: sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==
   /is-stream/1.1.0:
     dev: false
     engines:
@@ -3636,7 +3570,7 @@ packages:
   /is-typed-array/1.1.3:
     dependencies:
       available-typed-arrays: 1.0.2
-      es-abstract: 1.17.5
+      es-abstract: 1.17.6
       foreach: 2.0.5
       has-symbols: 1.0.1
     dev: false
@@ -3722,11 +3656,11 @@ packages:
       integrity: sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.9.6
-      '@babel/parser': 7.9.6
-      '@babel/template': 7.8.6
-      '@babel/traverse': 7.9.6
-      '@babel/types': 7.9.6
+      '@babel/generator': 7.10.2
+      '@babel/parser': 7.10.2
+      '@babel/template': 7.10.1
+      '@babel/traverse': 7.10.1
+      '@babel/types': 7.10.2
       istanbul-lib-coverage: 2.0.5
       semver: 6.3.0
     dev: false
@@ -3736,7 +3670,7 @@ packages:
       integrity: sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.9.6
+      '@babel/core': 7.10.2
       '@istanbuljs/schema': 0.1.2
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -3812,7 +3746,7 @@ packages:
       esprima: 2.7.3
       glob: 5.0.15
       handlebars: 4.7.6
-      js-yaml: 3.13.1
+      js-yaml: 3.14.0
       mkdirp: 0.5.5
       nopt: 3.0.6
       once: 1.4.0
@@ -3863,6 +3797,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  /js-yaml/3.14.0:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+    dev: false
+    hasBin: true
+    resolution:
+      integrity: sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
   /jsbn/0.1.1:
     dev: false
     resolution:
@@ -3900,13 +3842,6 @@ packages:
     dev: false
     resolution:
       integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
-  /json5/1.0.1:
-    dependencies:
-      minimist: 1.2.5
-    dev: false
-    hasBin: true
-    resolution:
-      integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   /json5/2.1.3:
     dependencies:
       minimist: 1.2.5
@@ -4128,7 +4063,7 @@ packages:
       isbinaryfile: 3.0.3
       lodash: 4.17.15
       log4js: 4.5.1
-      mime: 2.4.5
+      mime: 2.4.6
       minimatch: 3.0.4
       optimist: 0.6.1
       qjobs: 1.2.0
@@ -4191,16 +4126,6 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
-  /loader-utils/1.4.0:
-    dependencies:
-      big.js: 5.2.2
-      emojis-list: 3.0.0
-      json5: 1.0.1
-    dev: false
-    engines:
-      node: '>=4.0.0'
-    resolution:
-      integrity: sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
   /locate-path/3.0.0:
     dependencies:
       p-locate: 3.0.0
@@ -4349,12 +4274,6 @@ packages:
       node: '>=6.0'
     resolution:
       integrity: sha512-EEEgFcE9bLgaYUKuozyFfytQM2wDHtXn4tAN41pkaxpNjAykv11GVdeI4tHtmPWW4Xrgh9R/2d7XYghDVjbKKw==
-  /lolex/5.1.2:
-    dependencies:
-      '@sinonjs/commons': 1.8.0
-    dev: false
-    resolution:
-      integrity: sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==
   /long/4.0.0:
     dev: false
     resolution:
@@ -4465,15 +4384,6 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-  /memory-fs/0.5.0:
-    dependencies:
-      errno: 0.1.7
-      readable-stream: 2.3.7
-    dev: false
-    engines:
-      node: '>=4.3.0 <5.0.0 || >=5.10'
-    resolution:
-      integrity: sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==
   /memorystream/0.3.1:
     dev: false
     engines:
@@ -4517,15 +4427,6 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
-  /micromatch/4.0.2:
-    dependencies:
-      braces: 3.0.2
-      picomatch: 2.2.2
-    dev: false
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
   /mime-db/1.44.0:
     dev: false
     engines:
@@ -4547,13 +4448,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
-  /mime/2.4.5:
+  /mime/2.4.6:
     dev: false
     engines:
       node: '>=4.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-3hQhEUF027BuxZjQA3s7rIv/7VCQPa27hN9u9g87sEkWaKwQPuXOkVKtOeiyUrnWqTDiOs8Ed2rwg733mB0R5w==
+      integrity: sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
   /mimic-fn/2.1.0:
     dev: false
     engines:
@@ -4613,12 +4514,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
-  /mocha-junit-reporter/1.23.3_mocha@7.1.2:
+  /mocha-junit-reporter/1.23.3_mocha@7.2.0:
     dependencies:
       debug: 2.6.9
       md5: 2.2.1
       mkdirp: 0.5.5
-      mocha: 7.1.2
+      mocha: 7.2.0
       strip-ansi: 4.0.0
       xml: 1.0.1
     dev: false
@@ -4626,7 +4527,7 @@ packages:
       mocha: '>=2.2.5'
     resolution:
       integrity: sha512-ed8LqbRj1RxZfjt/oC9t12sfrWsjZ3gNnbhV1nuj9R/Jb5/P3Xb4duv2eCfCDMYH+fEu0mqca7m4wsiVjsxsvA==
-  /mocha/7.1.2:
+  /mocha/7.2.0:
     dependencies:
       ansi-colors: 3.2.3
       browser-stdout: 1.3.1
@@ -4657,7 +4558,7 @@ packages:
       node: '>= 8.10.0'
     hasBin: true
     resolution:
-      integrity: sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==
+      integrity: sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==
   /mock-fs/4.12.0:
     dev: false
     resolution:
@@ -4687,14 +4588,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-  /msal/1.3.1:
+  /msal/1.3.2:
     dependencies:
       tslib: 1.13.0
     dev: false
     engines:
       node: '>=0.8.0'
     resolution:
-      integrity: sha512-xfnn8k3GCTmNV571R8Sy0zeLIrpoMB/10MRG1XkeoiFNIQKY19ncq3isZNCRCMDMRy2qa/vd8exYEhK9EPLHIg==
+      integrity: sha512-vhcpM/ELL+UI7i4HzCegcbSfPMLqf3kp8mAT840bK1ZaDcb7Z1mOJik1jg202V0yfnh/bBPxZhQP6xFgD9g5eA==
   /multipipe/0.1.2:
     dependencies:
       duplexer2: 0.0.2
@@ -4709,13 +4610,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
-  /nanoid/3.1.9:
+  /nanoid/3.1.10:
     dev: false
     engines:
       node: ^10 || ^12 || >=13.7
     hasBin: true
     resolution:
-      integrity: sha512-fFiXlFo4Wkuei3i6w9SQI6yuzGRTGi8Z2zZKZpUxv/bQlBi4jtbVPBSNFZHQA9PNjofWqtIa8p+pnsc0kgZrhQ==
+      integrity: sha512-iZFMXKeXWkxzlfmMfM91gw7YhN2sdJtixY+eZh9V6QWJWTOiurhpKhBMgr82pfzgSqglQgqYSCowEYsz8D++6w==
   /napi-build-utils/1.0.2:
     dev: false
     resolution:
@@ -4748,16 +4649,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-  /nise/1.5.3:
-    dependencies:
-      '@sinonjs/formatio': 3.2.2
-      '@sinonjs/text-encoding': 0.7.1
-      just-extend: 4.1.0
-      lolex: 5.1.2
-      path-to-regexp: 1.8.0
-    dev: false
-    resolution:
-      integrity: sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==
   /nise/4.0.3:
     dependencies:
       '@sinonjs/commons': 1.8.0
@@ -4768,18 +4659,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==
-  /nock/11.9.1:
-    dependencies:
-      debug: 4.1.1
-      json-stringify-safe: 5.0.1
-      lodash: 4.17.15
-      mkdirp: 0.5.5
-      propagate: 2.0.1
-    dev: false
-    engines:
-      node: '>= 8.0'
-    resolution:
-      integrity: sha512-U5wPctaY4/ar2JJ5Jg4wJxlbBfayxgKbiAeGh+a1kk6Pwnc2ZEuKviLyDSG6t0uXl56q7AALIxoM6FJrBSsVXA==
   /nock/12.0.3:
     dependencies:
       debug: 4.1.1
@@ -4791,12 +4670,12 @@ packages:
       node: '>= 10.13'
     resolution:
       integrity: sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==
-  /node-abi/2.17.0:
+  /node-abi/2.18.0:
     dependencies:
       semver: 5.7.1
     dev: false
     resolution:
-      integrity: sha512-dFRAA0ACk/aBo0TIXQMEWMLUTyWYYT8OBYIzLmEUrQTElGRjxDCvyBZIsDL0QA7QCaj9PrawhOmTEdsuLY4uOQ==
+      integrity: sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==
   /node-abort-controller/1.0.4:
     dev: false
     resolution:
@@ -4912,7 +4791,7 @@ packages:
       istanbul-lib-report: 2.0.8
       istanbul-lib-source-maps: 3.0.6
       istanbul-reports: 2.2.7
-      js-yaml: 3.13.1
+      js-yaml: 3.14.0
       make-dir: 2.1.0
       merge-source-map: 1.1.0
       resolve-from: 4.0.0
@@ -4973,7 +4852,7 @@ packages:
   /object.getownpropertydescriptors/2.1.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.5
+      es-abstract: 1.17.6
     dev: false
     engines:
       node: '>= 0.8'
@@ -5039,7 +4918,7 @@ packages:
   /os-name/3.1.0:
     dependencies:
       macos-release: 2.3.0
-      windows-release: 3.3.0
+      windows-release: 3.3.1
     dev: false
     engines:
       node: '>=6'
@@ -5339,7 +5218,7 @@ packages:
       minimist: 1.2.5
       mkdirp: 0.5.5
       napi-build-utils: 1.0.2
-      node-abi: 2.17.0
+      node-abi: 2.18.0
       noop-logger: 0.1.1
       npmlog: 4.1.2
       pump: 3.0.0
@@ -5431,10 +5310,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-  /prr/1.0.1:
-    dev: false
-    resolution:
-      integrity: sha1-0/wRS6BplaRexok/SEzrHXj19HY=
   /pseudomap/1.0.2:
     dev: false
     resolution:
@@ -5473,7 +5348,7 @@ packages:
       debug: 4.1.1
       extract-zip: 2.0.1
       https-proxy-agent: 4.0.0
-      mime: 2.4.5
+      mime: 2.4.6
       progress: 2.0.3
       proxy-from-env: 1.1.0
       rimraf: 3.0.2
@@ -5750,7 +5625,7 @@ packages:
   /request/2.88.2:
     dependencies:
       aws-sign2: 0.7.0
-      aws4: 1.9.1
+      aws4: 1.10.0
       caseless: 0.12.0
       combined-stream: 1.0.8
       extend: 3.0.2
@@ -5848,7 +5723,7 @@ packages:
   /rhea-promise/0.1.15:
     dependencies:
       debug: 3.2.6
-      rhea: 1.0.21
+      rhea: 1.0.22
       tslib: 1.13.0
     dev: false
     resolution:
@@ -5856,17 +5731,17 @@ packages:
   /rhea-promise/1.0.0:
     dependencies:
       debug: 3.2.6
-      rhea: 1.0.21
+      rhea: 1.0.22
       tslib: 1.13.0
     dev: false
     resolution:
       integrity: sha512-odAjpbB/IpFFBenPDwPkTWMQldt+DUlMBH9yI48Ct5OgTeDuuQcBnlhB+YCc6g2z8+URiP2ejms88joEanNCaw==
-  /rhea/1.0.21:
+  /rhea/1.0.22:
     dependencies:
       debug: 3.2.6
     dev: false
     resolution:
-      integrity: sha512-9ddxyJR0nlWmynukzZTWN+bSYWu7KLHVMkIH/7PpFG5RHfV5t7zXIfZ6rqJSJe9wBAgnNr2Xz41KM2nPujWiFQ==
+      integrity: sha512-FLZtI4+Nka43ppZUvpdzC0TadWrLsXHhGEDm4WidmqSRVhaXs0Q3jCdCHCoQCBIV80KJU1cj79Xviklx4Avgag==
   /rimraf/2.6.3:
     dependencies:
       glob: 7.1.6
@@ -5911,12 +5786,12 @@ packages:
       integrity: sha1-YhJaqUCHqt97g+9N+vYptHMTXoc=
   /rollup-plugin-terser/5.3.0_rollup@1.32.1:
     dependencies:
-      '@babel/code-frame': 7.8.3
+      '@babel/code-frame': 7.10.1
       jest-worker: 24.9.0
       rollup: 1.32.1
       rollup-pluginutils: 2.8.2
       serialize-javascript: 2.1.2
-      terser: 4.7.0
+      terser: 4.8.0
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <3'
@@ -5924,11 +5799,11 @@ packages:
       integrity: sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==
   /rollup-plugin-uglify/6.0.4_rollup@1.32.1:
     dependencies:
-      '@babel/code-frame': 7.8.3
+      '@babel/code-frame': 7.10.1
       jest-worker: 24.9.0
       rollup: 1.32.1
       serialize-javascript: 2.1.2
-      uglify-js: 3.9.3
+      uglify-js: 3.9.4
     dev: false
     peerDependencies:
       rollup: '>=0.66.0 <2'
@@ -5936,7 +5811,7 @@ packages:
       integrity: sha512-ddgqkH02klveu34TF0JqygPwZnsbhHVI6t8+hGTcYHngPkQb5MIHI0XiztXIN/d6V9j+efwHAqEL7LspSxQXGw==
   /rollup-plugin-visualizer/4.0.4_rollup@1.32.1:
     dependencies:
-      nanoid: 3.1.9
+      nanoid: 3.1.10
       open: 7.0.4
       pupa: 2.0.1
       rollup: 1.32.1
@@ -5960,7 +5835,7 @@ packages:
     dependencies:
       '@types/estree': 0.0.44
       '@types/node': 8.10.61
-      acorn: 7.2.0
+      acorn: 7.3.1
     dev: false
     hasBin: true
     resolution:
@@ -6105,7 +5980,7 @@ packages:
   /shelljs/0.8.4:
     dependencies:
       glob: 7.1.6
-      interpret: 1.2.0
+      interpret: 1.4.0
       rechoir: 0.6.2
     dev: false
     engines:
@@ -6352,13 +6227,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==
-  /spdx-correct/3.1.0:
+  /spdx-correct/3.1.1:
     dependencies:
       spdx-expression-parse: 3.0.1
       spdx-license-ids: 3.0.5
     dev: false
     resolution:
-      integrity: sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
+      integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
   /spdx-exceptions/2.3.0:
     dev: false
     resolution:
@@ -6475,7 +6350,7 @@ packages:
   /string.prototype.padend/3.1.0:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.5
+      es-abstract: 1.17.6
     dev: false
     engines:
       node: '>= 0.4'
@@ -6484,34 +6359,14 @@ packages:
   /string.prototype.trimend/1.0.1:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.5
+      es-abstract: 1.17.6
     dev: false
     resolution:
       integrity: sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
-  /string.prototype.trimleft/2.1.2:
-    dependencies:
-      define-properties: 1.1.3
-      es-abstract: 1.17.5
-      string.prototype.trimstart: 1.0.1
-    dev: false
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
-  /string.prototype.trimright/2.1.2:
-    dependencies:
-      define-properties: 1.1.3
-      es-abstract: 1.17.5
-      string.prototype.trimend: 1.0.1
-    dev: false
-    engines:
-      node: '>= 0.4'
-    resolution:
-      integrity: sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
   /string.prototype.trimstart/1.0.1:
     dependencies:
       define-properties: 1.1.3
-      es-abstract: 1.17.5
+      es-abstract: 1.17.6
     dev: false
     resolution:
       integrity: sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
@@ -6667,12 +6522,6 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
-  /tapable/1.1.3:
-    dev: false
-    engines:
-      node: '>=6'
-    resolution:
-      integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
   /tar-fs/2.1.0:
     dependencies:
       chownr: 1.1.4
@@ -6692,7 +6541,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
-  /terser/4.7.0:
+  /terser/4.8.0:
     dependencies:
       commander: 2.20.3
       source-map: 0.6.1
@@ -6702,7 +6551,7 @@ packages:
       node: '>=6.0.0'
     hasBin: true
     resolution:
-      integrity: sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==
+      integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
   /test-exclude/5.2.3:
     dependencies:
       glob: 7.1.6
@@ -6806,28 +6655,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-WIeWa7WCpFA6QetST301ARgVphM=
-  /ts-loader/6.2.2_typescript@3.9.3:
-    dependencies:
-      chalk: 2.4.2
-      enhanced-resolve: 4.1.1
-      loader-utils: 1.4.0
-      micromatch: 4.0.2
-      semver: 6.3.0
-      typescript: 3.9.3
-    dev: false
-    engines:
-      node: '>=8.6'
-    peerDependencies:
-      typescript: '*'
-    resolution:
-      integrity: sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==
-  /ts-node/8.10.1_typescript@3.9.3:
+  /ts-node/8.10.2_typescript@3.9.5:
     dependencies:
       arg: 4.1.3
       diff: 4.0.2
       make-error: 1.3.6
       source-map-support: 0.5.19
-      typescript: 3.9.3
+      typescript: 3.9.5
       yn: 3.1.1
     dev: false
     engines:
@@ -6836,7 +6670,7 @@ packages:
     peerDependencies:
       typescript: '>=2.7'
     resolution:
-      integrity: sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==
+      integrity: sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
   /tslib/1.13.0:
     dev: false
     resolution:
@@ -6852,22 +6686,22 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==
-  /tslint/5.20.1_typescript@3.9.3:
+  /tslint/5.20.1_typescript@3.9.5:
     dependencies:
-      '@babel/code-frame': 7.8.3
+      '@babel/code-frame': 7.10.1
       builtin-modules: 1.1.1
       chalk: 2.4.2
       commander: 2.20.3
       diff: 4.0.2
       glob: 7.1.6
-      js-yaml: 3.13.1
+      js-yaml: 3.14.0
       minimatch: 3.0.4
       mkdirp: 0.5.5
       resolve: 1.17.0
       semver: 5.7.1
       tslib: 1.13.0
-      tsutils: 2.29.0_typescript@3.9.3
-      typescript: 3.9.3
+      tsutils: 2.29.0_typescript@3.9.5
+      typescript: 3.9.5
     dev: false
     engines:
       node: '>=4.8.0'
@@ -6876,19 +6710,19 @@ packages:
       typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
     resolution:
       integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
-  /tsutils/2.29.0_typescript@3.9.3:
+  /tsutils/2.29.0_typescript@3.9.5:
     dependencies:
       tslib: 1.13.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
       integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  /tsutils/3.17.1_typescript@3.9.3:
+  /tsutils/3.17.1_typescript@3.9.5:
     dependencies:
       tslib: 1.13.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     engines:
       node: '>= 6'
@@ -6984,21 +6818,14 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
-  /typescript/3.8.3:
+  /typescript/3.9.5:
     dev: false
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
-  /typescript/3.9.3:
-    dev: false
-    engines:
-      node: '>=4.2.0'
-    hasBin: true
-    resolution:
-      integrity: sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
-  /uglify-js/3.9.3:
+      integrity: sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+  /uglify-js/3.9.4:
     dependencies:
       commander: 2.20.3
     dev: false
@@ -7006,7 +6833,7 @@ packages:
       node: '>=0.8.0'
     hasBin: true
     resolution:
-      integrity: sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==
+      integrity: sha512-8RZBJq5smLOa7KslsNsVcSH+KOXf1uDU8yqLeNuVKwmT0T3FA0ZoXlinQfRad7SDcbZZRZE4ov+2v71EnxNyCA==
   /ultron/1.1.1:
     dev: false
     resolution:
@@ -7106,13 +6933,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
-  /v8-compile-cache/2.1.0:
+  /v8-compile-cache/2.1.1:
     dev: false
     resolution:
-      integrity: sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+      integrity: sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
   /validate-npm-package-license/3.0.4:
     dependencies:
-      spdx-correct: 3.1.0
+      spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: false
     resolution:
@@ -7191,7 +7018,7 @@ packages:
   /which-typed-array/1.1.2:
     dependencies:
       available-typed-arrays: 1.0.2
-      es-abstract: 1.17.5
+      es-abstract: 1.17.6
       foreach: 2.0.5
       function-bind: 1.1.1
       has-symbols: 1.0.1
@@ -7223,14 +7050,14 @@ packages:
     dev: false
     resolution:
       integrity: sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
-  /windows-release/3.3.0:
+  /windows-release/3.3.1:
     dependencies:
       execa: 1.0.0
     dev: false
     engines:
       node: '>=6'
     resolution:
-      integrity: sha512-2HetyTg1Y+R+rUgrKeUEhAG/ZuOmTrI1NBb3ZyAGQMYmOJjBBPe4MTodghRkmLJZHwkuPi02anbeGP+Zf401LQ==
+      integrity: sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==
   /word-wrap/1.2.3:
     dev: false
     engines:
@@ -7485,12 +7312,12 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       delay: 4.3.0
@@ -7510,17 +7337,17 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.2
       rollup: 1.32.1
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/abort-controller'
     resolution:
@@ -7533,17 +7360,17 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/fs-extra': 8.1.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       cross-env: 7.0.2
@@ -7567,8 +7394,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -7580,7 +7407,7 @@ packages:
       sinon: 9.0.2
       source-map-support: 0.5.19
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/ai-form-recognizer'
     resolution:
@@ -7593,17 +7420,17 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/chai-as-promised': 7.1.2
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
       cross-env: 7.0.2
@@ -7626,8 +7453,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -7639,7 +7466,7 @@ packages:
       sinon: 9.0.2
       source-map-support: 0.5.19
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/ai-text-analytics'
     resolution:
@@ -7652,10 +7479,10 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
@@ -7669,8 +7496,8 @@ packages:
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       esm: 3.2.25
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nock: 12.0.3
       nyc: 14.1.1
       prettier: 1.19.1
@@ -7679,10 +7506,10 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       sinon: 9.0.2
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
-      uglify-js: 3.9.3
+      typescript: 3.9.5
+      uglify-js: 3.9.4
     dev: false
     name: '@rush-temp/app-configuration'
     resolution:
@@ -7694,21 +7521,20 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/async-lock': 1.1.2
       '@types/chai': 4.2.11
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 4.1.5
       '@types/is-buffer': 2.0.0
-      '@types/jssha': 2.0.0
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       async-lock: 1.2.4
       buffer: 5.6.0
@@ -7729,13 +7555,13 @@ packages:
       karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-mocha: 1.3.0
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       process: 0.11.10
       puppeteer: 3.3.0
-      rhea: 1.0.21
+      rhea: 1.0.22
       rhea-promise: 1.0.0
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -7744,9 +7570,9 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       sinon: 9.0.2
       stream-browserify: 3.0.0
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       url: 0.11.0
       util: 0.12.3
       ws: 7.3.0
@@ -7758,20 +7584,20 @@ packages:
     version: 0.0.0
   'file:projects/core-arm.tgz':
     dependencies:
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       chai: 4.2.0
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
       eslint-plugin-no-null: 1.0.2_eslint@6.8.0
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       npm-run-all: 4.1.5
       nyc: 14.1.1
       rimraf: 3.0.2
@@ -7779,10 +7605,10 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       shx: 0.3.2
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
-      uglify-js: 3.9.3
+      typescript: 3.9.5
+      uglify-js: 3.9.4
     dev: false
     name: '@rush-temp/core-arm'
     resolution:
@@ -7792,15 +7618,15 @@ packages:
   'file:projects/core-asynciterator-polyfill.tgz':
     dependencies:
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
       eslint-plugin-no-null: 1.0.2_eslint@6.8.0
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       prettier: 1.19.1
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/core-asynciterator-polyfill'
     resolution:
@@ -7813,14 +7639,14 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       downlevel-dts: 0.4.0
@@ -7830,8 +7656,8 @@ packages:
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       inherits: 2.0.4
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       prettier: 1.19.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -7839,7 +7665,7 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/core-auth'
@@ -7855,13 +7681,12 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/express': 4.17.6
-      '@types/glob': 7.1.1
-      '@types/karma': 3.0.9
+      '@types/glob': 7.1.2
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/node-fetch': 2.5.7
@@ -7870,8 +7695,8 @@ packages:
       '@types/tunnel': 0.0.1
       '@types/uuid': 8.0.0
       '@types/xml2js': 0.4.5
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       babel-runtime: 6.26.0
       chai: 4.2.0
       cross-env: 7.0.2
@@ -7893,8 +7718,8 @@ packages:
       karma-mocha: 1.3.0
       karma-rollup-preprocessor: 7.0.5_rollup@1.32.1
       karma-sourcemap-loader: 0.3.7
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       node-fetch: 2.6.0
       npm-run-all: 4.1.5
       nyc: 14.1.1
@@ -7909,12 +7734,11 @@ packages:
       shx: 0.3.2
       sinon: 9.0.2
       tough-cookie: 4.0.0
-      ts-loader: 6.2.2_typescript@3.9.3
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
       tunnel: 0.0.6
-      typescript: 3.9.3
-      uglify-js: 3.9.3
+      typescript: 3.9.5
+      uglify-js: 3.9.4
       uuid: 8.1.0
       xhr-mock: 2.5.1
       xml2js: 0.4.23
@@ -7929,16 +7753,16 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       chai: 4.2.0
       cross-env: 7.0.2
       downlevel-dts: 0.4.0
@@ -7961,8 +7785,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       prettier: 1.19.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -7972,7 +7796,7 @@ packages:
       sinon: 9.0.2
       source-map-support: 0.5.19
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/core-https'
@@ -7986,13 +7810,13 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       chai: 4.2.0
       eslint: 6.8.0
@@ -8012,8 +7836,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       npm-run-all: 4.1.5
       nyc: 14.1.1
       prettier: 1.19.1
@@ -8023,10 +7847,10 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
-      uglify-js: 3.9.3
+      typescript: 3.9.5
+      uglify-js: 3.9.4
     dev: false
     name: '@rush-temp/core-lro'
     resolution:
@@ -8036,15 +7860,15 @@ packages:
   'file:projects/core-paging.tgz':
     dependencies:
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       eslint: 6.8.0
       eslint-config-prettier: 6.11.0_eslint@6.8.0
       eslint-plugin-no-null: 1.0.2_eslint@6.8.0
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       prettier: 1.19.1
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/core-paging'
     resolution:
@@ -8057,14 +7881,14 @@ packages:
       '@opencensus/web-types': 0.0.7
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       eslint: 6.8.0
@@ -8073,8 +7897,8 @@ packages:
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       inherits: 2.0.4
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       prettier: 1.19.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -8082,7 +7906,7 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/core-tracing'
@@ -8094,7 +7918,7 @@ packages:
     dependencies:
       '@azure/eslint-plugin-azure-sdk': 2.0.1_984cbb313f9ea271f36cadd8f9814e06
       '@microsoft/api-extractor': 7.7.11
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
       '@types/debug': 4.1.5
       '@types/fast-json-stable-stringify': 2.0.0
@@ -8107,9 +7931,9 @@ packages:
       '@types/tunnel': 0.0.1
       '@types/underscore': 1.10.0
       '@types/uuid': 8.0.0
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/eslint-plugin-tslint': 2.34.0_a41b4b021727de5dc0e615e83abafe21
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/eslint-plugin-tslint': 2.34.0_81790f39504d9fb1ae55c5faec13eab0
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       cross-env: 7.0.2
       debug: 4.1.1
       dotenv: 8.2.0
@@ -8122,8 +7946,8 @@ packages:
       esm: 3.2.25
       execa: 3.4.0
       fast-json-stable-stringify: 2.1.0
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       node-abort-controller: 1.0.4
       node-fetch: 2.6.0
       os-name: 3.1.0
@@ -8138,12 +7962,12 @@ packages:
       sinon: 9.0.2
       snap-shot-it: 7.9.3
       source-map-support: 0.5.19
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      tslint: 5.20.1_typescript@3.9.3
+      tslint: 5.20.1_typescript@3.9.5
       tslint-config-prettier: 1.18.0
       typedoc: 0.15.8
-      typescript: 3.9.3
+      typescript: 3.9.5
       uuid: 8.1.0
     dev: false
     name: '@rush-temp/cosmos'
@@ -8157,13 +7981,13 @@ packages:
       '@types/chai': 4.2.11
       '@types/eslint': 4.16.8
       '@types/estree': 0.0.39
-      '@types/glob': 7.1.1
+      '@types/glob': 7.1.2
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.3
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
-      '@typescript-eslint/typescript-estree': 2.34.0_typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@3.9.5
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
+      '@typescript-eslint/typescript-estree': 2.34.0_typescript@3.9.5
       bluebird: 3.7.2
       chai: 4.2.0
       eslint: 6.8.0
@@ -8171,13 +7995,13 @@ packages:
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       glob: 7.1.6
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       prettier: 1.19.1
       rimraf: 3.0.2
       source-map-support: 0.5.19
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/eslint-plugin-azure-sdk'
     resolution:
@@ -8191,10 +8015,10 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/async-lock': 1.1.2
       '@types/chai': 4.2.11
       '@types/chai-as-promised': 7.1.2
@@ -8205,11 +8029,10 @@ packages:
       '@types/node': 8.10.61
       '@types/sinon': 9.0.4
       '@types/uuid': 8.0.0
-      '@types/ws': 7.2.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@types/ws': 7.2.5
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
-      async-lock: 1.2.4
       buffer: 5.6.0
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
@@ -8224,9 +8047,6 @@ packages:
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
       esm: 3.2.25
-      https-proxy-agent: 3.0.1
-      is-buffer: 2.0.4
-      jssha: 2.4.2
       karma: 4.4.1
       karma-chrome-launcher: 3.1.0
       karma-coverage: 2.0.2
@@ -8238,8 +8058,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       process: 0.11.10
@@ -8251,9 +8071,9 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       sinon: 9.0.2
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       uuid: 8.1.0
       ws: 7.3.0
     dev: false
@@ -8269,10 +8089,10 @@ packages:
       '@azure/ms-rest-nodeauth': 0.9.3
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/async-lock': 1.1.2
       '@types/chai': 4.2.11
       '@types/chai-as-promised': 7.1.2
@@ -8281,9 +8101,9 @@ packages:
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/uuid': 8.0.0
-      '@types/ws': 7.2.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@types/ws': 7.2.5
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       async-lock: 1.2.4
       azure-storage: 2.10.3
       chai: 4.2.0
@@ -8299,8 +8119,8 @@ packages:
       eslint-plugin-promise: 4.2.1
       esm: 3.2.25
       https-proxy-agent: 5.0.0
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       path-browserify: 1.0.1
       prettier: 1.19.1
@@ -8308,9 +8128,9 @@ packages:
       rollup: 1.32.1
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-uglify: 6.0.4_rollup@1.32.1
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       uuid: 8.1.0
       ws: 7.3.0
     dev: false
@@ -8324,18 +8144,18 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/chai-as-promised': 7.1.2
       '@types/chai-string': 1.4.2
       '@types/debug': 4.1.5
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       chai: 4.2.0
       chai-as-promised: 7.1.1_chai@4.2.0
@@ -8363,8 +8183,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -8373,9 +8193,9 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/eventhubs-checkpointstore-blob'
@@ -8389,18 +8209,18 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/express': 4.17.6
       '@types/jws': 3.2.2
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/qs': 6.9.3
       '@types/uuid': 8.0.0
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       eslint: 6.8.0
@@ -8417,9 +8237,9 @@ packages:
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
       keytar: 5.6.0
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
-      msal: 1.3.1
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
+      msal: 1.3.2
       open: 7.0.4
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -8430,7 +8250,7 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
       uuid: 8.1.0
     dev: false
@@ -8445,18 +8265,18 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/fs-extra': 8.1.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       chai: 4.2.0
       cross-env: 7.0.2
@@ -8481,8 +8301,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -8496,8 +8316,8 @@ packages:
       sinon: 9.0.2
       source-map-support: 0.5.19
       tslib: 2.0.0
-      typescript: 3.9.3
-      uglify-js: 3.9.3
+      typescript: 3.9.5
+      uglify-js: 3.9.4
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-certificates'
@@ -8508,7 +8328,7 @@ packages:
   'file:projects/keyvault-common.tgz':
     dependencies:
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/keyvault-common'
     resolution:
@@ -8521,18 +8341,18 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/fs-extra': 8.1.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       chai: 4.2.0
       cross-env: 7.0.2
@@ -8557,8 +8377,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -8572,8 +8392,8 @@ packages:
       sinon: 9.0.2
       source-map-support: 0.5.19
       tslib: 2.0.0
-      typescript: 3.9.3
-      uglify-js: 3.9.3
+      typescript: 3.9.5
+      uglify-js: 3.9.4
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-keys'
@@ -8587,18 +8407,18 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/fs-extra': 8.1.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/query-string': 6.2.0
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       chai: 4.2.0
       cross-env: 7.0.2
@@ -8623,8 +8443,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -8638,8 +8458,8 @@ packages:
       sinon: 9.0.2
       source-map-support: 0.5.19
       tslib: 2.0.0
-      typescript: 3.9.3
-      uglify-js: 3.9.3
+      typescript: 3.9.5
+      uglify-js: 3.9.4
       url: 0.11.0
     dev: false
     name: '@rush-temp/keyvault-secrets'
@@ -8652,14 +8472,14 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       chai: 4.2.0
       cross-env: 7.0.2
@@ -8681,8 +8501,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -8691,9 +8511,9 @@ packages:
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       sinon: 9.0.2
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/logger'
     resolution:
@@ -8706,16 +8526,16 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
       '@types/sinon': 9.0.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       chai: 4.2.0
       cross-env: 7.0.2
       dotenv: 8.2.0
@@ -8738,8 +8558,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       rimraf: 3.0.2
@@ -8749,9 +8569,9 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       sinon: 9.0.2
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/search-documents'
@@ -8766,22 +8586,21 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-inject': 4.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
-      '@types/async-lock': 1.1.2
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/chai-as-promised': 7.1.2
       '@types/debug': 4.1.5
-      '@types/glob': 7.1.1
+      '@types/glob': 7.1.2
       '@types/is-buffer': 2.0.0
       '@types/long': 4.0.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@types/ws': 7.2.4
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@types/ws': 7.2.5
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       buffer: 5.6.0
       chai: 4.2.0
@@ -8799,7 +8618,6 @@ packages:
       eslint-plugin-promise: 4.2.1
       esm: 3.2.25
       glob: 7.1.6
-      https-proxy-agent: 3.0.1
       is-buffer: 2.0.4
       karma: 4.4.1
       karma-chrome-launcher: 3.1.0
@@ -8813,8 +8631,8 @@ packages:
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
       long: 4.0.0
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       moment: 2.26.0
       nyc: 14.1.1
       prettier: 1.19.1
@@ -8827,9 +8645,9 @@ packages:
       rollup-plugin-shim: 1.0.0
       rollup-plugin-sourcemaps: 0.4.2_rollup@1.32.1
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       ws: 7.3.0
     dev: false
     name: '@rush-temp/service-bus'
@@ -8844,12 +8662,12 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       dotenv: 8.2.0
@@ -8876,8 +8694,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -8888,9 +8706,9 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       source-map-support: 0.5.19
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-blob'
@@ -8905,15 +8723,14 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/fs-extra': 8.1.1
       '@types/mocha': 7.0.2
-      '@types/nise': 1.4.0
       '@types/node': 8.10.61
       '@types/query-string': 6.2.0
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       dotenv: 8.2.0
@@ -8942,10 +8759,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
-      nise: 1.5.3
-      nock: 11.9.1
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -8957,9 +8772,9 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       source-map-support: 0.5.19
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-file-datalake'
@@ -8974,12 +8789,12 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       dotenv: 8.2.0
@@ -9006,8 +8821,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -9018,9 +8833,9 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       source-map-support: 0.5.19
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-file-share'
@@ -9035,12 +8850,12 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       dotenv: 8.2.0
@@ -9066,8 +8881,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       nyc: 14.1.1
       prettier: 1.19.1
       puppeteer: 3.3.0
@@ -9078,9 +8893,9 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       source-map-support: 0.5.19
-      ts-node: 8.10.1_typescript@3.9.3
+      ts-node: 8.10.2_typescript@3.9.5
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/storage-queue'
@@ -9093,14 +8908,14 @@ packages:
       '@microsoft/api-extractor': 7.7.11
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
-      '@rollup/plugin-json': 4.0.3_rollup@1.32.1
+      '@rollup/plugin-json': 4.1.0_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/mocha': 7.0.2
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       assert: 1.5.0
       cross-env: 7.0.2
       eslint: 6.8.0
@@ -9121,8 +8936,8 @@ packages:
       karma-mocha: 1.3.0
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       prettier: 1.19.1
       rimraf: 3.0.2
       rollup: 1.32.1
@@ -9130,7 +8945,7 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       util: 0.12.3
     dev: false
     name: '@rush-temp/template'
@@ -9144,8 +8959,8 @@ packages:
       '@types/minimist': 1.2.0
       '@types/node': 8.10.61
       '@types/node-fetch': 2.5.7
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       eslint: 6.8.0
       eslint-plugin-no-only-tests: 2.4.0
       eslint-plugin-promise: 4.2.1
@@ -9158,7 +8973,7 @@ packages:
       prettier: 1.19.1
       rimraf: 3.0.2
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
     dev: false
     name: '@rush-temp/test-utils-perfstress'
     resolution:
@@ -9170,8 +8985,8 @@ packages:
       '@opentelemetry/api': 0.6.1
       '@rollup/plugin-commonjs': 11.0.2_rollup@1.32.1
       '@rollup/plugin-multi-entry': 3.0.1_rollup@1.32.1
-      '@rollup/plugin-node-resolve': 8.0.0_rollup@1.32.1
-      '@rollup/plugin-replace': 2.3.2_rollup@1.32.1
+      '@rollup/plugin-node-resolve': 8.0.1_rollup@1.32.1
+      '@rollup/plugin-replace': 2.3.3_rollup@1.32.1
       '@types/chai': 4.2.11
       '@types/fs-extra': 8.1.1
       '@types/md5': 2.2.0
@@ -9180,8 +8995,8 @@ packages:
       '@types/mock-require': 2.0.0
       '@types/nise': 1.4.0
       '@types/node': 8.10.61
-      '@typescript-eslint/eslint-plugin': 2.34.0_4d7b57a2de70d5f860ec42d3f1ecdb5d
-      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.3
+      '@typescript-eslint/eslint-plugin': 2.34.0_2ce5ff4d4c428c35a55f8b98c167bebb
+      '@typescript-eslint/parser': 2.34.0_eslint@6.8.0+typescript@3.9.5
       chai: 4.2.0
       eslint: 6.8.0
       eslint-plugin-no-only-tests: 2.4.0
@@ -9201,8 +9016,8 @@ packages:
       karma-mocha-reporter: 2.2.5_karma@4.4.1
       karma-remap-istanbul: 0.6.0_karma@4.4.1
       md5: 2.2.1
-      mocha: 7.1.2
-      mocha-junit-reporter: 1.23.3_mocha@7.1.2
+      mocha: 7.2.0
+      mocha-junit-reporter: 1.23.3_mocha@7.2.0
       mock-fs: 4.12.0
       mock-require: 3.0.3
       nise: 4.0.3
@@ -9217,7 +9032,7 @@ packages:
       rollup-plugin-terser: 5.3.0_rollup@1.32.1
       rollup-plugin-visualizer: 4.0.4_rollup@1.32.1
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       xhr-mock: 2.5.1
     dev: false
     name: '@rush-temp/test-utils-recorder'
@@ -9234,10 +9049,10 @@ packages:
       async-lock: 1.2.4
       death: 1.1.0
       debug: 4.1.1
-      rhea: 1.0.21
+      rhea: 1.0.22
       rimraf: 3.0.2
       tslib: 2.0.0
-      typescript: 3.9.3
+      typescript: 3.9.5
       uuid: 8.1.0
       yargs: 15.3.1
     dev: false
@@ -9282,3 +9097,4 @@ specifiers:
   '@rush-temp/test-utils-perfstress': 'file:./projects/test-utils-perfstress.tgz'
   '@rush-temp/test-utils-recorder': 'file:./projects/test-utils-recorder.tgz'
   '@rush-temp/testhub': 'file:./projects/testhub.tgz'
+  follow-redirects: 1.11.0


### PR DESCRIPTION
- follow-redirects@1.12.0 adds a peer dependency on "debug"
- http-proxy@1.18.1 depends on follow-redirects@^1.0.0, but does not depend on "debug", which causes an error due to missing peer dependencies
- rush update --full