### PR TITLE
[FormRecognizer] Renames based on Arch Board feedback

### DIFF
--- a/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
+++ b/sdk/formrecognizer/ai-form-recognizer/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-preview.4 (Unreleased)
 
 - [Breaking] Rename `includeTextDetails` to `includeTextContent` in custom form and receipt recognition options to be consistent with other languages.
+- [Breaking] Rename properties `requestedOn` to `trainingStartedOn` and `completedOn` to `trainingCompletedOn` in `CustomFormModel` and `CustomFormModelInfo` types.
 
 ## 1.0.0-preview.3 (2020-06-10)
 

--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -256,20 +256,19 @@ async function main() {
   const poller = await trainingClient.beginTraining(containerSasUrl, false, {
     onProgress: (state) => { console.log(`training status: ${state.status}`); }
   });
+  const model = await poller.pollUntilDone();
 
-  const response = await poller.pollUntilDone();
-
-  if (!response) {
-    throw new Error("Expecting valid response!");
+  if (!model) {
+    throw new Error("Expecting valid training result!");
   }
 
-  console.log(`Model ID: ${response.modelId}`);
-  console.log(`Status: ${response.status}`);
-  console.log(`Requested on: ${response.requestedOn}`);
-  console.log(`Completed on: ${response.completedOn}`);
+  console.log(`Model ID: ${model.modelId}`);
+  console.log(`Status: ${model.status}`);
+  console.log(`Requested on: ${model.trainingStartedOn}`);
+  console.log(`Completed on: ${model.trainingCompletedOn}`);
 
-  if (response.submodels) {
-    for (const submodel of response.submodels) {
+  if (model.submodels) {
+    for (const submodel of model.submodels) {
       // since the training data is unlabeled, we are unable to return the accuracy of this model
       console.log("We have recognized the following fields");
       for (const key in submodel.fields) {
@@ -279,8 +278,8 @@ async function main() {
     }
   }
   // Training document information
-  if (response.trainingDocuments) {
-    for (const doc of response.trainingDocuments) {
+  if (model.trainingDocuments) {
+    for (const doc of model.trainingDocuments) {
       console.log(`Document name: ${doc.documentName}`);
       console.log(`Document status: ${doc.status}`);
       console.log(`Document page count: ${doc.pageCount}`);

--- a/sdk/formrecognizer/ai-form-recognizer/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/README.md
@@ -264,8 +264,8 @@ async function main() {
 
   console.log(`Model ID: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
-  console.log(`Requested on: ${model.trainingStartedOn}`);
-  console.log(`Completed on: ${model.trainingCompletedOn}`);
+  console.log(`Training started on: ${model.trainingStartedOn}`);
+  console.log(`Training completed on: ${model.trainingCompletedOn}`);
 
   if (model.submodels) {
     for (const submodel of model.submodels) {

--- a/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
+++ b/sdk/formrecognizer/ai-form-recognizer/review/ai-form-recognizer.api.md
@@ -182,21 +182,21 @@ export interface CustomFormField {
 
 // @public
 export interface CustomFormModel {
-    completedOn: Date;
     errors?: FormRecognizerError[];
     modelId: string;
-    requestedOn: Date;
     status: CustomFormModelStatus;
     submodels?: CustomFormSubmodel[];
+    trainingCompletedOn: Date;
     trainingDocuments?: TrainingDocumentInfo[];
+    trainingStartedOn: Date;
 }
 
 // @public
 export interface CustomFormModelInfo {
-    completedOn: Date;
     modelId: string;
-    requestedOn: Date;
     status: CustomFormModelStatus;
+    trainingCompletedOn: Date;
+    trainingStartedOn: Date;
 }
 
 // @public

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainUnlabeledModel.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainUnlabeledModel.js
@@ -25,19 +25,19 @@ async function main() {
       console.log(`training status: ${state.status}`);
     }
   });
-  const response = await poller.pollUntilDone();
+  const model = await poller.pollUntilDone();
 
-  if (!response) {
-    throw new Error("Expecting valid response!");
+  if (!model) {
+    throw new Error("Expecting valid training result!");
   }
 
-  console.log(`Model ID: ${response.modelId}`);
-  console.log(`Status: ${response.status}`);
-  console.log(`Requested on: ${response.requestedOn}`);
-  console.log(`Completed on: ${response.completedOn}`);
+  console.log(`Model ID: ${model.modelId}`);
+  console.log(`Status: ${model.status}`);
+  console.log(`Requested on: ${model.trainingStartedOn}`);
+  console.log(`Completed on: ${model.trainingCompletedOn}`);
 
-  if (response.submodels) {
-    for (const submodel of response.submodels) {
+  if (model.submodels) {
+    for (const submodel of model.submodels) {
       // since the training data is unlabeled, we are unable to return the accuracy of this model
       console.log("We have recognized the following fields");
       for (const key in submodel.fields) {
@@ -47,8 +47,8 @@ async function main() {
     }
   }
   // Training document information
-  if (response.trainingDocuments) {
-    for (const doc of response.trainingDocuments) {
+  if (model.trainingDocuments) {
+    for (const doc of model.trainingDocuments) {
       console.log(`Document name: ${doc.documentName}`);
       console.log(`Document status: ${doc.status}`);
       console.log(`Document page count: ${doc.pageCount}`);

--- a/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainUnlabeledModel.js
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/javascript/trainUnlabeledModel.js
@@ -33,8 +33,8 @@ async function main() {
 
   console.log(`Model ID: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
-  console.log(`Requested on: ${model.trainingStartedOn}`);
-  console.log(`Completed on: ${model.trainingCompletedOn}`);
+  console.log(`Training started on: ${model.trainingStartedOn}`);
+  console.log(`Training completed on: ${model.trainingCompletedOn}`);
 
   if (model.submodels) {
     for (const submodel of model.submodels) {

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
@@ -34,8 +34,8 @@ export async function main() {
 
   console.log(`Model ID: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
-  console.log(`Requested on: ${model.trainingStartedOn}`);
-  console.log(`Completed on: ${model.trainingCompletedOn}`);
+  console.log(`Training started on: ${model.trainingStartedOn}`);
+  console.log(`Training completed on: ${model.trainingCompletedOn}`);
 
   if (model.submodels) {
     for (const submodel of model.submodels) {

--- a/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/samples/typescript/src/trainUnlabeledModel.ts
@@ -29,13 +29,13 @@ export async function main() {
   const model = await poller.pollUntilDone();
 
   if (!model) {
-    throw new Error("Expecting valid response!");
+    throw new Error("Expecting valid training result!");
   }
 
   console.log(`Model ID: ${model.modelId}`);
   console.log(`Status: ${model.status}`);
-  console.log(`Requested on: ${model.requestedOn}`);
-  console.log(`Completed on: ${model.completedOn}`);
+  console.log(`Requested on: ${model.trainingStartedOn}`);
+  console.log(`Completed on: ${model.trainingCompletedOn}`);
 
   if (model.submodels) {
     for (const submodel of model.submodels) {

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/index.ts
@@ -82,11 +82,11 @@ export interface ModelInfo {
   /**
    * Date and time (UTC) when the model was created.
    */
-  requestedOn: Date;
+  trainingStartedOn: Date;
   /**
    * Date and time (UTC) when the status was last updated.
    */
-  completedOn: Date;
+  trainingCompletedOn: Date;
 }
 
 /**

--- a/sdk/formrecognizer/ai-form-recognizer/src/generated/models/mappers.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/generated/models/mappers.ts
@@ -153,14 +153,14 @@ export const ModelInfo: coreHttp.CompositeMapper = {
           allowedValues: ["creating", "ready", "invalid"]
         }
       },
-      requestedOn: {
+      trainingStartedOn: {
         serializedName: "createdDateTime",
         required: true,
         type: {
           name: "DateTime"
         }
       },
-      completedOn: {
+      trainingCompletedOn: {
         serializedName: "lastUpdatedDateTime",
         required: true,
         type: {

--- a/sdk/formrecognizer/ai-form-recognizer/src/lro/copy/poller.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/lro/copy/poller.ts
@@ -202,8 +202,8 @@ function makeBeginCopyModelPollOperation(
         } else if (response.status === "succeeded") {
           state.result = {
             status: "ready",
-            requestedOn: response.createdOn,
-            completedOn: response.lastModified,
+            trainingStartedOn: response.createdOn,
+            trainingCompletedOn: response.lastModified,
             modelId: copyAuthorization.modelId
           };
           state.isCompleted = true;

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -418,11 +418,11 @@ export interface CustomFormModelInfo {
   /**
    * Date and time (UTC) when the custom model training request was received.
    */
-  requestedOn: Date;
+  trainingStartedOn: Date;
   /**
    * Date and time (UTC) when the training operation completed.
    */
-  completedOn: Date;
+  trainingCompletedOn: Date;
 }
 
 export interface CustomFormField {
@@ -473,11 +473,11 @@ export interface CustomFormModel {
   /**
    * Date and time (UTC) when the custom model training request was received.
    */
-  requestedOn: Date;
+  trainingStartedOn: Date;
   /**
    * Date and time (UTC) when the training operation completed.
    */
-  completedOn: Date;
+  trainingCompletedOn: Date;
   /**
    * List of document used to train the model and any errors reported for each document.
    */

--- a/sdk/formrecognizer/ai-form-recognizer/src/models.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/src/models.ts
@@ -416,7 +416,7 @@ export interface CustomFormModelInfo {
    */
   status: CustomFormModelStatus;
   /**
-   * Date and time (UTC) when the custom model training request was received.
+   * Date and time (UTC) when the custom model training started.
    */
   trainingStartedOn: Date;
   /**
@@ -471,7 +471,7 @@ export interface CustomFormModel {
    */
   status: CustomFormModelStatus;
   /**
-   * Date and time (UTC) when the custom model training request was received.
+   * Date and time (UTC) when the custom model training started.
    */
   trainingStartedOn: Date;
   /**

--- a/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
+++ b/sdk/formrecognizer/ai-form-recognizer/swagger/README.md
@@ -85,24 +85,24 @@ directive:
       $["x-ms-client-name"] = "lastModified";
 ```
 
-### ModelInfo `createDateTime` => `requestedOn`
+### ModelInfo `createDateTime` => `trainingStartedOn`
 
 ```yaml
 directive:
   - from: swagger-document
     where: $.definitions.ModelInfo.properties.createdDateTime
     transform: >
-      $["x-ms-client-name"] = "requestedOn";
+      $["x-ms-client-name"] = "trainingStartedOn";
 ```
 
-### ModelInfo `lastUpdatedDateTime` => `completedOn`
+### ModelInfo `lastUpdatedDateTime` => `trainingCompletedOn`
 
 ```yaml
 directive:
   - from: swagger-document
     where: $.definitions.ModelInfo.properties.lastUpdatedDateTime
     transform: >
-      $["x-ms-client-name"] = "completedOn";
+      $["x-ms-client-name"] = "trainingCompletedOn";
 ```
 
 ### `TrainingDocumentInfo.pages` => `TrainingDocumentInfo.pageCount`

--- a/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
+++ b/sdk/formrecognizer/ai-form-recognizer/test/node/formtrainingclient.spec.ts
@@ -209,8 +209,8 @@ describe("FormTrainingClient NodeJS only", () => {
     assert.ok(result, "Expecting valid copy result");
     assert.equal(result?.modelId, targetAuth.modelId, "Expecting matching model ids");
     assert.equal(result!.status, "ready");
-    assert.ok(result!.requestedOn, "Expecting valid 'createOn' property");
-    assert.ok(result!.completedOn, "Expecting valid 'lastModified' property");
+    assert.ok(result!.trainingStartedOn, "Expecting valid 'trainingStartedOn' property");
+    assert.ok(result!.trainingCompletedOn, "Expecting valid 'trainingCompletedOn' property");
   });
 }).timeout(60000);
 


### PR DESCRIPTION
- Rename properties `requestedOn` to `trainingStartedOn` and `completedOn` to `trainingCompletedOn` in `CustomFormModel` and `CustomFormModelInfo` types.
