### PR TITLE
[service-bus] Make sure we properly handle processError being treated as async.

### DIFF
--- a/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
+++ b/sdk/servicebus/service-bus/src/receivers/sessionReceiver.ts
@@ -25,7 +25,7 @@ import {
 } from "../util/errors";
 import * as log from "../log";
 import { OnError, OnMessage } from "../core/messageReceiver";
-import { assertValidMessageHandlers, getMessageIterator } from "./shared";
+import { assertValidMessageHandlers, getMessageIterator, wrapProcessErrorHandler } from "./shared";
 import { convertToInternalReceiveMode } from "../constructorHelpers";
 import { Receiver } from "./receiver";
 import Long from "long";
@@ -468,14 +468,13 @@ export class SessionReceiverImpl<ReceivedMessageT extends ReceivedMessage | Rece
     // TODO - receiverOptions for subscribe??
     assertValidMessageHandlers(handlers);
 
+    const processError = wrapProcessErrorHandler(handlers);
+
     this._registerMessageHandler(
       async (message: ServiceBusMessageImpl) => {
         return handlers.processMessage((message as any) as ReceivedMessageT);
       },
-      (err: Error) => {
-        // TODO: not async internally yet.
-        handlers.processError(err);
-      },
+      processError,
       options
     );
   }

--- a/sdk/servicebus/service-bus/src/receivers/shared.ts
+++ b/sdk/servicebus/service-bus/src/receivers/shared.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { GetMessageIteratorOptions } from "../models";
+import { GetMessageIteratorOptions, MessageHandlers } from "../models";
 import { Receiver } from "./receiver";
+import * as log from "../log";
 
 /**
  * @internal
@@ -42,4 +43,21 @@ export async function* getMessageIterator<ReceivedMessageT>(
 
     yield messages[0];
   }
+}
+
+/**
+ * @internal
+ * @ignore
+ */
+export function wrapProcessErrorHandler(
+  handlers: Pick<MessageHandlers<unknown>, "processError">,
+  logError: (formatter: any, ...args: any[]) => void = log.error
+): MessageHandlers<unknown>["processError"] {
+  return async (err: Error) => {
+    try {
+      await handlers.processError(err);
+    } catch (err) {
+      logError(`An error was thrown from the user's processError handler: ${err}`);
+    }
+  };
 }

--- a/sdk/servicebus/service-bus/test/internal/shared.spec.ts
+++ b/sdk/servicebus/service-bus/test/internal/shared.spec.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { wrapProcessErrorHandler } from "../../src/receivers/shared";
+import chai from "chai";
+const assert = chai.assert;
+
+describe("shared", () => {
+  it("error handler wrapper", () => {
+    const loggedMessages: string[] = [];
+
+    const wrappedProcessError = wrapProcessErrorHandler(
+      {
+        processError: () => {
+          throw new Error("Whoops!");
+        }
+      },
+      (msg) => {
+        loggedMessages.push(msg);
+      }
+    );
+
+    wrappedProcessError(
+      new Error(
+        "Doesn't matter, testing internal behavior when the user's process error handler throws"
+      )
+    );
+
+    assert.deepEqual(loggedMessages, [
+      `An error was thrown from the user's processError handler: Error: Whoops!`
+    ]);
+  });
+});


### PR DESCRIPTION
As part of formalizing processError being async we also need to handle errors that might be thrown from it.

This is an internals change but not contract breaking or changelog worthy. :)

Fixes #7836 