### PR TITLE
[keyvault-common,table] bump core-http dep version to 1.1.4

### DIFF
--- a/sdk/keyvault/keyvault-common/package.json
+++ b/sdk/keyvault/keyvault-common/package.json
@@ -46,7 +46,7 @@
     "unit-test": "npm run unit-test:node && npm run unit-test:browser"
   },
   "dependencies": {
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "tslib": "^2.0.0"
   },
   "devDependencies": {

--- a/sdk/tables/azure-tables/package.json
+++ b/sdk/tables/azure-tables/package.json
@@ -67,7 +67,7 @@
   "sideEffects": false,
   "prettier": "@azure/eslint-plugin-azure-sdk/prettier.json",
   "dependencies": {
-    "@azure/core-http": "^1.1.1",
+    "@azure/core-http": "^1.1.4",
     "@opentelemetry/api": "^0.6.1",
     "tslib": "^2.0.0"
   },

--- a/sdk/tables/ci.yml
+++ b/sdk/tables/ci.yml
@@ -25,7 +25,8 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      # TODO: re-enable master pr validation after tables tests are ready
+      #- master
       - feature/*
       - release/*
       - hotfix/*


### PR DESCRIPTION
These two libraries were not updated in #9539, possibly due to the exception of core-http v1.1.1 made for storage and
these two files came after #9539 was created/the the exception was made.