### PR TITLE
[core-http] Update copyright text

### DIFF
--- a/sdk/core/core-http/samples/node-sample.ts
+++ b/sdk/core/core-http/samples/node-sample.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 "use strict";
 

--- a/sdk/core/core-http/src/browserFetchHttpClient.ts
+++ b/sdk/core/core-http/src/browserFetchHttpClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT license.
 
 import { FetchHttpClient, CommonRequestInfo } from "./fetchHttpClient";
 import { HttpOperationResponse } from "./httpOperationResponse";

--- a/sdk/core/core-http/src/coreHttp.ts
+++ b/sdk/core/core-http/src/coreHttp.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /// <reference path="../dom-shim.d.ts" />
 

--- a/sdk/core/core-http/src/credentials/accessTokenCache.ts
+++ b/sdk/core/core-http/src/credentials/accessTokenCache.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { AccessToken } from "@azure/core-auth";
 

--- a/sdk/core/core-http/src/credentials/apiKeyCredentials.ts
+++ b/sdk/core/core-http/src/credentials/apiKeyCredentials.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpHeaders } from "../httpHeaders";
 import { WebResourceLike } from "../webResource";

--- a/sdk/core/core-http/src/credentials/basicAuthenticationCredentials.ts
+++ b/sdk/core/core-http/src/credentials/basicAuthenticationCredentials.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpHeaders } from "../httpHeaders";
 import * as base64 from "../util/base64";

--- a/sdk/core/core-http/src/credentials/credentials.ts
+++ b/sdk/core/core-http/src/credentials/credentials.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 export type Authenticator = (challenge: object) => Promise<string>;

--- a/sdk/core/core-http/src/credentials/serviceClientCredentials.ts
+++ b/sdk/core/core-http/src/credentials/serviceClientCredentials.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { WebResourceLike } from "../webResource";
 

--- a/sdk/core/core-http/src/credentials/topicCredentials.ts
+++ b/sdk/core/core-http/src/credentials/topicCredentials.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { ApiKeyCredentials, ApiKeyCredentialOptions } from "./apiKeyCredentials";
 

--- a/sdk/core/core-http/src/defaultHttpClient.browser.ts
+++ b/sdk/core/core-http/src/defaultHttpClient.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 export { XhrHttpClient as DefaultHttpClient } from "./xhrHttpClient";

--- a/sdk/core/core-http/src/defaultHttpClient.ts
+++ b/sdk/core/core-http/src/defaultHttpClient.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 export { NodeFetchHttpClient as DefaultHttpClient } from "./nodeFetchHttpClient";

--- a/sdk/core/core-http/src/fetchHttpClient.ts
+++ b/sdk/core/core-http/src/fetchHttpClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT license.
 
 import { AbortController, AbortError } from "@azure/abort-controller";
 import FormData from "form-data";

--- a/sdk/core/core-http/src/httpClient.ts
+++ b/sdk/core/core-http/src/httpClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { RequestPolicy } from "./policies/requestPolicy";
 

--- a/sdk/core/core-http/src/httpHeaders.ts
+++ b/sdk/core/core-http/src/httpHeaders.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * A collection of HttpHeaders that can be sent with a HTTP request.

--- a/sdk/core/core-http/src/httpOperationResponse.ts
+++ b/sdk/core/core-http/src/httpOperationResponse.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { WebResourceLike } from "./webResource";
 import { HttpHeadersLike } from "./httpHeaders";

--- a/sdk/core/core-http/src/httpPipelineLogLevel.ts
+++ b/sdk/core/core-http/src/httpPipelineLogLevel.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * The different levels of logs that can be used with the HttpPipelineLogger.

--- a/sdk/core/core-http/src/httpPipelineLogger.ts
+++ b/sdk/core/core-http/src/httpPipelineLogger.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpPipelineLogLevel } from "./httpPipelineLogLevel";
 

--- a/sdk/core/core-http/src/nodeFetchHttpClient.ts
+++ b/sdk/core/core-http/src/nodeFetchHttpClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT license.
 
 import * as tough from "tough-cookie";
 import * as http from "http";

--- a/sdk/core/core-http/src/operationArguments.ts
+++ b/sdk/core/core-http/src/operationArguments.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { RequestOptionsBase } from "./webResource";
 

--- a/sdk/core/core-http/src/operationParameter.ts
+++ b/sdk/core/core-http/src/operationParameter.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { QueryCollectionFormat } from "./queryCollectionFormat";
 import { Mapper } from "./serializer";

--- a/sdk/core/core-http/src/operationResponse.ts
+++ b/sdk/core/core-http/src/operationResponse.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { Mapper } from "./serializer";
 

--- a/sdk/core/core-http/src/operationSpec.ts
+++ b/sdk/core/core-http/src/operationSpec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   OperationParameter,

--- a/sdk/core/core-http/src/pipelineOptions.ts
+++ b/sdk/core/core-http/src/pipelineOptions.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpClient } from "./httpClient";
 import { RetryOptions } from "./policies/exponentialRetryPolicy";

--- a/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
+++ b/sdk/core/core-http/src/policies/bearerTokenAuthenticationPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { TokenCredential, GetTokenOptions } from "@azure/core-auth";
 import {

--- a/sdk/core/core-http/src/policies/deserializationPolicy.ts
+++ b/sdk/core/core-http/src/policies/deserializationPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { OperationResponse } from "../operationResponse";

--- a/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /*
  * NOTE: When moving this file, please update "browser" section in package.json

--- a/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.ts
+++ b/sdk/core/core-http/src/policies/disableResponseDecompressionPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from './requestPolicy';
 import { WebResource } from '../webResource';

--- a/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/exponentialRetryPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";

--- a/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
+++ b/sdk/core/core-http/src/policies/generateClientRequestIdPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { WebResourceLike } from "../webResource";

--- a/sdk/core/core-http/src/policies/keepAlivePolicy.ts
+++ b/sdk/core/core-http/src/policies/keepAlivePolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { BaseRequestPolicy, RequestPolicy, RequestPolicyOptions } from "./requestPolicy";
 import { WebResourceLike } from "../webResource";

--- a/sdk/core/core-http/src/policies/logPolicy.ts
+++ b/sdk/core/core-http/src/policies/logPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { WebResourceLike } from "../webResource";

--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /*
  * NOTE: When moving this file, please update "browser" section in package.json

--- a/sdk/core/core-http/src/policies/msRestUserAgentPolicy.ts
+++ b/sdk/core/core-http/src/policies/msRestUserAgentPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import * as os from "os";
 import { TelemetryInfo } from "./userAgentPolicy";

--- a/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { ProxySettings } from "../serviceClient";
 import {

--- a/sdk/core/core-http/src/policies/proxyPolicy.ts
+++ b/sdk/core/core-http/src/policies/proxyPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   BaseRequestPolicy,

--- a/sdk/core/core-http/src/policies/redirectPolicy.ts
+++ b/sdk/core/core-http/src/policies/redirectPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { URLBuilder } from "../url";

--- a/sdk/core/core-http/src/policies/requestPolicy.ts
+++ b/sdk/core/core-http/src/policies/requestPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import { HttpPipelineLogger } from "../httpPipelineLogger";

--- a/sdk/core/core-http/src/policies/rpRegistrationPolicy.ts
+++ b/sdk/core/core-http/src/policies/rpRegistrationPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";
 import { WebResourceLike } from "../webResource";

--- a/sdk/core/core-http/src/policies/signingPolicy.ts
+++ b/sdk/core/core-http/src/policies/signingPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { ServiceClientCredentials } from "../credentials/serviceClientCredentials";
 import { HttpOperationResponse } from "../httpOperationResponse";

--- a/sdk/core/core-http/src/policies/systemErrorRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/systemErrorRetryPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "../httpOperationResponse";
 import * as utils from "../util/utils";

--- a/sdk/core/core-http/src/policies/throttlingRetryPolicy.ts
+++ b/sdk/core/core-http/src/policies/throttlingRetryPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import {
   BaseRequestPolicy,

--- a/sdk/core/core-http/src/policies/tracingPolicy.ts
+++ b/sdk/core/core-http/src/policies/tracingPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { getTracer, getTraceParentHeader } from "@azure/core-tracing";
 import { SpanOptions, SpanKind } from "@opentelemetry/api";

--- a/sdk/core/core-http/src/policies/userAgentPolicy.ts
+++ b/sdk/core/core-http/src/policies/userAgentPolicy.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpHeaders } from "../httpHeaders";
 import { HttpOperationResponse } from "../httpOperationResponse";

--- a/sdk/core/core-http/src/proxyAgent.ts
+++ b/sdk/core/core-http/src/proxyAgent.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
+// Licensed under the MIT license.
 
 import * as http from "http";
 import * as https from "https";

--- a/sdk/core/core-http/src/queryCollectionFormat.ts
+++ b/sdk/core/core-http/src/queryCollectionFormat.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * The format that will be used to join an array of values together for a query parameter value.

--- a/sdk/core/core-http/src/restError.ts
+++ b/sdk/core/core-http/src/restError.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpOperationResponse } from "./httpOperationResponse";
 import { WebResourceLike } from "./webResource";

--- a/sdk/core/core-http/src/serializer.ts
+++ b/sdk/core/core-http/src/serializer.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import * as base64 from "./util/base64";
 import * as utils from "./util/utils";

--- a/sdk/core/core-http/src/serviceClient.ts
+++ b/sdk/core/core-http/src/serviceClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { TokenCredential, isTokenCredential } from "@azure/core-auth";
 import { DefaultHttpClient } from "./defaultHttpClient";

--- a/sdk/core/core-http/src/url.ts
+++ b/sdk/core/core-http/src/url.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { replaceAll } from "./util/utils";
 

--- a/sdk/core/core-http/src/util/base64.browser.ts
+++ b/sdk/core/core-http/src/util/base64.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * Encodes a string in base64 format.

--- a/sdk/core/core-http/src/util/base64.ts
+++ b/sdk/core/core-http/src/util/base64.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 /**
  * Encodes a string in base64 format.

--- a/sdk/core/core-http/src/util/constants.ts
+++ b/sdk/core/core-http/src/util/constants.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 export const Constants = {
   /**

--- a/sdk/core/core-http/src/util/inspect.browser.ts
+++ b/sdk/core/core-http/src/util/inspect.browser.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 export const custom = {};

--- a/sdk/core/core-http/src/util/inspect.ts
+++ b/sdk/core/core-http/src/util/inspect.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { inspect } from "util";
 

--- a/sdk/core/core-http/src/util/sanitizer.ts
+++ b/sdk/core/core-http/src/util/sanitizer.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { URLBuilder, URLQuery } from "../url";
 

--- a/sdk/core/core-http/src/util/utils.ts
+++ b/sdk/core/core-http/src/util/utils.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { v4 as uuidv4 } from "uuid";
 import { HttpOperationResponse } from "../httpOperationResponse";

--- a/sdk/core/core-http/src/util/xml.browser.ts
+++ b/sdk/core/core-http/src/util/xml.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 // tslint:disable-next-line:no-null-keyword
 const doc = document.implementation.createDocument(null, null, null);

--- a/sdk/core/core-http/src/util/xml.ts
+++ b/sdk/core/core-http/src/util/xml.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import * as xml2js from "xml2js";
 

--- a/sdk/core/core-http/src/webResource.ts
+++ b/sdk/core/core-http/src/webResource.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { HttpHeaders, HttpHeadersLike, isHttpHeadersLike } from "./httpHeaders";
 import { OperationSpec } from "./operationSpec";

--- a/sdk/core/core-http/src/xhrHttpClient.ts
+++ b/sdk/core/core-http/src/xhrHttpClient.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { AbortError } from "@azure/abort-controller";
 import { HttpClient } from "./httpClient";

--- a/sdk/core/core-http/test/credentialTests.ts
+++ b/sdk/core/core-http/test/credentialTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 import * as msRest from "../src/coreHttp";

--- a/sdk/core/core-http/test/defaultHttpClientTests.browser.ts
+++ b/sdk/core/core-http/test/defaultHttpClientTests.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 

--- a/sdk/core/core-http/test/defaultHttpClientTests.node.ts
+++ b/sdk/core/core-http/test/defaultHttpClientTests.node.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import "chai/register-should";

--- a/sdk/core/core-http/test/defaultHttpClientTests.ts
+++ b/sdk/core/core-http/test/defaultHttpClientTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert, AssertionError } from "chai";
 import { AbortController } from "@azure/abort-controller";

--- a/sdk/core/core-http/test/logFilterTests.ts
+++ b/sdk/core/core-http/test/logFilterTests.ts
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { HttpHeaders, RawHttpHeaders } from "../src/httpHeaders";

--- a/sdk/core/core-http/test/mockHttp.ts
+++ b/sdk/core/core-http/test/mockHttp.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import xhrMock, { proxy } from "xhr-mock";
 import { isNode, HttpMethods } from "../src/coreHttp";

--- a/sdk/core/core-http/test/msAssert.ts
+++ b/sdk/core/core-http/test/msAssert.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 

--- a/sdk/core/core-http/test/msRestUserAgentPolicyTests.browser.ts
+++ b/sdk/core/core-http/test/msRestUserAgentPolicyTests.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 

--- a/sdk/core/core-http/test/msRestUserAgentPolicyTests.node.ts
+++ b/sdk/core/core-http/test/msRestUserAgentPolicyTests.node.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 

--- a/sdk/core/core-http/test/operationParameterTests.ts
+++ b/sdk/core/core-http/test/operationParameterTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { getPathStringFromParameter, OperationParameter } from "../src/operationParameter";

--- a/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/bearerTokenAuthenticationPolicyTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { fake } from "sinon";

--- a/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/deserializationPolicyTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { HttpHeaders } from "../../src/httpHeaders";

--- a/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.browser.ts
+++ b/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 import { RequestPolicyOptions } from "../../src/policies/requestPolicy";

--- a/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.node.ts
+++ b/sdk/core/core-http/test/policies/disableResponseDecompressionPolicy.node.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 import { RequestPolicyOptions } from "../../src/policies/requestPolicy";

--- a/sdk/core/core-http/test/policies/proxyPolicyTests.browser.ts
+++ b/sdk/core/core-http/test/policies/proxyPolicyTests.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 import { should } from "chai";

--- a/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
+++ b/sdk/core/core-http/test/policies/proxyPolicyTests.node.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 import { should } from "chai";

--- a/sdk/core/core-http/test/policies/systemErrorRetryPolicyTests.spec.ts
+++ b/sdk/core/core-http/test/policies/systemErrorRetryPolicyTests.spec.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { SystemErrorRetryPolicy, RetryError } from "../../src/policies/systemErrorRetryPolicy";

--- a/sdk/core/core-http/test/policies/throttlingRetryPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/throttlingRetryPolicyTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert, AssertionError } from "chai";
 import sinon from "sinon";

--- a/sdk/core/core-http/test/policies/tracingPolicyTests.ts
+++ b/sdk/core/core-http/test/policies/tracingPolicyTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import {

--- a/sdk/core/core-http/test/proxyAgent.node.ts
+++ b/sdk/core/core-http/test/proxyAgent.node.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 import { should } from "chai";

--- a/sdk/core/core-http/test/restError.node.ts
+++ b/sdk/core/core-http/test/restError.node.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { RestError } from "../src/restError";

--- a/sdk/core/core-http/test/serializationTests.node.ts
+++ b/sdk/core/core-http/test/serializationTests.node.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import "chai/register-should";
 

--- a/sdk/core/core-http/test/serializationTests.ts
+++ b/sdk/core/core-http/test/serializationTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import "chai/register-should";

--- a/sdk/core/core-http/test/serviceClientTests.ts
+++ b/sdk/core/core-http/test/serviceClientTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { HttpClient } from "../src/httpClient";

--- a/sdk/core/core-http/test/urlTests.ts
+++ b/sdk/core/core-http/test/urlTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { URLTokenizer, URLToken, URLBuilder, URLQuery } from "../src/url";

--- a/sdk/core/core-http/test/utilsTests.ts
+++ b/sdk/core/core-http/test/utilsTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { expect } from "chai";
 import { isValidUuid } from "../src/util/utils";

--- a/sdk/core/core-http/test/webResourceTests.ts
+++ b/sdk/core/core-http/test/webResourceTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { WebResource, RequestPrepareOptions } from "../src/webResource";

--- a/sdk/core/core-http/test/xhrTests.browser.ts
+++ b/sdk/core/core-http/test/xhrTests.browser.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { assert } from "chai";
 import { parseHeaders, XhrHttpClient } from "../src/xhrHttpClient";

--- a/sdk/core/core-http/test/xmlTests.ts
+++ b/sdk/core/core-http/test/xmlTests.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 
 import { parseXML, stringifyXML } from "../src/util/xml";
 import { assert } from "chai";


### PR DESCRIPTION
This PR updates the copyright text in the core-http package to ease the code review efforts in #8687 which otherwise would have too many files to review