### PR TITLE
[event-hubs] ensure error stack traces only logged in verbose mode

### DIFF
--- a/sdk/eventhub/event-hubs/src/connectionContext.ts
+++ b/sdk/eventhub/event-hubs/src/connectionContext.ts
@@ -243,9 +243,10 @@ export namespace ConnectionContext {
             logger.info("Closed the amqp connection '%s' on the client.", this.connectionId);
           }
         } catch (err) {
-          err = err instanceof Error ? err : JSON.stringify(err);
+          const errorDescription =
+            err instanceof Error ? `${err.name}: ${err.message}` : JSON.stringify(err);
           logger.warning(
-            `An error occurred while closing the connection "${this.connectionId}":\n${err}`
+            `An error occurred while closing the connection "${this.connectionId}":\n${errorDescription}`
           );
           logErrorStackTrace(err);
           throw err;

--- a/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubReceiver.ts
@@ -389,7 +389,7 @@ export class EventHubReceiver extends LinkEntity {
       this._deleteFromCache();
       await this._closeLink(receiverLink);
     } catch (err) {
-      const msg = `[${this._context.connectionId}] An error occurred while closing receiver ${this.name}: ${err}`;
+      const msg = `[${this._context.connectionId}] An error occurred while closing receiver ${this.name}: ${err?.name}: ${err?.message}`;
       logger.warning(msg);
       logErrorStackTrace(err);
       throw err;
@@ -590,10 +590,10 @@ export class EventHubReceiver extends LinkEntity {
       this.isConnecting = false;
       const error = translate(err);
       logger.warning(
-        "[%s] An error occured while creating the receiver '%s': %O",
+        "[%s] An error occured while creating the receiver '%s': %s",
         this._context.connectionId,
         this.name,
-        error
+        `${error?.name}: ${error?.message}`
       );
       logErrorStackTrace(err);
       throw error;

--- a/sdk/eventhub/event-hubs/src/eventHubSender.ts
+++ b/sdk/eventhub/event-hubs/src/eventHubSender.ts
@@ -183,7 +183,7 @@ export class EventHubSender extends LinkEntity {
         await this._closeLink(senderLink);
       }
     } catch (err) {
-      const msg = `[${this._context.connectionId}] An error occurred while closing sender ${this.name}: ${err}`;
+      const msg = `[${this._context.connectionId}] An error occurred while closing sender ${this.name}: ${err?.name}: ${err?.message}`;
       logger.warning(msg);
       logErrorStackTrace(err);
       throw err;
@@ -347,7 +347,9 @@ export class EventHubSender extends LinkEntity {
       );
       return await this._trySendBatch(encodedBatchMessage, options);
     } catch (err) {
-      logger.warning("An error occurred while sending the batch message %O", err);
+      logger.warning(
+        `An error occurred while sending the batch message ${err?.name}: ${err?.message}`
+      );
       logErrorStackTrace(err);
       throw err;
     }
@@ -463,10 +465,10 @@ export class EventHubSender extends LinkEntity {
             removeListeners();
             err = translate(err);
             logger.warning(
-              "[%s] An error occurred while creating the sender %s",
+              "[%s] An error occurred while creating the sender %s: %s",
               this._context.connectionId,
               this.name,
-              err
+              `${err?.name}: ${err?.message}`
             );
             logErrorStackTrace(err);
             return reject(err);
@@ -504,9 +506,9 @@ export class EventHubSender extends LinkEntity {
           } catch (err) {
             err = translate(err.innerError || err);
             logger.warning(
-              "[%s] An error occurred while sending the message",
+              "[%s] An error occurred while sending the message %s",
               this._context.connectionId,
-              err
+              `${err?.name}: ${err?.message}`
             );
             logErrorStackTrace(err);
             return reject(err);
@@ -586,10 +588,10 @@ export class EventHubSender extends LinkEntity {
       this.isConnecting = false;
       err = translate(err);
       logger.warning(
-        "[%s] An error occurred while creating the sender %s",
+        "[%s] An error occurred while creating the sender %s: %s",
         this._context.connectionId,
         this.name,
-        err
+        `${err?.name}: ${err?.message}`
       );
       logErrorStackTrace(err);
       throw err;

--- a/sdk/eventhub/event-hubs/src/eventProcessor.ts
+++ b/sdk/eventhub/event-hubs/src/eventProcessor.ts
@@ -358,7 +358,9 @@ export class EventProcessor {
       try {
         await this._startPump(partitionId, abortSignal);
       } catch (err) {
-        logger.warning(`[${this._id}] An error occured within the EventProcessor loop: ${err}`);
+        logger.warning(
+          `[${this._id}] An error occured within the EventProcessor loop: ${err?.name}: ${err?.message}`
+        );
         logErrorStackTrace(err);
         await this._handleSubscriptionError(err);
       } finally {
@@ -456,7 +458,9 @@ export class EventProcessor {
           }
         }
       } catch (err) {
-        logger.warning(`[${this._id}] An error occured within the EventProcessor loop: ${err}`);
+        logger.warning(
+          `[${this._id}] An error occured within the EventProcessor loop: ${err?.name}: ${err?.message}`
+        );
         logErrorStackTrace(err);
         // Protect against the scenario where the user awaits on subscription.close() from inside processError.
         await Promise.race([this._handleSubscriptionError(err), cancelLoopPromise]);

--- a/sdk/eventhub/event-hubs/src/managementClient.ts
+++ b/sdk/eventhub/event-hubs/src/managementClient.ts
@@ -201,7 +201,9 @@ export class ManagementClient extends LinkEntity {
         code: CanonicalCode.UNKNOWN,
         message: error.message
       });
-      logger.warning("An error occurred while getting the hub runtime information: %O", error);
+      logger.warning(
+        `An error occurred while getting the hub runtime information: ${error?.name}: ${error?.message}`
+      );
       logErrorStackTrace(error);
       throw error;
     } finally {
@@ -271,7 +273,9 @@ export class ManagementClient extends LinkEntity {
         code: CanonicalCode.UNKNOWN,
         message: error.message
       });
-      logger.warning("An error occurred while getting the partition information: %O", error);
+      logger.warning(
+        `An error occurred while getting the partition information: ${error?.name}: ${error?.message}`
+      );
       logErrorStackTrace(error);
       throw error;
     } finally {
@@ -297,7 +301,7 @@ export class ManagementClient extends LinkEntity {
         logger.info("Successfully closed the management session.");
       }
     } catch (err) {
-      const msg = `An error occurred while closing the management session: ${err}`;
+      const msg = `An error occurred while closing the management session: ${err?.name}: ${err?.message}`;
       logger.warning(msg);
       logErrorStackTrace(err);
       throw new Error(msg);
@@ -365,9 +369,7 @@ export class ManagementClient extends LinkEntity {
     } catch (err) {
       err = translate(err);
       logger.warning(
-        "[%s] An error occured while establishing the $management links: %O",
-        this._context.connectionId,
-        err
+        `[${this._context.connectionId}] An error occured while establishing the $management links: ${err?.name}: ${err?.message}`
       );
       logErrorStackTrace(err);
       throw err;
@@ -474,10 +476,10 @@ export class ManagementClient extends LinkEntity {
             err = translate(err);
             logger.warning(
               "[%s] An error occurred during send on management request-response link with address " +
-                "'%s': %O",
+                "'%s': %s",
               this._context.connectionId,
               this.address,
-              err
+              `${err?.name}: ${err?.message}`
             );
             logErrorStackTrace(err);
             reject(err);
@@ -494,7 +496,9 @@ export class ManagementClient extends LinkEntity {
       return (await retry<Message>(config)).body;
     } catch (err) {
       err = translate(err);
-      logger.warning("An error occurred while making the request to $management endpoint: %O", err);
+      logger.warning(
+        `An error occurred while making the request to $management endpoint: ${err?.name}: ${err?.message}`
+      );
       logErrorStackTrace(err);
       throw err;
     }

--- a/sdk/eventhub/event-hubs/src/partitionPump.ts
+++ b/sdk/eventhub/event-hubs/src/partitionPump.ts
@@ -160,7 +160,7 @@ export class PartitionPump {
       }
       await this._partitionProcessor.close(reason);
     } catch (err) {
-      logger.warning("An error occurred while closing the receiver.", err);
+      logger.warning(`An error occurred while closing the receiver: ${err?.name}: ${err?.message}`);
       logErrorStackTrace(err);
       this._partitionProcessor.processError(err);
       throw err;

--- a/sdk/eventhub/event-hubs/src/receiveHandler.ts
+++ b/sdk/eventhub/event-hubs/src/receiveHandler.ts
@@ -63,10 +63,10 @@ export class ReceiveHandler {
         await this._receiver.close();
       } catch (err) {
         logger.warning(
-          "An error occurred while stopping the receiver '%s' with address '%s': %O",
+          "An error occurred while stopping the receiver '%s' with address '%s': %s",
           this._receiver.name,
           this._receiver.address,
-          err
+          `${err?.name}: ${err?.message}`
         );
         logErrorStackTrace(err);
       }

--- a/sdk/eventhub/event-hubs/src/util/error.ts
+++ b/sdk/eventhub/event-hubs/src/util/error.ts
@@ -14,7 +14,7 @@ export function throwErrorIfConnectionClosed(context: ConnectionContext): void {
   if (context && context.wasConnectionCloseCalled) {
     const errorMessage = "The underlying AMQP connection is closed.";
     const error = new Error(errorMessage);
-    logger.warning(`[${context.connectionId}] %O`, error);
+    logger.warning(`[${context.connectionId}] ${error.name}: ${error.message}`);
     logErrorStackTrace(error);
     throw error;
   }
@@ -39,7 +39,7 @@ export function throwTypeErrorIfParameterMissing(
     const error = new TypeError(
       `${methodName} called without required argument "${parameterName}"`
     );
-    logger.warning(`[${connectionId}] %O`, error);
+    logger.warning(`[${connectionId}] ${error.name}: ${error.message}`);
     logErrorStackTrace(error);
     throw error;
   }


### PR DESCRIPTION
Addresses #8481 from the event-hubs side. This ensures that error stack traces don't show up in logs under warning logging.