### PR TITLE
Code changes to nest user defined fields into a document property

### DIFF
--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -984,7 +984,7 @@ export interface ScoringProfile {
 export class SearchClient<T> {
     constructor(endpoint: string, indexName: string, credential: KeyCredential, options?: SearchClientOptions);
     readonly apiVersion: string;
-    autocomplete<Fields extends keyof T>(searchText: string, suggesterName: string, options: AutocompleteOptions<Fields>): Promise<AutocompleteResult>;
+    autocomplete<Fields extends keyof T>(searchText: string, suggesterName: string, options?: AutocompleteOptions<Fields>): Promise<AutocompleteResult>;
     deleteDocuments(documents: T[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
     deleteDocuments(keyName: keyof T, keyValues: string[], options?: DeleteDocumentsOptions): Promise<IndexDocumentsResult>;
     readonly endpoint: string;
@@ -995,7 +995,7 @@ export class SearchClient<T> {
     mergeDocuments(documents: T[], options?: MergeDocumentsOptions): Promise<IndexDocumentsResult>;
     mergeOrUploadDocuments(documents: T[], options?: MergeOrUploadDocumentsOptions): Promise<IndexDocumentsResult>;
     search<Fields extends keyof T>(searchText?: string, options?: SearchOptions<Fields>): Promise<SearchDocumentsResult<Pick<T, Fields>>>;
-    suggest<Fields extends keyof T = never>(searchText: string, suggesterName: string, options: SuggestOptions<Fields>): Promise<SuggestDocumentsResult<Pick<T, Fields>>>;
+    suggest<Fields extends keyof T = never>(searchText: string, suggesterName: string, options?: SuggestOptions<Fields>): Promise<SuggestDocumentsResult<Pick<T, Fields>>>;
     uploadDocuments(documents: T[], options?: UploadDocumentsOptions): Promise<IndexDocumentsResult>;
 }
 
@@ -1255,7 +1255,8 @@ export type SearchResult<T> = {
     readonly highlights?: {
         [propertyName: string]: string[];
     };
-} & T;
+    document: T;
+};
 
 // @public
 export interface SearchServiceStatistics {
@@ -1443,7 +1444,8 @@ export interface SuggestRequest<Fields> {
 // @public
 export type SuggestResult<T> = {
     readonly text: string;
-} & T;
+    document: T;
+};
 
 // @public
 export interface SynonymMap {

--- a/sdk/search/search-documents/src/generated/data/models/index.ts
+++ b/sdk/search/search-documents/src/generated/data/models/index.ts
@@ -17,7 +17,7 @@ export interface SuggestResult {
    * The text of the suggestion result.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly text: string;
+  readonly _text: string;
   /**
    * Describes unknown properties. The value of an unknown property can be of "any" type.
    */
@@ -166,13 +166,13 @@ export interface SearchResult {
    * The relevance score of the document compared to other documents returned by the query.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly score: number;
+  readonly _score: number;
   /**
    * Text fragments from the document that indicate the matching search terms, organized by each
    * applicable field; null if hit highlighting was not enabled for the query.
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
-  readonly highlights?: { [propertyName: string]: string[] };
+  readonly _highlights?: { [propertyName: string]: string[] };
   /**
    * Describes unknown properties. The value of an unknown property can be of "any" type.
    */

--- a/sdk/search/search-documents/src/generated/data/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/data/models/mappers.ts
@@ -15,7 +15,7 @@ export const SuggestResult: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "SuggestResult",
     modelProperties: {
-      text: {
+      _text: {
         required: true,
         readOnly: true,
         serializedName: "@search\\.text",
@@ -226,7 +226,7 @@ export const SearchResult: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "SearchResult",
     modelProperties: {
-      score: {
+      _score: {
         required: true,
         nullable: false,
         readOnly: true,
@@ -235,7 +235,7 @@ export const SearchResult: coreHttp.CompositeMapper = {
           name: "Number"
         }
       },
-      highlights: {
+      _highlights: {
         readOnly: true,
         serializedName: "@search\\.highlights",
         type: {

--- a/sdk/search/search-documents/src/indexModels.ts
+++ b/sdk/search/search-documents/src/indexModels.ts
@@ -7,8 +7,7 @@ import {
   SearchMode,
   FacetResult,
   AutocompleteMode,
-  IndexActionType,
-  SearchDocumentsResult as GeneratedSearchResult
+  IndexActionType
 } from "./generated/data/models";
 import { PagedAsyncIterableIterator } from "@azure/core-paging";
 
@@ -92,20 +91,6 @@ export type SearchIterator<Fields> = PagedAsyncIterableIterator<
   SearchDocumentsPageResult<Fields>,
   ListSearchResultsPageSettings
 >;
-
-/**
- * An intermediate type for encoding the continuation token.
- */
-export type ContinuableSearchResult = Omit<
-  GeneratedSearchResult,
-  "nextPageParameters" | "nextLink"
-> & {
-  /**
-   * A token used for retrieving the next page of results when the server
-   * enforces pagination.
-   */
-  continuationToken?: string;
-};
 
 // BEGIN manually modified generated interfaces
 //
@@ -326,7 +311,9 @@ export type SearchResult<T> = {
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly highlights?: { [propertyName: string]: string[] };
-} & T;
+
+  document: T;
+};
 
 /**
  * Response containing search results from an index.
@@ -449,7 +436,8 @@ export type SuggestResult<T> = {
    * **NOTE: This property will not be serialized. It can only be populated by the server.**
    */
   readonly text: string;
-} & T;
+  document: T;
+};
 
 /**
  * Response containing suggestion query results from an index.

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -48,6 +48,11 @@ import {
   SimilarityAlgorithm,
   SearchResourceEncryptionKey
 } from "./serviceModels";
+import { SuggestDocumentsResult, SuggestResult, SearchResult } from "./indexModels";
+import {
+  SuggestDocumentsResult as GeneratedSuggestDocumentsResult,
+  SearchResult as GeneratedSearchResult
+} from "./generated/data/models";
 
 export function convertSkillsToPublic(skills: SearchIndexerSkillUnion[]): SearchIndexerSkill[] {
   if (!skills) {
@@ -363,6 +368,54 @@ export function generatedIndexToPublicIndex(generatedIndex: GeneratedSearchIndex
     fields: convertFieldsToPublic(generatedIndex.fields),
     similarity: convertSimilarityToPublic(generatedIndex.similarity)
   };
+}
+
+export function generatedSearchResultToPublicSearchResult<T>(results: GeneratedSearchResult[]) {
+  const returnValues: SearchResult<T>[] = [];
+  results.forEach((result) => {
+    const { _score, _highlights, ...restProps } = result;
+    const obj = {
+      score: _score,
+      highlights: _highlights,
+      document: {}
+    };
+
+    const doc: { [key: string]: any } = {
+      ...restProps
+    };
+
+    obj.document = doc;
+
+    returnValues.push(obj as SearchResult<T>);
+  });
+  return returnValues;
+}
+
+export function generatedSuggestDocumentsResultToPublicSuggestDocumentsResult<T>(
+  searchDocumentsResult: GeneratedSuggestDocumentsResult
+): SuggestDocumentsResult<T> {
+  const result: SuggestDocumentsResult<T> = {
+    results: [],
+    coverage: searchDocumentsResult.coverage
+  };
+
+  searchDocumentsResult.results.forEach((element) => {
+    const { _text, ...restProps } = element;
+
+    const obj = {
+      text: _text,
+      document: {}
+    };
+
+    const doc: { [key: string]: any } = {
+      ...restProps
+    };
+
+    obj.document = doc;
+    result.results.push(obj as SuggestResult<T>);
+  });
+
+  return result;
 }
 
 export function publicIndexToGeneratedIndex(index: SearchIndex): GeneratedSearchIndex {

--- a/sdk/search/search-documents/src/serviceUtils.ts
+++ b/sdk/search/search-documents/src/serviceUtils.ts
@@ -371,22 +371,17 @@ export function generatedIndexToPublicIndex(generatedIndex: GeneratedSearchIndex
 }
 
 export function generatedSearchResultToPublicSearchResult<T>(results: GeneratedSearchResult[]) {
-  const returnValues: SearchResult<T>[] = [];
-  results.forEach((result) => {
+  const returnValues: SearchResult<T>[] = results.map<SearchResult<T>>((result) => {
     const { _score, _highlights, ...restProps } = result;
-    const obj = {
-      score: _score,
-      highlights: _highlights,
-      document: {}
-    };
-
     const doc: { [key: string]: any } = {
       ...restProps
     };
-
-    obj.document = doc;
-
-    returnValues.push(obj as SearchResult<T>);
+    const obj = {
+      score: _score,
+      highlights: _highlights,
+      document: doc
+    };
+    return obj as SearchResult<T>;
   });
   return returnValues;
 }
@@ -394,26 +389,25 @@ export function generatedSearchResultToPublicSearchResult<T>(results: GeneratedS
 export function generatedSuggestDocumentsResultToPublicSuggestDocumentsResult<T>(
   searchDocumentsResult: GeneratedSuggestDocumentsResult
 ): SuggestDocumentsResult<T> {
-  const result: SuggestDocumentsResult<T> = {
-    results: [],
-    coverage: searchDocumentsResult.coverage
-  };
-
-  searchDocumentsResult.results.forEach((element) => {
+  const results = searchDocumentsResult.results.map<SuggestResult<T>>((element) => {
     const { _text, ...restProps } = element;
-
-    const obj = {
-      text: _text,
-      document: {}
-    };
 
     const doc: { [key: string]: any } = {
       ...restProps
     };
 
-    obj.document = doc;
-    result.results.push(obj as SuggestResult<T>);
+    const obj = {
+      text: _text,
+      document: doc
+    };
+
+    return obj as SuggestResult<T>;
   });
+
+  const result: SuggestDocumentsResult<T> = {
+    results: results,
+    coverage: searchDocumentsResult.coverage
+  };
 
   return result;
 }

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -58,3 +58,25 @@ directive:
       $.properties['@search.action']['x-ms-client-name'] = '__actionType';
       $.required = ['@search.action'];
 ```
+
+
+### Change text to _text in SuggestResult
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.SuggestResult.properties['@search.text']
+    transform: >
+      $['x-ms-client-name'] = '_text'
+```
+
+### Change score to _score & highlights to _highlights in SuggestResult
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.SearchResult
+    transform: >
+      $.properties['@search.score']['x-ms-client-name'] = '_score';
+      $.properties['@search.highlights']['x-ms-client-name'] = '_highlights';
+```


### PR DESCRIPTION
This PR contains code changes for 2 issues:

1. Code changes to nest user defined fields into a document property
2. Mark options field with default empty object for suggest & autocomplete APIs

Tested with samples end to end and confirmed the code changes are working fine. 

@xirzec Please review and approve

@ramya-rao-a FYI.....