### PR TITLE
[core-amqp] ensure error stack traces only logged in verbose mode

### DIFF
--- a/sdk/core/core-amqp/src/cbs.ts
+++ b/sdk/core/core-amqp/src/cbs.ts
@@ -144,9 +144,9 @@ export class CbsClient {
     } catch (err) {
       const translatedError = translate(err);
       logger.warning(
-        "[%s] An error occurred while establishing the cbs links: %O",
+        "[%s] An error occurred while establishing the cbs links: %s",
         this.connection.id,
-        translatedError
+        `${translatedError?.name}: ${translatedError?.message}`
       );
       logErrorStackTrace(translatedError);
       throw translatedError;
@@ -207,9 +207,9 @@ export class CbsClient {
       return this._fromAmqpMessageResponse(responseMessage);
     } catch (err) {
       logger.warning(
-        "[%s] An error occurred while negotiating the cbs claim: %O",
+        "[%s] An error occurred while negotiating the cbs claim: %s",
         this.connection.id,
-        err
+        `${err?.name}: ${err?.message}`
       );
       logErrorStackTrace(err);
       throw err;

--- a/sdk/core/core-amqp/src/requestResponseLink.ts
+++ b/sdk/core/core-amqp/src/requestResponseLink.ts
@@ -85,7 +85,7 @@ export class RequestResponseLink implements ReqResLink {
 
     const aborter: AbortSignalLike | undefined = options.abortSignal;
 
-    // If message_id is not already set on the request, set it to a unique value 
+    // If message_id is not already set on the request, set it to a unique value
     // This helps in determining the right response for current request among multiple incoming messages
     if (!request.message_id) {
       request.message_id = generate_uuid();
@@ -194,7 +194,7 @@ export class RequestResponseLink implements ReqResLink {
             description: info.statusDescription
           };
           const error = translate(e);
-          logger.warning(error);
+          logger.warning(`${error?.name}: ${error?.message}`);
           logErrorStackTrace(error);
           return reject(error);
         }


### PR DESCRIPTION
Addresses #8481 from the core-amqp side. This ensures that error stack traces don't show up in logs under `warning` logging.