### PR TITLE
[KeyVault] tsconfig.json feedback by Will

### DIFF
--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -7,8 +7,6 @@
 // This file makes more sense if ordered based on how meaningful are some methods in relation to others.
 /* eslint-disable @typescript-eslint/member-ordering */
 
-/// <reference lib="esnext.asynciterable" />
-
 import {
   TokenCredential,
   isTokenCredential,

--- a/sdk/keyvault/keyvault-certificates/tsconfig.json
+++ b/sdk/keyvault/keyvault-certificates/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
+    "lib": ["dom", "esnext.asynciterable"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "../keyvault-common/node_modules", "./samples/**/*.ts"],

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint @typescript-eslint/member-ordering: 0 */
-/// <reference lib="esnext.asynciterable" />
 
 import {
   PipelineOptions,

--- a/sdk/keyvault/keyvault-keys/tsconfig.json
+++ b/sdk/keyvault/keyvault-keys/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
+    "lib": ["dom", "esnext.asynciterable"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "../keyvault-common/node_modules", "./samples/**/*.ts"],

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 /* eslint @typescript-eslint/member-ordering: 0 */
-/// <reference lib="esnext.asynciterable" />
 
 import {
   TokenCredential,

--- a/sdk/keyvault/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
+    "lib": ["dom", "esnext.asynciterable"],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "../keyvault-common/node_modules", "./samples/**/*.ts"],


### PR DESCRIPTION
In PR #8866 I merged a change suggested by Jeff, in which I moved this tsconfig.json configuration into the `index.ts` files.

Will suggests doing otherwise, so here's the PR.

From https://github.com/Azure/azure-sdk-for-js/pull/8866#discussion_r441774262

Will will be adding some other changes to this PR, to potentially remove the `dom` from the list of injected libraries.