### PR TITLE
[Service Bus] Add isServiceBusMessage checks to all methods that take messages

### DIFF
--- a/sdk/servicebus/service-bus/src/sender.ts
+++ b/sdk/servicebus/service-bus/src/sender.ts
@@ -176,11 +176,17 @@ export class SenderImpl implements Sender {
     options?: OperationOptions
   ): Promise<void> {
     this._throwIfSenderOrConnectionClosed();
+    throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "messages", messages);
+    const invalidTypeErrMsg =
+      "Provided value for 'messages' must be of type ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage.";
 
     if (Array.isArray(messages)) {
       const batch = await this.createBatch(options);
 
       for (const message of messages) {
+        if (!isServiceBusMessage(message)) {
+          throw new TypeError(invalidTypeErrMsg);
+        }
         if (!batch.tryAdd(message)) {
           // this is too big - throw an error
           const error = new MessagingError(
@@ -196,11 +202,8 @@ export class SenderImpl implements Sender {
       return this._sender.sendBatch(messages, options);
     } else if (isServiceBusMessage(messages)) {
       return this._sender.send(messages, options);
-    } else {
-      throw new TypeError(
-        "Invalid type for message. Must be a ServiceBusMessage, an array of ServiceBusMessage or a ServiceBusMessageBatch"
-      );
     }
+    throw new TypeError(invalidTypeErrMsg);
   }
 
   async createBatch(options?: CreateBatchOptions): Promise<ServiceBusMessageBatch> {
@@ -221,6 +224,14 @@ export class SenderImpl implements Sender {
     );
     throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "messages", messages);
     const messagesToSchedule = Array.isArray(messages) ? messages : [messages];
+
+    for (const message of messagesToSchedule) {
+      if (!isServiceBusMessage(message)) {
+        throw new TypeError(
+          "Provided value for 'messages' must be of type ServiceBusMessage or an array of type ServiceBusMessage."
+        );
+      }
+    }
 
     const scheduleMessageOperationPromise = async () => {
       return this._context.managementClient!.scheduleMessages(

--- a/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
+++ b/sdk/servicebus/service-bus/src/serviceBusMessageBatch.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { ServiceBusMessage, toAmqpMessage } from "./serviceBusMessage";
+import { ServiceBusMessage, toAmqpMessage, isServiceBusMessage } from "./serviceBusMessage";
 import { throwTypeErrorIfParameterMissing } from "./util/errors";
 import { ClientEntityContext } from "./clientEntityContext";
 import {
@@ -215,7 +215,10 @@ export class ServiceBusMessageBatchImpl implements ServiceBusMessageBatch {
    * @returns A boolean value indicating if the message has been added to the batch or not.
    */
   public tryAdd(message: ServiceBusMessage): boolean {
-    throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "tryAdd", "message");
+    throwTypeErrorIfParameterMissing(this._context.namespace.connectionId, "message", message);
+    if (!isServiceBusMessage(message)) {
+      throw new TypeError("Provided value for 'message' must be of type ServiceBusMessage.");
+    }
 
     // Convert ServiceBusMessage to AmqpMessage.
     const amqpMessage = toAmqpMessage(message);

--- a/sdk/servicebus/service-bus/test/internal/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/sender.spec.ts
@@ -9,7 +9,7 @@ import { isServiceBusMessageBatch, SenderImpl } from "../../src/sender";
 import { DefaultDataTransformer } from "@azure/core-amqp";
 const assert = chai.assert;
 
-describe.only("sender unit tests", () => {
+describe("sender unit tests", () => {
   it("isServiceBusMessageBatch", () => {
     assert.isTrue(
       isServiceBusMessageBatch(new ServiceBusMessageBatchImpl({} as ClientEntityContext, 100))
@@ -23,7 +23,8 @@ describe.only("sender unit tests", () => {
   ["hello", {}, 123, null, undefined, ["hello"]].forEach((invalidValue) => {
     it(`don't allow Sender.sendMessages(${invalidValue})`, async () => {
       const sender = new SenderImpl(createClientEntityContextForTests());
-      let expectedErrorMsg = "Provided value for 'messages' must be of type ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage.";
+      let expectedErrorMsg =
+        "Provided value for 'messages' must be of type ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage.";
       if (invalidValue === null || invalidValue === undefined) {
         expectedErrorMsg = `Missing parameter "messages"`;
       }
@@ -34,10 +35,7 @@ describe.only("sender unit tests", () => {
         );
       } catch (err) {
         assert.equal(err.name, "TypeError");
-        assert.equal(
-          err.message,
-          expectedErrorMsg
-        );
+        assert.equal(err.message, expectedErrorMsg);
       }
     });
   });
@@ -57,10 +55,7 @@ describe.only("sender unit tests", () => {
         );
       } catch (err) {
         assert.equal(err.name, "TypeError");
-        assert.equal(
-          err.message,
-          expectedErrorMsg
-        );
+        assert.equal(err.message, expectedErrorMsg);
       }
     });
   });
@@ -68,7 +63,8 @@ describe.only("sender unit tests", () => {
   ["hello", {}, null, undefined, ["hello"]].forEach((invalidValue) => {
     it(`don't allow Sender.scheduleMessages(${invalidValue})`, async () => {
       const sender = new SenderImpl(createClientEntityContextForTests());
-      let expectedErrorMsg = "Provided value for 'messages' must be of type ServiceBusMessage or an array of type ServiceBusMessage.";
+      let expectedErrorMsg =
+        "Provided value for 'messages' must be of type ServiceBusMessage or an array of type ServiceBusMessage.";
       if (invalidValue === null || invalidValue === undefined) {
         expectedErrorMsg = `Missing parameter "messages"`;
       }
@@ -81,10 +77,7 @@ describe.only("sender unit tests", () => {
         );
       } catch (err) {
         assert.equal(err.name, "TypeError");
-        assert.equal(
-          err.message,
-          expectedErrorMsg
-        );
+        assert.equal(err.message, expectedErrorMsg);
       }
     });
   });
@@ -98,7 +91,7 @@ function createClientEntityContextForTests(): ClientEntityContext & { initWasCal
     sender: {
       credit: 999,
       createBatch: () => {
-        return new ServiceBusMessageBatchImpl(fakeClientEntityContext as any, 100)
+        return new ServiceBusMessageBatchImpl(fakeClientEntityContext as any, 100);
       }
     },
     namespace: {

--- a/sdk/servicebus/service-bus/test/internal/sender.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/sender.spec.ts
@@ -9,7 +9,7 @@ import { isServiceBusMessageBatch, SenderImpl } from "../../src/sender";
 import { DefaultDataTransformer } from "@azure/core-amqp";
 const assert = chai.assert;
 
-describe("sender unit tests", () => {
+describe.only("sender unit tests", () => {
   it("isServiceBusMessageBatch", () => {
     assert.isTrue(
       isServiceBusMessageBatch(new ServiceBusMessageBatchImpl({} as ClientEntityContext, 100))
@@ -20,10 +20,13 @@ describe("sender unit tests", () => {
     assert.isFalse(isServiceBusMessageBatch(({} as any) as ServiceBusMessage));
   });
 
-  ["hello", {}, null, undefined].forEach((invalidValue) => {
-    it(`don't allow Sender.send(${invalidValue})`, async () => {
+  ["hello", {}, 123, null, undefined, ["hello"]].forEach((invalidValue) => {
+    it(`don't allow Sender.sendMessages(${invalidValue})`, async () => {
       const sender = new SenderImpl(createClientEntityContextForTests());
-
+      let expectedErrorMsg = "Provided value for 'messages' must be of type ServiceBusMessage, ServiceBusMessageBatch or an array of type ServiceBusMessage.";
+      if (invalidValue === null || invalidValue === undefined) {
+        expectedErrorMsg = `Missing parameter "messages"`;
+      }
       try {
         await sender.sendMessages(
           // @ts-expect-error
@@ -33,7 +36,54 @@ describe("sender unit tests", () => {
         assert.equal(err.name, "TypeError");
         assert.equal(
           err.message,
-          "Invalid type for message. Must be a ServiceBusMessage, an array of ServiceBusMessage or a ServiceBusMessageBatch"
+          expectedErrorMsg
+        );
+      }
+    });
+  });
+
+  ["hello", {}, null, undefined].forEach((invalidValue) => {
+    it(`don't allow tryAdd(${invalidValue})`, async () => {
+      const sender = new SenderImpl(createClientEntityContextForTests());
+      const batch = await sender.createBatch();
+      let expectedErrorMsg = "Provided value for 'message' must be of type ServiceBusMessage.";
+      if (invalidValue === null || invalidValue === undefined) {
+        expectedErrorMsg = `Missing parameter "message"`;
+      }
+      try {
+        batch.tryAdd(
+          // @ts-expect-error
+          invalidValue
+        );
+      } catch (err) {
+        assert.equal(err.name, "TypeError");
+        assert.equal(
+          err.message,
+          expectedErrorMsg
+        );
+      }
+    });
+  });
+
+  ["hello", {}, null, undefined, ["hello"]].forEach((invalidValue) => {
+    it(`don't allow Sender.scheduleMessages(${invalidValue})`, async () => {
+      const sender = new SenderImpl(createClientEntityContextForTests());
+      let expectedErrorMsg = "Provided value for 'messages' must be of type ServiceBusMessage or an array of type ServiceBusMessage.";
+      if (invalidValue === null || invalidValue === undefined) {
+        expectedErrorMsg = `Missing parameter "messages"`;
+      }
+
+      try {
+        await sender.scheduleMessages(
+          new Date(),
+          // @ts-expect-error
+          invalidValue
+        );
+      } catch (err) {
+        assert.equal(err.name, "TypeError");
+        assert.equal(
+          err.message,
+          expectedErrorMsg
         );
       }
     });
@@ -46,7 +96,10 @@ function createClientEntityContextForTests(): ClientEntityContext & { initWasCal
   const fakeClientEntityContext = {
     entityPath: "queue",
     sender: {
-      credit: 999
+      credit: 999,
+      createBatch: () => {
+        return new ServiceBusMessageBatchImpl(fakeClientEntityContext as any, 100)
+      }
     },
     namespace: {
       config: { endpoint: "my.service.bus" },


### PR DESCRIPTION
This PR ensures we have input validation in all apis that take messages as input.
Resolves #9487

