### PR TITLE
Bug Fix: Create failing for partition key values with DEL character

### DIFF
--- a/sdk/cosmosdb/cosmos/src/common/helper.ts
+++ b/sdk/cosmosdb/cosmos/src/common/helper.ts
@@ -11,7 +11,7 @@ const illegalResourceIdCharacters = new RegExp("[/\\\\?#]");
 export function jsonStringifyAndEscapeNonASCII(arg: any) {
   // TODO: better way for this? Not sure.
   // escapes non-ASCII characters as \uXXXX
-  return JSON.stringify(arg).replace(/[\u0080-\uFFFF]/g, (m) => {
+  return JSON.stringify(arg).replace(/[\u007F-\uFFFF]/g, (m) => {
     return "\\u" + ("0000" + m.charCodeAt(0).toString(16)).slice(-4);
   });
 }


### PR DESCRIPTION
\u007F (DEL) also needs to be escaped. Our backend cannot accept that character in a header.