### PR TITLE
[Storage] Revert the exception made for storage when bumping core-http dep version

### DIFF
--- a/common/config/rush/common-versions.json
+++ b/common/config/rush/common-versions.json
@@ -52,9 +52,6 @@
     // Following is required to allow for backward compatibility with Event Processor Host Track 1
     "@azure/event-hubs": ["^2.1.4"],
 
-    // Exception for storage before the preview release
-    "@azure/core-http": ["^1.1.1"],
-
     // Allow storage-blob-changefeed and storage-file-datalake to use the preview version of storage-blob.
     "@azure/storage-blob": ["^12.2.0-preview.1"]
   }

--- a/sdk/keyvault/keyvault-admin/package.json
+++ b/sdk/keyvault/keyvault-admin/package.json
@@ -72,7 +72,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "@azure/core-tracing": "1.0.0-preview.8",
     "@opentelemetry/api": "^0.6.1",
     "tslib": "^2.0.0"

--- a/sdk/storage/storage-blob-changefeed/package.json
+++ b/sdk/storage/storage-blob-changefeed/package.json
@@ -98,7 +98,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.2.0-preview.1",
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.8",

--- a/sdk/storage/storage-blob/package.json
+++ b/sdk/storage/storage-blob/package.json
@@ -101,7 +101,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "@azure/core-lro": "^1.0.2",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.8",

--- a/sdk/storage/storage-file-datalake/package.json
+++ b/sdk/storage/storage-file-datalake/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.8",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-file-share/package.json
+++ b/sdk/storage/storage-file-share/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.8",
     "@azure/logger": "^1.0.0",

--- a/sdk/storage/storage-queue/package.json
+++ b/sdk/storage/storage-queue/package.json
@@ -99,7 +99,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "@azure/core-paging": "^1.1.1",
     "@azure/core-tracing": "1.0.0-preview.8",
     "@azure/logger": "^1.0.0",


### PR DESCRIPTION
Revert "Make exception for storage"

This reverts commit a3035f8256e11105d9d16615f7e7809aa40fd1ff.