### PR TITLE
[Key Vault Secrets] keyId should be populated, as a string

### DIFF
--- a/sdk/keyvault/keyvault-secrets/CHANGELOG.md
+++ b/sdk/keyvault/keyvault-secrets/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed [bug 8378](https://github.com/Azure/azure-sdk-for-js/issues/8378), which caused the challenge based authentication to re-authenticate on every new request.
 - Fixed [bug 9005](https://github.com/Azure/azure-sdk-for-js/issues/9005), which caused parallel requests to throw if one of them needed to authenticate.
+- Fixed a bug in which the `keyId` was missing on the secret properties.
+- Removed the dependency of the TypeScript types for the `dom`.
 
 ## 4.0.3 (2020-05-13)
 

--- a/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
+++ b/sdk/keyvault/keyvault-secrets/review/keyvault-secrets.api.md
@@ -123,7 +123,7 @@ export interface SecretProperties {
     enabled?: boolean;
     readonly expiresOn?: Date;
     id?: string;
-    readonly keyId?: URL;
+    readonly keyId?: string;
     readonly managed?: boolean;
     name: string;
     readonly notBefore?: Date;

--- a/sdk/keyvault/keyvault-secrets/src/index.ts
+++ b/sdk/keyvault/keyvault-secrets/src/index.ts
@@ -958,6 +958,7 @@ export class SecretClient {
         expiresOn: (attributes as any).expires,
         createdOn: (attributes as any).created,
         updatedOn: (attributes as any).updated,
+        keyId: secretBundle.kid,
         ...secretBundle,
         ...parsedId,
         ...attributes

--- a/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
+++ b/sdk/keyvault/keyvault-secrets/src/secretsModels.ts
@@ -113,7 +113,7 @@ export interface SecretProperties {
    * **NOTE: This property will not be serialized. It can only be populated by
    * the server.**
    */
-  readonly keyId?: URL;
+  readonly keyId?: string;
   /**
    * True if the secret's lifetime is managed by
    * key vault. If this is a secret backing a certificate, then managed will be

--- a/sdk/keyvault/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": ["dom"],
+    "lib": [],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "../keyvault-common/node_modules", "./samples/**/*.ts"],

--- a/sdk/keyvault/keyvault-secrets/tsconfig.json
+++ b/sdk/keyvault/keyvault-secrets/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "declarationDir": "./types",
     "outDir": "./dist-esm",
-    "lib": [],
     "resolveJsonModule": true
   },
   "exclude": ["node_modules", "../keyvault-common/node_modules", "./samples/**/*.ts"],


### PR DESCRIPTION
Just like how we're doing in certificates: https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/keyvault/keyvault-certificates/src/index.ts#L2130

This is a bug fix, really.