### PR TITLE
[event-hubs] Fixing websockets sample to line up with Service Bus

### DIFF
--- a/sdk/eventhub/event-hubs/samples/javascript/package.json
+++ b/sdk/eventhub/event-hubs/samples/javascript/package.json
@@ -25,8 +25,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-amqp": "next",
-    "@azure/event-hubs": "next",
+    "@azure/core-amqp": "latest",
+    "@azure/event-hubs": "latest",
     "@types/dotenv": "^8.2.0",
     "@types/ws": "^6.0.4",
     "dotenv": "^8.2.0",

--- a/sdk/eventhub/event-hubs/samples/typescript/package.json
+++ b/sdk/eventhub/event-hubs/samples/typescript/package.json
@@ -29,9 +29,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-for-js#readme",
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-amqp": "next",
-    "@azure/event-hubs": "next",
-    "@types/dotenv": "^8.2.0",
+    "@azure/core-amqp": "latest",
+    "@azure/event-hubs": "latest",
     "@types/ws": "^6.0.4",
     "dotenv": "^8.2.0",
     "https-proxy-agent": "^5.0.0",

--- a/sdk/eventhub/event-hubs/samples/typescript/src/websockets.ts
+++ b/sdk/eventhub/event-hubs/samples/typescript/src/websockets.ts
@@ -16,7 +16,7 @@
 
 import WebSocket from "ws";
 const url = require("url");
-const httpsProxyAgent = require("https-proxy-agent");
+import { HttpsProxyAgent } from "https-proxy-agent";
 
 import { EventHubConsumerClient } from "@azure/event-hubs";
 
@@ -34,7 +34,7 @@ const consumerGroup = process.env["CONSUMER_GROUP_NAME"] || "";
 // Skip this section if you are not behind a proxy server
 const urlParts = url.parse("http://localhost:3128");
 urlParts.auth = "username:password"; // Skip this if proxy server does not need authentication.
-const proxyAgent = new httpsProxyAgent(urlParts);
+const proxyAgent = new HttpsProxyAgent(urlParts);
 
 export async function main(): Promise<void> {
   console.log(`Running websockets sample`);

--- a/sdk/eventhub/event-hubs/samples/typescript/tsconfig.json
+++ b/sdk/eventhub/event-hubs/samples/typescript/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "node",
 
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
 
     "outDir": "dist",
     "rootDir": "src"


### PR DESCRIPTION
Propagating the fixes we found for #9412 (websockets/proxy samples were broken) to the sample here.

Some small issues:
- The tsconfig.json needed to have esModulesInterop turned on
- package.json for both the JS and TS samples were referencing a tag we no longer publish (changed to 'latest' rather than 'next')
- Small changes for the TS so it can compile properly using `import`, rather than `require`.

Fixes #9415