### PR TITLE
Regeneration and Other changes

### DIFF
--- a/.scripts/readme.ts
+++ b/.scripts/readme.ts
@@ -102,7 +102,7 @@ export async function getSinglePackageName(typescriptReadmePath: string): Promis
     const readmeBuffer: Buffer = await fs.readFile(typescriptReadmePath);
     const yamlSectionBuffer = await getYamlSection(readmeBuffer, "``` yaml $(typescript)", "```");
     const yamlSectionText = yamlSectionBuffer.toString();
-    const yamlSection = yaml.safeLoad(yamlSectionText);
+    const yamlSection:any = yaml.safeLoad(yamlSectionText);
     return yamlSection["typescript"]["package-name"];
 }
 

--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release History
 
-## 1.0.0-preview.5 (Unreleased)
+## 11.0.0 (2020-07-06)
+- Set `ConnectionString` value to `<unchanged>` in `SearchIndexerDataSourceConnection`, if the value is not set by the user. 
+- [Breaking] In Suggest API & Search API return values, a new property called `document` is introduced. All user-defined fields are moved inside this `document` property.
+- [Breaking] In `analyzeText` API, the `text` parameter is moved from method level to inside `options` bag.
+- [Breaking] In `search` API, `includeTotalResultCount` property is renamed to `includeTotalCount`.
+- [Breaking] Modified the names of several properties. Please refer [#9321](https://github.com/Azure/azure-sdk-for-js/issues/9321) for a detailed list of renames.
 
 
 ## 1.0.0-preview.4 (2020-06-08)

--- a/sdk/search/search-documents/README.md
+++ b/sdk/search/search-documents/README.md
@@ -279,7 +279,7 @@ async function main() {
 main();
 ```
 
-For a more advanced search that uses [Lucene syntax](https://docs.microsoft.com/azure/search/query-lucene-syntax), specify `queryType` to be `all`:
+For a more advanced search that uses [Lucene syntax](https://docs.microsoft.com/azure/search/query-lucene-syntax), specify `queryType` to be `full`:
 
 ```js
 const { SearchClient, AzureKeyCredential } = require("@azure/search-documents");

--- a/sdk/search/search-documents/package.json
+++ b/sdk/search/search-documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/search-documents",
-  "version": "1.0.0-preview.5",
+  "version": "11.0.0",
   "description": "Azure client library to use Cognitive Search for node.js and browser.",
   "sdk-type": "client",
   "main": "dist/index.js",

--- a/sdk/search/search-documents/src/constants.ts
+++ b/sdk/search/search-documents/src/constants.ts
@@ -1,4 +1,4 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export const SDK_VERSION: string = "1.0.0-preview.5";
+export const SDK_VERSION: string = "11.0.0";

--- a/sdk/search/search-documents/src/generated/data/searchClientContext.ts
+++ b/sdk/search/search-documents/src/generated/data/searchClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "@azure/search-documents";
-const packageVersion = "1.0.0-preview.5";
+const packageVersion = "11.0.0";
 
 export class SearchClientContext extends coreHttp.ServiceClient {
   apiVersion: string;

--- a/sdk/search/search-documents/src/generated/service/models/parameters.ts
+++ b/sdk/search/search-documents/src/generated/service/models/parameters.ts
@@ -78,21 +78,21 @@ export const ifNoneMatch: coreHttp.OperationParameter = {
     }
   }
 };
-export const indexName: coreHttp.OperationURLParameter = {
-  parameterPath: "indexName",
-  mapper: {
-    required: true,
-    serializedName: "indexName",
-    type: {
-      name: "String"
-    }
-  }
-};
 export const indexerName: coreHttp.OperationURLParameter = {
   parameterPath: "indexerName",
   mapper: {
     required: true,
     serializedName: "indexerName",
+    type: {
+      name: "String"
+    }
+  }
+};
+export const indexName: coreHttp.OperationURLParameter = {
+  parameterPath: "indexName",
+  mapper: {
+    required: true,
+    serializedName: "indexName",
     type: {
       name: "String"
     }

--- a/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
+++ b/sdk/search/search-documents/src/generated/service/searchServiceClientContext.ts
@@ -11,7 +11,7 @@
 import * as coreHttp from "@azure/core-http";
 
 const packageName = "@azure/search-documents";
-const packageVersion = "1.0.0-preview.5";
+const packageVersion = "11.0.0";
 
 export class SearchServiceClientContext extends coreHttp.ServiceClient {
   apiVersion: string;

--- a/sdk/search/search-documents/src/searchClient.ts
+++ b/sdk/search/search-documents/src/searchClient.ts
@@ -66,7 +66,7 @@ export class SearchClient<T> {
   /**
    * The API version to use when communicating with the service.
    */
-  public readonly apiVersion: string = "2019-05-06-Preview";
+  public readonly apiVersion: string = "2020-06-30";
 
   /**
    * The endpoint of the search service

--- a/sdk/search/search-documents/src/searchIndexClient.ts
+++ b/sdk/search/search-documents/src/searchIndexClient.ts
@@ -57,7 +57,7 @@ export class SearchIndexClient {
   /**
    * The API version to use when communicating with the service.
    */
-  public readonly apiVersion: string = "2019-05-06-Preview";
+  public readonly apiVersion: string = "2020-06-30";
 
   /**
    * The endpoint of the search service

--- a/sdk/search/search-documents/src/searchIndexerClient.ts
+++ b/sdk/search/search-documents/src/searchIndexerClient.ts
@@ -55,7 +55,7 @@ export class SearchIndexerClient {
   /**
    * The API version to use when communicating with the service.
    */
-  public readonly apiVersion: string = "2019-05-06-Preview";
+  public readonly apiVersion: string = "2020-06-30";
 
   /**
    * The endpoint of the search service

--- a/sdk/search/search-documents/swagger/Data.md
+++ b/sdk/search/search-documents/swagger/Data.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/data
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/search/data-plane/Azure.Search/preview/2019-05-06-preview/searchindex.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/search/data-plane/Azure.Search/preview/2020-06-30/searchindex.json
 add-credentials: true
 title: SearchClient
 use-extension:

--- a/sdk/search/search-documents/swagger/Service.md
+++ b/sdk/search/search-documents/swagger/Service.md
@@ -10,7 +10,7 @@ generate-metadata: false
 license-header: MICROSOFT_MIT_NO_VERSION
 output-folder: ../
 source-code-folder-path: ./src/generated/service
-input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/search/data-plane/Azure.Search/preview/2019-05-06-preview/searchservice.json
+input-file: https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/specification/search/data-plane/Azure.Search/preview/2020-06-30/searchservice.json
 add-credentials: true
 use-extension:
   "@microsoft.azure/autorest.typescript": "5.0.1"


### PR DESCRIPTION
1. In the swagger configuration files (`Data.md`, `Service.md`) under the `swagger` file, changed the input files to point from `preview/2019-05-06-preview` to `preview/2020-06-30` folder. 

2. The regeneration of the SDK (as a result of the above change) does not produce any code changes. 

3. Modifed `apiVersion` property value in `searchClient.ts`, `searchIndexClient.ts` and `searchIndexerClient.ts` files from `2019-05-06-Preview` to `2020-06-30`. 

4. The next version (to be released) is supposed to be `1.0.0-preview.5`. But, now it has been decided that it is going to be `11.0.0` (https://github.com/Azure/azure-sdk-for-js/issues/9671). So, I have changed the version reference in `Changelog`, `package.json`, etc. 

5. Added release details in Changelog.

6. Minor Typo in Readme.

@xirzec Please review and approve

@ramya-rao-a FYI....