### PR TITLE
[core-http] Run formatter

### DIFF
--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -66,7 +66,8 @@ export { redirectPolicy, RedirectOptions } from "./policies/redirectPolicy";
 export { keepAlivePolicy, KeepAlivePolicy, KeepAliveOptions } from "./policies/keepAlivePolicy";
 export {
   DisableResponseDecompressionPolicy,
-  disableResponseDecompressionPolicy } from "./policies/disableResponseDecompressionPolicy";
+  disableResponseDecompressionPolicy
+} from "./policies/disableResponseDecompressionPolicy";
 export { signingPolicy } from "./policies/signingPolicy";
 export {
   userAgentPolicy,
@@ -74,7 +75,12 @@ export {
   UserAgentOptions,
   TelemetryInfo
 } from "./policies/userAgentPolicy";
-export { deserializationPolicy, DeserializationOptions, deserializeResponseBody, DeserializationContentTypes } from "./policies/deserializationPolicy";
+export {
+  deserializationPolicy,
+  DeserializationOptions,
+  deserializeResponseBody,
+  DeserializationContentTypes
+} from "./policies/deserializationPolicy";
 export { tracingPolicy, TracingPolicyOptions } from "./policies/tracingPolicy";
 export {
   MapperType,

--- a/sdk/core/core-http/src/nodeFetchHttpClient.ts
+++ b/sdk/core/core-http/src/nodeFetchHttpClient.ts
@@ -92,7 +92,7 @@ export class NodeFetchHttpClient extends FetchHttpClient {
   }
 
   async prepareRequest(httpRequest: WebResourceLike): Promise<Partial<RequestInit>> {
-    const requestInit: Partial<RequestInit & { agent?: any, compress?: boolean }> = {};
+    const requestInit: Partial<RequestInit & { agent?: any; compress?: boolean }> = {};
 
     if (this.cookieJar && !httpRequest.headers.get("Cookie")) {
       const cookieString = await new Promise<string>((resolve, reject) => {

--- a/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
@@ -4,11 +4,13 @@
 /*
  * NOTE: When moving this file, please update "browser" section in package.json
  */
-import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from './requestPolicy';
-import { WebResource } from '../webResource';
-import { HttpOperationResponse } from '../httpOperationResponse';
+import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from "./requestPolicy";
+import { WebResource } from "../webResource";
+import { HttpOperationResponse } from "../httpOperationResponse";
 
-const DisbleResponseDecompressionNotSupportedInBrowser = new Error("DisableResponseDecompressionPolicy is not supported in browser environment");
+const DisbleResponseDecompressionNotSupportedInBrowser = new Error(
+  "DisableResponseDecompressionPolicy is not supported in browser environment"
+);
 
 /**
  * {@link DisableResponseDecompressionPolicy} is not supported in browser and attempting
@@ -23,10 +25,7 @@ export function disableResponseDecompressionPolicy() {
 }
 
 export class DisableResponseDecompressionPolicy extends BaseRequestPolicy {
-  constructor(
-    nextPolicy: RequestPolicy,
-    options: RequestPolicyOptions,
-  ) {
+  constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
     throw DisbleResponseDecompressionNotSupportedInBrowser;
   }

--- a/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.ts
+++ b/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from './requestPolicy';
-import { WebResource } from '../webResource';
-import { HttpOperationResponse } from '../httpOperationResponse';
+import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from "./requestPolicy";
+import { WebResource } from "../webResource";
+import { HttpOperationResponse } from "../httpOperationResponse";
 
 /**
  * Returns a request policy factory that can be used to create an instance of
@@ -28,10 +28,7 @@ export class DisableResponseDecompressionPolicy extends BaseRequestPolicy {
    * @param {RequestPolicy} nextPolicy
    * @param {RequestPolicyOptions} options
    */
-  constructor(
-    nextPolicy: RequestPolicy,
-    options: RequestPolicyOptions
-  ) {
+  constructor(nextPolicy: RequestPolicy, options: RequestPolicyOptions) {
     super(nextPolicy, options);
   }
 

--- a/sdk/core/core-http/src/policies/systemErrorRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/systemErrorRetryPolicy.ts
@@ -88,7 +88,7 @@ export class SystemErrorRetryPolicy extends BaseRequestPolicy {
   public sendRequest(request: WebResourceLike): Promise<HttpOperationResponse> {
     return this._nextPolicy
       .sendRequest(request.clone())
-      .catch((error) => retry(this, request, error.response, error))
+      .catch((error) => retry(this, request, error.response, error));
   }
 }
 
@@ -141,8 +141,7 @@ function updateRetryData(
   // Adjust retry interval
   let incrementDelta = Math.pow(2, retryData.retryCount) - 1;
   const boundedRandDelta =
-    policy.retryInterval * 0.8 +
-    Math.floor(Math.random() * policy.retryInterval * 0.4);
+    policy.retryInterval * 0.8 + Math.floor(Math.random() * policy.retryInterval * 0.4);
   incrementDelta *= boundedRandDelta;
 
   retryData.retryInterval = Math.min(
@@ -175,8 +174,7 @@ async function retry(
     try {
       await utils.delay(retryData.retryInterval);
       return policy._nextPolicy.sendRequest(request.clone());
-    }
-    catch (err) {
+    } catch (err) {
       return retry(policy, request, operationResponse, err, retryData);
     }
   } else {

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -40,7 +40,10 @@ describe("BearerTokenAuthenticationPolicy", function() {
     await bearerTokenAuthPolicy.sendRequest(request);
 
     assert(
-      fakeGetToken.calledWith(tokenScopes, { abortSignal: undefined, tracingOptions: { spanOptions: undefined } }),
+      fakeGetToken.calledWith(tokenScopes, {
+        abortSignal: undefined,
+        tracingOptions: { spanOptions: undefined }
+      }),
       "fakeGetToken called incorrectly."
     );
     assert.strictEqual(

--- a/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.browser.ts
+++ b/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.browser.ts
@@ -5,8 +5,11 @@ import "chai/register-should";
 import { RequestPolicyOptions } from "../../src/policies/requestPolicy";
 import { WebResource } from "../../src/webResource";
 import { HttpHeaders } from "../../src/httpHeaders";
-import { disableResponseDecompressionPolicy, DisableResponseDecompressionPolicy } from "../../src/policies/disableResponseDecompressionPolicy";
-import { HttpClient, ServiceClient, Serializer } from '../../src/coreHttp';
+import {
+  disableResponseDecompressionPolicy,
+  DisableResponseDecompressionPolicy
+} from "../../src/policies/disableResponseDecompressionPolicy";
+import { HttpClient, ServiceClient, Serializer } from "../../src/coreHttp";
 
 describe("DisableResponseDecompressionPolicy (browser)", function() {
   const emptyRequestPolicy = {
@@ -69,10 +72,12 @@ describe("DisableResponseDecompressionPolicy (browser)", function() {
             }
           }
         );
-        throw new Error("Error should have been thrown already.")
+        throw new Error("Error should have been thrown already.");
       } catch (err) {
         err.should.be.an("Error");
-        (err as Error).message.should.equal("DisableResponseDecompressionPolicy is not supported in browser environment")
+        (err as Error).message.should.equal(
+          "DisableResponseDecompressionPolicy is not supported in browser environment"
+        );
       }
     });
   });

--- a/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.node.ts
+++ b/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.node.ts
@@ -5,22 +5,24 @@ import "chai/register-should";
 import { RequestPolicyOptions } from "../../src/policies/requestPolicy";
 import { WebResource } from "../../src/webResource";
 import { HttpHeaders } from "../../src/httpHeaders";
-import { disableResponseDecompressionPolicy, DisableResponseDecompressionPolicy } from "../../src/policies/disableResponseDecompressionPolicy";
-import { HttpOperationResponse } from '../../src/coreHttp';
+import {
+  disableResponseDecompressionPolicy,
+  DisableResponseDecompressionPolicy
+} from "../../src/policies/disableResponseDecompressionPolicy";
+import { HttpOperationResponse } from "../../src/coreHttp";
 
 describe("DisableResponseDecompressionPolicy (node)", function() {
-
   function responseOf(r: WebResource): HttpOperationResponse {
     return {
       request: r,
       status: 404,
       headers: new HttpHeaders(undefined)
-    }
+    };
   }
   const verifyDecompressionDisabledPolicy = {
-    sendRequest: async(request: WebResource) => {
+    sendRequest: async (request: WebResource) => {
       request.decompressResponse!.should.equal(false);
-      return Promise.resolve(responseOf(request))
+      return Promise.resolve(responseOf(request));
     }
   };
 
@@ -29,18 +31,27 @@ describe("DisableResponseDecompressionPolicy (node)", function() {
   describe("for Node.js", function() {
     it("factory passes correct option", async function() {
       const factory = disableResponseDecompressionPolicy();
-      const policy = factory.create(verifyDecompressionDisabledPolicy, emptyPolicyOptions) as DisableResponseDecompressionPolicy;
+      const policy = factory.create(
+        verifyDecompressionDisabledPolicy,
+        emptyPolicyOptions
+      ) as DisableResponseDecompressionPolicy;
       const request = new WebResource();
       await policy.sendRequest(request);
     });
     it("sets correct option through constructor", async function() {
-      const policy = new DisableResponseDecompressionPolicy(verifyDecompressionDisabledPolicy, emptyPolicyOptions);
+      const policy = new DisableResponseDecompressionPolicy(
+        verifyDecompressionDisabledPolicy,
+        emptyPolicyOptions
+      );
       const request = new WebResource();
       await policy.sendRequest(request);
     });
 
     it("should assign option to the web request", async () => {
-      const policy = new DisableResponseDecompressionPolicy(verifyDecompressionDisabledPolicy, emptyPolicyOptions);
+      const policy = new DisableResponseDecompressionPolicy(
+        verifyDecompressionDisabledPolicy,
+        emptyPolicyOptions
+      );
       const request = new WebResource();
       await policy.sendRequest(request);
     });

--- a/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
+++ b/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
@@ -91,12 +91,42 @@ describe("getDefaultProxySettings", () => {
     });
 
     [
-      { proxyUrl: "prot://user:pass@proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: "user", password: "pass" },
-      { proxyUrl: "prot://user@proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: "user", password: undefined },
-      { proxyUrl: "prot://:pass@proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: undefined, password: "pass" },
-      { proxyUrl: "prot://proxy.microsoft.com", proxyUrlWithoutAuth: "prot://proxy.microsoft.com", username: undefined, password: undefined },
-      { proxyUrl: "user:pass@proxy.microsoft.com", proxyUrlWithoutAuth: "proxy.microsoft.com", username: "user", password: "pass" },
-      { proxyUrl: "proxy.microsoft.com", proxyUrlWithoutAuth: "proxy.microsoft.com", username: undefined, password: undefined }
+      {
+        proxyUrl: "prot://user:pass@proxy.microsoft.com",
+        proxyUrlWithoutAuth: "prot://proxy.microsoft.com",
+        username: "user",
+        password: "pass"
+      },
+      {
+        proxyUrl: "prot://user@proxy.microsoft.com",
+        proxyUrlWithoutAuth: "prot://proxy.microsoft.com",
+        username: "user",
+        password: undefined
+      },
+      {
+        proxyUrl: "prot://:pass@proxy.microsoft.com",
+        proxyUrlWithoutAuth: "prot://proxy.microsoft.com",
+        username: undefined,
+        password: "pass"
+      },
+      {
+        proxyUrl: "prot://proxy.microsoft.com",
+        proxyUrlWithoutAuth: "prot://proxy.microsoft.com",
+        username: undefined,
+        password: undefined
+      },
+      {
+        proxyUrl: "user:pass@proxy.microsoft.com",
+        proxyUrlWithoutAuth: "proxy.microsoft.com",
+        username: "user",
+        password: "pass"
+      },
+      {
+        proxyUrl: "proxy.microsoft.com",
+        proxyUrlWithoutAuth: "proxy.microsoft.com",
+        username: undefined,
+        password: undefined
+      }
     ].forEach((testCase) => {
       it(`should return settings with passed proxyUrl : ${testCase.proxyUrl}`, () => {
         const proxySettings: ProxySettings = getDefaultProxySettings(testCase.proxyUrl)!;
@@ -107,7 +137,7 @@ describe("getDefaultProxySettings", () => {
         if (testCase.password) {
           proxySettings.password!.should.equal(testCase.password);
         }
-      })
+      });
     });
 
     describe("with loadEnvironmentProxyValue", () => {

--- a/sdk/core/core-http/test/policies/systemErrorRetryPolicyTests.spec.ts
+++ b/sdk/core/core-http/test/policies/systemErrorRetryPolicyTests.spec.ts
@@ -31,7 +31,7 @@ describe("SystemErrorRetryPolicy", () => {
           code: this.errorCode,
           name: "RetryError",
           message: `Error message for ${this.errorCode}`
-        }
+        };
         return Promise.reject(error);
       }
 
@@ -88,7 +88,7 @@ describe("SystemErrorRetryPolicy", () => {
       assert.deepEqual(response.request, request);
     });
 
-    [ "ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNREFUSED", "ECONNRESET", "ENOENT" ].forEach((code) => {
+    ["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNREFUSED", "ECONNRESET", "ENOENT"].forEach((code) => {
       it(`should retry if the error code is ${code}`, async () => {
         const request = new WebResource();
         const mockResponse = {
@@ -104,7 +104,8 @@ describe("SystemErrorRetryPolicy", () => {
           3,
           10,
           10,
-          20);
+          20
+        );
 
         const response = await policy.sendRequest(request);
         delete request.requestId;
@@ -122,30 +123,30 @@ describe("SystemErrorRetryPolicy", () => {
         3,
         10,
         10,
-        20);
+        20
+      );
 
       try {
         await policy.sendRequest(request);
         assert.fail("Expecting that an error has been thrown");
-      }
-      catch(err) {
+      } catch (err) {
         assert.equal((err as Error).message, "Error message for NonRetriableError");
       }
     });
 
-    [ "ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNREFUSED", "ECONNRESET", "ENOENT" ].forEach((code) => {
+    ["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNREFUSED", "ECONNRESET", "ENOENT"].forEach((code) => {
       it(`should fail after max retry count for error code ${code}`, async () => {
         class FailEveryRequestPolicy {
           count = 0;
           constructor(private errorCode: string) {}
           public sendRequest(_request: WebResource): Promise<HttpOperationResponse> {
-              const error: RetryError = {
-                code: this.errorCode,
-                name: "RetryError",
-                message: `Error message for ${this.errorCode}`
-              }
-              return Promise.reject(error);
-            }
+            const error: RetryError = {
+              code: this.errorCode,
+              name: "RetryError",
+              message: `Error message for ${this.errorCode}`
+            };
+            return Promise.reject(error);
+          }
         }
         const request = new WebResource();
         const faultyPolicy = new FailEveryRequestPolicy(code);
@@ -155,13 +156,13 @@ describe("SystemErrorRetryPolicy", () => {
           3,
           10,
           10,
-          20);
+          20
+        );
 
         try {
           await policy.sendRequest(request);
           assert.fail("Expecting that an error has been thrown");
-        }
-        catch(err) {
+        } catch (err) {
           assert.equal((err as Error).message, `Error message for ${code}`);
         }
       });

--- a/sdk/core/core-http/test/utilsTests.ts
+++ b/sdk/core/core-http/test/utilsTests.ts
@@ -7,11 +7,10 @@ import { isValidUuid } from "../src/util/utils";
 describe("utils", function() {
   describe("isValidUuid()", function() {
     it("should return true on a valid Uuid in multiple calls", function() {
-
       const uuidString = "ae9b0564-7aa1-47d1-8061-0ffd8f12f723";
 
       expect(isValidUuid(uuidString), "First call failed").to.be.true;
       expect(isValidUuid(uuidString), "Second call failed").to.be.true;
-    })
+    });
   });
-})
+});

--- a/sdk/core/core-http/test/xmlTests.ts
+++ b/sdk/core/core-http/test/xmlTests.ts
@@ -11,8 +11,8 @@ describe("XML serializer", function() {
       const error: Error = await msAssert.throwsAsync(parseXML(undefined as any));
       assert.ok(
         error.message.indexOf("Document is empty") !== -1 || // Chrome
-        (error.message.startsWith("XML Parsing Error: syntax error") &&
-          error.message.indexOf("undefined") !== -1), // Firefox
+          (error.message.startsWith("XML Parsing Error: syntax error") &&
+            error.message.indexOf("undefined") !== -1), // Firefox
         `error.message ("${error.message}") should have contained "Document is empty" or "undefined"`
       );
     });
@@ -22,8 +22,8 @@ describe("XML serializer", function() {
       const error: Error = await msAssert.throwsAsync(parseXML(null as any));
       assert.ok(
         error.message.indexOf("Document is empty") !== -1 || // Chrome
-        (error.message.startsWith("XML Parsing Error: syntax error") &&
-          error.message.indexOf("null") !== -1), // Firefox
+          (error.message.startsWith("XML Parsing Error: syntax error") &&
+            error.message.indexOf("null") !== -1), // Firefox
         `error.message ("${error.message}") should have contained "Document is empty" or "null"`
       );
     });


### PR DESCRIPTION
This PR has changes from running `npm run format` on the `core-http` package in order to reduce the noise in the PR #8687