### PR TITLE
[Service Bus] More info in the doc strings for ISO-8601 duration format

### DIFF
--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -140,6 +140,8 @@ export interface QueueDescription {
    * for consumption by the next receiver. Settable only at queue creation time.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   lockDuration?: string;
 
@@ -172,6 +174,8 @@ export interface QueueDescription {
    * This value is immutable after the Queue has been created.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   defaultMessageTtl?: string;
 
@@ -187,6 +191,8 @@ export interface QueueDescription {
    * Specifies the time span during which the Service Bus detects message duplication.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   duplicateDetectionHistoryTimeWindow?: string;
 
@@ -230,6 +236,8 @@ export interface QueueDescription {
    * Max idle time before entity is deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   autoDeleteOnIdle?: string;
 
@@ -260,6 +268,8 @@ export interface InternalQueueOptions {
    * Settable only at queue creation time.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   LockDuration?: string;
 
@@ -291,6 +301,8 @@ export interface InternalQueueOptions {
    * This value is immutable after the Queue has been created.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DefaultMessageTimeToLive?: string;
 
@@ -306,6 +318,8 @@ export interface InternalQueueOptions {
    * Specifies the time span during which the Service Bus detects message duplication.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DuplicateDetectionHistoryTimeWindow?: string;
 
@@ -350,6 +364,8 @@ export interface InternalQueueOptions {
    * Max idle time before entity is deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   AutoDeleteOnIdle?: string;
 

--- a/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/queueResourceSerializer.ts
@@ -141,7 +141,7 @@ export interface QueueDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   lockDuration?: string;
 
@@ -175,7 +175,7 @@ export interface QueueDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   defaultMessageTtl?: string;
 
@@ -192,7 +192,7 @@ export interface QueueDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   duplicateDetectionHistoryTimeWindow?: string;
 
@@ -237,7 +237,7 @@ export interface QueueDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   autoDeleteOnIdle?: string;
 
@@ -269,7 +269,7 @@ export interface InternalQueueOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   LockDuration?: string;
 
@@ -302,7 +302,7 @@ export interface InternalQueueOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DefaultMessageTimeToLive?: string;
 
@@ -319,7 +319,7 @@ export interface InternalQueueOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DuplicateDetectionHistoryTimeWindow?: string;
 
@@ -365,7 +365,7 @@ export interface InternalQueueOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   AutoDeleteOnIdle?: string;
 

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -134,6 +134,8 @@ export interface SubscriptionDescription {
    * duration. Settable only at subscription creation time.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   lockDuration?: string;
 
@@ -150,6 +152,8 @@ export interface SubscriptionDescription {
    * to the subscription’s associated DeadLtterQueue or permanently deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   defaultMessageTtl?: string;
 
@@ -216,6 +220,8 @@ export interface SubscriptionDescription {
    * Max idle time before entity is deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   autoDeleteOnIdle?: string;
 }
@@ -231,6 +237,8 @@ export interface InternalSubscriptionOptions {
    * duration. Settable only at subscription creation time.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   LockDuration?: string;
 
@@ -247,6 +255,8 @@ export interface InternalSubscriptionOptions {
    * to the subscription’s associated DeadLtterQueue or permanently deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DefaultMessageTimeToLive?: string;
 
@@ -313,6 +323,8 @@ export interface InternalSubscriptionOptions {
    * Max idle time before entity is deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   AutoDeleteOnIdle?: string;
 }

--- a/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/subscriptionResourceSerializer.ts
@@ -135,7 +135,7 @@ export interface SubscriptionDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   lockDuration?: string;
 
@@ -153,7 +153,7 @@ export interface SubscriptionDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   defaultMessageTtl?: string;
 
@@ -221,7 +221,7 @@ export interface SubscriptionDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   autoDeleteOnIdle?: string;
 }
@@ -238,7 +238,7 @@ export interface InternalSubscriptionOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   LockDuration?: string;
 
@@ -256,7 +256,7 @@ export interface InternalSubscriptionOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DefaultMessageTimeToLive?: string;
 
@@ -324,7 +324,7 @@ export interface InternalSubscriptionOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   AutoDeleteOnIdle?: string;
 }

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -121,6 +121,8 @@ export interface TopicDescription {
    * sub-queue or will be permanently deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   defaultMessageTtl?: string;
 
@@ -145,6 +147,8 @@ export interface TopicDescription {
    * Specifies the time span during which the Service Bus will detect message duplication.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   duplicateDetectionHistoryTimeWindow?: string;
 
@@ -179,6 +183,8 @@ export interface TopicDescription {
    * Max idle time before entity is deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   autoDeleteOnIdle?: string;
 
@@ -202,6 +208,8 @@ export interface InternalTopicOptions {
    * permanently deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DefaultMessageTimeToLive?: string;
 
@@ -227,6 +235,8 @@ export interface InternalTopicOptions {
    * duplication.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DuplicateDetectionHistoryTimeWindow?: string;
 
@@ -261,6 +271,8 @@ export interface InternalTopicOptions {
    * Max idle time before entity is deleted.
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
+   *
+   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   AutoDeleteOnIdle?: string;
 

--- a/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
+++ b/sdk/servicebus/service-bus/src/serializers/topicResourceSerializer.ts
@@ -122,7 +122,7 @@ export interface TopicDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   defaultMessageTtl?: string;
 
@@ -148,7 +148,7 @@ export interface TopicDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   duplicateDetectionHistoryTimeWindow?: string;
 
@@ -184,7 +184,7 @@ export interface TopicDescription {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   autoDeleteOnIdle?: string;
 
@@ -209,7 +209,7 @@ export interface InternalTopicOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DefaultMessageTimeToLive?: string;
 
@@ -236,7 +236,7 @@ export interface InternalTopicOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   DuplicateDetectionHistoryTimeWindow?: string;
 
@@ -272,7 +272,7 @@ export interface InternalTopicOptions {
    * This is to be specified in ISO-8601 duration format
    * such as "PT1M" for 1 minute, "PT5S" for 5 seconds.
    *
-   * ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
+   * More on ISO-8601 duration format: https://en.wikipedia.org/wiki/ISO_8601#Durations
    */
   AutoDeleteOnIdle?: string;
 


### PR DESCRIPTION

Based on the discussion from https://github.com/Azure/azure-sdk-for-js/pull/9430#discussion_r440320811...

Adding the wiki link(https://en.wikipedia.org/wiki/ISO_8601#Durations) in the doc strings for all the attributes that rely on ISO-8601 duration format.
