### PR TITLE
Remove SkillSetCounter Py in ServiceCounters model

### DIFF
--- a/sdk/search/search-documents/CHANGELOG.md
+++ b/sdk/search/search-documents/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Breaking] In Suggest API & Search API return values, a new property called `document` is introduced. All user-defined fields are moved inside this `document` property.
 - [Breaking] In `analyzeText` API, the `text` parameter is moved from method level to inside `options` bag.
 - [Breaking] In `search` API, `includeTotalResultCount` property is renamed to `includeTotalCount`.
+- [Breaking] In `ServiceCounters`, the `skillsetCounter` property has been removed.
 - [Breaking] Modified the names of several properties. Please refer [#9321](https://github.com/Azure/azure-sdk-for-js/issues/9321) for a detailed list of renames.
 
 

--- a/sdk/search/search-documents/review/search-documents.api.md
+++ b/sdk/search/search-documents/review/search-documents.api.md
@@ -1290,7 +1290,6 @@ export interface ServiceCounters {
     documentCounter: ResourceCounter;
     indexCounter: ResourceCounter;
     indexerCounter: ResourceCounter;
-    skillsetCounter: ResourceCounter;
     storageSizeCounter: ResourceCounter;
     synonymMapCounter: ResourceCounter;
 }

--- a/sdk/search/search-documents/src/generated/service/models/index.ts
+++ b/sdk/search/search-documents/src/generated/service/models/index.ts
@@ -3304,10 +3304,6 @@ export interface ServiceCounters {
    * Total number of synonym maps.
    */
   synonymMapCounter: ResourceCounter;
-  /**
-   * Total number of skillsets.
-   */
-  skillsetCounter: ResourceCounter;
 }
 
 /**

--- a/sdk/search/search-documents/src/generated/service/models/mappers.ts
+++ b/sdk/search/search-documents/src/generated/service/models/mappers.ts
@@ -4202,14 +4202,6 @@ export const ServiceCounters: coreHttp.CompositeMapper = {
           name: "Composite",
           className: "ResourceCounter"
         }
-      },
-      skillsetCounter: {
-        required: true,
-        serializedName: "skillsetCount",
-        type: {
-          name: "Composite",
-          className: "ResourceCounter"
-        }
       }
     }
   }


### PR DESCRIPTION
A new swagger update has happened on June 25 https://github.com/Azure/azure-rest-api-specs/pull/9968 which removes the SkillSetCounter property in ServiceCounters model. 

This PR is to accomodate that change. Only change is regenerate the SDK and update the changelog.

@xirzec Please review and approve

@ramya-rao-a FYI