### PR TITLE
[event-hubs][service-bus] update core-amqp to 1.1.4

### DIFF
--- a/sdk/eventhub/event-hubs/CHANGELOG.md
+++ b/sdk/eventhub/event-hubs/CHANGELOG.md
@@ -8,10 +8,13 @@
 - Fixes issue [#9083](https://github.com/Azure/azure-sdk-for-js/issues/9083)
   where calling `EventHubConsumerClient.close()` would not stop any actively
   running `Subscriptions`.
-- Fixes issue [8598](https://github.com/Azure/azure-sdk-for-js/issues/8598)
+- Fixes issue [#8598](https://github.com/Azure/azure-sdk-for-js/issues/8598)
   where the EventHubConsumerClient would remain open in the background beyond
   when `subscription.close()` was called. This would prevent the process from
   exiting until the `maxWaitTimeInSeconds` (default 60) was reached.
+- Updated to use the latest version of the `@azure/core-amqp` package.
+  This update fixes issue [#9287](https://github.com/Azure/azure-sdk-for-js/issues/9287)
+  where some failed operations would delay the process exiting.
 
 ## 5.2.1 (2020-06-08)
 

--- a/sdk/eventhub/event-hubs/package.json
+++ b/sdk/eventhub/event-hubs/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^1.1.3",
+    "@azure/core-amqp": "^1.1.4",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-tracing": "1.0.0-preview.8",
     "@azure/logger": "^1.0.0",

--- a/sdk/servicebus/service-bus/package.json
+++ b/sdk/servicebus/service-bus/package.json
@@ -86,7 +86,7 @@
   },
   "dependencies": {
     "@azure/abort-controller": "^1.0.0",
-    "@azure/core-amqp": "^1.1.3",
+    "@azure/core-amqp": "^1.1.4",
     "@azure/core-asynciterator-polyfill": "^1.0.0",
     "@azure/core-http": "^1.1.4",
     "@azure/core-tracing": "1.0.0-preview.8",


### PR DESCRIPTION
Since there are some bug fixes in core-amqp 1.1.4 that were made for service bus and event hubs, we should make that version our new minimum.