### PR TITLE
[Service Bus] Tracking expired sessions is not needed

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -198,7 +198,6 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
       throw error;
     }
     this.sessionId = this._messageSession.sessionId;
-    delete this._context.expiredMessageSessions[this._messageSession.sessionId];
     return;
   }
 


### PR DESCRIPTION
The tracking of expired sessions and throwing a custom SessionLockLostError when a message from such a session is attempted to be settled was introduced in #1180 to fix #1051 which was about unhelpful errors.

When a session lock expires, the AMQP receiver link first gets an error and then gets closed resulting in the corresponding instance of the `MessageSession` class getting cleared from the cache. We now have code in place which throws the `SessionLockLostError` with message `Failed to settle the message as the AMQP link with which the message was received is no longer alive` on not finding the right `MessageSession` instance in cache.

Therefore, we no longer need to track the expired sessions on our end and throw our own SessionLockLostError.

The tests in `renewSessionLock.spec.ts` file that checks that we throw `SessionLockLostError` when attempting to settle a message from a session that has its lock expired are all passing.