### PR TITLE
Fix release artifacts parameter name for passing to stage-artifacts.yml 

### DIFF
--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -33,7 +33,7 @@ stages:
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}}
                         TargetFolder: ${{artifact.safeName}}
-                        PackageName: ${{artifact.name}}-*
+                        PackageName: ${{artifact.name}}-*.tgz
                     - pwsh: |
                         Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                       workingDirectory: $(Pipeline.Workspace)
@@ -93,7 +93,7 @@ stages:
                         parameters:
                           SourceFolder: ${{parameters.ArtifactName}}
                           TargetFolder: ${{artifact.safeName}}
-                          PackageName: ${{artifact.name}}
+                          PackageName: ${{artifact.name}}-*.tgz
                       - pwsh: |
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -33,7 +33,7 @@ stages:
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}}
                         TargetFolder: ${{artifact.safeName}}
-                        PackageName: ${{artifact.name}}
+                        PackageName: ${{artifact.name}}-
                     - pwsh: |
                         Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                       workingDirectory: $(Pipeline.Workspace)
@@ -135,7 +135,7 @@ stages:
                         parameters:
                           SourceFolder: ${{parameters.DocArtifact}}
                           TargetFolder: ${{artifact.safeName}}/${{parameters.DocArtifact}}
-                          PackageName: $(Documentation.Zip)
+                          PackageName: $(Documentation.Zip).zip
                       - pwsh: |
                           Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                         workingDirectory: $(Pipeline.Workspace)

--- a/eng/pipelines/templates/stages/archetype-js-release.yml
+++ b/eng/pipelines/templates/stages/archetype-js-release.yml
@@ -33,7 +33,7 @@ stages:
                       parameters:
                         SourceFolder: ${{parameters.ArtifactName}}
                         TargetFolder: ${{artifact.safeName}}
-                        PackageName: ${{artifact.name}}-
+                        PackageName: ${{artifact.name}}-*
                     - pwsh: |
                         Get-ChildItem -Recurse $(Pipeline.Workspace)/${{artifact.safeName}}
                       workingDirectory: $(Pipeline.Workspace)

--- a/eng/pipelines/templates/steps/stage-artifacts.yml
+++ b/eng/pipelines/templates/steps/stage-artifacts.yml
@@ -6,5 +6,5 @@ parameters:
 steps:
   - pwsh: |
       New-Item -Type Directory -Name ${{parameters.TargetFolder}} -Path $(Pipeline.Workspace)
-      Copy-Item $(Pipeline.Workspace)/${{parameters.SourceFolder}}/${{parameters.PackageName}}* $(Pipeline.Workspace)/${{parameters.TargetFolder}}
+      Copy-Item $(Pipeline.Workspace)/${{parameters.SourceFolder}}/${{parameters.PackageName}} $(Pipeline.Workspace)/${{parameters.TargetFolder}}
     displayName: Stage artifacts


### PR DESCRIPTION
This is a fix to avoid the match on shorter package name accidentally match the longer package name.
For eg - if there is a package `core-http` then the regex `core-http*` also matches `core-https` . To avoid this situation we are introducing some fixes in the parameters for matching artifact name and matching .zip packages