### PR TITLE
Avoid passing unused credentials to generated client constructors

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/package.json
+++ b/sdk/formrecognizer/ai-form-recognizer/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
-    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=1.0.0-preview.3 --version=3.0.6267",
+    "build:autorest": "autorest ./swagger/README.md --typescript --package-version=1.0.0-preview.4 --version=3.0.6267",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:samples": "node ../../../common/scripts/prep-samples.js && cd samples && tsc -p .",

--- a/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formRecognizerClient.ts
@@ -7,8 +7,7 @@ import {
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
   operationOptionsToRequestOptionsBase,
-  AbortSignalLike,
-  ServiceClientCredentials
+  AbortSignalLike
 } from "@azure/core-http";
 import { TokenCredential } from "@azure/identity";
 import { KeyCredential } from "@azure/core-auth";
@@ -266,18 +265,7 @@ export class FormRecognizerClient {
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
 
-    // The contract with the generated client requires a credential, even though it is never used
-    // when a pipeline is provided. Until that contract can be changed, this dummy credential will
-    // throw an error if the client ever attempts to use it.
-    const dummyCredential: ServiceClientCredentials = {
-      signRequest() {
-        throw new Error(
-          "Internal error: Attempted to use credential from service client, but a pipeline was provided."
-        );
-      }
-    };
-
-    this.client = new GeneratedClient(dummyCredential, this.endpointUrl, pipeline);
+    this.client = new GeneratedClient(this.endpointUrl, pipeline);
   }
 
   /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/formTrainingClient.ts
@@ -9,8 +9,7 @@ import {
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
   operationOptionsToRequestOptionsBase,
-  RestResponse,
-  ServiceClientCredentials
+  RestResponse 
 } from "@azure/core-http";
 import { TokenCredential } from "@azure/identity";
 import { KeyCredential } from "@azure/core-auth";
@@ -201,18 +200,7 @@ export class FormTrainingClient {
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
 
-    // The contract with the generated client requires a credential, even though it is never used
-    // when a pipeline is provided. Until that contract can be changed, this dummy credential will
-    // throw an error if the client ever attempts to use it.
-    const dummyCredential: ServiceClientCredentials = {
-      signRequest() {
-        throw new Error(
-          "Internal error: Attempted to use credential from service client, but a pipeline was provided."
-        );
-      }
-    };
-
-    this.client = new GeneratedClient(dummyCredential, this.endpointUrl, pipeline);
+    this.client = new GeneratedClient(this.endpointUrl, pipeline);
   }
 
   /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClient.ts
@@ -41,17 +41,15 @@ import {
 class GeneratedClient extends GeneratedClientContext {
   /**
    * Initializes a new instance of the GeneratedClient class.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
    *                 https://westus2.api.cognitive.microsoft.com).
    * @param options The parameter options
    */
   constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     endpoint: string,
     options?: Models.GeneratedClientOptionalParams
   ) {
-    super(credentials, endpoint, options);
+    super(endpoint, options);
   }
 
   /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
@@ -10,7 +10,7 @@ import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 
 const packageName = "@azure/ai-form-recognizer";
-const packageVersion = "1.0.0-preview.3";
+const packageVersion = "1.0.0-preview.4";
 
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/generatedClientContext.ts
@@ -10,26 +10,21 @@ import * as coreHttp from "@azure/core-http";
 import * as Models from "./models";
 
 const packageName = "@azure/ai-form-recognizer";
-const packageVersion = "1.0.0-preview.4";
+const packageVersion = "1.0.0-preview.3";
 
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;
 
   /**
    * Initializes a new instance of the GeneratedClientContext class.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
    *                 https://westus2.api.cognitive.microsoft.com).
    * @param options The parameter options
    */
   constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     endpoint: string,
     options?: Models.GeneratedClientOptionalParams
   ) {
-    if (credentials === undefined) {
-      throw new Error("'credentials' cannot be null");
-    }
     if (endpoint === undefined) {
       throw new Error("'endpoint' cannot be null");
     }
@@ -44,7 +39,7 @@ export class GeneratedClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(credentials, options);
+    super(undefined, options);
 
     this.requestContentType = "application/json; charset=utf-8";
 

--- a/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
@@ -14,7 +14,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
-add-credentials: true
+add-credentials: false
 override-client-name: GeneratedClient
 use-extension:
   "@autorest/typescript": "6.0.0-dev.20200505.1"

--- a/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
+++ b/sdk/keyvault/keyvault-certificates/review/keyvault-certificates.api.md
@@ -12,7 +12,7 @@ import { PollOperationState } from '@azure/core-lro';
 import { TokenCredential } from '@azure/core-http';
 
 // @public
-export type ActionType = "EmailContacts" | "AutoRenew";
+export type ActionType = 'EmailContacts' | 'AutoRenew';
 
 // @public
 export interface AdministratorContact {
@@ -246,7 +246,7 @@ export interface DeletedCertificate extends KeyVaultCertificateWithPolicy {
 export type DeleteIssuerOptions = coreHttp.OperationOptions;
 
 // @public
-export type DeletionRecoveryLevel = "Purgeable" | "Recoverable+Purgeable" | "Recoverable" | "Recoverable+ProtectedSubscription" | "CustomizedRecoverable+Purgeable" | "CustomizedRecoverable" | "CustomizedRecoverable+ProtectedSubscription";
+export type DeletionRecoveryLevel = 'Purgeable' | 'Recoverable+Purgeable' | 'Recoverable' | 'Recoverable+ProtectedSubscription' | 'CustomizedRecoverable+Purgeable' | 'CustomizedRecoverable' | 'CustomizedRecoverable+ProtectedSubscription';
 
 // @public
 export interface ErrorModel {
@@ -315,7 +315,7 @@ export interface IssuerProperties {
 }
 
 // @public
-export type KeyUsageType = "digitalSignature" | "nonRepudiation" | "keyEncipherment" | "dataEncipherment" | "keyAgreement" | "keyCertSign" | "cRLSign" | "encipherOnly" | "decipherOnly";
+export type KeyUsageType = 'digitalSignature' | 'nonRepudiation' | 'keyEncipherment' | 'dataEncipherment' | 'keyAgreement' | 'keyCertSign' | 'cRLSign' | 'encipherOnly' | 'decipherOnly';
 
 // @public
 export interface KeyVaultCertificate {

--- a/sdk/keyvault/keyvault-certificates/src/core/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/keyVaultClient.ts
@@ -18,15 +18,10 @@ class KeyVaultClient extends KeyVaultClientContext {
   /**
    * Initializes a new instance of the KeyVaultClient class.
    * @param apiVersion Client API version.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    apiVersion: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
-    super(credentials, apiVersion, options);
+  constructor(apiVersion: string, options?: coreHttp.ServiceClientOptions) {
+    super(apiVersion, options);
   }
 
   /**
@@ -37,43 +32,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificatesResponse>
    */
-  getCertificates(
-    vaultBaseUrl: string,
-    options?: Models.KeyVaultClientGetCertificatesOptionalParams
-  ): Promise<Models.GetCertificatesResponse>;
+  getCertificates(vaultBaseUrl: string, options?: Models.KeyVaultClientGetCertificatesOptionalParams): Promise<Models.GetCertificatesResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  getCertificates(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateListResult>
-  ): void;
+  getCertificates(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.CertificateListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificates(
-    vaultBaseUrl: string,
-    options: Models.KeyVaultClientGetCertificatesOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.CertificateListResult>
-  ): void;
-  getCertificates(
-    vaultBaseUrl: string,
-    options?:
-      | Models.KeyVaultClientGetCertificatesOptionalParams
-      | coreHttp.ServiceCallback<Models.CertificateListResult>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateListResult>
-  ): Promise<Models.GetCertificatesResponse> {
+  getCertificates(vaultBaseUrl: string, options: Models.KeyVaultClientGetCertificatesOptionalParams, callback: coreHttp.ServiceCallback<Models.CertificateListResult>): void;
+  getCertificates(vaultBaseUrl: string, options?: Models.KeyVaultClientGetCertificatesOptionalParams | coreHttp.ServiceCallback<Models.CertificateListResult>, callback?: coreHttp.ServiceCallback<Models.CertificateListResult>): Promise<Models.GetCertificatesResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getCertificatesOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificatesResponse>;
+      callback) as Promise<Models.GetCertificatesResponse>;
   }
 
   /**
@@ -86,41 +64,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeleteCertificateResponse>
    */
-  deleteCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DeleteCertificateResponse>;
+  deleteCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeleteCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param callback The callback
    */
-  deleteCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>
-  ): void;
+  deleteCertificate(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>
-  ): void;
-  deleteCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?:
-      | coreHttp.RequestOptionsBase
-      | coreHttp.ServiceCallback<Models.DeletedCertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>
-  ): Promise<Models.DeleteCertificateResponse> {
+  deleteCertificate(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>): void;
+  deleteCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedCertificateBundle>, callback?: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>): Promise<Models.DeleteCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -128,8 +86,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       deleteCertificateOperationSpec,
-      callback
-    ) as Promise<Models.DeleteCertificateResponse>;
+      callback) as Promise<Models.DeleteCertificateResponse>;
   }
 
   /**
@@ -141,39 +98,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.SetCertificateContactsResponse>
    */
-  setCertificateContacts(
-    vaultBaseUrl: string,
-    contacts: Models.Contacts,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.SetCertificateContactsResponse>;
+  setCertificateContacts(vaultBaseUrl: string, contacts: Models.Contacts, options?: coreHttp.RequestOptionsBase): Promise<Models.SetCertificateContactsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param contacts The contacts for the key vault certificate.
    * @param callback The callback
    */
-  setCertificateContacts(
-    vaultBaseUrl: string,
-    contacts: Models.Contacts,
-    callback: coreHttp.ServiceCallback<Models.Contacts>
-  ): void;
+  setCertificateContacts(vaultBaseUrl: string, contacts: Models.Contacts, callback: coreHttp.ServiceCallback<Models.Contacts>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param contacts The contacts for the key vault certificate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  setCertificateContacts(
-    vaultBaseUrl: string,
-    contacts: Models.Contacts,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.Contacts>
-  ): void;
-  setCertificateContacts(
-    vaultBaseUrl: string,
-    contacts: Models.Contacts,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Contacts>,
-    callback?: coreHttp.ServiceCallback<Models.Contacts>
-  ): Promise<Models.SetCertificateContactsResponse> {
+  setCertificateContacts(vaultBaseUrl: string, contacts: Models.Contacts, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Contacts>): void;
+  setCertificateContacts(vaultBaseUrl: string, contacts: Models.Contacts, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Contacts>, callback?: coreHttp.ServiceCallback<Models.Contacts>): Promise<Models.SetCertificateContactsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -181,8 +120,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       setCertificateContactsOperationSpec,
-      callback
-    ) as Promise<Models.SetCertificateContactsResponse>;
+      callback) as Promise<Models.SetCertificateContactsResponse>;
   }
 
   /**
@@ -193,41 +131,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificateContactsResponse>
    */
-  getCertificateContacts(
-    vaultBaseUrl: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetCertificateContactsResponse>;
+  getCertificateContacts(vaultBaseUrl: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetCertificateContactsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  getCertificateContacts(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.Contacts>
-  ): void;
+  getCertificateContacts(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.Contacts>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificateContacts(
-    vaultBaseUrl: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.Contacts>
-  ): void;
-  getCertificateContacts(
-    vaultBaseUrl: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Contacts>,
-    callback?: coreHttp.ServiceCallback<Models.Contacts>
-  ): Promise<Models.GetCertificateContactsResponse> {
+  getCertificateContacts(vaultBaseUrl: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Contacts>): void;
+  getCertificateContacts(vaultBaseUrl: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Contacts>, callback?: coreHttp.ServiceCallback<Models.Contacts>): Promise<Models.GetCertificateContactsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getCertificateContactsOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificateContactsResponse>;
+      callback) as Promise<Models.GetCertificateContactsResponse>;
   }
 
   /**
@@ -238,41 +161,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeleteCertificateContactsResponse>
    */
-  deleteCertificateContacts(
-    vaultBaseUrl: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DeleteCertificateContactsResponse>;
+  deleteCertificateContacts(vaultBaseUrl: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeleteCertificateContactsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  deleteCertificateContacts(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.Contacts>
-  ): void;
+  deleteCertificateContacts(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.Contacts>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteCertificateContacts(
-    vaultBaseUrl: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.Contacts>
-  ): void;
-  deleteCertificateContacts(
-    vaultBaseUrl: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Contacts>,
-    callback?: coreHttp.ServiceCallback<Models.Contacts>
-  ): Promise<Models.DeleteCertificateContactsResponse> {
+  deleteCertificateContacts(vaultBaseUrl: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.Contacts>): void;
+  deleteCertificateContacts(vaultBaseUrl: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.Contacts>, callback?: coreHttp.ServiceCallback<Models.Contacts>): Promise<Models.DeleteCertificateContactsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       deleteCertificateContactsOperationSpec,
-      callback
-    ) as Promise<Models.DeleteCertificateContactsResponse>;
+      callback) as Promise<Models.DeleteCertificateContactsResponse>;
   }
 
   /**
@@ -284,43 +192,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificateIssuersResponse>
    */
-  getCertificateIssuers(
-    vaultBaseUrl: string,
-    options?: Models.KeyVaultClientGetCertificateIssuersOptionalParams
-  ): Promise<Models.GetCertificateIssuersResponse>;
+  getCertificateIssuers(vaultBaseUrl: string, options?: Models.KeyVaultClientGetCertificateIssuersOptionalParams): Promise<Models.GetCertificateIssuersResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  getCertificateIssuers(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateIssuerListResult>
-  ): void;
+  getCertificateIssuers(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.CertificateIssuerListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificateIssuers(
-    vaultBaseUrl: string,
-    options: Models.KeyVaultClientGetCertificateIssuersOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.CertificateIssuerListResult>
-  ): void;
-  getCertificateIssuers(
-    vaultBaseUrl: string,
-    options?:
-      | Models.KeyVaultClientGetCertificateIssuersOptionalParams
-      | coreHttp.ServiceCallback<Models.CertificateIssuerListResult>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateIssuerListResult>
-  ): Promise<Models.GetCertificateIssuersResponse> {
+  getCertificateIssuers(vaultBaseUrl: string, options: Models.KeyVaultClientGetCertificateIssuersOptionalParams, callback: coreHttp.ServiceCallback<Models.CertificateIssuerListResult>): void;
+  getCertificateIssuers(vaultBaseUrl: string, options?: Models.KeyVaultClientGetCertificateIssuersOptionalParams | coreHttp.ServiceCallback<Models.CertificateIssuerListResult>, callback?: coreHttp.ServiceCallback<Models.CertificateIssuerListResult>): Promise<Models.GetCertificateIssuersResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getCertificateIssuersOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificateIssuersResponse>;
+      callback) as Promise<Models.GetCertificateIssuersResponse>;
   }
 
   /**
@@ -333,24 +224,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.SetCertificateIssuerResponse>
    */
-  setCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    provider: string,
-    options?: Models.KeyVaultClientSetCertificateIssuerOptionalParams
-  ): Promise<Models.SetCertificateIssuerResponse>;
+  setCertificateIssuer(vaultBaseUrl: string, issuerName: string, provider: string, options?: Models.KeyVaultClientSetCertificateIssuerOptionalParams): Promise<Models.SetCertificateIssuerResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
    * @param provider The issuer provider.
    * @param callback The callback
    */
-  setCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    provider: string,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
+  setCertificateIssuer(vaultBaseUrl: string, issuerName: string, provider: string, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
@@ -358,22 +239,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  setCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    provider: string,
-    options: Models.KeyVaultClientSetCertificateIssuerOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
-  setCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    provider: string,
-    options?:
-      | Models.KeyVaultClientSetCertificateIssuerOptionalParams
-      | coreHttp.ServiceCallback<Models.IssuerBundle>,
-    callback?: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): Promise<Models.SetCertificateIssuerResponse> {
+  setCertificateIssuer(vaultBaseUrl: string, issuerName: string, provider: string, options: Models.KeyVaultClientSetCertificateIssuerOptionalParams, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
+  setCertificateIssuer(vaultBaseUrl: string, issuerName: string, provider: string, options?: Models.KeyVaultClientSetCertificateIssuerOptionalParams | coreHttp.ServiceCallback<Models.IssuerBundle>, callback?: coreHttp.ServiceCallback<Models.IssuerBundle>): Promise<Models.SetCertificateIssuerResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -382,8 +249,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       setCertificateIssuerOperationSpec,
-      callback
-    ) as Promise<Models.SetCertificateIssuerResponse>;
+      callback) as Promise<Models.SetCertificateIssuerResponse>;
   }
 
   /**
@@ -395,41 +261,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.UpdateCertificateIssuerResponse>
    */
-  updateCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options?: Models.KeyVaultClientUpdateCertificateIssuerOptionalParams
-  ): Promise<Models.UpdateCertificateIssuerResponse>;
+  updateCertificateIssuer(vaultBaseUrl: string, issuerName: string, options?: Models.KeyVaultClientUpdateCertificateIssuerOptionalParams): Promise<Models.UpdateCertificateIssuerResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
    * @param callback The callback
    */
-  updateCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
+  updateCertificateIssuer(vaultBaseUrl: string, issuerName: string, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options: Models.KeyVaultClientUpdateCertificateIssuerOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
-  updateCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options?:
-      | Models.KeyVaultClientUpdateCertificateIssuerOptionalParams
-      | coreHttp.ServiceCallback<Models.IssuerBundle>,
-    callback?: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): Promise<Models.UpdateCertificateIssuerResponse> {
+  updateCertificateIssuer(vaultBaseUrl: string, issuerName: string, options: Models.KeyVaultClientUpdateCertificateIssuerOptionalParams, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
+  updateCertificateIssuer(vaultBaseUrl: string, issuerName: string, options?: Models.KeyVaultClientUpdateCertificateIssuerOptionalParams | coreHttp.ServiceCallback<Models.IssuerBundle>, callback?: coreHttp.ServiceCallback<Models.IssuerBundle>): Promise<Models.UpdateCertificateIssuerResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -437,8 +283,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       updateCertificateIssuerOperationSpec,
-      callback
-    ) as Promise<Models.UpdateCertificateIssuerResponse>;
+      callback) as Promise<Models.UpdateCertificateIssuerResponse>;
   }
 
   /**
@@ -451,39 +296,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificateIssuerResponse>
    */
-  getCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetCertificateIssuerResponse>;
+  getCertificateIssuer(vaultBaseUrl: string, issuerName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetCertificateIssuerResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
    * @param callback The callback
    */
-  getCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
+  getCertificateIssuer(vaultBaseUrl: string, issuerName: string, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
-  getCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.IssuerBundle>,
-    callback?: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): Promise<Models.GetCertificateIssuerResponse> {
+  getCertificateIssuer(vaultBaseUrl: string, issuerName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
+  getCertificateIssuer(vaultBaseUrl: string, issuerName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.IssuerBundle>, callback?: coreHttp.ServiceCallback<Models.IssuerBundle>): Promise<Models.GetCertificateIssuerResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -491,8 +318,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getCertificateIssuerOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificateIssuerResponse>;
+      callback) as Promise<Models.GetCertificateIssuerResponse>;
   }
 
   /**
@@ -504,39 +330,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeleteCertificateIssuerResponse>
    */
-  deleteCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DeleteCertificateIssuerResponse>;
+  deleteCertificateIssuer(vaultBaseUrl: string, issuerName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeleteCertificateIssuerResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
    * @param callback The callback
    */
-  deleteCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
+  deleteCertificateIssuer(vaultBaseUrl: string, issuerName: string, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param issuerName The name of the issuer.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): void;
-  deleteCertificateIssuer(
-    vaultBaseUrl: string,
-    issuerName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.IssuerBundle>,
-    callback?: coreHttp.ServiceCallback<Models.IssuerBundle>
-  ): Promise<Models.DeleteCertificateIssuerResponse> {
+  deleteCertificateIssuer(vaultBaseUrl: string, issuerName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.IssuerBundle>): void;
+  deleteCertificateIssuer(vaultBaseUrl: string, issuerName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.IssuerBundle>, callback?: coreHttp.ServiceCallback<Models.IssuerBundle>): Promise<Models.DeleteCertificateIssuerResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -544,8 +352,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       deleteCertificateIssuerOperationSpec,
-      callback
-    ) as Promise<Models.DeleteCertificateIssuerResponse>;
+      callback) as Promise<Models.DeleteCertificateIssuerResponse>;
   }
 
   /**
@@ -557,41 +364,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.CreateCertificateResponse>
    */
-  createCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: Models.KeyVaultClientCreateCertificateOptionalParams
-  ): Promise<Models.CreateCertificateResponse>;
+  createCertificate(vaultBaseUrl: string, certificateName: string, options?: Models.KeyVaultClientCreateCertificateOptionalParams): Promise<Models.CreateCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param callback The callback
    */
-  createCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
+  createCertificate(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  createCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: Models.KeyVaultClientCreateCertificateOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
-  createCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?:
-      | Models.KeyVaultClientCreateCertificateOptionalParams
-      | coreHttp.ServiceCallback<Models.CertificateOperation>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): Promise<Models.CreateCertificateResponse> {
+  createCertificate(vaultBaseUrl: string, certificateName: string, options: Models.KeyVaultClientCreateCertificateOptionalParams, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
+  createCertificate(vaultBaseUrl: string, certificateName: string, options?: Models.KeyVaultClientCreateCertificateOptionalParams | coreHttp.ServiceCallback<Models.CertificateOperation>, callback?: coreHttp.ServiceCallback<Models.CertificateOperation>): Promise<Models.CreateCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -599,8 +386,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       createCertificateOperationSpec,
-      callback
-    ) as Promise<Models.CreateCertificateResponse>;
+      callback) as Promise<Models.CreateCertificateResponse>;
   }
 
   /**
@@ -616,12 +402,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImportCertificateResponse>
    */
-  importCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    base64EncodedCertificate: string,
-    options?: Models.KeyVaultClientImportCertificateOptionalParams
-  ): Promise<Models.ImportCertificateResponse>;
+  importCertificate(vaultBaseUrl: string, certificateName: string, base64EncodedCertificate: string, options?: Models.KeyVaultClientImportCertificateOptionalParams): Promise<Models.ImportCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
@@ -629,12 +410,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * import. This certificate needs to contain the private key.
    * @param callback The callback
    */
-  importCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    base64EncodedCertificate: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
+  importCertificate(vaultBaseUrl: string, certificateName: string, base64EncodedCertificate: string, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
@@ -643,22 +419,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  importCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    base64EncodedCertificate: string,
-    options: Models.KeyVaultClientImportCertificateOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
-  importCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    base64EncodedCertificate: string,
-    options?:
-      | Models.KeyVaultClientImportCertificateOptionalParams
-      | coreHttp.ServiceCallback<Models.CertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): Promise<Models.ImportCertificateResponse> {
+  importCertificate(vaultBaseUrl: string, certificateName: string, base64EncodedCertificate: string, options: Models.KeyVaultClientImportCertificateOptionalParams, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
+  importCertificate(vaultBaseUrl: string, certificateName: string, base64EncodedCertificate: string, options?: Models.KeyVaultClientImportCertificateOptionalParams | coreHttp.ServiceCallback<Models.CertificateBundle>, callback?: coreHttp.ServiceCallback<Models.CertificateBundle>): Promise<Models.ImportCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -667,8 +429,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       importCertificateOperationSpec,
-      callback
-    ) as Promise<Models.ImportCertificateResponse>;
+      callback) as Promise<Models.ImportCertificateResponse>;
   }
 
   /**
@@ -680,41 +441,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificateVersionsResponse>
    */
-  getCertificateVersions(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: Models.KeyVaultClientGetCertificateVersionsOptionalParams
-  ): Promise<Models.GetCertificateVersionsResponse>;
+  getCertificateVersions(vaultBaseUrl: string, certificateName: string, options?: Models.KeyVaultClientGetCertificateVersionsOptionalParams): Promise<Models.GetCertificateVersionsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param callback The callback
    */
-  getCertificateVersions(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateListResult>
-  ): void;
+  getCertificateVersions(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.CertificateListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificateVersions(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: Models.KeyVaultClientGetCertificateVersionsOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.CertificateListResult>
-  ): void;
-  getCertificateVersions(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?:
-      | Models.KeyVaultClientGetCertificateVersionsOptionalParams
-      | coreHttp.ServiceCallback<Models.CertificateListResult>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateListResult>
-  ): Promise<Models.GetCertificateVersionsResponse> {
+  getCertificateVersions(vaultBaseUrl: string, certificateName: string, options: Models.KeyVaultClientGetCertificateVersionsOptionalParams, callback: coreHttp.ServiceCallback<Models.CertificateListResult>): void;
+  getCertificateVersions(vaultBaseUrl: string, certificateName: string, options?: Models.KeyVaultClientGetCertificateVersionsOptionalParams | coreHttp.ServiceCallback<Models.CertificateListResult>, callback?: coreHttp.ServiceCallback<Models.CertificateListResult>): Promise<Models.GetCertificateVersionsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -722,8 +463,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getCertificateVersionsOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificateVersionsResponse>;
+      callback) as Promise<Models.GetCertificateVersionsResponse>;
   }
 
   /**
@@ -735,39 +475,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificatePolicyResponse>
    */
-  getCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetCertificatePolicyResponse>;
+  getCertificatePolicy(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetCertificatePolicyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in a given key vault.
    * @param callback The callback
    */
-  getCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.CertificatePolicy>
-  ): void;
+  getCertificatePolicy(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.CertificatePolicy>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in a given key vault.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificatePolicy>
-  ): void;
-  getCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificatePolicy>,
-    callback?: coreHttp.ServiceCallback<Models.CertificatePolicy>
-  ): Promise<Models.GetCertificatePolicyResponse> {
+  getCertificatePolicy(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificatePolicy>): void;
+  getCertificatePolicy(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificatePolicy>, callback?: coreHttp.ServiceCallback<Models.CertificatePolicy>): Promise<Models.GetCertificatePolicyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -775,8 +497,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getCertificatePolicyOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificatePolicyResponse>;
+      callback) as Promise<Models.GetCertificatePolicyResponse>;
   }
 
   /**
@@ -789,24 +510,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.UpdateCertificatePolicyResponse>
    */
-  updateCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificatePolicy: Models.CertificatePolicy,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.UpdateCertificatePolicyResponse>;
+  updateCertificatePolicy(vaultBaseUrl: string, certificateName: string, certificatePolicy: Models.CertificatePolicy, options?: coreHttp.RequestOptionsBase): Promise<Models.UpdateCertificatePolicyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in the given vault.
    * @param certificatePolicy The policy for the certificate.
    * @param callback The callback
    */
-  updateCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificatePolicy: Models.CertificatePolicy,
-    callback: coreHttp.ServiceCallback<Models.CertificatePolicy>
-  ): void;
+  updateCertificatePolicy(vaultBaseUrl: string, certificateName: string, certificatePolicy: Models.CertificatePolicy, callback: coreHttp.ServiceCallback<Models.CertificatePolicy>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in the given vault.
@@ -814,20 +525,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificatePolicy: Models.CertificatePolicy,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificatePolicy>
-  ): void;
-  updateCertificatePolicy(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificatePolicy: Models.CertificatePolicy,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificatePolicy>,
-    callback?: coreHttp.ServiceCallback<Models.CertificatePolicy>
-  ): Promise<Models.UpdateCertificatePolicyResponse> {
+  updateCertificatePolicy(vaultBaseUrl: string, certificateName: string, certificatePolicy: Models.CertificatePolicy, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificatePolicy>): void;
+  updateCertificatePolicy(vaultBaseUrl: string, certificateName: string, certificatePolicy: Models.CertificatePolicy, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificatePolicy>, callback?: coreHttp.ServiceCallback<Models.CertificatePolicy>): Promise<Models.UpdateCertificatePolicyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -836,8 +535,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       updateCertificatePolicyOperationSpec,
-      callback
-    ) as Promise<Models.UpdateCertificatePolicyResponse>;
+      callback) as Promise<Models.UpdateCertificatePolicyResponse>;
   }
 
   /**
@@ -851,24 +549,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.UpdateCertificateResponse>
    */
-  updateCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    options?: Models.KeyVaultClientUpdateCertificateOptionalParams
-  ): Promise<Models.UpdateCertificateResponse>;
+  updateCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, options?: Models.KeyVaultClientUpdateCertificateOptionalParams): Promise<Models.UpdateCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in the given key vault.
    * @param certificateVersion The version of the certificate.
    * @param callback The callback
    */
-  updateCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
+  updateCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in the given key vault.
@@ -876,22 +564,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    options: Models.KeyVaultClientUpdateCertificateOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
-  updateCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    options?:
-      | Models.KeyVaultClientUpdateCertificateOptionalParams
-      | coreHttp.ServiceCallback<Models.CertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): Promise<Models.UpdateCertificateResponse> {
+  updateCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, options: Models.KeyVaultClientUpdateCertificateOptionalParams, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
+  updateCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, options?: Models.KeyVaultClientUpdateCertificateOptionalParams | coreHttp.ServiceCallback<Models.CertificateBundle>, callback?: coreHttp.ServiceCallback<Models.CertificateBundle>): Promise<Models.UpdateCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -900,8 +574,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       updateCertificateOperationSpec,
-      callback
-    ) as Promise<Models.UpdateCertificateResponse>;
+      callback) as Promise<Models.UpdateCertificateResponse>;
   }
 
   /**
@@ -910,49 +583,30 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @summary Gets information about a certificate.
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in the given vault.
-   * @param certificateVersion The version of the certificate.
+   * @param certificateVersion The version of the certificate. This URI fragment is optional. If not
+   * specified, the latest version of the certificate is returned.
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificateResponse>
    */
-  getCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetCertificateResponse>;
+  getCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in the given vault.
-   * @param certificateVersion The version of the certificate.
+   * @param certificateVersion The version of the certificate. This URI fragment is optional. If not
+   * specified, the latest version of the certificate is returned.
    * @param callback The callback
    */
-  getCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
+  getCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate in the given vault.
-   * @param certificateVersion The version of the certificate.
+   * @param certificateVersion The version of the certificate. This URI fragment is optional. If not
+   * specified, the latest version of the certificate is returned.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
-  getCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    certificateVersion: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): Promise<Models.GetCertificateResponse> {
+  getCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
+  getCertificate(vaultBaseUrl: string, certificateName: string, certificateVersion: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateBundle>, callback?: coreHttp.ServiceCallback<Models.CertificateBundle>): Promise<Models.GetCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -961,8 +615,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getCertificateOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificateResponse>;
+      callback) as Promise<Models.GetCertificateResponse>;
   }
 
   /**
@@ -976,12 +629,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.UpdateCertificateOperationResponse>
    */
-  updateCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    cancellationRequested: boolean,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.UpdateCertificateOperationResponse>;
+  updateCertificateOperation(vaultBaseUrl: string, certificateName: string, cancellationRequested: boolean, options?: coreHttp.RequestOptionsBase): Promise<Models.UpdateCertificateOperationResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
@@ -989,12 +637,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * operation.
    * @param callback The callback
    */
-  updateCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    cancellationRequested: boolean,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
+  updateCertificateOperation(vaultBaseUrl: string, certificateName: string, cancellationRequested: boolean, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
@@ -1003,20 +646,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    cancellationRequested: boolean,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
-  updateCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    cancellationRequested: boolean,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateOperation>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): Promise<Models.UpdateCertificateOperationResponse> {
+  updateCertificateOperation(vaultBaseUrl: string, certificateName: string, cancellationRequested: boolean, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
+  updateCertificateOperation(vaultBaseUrl: string, certificateName: string, cancellationRequested: boolean, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateOperation>, callback?: coreHttp.ServiceCallback<Models.CertificateOperation>): Promise<Models.UpdateCertificateOperationResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1025,8 +656,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       updateCertificateOperationOperationSpec,
-      callback
-    ) as Promise<Models.UpdateCertificateOperationResponse>;
+      callback) as Promise<Models.UpdateCertificateOperationResponse>;
   }
 
   /**
@@ -1038,39 +668,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetCertificateOperationResponse>
    */
-  getCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetCertificateOperationResponse>;
+  getCertificateOperation(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetCertificateOperationResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param callback The callback
    */
-  getCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
+  getCertificateOperation(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
-  getCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateOperation>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): Promise<Models.GetCertificateOperationResponse> {
+  getCertificateOperation(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
+  getCertificateOperation(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateOperation>, callback?: coreHttp.ServiceCallback<Models.CertificateOperation>): Promise<Models.GetCertificateOperationResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1078,8 +690,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getCertificateOperationOperationSpec,
-      callback
-    ) as Promise<Models.GetCertificateOperationResponse>;
+      callback) as Promise<Models.GetCertificateOperationResponse>;
   }
 
   /**
@@ -1092,39 +703,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeleteCertificateOperationResponse>
    */
-  deleteCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DeleteCertificateOperationResponse>;
+  deleteCertificateOperation(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeleteCertificateOperationResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param callback The callback
    */
-  deleteCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
+  deleteCertificateOperation(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): void;
-  deleteCertificateOperation(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateOperation>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateOperation>
-  ): Promise<Models.DeleteCertificateOperationResponse> {
+  deleteCertificateOperation(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificateOperation>): void;
+  deleteCertificateOperation(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateOperation>, callback?: coreHttp.ServiceCallback<Models.CertificateOperation>): Promise<Models.DeleteCertificateOperationResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1132,8 +725,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       deleteCertificateOperationOperationSpec,
-      callback
-    ) as Promise<Models.DeleteCertificateOperationResponse>;
+      callback) as Promise<Models.DeleteCertificateOperationResponse>;
   }
 
   /**
@@ -1147,24 +739,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.MergeCertificateResponse>
    */
-  mergeCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    x509Certificates: Uint8Array[],
-    options?: Models.KeyVaultClientMergeCertificateOptionalParams
-  ): Promise<Models.MergeCertificateResponse>;
+  mergeCertificate(vaultBaseUrl: string, certificateName: string, x509Certificates: Uint8Array[], options?: Models.KeyVaultClientMergeCertificateOptionalParams): Promise<Models.MergeCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param x509Certificates The certificate or the certificate chain to merge.
    * @param callback The callback
    */
-  mergeCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    x509Certificates: Uint8Array[],
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
+  mergeCertificate(vaultBaseUrl: string, certificateName: string, x509Certificates: Uint8Array[], callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
@@ -1172,22 +754,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  mergeCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    x509Certificates: Uint8Array[],
-    options: Models.KeyVaultClientMergeCertificateOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
-  mergeCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    x509Certificates: Uint8Array[],
-    options?:
-      | Models.KeyVaultClientMergeCertificateOptionalParams
-      | coreHttp.ServiceCallback<Models.CertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): Promise<Models.MergeCertificateResponse> {
+  mergeCertificate(vaultBaseUrl: string, certificateName: string, x509Certificates: Uint8Array[], options: Models.KeyVaultClientMergeCertificateOptionalParams, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
+  mergeCertificate(vaultBaseUrl: string, certificateName: string, x509Certificates: Uint8Array[], options?: Models.KeyVaultClientMergeCertificateOptionalParams | coreHttp.ServiceCallback<Models.CertificateBundle>, callback?: coreHttp.ServiceCallback<Models.CertificateBundle>): Promise<Models.MergeCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1196,8 +764,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       mergeCertificateOperationSpec,
-      callback
-    ) as Promise<Models.MergeCertificateResponse>;
+      callback) as Promise<Models.MergeCertificateResponse>;
   }
 
   /**
@@ -1209,41 +776,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.BackupCertificateResponse>
    */
-  backupCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BackupCertificateResponse>;
+  backupCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.BackupCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param callback The callback
    */
-  backupCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.BackupCertificateResult>
-  ): void;
+  backupCertificate(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.BackupCertificateResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate.
    * @param options The optional parameters
    * @param callback The callback
    */
-  backupCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.BackupCertificateResult>
-  ): void;
-  backupCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?:
-      | coreHttp.RequestOptionsBase
-      | coreHttp.ServiceCallback<Models.BackupCertificateResult>,
-    callback?: coreHttp.ServiceCallback<Models.BackupCertificateResult>
-  ): Promise<Models.BackupCertificateResponse> {
+  backupCertificate(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.BackupCertificateResult>): void;
+  backupCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.BackupCertificateResult>, callback?: coreHttp.ServiceCallback<Models.BackupCertificateResult>): Promise<Models.BackupCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1251,8 +798,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       backupCertificateOperationSpec,
-      callback
-    ) as Promise<Models.BackupCertificateResponse>;
+      callback) as Promise<Models.BackupCertificateResponse>;
   }
 
   /**
@@ -1264,39 +810,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.RestoreCertificateResponse>
    */
-  restoreCertificate(
-    vaultBaseUrl: string,
-    certificateBundleBackup: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.RestoreCertificateResponse>;
+  restoreCertificate(vaultBaseUrl: string, certificateBundleBackup: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.RestoreCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateBundleBackup The backup blob associated with a certificate bundle.
    * @param callback The callback
    */
-  restoreCertificate(
-    vaultBaseUrl: string,
-    certificateBundleBackup: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
+  restoreCertificate(vaultBaseUrl: string, certificateBundleBackup: Uint8Array, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateBundleBackup The backup blob associated with a certificate bundle.
    * @param options The optional parameters
    * @param callback The callback
    */
-  restoreCertificate(
-    vaultBaseUrl: string,
-    certificateBundleBackup: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
-  restoreCertificate(
-    vaultBaseUrl: string,
-    certificateBundleBackup: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): Promise<Models.RestoreCertificateResponse> {
+  restoreCertificate(vaultBaseUrl: string, certificateBundleBackup: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
+  restoreCertificate(vaultBaseUrl: string, certificateBundleBackup: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateBundle>, callback?: coreHttp.ServiceCallback<Models.CertificateBundle>): Promise<Models.RestoreCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1304,8 +832,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       restoreCertificateOperationSpec,
-      callback
-    ) as Promise<Models.RestoreCertificateResponse>;
+      callback) as Promise<Models.RestoreCertificateResponse>;
   }
 
   /**
@@ -1318,43 +845,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetDeletedCertificatesResponse>
    */
-  getDeletedCertificates(
-    vaultBaseUrl: string,
-    options?: Models.KeyVaultClientGetDeletedCertificatesOptionalParams
-  ): Promise<Models.GetDeletedCertificatesResponse>;
+  getDeletedCertificates(vaultBaseUrl: string, options?: Models.KeyVaultClientGetDeletedCertificatesOptionalParams): Promise<Models.GetDeletedCertificatesResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  getDeletedCertificates(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedCertificateListResult>
-  ): void;
+  getDeletedCertificates(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.DeletedCertificateListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getDeletedCertificates(
-    vaultBaseUrl: string,
-    options: Models.KeyVaultClientGetDeletedCertificatesOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.DeletedCertificateListResult>
-  ): void;
-  getDeletedCertificates(
-    vaultBaseUrl: string,
-    options?:
-      | Models.KeyVaultClientGetDeletedCertificatesOptionalParams
-      | coreHttp.ServiceCallback<Models.DeletedCertificateListResult>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedCertificateListResult>
-  ): Promise<Models.GetDeletedCertificatesResponse> {
+  getDeletedCertificates(vaultBaseUrl: string, options: Models.KeyVaultClientGetDeletedCertificatesOptionalParams, callback: coreHttp.ServiceCallback<Models.DeletedCertificateListResult>): void;
+  getDeletedCertificates(vaultBaseUrl: string, options?: Models.KeyVaultClientGetDeletedCertificatesOptionalParams | coreHttp.ServiceCallback<Models.DeletedCertificateListResult>, callback?: coreHttp.ServiceCallback<Models.DeletedCertificateListResult>): Promise<Models.GetDeletedCertificatesResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getDeletedCertificatesOperationSpec,
-      callback
-    ) as Promise<Models.GetDeletedCertificatesResponse>;
+      callback) as Promise<Models.GetDeletedCertificatesResponse>;
   }
 
   /**
@@ -1367,41 +877,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetDeletedCertificateResponse>
    */
-  getDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetDeletedCertificateResponse>;
+  getDeletedCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetDeletedCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate
    * @param callback The callback
    */
-  getDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>
-  ): void;
+  getDeletedCertificate(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate
    * @param options The optional parameters
    * @param callback The callback
    */
-  getDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>
-  ): void;
-  getDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?:
-      | coreHttp.RequestOptionsBase
-      | coreHttp.ServiceCallback<Models.DeletedCertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>
-  ): Promise<Models.GetDeletedCertificateResponse> {
+  getDeletedCertificate(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>): void;
+  getDeletedCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedCertificateBundle>, callback?: coreHttp.ServiceCallback<Models.DeletedCertificateBundle>): Promise<Models.GetDeletedCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1409,8 +899,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getDeletedCertificateOperationSpec,
-      callback
-    ) as Promise<Models.GetDeletedCertificateResponse>;
+      callback) as Promise<Models.GetDeletedCertificateResponse>;
   }
 
   /**
@@ -1423,39 +912,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<coreHttp.RestResponse>
    */
-  purgeDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
+  purgeDeletedCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate
    * @param callback The callback
    */
-  purgeDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<void>
-  ): void;
+  purgeDeletedCertificate(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the certificate
    * @param options The optional parameters
    * @param callback The callback
    */
-  purgeDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<void>
-  ): void;
-  purgeDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>,
-    callback?: coreHttp.ServiceCallback<void>
-  ): Promise<coreHttp.RestResponse> {
+  purgeDeletedCertificate(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  purgeDeletedCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1463,8 +934,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       purgeDeletedCertificateOperationSpec,
-      callback
-    );
+      callback);
   }
 
   /**
@@ -1478,39 +948,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.RecoverDeletedCertificateResponse>
    */
-  recoverDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.RecoverDeletedCertificateResponse>;
+  recoverDeletedCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.RecoverDeletedCertificateResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the deleted certificate
    * @param callback The callback
    */
-  recoverDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
+  recoverDeletedCertificate(vaultBaseUrl: string, certificateName: string, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param certificateName The name of the deleted certificate
    * @param options The optional parameters
    * @param callback The callback
    */
-  recoverDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): void;
-  recoverDeletedCertificate(
-    vaultBaseUrl: string,
-    certificateName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateBundle>,
-    callback?: coreHttp.ServiceCallback<Models.CertificateBundle>
-  ): Promise<Models.RecoverDeletedCertificateResponse> {
+  recoverDeletedCertificate(vaultBaseUrl: string, certificateName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.CertificateBundle>): void;
+  recoverDeletedCertificate(vaultBaseUrl: string, certificateName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.CertificateBundle>, callback?: coreHttp.ServiceCallback<Models.CertificateBundle>): Promise<Models.RecoverDeletedCertificateResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1518,8 +970,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       recoverDeletedCertificateOperationSpec,
-      callback
-    ) as Promise<Models.RecoverDeletedCertificateResponse>;
+      callback) as Promise<Models.RecoverDeletedCertificateResponse>;
   }
 }
 
@@ -1528,8 +979,14 @@ const serializer = new coreHttp.Serializer(Mappers);
 const getCertificatesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "certificates",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.maxresults, Parameters.includePending, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.includePending,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificateListResult
@@ -1544,8 +1001,13 @@ const getCertificatesOperationSpec: coreHttp.OperationSpec = {
 const deleteCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "certificates/{certificate-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedCertificateBundle
@@ -1560,8 +1022,12 @@ const deleteCertificateOperationSpec: coreHttp.OperationSpec = {
 const setCertificateContactsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "certificates/contacts",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: "contacts",
     mapper: {
@@ -1583,8 +1049,12 @@ const setCertificateContactsOperationSpec: coreHttp.OperationSpec = {
 const getCertificateContactsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "certificates/contacts",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.Contacts
@@ -1599,8 +1069,12 @@ const getCertificateContactsOperationSpec: coreHttp.OperationSpec = {
 const deleteCertificateContactsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "certificates/contacts",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.Contacts
@@ -1615,8 +1089,13 @@ const deleteCertificateContactsOperationSpec: coreHttp.OperationSpec = {
 const getCertificateIssuersOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "certificates/issuers",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificateIssuerListResult
@@ -1631,14 +1110,28 @@ const getCertificateIssuersOperationSpec: coreHttp.OperationSpec = {
 const setCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "certificates/issuers/{issuer-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.issuerName],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.issuerName
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       provider: "provider",
-      credentials: ["options", "credentials"],
-      organizationDetails: ["options", "organizationDetails"],
-      attributes: ["options", "attributes"]
+      credentials: [
+        "options",
+        "credentials"
+      ],
+      organizationDetails: [
+        "options",
+        "organizationDetails"
+      ],
+      attributes: [
+        "options",
+        "attributes"
+      ]
     },
     mapper: {
       ...Mappers.CertificateIssuerSetParameters,
@@ -1659,14 +1152,31 @@ const setCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
 const updateCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "certificates/issuers/{issuer-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.issuerName],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.issuerName
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
-      provider: ["options", "provider"],
-      credentials: ["options", "credentials"],
-      organizationDetails: ["options", "organizationDetails"],
-      attributes: ["options", "attributes"]
+      provider: [
+        "options",
+        "provider"
+      ],
+      credentials: [
+        "options",
+        "credentials"
+      ],
+      organizationDetails: [
+        "options",
+        "organizationDetails"
+      ],
+      attributes: [
+        "options",
+        "attributes"
+      ]
     },
     mapper: {
       ...Mappers.CertificateIssuerUpdateParameters,
@@ -1687,8 +1197,13 @@ const updateCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
 const getCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "certificates/issuers/{issuer-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.issuerName],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.issuerName
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.IssuerBundle
@@ -1703,8 +1218,13 @@ const getCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
 const deleteCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "certificates/issuers/{issuer-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.issuerName],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.issuerName
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.IssuerBundle
@@ -1719,13 +1239,27 @@ const deleteCertificateIssuerOperationSpec: coreHttp.OperationSpec = {
 const createCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "certificates/{certificate-name}/create",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
-      certificatePolicy: ["options", "certificatePolicy"],
-      certificateAttributes: ["options", "certificateAttributes"],
-      tags: ["options", "tags"]
+      certificatePolicy: [
+        "options",
+        "certificatePolicy"
+      ],
+      certificateAttributes: [
+        "options",
+        "certificateAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ]
     },
     mapper: {
       ...Mappers.CertificateCreateParameters,
@@ -1746,15 +1280,32 @@ const createCertificateOperationSpec: coreHttp.OperationSpec = {
 const importCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "certificates/{certificate-name}/import",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       base64EncodedCertificate: "base64EncodedCertificate",
-      password: ["options", "password"],
-      certificatePolicy: ["options", "certificatePolicy"],
-      certificateAttributes: ["options", "certificateAttributes"],
-      tags: ["options", "tags"]
+      password: [
+        "options",
+        "password"
+      ],
+      certificatePolicy: [
+        "options",
+        "certificatePolicy"
+      ],
+      certificateAttributes: [
+        "options",
+        "certificateAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ]
     },
     mapper: {
       ...Mappers.CertificateImportParameters,
@@ -1775,8 +1326,14 @@ const importCertificateOperationSpec: coreHttp.OperationSpec = {
 const getCertificateVersionsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "certificates/{certificate-name}/versions",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificateListResult
@@ -1791,8 +1348,13 @@ const getCertificateVersionsOperationSpec: coreHttp.OperationSpec = {
 const getCertificatePolicyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "certificates/{certificate-name}/policy",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificatePolicy
@@ -1807,8 +1369,13 @@ const getCertificatePolicyOperationSpec: coreHttp.OperationSpec = {
 const updateCertificatePolicyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "certificates/{certificate-name}/policy",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: "certificatePolicy",
     mapper: {
@@ -1835,12 +1402,23 @@ const updateCertificateOperationSpec: coreHttp.OperationSpec = {
     Parameters.certificateName0,
     Parameters.certificateVersion
   ],
-  queryParameters: [Parameters.apiVersion],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
-      certificatePolicy: ["options", "certificatePolicy"],
-      certificateAttributes: ["options", "certificateAttributes"],
-      tags: ["options", "tags"]
+      certificatePolicy: [
+        "options",
+        "certificatePolicy"
+      ],
+      certificateAttributes: [
+        "options",
+        "certificateAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ]
     },
     mapper: {
       ...Mappers.CertificateUpdateParameters,
@@ -1866,7 +1444,9 @@ const getCertificateOperationSpec: coreHttp.OperationSpec = {
     Parameters.certificateName0,
     Parameters.certificateVersion
   ],
-  queryParameters: [Parameters.apiVersion],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificateBundle
@@ -1881,8 +1461,13 @@ const getCertificateOperationSpec: coreHttp.OperationSpec = {
 const updateCertificateOperationOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "certificates/{certificate-name}/pending",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       cancellationRequested: "cancellationRequested"
@@ -1906,8 +1491,13 @@ const updateCertificateOperationOperationSpec: coreHttp.OperationSpec = {
 const getCertificateOperationOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "certificates/{certificate-name}/pending",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificateOperation
@@ -1922,8 +1512,13 @@ const getCertificateOperationOperationSpec: coreHttp.OperationSpec = {
 const deleteCertificateOperationOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "certificates/{certificate-name}/pending",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificateOperation
@@ -1938,13 +1533,24 @@ const deleteCertificateOperationOperationSpec: coreHttp.OperationSpec = {
 const mergeCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "certificates/{certificate-name}/pending/merge",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       x509Certificates: "x509Certificates",
-      certificateAttributes: ["options", "certificateAttributes"],
-      tags: ["options", "tags"]
+      certificateAttributes: [
+        "options",
+        "certificateAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ]
     },
     mapper: {
       ...Mappers.CertificateMergeParameters,
@@ -1965,8 +1571,13 @@ const mergeCertificateOperationSpec: coreHttp.OperationSpec = {
 const backupCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "certificates/{certificate-name}/backup",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.BackupCertificateResult
@@ -1981,8 +1592,12 @@ const backupCertificateOperationSpec: coreHttp.OperationSpec = {
 const restoreCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "certificates/restore",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       certificateBundleBackup: "certificateBundleBackup"
@@ -2006,8 +1621,14 @@ const restoreCertificateOperationSpec: coreHttp.OperationSpec = {
 const getDeletedCertificatesOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "deletedcertificates",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.maxresults, Parameters.includePending, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.includePending,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedCertificateListResult
@@ -2022,8 +1643,13 @@ const getDeletedCertificatesOperationSpec: coreHttp.OperationSpec = {
 const getDeletedCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "deletedcertificates/{certificate-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedCertificateBundle
@@ -2038,8 +1664,13 @@ const getDeletedCertificateOperationSpec: coreHttp.OperationSpec = {
 const purgeDeletedCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "deletedcertificates/{certificate-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     204: {},
     default: {
@@ -2052,8 +1683,13 @@ const purgeDeletedCertificateOperationSpec: coreHttp.OperationSpec = {
 const recoverDeletedCertificateOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "deletedcertificates/{certificate-name}/recover",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.certificateName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.certificateName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.CertificateBundle

--- a/sdk/keyvault/keyvault-certificates/src/core/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/keyVaultClientContext.ts
@@ -15,24 +15,15 @@ export const packageVersion = "4.1.0-preview.2";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: string;
-  credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
    * @param apiVersion Client API version.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    apiVersion: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
+  constructor(apiVersion: string, options?: coreHttp.ServiceClientOptions) {
     if (apiVersion == undefined) {
       throw new Error("'apiVersion' cannot be null.");
-    }
-    if (credentials == undefined) {
-      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -44,11 +35,10 @@ export class KeyVaultClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(credentials, options);
+    super(undefined, options);
 
     this.baseUri = "{vaultBaseUrl}";
     this.requestContentType = "application/json; charset=utf-8";
     this.apiVersion = apiVersion;
-    this.credentials = credentials;
   }
 }

--- a/sdk/keyvault/keyvault-certificates/src/core/models/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/models/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+
 import * as coreHttp from "@azure/core-http";
 
 /**
@@ -797,8 +798,7 @@ export interface KeyVaultClientGetCertificatesOptionalParams extends coreHttp.Re
 /**
  * Optional Parameters.
  */
-export interface KeyVaultClientGetCertificateIssuersOptionalParams
-  extends coreHttp.RequestOptionsBase {
+export interface KeyVaultClientGetCertificateIssuersOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Maximum number of results to return in a page. If not specified the service will return up to
    * 25 results.
@@ -809,8 +809,7 @@ export interface KeyVaultClientGetCertificateIssuersOptionalParams
 /**
  * Optional Parameters.
  */
-export interface KeyVaultClientSetCertificateIssuerOptionalParams
-  extends coreHttp.RequestOptionsBase {
+export interface KeyVaultClientSetCertificateIssuerOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The credentials to be used for the issuer.
    */
@@ -828,8 +827,7 @@ export interface KeyVaultClientSetCertificateIssuerOptionalParams
 /**
  * Optional Parameters.
  */
-export interface KeyVaultClientUpdateCertificateIssuerOptionalParams
-  extends coreHttp.RequestOptionsBase {
+export interface KeyVaultClientUpdateCertificateIssuerOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * The issuer provider.
    */
@@ -891,8 +889,7 @@ export interface KeyVaultClientImportCertificateOptionalParams extends coreHttp.
 /**
  * Optional Parameters.
  */
-export interface KeyVaultClientGetCertificateVersionsOptionalParams
-  extends coreHttp.RequestOptionsBase {
+export interface KeyVaultClientGetCertificateVersionsOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Maximum number of results to return in a page. If not specified the service will return up to
    * 25 results.
@@ -935,8 +932,7 @@ export interface KeyVaultClientMergeCertificateOptionalParams extends coreHttp.R
 /**
  * Optional Parameters.
  */
-export interface KeyVaultClientGetDeletedCertificatesOptionalParams
-  extends coreHttp.RequestOptionsBase {
+export interface KeyVaultClientGetDeletedCertificatesOptionalParams extends coreHttp.RequestOptionsBase {
   /**
    * Maximum number of results to return in a page. If not specified the service will return up to
    * 25 results.
@@ -956,14 +952,7 @@ export interface KeyVaultClientGetDeletedCertificatesOptionalParams
  * @readonly
  * @enum {string}
  */
-export type DeletionRecoveryLevel =
-  | "Purgeable"
-  | "Recoverable+Purgeable"
-  | "Recoverable"
-  | "Recoverable+ProtectedSubscription"
-  | "CustomizedRecoverable+Purgeable"
-  | "CustomizedRecoverable"
-  | "CustomizedRecoverable+ProtectedSubscription";
+export type DeletionRecoveryLevel = 'Purgeable' | 'Recoverable+Purgeable' | 'Recoverable' | 'Recoverable+ProtectedSubscription' | 'CustomizedRecoverable+Purgeable' | 'CustomizedRecoverable' | 'CustomizedRecoverable+ProtectedSubscription';
 
 /**
  * Defines values for JsonWebKeyType.
@@ -971,7 +960,7 @@ export type DeletionRecoveryLevel =
  * @readonly
  * @enum {string}
  */
-export type JsonWebKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM" | "oct";
+export type JsonWebKeyType = 'EC' | 'EC-HSM' | 'RSA' | 'RSA-HSM' | 'oct';
 
 /**
  * Defines values for JsonWebKeyCurveName.
@@ -979,7 +968,7 @@ export type JsonWebKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM" | "oct";
  * @readonly
  * @enum {string}
  */
-export type JsonWebKeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
+export type JsonWebKeyCurveName = 'P-256' | 'P-384' | 'P-521' | 'P-256K';
 
 /**
  * Defines values for KeyUsageType.
@@ -988,16 +977,7 @@ export type JsonWebKeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
  * @readonly
  * @enum {string}
  */
-export type KeyUsageType =
-  | "digitalSignature"
-  | "nonRepudiation"
-  | "keyEncipherment"
-  | "dataEncipherment"
-  | "keyAgreement"
-  | "keyCertSign"
-  | "cRLSign"
-  | "encipherOnly"
-  | "decipherOnly";
+export type KeyUsageType = 'digitalSignature' | 'nonRepudiation' | 'keyEncipherment' | 'dataEncipherment' | 'keyAgreement' | 'keyCertSign' | 'cRLSign' | 'encipherOnly' | 'decipherOnly';
 
 /**
  * Defines values for ActionType.
@@ -1005,7 +985,7 @@ export type KeyUsageType =
  * @readonly
  * @enum {string}
  */
-export type ActionType = "EmailContacts" | "AutoRenew";
+export type ActionType = 'EmailContacts' | 'AutoRenew';
 
 /**
  * Contains response data for the getCertificates operation.
@@ -1015,16 +995,16 @@ export type GetCertificatesResponse = CertificateListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateListResult;
+    };
 };
 
 /**
@@ -1035,16 +1015,16 @@ export type DeleteCertificateResponse = DeletedCertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedCertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedCertificateBundle;
+    };
 };
 
 /**
@@ -1055,16 +1035,16 @@ export type SetCertificateContactsResponse = Contacts & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Contacts;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Contacts;
+    };
 };
 
 /**
@@ -1075,16 +1055,16 @@ export type GetCertificateContactsResponse = Contacts & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Contacts;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Contacts;
+    };
 };
 
 /**
@@ -1095,16 +1075,16 @@ export type DeleteCertificateContactsResponse = Contacts & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: Contacts;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: Contacts;
+    };
 };
 
 /**
@@ -1115,16 +1095,16 @@ export type GetCertificateIssuersResponse = CertificateIssuerListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateIssuerListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateIssuerListResult;
+    };
 };
 
 /**
@@ -1135,16 +1115,16 @@ export type SetCertificateIssuerResponse = IssuerBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: IssuerBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: IssuerBundle;
+    };
 };
 
 /**
@@ -1155,16 +1135,16 @@ export type UpdateCertificateIssuerResponse = IssuerBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: IssuerBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: IssuerBundle;
+    };
 };
 
 /**
@@ -1175,16 +1155,16 @@ export type GetCertificateIssuerResponse = IssuerBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: IssuerBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: IssuerBundle;
+    };
 };
 
 /**
@@ -1195,16 +1175,16 @@ export type DeleteCertificateIssuerResponse = IssuerBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: IssuerBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: IssuerBundle;
+    };
 };
 
 /**
@@ -1215,16 +1195,16 @@ export type CreateCertificateResponse = CertificateOperation & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateOperation;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateOperation;
+    };
 };
 
 /**
@@ -1235,16 +1215,16 @@ export type ImportCertificateResponse = CertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateBundle;
+    };
 };
 
 /**
@@ -1255,16 +1235,16 @@ export type GetCertificateVersionsResponse = CertificateListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateListResult;
+    };
 };
 
 /**
@@ -1275,16 +1255,16 @@ export type GetCertificatePolicyResponse = CertificatePolicy & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificatePolicy;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificatePolicy;
+    };
 };
 
 /**
@@ -1295,16 +1275,16 @@ export type UpdateCertificatePolicyResponse = CertificatePolicy & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificatePolicy;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificatePolicy;
+    };
 };
 
 /**
@@ -1315,16 +1295,16 @@ export type UpdateCertificateResponse = CertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateBundle;
+    };
 };
 
 /**
@@ -1335,16 +1315,16 @@ export type GetCertificateResponse = CertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateBundle;
+    };
 };
 
 /**
@@ -1355,16 +1335,16 @@ export type UpdateCertificateOperationResponse = CertificateOperation & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateOperation;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateOperation;
+    };
 };
 
 /**
@@ -1375,16 +1355,16 @@ export type GetCertificateOperationResponse = CertificateOperation & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateOperation;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateOperation;
+    };
 };
 
 /**
@@ -1395,16 +1375,16 @@ export type DeleteCertificateOperationResponse = CertificateOperation & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateOperation;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateOperation;
+    };
 };
 
 /**
@@ -1415,16 +1395,16 @@ export type MergeCertificateResponse = CertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateBundle;
+    };
 };
 
 /**
@@ -1435,16 +1415,16 @@ export type BackupCertificateResponse = BackupCertificateResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: BackupCertificateResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: BackupCertificateResult;
+    };
 };
 
 /**
@@ -1455,16 +1435,16 @@ export type RestoreCertificateResponse = CertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateBundle;
+    };
 };
 
 /**
@@ -1475,16 +1455,16 @@ export type GetDeletedCertificatesResponse = DeletedCertificateListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedCertificateListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedCertificateListResult;
+    };
 };
 
 /**
@@ -1495,16 +1475,16 @@ export type GetDeletedCertificateResponse = DeletedCertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedCertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedCertificateBundle;
+    };
 };
 
 /**
@@ -1515,14 +1495,14 @@ export type RecoverDeletedCertificateResponse = CertificateBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: CertificateBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: CertificateBundle;
+    };
 };

--- a/sdk/keyvault/keyvault-certificates/src/core/models/mappers.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/models/mappers.ts
@@ -8,6 +8,7 @@
 
 import * as coreHttp from "@azure/core-http";
 
+
 export const Attributes: coreHttp.CompositeMapper = {
   serializedName: "Attributes",
   type: {
@@ -327,7 +328,10 @@ export const Action: coreHttp.CompositeMapper = {
         serializedName: "action_type",
         type: {
           name: "Enum",
-          allowedValues: ["EmailContacts", "AutoRenew"]
+          allowedValues: [
+            "EmailContacts",
+            "AutoRenew"
+          ]
         }
       }
     }

--- a/sdk/keyvault/keyvault-certificates/src/core/models/parameters.ts
+++ b/sdk/keyvault/keyvault-certificates/src/core/models/parameters.ts
@@ -54,7 +54,10 @@ export const certificateVersion: coreHttp.OperationURLParameter = {
   }
 };
 export const includePending: coreHttp.OperationQueryParameter = {
-  parameterPath: ["options", "includePending"],
+  parameterPath: [
+    "options",
+    "includePending"
+  ],
   mapper: {
     serializedName: "includePending",
     type: {
@@ -73,7 +76,10 @@ export const issuerName: coreHttp.OperationURLParameter = {
   }
 };
 export const maxresults: coreHttp.OperationQueryParameter = {
-  parameterPath: ["options", "maxresults"],
+  parameterPath: [
+    "options",
+    "maxresults"
+  ],
   mapper: {
     serializedName: "maxresults",
     constraints: {
@@ -90,7 +96,7 @@ export const vaultBaseUrl: coreHttp.OperationURLParameter = {
   mapper: {
     required: true,
     serializedName: "vaultBaseUrl",
-    defaultValue: "",
+    defaultValue: '',
     type: {
       name: "String"
     }

--- a/sdk/keyvault/keyvault-certificates/src/index.ts
+++ b/sdk/keyvault/keyvault-certificates/src/index.ts
@@ -472,7 +472,6 @@ export class CertificateClient {
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
     this.client = new KeyVaultClient(
-      credential,
       pipelineOptions.apiVersion || LATEST_API_VERSION,
       pipeline
     );

--- a/sdk/keyvault/keyvault-certificates/swagger/README.md
+++ b/sdk/keyvault/keyvault-certificates/swagger/README.md
@@ -9,7 +9,7 @@ use-extension:
   "@microsoft.azure/autorest.typescript": "~5.0.1"
 azure-arm: false
 generate-metadata: false
-add-credentials: true
+add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/certificates.json
 output-folder: ../

--- a/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
+++ b/sdk/keyvault/keyvault-keys/review/keyvault-keys.api.md
@@ -97,7 +97,7 @@ export interface DeletedKey {
 }
 
 // @public
-export type DeletionRecoveryLevel = "Purgeable" | "Recoverable+Purgeable" | "Recoverable" | "Recoverable+ProtectedSubscription" | "CustomizedRecoverable+Purgeable" | "CustomizedRecoverable" | "CustomizedRecoverable+ProtectedSubscription";
+export type DeletionRecoveryLevel = 'Purgeable' | 'Recoverable+Purgeable' | 'Recoverable' | 'Recoverable+ProtectedSubscription' | 'CustomizedRecoverable+Purgeable' | 'CustomizedRecoverable' | 'CustomizedRecoverable+ProtectedSubscription';
 
 // @public
 export type EncryptionAlgorithm = "RSA-OAEP" | "RSA-OAEP-256" | "RSA1_5";

--- a/sdk/keyvault/keyvault-keys/src/core/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/keyVaultClient.ts
@@ -18,15 +18,10 @@ class KeyVaultClient extends KeyVaultClientContext {
   /**
    * Initializes a new instance of the KeyVaultClient class.
    * @param apiVersion Client API version.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    apiVersion: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
-    super(credentials, apiVersion, options);
+  constructor(apiVersion: string, options?: coreHttp.ServiceClientOptions) {
+    super(apiVersion, options);
   }
 
   /**
@@ -42,12 +37,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.CreateKeyResponse>
    */
-  createKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    kty: Models.JsonWebKeyType,
-    options?: Models.KeyVaultClientCreateKeyOptionalParams
-  ): Promise<Models.CreateKeyResponse>;
+  createKey(vaultBaseUrl: string, keyName: string, kty: Models.JsonWebKeyType, options?: Models.KeyVaultClientCreateKeyOptionalParams): Promise<Models.CreateKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name for the new key. The system will generate the version name for the new
@@ -56,12 +46,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * include: 'EC', 'EC-HSM', 'RSA', 'RSA-HSM', 'oct'
    * @param callback The callback
    */
-  createKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    kty: Models.JsonWebKeyType,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
+  createKey(vaultBaseUrl: string, keyName: string, kty: Models.JsonWebKeyType, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name for the new key. The system will generate the version name for the new
@@ -71,22 +56,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  createKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    kty: Models.JsonWebKeyType,
-    options: Models.KeyVaultClientCreateKeyOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
-  createKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    kty: Models.JsonWebKeyType,
-    options?:
-      | Models.KeyVaultClientCreateKeyOptionalParams
-      | coreHttp.ServiceCallback<Models.KeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): Promise<Models.CreateKeyResponse> {
+  createKey(vaultBaseUrl: string, keyName: string, kty: Models.JsonWebKeyType, options: Models.KeyVaultClientCreateKeyOptionalParams, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
+  createKey(vaultBaseUrl: string, keyName: string, kty: Models.JsonWebKeyType, options?: Models.KeyVaultClientCreateKeyOptionalParams | coreHttp.ServiceCallback<Models.KeyBundle>, callback?: coreHttp.ServiceCallback<Models.KeyBundle>): Promise<Models.CreateKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -95,8 +66,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       createKeyOperationSpec,
-      callback
-    ) as Promise<Models.CreateKeyResponse>;
+      callback) as Promise<Models.CreateKeyResponse>;
   }
 
   /**
@@ -111,24 +81,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.ImportKeyResponse>
    */
-  importKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    key: Models.JsonWebKey,
-    options?: Models.KeyVaultClientImportKeyOptionalParams
-  ): Promise<Models.ImportKeyResponse>;
+  importKey(vaultBaseUrl: string, keyName: string, key: Models.JsonWebKey, options?: Models.KeyVaultClientImportKeyOptionalParams): Promise<Models.ImportKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName Name for the imported key.
    * @param key The Json web key
    * @param callback The callback
    */
-  importKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    key: Models.JsonWebKey,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
+  importKey(vaultBaseUrl: string, keyName: string, key: Models.JsonWebKey, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName Name for the imported key.
@@ -136,22 +96,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  importKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    key: Models.JsonWebKey,
-    options: Models.KeyVaultClientImportKeyOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
-  importKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    key: Models.JsonWebKey,
-    options?:
-      | Models.KeyVaultClientImportKeyOptionalParams
-      | coreHttp.ServiceCallback<Models.KeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): Promise<Models.ImportKeyResponse> {
+  importKey(vaultBaseUrl: string, keyName: string, key: Models.JsonWebKey, options: Models.KeyVaultClientImportKeyOptionalParams, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
+  importKey(vaultBaseUrl: string, keyName: string, key: Models.JsonWebKey, options?: Models.KeyVaultClientImportKeyOptionalParams | coreHttp.ServiceCallback<Models.KeyBundle>, callback?: coreHttp.ServiceCallback<Models.KeyBundle>): Promise<Models.ImportKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -160,8 +106,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       importKeyOperationSpec,
-      callback
-    ) as Promise<Models.ImportKeyResponse>;
+      callback) as Promise<Models.ImportKeyResponse>;
   }
 
   /**
@@ -175,39 +120,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeleteKeyResponse>
    */
-  deleteKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DeleteKeyResponse>;
+  deleteKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeleteKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key to delete.
    * @param callback The callback
    */
-  deleteKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>
-  ): void;
+  deleteKey(vaultBaseUrl: string, keyName: string, callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key to delete.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>
-  ): void;
-  deleteKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedKeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedKeyBundle>
-  ): Promise<Models.DeleteKeyResponse> {
+  deleteKey(vaultBaseUrl: string, keyName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>): void;
+  deleteKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedKeyBundle>, callback?: coreHttp.ServiceCallback<Models.DeletedKeyBundle>): Promise<Models.DeleteKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -215,8 +142,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       deleteKeyOperationSpec,
-      callback
-    ) as Promise<Models.DeleteKeyResponse>;
+      callback) as Promise<Models.DeleteKeyResponse>;
   }
 
   /**
@@ -231,24 +157,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.UpdateKeyResponse>
    */
-  updateKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    options?: Models.KeyVaultClientUpdateKeyOptionalParams
-  ): Promise<Models.UpdateKeyResponse>;
+  updateKey(vaultBaseUrl: string, keyName: string, keyVersion: string, options?: Models.KeyVaultClientUpdateKeyOptionalParams): Promise<Models.UpdateKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of key to update.
    * @param keyVersion The version of the key to update.
    * @param callback The callback
    */
-  updateKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
+  updateKey(vaultBaseUrl: string, keyName: string, keyVersion: string, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of key to update.
@@ -256,22 +172,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    options: Models.KeyVaultClientUpdateKeyOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
-  updateKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    options?:
-      | Models.KeyVaultClientUpdateKeyOptionalParams
-      | coreHttp.ServiceCallback<Models.KeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): Promise<Models.UpdateKeyResponse> {
+  updateKey(vaultBaseUrl: string, keyName: string, keyVersion: string, options: Models.KeyVaultClientUpdateKeyOptionalParams, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
+  updateKey(vaultBaseUrl: string, keyName: string, keyVersion: string, options?: Models.KeyVaultClientUpdateKeyOptionalParams | coreHttp.ServiceCallback<Models.KeyBundle>, callback?: coreHttp.ServiceCallback<Models.KeyBundle>): Promise<Models.UpdateKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -280,8 +182,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       updateKeyOperationSpec,
-      callback
-    ) as Promise<Models.UpdateKeyResponse>;
+      callback) as Promise<Models.UpdateKeyResponse>;
   }
 
   /**
@@ -290,49 +191,30 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @summary Gets the public part of a stored key.
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key to get.
-   * @param keyVersion Adding the version parameter retrieves a specific version of a key.
+   * @param keyVersion Adding the version parameter retrieves a specific version of a key. This URI
+   * fragment is optional. If not specified, the latest version of the key is returned.
    * @param [options] The optional parameters
    * @returns Promise<Models.GetKeyResponse>
    */
-  getKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetKeyResponse>;
+  getKey(vaultBaseUrl: string, keyName: string, keyVersion: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key to get.
-   * @param keyVersion Adding the version parameter retrieves a specific version of a key.
+   * @param keyVersion Adding the version parameter retrieves a specific version of a key. This URI
+   * fragment is optional. If not specified, the latest version of the key is returned.
    * @param callback The callback
    */
-  getKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
+  getKey(vaultBaseUrl: string, keyName: string, keyVersion: string, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key to get.
-   * @param keyVersion Adding the version parameter retrieves a specific version of a key.
+   * @param keyVersion Adding the version parameter retrieves a specific version of a key. This URI
+   * fragment is optional. If not specified, the latest version of the key is returned.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
-  getKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): Promise<Models.GetKeyResponse> {
+  getKey(vaultBaseUrl: string, keyName: string, keyVersion: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
+  getKey(vaultBaseUrl: string, keyName: string, keyVersion: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyBundle>, callback?: coreHttp.ServiceCallback<Models.KeyBundle>): Promise<Models.GetKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -341,8 +223,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getKeyOperationSpec,
-      callback
-    ) as Promise<Models.GetKeyResponse>;
+      callback) as Promise<Models.GetKeyResponse>;
   }
 
   /**
@@ -354,41 +235,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetKeyVersionsResponse>
    */
-  getKeyVersions(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: Models.KeyVaultClientGetKeyVersionsOptionalParams
-  ): Promise<Models.GetKeyVersionsResponse>;
+  getKeyVersions(vaultBaseUrl: string, keyName: string, options?: Models.KeyVaultClientGetKeyVersionsOptionalParams): Promise<Models.GetKeyVersionsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
    * @param callback The callback
    */
-  getKeyVersions(
-    vaultBaseUrl: string,
-    keyName: string,
-    callback: coreHttp.ServiceCallback<Models.KeyListResult>
-  ): void;
+  getKeyVersions(vaultBaseUrl: string, keyName: string, callback: coreHttp.ServiceCallback<Models.KeyListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getKeyVersions(
-    vaultBaseUrl: string,
-    keyName: string,
-    options: Models.KeyVaultClientGetKeyVersionsOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.KeyListResult>
-  ): void;
-  getKeyVersions(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?:
-      | Models.KeyVaultClientGetKeyVersionsOptionalParams
-      | coreHttp.ServiceCallback<Models.KeyListResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyListResult>
-  ): Promise<Models.GetKeyVersionsResponse> {
+  getKeyVersions(vaultBaseUrl: string, keyName: string, options: Models.KeyVaultClientGetKeyVersionsOptionalParams, callback: coreHttp.ServiceCallback<Models.KeyListResult>): void;
+  getKeyVersions(vaultBaseUrl: string, keyName: string, options?: Models.KeyVaultClientGetKeyVersionsOptionalParams | coreHttp.ServiceCallback<Models.KeyListResult>, callback?: coreHttp.ServiceCallback<Models.KeyListResult>): Promise<Models.GetKeyVersionsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -396,8 +257,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getKeyVersionsOperationSpec,
-      callback
-    ) as Promise<Models.GetKeyVersionsResponse>;
+      callback) as Promise<Models.GetKeyVersionsResponse>;
   }
 
   /**
@@ -410,10 +270,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetKeysResponse>
    */
-  getKeys(
-    vaultBaseUrl: string,
-    options?: Models.KeyVaultClientGetKeysOptionalParams
-  ): Promise<Models.GetKeysResponse>;
+  getKeys(vaultBaseUrl: string, options?: Models.KeyVaultClientGetKeysOptionalParams): Promise<Models.GetKeysResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
@@ -424,26 +281,15 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  getKeys(
-    vaultBaseUrl: string,
-    options: Models.KeyVaultClientGetKeysOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.KeyListResult>
-  ): void;
-  getKeys(
-    vaultBaseUrl: string,
-    options?:
-      | Models.KeyVaultClientGetKeysOptionalParams
-      | coreHttp.ServiceCallback<Models.KeyListResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyListResult>
-  ): Promise<Models.GetKeysResponse> {
+  getKeys(vaultBaseUrl: string, options: Models.KeyVaultClientGetKeysOptionalParams, callback: coreHttp.ServiceCallback<Models.KeyListResult>): void;
+  getKeys(vaultBaseUrl: string, options?: Models.KeyVaultClientGetKeysOptionalParams | coreHttp.ServiceCallback<Models.KeyListResult>, callback?: coreHttp.ServiceCallback<Models.KeyListResult>): Promise<Models.GetKeysResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getKeysOperationSpec,
-      callback
-    ) as Promise<Models.GetKeysResponse>;
+      callback) as Promise<Models.GetKeysResponse>;
   }
 
   /**
@@ -464,39 +310,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.BackupKeyResponse>
    */
-  backupKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BackupKeyResponse>;
+  backupKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.BackupKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
    * @param callback The callback
    */
-  backupKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    callback: coreHttp.ServiceCallback<Models.BackupKeyResult>
-  ): void;
+  backupKey(vaultBaseUrl: string, keyName: string, callback: coreHttp.ServiceCallback<Models.BackupKeyResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
    * @param options The optional parameters
    * @param callback The callback
    */
-  backupKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.BackupKeyResult>
-  ): void;
-  backupKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.BackupKeyResult>,
-    callback?: coreHttp.ServiceCallback<Models.BackupKeyResult>
-  ): Promise<Models.BackupKeyResponse> {
+  backupKey(vaultBaseUrl: string, keyName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.BackupKeyResult>): void;
+  backupKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.BackupKeyResult>, callback?: coreHttp.ServiceCallback<Models.BackupKeyResult>): Promise<Models.BackupKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -504,8 +332,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       backupKeyOperationSpec,
-      callback
-    ) as Promise<Models.BackupKeyResponse>;
+      callback) as Promise<Models.BackupKeyResponse>;
   }
 
   /**
@@ -525,39 +352,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.RestoreKeyResponse>
    */
-  restoreKey(
-    vaultBaseUrl: string,
-    keyBundleBackup: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.RestoreKeyResponse>;
+  restoreKey(vaultBaseUrl: string, keyBundleBackup: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.RestoreKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyBundleBackup The backup blob associated with a key bundle.
    * @param callback The callback
    */
-  restoreKey(
-    vaultBaseUrl: string,
-    keyBundleBackup: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
+  restoreKey(vaultBaseUrl: string, keyBundleBackup: Uint8Array, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyBundleBackup The backup blob associated with a key bundle.
    * @param options The optional parameters
    * @param callback The callback
    */
-  restoreKey(
-    vaultBaseUrl: string,
-    keyBundleBackup: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
-  restoreKey(
-    vaultBaseUrl: string,
-    keyBundleBackup: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): Promise<Models.RestoreKeyResponse> {
+  restoreKey(vaultBaseUrl: string, keyBundleBackup: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
+  restoreKey(vaultBaseUrl: string, keyBundleBackup: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyBundle>, callback?: coreHttp.ServiceCallback<Models.KeyBundle>): Promise<Models.RestoreKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -565,8 +374,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       restoreKeyOperationSpec,
-      callback
-    ) as Promise<Models.RestoreKeyResponse>;
+      callback) as Promise<Models.RestoreKeyResponse>;
   }
 
   /**
@@ -589,14 +397,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.EncryptResponse>
    */
-  encrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.EncryptResponse>;
+  encrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.EncryptResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -606,14 +407,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param value
    * @param callback The callback
    */
-  encrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
+  encrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -624,24 +418,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  encrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
-  encrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): Promise<Models.EncryptResponse> {
+  encrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
+  encrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>, callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>): Promise<Models.EncryptResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -652,8 +430,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       encryptOperationSpec,
-      callback
-    ) as Promise<Models.EncryptResponse>;
+      callback) as Promise<Models.EncryptResponse>;
   }
 
   /**
@@ -673,14 +450,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DecryptResponse>
    */
-  decrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DecryptResponse>;
+  decrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.DecryptResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -690,14 +460,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param value
    * @param callback The callback
    */
-  decrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
+  decrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -708,24 +471,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  decrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
-  decrypt(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): Promise<Models.DecryptResponse> {
+  decrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
+  decrypt(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>, callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>): Promise<Models.DecryptResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -736,8 +483,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       decryptOperationSpec,
-      callback
-    ) as Promise<Models.DecryptResponse>;
+      callback) as Promise<Models.DecryptResponse>;
   }
 
   /**
@@ -755,14 +501,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.SignResponse>
    */
-  sign(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.SignResponse>;
+  sign(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.SignResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -773,14 +512,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param value
    * @param callback The callback
    */
-  sign(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    value: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
+  sign(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, value: Uint8Array, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -792,24 +524,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  sign(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    value: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
-  sign(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): Promise<Models.SignResponse> {
+  sign(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, value: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
+  sign(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>, callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>): Promise<Models.SignResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -820,8 +536,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       signOperationSpec,
-      callback
-    ) as Promise<Models.SignResponse>;
+      callback) as Promise<Models.SignResponse>;
   }
 
   /**
@@ -842,15 +557,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.VerifyResponse>
    */
-  verify(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    digest: Uint8Array,
-    signature: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.VerifyResponse>;
+  verify(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, digest: Uint8Array, signature: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.VerifyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -862,15 +569,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param signature The signature to be verified.
    * @param callback The callback
    */
-  verify(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    digest: Uint8Array,
-    signature: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.KeyVerifyResult>
-  ): void;
+  verify(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, digest: Uint8Array, signature: Uint8Array, callback: coreHttp.ServiceCallback<Models.KeyVerifyResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -883,26 +582,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  verify(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    digest: Uint8Array,
-    signature: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyVerifyResult>
-  ): void;
-  verify(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeySignatureAlgorithm,
-    digest: Uint8Array,
-    signature: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyVerifyResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyVerifyResult>
-  ): Promise<Models.VerifyResponse> {
+  verify(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, digest: Uint8Array, signature: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyVerifyResult>): void;
+  verify(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeySignatureAlgorithm, digest: Uint8Array, signature: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyVerifyResult>, callback?: coreHttp.ServiceCallback<Models.KeyVerifyResult>): Promise<Models.VerifyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -914,8 +595,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       verifyOperationSpec,
-      callback
-    ) as Promise<Models.VerifyResponse>;
+      callback) as Promise<Models.VerifyResponse>;
   }
 
   /**
@@ -935,14 +615,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.WrapKeyResponse>
    */
-  wrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.WrapKeyResponse>;
+  wrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.WrapKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -952,14 +625,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param value
    * @param callback The callback
    */
-  wrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
+  wrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -970,24 +636,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  wrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
-  wrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): Promise<Models.WrapKeyResponse> {
+  wrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
+  wrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>, callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>): Promise<Models.WrapKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -998,8 +648,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       wrapKeyOperationSpec,
-      callback
-    ) as Promise<Models.WrapKeyResponse>;
+      callback) as Promise<Models.WrapKeyResponse>;
   }
 
   /**
@@ -1018,14 +667,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.UnwrapKeyResponse>
    */
-  unwrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.UnwrapKeyResponse>;
+  unwrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.UnwrapKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -1035,14 +677,7 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param value
    * @param callback The callback
    */
-  unwrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
+  unwrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
@@ -1053,24 +688,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  unwrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): void;
-  unwrapKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    keyVersion: string,
-    algorithm: Models.JsonWebKeyEncryptionAlgorithm,
-    value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>,
-    callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>
-  ): Promise<Models.UnwrapKeyResponse> {
+  unwrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyOperationResult>): void;
+  unwrapKey(vaultBaseUrl: string, keyName: string, keyVersion: string, algorithm: Models.JsonWebKeyEncryptionAlgorithm, value: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyOperationResult>, callback?: coreHttp.ServiceCallback<Models.KeyOperationResult>): Promise<Models.UnwrapKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1081,8 +700,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       unwrapKeyOperationSpec,
-      callback
-    ) as Promise<Models.UnwrapKeyResponse>;
+      callback) as Promise<Models.UnwrapKeyResponse>;
   }
 
   /**
@@ -1096,43 +714,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetDeletedKeysResponse>
    */
-  getDeletedKeys(
-    vaultBaseUrl: string,
-    options?: Models.KeyVaultClientGetDeletedKeysOptionalParams
-  ): Promise<Models.GetDeletedKeysResponse>;
+  getDeletedKeys(vaultBaseUrl: string, options?: Models.KeyVaultClientGetDeletedKeysOptionalParams): Promise<Models.GetDeletedKeysResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  getDeletedKeys(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedKeyListResult>
-  ): void;
+  getDeletedKeys(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.DeletedKeyListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getDeletedKeys(
-    vaultBaseUrl: string,
-    options: Models.KeyVaultClientGetDeletedKeysOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.DeletedKeyListResult>
-  ): void;
-  getDeletedKeys(
-    vaultBaseUrl: string,
-    options?:
-      | Models.KeyVaultClientGetDeletedKeysOptionalParams
-      | coreHttp.ServiceCallback<Models.DeletedKeyListResult>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedKeyListResult>
-  ): Promise<Models.GetDeletedKeysResponse> {
+  getDeletedKeys(vaultBaseUrl: string, options: Models.KeyVaultClientGetDeletedKeysOptionalParams, callback: coreHttp.ServiceCallback<Models.DeletedKeyListResult>): void;
+  getDeletedKeys(vaultBaseUrl: string, options?: Models.KeyVaultClientGetDeletedKeysOptionalParams | coreHttp.ServiceCallback<Models.DeletedKeyListResult>, callback?: coreHttp.ServiceCallback<Models.DeletedKeyListResult>): Promise<Models.GetDeletedKeysResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getDeletedKeysOperationSpec,
-      callback
-    ) as Promise<Models.GetDeletedKeysResponse>;
+      callback) as Promise<Models.GetDeletedKeysResponse>;
   }
 
   /**
@@ -1145,39 +746,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetDeletedKeyResponse>
    */
-  getDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetDeletedKeyResponse>;
+  getDeletedKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetDeletedKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
    * @param callback The callback
    */
-  getDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>
-  ): void;
+  getDeletedKey(vaultBaseUrl: string, keyName: string, callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>
-  ): void;
-  getDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedKeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedKeyBundle>
-  ): Promise<Models.GetDeletedKeyResponse> {
+  getDeletedKey(vaultBaseUrl: string, keyName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeletedKeyBundle>): void;
+  getDeletedKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedKeyBundle>, callback?: coreHttp.ServiceCallback<Models.DeletedKeyBundle>): Promise<Models.GetDeletedKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1185,8 +768,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getDeletedKeyOperationSpec,
-      callback
-    ) as Promise<Models.GetDeletedKeyResponse>;
+      callback) as Promise<Models.GetDeletedKeyResponse>;
   }
 
   /**
@@ -1199,39 +781,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<coreHttp.RestResponse>
    */
-  purgeDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
+  purgeDeletedKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key
    * @param callback The callback
    */
-  purgeDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    callback: coreHttp.ServiceCallback<void>
-  ): void;
+  purgeDeletedKey(vaultBaseUrl: string, keyName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the key
    * @param options The optional parameters
    * @param callback The callback
    */
-  purgeDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<void>
-  ): void;
-  purgeDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>,
-    callback?: coreHttp.ServiceCallback<void>
-  ): Promise<coreHttp.RestResponse> {
+  purgeDeletedKey(vaultBaseUrl: string, keyName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  purgeDeletedKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1239,8 +803,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       purgeDeletedKeyOperationSpec,
-      callback
-    );
+      callback);
   }
 
   /**
@@ -1254,39 +817,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.RecoverDeletedKeyResponse>
    */
-  recoverDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.RecoverDeletedKeyResponse>;
+  recoverDeletedKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.RecoverDeletedKeyResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the deleted key.
    * @param callback The callback
    */
-  recoverDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
+  recoverDeletedKey(vaultBaseUrl: string, keyName: string, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param keyName The name of the deleted key.
    * @param options The optional parameters
    * @param callback The callback
    */
-  recoverDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): void;
-  recoverDeletedKey(
-    vaultBaseUrl: string,
-    keyName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyBundle>,
-    callback?: coreHttp.ServiceCallback<Models.KeyBundle>
-  ): Promise<Models.RecoverDeletedKeyResponse> {
+  recoverDeletedKey(vaultBaseUrl: string, keyName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.KeyBundle>): void;
+  recoverDeletedKey(vaultBaseUrl: string, keyName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.KeyBundle>, callback?: coreHttp.ServiceCallback<Models.KeyBundle>): Promise<Models.RecoverDeletedKeyResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -1294,8 +839,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       recoverDeletedKeyOperationSpec,
-      callback
-    ) as Promise<Models.RecoverDeletedKeyResponse>;
+      callback) as Promise<Models.RecoverDeletedKeyResponse>;
   }
 }
 
@@ -1304,16 +848,36 @@ const serializer = new coreHttp.Serializer(Mappers);
 const createKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/create",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       kty: "kty",
-      keySize: ["options", "keySize"],
-      keyOps: ["options", "keyOps"],
-      keyAttributes: ["options", "keyAttributes"],
-      tags: ["options", "tags"],
-      curve: ["options", "curve"]
+      keySize: [
+        "options",
+        "keySize"
+      ],
+      keyOps: [
+        "options",
+        "keyOps"
+      ],
+      keyAttributes: [
+        "options",
+        "keyAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ],
+      curve: [
+        "options",
+        "curve"
+      ]
     },
     mapper: {
       ...Mappers.KeyCreateParameters,
@@ -1334,14 +898,28 @@ const createKeyOperationSpec: coreHttp.OperationSpec = {
 const importKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "keys/{key-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
-      hsm: ["options", "hsm"],
+      hsm: [
+        "options",
+        "hsm"
+      ],
       key: "key",
-      keyAttributes: ["options", "keyAttributes"],
-      tags: ["options", "tags"]
+      keyAttributes: [
+        "options",
+        "keyAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ]
     },
     mapper: {
       ...Mappers.KeyImportParameters,
@@ -1362,8 +940,13 @@ const importKeyOperationSpec: coreHttp.OperationSpec = {
 const deleteKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "keys/{key-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedKeyBundle
@@ -1378,13 +961,28 @@ const deleteKeyOperationSpec: coreHttp.OperationSpec = {
 const updateKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "keys/{key-name}/{key-version}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
-      keyOps: ["options", "keyOps"],
-      keyAttributes: ["options", "keyAttributes"],
-      tags: ["options", "tags"]
+      keyOps: [
+        "options",
+        "keyOps"
+      ],
+      keyAttributes: [
+        "options",
+        "keyAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ]
     },
     mapper: {
       ...Mappers.KeyUpdateParameters,
@@ -1405,8 +1003,14 @@ const updateKeyOperationSpec: coreHttp.OperationSpec = {
 const getKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "keys/{key-name}/{key-version}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.KeyBundle
@@ -1421,8 +1025,14 @@ const getKeyOperationSpec: coreHttp.OperationSpec = {
 const getKeyVersionsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "keys/{key-name}/versions",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.KeyListResult
@@ -1437,8 +1047,13 @@ const getKeyVersionsOperationSpec: coreHttp.OperationSpec = {
 const getKeysOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "keys",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.KeyListResult
@@ -1453,8 +1068,13 @@ const getKeysOperationSpec: coreHttp.OperationSpec = {
 const backupKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/backup",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.BackupKeyResult
@@ -1469,8 +1089,12 @@ const backupKeyOperationSpec: coreHttp.OperationSpec = {
 const restoreKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/restore",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       keyBundleBackup: "keyBundleBackup"
@@ -1494,8 +1118,14 @@ const restoreKeyOperationSpec: coreHttp.OperationSpec = {
 const encryptOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/{key-version}/encrypt",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       algorithm: "algorithm",
@@ -1520,8 +1150,14 @@ const encryptOperationSpec: coreHttp.OperationSpec = {
 const decryptOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/{key-version}/decrypt",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       algorithm: "algorithm",
@@ -1546,8 +1182,14 @@ const decryptOperationSpec: coreHttp.OperationSpec = {
 const signOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/{key-version}/sign",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       algorithm: "algorithm",
@@ -1572,8 +1214,14 @@ const signOperationSpec: coreHttp.OperationSpec = {
 const verifyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/{key-version}/verify",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       algorithm: "algorithm",
@@ -1599,8 +1247,14 @@ const verifyOperationSpec: coreHttp.OperationSpec = {
 const wrapKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/{key-version}/wrapkey",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       algorithm: "algorithm",
@@ -1625,8 +1279,14 @@ const wrapKeyOperationSpec: coreHttp.OperationSpec = {
 const unwrapKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "keys/{key-name}/{key-version}/unwrapkey",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1, Parameters.keyVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1,
+    Parameters.keyVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       algorithm: "algorithm",
@@ -1651,8 +1311,13 @@ const unwrapKeyOperationSpec: coreHttp.OperationSpec = {
 const getDeletedKeysOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "deletedkeys",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedKeyListResult
@@ -1667,8 +1332,13 @@ const getDeletedKeysOperationSpec: coreHttp.OperationSpec = {
 const getDeletedKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "deletedkeys/{key-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedKeyBundle
@@ -1683,8 +1353,13 @@ const getDeletedKeyOperationSpec: coreHttp.OperationSpec = {
 const purgeDeletedKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "deletedkeys/{key-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     204: {},
     default: {
@@ -1697,8 +1372,13 @@ const purgeDeletedKeyOperationSpec: coreHttp.OperationSpec = {
 const recoverDeletedKeyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "deletedkeys/{key-name}/recover",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.keyName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.keyName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.KeyBundle

--- a/sdk/keyvault/keyvault-keys/src/core/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/keyVaultClientContext.ts
@@ -15,24 +15,15 @@ export const packageVersion = "4.1.0-preview.2";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: string;
-  credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
    * @param apiVersion Client API version.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    apiVersion: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
+  constructor(apiVersion: string, options?: coreHttp.ServiceClientOptions) {
     if (apiVersion == undefined) {
       throw new Error("'apiVersion' cannot be null.");
-    }
-    if (credentials == undefined) {
-      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -44,11 +35,10 @@ export class KeyVaultClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(credentials, options);
+    super(undefined, options);
 
     this.baseUri = "{vaultBaseUrl}";
     this.requestContentType = "application/json; charset=utf-8";
     this.apiVersion = apiVersion;
-    this.credentials = credentials;
   }
 }

--- a/sdk/keyvault/keyvault-keys/src/core/models/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/models/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+
 import * as coreHttp from "@azure/core-http";
 
 /**
@@ -557,7 +558,7 @@ export interface KeyVaultClientGetDeletedKeysOptionalParams extends coreHttp.Req
  * @readonly
  * @enum {string}
  */
-export type JsonWebKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM" | "oct";
+export type JsonWebKeyType = 'EC' | 'EC-HSM' | 'RSA' | 'RSA-HSM' | 'oct';
 
 /**
  * Defines values for JsonWebKeyCurveName.
@@ -565,7 +566,7 @@ export type JsonWebKeyType = "EC" | "EC-HSM" | "RSA" | "RSA-HSM" | "oct";
  * @readonly
  * @enum {string}
  */
-export type JsonWebKeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
+export type JsonWebKeyCurveName = 'P-256' | 'P-384' | 'P-521' | 'P-256K';
 
 /**
  * Defines values for DeletionRecoveryLevel.
@@ -575,14 +576,7 @@ export type JsonWebKeyCurveName = "P-256" | "P-384" | "P-521" | "P-256K";
  * @readonly
  * @enum {string}
  */
-export type DeletionRecoveryLevel =
-  | "Purgeable"
-  | "Recoverable+Purgeable"
-  | "Recoverable"
-  | "Recoverable+ProtectedSubscription"
-  | "CustomizedRecoverable+Purgeable"
-  | "CustomizedRecoverable"
-  | "CustomizedRecoverable+ProtectedSubscription";
+export type DeletionRecoveryLevel = 'Purgeable' | 'Recoverable+Purgeable' | 'Recoverable' | 'Recoverable+ProtectedSubscription' | 'CustomizedRecoverable+Purgeable' | 'CustomizedRecoverable' | 'CustomizedRecoverable+ProtectedSubscription';
 
 /**
  * Defines values for JsonWebKeyOperation.
@@ -591,14 +585,7 @@ export type DeletionRecoveryLevel =
  * @readonly
  * @enum {string}
  */
-export type JsonWebKeyOperation =
-  | "encrypt"
-  | "decrypt"
-  | "sign"
-  | "verify"
-  | "wrapKey"
-  | "unwrapKey"
-  | "import";
+export type JsonWebKeyOperation = 'encrypt' | 'decrypt' | 'sign' | 'verify' | 'wrapKey' | 'unwrapKey' | 'import';
 
 /**
  * Defines values for JsonWebKeyEncryptionAlgorithm.
@@ -606,7 +593,7 @@ export type JsonWebKeyOperation =
  * @readonly
  * @enum {string}
  */
-export type JsonWebKeyEncryptionAlgorithm = "RSA-OAEP" | "RSA-OAEP-256" | "RSA1_5";
+export type JsonWebKeyEncryptionAlgorithm = 'RSA-OAEP' | 'RSA-OAEP-256' | 'RSA1_5';
 
 /**
  * Defines values for JsonWebKeySignatureAlgorithm.
@@ -615,18 +602,7 @@ export type JsonWebKeyEncryptionAlgorithm = "RSA-OAEP" | "RSA-OAEP-256" | "RSA1_
  * @readonly
  * @enum {string}
  */
-export type JsonWebKeySignatureAlgorithm =
-  | "PS256"
-  | "PS384"
-  | "PS512"
-  | "RS256"
-  | "RS384"
-  | "RS512"
-  | "RSNULL"
-  | "ES256"
-  | "ES384"
-  | "ES512"
-  | "ES256K";
+export type JsonWebKeySignatureAlgorithm = 'PS256' | 'PS384' | 'PS512' | 'RS256' | 'RS384' | 'RS512' | 'RSNULL' | 'ES256' | 'ES384' | 'ES512' | 'ES256K';
 
 /**
  * Contains response data for the createKey operation.
@@ -636,16 +612,16 @@ export type CreateKeyResponse = KeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyBundle;
+    };
 };
 
 /**
@@ -656,16 +632,16 @@ export type ImportKeyResponse = KeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyBundle;
+    };
 };
 
 /**
@@ -676,16 +652,16 @@ export type DeleteKeyResponse = DeletedKeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedKeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedKeyBundle;
+    };
 };
 
 /**
@@ -696,16 +672,16 @@ export type UpdateKeyResponse = KeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyBundle;
+    };
 };
 
 /**
@@ -716,16 +692,16 @@ export type GetKeyResponse = KeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyBundle;
+    };
 };
 
 /**
@@ -736,16 +712,16 @@ export type GetKeyVersionsResponse = KeyListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyListResult;
+    };
 };
 
 /**
@@ -756,16 +732,16 @@ export type GetKeysResponse = KeyListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyListResult;
+    };
 };
 
 /**
@@ -776,16 +752,16 @@ export type BackupKeyResponse = BackupKeyResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: BackupKeyResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: BackupKeyResult;
+    };
 };
 
 /**
@@ -796,16 +772,16 @@ export type RestoreKeyResponse = KeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyBundle;
+    };
 };
 
 /**
@@ -816,16 +792,16 @@ export type EncryptResponse = KeyOperationResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyOperationResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyOperationResult;
+    };
 };
 
 /**
@@ -836,16 +812,16 @@ export type DecryptResponse = KeyOperationResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyOperationResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyOperationResult;
+    };
 };
 
 /**
@@ -856,16 +832,16 @@ export type SignResponse = KeyOperationResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyOperationResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyOperationResult;
+    };
 };
 
 /**
@@ -876,16 +852,16 @@ export type VerifyResponse = KeyVerifyResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyVerifyResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyVerifyResult;
+    };
 };
 
 /**
@@ -896,16 +872,16 @@ export type WrapKeyResponse = KeyOperationResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyOperationResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyOperationResult;
+    };
 };
 
 /**
@@ -916,16 +892,16 @@ export type UnwrapKeyResponse = KeyOperationResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyOperationResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyOperationResult;
+    };
 };
 
 /**
@@ -936,16 +912,16 @@ export type GetDeletedKeysResponse = DeletedKeyListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedKeyListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedKeyListResult;
+    };
 };
 
 /**
@@ -956,16 +932,16 @@ export type GetDeletedKeyResponse = DeletedKeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedKeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedKeyBundle;
+    };
 };
 
 /**
@@ -976,14 +952,14 @@ export type RecoverDeletedKeyResponse = KeyBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: KeyBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: KeyBundle;
+    };
 };

--- a/sdk/keyvault/keyvault-keys/src/core/models/mappers.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/models/mappers.ts
@@ -8,6 +8,7 @@
 
 import * as coreHttp from "@azure/core-http";
 
+
 export const JsonWebKey: coreHttp.CompositeMapper = {
   serializedName: "JsonWebKey",
   type: {

--- a/sdk/keyvault/keyvault-keys/src/core/models/parameters.ts
+++ b/sdk/keyvault/keyvault-keys/src/core/models/parameters.ts
@@ -54,7 +54,10 @@ export const keyVersion: coreHttp.OperationURLParameter = {
   }
 };
 export const maxresults: coreHttp.OperationQueryParameter = {
-  parameterPath: ["options", "maxresults"],
+  parameterPath: [
+    "options",
+    "maxresults"
+  ],
   mapper: {
     serializedName: "maxresults",
     constraints: {
@@ -71,7 +74,7 @@ export const vaultBaseUrl: coreHttp.OperationURLParameter = {
   mapper: {
     required: true,
     serializedName: "vaultBaseUrl",
-    defaultValue: "",
+    defaultValue: '',
     type: {
       name: "String"
     }

--- a/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
+++ b/sdk/keyvault/keyvault-keys/src/cryptographyClient.ts
@@ -710,7 +710,6 @@ export class CryptographyClient {
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
     this.client = new KeyVaultClient(
-      credential,
       pipelineOptions.apiVersion || LATEST_API_VERSION,
       pipeline
     );

--- a/sdk/keyvault/keyvault-keys/src/index.ts
+++ b/sdk/keyvault/keyvault-keys/src/index.ts
@@ -240,7 +240,6 @@ export class KeyClient {
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
     this.client = new KeyVaultClient(
-      credential,
       pipelineOptions.apiVersion || LATEST_API_VERSION,
       pipeline
     );

--- a/sdk/keyvault/keyvault-keys/swagger/README.md
+++ b/sdk/keyvault/keyvault-keys/swagger/README.md
@@ -9,7 +9,7 @@ use-extension:
   "@microsoft.azure/autorest.typescript": "~5.0.1"
 azure-arm: false
 generate-metadata: false
-add-credentials: true
+add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/keys.json
 output-folder: ../

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -36,7 +36,7 @@ export interface DeletedSecret {
 }
 
 // @public
-export type DeletionRecoveryLevel = "Purgeable" | "Recoverable+Purgeable" | "Recoverable" | "Recoverable+ProtectedSubscription" | "CustomizedRecoverable+Purgeable" | "CustomizedRecoverable" | "CustomizedRecoverable+ProtectedSubscription";
+export type DeletionRecoveryLevel = 'Purgeable' | 'Recoverable+Purgeable' | 'Recoverable' | 'Recoverable+ProtectedSubscription' | 'CustomizedRecoverable+Purgeable' | 'CustomizedRecoverable' | 'CustomizedRecoverable+ProtectedSubscription';
 
 // @public
 export interface GetDeletedSecretOptions extends coreHttp.OperationOptions {

--- a/sdk/keyvault/keyvault-secrets/src/core/keyVaultClient.ts
+++ b/sdk/keyvault/keyvault-secrets/src/core/keyVaultClient.ts
@@ -18,15 +18,10 @@ class KeyVaultClient extends KeyVaultClientContext {
   /**
    * Initializes a new instance of the KeyVaultClient class.
    * @param apiVersion Client API version.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    apiVersion: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
-    super(credentials, apiVersion, options);
+  constructor(apiVersion: string, options?: coreHttp.ServiceClientOptions) {
+    super(apiVersion, options);
   }
 
   /**
@@ -40,24 +35,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.SetSecretResponse>
    */
-  setSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    value: string,
-    options?: Models.KeyVaultClientSetSecretOptionalParams
-  ): Promise<Models.SetSecretResponse>;
+  setSecret(vaultBaseUrl: string, secretName: string, value: string, options?: Models.KeyVaultClientSetSecretOptionalParams): Promise<Models.SetSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param value The value of the secret.
    * @param callback The callback
    */
-  setSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    value: string,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
+  setSecret(vaultBaseUrl: string, secretName: string, value: string, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
@@ -65,22 +50,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  setSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    value: string,
-    options: Models.KeyVaultClientSetSecretOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
-  setSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    value: string,
-    options?:
-      | Models.KeyVaultClientSetSecretOptionalParams
-      | coreHttp.ServiceCallback<Models.SecretBundle>,
-    callback?: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): Promise<Models.SetSecretResponse> {
+  setSecret(vaultBaseUrl: string, secretName: string, value: string, options: Models.KeyVaultClientSetSecretOptionalParams, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
+  setSecret(vaultBaseUrl: string, secretName: string, value: string, options?: Models.KeyVaultClientSetSecretOptionalParams | coreHttp.ServiceCallback<Models.SecretBundle>, callback?: coreHttp.ServiceCallback<Models.SecretBundle>): Promise<Models.SetSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -89,8 +60,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       setSecretOperationSpec,
-      callback
-    ) as Promise<Models.SetSecretResponse>;
+      callback) as Promise<Models.SetSecretResponse>;
   }
 
   /**
@@ -102,39 +72,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.DeleteSecretResponse>
    */
-  deleteSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DeleteSecretResponse>;
+  deleteSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.DeleteSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param callback The callback
    */
-  deleteSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>
-  ): void;
+  deleteSecret(vaultBaseUrl: string, secretName: string, callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param options The optional parameters
    * @param callback The callback
    */
-  deleteSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>
-  ): void;
-  deleteSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedSecretBundle>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedSecretBundle>
-  ): Promise<Models.DeleteSecretResponse> {
+  deleteSecret(vaultBaseUrl: string, secretName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>): void;
+  deleteSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedSecretBundle>, callback?: coreHttp.ServiceCallback<Models.DeletedSecretBundle>): Promise<Models.DeleteSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -142,8 +94,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       deleteSecretOperationSpec,
-      callback
-    ) as Promise<Models.DeleteSecretResponse>;
+      callback) as Promise<Models.DeleteSecretResponse>;
   }
 
   /**
@@ -157,24 +108,14 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.UpdateSecretResponse>
    */
-  updateSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    options?: Models.KeyVaultClientUpdateSecretOptionalParams
-  ): Promise<Models.UpdateSecretResponse>;
+  updateSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, options?: Models.KeyVaultClientUpdateSecretOptionalParams): Promise<Models.UpdateSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param secretVersion The version of the secret.
    * @param callback The callback
    */
-  updateSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
+  updateSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
@@ -182,22 +123,8 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param options The optional parameters
    * @param callback The callback
    */
-  updateSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    options: Models.KeyVaultClientUpdateSecretOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
-  updateSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    options?:
-      | Models.KeyVaultClientUpdateSecretOptionalParams
-      | coreHttp.ServiceCallback<Models.SecretBundle>,
-    callback?: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): Promise<Models.UpdateSecretResponse> {
+  updateSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, options: Models.KeyVaultClientUpdateSecretOptionalParams, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
+  updateSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, options?: Models.KeyVaultClientUpdateSecretOptionalParams | coreHttp.ServiceCallback<Models.SecretBundle>, callback?: coreHttp.ServiceCallback<Models.SecretBundle>): Promise<Models.UpdateSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -206,8 +133,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       updateSecretOperationSpec,
-      callback
-    ) as Promise<Models.UpdateSecretResponse>;
+      callback) as Promise<Models.UpdateSecretResponse>;
   }
 
   /**
@@ -216,49 +142,30 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @summary Get a specified secret from a given key vault.
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
-   * @param secretVersion The version of the secret.
+   * @param secretVersion The version of the secret. This URI fragment is optional. If not specified,
+   * the latest version of the secret is returned.
    * @param [options] The optional parameters
    * @returns Promise<Models.GetSecretResponse>
    */
-  getSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetSecretResponse>;
+  getSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
-   * @param secretVersion The version of the secret.
+   * @param secretVersion The version of the secret. This URI fragment is optional. If not specified,
+   * the latest version of the secret is returned.
    * @param callback The callback
    */
-  getSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
+  getSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
-   * @param secretVersion The version of the secret.
+   * @param secretVersion The version of the secret. This URI fragment is optional. If not specified,
+   * the latest version of the secret is returned.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
-  getSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    secretVersion: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SecretBundle>,
-    callback?: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): Promise<Models.GetSecretResponse> {
+  getSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
+  getSecret(vaultBaseUrl: string, secretName: string, secretVersion: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SecretBundle>, callback?: coreHttp.ServiceCallback<Models.SecretBundle>): Promise<Models.GetSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -267,8 +174,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getSecretOperationSpec,
-      callback
-    ) as Promise<Models.GetSecretResponse>;
+      callback) as Promise<Models.GetSecretResponse>;
   }
 
   /**
@@ -280,43 +186,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetSecretsResponse>
    */
-  getSecrets(
-    vaultBaseUrl: string,
-    options?: Models.KeyVaultClientGetSecretsOptionalParams
-  ): Promise<Models.GetSecretsResponse>;
+  getSecrets(vaultBaseUrl: string, options?: Models.KeyVaultClientGetSecretsOptionalParams): Promise<Models.GetSecretsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  getSecrets(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.SecretListResult>
-  ): void;
+  getSecrets(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.SecretListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getSecrets(
-    vaultBaseUrl: string,
-    options: Models.KeyVaultClientGetSecretsOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.SecretListResult>
-  ): void;
-  getSecrets(
-    vaultBaseUrl: string,
-    options?:
-      | Models.KeyVaultClientGetSecretsOptionalParams
-      | coreHttp.ServiceCallback<Models.SecretListResult>,
-    callback?: coreHttp.ServiceCallback<Models.SecretListResult>
-  ): Promise<Models.GetSecretsResponse> {
+  getSecrets(vaultBaseUrl: string, options: Models.KeyVaultClientGetSecretsOptionalParams, callback: coreHttp.ServiceCallback<Models.SecretListResult>): void;
+  getSecrets(vaultBaseUrl: string, options?: Models.KeyVaultClientGetSecretsOptionalParams | coreHttp.ServiceCallback<Models.SecretListResult>, callback?: coreHttp.ServiceCallback<Models.SecretListResult>): Promise<Models.GetSecretsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getSecretsOperationSpec,
-      callback
-    ) as Promise<Models.GetSecretsResponse>;
+      callback) as Promise<Models.GetSecretsResponse>;
   }
 
   /**
@@ -328,41 +217,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetSecretVersionsResponse>
    */
-  getSecretVersions(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: Models.KeyVaultClientGetSecretVersionsOptionalParams
-  ): Promise<Models.GetSecretVersionsResponse>;
+  getSecretVersions(vaultBaseUrl: string, secretName: string, options?: Models.KeyVaultClientGetSecretVersionsOptionalParams): Promise<Models.GetSecretVersionsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param callback The callback
    */
-  getSecretVersions(
-    vaultBaseUrl: string,
-    secretName: string,
-    callback: coreHttp.ServiceCallback<Models.SecretListResult>
-  ): void;
+  getSecretVersions(vaultBaseUrl: string, secretName: string, callback: coreHttp.ServiceCallback<Models.SecretListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getSecretVersions(
-    vaultBaseUrl: string,
-    secretName: string,
-    options: Models.KeyVaultClientGetSecretVersionsOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.SecretListResult>
-  ): void;
-  getSecretVersions(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?:
-      | Models.KeyVaultClientGetSecretVersionsOptionalParams
-      | coreHttp.ServiceCallback<Models.SecretListResult>,
-    callback?: coreHttp.ServiceCallback<Models.SecretListResult>
-  ): Promise<Models.GetSecretVersionsResponse> {
+  getSecretVersions(vaultBaseUrl: string, secretName: string, options: Models.KeyVaultClientGetSecretVersionsOptionalParams, callback: coreHttp.ServiceCallback<Models.SecretListResult>): void;
+  getSecretVersions(vaultBaseUrl: string, secretName: string, options?: Models.KeyVaultClientGetSecretVersionsOptionalParams | coreHttp.ServiceCallback<Models.SecretListResult>, callback?: coreHttp.ServiceCallback<Models.SecretListResult>): Promise<Models.GetSecretVersionsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -370,8 +239,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getSecretVersionsOperationSpec,
-      callback
-    ) as Promise<Models.GetSecretVersionsResponse>;
+      callback) as Promise<Models.GetSecretVersionsResponse>;
   }
 
   /**
@@ -382,43 +250,26 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetDeletedSecretsResponse>
    */
-  getDeletedSecrets(
-    vaultBaseUrl: string,
-    options?: Models.KeyVaultClientGetDeletedSecretsOptionalParams
-  ): Promise<Models.GetDeletedSecretsResponse>;
+  getDeletedSecrets(vaultBaseUrl: string, options?: Models.KeyVaultClientGetDeletedSecretsOptionalParams): Promise<Models.GetDeletedSecretsResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param callback The callback
    */
-  getDeletedSecrets(
-    vaultBaseUrl: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedSecretListResult>
-  ): void;
+  getDeletedSecrets(vaultBaseUrl: string, callback: coreHttp.ServiceCallback<Models.DeletedSecretListResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getDeletedSecrets(
-    vaultBaseUrl: string,
-    options: Models.KeyVaultClientGetDeletedSecretsOptionalParams,
-    callback: coreHttp.ServiceCallback<Models.DeletedSecretListResult>
-  ): void;
-  getDeletedSecrets(
-    vaultBaseUrl: string,
-    options?:
-      | Models.KeyVaultClientGetDeletedSecretsOptionalParams
-      | coreHttp.ServiceCallback<Models.DeletedSecretListResult>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedSecretListResult>
-  ): Promise<Models.GetDeletedSecretsResponse> {
+  getDeletedSecrets(vaultBaseUrl: string, options: Models.KeyVaultClientGetDeletedSecretsOptionalParams, callback: coreHttp.ServiceCallback<Models.DeletedSecretListResult>): void;
+  getDeletedSecrets(vaultBaseUrl: string, options?: Models.KeyVaultClientGetDeletedSecretsOptionalParams | coreHttp.ServiceCallback<Models.DeletedSecretListResult>, callback?: coreHttp.ServiceCallback<Models.DeletedSecretListResult>): Promise<Models.GetDeletedSecretsResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
         options
       },
       getDeletedSecretsOperationSpec,
-      callback
-    ) as Promise<Models.GetDeletedSecretsResponse>;
+      callback) as Promise<Models.GetDeletedSecretsResponse>;
   }
 
   /**
@@ -430,39 +281,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.GetDeletedSecretResponse>
    */
-  getDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.GetDeletedSecretResponse>;
+  getDeletedSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.GetDeletedSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param callback The callback
    */
-  getDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>
-  ): void;
+  getDeletedSecret(vaultBaseUrl: string, secretName: string, callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param options The optional parameters
    * @param callback The callback
    */
-  getDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>
-  ): void;
-  getDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedSecretBundle>,
-    callback?: coreHttp.ServiceCallback<Models.DeletedSecretBundle>
-  ): Promise<Models.GetDeletedSecretResponse> {
+  getDeletedSecret(vaultBaseUrl: string, secretName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.DeletedSecretBundle>): void;
+  getDeletedSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.DeletedSecretBundle>, callback?: coreHttp.ServiceCallback<Models.DeletedSecretBundle>): Promise<Models.GetDeletedSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -470,8 +303,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       getDeletedSecretOperationSpec,
-      callback
-    ) as Promise<Models.GetDeletedSecretResponse>;
+      callback) as Promise<Models.GetDeletedSecretResponse>;
   }
 
   /**
@@ -484,39 +316,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<coreHttp.RestResponse>
    */
-  purgeDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
+  purgeDeletedSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase): Promise<coreHttp.RestResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param callback The callback
    */
-  purgeDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    callback: coreHttp.ServiceCallback<void>
-  ): void;
+  purgeDeletedSecret(vaultBaseUrl: string, secretName: string, callback: coreHttp.ServiceCallback<void>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param options The optional parameters
    * @param callback The callback
    */
-  purgeDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<void>
-  ): void;
-  purgeDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>,
-    callback?: coreHttp.ServiceCallback<void>
-  ): Promise<coreHttp.RestResponse> {
+  purgeDeletedSecret(vaultBaseUrl: string, secretName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<void>): void;
+  purgeDeletedSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<void>, callback?: coreHttp.ServiceCallback<void>): Promise<coreHttp.RestResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -524,8 +338,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       purgeDeletedSecretOperationSpec,
-      callback
-    );
+      callback);
   }
 
   /**
@@ -537,39 +350,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.RecoverDeletedSecretResponse>
    */
-  recoverDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.RecoverDeletedSecretResponse>;
+  recoverDeletedSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.RecoverDeletedSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the deleted secret.
    * @param callback The callback
    */
-  recoverDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
+  recoverDeletedSecret(vaultBaseUrl: string, secretName: string, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the deleted secret.
    * @param options The optional parameters
    * @param callback The callback
    */
-  recoverDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
-  recoverDeletedSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SecretBundle>,
-    callback?: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): Promise<Models.RecoverDeletedSecretResponse> {
+  recoverDeletedSecret(vaultBaseUrl: string, secretName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
+  recoverDeletedSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SecretBundle>, callback?: coreHttp.ServiceCallback<Models.SecretBundle>): Promise<Models.RecoverDeletedSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -577,8 +372,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       recoverDeletedSecretOperationSpec,
-      callback
-    ) as Promise<Models.RecoverDeletedSecretResponse>;
+      callback) as Promise<Models.RecoverDeletedSecretResponse>;
   }
 
   /**
@@ -590,39 +384,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.BackupSecretResponse>
    */
-  backupSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BackupSecretResponse>;
+  backupSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase): Promise<Models.BackupSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param callback The callback
    */
-  backupSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    callback: coreHttp.ServiceCallback<Models.BackupSecretResult>
-  ): void;
+  backupSecret(vaultBaseUrl: string, secretName: string, callback: coreHttp.ServiceCallback<Models.BackupSecretResult>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretName The name of the secret.
    * @param options The optional parameters
    * @param callback The callback
    */
-  backupSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.BackupSecretResult>
-  ): void;
-  backupSecret(
-    vaultBaseUrl: string,
-    secretName: string,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.BackupSecretResult>,
-    callback?: coreHttp.ServiceCallback<Models.BackupSecretResult>
-  ): Promise<Models.BackupSecretResponse> {
+  backupSecret(vaultBaseUrl: string, secretName: string, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.BackupSecretResult>): void;
+  backupSecret(vaultBaseUrl: string, secretName: string, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.BackupSecretResult>, callback?: coreHttp.ServiceCallback<Models.BackupSecretResult>): Promise<Models.BackupSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -630,8 +406,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       backupSecretOperationSpec,
-      callback
-    ) as Promise<Models.BackupSecretResponse>;
+      callback) as Promise<Models.BackupSecretResponse>;
   }
 
   /**
@@ -643,39 +418,21 @@ class KeyVaultClient extends KeyVaultClientContext {
    * @param [options] The optional parameters
    * @returns Promise<Models.RestoreSecretResponse>
    */
-  restoreSecret(
-    vaultBaseUrl: string,
-    secretBundleBackup: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.RestoreSecretResponse>;
+  restoreSecret(vaultBaseUrl: string, secretBundleBackup: Uint8Array, options?: coreHttp.RequestOptionsBase): Promise<Models.RestoreSecretResponse>;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretBundleBackup The backup blob associated with a secret bundle.
    * @param callback The callback
    */
-  restoreSecret(
-    vaultBaseUrl: string,
-    secretBundleBackup: Uint8Array,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
+  restoreSecret(vaultBaseUrl: string, secretBundleBackup: Uint8Array, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
   /**
    * @param vaultBaseUrl The vault name, for example https://myvault.vault.azure.net.
    * @param secretBundleBackup The backup blob associated with a secret bundle.
    * @param options The optional parameters
    * @param callback The callback
    */
-  restoreSecret(
-    vaultBaseUrl: string,
-    secretBundleBackup: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): void;
-  restoreSecret(
-    vaultBaseUrl: string,
-    secretBundleBackup: Uint8Array,
-    options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SecretBundle>,
-    callback?: coreHttp.ServiceCallback<Models.SecretBundle>
-  ): Promise<Models.RestoreSecretResponse> {
+  restoreSecret(vaultBaseUrl: string, secretBundleBackup: Uint8Array, options: coreHttp.RequestOptionsBase, callback: coreHttp.ServiceCallback<Models.SecretBundle>): void;
+  restoreSecret(vaultBaseUrl: string, secretBundleBackup: Uint8Array, options?: coreHttp.RequestOptionsBase | coreHttp.ServiceCallback<Models.SecretBundle>, callback?: coreHttp.ServiceCallback<Models.SecretBundle>): Promise<Models.RestoreSecretResponse> {
     return this.sendOperationRequest(
       {
         vaultBaseUrl,
@@ -683,8 +440,7 @@ class KeyVaultClient extends KeyVaultClientContext {
         options
       },
       restoreSecretOperationSpec,
-      callback
-    ) as Promise<Models.RestoreSecretResponse>;
+      callback) as Promise<Models.RestoreSecretResponse>;
   }
 }
 
@@ -693,14 +449,28 @@ const serializer = new coreHttp.Serializer(Mappers);
 const setSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PUT",
   path: "secrets/{secret-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName0],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName0
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       value: "value",
-      tags: ["options", "tags"],
-      contentType: ["options", "contentType"],
-      secretAttributes: ["options", "secretAttributes"]
+      tags: [
+        "options",
+        "tags"
+      ],
+      contentType: [
+        "options",
+        "contentType"
+      ],
+      secretAttributes: [
+        "options",
+        "secretAttributes"
+      ]
     },
     mapper: {
       ...Mappers.SecretSetParameters,
@@ -721,8 +491,13 @@ const setSecretOperationSpec: coreHttp.OperationSpec = {
 const deleteSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "secrets/{secret-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedSecretBundle
@@ -737,13 +512,28 @@ const deleteSecretOperationSpec: coreHttp.OperationSpec = {
 const updateSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "PATCH",
   path: "secrets/{secret-name}/{secret-version}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1, Parameters.secretVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1,
+    Parameters.secretVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
-      contentType: ["options", "contentType"],
-      secretAttributes: ["options", "secretAttributes"],
-      tags: ["options", "tags"]
+      contentType: [
+        "options",
+        "contentType"
+      ],
+      secretAttributes: [
+        "options",
+        "secretAttributes"
+      ],
+      tags: [
+        "options",
+        "tags"
+      ]
     },
     mapper: {
       ...Mappers.SecretUpdateParameters,
@@ -764,8 +554,14 @@ const updateSecretOperationSpec: coreHttp.OperationSpec = {
 const getSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "secrets/{secret-name}/{secret-version}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1, Parameters.secretVersion],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1,
+    Parameters.secretVersion
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.SecretBundle
@@ -780,8 +576,13 @@ const getSecretOperationSpec: coreHttp.OperationSpec = {
 const getSecretsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "secrets",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.SecretListResult
@@ -796,8 +597,14 @@ const getSecretsOperationSpec: coreHttp.OperationSpec = {
 const getSecretVersionsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "secrets/{secret-name}/versions",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.SecretListResult
@@ -812,8 +619,13 @@ const getSecretVersionsOperationSpec: coreHttp.OperationSpec = {
 const getDeletedSecretsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "deletedsecrets",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.maxresults, Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.maxresults,
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedSecretListResult
@@ -828,8 +640,13 @@ const getDeletedSecretsOperationSpec: coreHttp.OperationSpec = {
 const getDeletedSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   path: "deletedsecrets/{secret-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.DeletedSecretBundle
@@ -844,8 +661,13 @@ const getDeletedSecretOperationSpec: coreHttp.OperationSpec = {
 const purgeDeletedSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "DELETE",
   path: "deletedsecrets/{secret-name}",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     204: {},
     default: {
@@ -858,8 +680,13 @@ const purgeDeletedSecretOperationSpec: coreHttp.OperationSpec = {
 const recoverDeletedSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "deletedsecrets/{secret-name}/recover",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.SecretBundle
@@ -874,8 +701,13 @@ const recoverDeletedSecretOperationSpec: coreHttp.OperationSpec = {
 const backupSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "secrets/{secret-name}/backup",
-  urlParameters: [Parameters.vaultBaseUrl, Parameters.secretName1],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl,
+    Parameters.secretName1
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   responses: {
     200: {
       bodyMapper: Mappers.BackupSecretResult
@@ -890,8 +722,12 @@ const backupSecretOperationSpec: coreHttp.OperationSpec = {
 const restoreSecretOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   path: "secrets/restore",
-  urlParameters: [Parameters.vaultBaseUrl],
-  queryParameters: [Parameters.apiVersion],
+  urlParameters: [
+    Parameters.vaultBaseUrl
+  ],
+  queryParameters: [
+    Parameters.apiVersion
+  ],
   requestBody: {
     parameterPath: {
       secretBundleBackup: "secretBundleBackup"

--- a/sdk/keyvault/keyvault-secrets/src/core/keyVaultClientContext.ts
+++ b/sdk/keyvault/keyvault-secrets/src/core/keyVaultClientContext.ts
@@ -15,24 +15,15 @@ export const packageVersion = "4.1.0-preview.2";
 
 export class KeyVaultClientContext extends coreHttp.ServiceClient {
   apiVersion: string;
-  credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the KeyVaultClientContext class.
    * @param apiVersion Client API version.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    apiVersion: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
+  constructor(apiVersion: string, options?: coreHttp.ServiceClientOptions) {
     if (apiVersion == undefined) {
       throw new Error("'apiVersion' cannot be null.");
-    }
-    if (credentials == undefined) {
-      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -44,11 +35,10 @@ export class KeyVaultClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(credentials, options);
+    super(undefined, options);
 
     this.baseUri = "{vaultBaseUrl}";
     this.requestContentType = "application/json; charset=utf-8";
     this.apiVersion = apiVersion;
-    this.credentials = credentials;
   }
 }

--- a/sdk/keyvault/keyvault-secrets/src/core/models/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/core/models/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+
 import * as coreHttp from "@azure/core-http";
 
 /**
@@ -377,14 +378,7 @@ export interface KeyVaultClientGetDeletedSecretsOptionalParams extends coreHttp.
  * @readonly
  * @enum {string}
  */
-export type DeletionRecoveryLevel =
-  | "Purgeable"
-  | "Recoverable+Purgeable"
-  | "Recoverable"
-  | "Recoverable+ProtectedSubscription"
-  | "CustomizedRecoverable+Purgeable"
-  | "CustomizedRecoverable"
-  | "CustomizedRecoverable+ProtectedSubscription";
+export type DeletionRecoveryLevel = 'Purgeable' | 'Recoverable+Purgeable' | 'Recoverable' | 'Recoverable+ProtectedSubscription' | 'CustomizedRecoverable+Purgeable' | 'CustomizedRecoverable' | 'CustomizedRecoverable+ProtectedSubscription';
 
 /**
  * Contains response data for the setSecret operation.
@@ -394,16 +388,16 @@ export type SetSecretResponse = SecretBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SecretBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SecretBundle;
+    };
 };
 
 /**
@@ -414,16 +408,16 @@ export type DeleteSecretResponse = DeletedSecretBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedSecretBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedSecretBundle;
+    };
 };
 
 /**
@@ -434,16 +428,16 @@ export type UpdateSecretResponse = SecretBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SecretBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SecretBundle;
+    };
 };
 
 /**
@@ -454,16 +448,16 @@ export type GetSecretResponse = SecretBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SecretBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SecretBundle;
+    };
 };
 
 /**
@@ -474,16 +468,16 @@ export type GetSecretsResponse = SecretListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SecretListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SecretListResult;
+    };
 };
 
 /**
@@ -494,16 +488,16 @@ export type GetSecretVersionsResponse = SecretListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SecretListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SecretListResult;
+    };
 };
 
 /**
@@ -514,16 +508,16 @@ export type GetDeletedSecretsResponse = DeletedSecretListResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedSecretListResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedSecretListResult;
+    };
 };
 
 /**
@@ -534,16 +528,16 @@ export type GetDeletedSecretResponse = DeletedSecretBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: DeletedSecretBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: DeletedSecretBundle;
+    };
 };
 
 /**
@@ -554,16 +548,16 @@ export type RecoverDeletedSecretResponse = SecretBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SecretBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SecretBundle;
+    };
 };
 
 /**
@@ -574,16 +568,16 @@ export type BackupSecretResponse = BackupSecretResult & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: BackupSecretResult;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: BackupSecretResult;
+    };
 };
 
 /**
@@ -594,14 +588,14 @@ export type RestoreSecretResponse = SecretBundle & {
    * The underlying HTTP response.
    */
   _response: coreHttp.HttpResponse & {
-    /**
-     * The response body as text (string format)
-     */
-    bodyAsText: string;
+      /**
+       * The response body as text (string format)
+       */
+      bodyAsText: string;
 
-    /**
-     * The response body as parsed JSON or XML
-     */
-    parsedBody: SecretBundle;
-  };
+      /**
+       * The response body as parsed JSON or XML
+       */
+      parsedBody: SecretBundle;
+    };
 };

--- a/sdk/keyvault/keyvault-secrets/src/core/models/mappers.ts
+++ b/sdk/keyvault/keyvault-secrets/src/core/models/mappers.ts
@@ -8,6 +8,7 @@
 
 import * as coreHttp from "@azure/core-http";
 
+
 export const Attributes: coreHttp.CompositeMapper = {
   serializedName: "Attributes",
   type: {

--- a/sdk/keyvault/keyvault-secrets/src/core/models/parameters.ts
+++ b/sdk/keyvault/keyvault-secrets/src/core/models/parameters.ts
@@ -21,7 +21,10 @@ export const apiVersion: coreHttp.OperationQueryParameter = {
   }
 };
 export const maxresults: coreHttp.OperationQueryParameter = {
-  parameterPath: ["options", "maxresults"],
+  parameterPath: [
+    "options",
+    "maxresults"
+  ],
   mapper: {
     serializedName: "maxresults",
     constraints: {
@@ -71,7 +74,7 @@ export const vaultBaseUrl: coreHttp.OperationURLParameter = {
   mapper: {
     required: true,
     serializedName: "vaultBaseUrl",
-    defaultValue: "",
+    defaultValue: '',
     type: {
       name: "String"
     }

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -184,7 +184,6 @@ export class SecretClient {
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
     this.client = new KeyVaultClient(
-      credential,
       pipelineOptions.apiVersion || LATEST_API_VERSION,
       pipeline
     );

--- a/sdk/keyvault/keyvault-secrets/swagger/README.md
+++ b/sdk/keyvault/keyvault-secrets/swagger/README.md
@@ -9,7 +9,7 @@ use-extension:
   "@microsoft.azure/autorest.typescript": "~5.0.1"
 azure-arm: false
 generate-metadata: false
-add-credentials: true
+add-credentials: false
 license-header: MICROSOFT_MIT_NO_VERSION
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/keyvault/data-plane/Microsoft.KeyVault/preview/7.1/secrets.json
 output-folder: ../

--- a/sdk/search/search-documents/src/generated/data/searchClient.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClient.ts
@@ -23,11 +23,10 @@ class SearchClient extends SearchClientContext {
    * @param apiVersion Client Api Version.
    * @param endpoint The endpoint URL of the search service.
    * @param indexName The name of the index.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, apiVersion: string, endpoint: string, indexName: string, options?: coreHttp.ServiceClientOptions) {
-    super(credentials, apiVersion, endpoint, indexName, options);
+  constructor(apiVersion: string, endpoint: string, indexName: string, options?: coreHttp.ServiceClientOptions) {
+    super(apiVersion, endpoint, indexName, options);
     this.documents = new operations.Documents(this);
   }
 }

--- a/sdk/search/search-documents/src/generated/data/searchClientContext.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClientContext.ts
@@ -17,17 +17,15 @@ export class SearchClientContext extends coreHttp.ServiceClient {
   apiVersion: string;
   endpoint: string;
   indexName: string;
-  credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the SearchClientContext class.
    * @param apiVersion Client Api Version.
    * @param endpoint The endpoint URL of the search service.
    * @param indexName The name of the index.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, apiVersion: string, endpoint: string, indexName: string, options?: coreHttp.ServiceClientOptions) {
+  constructor(apiVersion: string, endpoint: string, indexName: string, options?: coreHttp.ServiceClientOptions) {
     if (apiVersion == undefined) {
       throw new Error("'apiVersion' cannot be null.");
     }
@@ -36,9 +34,6 @@ export class SearchClientContext extends coreHttp.ServiceClient {
     }
     if (indexName == undefined) {
       throw new Error("'indexName' cannot be null.");
-    }
-    if (credentials == undefined) {
-      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -50,13 +45,12 @@ export class SearchClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(credentials, options);
+    super(undefined, options);
 
     this.baseUri = "{endpoint}/indexes('{indexName}')";
     this.requestContentType = "application/json; charset=utf-8";
     this.apiVersion = apiVersion;
     this.endpoint = endpoint;
     this.indexName = indexName;
-    this.credentials = credentials;
   }
 }

--- a/sdk/search/search-documents/src/generated/service/models/parameters.ts
+++ b/sdk/search/search-documents/src/generated/service/models/parameters.ts
@@ -78,21 +78,21 @@ export const ifNoneMatch: coreHttp.OperationParameter = {
     }
   }
 };
-export const indexerName: coreHttp.OperationURLParameter = {
-  parameterPath: "indexerName",
-  mapper: {
-    required: true,
-    serializedName: "indexerName",
-    type: {
-      name: "String"
-    }
-  }
-};
 export const indexName: coreHttp.OperationURLParameter = {
   parameterPath: "indexName",
   mapper: {
     required: true,
     serializedName: "indexName",
+    type: {
+      name: "String"
+    }
+  }
+};
+export const indexerName: coreHttp.OperationURLParameter = {
+  parameterPath: "indexerName",
+  mapper: {
+    required: true,
+    serializedName: "indexerName",
     type: {
       name: "String"
     }

--- a/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClient.ts
@@ -27,11 +27,10 @@ class SearchServiceClient extends SearchServiceClientContext {
    * Initializes a new instance of the SearchServiceClient class.
    * @param apiVersion Client Api Version.
    * @param endpoint The endpoint URL of the search service.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, apiVersion: string, endpoint: string, options?: coreHttp.ServiceClientOptions) {
-    super(credentials, apiVersion, endpoint, options);
+  constructor(apiVersion: string, endpoint: string, options?: coreHttp.ServiceClientOptions) {
+    super(apiVersion, endpoint, options);
     this.dataSources = new operations.DataSources(this);
     this.indexers = new operations.Indexers(this);
     this.skillsets = new operations.Skillsets(this);

--- a/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
@@ -16,24 +16,19 @@ const packageVersion = "1.0.0-preview.5";
 export class SearchServiceClientContext extends coreHttp.ServiceClient {
   apiVersion: string;
   endpoint: string;
-  credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the SearchServiceClientContext class.
    * @param apiVersion Client Api Version.
    * @param endpoint The endpoint URL of the search service.
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, apiVersion: string, endpoint: string, options?: coreHttp.ServiceClientOptions) {
+  constructor(apiVersion: string, endpoint: string, options?: coreHttp.ServiceClientOptions) {
     if (apiVersion == undefined) {
       throw new Error("'apiVersion' cannot be null.");
     }
     if (endpoint == undefined) {
       throw new Error("'endpoint' cannot be null.");
-    }
-    if (credentials == undefined) {
-      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -45,12 +40,11 @@ export class SearchServiceClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(credentials, options);
+    super(undefined, options);
 
     this.baseUri = "{endpoint}";
     this.requestContentType = "application/json; charset=utf-8";
     this.apiVersion = apiVersion;
     this.endpoint = endpoint;
-    this.credentials = credentials;
   }
 }

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -8,8 +8,7 @@ import {
   InternalPipelineOptions,
   createPipelineFromOptions,
   OperationOptions,
-  operationOptionsToRequestOptionsBase,
-  ServiceClientCredentials
+  operationOptionsToRequestOptionsBase
 } from "@azure/core-http";
 import { SearchClient as GeneratedClient } from "./generated/data/searchClient";
 import { KeyCredential } from "@azure/core-auth";
@@ -147,19 +146,7 @@ export class SearchClient<T> {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("none"));
     }
 
-    // The contract with the generated client requires a credential, even though it is never used
-    // when a pipeline is provided. Until that contract can be changed, this dummy credential will
-    // throw an error if the client ever attempts to use it.
-    const dummyCredential: ServiceClientCredentials = {
-      signRequest() {
-        throw new Error(
-          "Internal error: Attempted to use credential from service client, but a pipeline was provided."
-        );
-      }
-    };
-
     this.client = new GeneratedClient(
-      dummyCredential,
       this.apiVersion,
       this.endpoint,
       this.indexName,

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -8,8 +8,7 @@ import {
   createPipelineFromOptions,
   InternalPipelineOptions,
   operationOptionsToRequestOptionsBase,
-  PipelineOptions,
-  ServiceClientCredentials
+  PipelineOptions
 } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/api";
 import { SDK_VERSION } from "./constants";
@@ -129,17 +128,6 @@ export class SearchIndexClient {
       }
     };
 
-    // The contract with the generated client requires a credential, even though it is never used
-    // when a pipeline is provided. Until that contract can be changed, this dummy credential will
-    // throw an error if the client ever attempts to use it.
-    const dummyCredential: ServiceClientCredentials = {
-      signRequest() {
-        throw new Error(
-          "Internal error: Attempted to use credential from service client, but a pipeline was provided."
-        );
-      }
-    };
-
     const pipeline = createPipelineFromOptions(
       internalPipelineOptions,
       createSearchApiKeyCredentialPolicy(credential)
@@ -149,7 +137,7 @@ export class SearchIndexClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    this.client = new GeneratedClient(dummyCredential, this.apiVersion, this.endpoint, pipeline);
+    this.client = new GeneratedClient(this.apiVersion, this.endpoint, pipeline);
   }
 
   private async *listIndexesPage(

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -6,8 +6,7 @@ import {
   createPipelineFromOptions,
   InternalPipelineOptions,
   operationOptionsToRequestOptionsBase,
-  PipelineOptions,
-  ServiceClientCredentials
+  PipelineOptions
 } from "@azure/core-http";
 import { CanonicalCode } from "@opentelemetry/api";
 import { SDK_VERSION } from "./constants";
@@ -119,17 +118,6 @@ export class SearchIndexerClient {
       }
     };
 
-    // The contract with the generated client requires a credential, even though it is never used
-    // when a pipeline is provided. Until that contract can be changed, this dummy credential will
-    // throw an error if the client ever attempts to use it.
-    const dummyCredential: ServiceClientCredentials = {
-      signRequest() {
-        throw new Error(
-          "Internal error: Attempted to use credential from service client, but a pipeline was provided."
-        );
-      }
-    };
-
     const pipeline = createPipelineFromOptions(
       internalPipelineOptions,
       createSearchApiKeyCredentialPolicy(credential)
@@ -139,7 +127,7 @@ export class SearchIndexerClient {
       pipeline.requestPolicyFactories.unshift(odataMetadataPolicy("minimal"));
     }
 
-    this.client = new GeneratedClient(dummyCredential, this.apiVersion, this.endpoint, pipeline);
+    this.client = new GeneratedClient(this.apiVersion, this.endpoint, pipeline);
   }
 
   /**

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -11,7 +11,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/data
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/search/data-plane/Azure.Search/preview/2019-05-06-preview/searchindex.json
-add-credentials: true
+add-credentials: false
 title: SearchClient
 use-extension:
   "@microsoft.azure/autorest.typescript": "5.0.1"

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -11,7 +11,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/service
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/search/data-plane/Azure.Search/preview/2019-05-06-preview/searchservice.json
-add-credentials: true
+add-credentials: false
 use-extension:
   "@microsoft.azure/autorest.typescript": "5.0.1"
 ```

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClient.ts
@@ -19,11 +19,10 @@ class GeneratedClient extends GeneratedClientContext {
    * Initializes a new instance of the GeneratedClient class.
    * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
    * https://westus.api.cognitive.microsoft.com).
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials, endpoint: string, options?: coreHttp.ServiceClientOptions) {
-    super(credentials, endpoint, options);
+  constructor(endpoint: string, options?: coreHttp.ServiceClientOptions) {
+    super(endpoint, options);
   }
 
   /**

--- a/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/generated/generatedClientContext.ts
@@ -15,25 +15,16 @@ const packageVersion = "1.0.0";
 
 export class GeneratedClientContext extends coreHttp.ServiceClient {
   endpoint: string;
-  credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials;
 
   /**
    * Initializes a new instance of the GeneratedClientContext class.
    * @param endpoint Supported Cognitive Services endpoints (protocol and hostname, for example:
    * https://westus.api.cognitive.microsoft.com).
-   * @param credentials Subscription credentials which uniquely identify client subscription.
    * @param [options] The parameter options
    */
-  constructor(
-    credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    endpoint: string,
-    options?: coreHttp.ServiceClientOptions
-  ) {
+  constructor(endpoint: string, options?: coreHttp.ServiceClientOptions) {
     if (endpoint == undefined) {
       throw new Error("'endpoint' cannot be null.");
-    }
-    if (credentials == undefined) {
-      throw new Error("'credentials' cannot be null.");
     }
 
     if (!options) {
@@ -45,11 +36,10 @@ export class GeneratedClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    super(credentials, options);
+    super(undefined, options);
 
     this.baseUri = "{Endpoint}/text/analytics/v3.0";
     this.requestContentType = "application/json; charset=utf-8";
     this.endpoint = endpoint;
-    this.credentials = credentials;
   }
 }

--- a/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
+++ b/sdk/textanalytics/ai-text-analytics/src/textAnalyticsClient.ts
@@ -8,8 +8,7 @@ import {
   isTokenCredential,
   bearerTokenAuthenticationPolicy,
   operationOptionsToRequestOptionsBase,
-  OperationOptions,
-  ServiceClientCredentials
+  OperationOptions
 } from "@azure/core-http";
 import { TokenCredential, KeyCredential } from "@azure/core-auth";
 import { SDK_VERSION } from "./constants";
@@ -177,18 +176,7 @@ export class TextAnalyticsClient {
 
     const pipeline = createPipelineFromOptions(internalPipelineOptions, authPolicy);
 
-    // The contract with the generated client requires a credential, even though it is never used
-    // when a pipeline is provided. Until that contract can be changed, this dummy credential will
-    // throw an error if the client ever attempts to use it.
-    const dummyCredential: ServiceClientCredentials = {
-      signRequest() {
-        throw new Error(
-          "Internal error: Attempted to use credential from service client, but a pipeline was provided."
-        );
-      }
-    };
-
-    this.client = new GeneratedClient(dummyCredential, this.endpointUrl, pipeline);
+    this.client = new GeneratedClient(this.endpointUrl, pipeline);
   }
 
   /**

--- a/sdk/textanalytics/ai-text-analytics/swagger/README.md
+++ b/sdk/textanalytics/ai-text-analytics/swagger/README.md
@@ -13,7 +13,7 @@ license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated
 input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/cognitiveservices/data-plane/TextAnalytics/stable/v3.0/TextAnalytics.json
-add-credentials: true
+add-credentials: false
 use-extension:
   "@microsoft.azure/autorest.typescript": "5.0.1"
 ```


### PR DESCRIPTION
Set add-credentials: false in swagger readme so that the generated clients' constructor don't take credentials as the first parameter, thus we don't have to pass the credential when it is already included as a request policy factory method in the created pipeline.

Packages impacted:
- Form Recognizer
- Key Vault (Certificates, Keys, and Secrets)
- Search Documents
- Text Analytics
