### PR TITLE
Generate id before extracting partition key

### DIFF
--- a/sdk/cosmosdb/cosmos/CHANGELOG.md
+++ b/sdk/cosmosdb/cosmos/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Release History
 
-## 3.7.3 (Unreleased)
+## 3.7.3 (2020-6-29)
 
+- BUGFIX: Cannot create item with automatic id generation and a container partitioned on ID (#9734)
 
-## 3.7.2 (Unreleased)
+## 3.7.2 (2020-6-16)
 
 - BUGFIX: Internal abort signal incorrectly triggered when user passes a custom abort signal. See #9510 for details.
 
@@ -206,14 +207,14 @@ Constructor options have been simplified:
 const client = new CosmosClient({
   endpoint: "https://your-database.cosmos.azure.com",
   auth: {
-    masterKey: "your-primary-key",
-  },
+    masterKey: "your-primary-key"
+  }
 });
 
 // v3
 const client = new CosmosClient({
   endpoint: "https://your-database.cosmos.azure.com",
-  key: "your-primary-key",
+  key: "your-primary-key"
 });
 ```
 

--- a/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
+++ b/sdk/cosmosdb/cosmos/src/client/Item/Items.ts
@@ -39,7 +39,7 @@ export class Items {
   constructor(
     public readonly container: Container,
     private readonly clientContext: ClientContext
-  ) {}
+  ) { }
 
   /**
    * Queries all items.
@@ -264,14 +264,14 @@ export class Items {
     body: T,
     options: RequestOptions = {}
   ): Promise<ItemResponse<T>> {
-    const { resource: partitionKeyDefinition } = await this.container.readPartitionKeyDefinition();
-    const partitionKey = extractPartitionKey(body, partitionKeyDefinition);
-
     // Generate random document id if the id is missing in the payload and
     // options.disableAutomaticIdGeneration != true
     if ((body.id === undefined || body.id === "") && !options.disableAutomaticIdGeneration) {
       body.id = uuid();
     }
+
+    const { resource: partitionKeyDefinition } = await this.container.readPartitionKeyDefinition();
+    const partitionKey = extractPartitionKey(body, partitionKeyDefinition);
 
     const err = {};
     if (!isResourceValid(body, err)) {

--- a/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
@@ -12,7 +12,8 @@ import {
   createOrUpsertItem,
   getTestDatabase,
   removeAllDatabases,
-  replaceOrUpsertItem
+  replaceOrUpsertItem,
+  getTestContainer
 } from "../common/TestHelpers";
 
 /**
@@ -210,5 +211,12 @@ describe("Item CRUD", function() {
     );
 
     await bulkDeleteItems(container, returnedDocuments, partitionKey);
+  });
+
+  it("Should auto generate an ID for a colleciton partitioned on id", async function() {
+    // https://github.com/Azure/azure-sdk-for-js/issues/9734
+    const container = await getTestContainer("db1", undefined, { partitionKey: "/id" });
+    const { resource } = await container.items.create({});
+    assert.ok(resource.id);
   });
 });

--- a/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
+++ b/sdk/cosmosdb/cosmos/test/functional/item.spec.ts
@@ -213,7 +213,7 @@ describe("Item CRUD", function() {
     await bulkDeleteItems(container, returnedDocuments, partitionKey);
   });
 
-  it("Should auto generate an ID for a colleciton partitioned on id", async function() {
+  it("Should auto generate an id for a collection partitioned on id", async function() {
     // https://github.com/Azure/azure-sdk-for-js/issues/9734
     const container = await getTestContainer("db1", undefined, { partitionKey: "/id" });
     const { resource } = await container.items.create({});


### PR DESCRIPTION
Fix #9734

When the parition key is the 'id' field, it must be generated before being extracted.